### PR TITLE
[Backport stable/0.26] Test that a new incident is created when resolve incident fails to continue the processing

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/processing/incident/ServiceTaskIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/incident/ServiceTaskIncidentTest.java
@@ -294,4 +294,49 @@ public class ServiceTaskIncidentTest {
 
     assertThat(incidentResolvedEvent.getKey()).isEqualTo(incidentRecord.getKey());
   }
+
+  @Test
+  public void shouldResolveIncidentAndCreateNewIncidentWhenContinuationFails() {
+    // given a deployed process with a service task with an input expression
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process-incident-on-leaving-task")
+                .startEvent()
+                .serviceTask(
+                    "task",
+                    b -> b.zeebeJobType("task").zeebeInputExpression("unknown_var", "input"))
+                .done())
+        .deploy();
+
+    // and an instance of that process is created without a variable for the input expression
+    final var workflowInstanceKey =
+        ENGINE.workflowInstance().ofBpmnProcessId("process-incident-on-leaving-task").create();
+
+    // and an incident created
+    final var incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withWorkflowInstanceKey(workflowInstanceKey)
+            .getFirst();
+
+    // when we try to resolve the incident
+    ENGINE.incident().ofInstance(workflowInstanceKey).withKey(incident.getKey()).resolve();
+
+    // then
+    assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.RESOLVED)
+                .withWorkflowInstanceKey(workflowInstanceKey)
+                .withRecordKey(incident.getKey())
+                .exists())
+        .describedAs("original incident is resolved")
+        .isTrue();
+
+    assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+                .withWorkflowInstanceKey(workflowInstanceKey)
+                .filter(i -> i.getKey() != incident.getKey())
+                .exists())
+        .describedAs("a new incident is created")
+        .isTrue();
+  }
 }


### PR DESCRIPTION
# Description
Backport of #7130 to `stable/0.26`.

relates to #7127

Modifications were necessary to resolve the conflicts (i.e. naming changes from 0.26 to 1.0.0).