### PR TITLE
prevent accidental reset of property

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/AwaitProcessInstanceResultMetadata.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/AwaitProcessInstanceResultMetadata.java
@@ -54,8 +54,10 @@ public final class AwaitProcessInstanceResultMetadata extends UnifiedRecordValue
 
   public AwaitProcessInstanceResultMetadata setFetchVariables(
       final ArrayProperty<StringValue> variables) {
-    fetchVariablesProperty.reset();
-    variables.forEach(variable -> fetchVariablesProperty.add().wrap(variable));
+    if (variables != fetchVariablesProperty) {
+      fetchVariablesProperty.reset();
+      variables.forEach(variable -> fetchVariablesProperty.add().wrap(variable));
+    }
     return this;
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/AwaitProcessInstanceResultMetadataTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/AwaitProcessInstanceResultMetadataTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.instance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayList;
+import java.util.List;
+import org.agrona.DirectBuffer;
+import org.junit.jupiter.api.Test;
+
+public class AwaitProcessInstanceResultMetadataTest {
+
+  @Test
+  public void fetchVariablesShouldAlsoWorkWhenItsOwnPropertyIsPassedIn() {
+    // given
+    final var sut = new AwaitProcessInstanceResultMetadata();
+    final var fetchVariables = sut.fetchVariables();
+    final var stringBuffer = BufferUtil.wrapString("test");
+    fetchVariables.add().wrap(stringBuffer);
+
+    // when
+    sut.setFetchVariables(fetchVariables);
+
+    // then
+    final List<DirectBuffer> actualList = new ArrayList<>();
+    sut.fetchVariables().iterator().forEachRemaining(item -> actualList.add(item.getValue()));
+
+    assertThat(actualList).hasSize(1).containsExactly(stringBuffer);
+  }
+}


### PR DESCRIPTION
## Description

This is a minor change. Not sure whether it is really worth it, tbh. 

After I debugged the accidental reset of properties in `DbProcessMessageSubscriptionState.put()`, I also looked at all other uses where `reset()` is called to see whether any such call could accidentally reset the parameters that are passed in.

Turns out, must call sites for `reset()` are fine, or at least it is very unlikely that it will cause an issue. 

This one wasn't, so I made a slight change here.

However, I am also fine if we drop this change and wait if this error will ever happen in real life.

<!-- Cut-off marker
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
