### PR TITLE
Support resolving incidents created by parent processors when child is completing

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContainerProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContainerProcessor.java
@@ -45,13 +45,13 @@ public interface BpmnElementContainerProcessor<T extends ExecutableFlowElement>
    * @param element the instance of the BPMN element container
    * @param flowScopeContext process instance-related data of the element container
    * @param childContext process instance-related data of the child element that is completed. At
-   *     this point in time the element is still present in the state
+   * @return either a failure (Left) or any success value (Right)
    */
-  default void beforeExecutionPathCompleted(
+  default Either<Failure, ?> beforeExecutionPathCompleted(
       final T element,
       final BpmnElementContext flowScopeContext,
       final BpmnElementContext childContext) {
-    // nothing to do
+    return Either.right(null);
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.state.immutable.IncidentState;
 import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.util.collection.Tuple;
 
 public final class BpmnIncidentBehavior {
 
@@ -39,6 +40,10 @@ public final class BpmnIncidentBehavior {
       final IncidentRecord incidentRecord = incidentState.getIncidentRecord(incidentKey);
       stateWriter.appendFollowUpEvent(incidentKey, IncidentIntent.RESOLVED, incidentRecord);
     }
+  }
+
+  public void createIncident(final Tuple<Failure, BpmnElementContext> failureAndContext) {
+    createIncident(failureAndContext.getLeft(), failureAndContext.getRight());
   }
 
   public void createIncident(final Failure failure, final BpmnElementContext context) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -84,9 +84,7 @@ public final class CallActivityProcessor
         .ifRightOrLeft(
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(context);
-              final var completed =
-                  stateTransitionBehavior.transitionToCompletedWithParentNotification(
-                      element, context);
+              final var completed = stateTransitionBehavior.transitionToCompleted(element, context);
               stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
             },
             failure -> incidentBehavior.createIncident(failure, context));

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -81,12 +81,13 @@ public final class CallActivityProcessor
   public void onComplete(final ExecutableCallActivity element, final BpmnElementContext context) {
     variableMappingBehavior
         .applyOutputMappings(context, element)
-        .ifRightOrLeft(
+        .flatMap(
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(context);
-              final var completed = stateTransitionBehavior.transitionToCompleted(element, context);
-              stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
-            },
+              return stateTransitionBehavior.transitionToCompleted(element, context);
+            })
+        .ifRightOrLeft(
+            completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed),
             failure -> incidentBehavior.createIncident(failure, context));
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
@@ -56,9 +56,8 @@ public final class EventSubProcessProcessor
 
     variableMappingBehavior
         .applyOutputMappings(completing, element)
-        .ifRightOrLeft(
-            ok -> stateTransitionBehavior.transitionToCompleted(element, completing),
-            failure -> incidentBehavior.createIncident(failure, completing));
+        .flatMap(ok -> stateTransitionBehavior.transitionToCompleted(element, completing))
+        .ifLeft(failure -> incidentBehavior.createIncident(failure, completing));
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
@@ -57,9 +57,7 @@ public final class EventSubProcessProcessor
     variableMappingBehavior
         .applyOutputMappings(completing, element)
         .ifRightOrLeft(
-            ok ->
-                stateTransitionBehavior.transitionToCompletedWithParentNotification(
-                    element, completing),
+            ok -> stateTransitionBehavior.transitionToCompleted(element, completing),
             failure -> incidentBehavior.createIncident(failure, completing));
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -91,8 +91,7 @@ public final class MultiInstanceBodyProcessor
         .getOutputCollection()
         .ifPresent(variableName -> stateBehavior.propagateVariable(context, variableName));
 
-    final var completed =
-        stateTransitionBehavior.transitionToCompletedWithParentNotification(element, context);
+    final var completed = stateTransitionBehavior.transitionToCompleted(element, context);
     stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -70,7 +70,10 @@ public final class ProcessProcessor
     // event applier will delete the element instance
     processResultSenderBehavior.sendResult(context);
 
-    transitionTo(element, context, stateTransitionBehavior::transitionToCompleted);
+    transitionTo(
+        element,
+        context,
+        completing -> stateTransitionBehavior.transitionToCompleted(element, completing));
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -17,10 +17,12 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnProcessResultSenderBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
+import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.util.Either;
 import java.util.function.Consumer;
-import java.util.function.UnaryOperator;
+import java.util.function.Function;
 
 public final class ProcessProcessor
     implements BpmnElementContainerProcessor<ExecutableFlowElementContainer> {
@@ -86,7 +88,10 @@ public final class ProcessProcessor
     final var noActiveChildInstances = stateTransitionBehavior.terminateChildInstances(context);
 
     if (noActiveChildInstances) {
-      transitionTo(element, context, stateTransitionBehavior::transitionToTerminated);
+      transitionTo(
+          element,
+          context,
+          terminating -> Either.right(stateTransitionBehavior.transitionToTerminated(terminating)));
     }
   }
 
@@ -144,19 +149,22 @@ public final class ProcessProcessor
                       eventTrigger,
                       flowScopeContext));
     } else if (stateBehavior.canBeTerminated(childContext)) {
-      transitionTo(element, flowScopeContext, stateTransitionBehavior::transitionToTerminated);
+      transitionTo(
+          element,
+          flowScopeContext,
+          context -> Either.right(stateTransitionBehavior.transitionToTerminated(context)));
     }
   }
 
   private void transitionTo(
       final ExecutableFlowElementContainer element,
       final BpmnElementContext context,
-      final UnaryOperator<BpmnElementContext> transitionOperation) {
+      final Function<BpmnElementContext, Either<Failure, BpmnElementContext>> transitionOperation) {
 
-    final var action = getPostTransitionAction(element, context);
+    final var postTransitionAction = getPostTransitionAction(element, context);
     final var afterTransition = transitionOperation.apply(context);
-
-    action.accept(afterTransition);
+    afterTransition.ifRightOrLeft(
+        postTransitionAction, failure -> incidentBehavior.createIncident(failure, context));
   }
 
   private Consumer<BpmnElementContext> getPostTransitionAction(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -71,13 +71,13 @@ public final class SubProcessProcessor
 
     variableMappingBehavior
         .applyOutputMappings(completing, element)
-        .ifRightOrLeft(
+        .flatMap(
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(completing);
-              final var completed =
-                  stateTransitionBehavior.transitionToCompleted(element, completing);
-              stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
-            },
+              return stateTransitionBehavior.transitionToCompleted(element, completing);
+            })
+        .ifRightOrLeft(
+            completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed),
             failure -> incidentBehavior.createIncident(failure, completing));
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -75,8 +75,7 @@ public final class SubProcessProcessor
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(completing);
               final var completed =
-                  stateTransitionBehavior.transitionToCompletedWithParentNotification(
-                      element, completing);
+                  stateTransitionBehavior.transitionToCompleted(element, completing);
               stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
             },
             failure -> incidentBehavior.createIncident(failure, completing));

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/BoundaryEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/BoundaryEventProcessor.java
@@ -47,11 +47,9 @@ public final class BoundaryEventProcessor implements BpmnElementProcessor<Execut
 
     variableMappingBehavior
         .applyOutputMappings(context, element)
+        .flatMap(ok -> stateTransitionBehavior.transitionToCompleted(element, context))
         .ifRightOrLeft(
-            ok -> {
-              final var completed = stateTransitionBehavior.transitionToCompleted(element, context);
-              stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
-            },
+            completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed),
             failure -> incidentBehavior.createIncident(failure, context));
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/BoundaryEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/BoundaryEventProcessor.java
@@ -49,9 +49,7 @@ public final class BoundaryEventProcessor implements BpmnElementProcessor<Execut
         .applyOutputMappings(context, element)
         .ifRightOrLeft(
             ok -> {
-              final var completed =
-                  stateTransitionBehavior.transitionToCompletedWithParentNotification(
-                      element, context);
+              final var completed = stateTransitionBehavior.transitionToCompleted(element, context);
               stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
             },
             failure -> incidentBehavior.createIncident(failure, context));

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -17,8 +17,11 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventPublicationBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
+import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEndEvent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.collection.Tuple;
 
 public final class EndEventProcessor implements BpmnElementProcessor<ExecutableEndEvent> {
   private static final String TRANSITION_TO_COMPLETED_PRECONDITION_ERROR =
@@ -42,7 +45,7 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
   @Override
   public void onActivate(final ExecutableEndEvent element, final BpmnElementContext activating) {
     if (!element.hasError()) {
-      transitionUntilCompleted(element, activating);
+      transitionUntilCompleted(element, activating).ifLeft(incidentBehavior::createIncident);
       return;
     }
 
@@ -75,7 +78,7 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
   // there's some duplication here with ExclusiveGatewayProcessor where we want to short circuit and
   // go directly from activated -> completed, which could be dry'd up
   // TODO(npepinpe): candidate for clean up for https://github.com/camunda-cloud/zeebe/issues/6202
-  private void transitionUntilCompleted(
+  private Either<Tuple<Failure, BpmnElementContext>, BpmnElementContext> transitionUntilCompleted(
       final ExecutableEndEvent element, final BpmnElementContext activating) {
     if (activating.getIntent() != ProcessInstanceIntent.ELEMENT_ACTIVATING) {
       throw new BpmnProcessingException(activating, TRANSITION_TO_COMPLETED_PRECONDITION_ERROR);
@@ -83,7 +86,8 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
 
     final var activated = stateTransitionBehavior.transitionToActivated(activating);
     final var completing = stateTransitionBehavior.transitionToCompleting(activated);
-
-    stateTransitionBehavior.transitionToCompleted(element, completing);
+    return stateTransitionBehavior
+        .transitionToCompleted(element, completing)
+        .mapLeft(failure -> new Tuple<>(failure, completing));
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -84,6 +84,6 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
     final var activated = stateTransitionBehavior.transitionToActivated(activating);
     final var completing = stateTransitionBehavior.transitionToCompleting(activated);
 
-    stateTransitionBehavior.transitionToCompletedWithParentNotification(element, completing);
+    stateTransitionBehavior.transitionToCompleted(element, completing);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateCatchEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateCatchEventProcessor.java
@@ -52,13 +52,13 @@ public class IntermediateCatchEventProcessor
       final ExecutableCatchEventElement element, final BpmnElementContext completing) {
     variableMappingBehavior
         .applyOutputMappings(completing, element)
-        .ifRightOrLeft(
+        .flatMap(
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(completing);
-              final var completed =
-                  stateTransitionBehavior.transitionToCompleted(element, completing);
-              stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
-            },
+              return stateTransitionBehavior.transitionToCompleted(element, completing);
+            })
+        .ifRightOrLeft(
+            completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed),
             failure -> incidentBehavior.createIncident(failure, completing));
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateCatchEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateCatchEventProcessor.java
@@ -56,8 +56,7 @@ public class IntermediateCatchEventProcessor
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(completing);
               final var completed =
-                  stateTransitionBehavior.transitionToCompletedWithParentNotification(
-                      element, completing);
+                  stateTransitionBehavior.transitionToCompleted(element, completing);
               stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
             },
             failure -> incidentBehavior.createIncident(failure, completing));

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/StartEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/StartEventProcessor.java
@@ -42,7 +42,7 @@ public class StartEventProcessor implements BpmnElementProcessor<ExecutableStart
   public void onComplete(final ExecutableStartEvent element, final BpmnElementContext context) {
     variableMappingBehavior
         .applyOutputMappings(context, element)
-        .map(ok -> stateTransitionBehavior.transitionToCompleted(element, context))
+        .flatMap(ok -> stateTransitionBehavior.transitionToCompleted(element, context))
         .ifRightOrLeft(
             completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed),
             failure -> incidentBehavior.createIncident(failure, context));

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/StartEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/StartEventProcessor.java
@@ -42,10 +42,7 @@ public class StartEventProcessor implements BpmnElementProcessor<ExecutableStart
   public void onComplete(final ExecutableStartEvent element, final BpmnElementContext context) {
     variableMappingBehavior
         .applyOutputMappings(context, element)
-        .map(
-            c ->
-                stateTransitionBehavior.transitionToCompletedWithParentNotification(
-                    element, context))
+        .map(ok -> stateTransitionBehavior.transitionToCompleted(element, context))
         .ifRightOrLeft(
             completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed),
             failure -> incidentBehavior.createIncident(failure, context));

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/EventBasedGatewayProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/EventBasedGatewayProcessor.java
@@ -62,9 +62,16 @@ public final class EventBasedGatewayProcessor
 
     // transition to completed and continue on the event of the gateway that was triggered
     // - according to the BPMN specification, the sequence flow to this event is not taken
-    final var completed = stateTransitionBehavior.transitionToCompleted(element, context);
-    eventSubscriptionBehavior.activateTriggeredEvent(
-        context.getElementInstanceKey(), completed.getFlowScopeKey(), eventTrigger, completed);
+    stateTransitionBehavior
+        .transitionToCompleted(element, context)
+        .ifRightOrLeft(
+            completed ->
+                eventSubscriptionBehavior.activateTriggeredEvent(
+                    context.getElementInstanceKey(),
+                    completed.getFlowScopeKey(),
+                    eventTrigger,
+                    completed),
+            failure -> incidentBehavior.createIncident(failure, context));
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/EventBasedGatewayProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/EventBasedGatewayProcessor.java
@@ -62,7 +62,7 @@ public final class EventBasedGatewayProcessor
 
     // transition to completed and continue on the event of the gateway that was triggered
     // - according to the BPMN specification, the sequence flow to this event is not taken
-    final var completed = stateTransitionBehavior.transitionToCompleted(context);
+    final var completed = stateTransitionBehavior.transitionToCompleted(element, context);
     eventSubscriptionBehavior.activateTriggeredEvent(
         context.getElementInstanceKey(), completed.getFlowScopeKey(), eventTrigger, completed);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
@@ -88,7 +88,7 @@ public final class ExclusiveGatewayProcessor
     }
     final var activated = stateTransitionBehavior.transitionToActivated(activating);
     final var completing = stateTransitionBehavior.transitionToCompleting(activated);
-    return stateTransitionBehavior.transitionToCompletedWithParentNotification(element, completing);
+    return stateTransitionBehavior.transitionToCompleted(element, completing);
   }
 
   private Either<Failure, ExecutableSequenceFlow> findSequenceFlowToTake(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ParallelGatewayProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ParallelGatewayProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.bpmn.gateway;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -17,9 +18,11 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 public final class ParallelGatewayProcessor implements BpmnElementProcessor<ExecutableFlowNode> {
 
   private final BpmnStateTransitionBehavior stateTransitionBehavior;
+  private final BpmnIncidentBehavior bpmnIncidentBehavior;
 
   public ParallelGatewayProcessor(final BpmnBehaviors behaviors) {
     stateTransitionBehavior = behaviors.stateTransitionBehavior();
+    bpmnIncidentBehavior = behaviors.incidentBehavior();
   }
 
   @Override
@@ -34,9 +37,14 @@ public final class ParallelGatewayProcessor implements BpmnElementProcessor<Exec
     // incoming sequence flows are taken
     final var activated = stateTransitionBehavior.transitionToActivated(context);
     final var completing = stateTransitionBehavior.transitionToCompleting(activated);
-    final var completed = stateTransitionBehavior.transitionToCompleted(element, completing);
-    // fork the process processing by taking all outgoing sequence flows of the parallel gateway
-    stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
+    stateTransitionBehavior
+        .transitionToCompleted(element, completing)
+        .ifRightOrLeft(
+            completed ->
+                // fork the process processing by taking all outgoing sequence flows of the parallel
+                // gateway
+                stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed),
+            failure -> bpmnIncidentBehavior.createIncident(failure, completing));
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ParallelGatewayProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ParallelGatewayProcessor.java
@@ -34,8 +34,7 @@ public final class ParallelGatewayProcessor implements BpmnElementProcessor<Exec
     // incoming sequence flows are taken
     final var activated = stateTransitionBehavior.transitionToActivated(context);
     final var completing = stateTransitionBehavior.transitionToCompleting(activated);
-    final var completed =
-        stateTransitionBehavior.transitionToCompletedWithParentNotification(element, completing);
+    final var completed = stateTransitionBehavior.transitionToCompleted(element, completing);
     // fork the process processing by taking all outgoing sequence flows of the parallel gateway
     stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ReceiveTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ReceiveTaskProcessor.java
@@ -51,12 +51,13 @@ public final class ReceiveTaskProcessor implements BpmnElementProcessor<Executab
 
     variableMappingBehavior
         .applyOutputMappings(context, element)
-        .ifRightOrLeft(
+        .flatMap(
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(context);
-              final var completed = stateTransitionBehavior.transitionToCompleted(element, context);
-              stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
-            },
+              return stateTransitionBehavior.transitionToCompleted(element, context);
+            })
+        .ifRightOrLeft(
+            completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed),
             failure -> incidentBehavior.createIncident(failure, context));
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ReceiveTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ReceiveTaskProcessor.java
@@ -54,9 +54,7 @@ public final class ReceiveTaskProcessor implements BpmnElementProcessor<Executab
         .ifRightOrLeft(
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(context);
-              final var completed =
-                  stateTransitionBehavior.transitionToCompletedWithParentNotification(
-                      element, context);
+              final var completed = stateTransitionBehavior.transitionToCompleted(element, context);
               stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
             },
             failure -> incidentBehavior.createIncident(failure, context));

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ServiceTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ServiceTaskProcessor.java
@@ -72,9 +72,7 @@ public final class ServiceTaskProcessor implements BpmnElementProcessor<Executab
         .ifRightOrLeft(
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(context);
-              final var completed =
-                  stateTransitionBehavior.transitionToCompletedWithParentNotification(
-                      element, context);
+              final var completed = stateTransitionBehavior.transitionToCompleted(element, context);
               stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
             },
             failure -> incidentBehavior.createIncident(failure, context));

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ServiceTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ServiceTaskProcessor.java
@@ -69,12 +69,13 @@ public final class ServiceTaskProcessor implements BpmnElementProcessor<Executab
   public void onComplete(final ExecutableServiceTask element, final BpmnElementContext context) {
     variableMappingBehavior
         .applyOutputMappings(context, element)
-        .ifRightOrLeft(
+        .flatMap(
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(context);
-              final var completed = stateTransitionBehavior.transitionToCompleted(element, context);
-              stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
-            },
+              return stateTransitionBehavior.transitionToCompleted(element, context);
+            })
+        .ifRightOrLeft(
+            completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed),
             failure -> incidentBehavior.createIncident(failure, context));
   }
 


### PR DESCRIPTION
## Description

When a child element completes (complete command is being processed), it may inform the container processor (i.e. processor for the parent/flowscope element) of its completion. This happens specifically when the child is at the end of the execution path within the container element. For example, the end event element (child) at the end of a sub process element (parent).

The parent processor can perform some logic when it is informed of the completion of the child. In some cases, the parent processor is allowed to fail executing this logic (for example, multi instance body container processor can fail evaluation of the input collection variable). This failure should then result in an incident on the child element, so the child element completion can be retried when the incident is being resolved. It should also not yet write `ELEMENT_COMPLETED` for the child, because then the incident could no longer be resolved (i.e. the child element is already removed from state).

This pull request allows parent processors to fail the `beforeExecutionPathCompleted` method by returning either a failure or a success. All child processors deal with it accordingly.

### Special note 
In some specific cases (e.g. ExclusiveGateway), the onComplete method is not implemented, so it would not be possible to resolve the created incident. However, at this time the exclusive gateway would never be the end of an execution path for a parent element that could fail the method beforeExecutionPathCompleted. If this changes in the future, and an incident is created by these processors, then we can implement this onComplete method at that time to allow the incidents to be resolved in a future version.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6952

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
