### PR TITLE
Improve I/O performance of CI builds

### DIFF
--- a/.ci/podSpecs/distribution-template.yml
+++ b/.ci/podSpecs/distribution-template.yml
@@ -85,6 +85,9 @@ spec:
       securityContext:
         privileged: true
       tty: true
+      volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-storage
       resources:
         limits:
           cpu: 12
@@ -92,3 +95,6 @@ spec:
         requests:
           cpu: 12
           memory: 50Gi
+  volumes:
+    - name: docker-storage
+      emptyDir: { }

--- a/.ci/podSpecs/distribution-template.yml
+++ b/.ci/podSpecs/distribution-template.yml
@@ -72,7 +72,8 @@ spec:
     - name: docker
       image: docker:20.10.5-dind
       args:
-        - --storage-driver=overlay
+        - --storage-driver
+        - overlay2
         - --ipv6
         - --fixed-cidr-v6
         - "2001:db8:1::/64"

--- a/.ci/podSpecs/integration-test-template.yml
+++ b/.ci/podSpecs/integration-test-template.yml
@@ -51,6 +51,9 @@ spec:
           value: ""
       securityContext:
         privileged: true
+      volumeMounts:
+        - mountPath: /var/lib/docker
+          name: docker-storage
       tty: true
       resources:
         limits:
@@ -59,3 +62,6 @@ spec:
         requests:
           cpu: 18
           memory: 60Gi
+  volumes:
+    - name: docker-storage
+      emptyDir: {}

--- a/.ci/podSpecs/integration-test-template.yml
+++ b/.ci/podSpecs/integration-test-template.yml
@@ -39,7 +39,8 @@ spec:
     - name: docker
       image: docker:20.10.5-dind
       args:
-        - --storage-driver=overlay
+        - --storage-driver
+        - overlay2
         - --ipv6
         - --fixed-cidr-v6
         - "2001:db8:1::/64"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -514,7 +514,7 @@ def templatePodspec(String podspecPath, flags = [:]) {
     // will merge Maps by overwriting left Map with values of the right Map
     def effectiveFlags = defaultFlags + flags
 
-    def nodePoolName = "agents-n1-standard-32-netssd-${effectiveFlags.useStableNodePool ? 'stable' : 'preempt'}"
+    def nodePoolName = "agents-n1-standard-32-physsd-${effectiveFlags.useStableNodePool ? 'stable' : 'preempt'}"
 
     String templateString = readTrusted(podspecPath)
 


### PR DESCRIPTION
## Description

I noticed that in some cases we were being I/O throttled in CI builds. When using the standard node pool with net SSDs, we have a maximum write throughput of 30 MB/s, which we reach for some tests, resulting in an unpredictable drop in performance. It also means we can't parallelize much more before running into this more often.

After talking with our SREs, we decided the simplest for now is to switch to local SSDs. Additionally, from some sources, it seems promoting the Docker data folder of the dind container to a host volume will give us better performance, since otherwise it cannot run OverlayFS on top of OverlayFS - see:

- https://devops.stackexchange.com/questions/676/why-is-docker-in-docker-considered-bad
- https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
