### PR TITLE
test(engine): use correct input expression target

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ServiceTaskIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ServiceTaskIncidentTest.java
@@ -297,7 +297,7 @@ public class ServiceTaskIncidentTest {
                 .startEvent()
                 .serviceTask(
                     "task",
-                    b -> b.zeebeJobType("task").zeebeInputExpression("unknown_var", "output"))
+                    b -> b.zeebeJobType("task").zeebeInputExpression("unknown_var", "input"))
                 .done())
         .deploy();
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

I missed a review comment in #7130. It came back up in [a review comment](https://github.com/camunda-cloud/zeebe/pull/7139#discussion_r640669819) on the manual backport PR. This fixes it for the develop branch.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #7127

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
