### PR TITLE
Improve latency metrics section

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/StreamProcessorMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/StreamProcessorMetrics.java
@@ -44,8 +44,8 @@ public final class StreamProcessorMetrics {
           .namespace(NAMESPACE)
           .name("stream_processor_latency")
           .help(
-              "Time between a record is written until it is picked up for processing (in seconds)")
-          .labelNames(LABEL_NAME_RECORD_TYPE, LABEL_NAME_PARTITION)
+              "Time between a command is written until it is picked up for processing (in seconds)")
+          .labelNames(LABEL_NAME_PARTITION)
           .register();
   private static final Histogram PROCESSING_DURATION =
       Histogram.build()
@@ -72,11 +72,8 @@ public final class StreamProcessorMetrics {
     STREAM_PROCESSOR_EVENTS.labels(action, partitionIdLabel).inc();
   }
 
-  public void processingLatency(
-      final RecordType recordType, final long written, final long processed) {
-    PROCESSING_LATENCY
-        .labels(recordType.name(), partitionIdLabel)
-        .observe((processed - written) / 1000f);
+  public void processingLatency(final long written, final long processed) {
+    PROCESSING_LATENCY.labels(partitionIdLabel).observe((processed - written) / 1000f);
   }
 
   public void processingDuration(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -248,8 +248,7 @@ public final class ProcessingStateMachine {
         return;
       }
 
-      metrics.processingLatency(
-          metadata.getRecordType(), event.getTimestamp(), processingStartTime);
+      metrics.processingLatency(event.getTimestamp(), processingStartTime);
 
       processInTransaction(typedEvent);
 

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -89,7 +89,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1621341468042,
+  "iteration": 1622032934713,
   "links": [],
   "panels": [
     {
@@ -4739,146 +4739,6 @@
           },
           "dataFormat": "tsbuckets",
           "datasource": "$DS_PROMETHEUS",
-          "description": "Shows the time (latency) between writing the command on the dispatcher and processing it.",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 42
-          },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
-          "id": 28,
-          "legend": {
-            "show": false
-          },
-          "links": [],
-          "reverseYBuckets": false,
-          "targets": [
-            {
-              "expr": "sum(increase(zeebe_stream_processor_latency_bucket{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\",recordType=\"COMMAND\"}[30s])) by (le)",
-              "format": "heatmap",
-              "interval": "30s",
-              "intervalFactor": 1,
-              "legendFormat": "{{le}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Processing Latency (Command)",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "xBucketNumber": null,
-          "xBucketSize": null,
-          "yAxis": {
-            "decimals": null,
-            "format": "dtdurations",
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true,
-            "splitFactor": null
-          },
-          "yBucketBound": "auto",
-          "yBucketNumber": null,
-          "yBucketSize": null
-        },
-        {
-          "cards": {
-            "cardPadding": null,
-            "cardRound": null
-          },
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
-          "datasource": "$DS_PROMETHEUS",
-          "description": "Shows the time (latency) between writing the event on the dispatcher and processing it.",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 42
-          },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
-          "id": 29,
-          "legend": {
-            "show": false
-          },
-          "links": [],
-          "reverseYBuckets": false,
-          "targets": [
-            {
-              "expr": "sum(increase(zeebe_stream_processor_latency_bucket{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\", recordType=\"EVENT\"}[30s])) by (le)",
-              "format": "heatmap",
-              "interval": "30s",
-              "intervalFactor": 1,
-              "legendFormat": "{{le}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Processing Latency (Event)",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "xBucketNumber": null,
-          "xBucketSize": null,
-          "yAxis": {
-            "decimals": null,
-            "format": "dtdurations",
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true,
-            "splitFactor": null
-          },
-          "yBucketBound": "auto",
-          "yBucketNumber": null,
-          "yBucketSize": null
-        },
-        {
-          "cards": {
-            "cardPadding": null,
-            "cardRound": null
-          },
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
-          "datasource": "$DS_PROMETHEUS",
           "description": "Shows the execution time of a process instance. This means the time (latency) between creating the instance and completing it.",
           "fieldConfig": {
             "defaults": {
@@ -4888,9 +4748,9 @@
           },
           "gridPos": {
             "h": 8,
-            "w": 24,
+            "w": 12,
             "x": 0,
-            "y": 49
+            "y": 7
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -4911,7 +4771,7 @@
               "refId": "A"
             }
           ],
-          "title": "Processing Execution Time",
+          "title": "Process Instance Execution Time",
           "tooltip": {
             "show": true,
             "showHistogram": false
@@ -4952,9 +4812,9 @@
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
-            "w": 24,
-            "x": 0,
-            "y": 57
+            "w": 12,
+            "x": 12,
+            "y": 7
           },
           "hiddenSeries": false,
           "id": 222,
@@ -5002,7 +4862,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Processing Execution Time (avg)",
+          "title": "Process Instance Execution Time (avg)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -5066,7 +4926,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 65
+            "y": 15
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5136,7 +4996,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 65
+            "y": 15
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5206,7 +5066,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 73
+            "y": 23
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5227,7 +5087,7 @@
               "refId": "A"
             }
           ],
-          "title": "Processing Duration",
+          "title": "Record Processing Duration",
           "tooltip": {
             "show": true,
             "showHistogram": false
@@ -5276,7 +5136,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 73
+            "y": 23
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5346,7 +5206,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 80
+            "y": 30
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5390,9 +5250,79 @@
           "yBucketBound": "auto",
           "yBucketNumber": null,
           "yBucketSize": null
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#ef843c",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateSpectral",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": "$DS_PROMETHEUS",
+          "description": "Shows the time (latency) between writing the command to the dispatcher and processing the record.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 30
+          },
+          "heatmap": {},
+          "hideZeroBuckets": true,
+          "highlightCards": true,
+          "id": 28,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "sum(increase(zeebe_stream_processor_latency_bucket{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\",recordType=\"COMMAND\"}[30s])) by (le)",
+              "format": "heatmap",
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Overall Processing Latency",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "dtdurations",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
         }
       ],
-      "title": "Processing Latency",
+      "title": "Latency",
       "type": "row"
     },
     {
@@ -9300,9 +9230,9 @@
           },
           "gridPos": {
             "h": 10,
-            "w": 12,
+            "w": 8,
             "x": 0,
-            "y": 47
+            "y": 12
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -9348,101 +9278,6 @@
           "yBucketSize": null
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "$DS_PROMETHEUS",
-          "description": "The rate of failure of flush operations, averaged over 15s intervals",
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 12,
-            "y": 47
-          },
-          "hiddenSeries": false,
-          "id": 255,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.5.3",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "rate(zeebe_elasticsearch_exporter_failed_flush_total{namespace=~\"$namespace\", pod=~\"$pod\"}[15s]) / rate(zeebe_elasticsearch_exporter_flush_duration_seconds_count{namespace=~\"$namespace\", pod=~\"$pod\"}[15s])",
-              "interval": "",
-              "legendFormat": "{{pod}} Exporter {{partition}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Elasticsearch Exporter (Flush Failure Rate)",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:58",
-              "format": "percentunit",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:59",
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
           "cards": {
             "cardPadding": null,
             "cardRound": null
@@ -9464,9 +9299,9 @@
           },
           "gridPos": {
             "h": 10,
-            "w": 12,
-            "x": 0,
-            "y": 57
+            "w": 8,
+            "x": 8,
+            "y": 12
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -9527,9 +9362,9 @@
           "fillGradient": 0,
           "gridPos": {
             "h": 10,
-            "w": 12,
-            "x": 12,
-            "y": 57
+            "w": 8,
+            "x": 16,
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 185,
@@ -9633,7 +9468,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 67
+            "y": 22
           },
           "height": "400",
           "hiddenSeries": false,
@@ -10171,5 +10006,5 @@
   "timezone": "",
   "title": "Zeebe",
   "uid": "I4lo7_EZk",
-  "version": 8
+  "version": 9
 }


### PR DESCRIPTION
## Description

### Before

![before-latency1](https://user-images.githubusercontent.com/2758593/119677249-db370d00-be3e-11eb-89e1-1549a9a65d4a.png)
![before-latency2](https://user-images.githubusercontent.com/2758593/119677254-dbcfa380-be3e-11eb-9ea9-c4fd1fad249e.png)
![before-latency3](https://user-images.githubusercontent.com/2758593/119677256-dc683a00-be3e-11eb-96b4-749e832a90c8.png)

### After change

![latency1](https://user-images.githubusercontent.com/2758593/119677314-e5f1a200-be3e-11eb-9abb-466720d37b2d.png)
![latency2](https://user-images.githubusercontent.com/2758593/119677317-e68a3880-be3e-11eb-92cc-07d8c8f421c0.png)

Rework the Processing Latency Section:

 * Rename it to Latency, since it contains more then only processing
   latencies
 * Remove unnecessary event processing, it is no longer exported
 * Resize and reorganize panels to make view more clean
 * Rename panels and adjust descriptions to make the purpose more clear

The record type label for the processing metric didn't make sense anymore since we only process commands. I removed it.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7076 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
