### PR TITLE
test(atomix): fix flaky swim test

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
@@ -255,7 +255,9 @@ public class SwimProtocolTest extends ConcurrentTestCase {
     startProtocol(member);
 
     // then - verify that version 1 is removed and version 2 is added.
-    checkEvent(member1, MEMBER_REMOVED, member2);
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(2))
+        .untilAsserted(() -> checkEvent(member1, MEMBER_REMOVED, member2));
     checkEvent(member1, MEMBER_ADDED, member);
   }
 


### PR DESCRIPTION
## Description

It is possible that member1 detects member2 as a suspect before it is removed. This can happen if member1 probes old member2 before member2 with new version communicates with member1. This leads to "REACHABILITY_CHANGED" event before the expected "MEMBER_ADDED" event which caused the tests to fail.

To fix the test, the check is updated to 'wait until' the MEMBER_ADDED event occurs, ignoring other events that can happen before.

## Related issues

closes #6889 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
