### PR TITLE
Report the failure rate of flush operations of the Elasticsearch exporter

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -38,6 +38,8 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.impl.nio.reactor.IOReactorConfig;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
@@ -120,20 +122,36 @@ public class ElasticsearchClient {
     final var bulkMemorySize = getBulkMemorySize();
     metrics.recordBulkMemorySize(bulkMemorySize);
 
-    final BulkResponse bulkResponse;
-    try {
-      bulkResponse = exportBulk();
+    try (final Histogram.Timer timer = metrics.measureFlushDuration()) {
+      exportBulk();
+      // all records where flushed, create new bulk request, otherwise retry next time
+      bulkRequest = new ArrayList<>();
+    } catch (final ElasticsearchExporterException e) {
+      metrics.recordFailedFlush();
+      throw e;
+    }
+  }
 
+  private void exportBulk() {
+    final Response httpResponse;
+    try {
+      httpResponse = sendBulkRequest();
+    } catch (final ResponseException e) {
+      throw new ElasticsearchExporterException("Elastic returned an error response on flush", e);
     } catch (final IOException e) {
       throw new ElasticsearchExporterException("Failed to flush bulk", e);
+    }
+
+    final BulkResponse bulkResponse;
+    try {
+      bulkResponse = MAPPER.readValue(httpResponse.getEntity().getContent(), BulkResponse.class);
+    } catch (final IOException e) {
+      throw new ElasticsearchExporterException("Failed to parse response when flushing", e);
     }
 
     if (bulkResponse.hasErrors()) {
       throwCollectedBulkError(bulkResponse);
     }
-
-    // all records where flushed, create new bulk request, otherwise retry next time
-    bulkRequest = new ArrayList<>();
   }
 
   private void throwCollectedBulkError(final BulkResponse bulkResponse) {
@@ -152,15 +170,11 @@ public class ElasticsearchClient {
     throw new ElasticsearchExporterException("Failed to flush bulk request: " + collectedErrors);
   }
 
-  private BulkResponse exportBulk() throws IOException {
-    try (final Histogram.Timer timer = metrics.measureFlushDuration()) {
-      final var request = new Request("POST", "/_bulk");
-      request.setJsonEntity(String.join("\n", bulkRequest) + "\n");
+  private Response sendBulkRequest() throws IOException {
+    final var request = new Request("POST", "/_bulk");
+    request.setJsonEntity(String.join("\n", bulkRequest) + "\n");
 
-      final var response = client.performRequest(request);
-
-      return MAPPER.readValue(response.getEntity().getContent(), BulkResponse.class);
-    }
+    return client.performRequest(request);
   }
 
   public boolean shouldFlush() {

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchMetrics.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchMetrics.java
@@ -7,34 +7,45 @@
  */
 package io.camunda.zeebe.exporter;
 
+import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
 
 public class ElasticsearchMetrics {
+  private static final String NAMESPACE = "zeebe_elasticsearch_exporter";
+  private static final String PARTITION_LABEL = "partition";
 
   private static final Histogram FLUSH_DURATION =
       Histogram.build()
-          .namespace("zeebe_elasticsearch_exporter")
+          .namespace(NAMESPACE)
           .name("flush_duration_seconds")
           .help("Flush duration of bulk exporters in seconds")
-          .labelNames("partition")
+          .labelNames(PARTITION_LABEL)
+          .register();
+
+  private static final Counter FAILED_FLUSH =
+      Counter.build()
+          .namespace(NAMESPACE)
+          .name("failed_flush")
+          .help("Number of failed flush operations")
+          .labelNames(PARTITION_LABEL)
           .register();
 
   private static final Histogram BULK_SIZE =
       Histogram.build()
-          .namespace("zeebe_elasticsearch_exporter")
+          .namespace(NAMESPACE)
           .name("bulk_size")
           .help("Exporter bulk size")
           .buckets(10, 100, 1_000, 10_000, 100_000)
-          .labelNames("partition")
+          .labelNames(PARTITION_LABEL)
           .register();
 
   private static final Gauge BULK_MEMORY_SIZE =
       Gauge.build()
-          .namespace("zeebe_elasticsearch_exporter")
+          .namespace(NAMESPACE)
           .name("bulk_memory_size")
           .help("Exporter bulk memory size")
-          .labelNames("partition")
+          .labelNames(PARTITION_LABEL)
           .register();
 
   private final String partitionIdLabel;
@@ -53,5 +64,9 @@ public class ElasticsearchMetrics {
 
   public void recordBulkMemorySize(final int bulkMemorySize) {
     BULK_MEMORY_SIZE.labels(partitionIdLabel).set(bulkMemorySize);
+  }
+
+  public void recordFailedFlush() {
+    FAILED_FLUSH.labels(partitionIdLabel).inc();
   }
 }

--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - 9090:9090
 
   grafana:
-    image: grafana/grafana:6.7.5
+    image: grafana/grafana:7.5.2
     depends_on:
       - prometheus
     ports:

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -9300,7 +9300,7 @@
           },
           "gridPos": {
             "h": 10,
-            "w": 8,
+            "w": 12,
             "x": 0,
             "y": 47
           },
@@ -9348,6 +9348,101 @@
           "yBucketSize": null
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DS_PROMETHEUS",
+          "description": "The rate of failure of flush operations, averaged over 15s intervals",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 47
+          },
+          "hiddenSeries": false,
+          "id": 255,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "rate(zeebe_elasticsearch_exporter_failed_flush_total{namespace=~\"$namespace\", pod=~\"$pod\"}[15s]) / rate(zeebe_elasticsearch_exporter_flush_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[15s])",
+              "interval": "",
+              "legendFormat": "{{pod}} Exporter {{partition}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Elasticsearch Exporter (Flush Failure Rate)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:58",
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:59",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
           "cards": {
             "cardPadding": null,
             "cardRound": null
@@ -9369,9 +9464,9 @@
           },
           "gridPos": {
             "h": 10,
-            "w": 8,
-            "x": 8,
-            "y": 47
+            "w": 12,
+            "x": 0,
+            "y": 57
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -9432,9 +9527,9 @@
           "fillGradient": 0,
           "gridPos": {
             "h": 10,
-            "w": 8,
-            "x": 16,
-            "y": 47
+            "w": 12,
+            "x": 12,
+            "y": 57
           },
           "hiddenSeries": false,
           "id": 185,
@@ -9538,7 +9633,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 57
+            "y": 67
           },
           "height": "400",
           "hiddenSeries": false,


### PR DESCRIPTION
## Description

This PR adds a new metric to visualize the failure rate of flush operations in the Elasticsearch exporter. Flush metrics are still reported on failure anyway as it can still be useful to have these metrics even on failure.

It looks like this in Grafana:

![es-failed-flush](https://user-images.githubusercontent.com/43373/119139630-86148900-ba43-11eb-9a4a-a82a915193d4.png)

## Related issues

closes #4830 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
