### PR TITLE
Improve version reading/maintenance logic

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/file/JournalSegmentDescriptor.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/JournalSegmentDescriptor.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import io.camunda.zeebe.journal.file.record.CorruptedLogException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.Objects;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -217,14 +216,6 @@ public final class JournalSegmentDescriptor {
         + MessageHeaderEncoder.ENCODED_LENGTH * 2
         + DescriptorMetadataEncoder.BLOCK_LENGTH
         + SegmentDescriptorEncoder.BLOCK_LENGTH;
-  }
-
-  /** The largest encoding length across all versions of the descriptor. */
-  public static int getMaximumEncodingLength() {
-    return Arrays.stream(VERSION_LENGTHS)
-        .max()
-        .orElseThrow(
-            () -> new IllegalStateException("Expected to contain some supported version."));
   }
 
   /** The number of bytes required to read and write a descriptor of a given version. */

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/JournalSegmentDescriptor.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/JournalSegmentDescriptor.java
@@ -51,8 +51,7 @@ public final class JournalSegmentDescriptor {
   private static final byte NO_META_VERSION = 1;
   // the combined length for each version of the descriptor (starting at version 1)
   // V1 - 29: version byte (1) + header (8) + descriptor (20)
-  // V2 - 45: version byte (1) + header (8) + metadata(8) + header(8) + descriptor (20)
-  private static final int[] VERSION_LENGTHS = {29, 45};
+  private static final int[] VERSION_LENGTHS = {29, getEncodingLength()};
 
   private long id;
   private long index;

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/record/CorruptedLogException.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/record/CorruptedLogException.java
@@ -26,4 +26,8 @@ public final class CorruptedLogException extends UnrecoverableException {
   public CorruptedLogException(final Throwable cause) {
     super(cause);
   }
+
+  public CorruptedLogException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
 }


### PR DESCRIPTION
## Description

Simplifies maintaining backwards compatibility in the descriptor by replacing the hardcoded length with a static calculation. This removes the need to change the value every time we add fields to the descriptor.
Simplifies the loading of the descriptor by reading the version byte first and using that to determine the size of buffer to allocate. This eliminates the need calculate and allocate the largest buffer possible.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7120 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
