### PR TITLE
Ease usage of remote debugging with container tests

### DIFF
--- a/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/RemoteDebugger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/RemoteDebugger.java
@@ -1,5 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
 package io.camunda.zeebe.test.util.testcontainers;
 
+import java.time.Duration;
 import org.testcontainers.containers.GenericContainer;
 
 /**
@@ -18,7 +26,8 @@ import org.testcontainers.containers.GenericContainer;
  * <p>TODO(npepinpe): document, and add to zeebe-test-container as base capability
  */
 public final class RemoteDebugger {
-  private static final int DEFAULT_REMOTE_DEBUGGER_PORT = 5005;
+  public static final int DEFAULT_REMOTE_DEBUGGER_PORT = 5005;
+  public static final Duration DEFAULT_START_TIMEOUT = Duration.ofMinutes(5);
 
   private RemoteDebugger() {}
 
@@ -42,5 +51,7 @@ public final class RemoteDebugger {
             + port
             + " "
             + javaOpts);
+
+    container.withStartupTimeout(DEFAULT_START_TIMEOUT);
   }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/RemoteDebugger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/RemoteDebugger.java
@@ -1,0 +1,46 @@
+package io.camunda.zeebe.test.util.testcontainers;
+
+import org.testcontainers.containers.GenericContainer;
+
+/**
+ * To use, create a new instance with the desired port (or, by default, 5005), and pass the
+ * container you wish to configure to it.
+ *
+ * <p>This will start the container and wait for the debugger to attach. To use with Intellij,
+ * create a new debug configuration template and pick "Remote JVM Debug". By default, it will be
+ * setup for port 5005, which is the default port here as well. You can find out more about this
+ * from <a href="https://www.jetbrains.com/help/idea/tutorial-remote-debug.html">this IntelliJ
+ * tutorial</a>.
+ *
+ * <p>This idea came from bsideup's blog, and you can read more about it <a
+ * href="https://bsideup.github.io/posts/debugging_containers/">here</a>
+ *
+ * <p>TODO(npepinpe): document, and add to zeebe-test-container as base capability
+ */
+public final class RemoteDebugger {
+  private static final int DEFAULT_REMOTE_DEBUGGER_PORT = 5005;
+
+  private RemoteDebugger() {}
+
+  public static void configureContainer(final GenericContainer<?> container) {
+    configureContainer(container, DEFAULT_REMOTE_DEBUGGER_PORT);
+  }
+
+  public static void configureContainer(final GenericContainer<?> container, final int port) {
+    final var javaOpts = container.getEnvMap().getOrDefault("JAVA_OPTS", "");
+
+    // when configuring a port binding, we need to expose the port as well; the port binding just
+    // decides to which host port the exposed port will bind, but it will not expose the port itself
+    container.addExposedPort(port);
+    container.getPortBindings().add(port + ":" + port);
+
+    // prepend agent configuration in front of javaOpts to ensure it's enabled but also keep
+    // previously defined options
+    container.withEnv(
+        "JAVA_OPTS",
+        "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0.0.0.0:"
+            + port
+            + " "
+            + javaOpts);
+  }
+}

--- a/update-tests/README.md
+++ b/update-tests/README.md
@@ -1,6 +1,27 @@
+## Pre-requisites
+
 To run the upgradability tests, a Docker image for Zeebe must be built with the tag 'current-test'. To do that you can run (in the zeebe-io/zeebe dir):
 
 ```
 docker build --build-arg DISTBALL=dist/target/camunda-cloud-zeebe*.tar.gz -t camunda/zeebe:current-test --target app .
 ```
 
+## Debugging
+
+If you need to debug a remote container, you can use the `RemoteDebugger#configureContainer` utility
+method, or use the `withDebugger` flagged when starting your `ContainerState`, which will do it for
+you.
+
+By using this utility, it will launch the container with a remote debugger which will wait for your
+local debugger to connect before starting the container. See
+[this IntelliJ tutorial](https://www.jetbrains.com/help/idea/tutorial-remote-debug.htm) on how to
+use a remote debugger with IntelliJ.
+
+### Limitations
+
+One current limitation is that if your code relies on timeouts (which, for example, the update
+tests do), then when your debugger is at a break point, only the remote JVM is stopped - this means
+your tests will definitely time out. The current workaround is to simply increase all timeouts,
+but in the long term we should find a solution for this. This means not only the startup timeout of
+the container, but also any use of `Awaitility` in the tests themselves, e.g. waiting for a message
+to be published.


### PR DESCRIPTION
## Description

This PR add a utility to more easily debug running containers. After creating a `GenericContainer` instance, but before starting it, you can call `RemoteDebugger#configureContainer(GenericContainer, int)` with your container, and it will set up the container such that it will wait for a debugger to attach itself before starting the application. By default, the debugger is listening for port 5005.

I hope to improve this in the near future (i.e. how would it work with clusters, how to handle time outs, maybe share the IntelliJ remote debug config), but for now it should let the team more easily debug failing tests, especially the update tests.

To connect your IDE to the remote agent, for IntelliJ you need to create a `Remote JVM Debug` run configuration, and set the classpath to that of `zeebe-distribution` (since this is what it runs). Then you run your test with the container configured, and once its starting you can connect your debugger to it by selecting the `Remote JVM Debug` configuration and running it. See this [tutorial](https://www.jetbrains.com/help/idea/tutorial-remote-debug.html) on how to create this configuration for IntelliJ.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
