### PR TITLE
fix: reset object before reading in new values

### DIFF
--- a/msgpack-value/pom.xml
+++ b/msgpack-value/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Msgpack Value</name>
   <artifactId>zeebe-msgpack-value</artifactId>
@@ -34,6 +36,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
@@ -45,6 +54,13 @@
       <scope>test</scope>
     </dependency>
 
-</dependencies>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+
+  </dependencies>
 
 </project>

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/UnpackedObject.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/UnpackedObject.java
@@ -26,6 +26,7 @@ public class UnpackedObject extends ObjectValue implements Recyclable, BufferRea
 
   @Override
   public void wrap(final DirectBuffer buff, final int offset, final int length) {
+    reset();
     reader.wrap(buff, offset, length);
     try {
       read(reader);

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ObjectMappingDefaultValuesTest.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ObjectMappingDefaultValuesTest.java
@@ -121,11 +121,7 @@ public final class ObjectMappingDefaultValuesTest {
   @Test
   public void shouldSupportDefaultValuesForAllPropertyTypes() {
     // given
-    final MutableDirectBuffer msgPackBuffer =
-        encodeMsgPack(
-            (w) -> {
-              w.writeMapHeader(0);
-            });
+    final MutableDirectBuffer msgPackBuffer = encodeMsgPack((w) -> w.writeMapHeader(0));
 
     final MutableDirectBuffer packedMsgPackBuffer =
         encodeMsgPack(
@@ -143,7 +139,7 @@ public final class ObjectMappingDefaultValuesTest {
             "defaultString",
             packedMsgPackBuffer,
             wrapString("defaultBinary"),
-            new POJONested().setLong(12L));
+            new POJONested());
 
     // when
     pojo.wrap(msgPackBuffer);
@@ -155,6 +151,6 @@ public final class ObjectMappingDefaultValuesTest {
     assertThatBuffer(pojo.getString()).hasBytes(wrapString("defaultString"));
     assertThatBuffer(pojo.getPacked()).hasBytes(packedMsgPackBuffer);
     assertThatBuffer(pojo.getBinary()).hasBytes(wrapString("defaultBinary"));
-    assertThat(pojo.getNestedObject().getLong()).isEqualTo(12L);
+    assertThat(pojo.getNestedObject().getLong()).isEqualTo(-1L);
   }
 }

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/UnpackedObjectTest.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/UnpackedObjectTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.msgpack;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import java.nio.ByteBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class UnpackedObjectTest {
+
+  @Nested
+  public class GreyBox {
+
+    @Test
+    public void shouldResetObjectBeforeReadingValue() {
+      // given
+      final var property = new StringProperty("property", "default");
+      final var unpackedObject = new UnpackedObject();
+
+      unpackedObject.declareProperty(property);
+
+      final var buffer = new UnsafeBuffer(ByteBuffer.allocate(100));
+
+      unpackedObject.write(buffer, 0);
+
+      final var spyUnpackedObject = spy(unpackedObject);
+
+      // when
+      spyUnpackedObject.wrap(buffer);
+
+      // then
+      final var orderOfInvocations = Mockito.inOrder(spyUnpackedObject);
+      orderOfInvocations.verify(spyUnpackedObject).reset();
+      orderOfInvocations.verify(spyUnpackedObject).read(Mockito.any());
+    }
+  }
+
+  @Nested
+  public class SchemaEvolution {
+    private final StringProperty sharedProperty = new StringProperty("shared", "default");
+
+    private final UnpackedObject oldSchemaObject = new UnpackedObject();
+    private final IntegerProperty removedProperty = new IntegerProperty("removedProperty", 42);
+
+    private final UnpackedObject newSchemaObject = new UnpackedObject();
+    private final BooleanProperty addedProperty = new BooleanProperty("addedProperty", false);
+
+    private final MutableDirectBuffer bufferSerializedWithOldSchema =
+        new UnsafeBuffer(ByteBuffer.allocate(100));
+
+    {
+      oldSchemaObject.declareProperty(sharedProperty);
+      oldSchemaObject.declareProperty(removedProperty);
+
+      newSchemaObject.declareProperty(sharedProperty);
+      newSchemaObject.declareProperty(addedProperty);
+
+      oldSchemaObject.write(bufferSerializedWithOldSchema, 0);
+    }
+
+    @Test
+    public void newPropertiesShouldHaveDefaultValueAfterReadingOldSerialization() {
+      // given
+
+      // set the new property to a value that is different from the default value
+      addedProperty.setValue(true);
+
+      // when
+      newSchemaObject.wrap(bufferSerializedWithOldSchema);
+
+      // then
+      assertThat(addedProperty.getValue())
+          .describedAs("value of added property after reading")
+          .isFalse();
+    }
+
+    @Test
+    /* Motivated by https://github.com/camunda-cloud/zeebe/pull/7143 */
+    public void shouldNotAccumulateSizeWithUndeclaredProperties() {
+
+      // given
+      newSchemaObject.wrap(bufferSerializedWithOldSchema);
+      final int length = newSchemaObject.getLength();
+
+      final var buffer = new UnsafeBuffer(ByteBuffer.allocate(100));
+      newSchemaObject.write(buffer, 0);
+
+      // when
+      newSchemaObject.wrap(buffer);
+
+      // then
+      assertThat(newSchemaObject.getLength()).isEqualTo(length);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This is one of the things where you spend hours debugging something very peculiar, and then the fix is a simple line of code.
However, since this line of code is at a prominent spot, I thought I make it a PR of its own. Maybe there are more side effects, or maybe there are other places which need to get changed as well.

Without the reset there are problems if the schema changes. Undeclared properties will accumulate,
because each read will add the same undeclared property to the list.
![2561084e86c7466ab6f6b35b88b4f2cd](https://user-images.githubusercontent.com/14032870/119957365-4ea55f80-bfa2-11eb-8e0c-86dcfd4940cc.png)
Worse yet, on each write the accumulated list of undeclared properties will be written, so this can grow quite fast.

Also properties which are not present in the data stream will keep the value they currently have,
instead of resetting to their default value.

<!-- Please explain the changes you made here. -->

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [X] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
