### PR TITLE
Add transient state for command sent information

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/TransientSubscriptionCommandState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/TransientSubscriptionCommandState.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.message;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This class keeps track of the last sent time of commands related to either message subscriptions
+ * or process message subscriptions.
+ *
+ * <p><strong>Note:</strong> this class is not thread safe. It is assumed that it will be called
+ * from a single thread only</b>
+ */
+public final class TransientSubscriptionCommandState {
+
+  private final List<CommandEntry> transientState = new ArrayList<>();
+
+  public final void add(final CommandEntry commandEntryToAdd) {
+    removeEqualEntry(commandEntryToAdd);
+    transientState.add(commandEntryToAdd);
+  }
+
+  public final void updateCommandSentTime(final CommandEntry updatedCommandEntry) {
+    if (removeEqualEntry(updatedCommandEntry)) {
+      add(updatedCommandEntry);
+    }
+  }
+
+  public final void remove(final CommandEntry templateOfCommandEntryToBeRemoved) {
+    removeEqualEntry(templateOfCommandEntryToBeRemoved);
+  }
+
+  private boolean removeEqualEntry(final CommandEntry templateCommandEntry) {
+    return transientState.removeIf(templateCommandEntry::equals);
+  }
+
+  final Iterable<CommandEntry> getEntriesBefore(final long deadline) {
+    return transientState.stream()
+        .sorted()
+        .takeWhile(commandEntry -> commandEntry.getCommandSentTime() < deadline)
+        .collect(Collectors.toList());
+  }
+
+  public static final class CommandEntry implements Comparable<CommandEntry> {
+
+    private final long elementInstanceKey;
+    private final String messageName;
+    private final long commandSentTime;
+
+    public CommandEntry(
+        final long elementInstanceKey, final String messageName, final long commandSentTime) {
+      this.elementInstanceKey = elementInstanceKey;
+      this.messageName = messageName;
+      this.commandSentTime = commandSentTime;
+    }
+
+    public long getElementInstanceKey() {
+      return elementInstanceKey;
+    }
+
+    public String getMessageName() {
+      return messageName;
+    }
+
+    public long getCommandSentTime() {
+      return commandSentTime;
+    }
+
+    @Override
+    public int hashCode() {
+      return (int) (elementInstanceKey ^ (elementInstanceKey >>> 32));
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      final CommandEntry commandEntry = (CommandEntry) o;
+
+      if (elementInstanceKey != commandEntry.elementInstanceKey) {
+        return false;
+      }
+      return messageName.equals(commandEntry.messageName);
+    }
+
+    @Override
+    public String toString() {
+      return "Entry{"
+          + "elementInstanceKey="
+          + elementInstanceKey
+          + ", messageName='"
+          + messageName
+          + '\''
+          + ", commandSentTime="
+          + commandSentTime
+          + '}';
+    }
+
+    @Override
+    public int compareTo(final CommandEntry commandEntry) {
+      return (int) (commandSentTime - commandEntry.commandSentTime);
+    }
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/message/TransientSubscriptionCommandStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/message/TransientSubscriptionCommandStateTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import io.camunda.zeebe.engine.state.message.TransientSubscriptionCommandState.CommandEntry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TransientSubscriptionCommandStateTest {
+
+  private TransientSubscriptionCommandState sut;
+
+  @BeforeEach
+  public void setUp() {
+    sut = new TransientSubscriptionCommandState();
+  }
+
+  @Test
+  public void shouldReturnNoEntriesByDefault() {
+    // when
+    final var actual = sut.getEntriesBefore(Long.MAX_VALUE);
+
+    // then
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  public void shouldReturnEntriesBeforeDeadline() {
+    // when
+    final var expected = new CommandEntry(1, "message", 500);
+    sut.add(expected);
+    sut.add(new CommandEntry(2, "message", 2000));
+
+    // when
+    final var actual = sut.getEntriesBefore(1000);
+
+    // then
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  public void shouldReturnEntriesOrderedBySentTime() {
+    // when
+    final var first = new CommandEntry(1, "message", 500);
+    final var second = new CommandEntry(2, "message", 600);
+    final var third = new CommandEntry(3, "message", 700);
+
+    sut.add(second);
+    sut.add(first);
+    sut.add(third);
+
+    // when
+    final var actual = sut.getEntriesBefore(1000);
+
+    // then
+    assertThat(actual).containsExactly(first, second, third);
+  }
+
+  @Test
+  public void shouldOverwriteExistingEntries() {
+    // when
+    final var first = new CommandEntry(1, "message", 500);
+    final var second = new CommandEntry(1, "message", 600);
+
+    sut.add(first);
+    sut.add(second);
+
+    // when
+    final var actual = sut.getEntriesBefore(1000);
+
+    // then
+    assertThat(actual).containsExactly(second);
+  }
+
+  @Test
+  public void shouldAcceptEntriesWithTheSameSentTime() {
+    // when
+    sut.add(new CommandEntry(1, "message", 500));
+    sut.add(new CommandEntry(2, "message", 500));
+
+    // when
+    final var actual = sut.getEntriesBefore(1000);
+
+    // then
+    assertThat(actual).hasSize(2);
+  }
+
+  @Test
+  public void shouldReturnEntriesBasedOnUpdatedSentTime() {
+    // when
+    sut.add(new CommandEntry(1, "message", 3000));
+    sut.add(new CommandEntry(2, "message", 2000));
+
+    // when
+    final var expected = new CommandEntry(1, "message", 500);
+    sut.updateCommandSentTime(expected);
+    final var actual = sut.getEntriesBefore(1000);
+
+    // then
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  public void shouldNotReturnEntriesThatHaveBeenRemoved() {
+    // when
+    sut.add(new CommandEntry(1, "message", 500));
+    sut.add(new CommandEntry(2, "message", 2000));
+
+    // when
+    sut.remove(new CommandEntry(1, "message", 500));
+    final var actual = sut.getEntriesBefore(1000);
+
+    // then
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  public void shouldBeTolerantWhenRemovingEntriesThatDoNotExist() {
+    // when + then
+    assertThatNoException().isThrownBy(() -> sut.remove(new CommandEntry(1, "message", 500)));
+  }
+
+  @Test
+  public void shouldBeTolerantWhenUpdatingEntriesThatDoNotExist() {
+    // when + then
+    assertThatNoException()
+        .isThrownBy(() -> sut.updateCommandSentTime(new CommandEntry(1, "message", 500)));
+  }
+}


### PR DESCRIPTION
## Description

Adds a class to track when a command related to subscriptions was last sent.

Note some methods are public, although they are not used yet. This is because several subsequent changes will need these methods.

<!-- Cut-off marker
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
