### PR TITLE
Add mechanism to run migrations on startup

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.migration.DbMigrationController;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
@@ -55,6 +56,9 @@ public final class EngineProcessors {
     final var writers = processingContext.getWriters();
     final TypedRecordProcessors typedRecordProcessors =
         TypedRecordProcessors.processors(zeebeState.getKeyGenerator(), writers);
+
+    // register listener that handles migrations immediately, so it is the first to be called
+    typedRecordProcessors.withListener(new DbMigrationController());
 
     final LogStream stream = processingContext.getLogStream();
     final int partitionId = stream.getPartitionId();

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationController.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationController.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.ReadonlyProcessingContext;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import java.util.function.Function;
+
+public final class DbMigrationController implements StreamProcessorLifecycleAware {
+
+  private DbMigrator dbMigrator;
+  private final Function<MutableZeebeState, DbMigrator> migratorFactory;
+
+  public DbMigrationController() {
+    this(DbMigratorImpl::new);
+  }
+
+  DbMigrationController(final Function<MutableZeebeState, DbMigrator> migratorFactory) {
+    this.migratorFactory = migratorFactory;
+  }
+
+  @Override
+  public final void onRecovered(final ReadonlyProcessingContext context) {
+    final var migrator = migratorFactory.apply(context.getZeebeState());
+
+    synchronized (this) {
+      dbMigrator = migrator;
+    }
+    try {
+      migrator.runMigrations();
+    } finally {
+      synchronized (this) {
+        dbMigrator = null;
+      }
+    }
+  }
+
+  @Override
+  public final void onClose() {
+    abortMigrationIfRunning();
+  }
+
+  @Override
+  public final void onFailed() {
+    abortMigrationIfRunning();
+  }
+
+  private void abortMigrationIfRunning() {
+    synchronized (this) {
+      if (dbMigrator != null) {
+        dbMigrator.abort();
+      }
+    }
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrator.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration;
+
+public interface DbMigrator {
+
+  void runMigrations();
+
+  void abort();
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration;
+
+import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DbMigratorImpl implements DbMigrator {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(DbMigratorImpl.class.getPackageName());
+
+  // add new migration tasks here, migrations are executed in the order they appear in the list
+  private static final List<MigrationTask> MIGRATION_TASKS = Collections.emptyList();
+  // Be mindful of https://github.com/camunda-cloud/zeebe/issues/7248. In particular, that issue
+  // should be solved first, before adding any migration that can take a long time
+
+  private final MutableZeebeState zeebeState;
+  private final Supplier<List<MigrationTask>> migrationSupplier;
+  private boolean abortRequested = false;
+
+  private MigrationTask currentMigration;
+
+  public DbMigratorImpl(final MutableZeebeState zeebeState) {
+    this(zeebeState, () -> MIGRATION_TASKS);
+  }
+
+  DbMigratorImpl(
+      final MutableZeebeState zeebeState, final Supplier<List<MigrationTask>> migrationSupplier) {
+
+    this.zeebeState = zeebeState;
+    this.migrationSupplier = migrationSupplier;
+  }
+
+  @Override
+  public void runMigrations() {
+
+    final var migrationTasks = migrationSupplier.get();
+    logPreview(migrationTasks);
+
+    final var executedMigrations = new ArrayList<MigrationTask>();
+    for (int index = 1; index <= migrationTasks.size() && !abortRequested; index++) {
+      // one based index looks nicer in logs
+
+      final var migration = migrationTasks.get(index - 1);
+      final var executed = handleMigrationTask(migration, index, migrationTasks.size());
+      if (executed) {
+        executedMigrations.add(migration);
+      }
+    }
+    if (!abortRequested) {
+      logSummary(executedMigrations);
+    }
+  }
+
+  private void logPreview(final List<MigrationTask> migrationTasks) {
+    LOGGER.info(
+        "Starting processing of migration tasks (use LogLevel.DEBUG for more details) ... ");
+    LOGGER.debug(
+        "Found "
+            + migrationTasks.size()
+            + " migration tasks: "
+            + migrationTasks.stream()
+                .map(MigrationTask::getIdentifier)
+                .collect(Collectors.joining(", ")));
+  }
+
+  private void logSummary(final List<MigrationTask> migrationTasks) {
+    LOGGER.info(
+        "Completed processing of migration tasks (use LogLevel.DEBUG for more details) ... ");
+    LOGGER.debug(
+        "Executed "
+            + migrationTasks.size()
+            + " migration tasks: "
+            + migrationTasks.stream()
+                .map(MigrationTask::getIdentifier)
+                .collect(Collectors.joining(", ")));
+  }
+
+  @Override
+  public void abort() {
+    final var message =
+        currentMigration == null
+            ? "Received abort signal (no migration running)"
+            : "Aborting " + currentMigration.getIdentifier() + " migration as requested";
+    LOGGER.info(message);
+    abortRequested = true;
+  }
+
+  private boolean handleMigrationTask(
+      final MigrationTask migrationTask, final int index, final int total) {
+    if (migrationTask.needsToRun(zeebeState)) {
+      try {
+        currentMigration = migrationTask;
+        runMigration(migrationTask, index, total);
+      } finally {
+        currentMigration = null;
+      }
+      return true;
+    } else {
+      logMigrationSkipped(migrationTask, index, total);
+      return false;
+    }
+  }
+
+  private void logMigrationSkipped(
+      final MigrationTask migrationTask, final int index, final int total) {
+    LOGGER.info(
+        "Skipping "
+            + migrationTask.getIdentifier()
+            + " migration ("
+            + index
+            + "/"
+            + total
+            + ").  It was determined it does not need to run right now.");
+  }
+
+  private void runMigration(final MigrationTask migrationTask, final int index, final int total) {
+    LOGGER.info(
+        "Starting " + migrationTask.getIdentifier() + " migration (" + index + "/" + total + ")");
+    final var startTime = System.currentTimeMillis();
+    migrationTask.runMigration(zeebeState);
+    final var duration = System.currentTimeMillis() - startTime;
+
+    LOGGER.debug(migrationTask.getIdentifier() + " migration completed in " + duration + " ms.");
+    LOGGER.info(
+        "Finished " + migrationTask.getIdentifier() + " migration (" + index + "/" + total + ")");
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MigrationTask.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MigrationTask.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration;
+
+import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+
+/**
+ * Interface for migration tasks.
+ *
+ * <p>Implementations of this class can/must assume the following contract:
+ *
+ * <ul>
+ *   <li>Implementation will be called before any processing is performed
+ *   <li>Implementation will be called with an open database and open transaction
+ *   <li>Implementation may be called more than once throughout the lifetime of the deployment of a
+ *       given version of software in production
+ *   <li>The method {@code runMigration(...)} will only be called after {@code needsToRun(...)} was
+ *       called and did return {@code true}
+ *   <li>All methods should be implemented with the context in mind, that they will be called
+ *       synchronously during recovery.
+ *   <li>Migrations that are expected to potentially take a long time, should only be implemented
+ *       after https://github.com/camunda-cloud/zeebe/issues/7248 has been solved
+ *   <li>None of the methods must commit or roll back the transaction. The transaction is handled
+ *       outside
+ *   <li>Methods may throw exceptions to indicate a critical error during migration
+ *       <ul>
+ *         <li>Any exception thrown will cancel all subsequent migrations and will prevent the
+ *             stream processor from starting
+ *         <li>Therefore, great care shall be taken to handle exceptions and recoverable situations
+ *             internally
+ *       </ul>
+ * </ul>
+ */
+public interface MigrationTask {
+
+  /**
+   * Returns identifier for the migration task.
+   *
+   * <p>The identifier is used for logging.
+   *
+   * <p>In the future, it might also be used to store the migrations that were run in persistent
+   * state
+   *
+   * @return identifier for the migration task
+   */
+  String getIdentifier();
+
+  /**
+   * Returns whether the migration needs to run
+   *
+   * @param zeebeState the immutable Zeebe state
+   * @return whether the migration needs to run
+   */
+  boolean needsToRun(final ZeebeState zeebeState);
+
+  /**
+   * Implementations of this method perform the actual migration
+   *
+   * @param zeebeState the mutable Zeebe state
+   */
+  void runMigration(final MutableZeebeState zeebeState);
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigrationControllerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigrationControllerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.ReadonlyProcessingContext;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DbMigrationControllerTest {
+
+  private ReadonlyProcessingContext mockContext;
+  private DbMigrator mockDbMigrator;
+
+  private DbMigrationController sutMigrationController;
+
+  @BeforeEach
+  public void setUp() {
+    mockContext = mock(ReadonlyProcessingContext.class);
+    mockDbMigrator = mock(DbMigrator.class);
+
+    sutMigrationController = new DbMigrationController(zeebeState -> mockDbMigrator);
+  }
+
+  @Test
+  public void shouldTriggerMigrationsWhenOnRecoveredEventIsReceived() {
+    // when
+    sutMigrationController.onRecovered(mockContext);
+
+    // then
+    verify(mockDbMigrator).runMigrations();
+  }
+
+  @Test
+  public void shouldAbortMigratorWhenOnCloseEventIsReceived() {
+    // given
+    final var countdownLatch = new CountDownLatch(1);
+    makeMigrationsMockWaitForCountDownLatch(countdownLatch);
+
+    // when
+    sendOnRecoveredInNewThreadAndWaitForMigrationToStart();
+    sutMigrationController.onClose();
+    countdownLatch.countDown();
+
+    // then
+    verify(mockDbMigrator).abort();
+  }
+
+  @Test
+  public void shouldAbortMigratorWhenOnFailedEventIsReceived() {
+    // given
+    final var countdownLatch = new CountDownLatch(1);
+    makeMigrationsMockWaitForCountDownLatch(countdownLatch);
+
+    // when
+    sendOnRecoveredInNewThreadAndWaitForMigrationToStart();
+    sutMigrationController.onFailed();
+    countdownLatch.countDown();
+
+    // then
+    verify(mockDbMigrator).abort();
+  }
+
+  private void sendOnRecoveredInNewThreadAndWaitForMigrationToStart() {
+    new Thread(() -> sutMigrationController.onRecovered(mockContext)).start();
+    await()
+        .pollInterval(10, TimeUnit.MILLISECONDS)
+        .untilAsserted(() -> verify(mockDbMigrator).runMigrations());
+  }
+
+  private void makeMigrationsMockWaitForCountDownLatch(final CountDownLatch countDownLatch) {
+    doAnswer(
+            invocationOnMock -> {
+              countDownLatch.await();
+              return null;
+            })
+        .when(mockDbMigrator)
+        .runMigrations();
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration;
+
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class DbMigratorImplTest {
+
+  @Test
+  void shouldRunMigrationThatNeedsToBeRun() {
+    // given
+    final var mockZeebeState = mock(MutableZeebeState.class);
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(mockZeebeState)).thenReturn(true);
+
+    final var sut =
+        new DbMigratorImpl(mockZeebeState, () -> Collections.singletonList(mockMigration));
+
+    // when
+    sut.runMigrations();
+
+    // then
+    verify(mockMigration).runMigration(mockZeebeState);
+  }
+
+  @Test
+  void shouldNotRunMigrationThatDoesNotNeedToBeRun() {
+    // given
+    final var mockZeebeState = mock(MutableZeebeState.class);
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(mockZeebeState)).thenReturn(false);
+
+    final var sut =
+        new DbMigratorImpl(mockZeebeState, () -> Collections.singletonList(mockMigration));
+
+    // when
+    sut.runMigrations();
+
+    // then
+    verify(mockMigration, never()).runMigration(mockZeebeState);
+  }
+
+  @Test
+  void shouldRunMigrationsInOrder() {
+    // given
+    final var mockZeebeState = mock(MutableZeebeState.class);
+    final var mockMigration1 = mock(MigrationTask.class);
+    when(mockMigration1.needsToRun(mockZeebeState)).thenReturn(true);
+    final var mockMigration2 = mock(MigrationTask.class);
+    when(mockMigration2.needsToRun(mockZeebeState)).thenReturn(true);
+
+    final var sut =
+        new DbMigratorImpl(mockZeebeState, () -> List.of(mockMigration1, mockMigration2));
+
+    // when
+    sut.runMigrations();
+
+    // then
+    final var inOrder = Mockito.inOrder(mockMigration1, mockMigration2);
+
+    inOrder.verify(mockMigration1).runMigration(mockZeebeState);
+    inOrder.verify(mockMigration2).runMigration(mockZeebeState);
+  }
+
+  @Test
+  void shouldNotRunAnyMigrationIfAbortSignalWasReceivedInTheVeryBeginning() {
+    // given
+    final var mockZeebeState = mock(MutableZeebeState.class);
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(mockZeebeState)).thenReturn(false);
+
+    final var sut =
+        new DbMigratorImpl(mockZeebeState, () -> Collections.singletonList(mockMigration));
+
+    // when
+    sut.abort();
+    sut.runMigrations();
+
+    // then
+    verify(mockMigration, never()).needsToRun(Mockito.any());
+    verify(mockMigration, never()).runMigration(Mockito.any());
+  }
+
+  @Test
+  void shouldNotRunSubsequentMigrationsAfterAbortSignalWasReceived() {
+    // given
+    final var mockZeebeState = mock(MutableZeebeState.class);
+    final var mockMigration1 = mock(MigrationTask.class);
+    when(mockMigration1.needsToRun(mockZeebeState)).thenReturn(true);
+    final var mockMigration2 = mock(MigrationTask.class);
+    when(mockMigration2.needsToRun(mockZeebeState)).thenReturn(true);
+
+    final var sut =
+        new DbMigratorImpl(mockZeebeState, () -> List.of(mockMigration1, mockMigration2));
+
+    doAnswer(
+            (invocationOnMock) -> {
+              // send abort signal during first migration
+              sut.abort();
+              return null;
+            })
+        .when(mockMigration1)
+        .runMigration(mockZeebeState);
+
+    // when
+    sut.runMigrations();
+
+    // then
+    verify(mockMigration1).runMigration(mockZeebeState);
+    verify(mockMigration2, never()).runMigration(mockZeebeState);
+  }
+}


### PR DESCRIPTION
## Description

Adds a mechanism to run migrations on startup. Each migration is asked whether it needs to run. and there is logging to document when which migration is run.

<!-- Cut-off marker
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
