### PR TITLE
fix(util): serialize datasize to lower units

### DIFF
--- a/util/src/main/java/io/camunda/zeebe/util/ObjectWriterFactory.java
+++ b/util/src/main/java/io/camunda/zeebe/util/ObjectWriterFactory.java
@@ -58,8 +58,13 @@ public class ObjectWriterFactory {
         final JsonGenerator jsonGenerator,
         final SerializerProvider serializerProvider)
         throws IOException {
-
-      jsonGenerator.writeString(dataSize.toMegabytes() + "MB");
+      if (dataSize.toMegabytes() > 0) {
+        jsonGenerator.writeString(dataSize.toMegabytes() + "MB");
+      } else if (dataSize.toKilobytes() > 0) {
+        jsonGenerator.writeString(dataSize.toKilobytes() + "KB");
+      } else {
+        jsonGenerator.writeString(dataSize.toBytes() + "B");
+      }
     }
   }
 

--- a/util/src/test/java/io/camunda/zeebe/util/ObjectWriterFactoryTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/ObjectWriterFactoryTest.java
@@ -41,7 +41,7 @@ public class ObjectWriterFactoryTest {
     // when
     try {
       actual = getDefaultJsonObjectWriter().writeValueAsString(objectToSerialize);
-    } catch (JsonProcessingException e) {
+    } catch (final JsonProcessingException e) {
       fail(e.getMessage());
       actual = "";
     }
@@ -61,7 +61,7 @@ public class ObjectWriterFactoryTest {
     // when
     try {
       actual = getDefaultJsonObjectWriter().writeValueAsString(objectToSerialize);
-    } catch (JsonProcessingException e) {
+    } catch (final JsonProcessingException e) {
       fail(e.getMessage());
       actual = "";
     }
@@ -81,12 +81,48 @@ public class ObjectWriterFactoryTest {
     // when
     try {
       actual = getDefaultJsonObjectWriter().writeValueAsString(objectToSerialize);
-    } catch (JsonProcessingException e) {
+    } catch (final JsonProcessingException e) {
       fail(e.getMessage());
       actual = "";
     }
 
     // then
     assertThat(actual).describedAs("Serialized form of DataSize").isEqualTo("\"512MB\"");
+  }
+
+  @Test
+  public void shouldReturnObjectWriterThatWritesDataSizesInKB() {
+    // given
+    final DataSize objectToSerialize = DataSize.ofKilobytes(512);
+
+    String actual;
+    // when
+    try {
+      actual = getDefaultJsonObjectWriter().writeValueAsString(objectToSerialize);
+    } catch (final JsonProcessingException e) {
+      fail(e.getMessage());
+      actual = "";
+    }
+
+    // then
+    assertThat(actual).describedAs("Serialized form of DataSize").isEqualTo("\"512KB\"");
+  }
+
+  @Test
+  public void shouldReturnObjectWriterThatWritesDataSizesInBytes() {
+    // given
+    final DataSize objectToSerialize = DataSize.ofBytes(512);
+
+    String actual;
+    // when
+    try {
+      actual = getDefaultJsonObjectWriter().writeValueAsString(objectToSerialize);
+    } catch (final JsonProcessingException e) {
+      fail(e.getMessage());
+      actual = "";
+    }
+
+    // then
+    assertThat(actual).describedAs("Serialized form of DataSize").isEqualTo("\"512B\"");
   }
 }


### PR DESCRIPTION
## Description

Previously datasize was always serialized to MB, that means any value less than 1MB will be serialized to 0MB. This commit fixes it by serializing into lower units. All higher values will be always serialized to MB. One problem with this approach is that the values are rounded down. 1.5MB will be serialized to 1MB. This is ok because this serializer is only used to print out the configuration parameters. Alternative is to always serialize into bytes.

## Related issues

closes #7048 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
