### PR TITLE
Fix deletion of already committed pending snapshots

### DIFF
--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
@@ -211,12 +210,7 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
   private void abortInternal() {
     try {
       LOGGER.debug("Aborting received snapshot in dir {}", directory);
-      FileUtil.deleteFolder(directory);
-    } catch (final NoSuchFileException nsfe) {
-      LOGGER.debug(
-          "Tried to delete pending dir {}, but doesn't exist. Either was already removed or no chunk was applied until now.",
-          directory,
-          nsfe);
+      FileUtil.deleteFolderIfExists(directory);
     } catch (final IOException e) {
       LOGGER.warn("Failed to delete pending snapshot {}", this, e);
     } finally {
@@ -255,6 +249,8 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
     } catch (final Exception e) {
       future.completeExceptionally(e);
     }
+
+    snapshotStore.removePendingSnapshot(this);
   }
 
   @Override

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
@@ -98,31 +98,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
   @Override
   public ActorFuture<PersistedSnapshot> persist() {
     final CompletableActorFuture<PersistedSnapshot> future = new CompletableActorFuture<>();
-    actor.call(
-        () -> {
-          if (snapshot != null) {
-            future.complete(snapshot);
-            return;
-          }
-
-          if (!takenFuture.isDone()) {
-            future.completeExceptionally(new IllegalStateException("Snapshot is not taken"));
-            return;
-          }
-
-          if (!isValid) {
-            future.completeExceptionally(
-                new IllegalStateException("Snapshot is not valid. It may have been deleted."));
-            return;
-          }
-
-          try {
-            snapshot = snapshotStore.newSnapshot(metadata, directory, checksum);
-            future.complete(snapshot);
-          } catch (final Exception e) {
-            future.completeExceptionally(e);
-          }
-        });
+    actor.call(() -> persistInternal(future));
     return future;
   }
 
@@ -134,6 +110,33 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
   @Override
   public Path getPath() {
     return directory;
+  }
+
+  private void persistInternal(final CompletableActorFuture<PersistedSnapshot> future) {
+    if (snapshot != null) {
+      future.complete(snapshot);
+      return;
+    }
+
+    if (!takenFuture.isDone()) {
+      future.completeExceptionally(new IllegalStateException("Snapshot is not taken"));
+      return;
+    }
+
+    if (!isValid) {
+      future.completeExceptionally(
+          new IllegalStateException("Snapshot is not valid. It may have been deleted."));
+      return;
+    }
+
+    try {
+      snapshot = snapshotStore.newSnapshot(metadata, directory, checksum);
+      future.complete(snapshot);
+    } catch (final Exception e) {
+      future.completeExceptionally(e);
+    }
+
+    snapshotStore.removePendingSnapshot(this);
   }
 
   private void abortInternal() {


### PR DESCRIPTION
## Description

FilebasedSnapshotStore keeps track of a list of pending snapshots which will be used to deleted them. When a pending snapshot is committed, it was not deleted from the list. Later when snapshot store purges all pending snapshots, it tries to delete also this non existing pending snapshot which caused unnecessary warning in the log message. This PR fixes it by removing the pending snapshot from the list after a snapshot is successfully committed.

Blocked by #7153 

## Related issues

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
