### PR TITLE
refactor(msgpack-value): add class to log message

### DIFF
--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/UnpackedObject.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/UnpackedObject.java
@@ -32,7 +32,9 @@ public class UnpackedObject extends ObjectValue implements Recyclable, BufferRea
       read(reader);
     } catch (final Exception e) {
       throw new RuntimeException(
-          "Could not deserialize object. Deserialization stuck at offset "
+          "Could not deserialize object ["
+              + getClass().getSimpleName()
+              + "]. Deserialization stuck at offset "
               + reader.getOffset()
               + " of length "
               + length,

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/DocumentPropertyTest.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/DocumentPropertyTest.java
@@ -175,7 +175,7 @@ public final class DocumentPropertyTest {
     // then
     assertThat(throwable).isExactlyInstanceOf(RuntimeException.class);
     assertThat(throwable)
-        .hasMessageContaining("Could not deserialize object. Deserialization stuck");
+        .hasMessageContaining("Could not deserialize object [Document]. Deserialization stuck");
 
     final Throwable cause = throwable.getCause();
     assertThat(cause).isExactlyInstanceOf(RuntimeException.class);

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ObjectMappingTest.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ObjectMappingTest.java
@@ -89,11 +89,9 @@ public final class ObjectMappingTest {
             entry("stringProp", "foo"),
             entry("binaryProp", BUF2.byteArray()));
 
-    @SuppressWarnings("unchecked")
     final Map<String, Object> packedProp = (Map<String, Object>) msgPackMap.get("packedProp");
     assertThat(packedProp).containsExactly(entry("foo", 123123L));
 
-    @SuppressWarnings("unchecked")
     final Map<String, Object> objectProp = (Map<String, Object>) msgPackMap.get("objectProp");
     assertThat(objectProp).containsExactly(entry("foo", 24L));
   }
@@ -159,7 +157,8 @@ public final class ObjectMappingTest {
 
     // then
     exception.expect(RuntimeException.class);
-    exception.expectMessage("Could not deserialize object. Deserialization stuck at offset 13");
+    exception.expectMessage(
+        "Could not deserialize object [POJO]. Deserialization stuck at offset 13");
 
     // when
     pojo.wrap(buffer);
@@ -181,7 +180,8 @@ public final class ObjectMappingTest {
 
     // then
     exception.expect(RuntimeException.class);
-    exception.expectMessage("Could not deserialize object. Deserialization stuck at offset 2");
+    exception.expectMessage(
+        "Could not deserialize object [POJO]. Deserialization stuck at offset 2");
 
     // when
     pojo.wrap(buffer);
@@ -201,7 +201,8 @@ public final class ObjectMappingTest {
 
     // then
     exception.expect(RuntimeException.class);
-    exception.expectMessage("Could not deserialize object. Deserialization stuck at offset 1");
+    exception.expectMessage(
+        "Could not deserialize object [POJO]. Deserialization stuck at offset 1");
 
     // when
     pojo.wrap(buffer);
@@ -240,7 +241,7 @@ public final class ObjectMappingTest {
 
     // then
     exception.expect(RuntimeException.class);
-    exception.expectMessage("Could not deserialize object.");
+    exception.expectMessage("Could not deserialize object");
 
     // when
     pojo.wrap(buffer);
@@ -277,7 +278,7 @@ public final class ObjectMappingTest {
 
     // then
     exception.expect(RuntimeException.class);
-    exception.expectMessage("Could not deserialize object.");
+    exception.expectMessage("Could not deserialize object");
 
     // when
     pojo.wrap(buffer);


### PR DESCRIPTION
## Description

Adds information about the class to the log message.

Before:
> Could not deserialize object. Deserialization stuck at offset 1 of length 1

After:
> Could not deserialize object [MessageStartEventSubscription]. Deserialization stuck at offset 1 of length 1

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
