### PR TITLE
Allow embedded boundary events inside event sub process

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
@@ -115,7 +115,8 @@ public final class EventHandle {
       if (isElementActivated(catchEvent)) {
         commandWriter.appendFollowUpCommand(
             eventScopeKey, ProcessInstanceIntent.COMPLETE_ELEMENT, elementRecord);
-      } else if (catchEvent.getFlowScope().getElementType() == BpmnElementType.EVENT_SUB_PROCESS) {
+      } else if (catchEvent.getFlowScope().getElementType() == BpmnElementType.EVENT_SUB_PROCESS
+          && catchEvent.getElementType() == BpmnElementType.START_EVENT) {
         final var startEvent = (ExecutableStartEvent) catchEvent;
         eventTriggerBehavior.triggerEventSubProcess(
             startEvent, eventScopeKey, elementRecord, variables);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
@@ -304,14 +304,10 @@ public class EventTriggerBehavior {
         eventScopeKey,
         triggeredEvent.getId());
 
-    if (flowScope.getElementType() == BpmnElementType.EVENT_SUB_PROCESS) {
-      if (triggeredEvent instanceof ExecutableStartEvent) {
-        activateEventSubProcess((ExecutableStartEvent) triggeredEvent, flowScope);
-        return;
-      } else {
-        throw new IllegalStateException(
-            String.format(ERROR_MSG_EXPECTED_START_EVENT, triggeredEvent.getClass()));
-      }
+    if (flowScope.getElementType() == BpmnElementType.EVENT_SUB_PROCESS
+        && triggeredEvent.getElementType() == BpmnElementType.START_EVENT) {
+      activateEventSubProcess((ExecutableStartEvent) triggeredEvent, flowScope);
+      return;
     }
 
     eventRecord


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Removes some unnecessary restrictions for triggering events inside event sub processes.

These restrictions were most likely added due to complex nature of dealing with triggered events for event sub processes.

Note that the changes related to the correlationKey in the test class NonInterruptingEventSubprocessTest were made to deal with the parameterized nature of the test class. I wanted to reuse the correlationKey in the new test for both message subscriptions (the event sub process start event AND the boundary event). Adding the testname to the correlation key was necessary, because in the new test the process instance is not completed (and thus the subscription is left open). If the correlation key was left "123", the second test case would correlate to the process instance of the first test case.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7097

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
