### PR TITLE
Improve logging

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -193,7 +193,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
       // There is no snapshot, but the log has been compacted!
       throw new IllegalStateException(
           String.format(
-              "Expected to find a snapshot at index >= log's first index %d, but found snapshot %d",
+              "Expected to find a snapshot at index >= log's first index %d, but found snapshot %d. A previous snapshot is most likely corrupted.",
               raftLog.getFirstIndex(), currentSnapshotIndex));
     }
   }
@@ -286,16 +286,6 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
    */
   public void removeRoleChangeListener(final RaftRoleChangeListener listener) {
     roleChangeListeners.remove(listener);
-  }
-
-  /** Adds a failure listener which will be invoked when an uncaught exception occurs */
-  public void addFailureListener(final FailureListener listener) {
-    failureListeners.add(listener);
-  }
-
-  /** Remove a failure listener */
-  public void removeFailureListener(final FailureListener listener) {
-    failureListeners.remove(listener);
   }
 
   /**
@@ -544,6 +534,16 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   @Override
   public HealthStatus getHealthStatus() {
     return health;
+  }
+
+  /** Adds a failure listener which will be invoked when an uncaught exception occurs */
+  public void addFailureListener(final FailureListener listener) {
+    failureListeners.add(listener);
+  }
+
+  /** Remove a failure listener */
+  public void removeFailureListener(final FailureListener listener) {
+    failureListeners.remove(listener);
   }
 
   private void notifyRoleChangeListeners() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogCompactor.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogCompactor.java
@@ -27,7 +27,7 @@ public final class AtomixLogCompactor implements LogCompactor {
    */
   @Override
   public CompletableFuture<Void> compactLog(final long compactionBound) {
-    Loggers.DELETION_SERVICE.debug("Compacting Atomix log up to index {}", compactionBound);
+    Loggers.DELETION_SERVICE.debug("Scheduling log compaction up to index {}", compactionBound);
     partitionServer.setCompactableIndex(compactionBound);
     return partitionServer.snapshot();
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -31,7 +31,7 @@ public final class AsyncSnapshotDirector extends Actor implements HealthMonitora
 
   private static final Logger LOG = Loggers.SNAPSHOT_LOGGER;
   private static final String LOG_MSG_WAIT_UNTIL_COMMITTED =
-      "Finished taking snapshot, need to wait until last written event position {} is committed, current commit position is {}. After that snapshot can be marked as valid.";
+      "Finished taking temporary snapshot, need to wait until last written event position {} is committed, current commit position is {}. After that snapshot will be committed.";
   private static final String ERROR_MSG_ON_RESOLVE_PROCESSED_POS =
       "Unexpected error in resolving last processed position.";
   private static final String ERROR_MSG_ON_RESOLVE_WRITTEN_POS =
@@ -206,7 +206,7 @@ public final class AsyncSnapshotDirector extends Actor implements HealthMonitora
                             "Could not take a snapshot for {}", processorName, snapshotTakenError);
                         return;
                       }
-                      LOG.debug("Created pending snapshot for {}", processorName);
+                      LOG.trace("Created temporary snapshot for {}", processorName);
                       pendingSnapshot = optionalPendingSnapshot.get();
                       onRecovered();
 
@@ -254,7 +254,7 @@ public final class AsyncSnapshotDirector extends Actor implements HealthMonitora
                       if (persistError != null) {
                         LOG.error(ERROR_MSG_MOVE_SNAPSHOT, persistError);
                       } else {
-                        LOG.info(
+                        LOG.debug(
                             "Current commit position {} >= {}, snapshot {} is valid and has been persisted.",
                             currentCommitPosition,
                             lastWrittenEventPosition,

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -247,18 +247,17 @@ public final class AsyncSnapshotDirector extends Actor implements HealthMonitora
                   && !persistingSnapshot) {
                 persistingSnapshot = true;
 
+                LOG.debug(
+                    "Current commit position {} >= {}, committing snapshot {}.",
+                    currentCommitPosition,
+                    lastWrittenEventPosition,
+                    pendingSnapshot);
                 final var snapshotPersistFuture = pendingSnapshot.persist();
 
                 snapshotPersistFuture.onComplete(
                     (snapshot, persistError) -> {
                       if (persistError != null) {
                         LOG.error(ERROR_MSG_MOVE_SNAPSHOT, persistError);
-                      } else {
-                        LOG.debug(
-                            "Current commit position {} >= {}, snapshot {} is valid and has been persisted.",
-                            currentCommitPosition,
-                            lastWrittenEventPosition,
-                            snapshot.getId());
                       }
                       lastWrittenEventPosition = null;
                       takingSnapshot = false;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -85,8 +85,10 @@ public class StateControllerImpl implements StateController, PersistedSnapshotLi
     final var optionalIndexed = entrySupplier.getPreviousIndexedEntry(snapshotPosition);
     if (optionalIndexed.isEmpty()) {
       LOG.warn(
-          "Failed to take snapshot. Expected to find an indexed entry for determined snapshot position {}, but found no matching indexed entry which contains this position.",
-          snapshotPosition);
+          "Failed to take snapshot. Expected to find an indexed entry for determined snapshot position {} (processedPosition = {}, exportedPosition={}), but found no matching indexed entry which contains this position.",
+          snapshotPosition,
+          lowerBoundSnapshotPosition,
+          exportedPosition);
       return Optional.empty();
     }
 
@@ -211,6 +213,10 @@ public class StateControllerImpl implements StateController, PersistedSnapshotLi
               final var startTimestamp = System.currentTimeMillis();
               final ReceivedSnapshot transientSnapshot =
                   receivableSnapshotStore.newReceivedSnapshot(snapshotChunk.getSnapshotId());
+              LOG.debug(
+                  "Started receiving new snapshot {} with {} chunks.",
+                  transientSnapshot.snapshotId(),
+                  snapshotChunk.getTotalCount());
               return newReplication(startTimestamp, transientSnapshot);
             });
     if (context == INVALID_SNAPSHOT) {
@@ -250,15 +256,15 @@ public class StateControllerImpl implements StateController, PersistedSnapshotLi
 
     if (context.incrementCount() == totalChunkCount) {
       LOG.debug(
-          "Received all snapshot chunks ({}/{}), snapshot {} is valid",
+          "Received all snapshot chunks ({}/{}) of snapshot {}. Committing snapshot.",
           context.getChunkCount(),
           totalChunkCount,
           snapshotChunk.getSnapshotId());
       if (!tryToMarkSnapshotAsValid(snapshotChunk, context)) {
-        LOG.debug("Failed to mark snapshot {} as valid", snapshotChunk.getSnapshotId());
+        LOG.debug("Failed to commit snapshot {}", snapshotChunk.getSnapshotId());
       }
     } else {
-      LOG.debug(
+      LOG.trace(
           "Waiting for more snapshot chunks of snapshot {}, currently have {}/{}",
           snapshotChunk.getSnapshotId(),
           context.getChunkCount(),
@@ -288,7 +294,7 @@ public class StateControllerImpl implements StateController, PersistedSnapshotLi
   private long determineSnapshotPosition(
       final long lowerBoundSnapshotPosition, final long exportedPosition) {
     final long snapshotPosition = Math.min(exportedPosition, lowerBoundSnapshotPosition);
-    LOG.debug(
+    LOG.trace(
         "Based on lowest exporter position '{}' and last processed position '{}', determined '{}' as snapshot position.",
         exportedPosition,
         lowerBoundSnapshotPosition,

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -187,7 +187,7 @@ public class StateControllerImpl implements StateController, PersistedSnapshotLi
 
   @Override
   public void onNewSnapshot(final PersistedSnapshot newPersistedSnapshot) {
-    LOG.debug("New snapshot {} was persisted. Start replicating.", newPersistedSnapshot.getId());
+    LOG.debug("Start replicating new snapshot {}", newPersistedSnapshot.getId());
     // replicate snapshots when new snapshot was committed
     try (final var snapshotChunkReader = newPersistedSnapshot.newChunkReader()) {
       while (snapshotChunkReader.hasNext()) {

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
@@ -110,7 +110,7 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
       return FAILED;
     }
 
-    LOGGER.debug("Consume snapshot snapshotChunk {} of snapshot {}", chunkName, snapshotId);
+    LOGGER.trace("Consume snapshot snapshotChunk {} of snapshot {}", chunkName, snapshotId);
     return writeReceivedSnapshotChunk(snapshotChunk, snapshotFile);
   }
 
@@ -210,7 +210,7 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
 
   private void abortInternal() {
     try {
-      LOGGER.debug("DELETE dir {}", directory);
+      LOGGER.debug("Aborting received snapshot in dir {}", directory);
       FileUtil.deleteFolder(directory);
     } catch (final NoSuchFileException nsfe) {
       LOGGER.debug(

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -161,7 +161,7 @@ public final class FileBasedSnapshotStore extends Actor
       final var actualChecksum = SnapshotChecksum.calculate(path);
       if (expectedChecksum != actualChecksum) {
         LOGGER.warn(
-            "Expected snapshot {} to have checksum {}, but the actual checksum is {}; the snapshot is most likely corrupted",
+            "Expected snapshot {} to have checksum {}, but the actual checksum is {}; the snapshot is most likely corrupted. The startup will fail if there is no other valid snapshot and the log has been compacted.",
             path,
             expectedChecksum,
             actualChecksum);

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -440,7 +440,7 @@ public final class FileBasedSnapshotStore extends Actor
               currentPersistedSnapshotRef.get()));
     }
 
-    LOGGER.info("Committed new snapshot {}", newPersistedSnapshot);
+    LOGGER.info("Committed new snapshot {}", newPersistedSnapshot.getId());
 
     snapshotMetrics.incrementSnapshotCount();
     observeSnapshotSize(newPersistedSnapshot);

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
@@ -156,8 +156,6 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
         + directory
         + ", checksum="
         + checksum
-        + ", snapshotStore="
-        + snapshotStore
         + ", metadata="
         + metadata
         + '}';


### PR DESCRIPTION
## Description

* Improved log messages
* Remove some duplicated logs
* Changed some logs to trace

With this PR the logs on the leader when taking a snapshot is as follows:
```
D 2021-05-31T09:46:25.325267Z Broker-2-SnapshotStore-1 Taking temporary snapshot into /usr/local/zeebe/data/raft-partition/partitions/1/pending/408095-1-1413852-1413500.  Broker-2-SnapshotStore-1
I 2021-05-31T09:46:25.386284Z Broker-2-SnapshotDirector-1 Finished taking temporary snapshot, need to wait until last written event position 1414267 is committed, current commit position is 1413834. After that snapshot will be committed.  Broker-2-SnapshotDirector-1
I 2021-05-31T09:46:25.509406Z Broker-2-SnapshotStore-1 Committed new snapshot FileBasedSnapshot{directory=/usr/local/zeebe/data/raft-partition/partitions/1/snapshots/408095-1-1413852-1413500, checksumFile=/usr/local/zeebe/data/raft-partition/partitions/1/snapshots/408095-1-1413852-1413500.checksum, checksum=771660498, metadata=FileBasedSnapshotMetadata{index=408095, term=1, processedPosition=1413852, exporterPosition=1413500}}  Broker-2-SnapshotStore-1
D 2021-05-31T09:46:25.510787Z Broker-2-SnapshotStore-1 Deleting previous snapshot 142629-1-495701-494710  Broker-2-SnapshotStore-1
D 2021-05-31T09:46:25.515182Z Broker-2-DeletionService-1 Compacting Atomix log up to index 408095  Broker-2-DeletionService-1
D 2021-05-31T09:46:25.515266Z Broker-2-SnapshotStore-1 New snapshot 408095-1-1413852-1413500 was persisted. Start replicating.  Broker-2-SnapshotStore-1
D 2021-05-31T09:46:25.526633Z raft-partition-partition-1 - Deleting log up from 136375 up to 382447 (removing 19 segments)  
D 2021-05-31T09:46:25.532030Z Broker-2-SnapshotDirector-1 Current commit position 1414290 >= 1414267, snapshot 408095-1-1413852-1413500 is valid and has been persisted.  Broker-2-SnapshotDirector-1
D 2021-05-31T09:46:27.891380Z Created segment: JournalSegment{id=31, index=410066}  

```
New logs on the follower when receiving a snapshot:
```
D 2021-05-31T09:46:25.532935Z Started receiving new snapshot FileBasedSnapshotMetadata{index=408095, term=1, processedPosition=1413852, exporterPosition=1413500} with 8 chunks.  
D 2021-05-31T09:46:25.548359Z Received all snapshot chunks (8/8) of snapshot 408095-1-1413852-1413500. Committing snapshot.  
I 2021-05-31T09:46:25.570591Z Broker-1-SnapshotStore-1 Committed new snapshot FileBasedSnapshot{directory=/usr/local/zeebe/data/raft-partition/partitions/1/snapshots/408095-1-1413852-1413500, checksumFile=/usr/local/zeebe/data/raft-partition/partitions/1/snapshots/408095-1-1413852-1413500.checksum, checksum=771660498, metadata=FileBasedSnapshotMetadata{index=408095, term=1, processedPosition=1413852, exporterPosition=1413500}}  Broker-1-SnapshotStore-1
D 2021-05-31T09:46:25.571814Z Broker-1-SnapshotStore-1 Deleting previous snapshot 142629-1-495701-494710  Broker-1-SnapshotStore-1
D 2021-05-31T09:46:25.576494Z Broker-1-DeletionService-1 Compacting Atomix log up to index 408095  Broker-1-DeletionService-1
I 2021-05-31T09:46:25.576612Z RaftServer{raft-partition-partition-1}{role=FOLLOWER} - Delete existing log (lastIndex '323917') and replace with received snapshot (index '408095')  
```


Old logs:
```
D 2021-05-31T07:42:10.022527Z Based on lowest exporter position '1318110348' and last processed position '1318111856', determined '1318110348' as snapshot position. 
D 2021-05-31T07:42:10.023538Z Taking temporary snapshot into /usr/local/zeebe/data/raft-partition/partitions/1/pending/447467168-21-1318111856-1318110348. 
D 2021-05-31T07:42:10.075404Z Created pending snapshot for Broker-0-StreamProcessor-1 
I 2021-05-31T07:42:10.075812Z Finished taking snapshot, need to wait until last written event position 1318112064 is committed, current commit position is 1318111856. After that snapshot can be marked as valid. 
D 2021-05-31T07:42:10.128173Z Purging snapshots older than FileBasedSnapshot{directory=/usr/local/zeebe/data/raft-partition/partitions/1/snapshots/447467168-21-1318111856-1318110348, checksumFile=/usr/local/zeebe/data/raft-partition/partitions/1/snapshots/447467168-21-1318111856-1318110348.checksum, checksum=2863940347, metadata=FileBasedSnapshotMetadata{index=447467168, term=21, processedPosition=1318111856, exporterPosition=1318110348}} 
D 2021-05-31T07:42:10.128427Z Deleting snapshot FileBasedSnapshot{directory=/usr/local/zeebe/data/raft-partition/partitions/1/snapshots/447191739-21-1317296900-1317295700, checksumFile=/usr/local/zeebe/data/raft-partition/partitions/1/snapshots/447191739-21-1317296900-1317295700.checksum, checksum=3208231844, metadata=FileBasedSnapshotMetadata{index=447191739, term=21, processedPosition=1317296900, exporterPosition=1317295700}} 
D 2021-05-31T07:42:10.130423Z Search for orphaned snapshots below oldest valid snapshot with index FileBasedSnapshotMetadata{index=447467168, term=21, processedPosition=1318111856, exporterPosition=1318110348} in /usr/local/zeebe/data/raft-partition/partitions/1/pending 
D 2021-05-31T07:42:10.130927Z Compacting Atomix log up to index 447467168 
D 2021-05-31T07:42:10.130960Z New snapshot 447467168-21-1318111856-1318110348 was persisted. Start replicating. 
D 2021-05-31T07:42:10.135840Z raft-partition-partition-1 - Deleting log up from 447189444 up to 447445514 (removing 16 segments) 
D 2021-05-31T07:42:10.141338Z Created new snapshot FileBasedSnapshot{directory=/usr/local/zeebe/data/raft-partition/partitions/1/snapshots/447467168-21-1318111856-1318110348, checksumFile=/usr/local/zeebe/data/raft-partition/partitions/1/snapshots/447467168-21-1318111856-1318110348.checksum, checksum=2863940347, metadata=FileBasedSnapshotMetadata{index=447467168, term=21, processedPosition=1318111856, exporterPosition=1318110348}} 
D 2021-05-31T07:42:10.141620Z Aborting transient snapshot FileBasedTransientSnapshot{directory=/usr/local/zeebe/data/raft-partition/partitions/1/pending/447191739-21-1317296900-1317295700, checksum=3208231844, snapshotStore=io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore@627a5eb9, metadata=FileBasedSnapshotMetadata{index=447191739, term=21, processedPosition=1317296900, exporterPosition=1317295700}} 
I 2021-05-31T07:42:10.141838Z Current commit position 1318112065 >= 1318112064, snapshot 447467168-21-1318111856-1318110348 is valid and has been persisted. 
```


```
D 2021-05-31T07:39:04.652828Z Consume snapshot snapshotChunk 087847.sst of snapshot 447691219-15-1317123897-1317122946 
D 2021-05-31T07:39:04.654241Z Waiting for more snapshot chunks of snapshot 447691219-15-1317123897-1317122946, currently have 1/8 
D 2021-05-31T07:39:04.655738Z Consume snapshot snapshotChunk 087848.log of snapshot 447691219-15-1317123897-1317122946 
D 2021-05-31T07:39:04.656438Z Waiting for more snapshot chunks of snapshot 447691219-15-1317123897-1317122946, currently have 2/8 
D 2021-05-31T07:39:04.659520Z Consume snapshot snapshotChunk 087849.sst of snapshot 447691219-15-1317123897-1317122946 
D 2021-05-31T07:39:04.660956Z Waiting for more snapshot chunks of snapshot 447691219-15-1317123897-1317122946, currently have 3/8 
D 2021-05-31T07:39:04.661851Z Consume snapshot snapshotChunk 087850.log of snapshot 447691219-15-1317123897-1317122946 
D 2021-05-31T07:39:04.662246Z Waiting for more snapshot chunks of snapshot 447691219-15-1317123897-1317122946, currently have 4/8 
D 2021-05-31T07:39:04.663139Z Consume snapshot snapshotChunk 087852.sst of snapshot 447691219-15-1317123897-1317122946 
D 2021-05-31T07:39:04.663527Z Waiting for more snapshot chunks of snapshot 447691219-15-1317123897-1317122946, currently have 5/8 
D 2021-05-31T07:39:04.663901Z Consume snapshot snapshotChunk CURRENT of snapshot 447691219-15-1317123897-1317122946 
D 2021-05-31T07:39:04.664244Z Waiting for more snapshot chunks of snapshot 447691219-15-1317123897-1317122946, currently have 6/8 
D 2021-05-31T07:39:04.670394Z Consume snapshot snapshotChunk MANIFEST-072790 of snapshot 447691219-15-1317123897-1317122946 
D 2021-05-31T07:39:04.671852Z Waiting for more snapshot chunks of snapshot 447691219-15-1317123897-1317122946, currently have 7/8 
D 2021-05-31T07:39:04.672248Z Consume snapshot snapshotChunk OPTIONS-072793 of snapshot 447691219-15-1317123897-1317122946 
D 2021-05-31T07:39:04.672561Z Received all snapshot chunks (8/8), snapshot 447691219-15-1317123897-1317122946 is valid 
D 2021-05-31T07:39:04.697304Z Purging snapshots older than FileBasedSnapshot{directory=/usr/local/zeebe/data/raft-partition/partitions/2/snapshots/447691219-15-1317123897-1317122946, checksumFile=/usr/local/zeebe/data/raft-partition/partitions/2/snapshots/447691219-15-1317123897-1317122946.checksum, checksum=4166507939, metadata=FileBasedSnapshotMetadata{index=447691219, term=15, processedPosition=1317123897, exporterPosition=1317122946}} 
D 2021-05-31T07:39:04.697681Z Deleting snapshot FileBasedSnapshot{directory=/usr/local/zeebe/data/raft-partition/partitions/2/snapshots/447409604-15-1316304185-1316302802, checksumFile=/usr/local/zeebe/data/raft-partition/partitions/2/snapshots/447409604-15-1316304185-1316302802.checksum, checksum=4013793646, metadata=FileBasedSnapshotMetadata{index=447409604, term=15, processedPosition=1316304185, exporterPosition=1316302802}} 
D 2021-05-31T07:39:04.699496Z Search for orphaned snapshots below oldest valid snapshot with index FileBasedSnapshotMetadata{index=447691219, term=15, processedPosition=1317123897, exporterPosition=1317122946} in /usr/local/zeebe/data/raft-partition/partitions/2/pending 
D 2021-05-31T07:39:04.699874Z Compacting Atomix log up to index 447691219 
D 2021-05-31T07:39:04.699875Z Created new snapshot FileBasedSnapshot{directory=/usr/local/zeebe/data/raft-partition/partitions/2/snapshots/447691219-15-1317123897-1317122946, checksumFile=/usr/local/zeebe/data/raft-partition/partitions/2/snapshots/447691219-15-1317123897-1317122946.checksum, checksum=4166507939, metadata=FileBasedSnapshotMetadata{index=447691219, term=15, processedPosition=1317123897, exporterPosition=1317122946}} 
D 2021-05-31T07:39:04.700078Z DELETE dir /usr/local/zeebe/data/raft-partition/partitions/2/pending/447409604-15-1316304185-1316302802-279 
D 2021-05-31T07:39:04.700345Z raft-partition-partition-2 - Deleting log up from 447406264 up to 447667920 (removing 16 segments)
```
## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7145 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
