### PR TITLE
Add regression test for multi-instance incident

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.incident;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
@@ -24,7 +25,9 @@ import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.collection.Maps;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Arrays;
@@ -170,6 +173,65 @@ public final class MultiInstanceIncidentTest {
         .hasErrorMessage(
             "failed to evaluate expression 'sum(undefined_var)': expected number but found "
                 + "'ValError(no variable found for name 'undefined_var')'");
+  }
+
+  @Test
+  public void shouldCollectOutputResultsForResolvedIncidentOfOutputElementExpression() {
+    // given an instance of a process with an output mapping referring to a variable 'undefined_var'
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(MULTI_TASK_PROCESS)
+            .withVariable(INPUT_COLLECTION, List.of(1, 2, 3))
+            .create();
+
+    completeNthJob(processInstanceKey, 1);
+
+    // an incident is created because the variable `undefined_var` is missing
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // when the missing variable is provided
+    ENGINE
+        .variables()
+        .ofScope(processInstanceKey)
+        .withDocument(Maps.of(entry("undefined_var", 1)))
+        .update();
+
+    // and we resolve the incident
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+
+    // and complete the other jobs
+    completeNthJob(processInstanceKey, 2);
+    completeNthJob(processInstanceKey, 3);
+
+    // then the process is able to complete
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withElementType(BpmnElementType.PROCESS)
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted()
+                .exists())
+        .describedAs("the process has completed")
+        .isTrue();
+
+    // and all results can be collected
+    // note, that this failed in a bug where the task was completed at the same time the incident
+    // was created. If the problem was resolved and the other tasks completed, the multi instance
+    // would still complete normally, but would not have collected the output of the first task.
+    // for more information see: https://github.com/camunda-cloud/zeebe/issues/6546
+    assertThat(
+            RecordingExporter.variableRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withName("results")
+                .limit(4)
+                .getLast())
+        .extracting(Record::getValue)
+        .extracting(VariableRecordValue::getValue)
+        .describedAs("the results have been collected")
+        .isEqualTo("[1,1,1]");
   }
 
   @Test


### PR DESCRIPTION
## Description

Previously, it was possible that an incident was created for an element
that was already removed, which led to multiple problems. One of those
problems is that it never allowed for correctly informing the container
processor that an element completed as part of resolving that incident.
Mostly, because the incident couldn't really be resolved, but also
because the container could still continue if all other children would
finish their processing, which is a very strange state to be in.

This test verifies that a container processor (multi-instance) is
informed of the child completing (which results in the collection of the
output in the result variable), when an incident is resolved that was
created by the failure of that parent.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6546

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
