### PR TITLE
Add ZeebeStateExtension

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Workflow Engine</name>
@@ -150,6 +152,13 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-commons</artifactId>
+      <scope>test</scope>
+    </dependency>
+
 
     <!-- TEMPORARY -->
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ZeebeStateExtension.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ZeebeStateExtension.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.util;
+
+import static java.nio.file.FileVisitResult.CONTINUE;
+import static java.util.stream.Collectors.joining;
+import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
+
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
+import io.camunda.zeebe.engine.state.ZbColumnFamilies;
+import io.camunda.zeebe.engine.state.ZeebeDbState;
+import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.junit.platform.commons.util.ExceptionUtils;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode;
+
+/**
+ * Extension that creates a temporary folder, and sets up a Zeebe database in that temporary folder.
+ * The extension injects instances of
+ *
+ * <ul>
+ *   <li>{@code ZeebeDb} (exact type match)
+ *   <li>{@code TransactionContext} (exact type match)
+ *   <li>{@code MutableZeebeState} (exact type match or supertypes)
+ * </ul>
+ *
+ * on fields with the corresponding type.
+ *
+ * <p>Usage:
+ *
+ * <pre>{@code
+ * @ExtendWith(ZeebeStateExtension)
+ * public class Test {
+ *   private ZeebeDb db; //will be injected
+ *   private TransactionContext txContext; //will be injected
+ *   private MutableZeebeState state //will be injected
+ *
+ *   ...
+ * }
+ * }</pre>
+ *
+ * <p>Not Supported:
+ *
+ * <pre>{@code
+ * private ZeebeDb db1; // will be injected
+ * private ZeebeDb db2; // will be injected, but will be the same instance as db1
+ * }</pre>
+ */
+public class ZeebeStateExtension implements BeforeEachCallback {
+
+  private static final String FIELD_STATE = "state";
+
+  @Override
+  public void beforeEach(final ExtensionContext context) {
+    context
+        .getRequiredTestInstances()
+        .getAllInstances()
+        .forEach(instance -> injectFields(context, instance, instance.getClass()));
+  }
+
+  public ZeebeStateExtensionState lookupOrCreate(final ExtensionContext extensionContext) {
+    final var store = getStore(extensionContext);
+
+    return (ZeebeStateExtensionState)
+        store.getOrComputeIfAbsent(FIELD_STATE, (key) -> new ZeebeStateExtensionState());
+  }
+
+  private void injectFields(
+      final ExtensionContext context, final Object testInstance, final Class<?> testClass) {
+
+    ReflectionUtils.findFields(
+            testClass,
+            field -> ReflectionUtils.isNotStatic(field) && field.getType() == ZeebeDb.class,
+            HierarchyTraversalMode.TOP_DOWN)
+        .forEach(
+            field -> {
+              try {
+                makeAccessible(field).set(testInstance, lookupOrCreate(context).getZeebeDb());
+              } catch (final Throwable t) {
+                ExceptionUtils.throwAsUncheckedException(t);
+              }
+            });
+
+    ReflectionUtils.findFields(
+            testClass,
+            field ->
+                ReflectionUtils.isNotStatic(field) && field.getType() == TransactionContext.class,
+            HierarchyTraversalMode.TOP_DOWN)
+        .forEach(
+            field -> {
+              try {
+                makeAccessible(field)
+                    .set(testInstance, lookupOrCreate(context).getTransactionContext());
+              } catch (final Throwable t) {
+                ExceptionUtils.throwAsUncheckedException(t);
+              }
+            });
+
+    ReflectionUtils.findFields(
+            testClass,
+            field ->
+                ReflectionUtils.isNotStatic(field)
+                    && field.getType().isAssignableFrom(MutableZeebeState.class),
+            HierarchyTraversalMode.TOP_DOWN)
+        .forEach(
+            field -> {
+              try {
+                makeAccessible(field).set(testInstance, lookupOrCreate(context).getZeebeState());
+              } catch (final Throwable t) {
+                ExceptionUtils.throwAsUncheckedException(t);
+              }
+            });
+  }
+
+  private Store getStore(final ExtensionContext context) {
+    return context.getStore(Namespace.create(getClass(), context.getUniqueId()));
+  }
+
+  private static final class ZeebeStateExtensionState implements CloseableResource {
+    private Path tempFolder;
+    private ZeebeDb<ZbColumnFamilies> zeebeDb;
+    private TransactionContext transactionContext;
+    private MutableZeebeState zeebeState;
+
+    private ZeebeStateExtensionState() {
+
+      final var factory = DefaultZeebeDbFactory.defaultFactory();
+      try {
+        tempFolder = Files.createTempDirectory(null);
+        zeebeDb = factory.createDb(tempFolder.toFile());
+        transactionContext = zeebeDb.createContext();
+        zeebeState = new ZeebeDbState(zeebeDb, transactionContext);
+      } catch (final Exception e) {
+        ExceptionUtils.throwAsUncheckedException(e);
+      }
+    }
+
+    @Override
+    public void close() throws Throwable {
+      transactionContext.getCurrentTransaction().rollback();
+      zeebeDb.close();
+
+      final SortedMap<Path, IOException> failures = clearFolder();
+
+      if (!failures.isEmpty()) {
+        throwException(failures);
+      }
+    }
+
+    private void throwException(final SortedMap<Path, IOException> failures) throws IOException {
+      final String joinedPaths =
+          failures.keySet().stream().map(Path::toString).collect(joining(", "));
+
+      final IOException exception =
+          new IOException(
+              "Failed to clear temp directory "
+                  + tempFolder.toAbsolutePath()
+                  + ". The following paths could not be deleted: "
+                  + joinedPaths);
+      failures.values().forEach(exception::addSuppressed);
+      throw exception;
+    }
+
+    private SortedMap<Path, IOException> clearFolder() throws IOException {
+      final SortedMap<Path, IOException> failures = new TreeMap<>();
+      Files.walkFileTree(
+          tempFolder,
+          new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(
+                final Path file, final BasicFileAttributes attributes) {
+              return delete(file);
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(final Path dir, final IOException exc) {
+              return delete(dir);
+            }
+
+            private FileVisitResult delete(final Path path) {
+              try {
+                Files.delete(path);
+              } catch (final NoSuchFileException ignore) {
+                // ignore
+              } catch (final IOException exception) {
+                try {
+                  path.toFile().deleteOnExit();
+                } catch (final UnsupportedOperationException ignore) {
+                  // ignore
+                }
+                failures.put(path, exception);
+              }
+              return CONTINUE;
+            }
+          });
+      return failures;
+    }
+
+    private ZeebeDb<ZbColumnFamilies> getZeebeDb() {
+      return zeebeDb;
+    }
+
+    private MutableZeebeState getZeebeState() {
+      return zeebeState;
+    }
+
+    private TransactionContext getTransactionContext() {
+      return transactionContext;
+    }
+  }
+}


### PR DESCRIPTION
## Description

This is the JUnit5 version of ZeebeStateRule. It uses field injection to provide the state to the test class

<!-- Cut-off marker
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
