### PR TITLE
Removes duplicate descriptor load

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/file/JournalSegmentFile.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/JournalSegmentFile.java
@@ -18,11 +18,7 @@ package io.camunda.zeebe.journal.file;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import io.camunda.zeebe.journal.JournalException;
 import java.io.File;
-import java.io.IOException;
-import java.nio.channels.FileChannel;
-import java.nio.file.StandardOpenOption;
 
 /**
  * Segment file utility.
@@ -94,7 +90,14 @@ final class JournalSegmentFile {
   /** Creates a segment file for the given directory, log name, segment ID, and segment version. */
   static File createSegmentFile(final String name, final File directory, final long id) {
     return new File(
-        directory, String.format("%s-%d.log", checkNotNull(name, "name cannot be null"), id));
+        directory,
+        String.format(
+            "%s%s%d%s%s",
+            checkNotNull(name, "name cannot be null"),
+            PART_SEPARATOR,
+            id,
+            EXTENSION_SEPARATOR,
+            EXTENSION));
   }
 
   /**
@@ -104,14 +107,6 @@ final class JournalSegmentFile {
    */
   public File file() {
     return file;
-  }
-
-  FileChannel openChannel(final StandardOpenOption... options) {
-    try {
-      return FileChannel.open(file.toPath(), options);
-    } catch (final IOException e) {
-      throw new JournalException(e);
-    }
   }
 
   public String name() {


### PR DESCRIPTION
## Description

Remove second descriptor load and fix some issues in JournalSegmentFile.

blocked by #7121

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7116 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
