### PR TITLE
Refactors the DefaultClusterMembershipService tests and fixes flakiness

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/ClusterMembershipService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/ClusterMembershipService.java
@@ -19,7 +19,6 @@ package io.atomix.cluster;
 import io.atomix.utils.event.ListenerService;
 import io.atomix.utils.net.Address;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /** Service for obtaining information about the individual members within the cluster. */
 public interface ClusterMembershipService
@@ -38,29 +37,6 @@ public interface ClusterMembershipService
    * @return set of cluster members
    */
   Set<Member> getMembers();
-
-  /**
-   * Returns the set of active reachable members.
-   *
-   * @return the set of active reachable members
-   */
-  default Set<Member> getReachableMembers() {
-    return getMembers().stream().filter(member -> member.isReachable()).collect(Collectors.toSet());
-  }
-
-  /**
-   * Returns the specified member node.
-   *
-   * <p>This is a convenience method that wraps the given {@link String} in a {@link MemberId}. To
-   * avoid unnecessary object allocation, repeated invocations of this method should instead use
-   * {@link #getMember(MemberId)}.
-   *
-   * @param memberId the member identifier
-   * @return the member or {@code null} if no node with the given identifier exists
-   */
-  default Member getMember(final String memberId) {
-    return getMember(MemberId.from(memberId));
-  }
 
   /**
    * Returns the specified member.

--- a/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
@@ -26,8 +26,8 @@ import java.util.Properties;
 
 /** Represents a node as a member in a cluster. */
 public class Member extends Node {
+  private static final int UNKNOWN_TIMESTAMP = 0;
 
-  public static final int UNKNOWN_TIMESTAMP = 0;
   private final MemberId id;
   private final String zone;
   private final String rack;
@@ -163,7 +163,7 @@ public class Member extends Node {
       return true;
     }
 
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof Member)) {
       return false;
     }
 

--- a/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
@@ -27,6 +27,7 @@ import java.util.Properties;
 /** Represents a node as a member in a cluster. */
 public class Member extends Node {
 
+  public static final int UNKNOWN_TIMESTAMP = 0;
   private final MemberId id;
   private final String zone;
   private final String rack;
@@ -153,26 +154,29 @@ public class Member extends Node {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id(), address(), zone(), rack(), host(), properties());
+    return Objects.hash(super.hashCode(), id, zone, rack, host, properties);
   }
 
   @Override
-  public boolean equals(final Object object) {
-
-    if (object instanceof Member) {
-      final Member member = (Member) object;
-      return member.id().equals(id())
-          && member.address().equals(address())
-          && Objects.equals(member.zone(), zone())
-          && Objects.equals(member.rack(), rack())
-          && Objects.equals(member.host(), host())
-          && Objects.equals(member.properties(), properties());
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
     }
 
-    if (object instanceof Node) {
-      return object.equals(this);
+    if (o == null || getClass() != o.getClass()) {
+      return false;
     }
-    return false;
+
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    final Member member = (Member) o;
+    return Objects.equals(id, member.id)
+        && Objects.equals(zone, member.zone)
+        && Objects.equals(rack, member.rack)
+        && Objects.equals(host, member.host)
+        && Objects.equals(properties, member.properties);
   }
 
   @Override
@@ -257,6 +261,6 @@ public class Member extends Node {
    * @return the member timestamp
    */
   public long timestamp() {
-    return 0;
+    return UNKNOWN_TIMESTAMP;
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/discovery/BootstrapDiscoveryProvider.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/discovery/BootstrapDiscoveryProvider.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  * heartbeat all newly discovered peers before triggering a {@link
  * io.atomix.cluster.ClusterMembershipEvent.Type#MEMBER_REMOVED} event.
  */
-public class BootstrapDiscoveryProvider
+public final class BootstrapDiscoveryProvider
     extends AbstractListenerManager<NodeDiscoveryEvent, NodeDiscoveryEventListener>
     implements NodeDiscoveryProvider {
 
@@ -95,13 +95,13 @@ public class BootstrapDiscoveryProvider
 
   @Override
   public CompletableFuture<Void> join(final BootstrapService bootstrap, final Node localNode) {
-    LOGGER.info("Joined");
+    LOGGER.info("Local node {} joined the bootstrap service", localNode);
     return CompletableFuture.completedFuture(null);
   }
 
   @Override
   public CompletableFuture<Void> leave(final Node localNode) {
-    LOGGER.info("Left");
+    LOGGER.info("Local node {} left the bootstrap servide", localNode);
     return CompletableFuture.completedFuture(null);
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterMembershipService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterMembershipService.java
@@ -43,15 +43,13 @@ public class DefaultClusterMembershipService
     implements ManagedClusterMembershipService {
 
   private static final Logger LOGGER = getLogger(DefaultClusterMembershipService.class);
-
   private static final String HEARTBEAT_MESSAGE = "atomix-cluster-membership";
 
   private final ManagedNodeDiscoveryService discoveryService;
   private final BootstrapService bootstrapService;
   private final GroupMembershipProtocol protocol;
-
-  private final AtomicBoolean started = new AtomicBoolean();
   private final StatefulMember localMember;
+  private final AtomicBoolean started = new AtomicBoolean();
   private final GroupMembershipEventListener membershipEventListener = this::handleMembershipEvent;
 
   public DefaultClusterMembershipService(
@@ -89,13 +87,6 @@ public class DefaultClusterMembershipService
     return protocol.getMember(memberId);
   }
 
-  /** Handles a group membership event. */
-  private void handleMembershipEvent(final GroupMembershipEvent event) {
-    post(
-        new ClusterMembershipEvent(
-            ClusterMembershipEvent.Type.valueOf(event.type().name()), event.member()));
-  }
-
   @Override
   public CompletableFuture<ClusterMembershipService> start() {
     if (started.compareAndSet(false, true)) {
@@ -110,7 +101,7 @@ public class DefaultClusterMembershipService
               })
           .thenApply(
               v -> {
-                LOGGER.info("Started");
+                LOGGER.info("Started cluster membership service for member {}", localMember);
                 return this;
               });
     }
@@ -134,9 +125,16 @@ public class DefaultClusterMembershipService
                 localMember.setReachable(false);
                 bootstrapService.getMessagingService().unregisterHandler(HEARTBEAT_MESSAGE);
                 protocol.removeListener(membershipEventListener);
-                LOGGER.info("Stopped");
+                LOGGER.info("Stopped cluster membership service for member {}", localMember);
               });
     }
     return CompletableFuture.completedFuture(null);
+  }
+
+  /** Handles a group membership event. */
+  private void handleMembershipEvent(final GroupMembershipEvent event) {
+    post(
+        new ClusterMembershipEvent(
+            ClusterMembershipEvent.Type.valueOf(event.type().name()), event.member()));
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/impl/StatefulMember.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/impl/StatefulMember.java
@@ -22,12 +22,10 @@ import io.atomix.utils.Version;
 import io.atomix.utils.net.Address;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicLong;
 
 /** Default cluster node. */
 public final class StatefulMember extends Member {
   private final Version version;
-  private final AtomicLong timestamp = new AtomicLong();
   private volatile boolean active;
   private volatile boolean reachable;
 
@@ -41,35 +39,11 @@ public final class StatefulMember extends Member {
       final Version version) {
     super(id, address, zone, rack, host, properties);
     this.version = version;
-    timestamp.set(1);
-  }
-
-  /**
-   * Returns the member logical timestamp.
-   *
-   * @return the member logical timestamp
-   */
-  public long getTimestamp() {
-    return timestamp.get();
-  }
-
-  /**
-   * Sets the member's logical timestamp.
-   *
-   * @param timestamp the member's logical timestamp
-   */
-  void setTimestamp(final long timestamp) {
-    this.timestamp.accumulateAndGet(timestamp, Math::max);
-  }
-
-  /** Increments the member's timestamp. */
-  void incrementTimestamp() {
-    timestamp.incrementAndGet();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), version, timestamp);
+    return Objects.hash(super.hashCode(), version);
   }
 
   @Override
@@ -87,7 +61,7 @@ public final class StatefulMember extends Member {
     }
 
     final StatefulMember that = (StatefulMember) o;
-    return version.equals(that.version) && timestamp.get() == that.timestamp.get();
+    return version.equals(that.version);
   }
 
   @Override

--- a/atomix/cluster/src/main/java/io/atomix/cluster/impl/StatefulMember.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/impl/StatefulMember.java
@@ -17,11 +17,8 @@
 package io.atomix.cluster.impl;
 
 import io.atomix.cluster.Member;
-import io.atomix.cluster.MemberId;
 import io.atomix.utils.Version;
-import io.atomix.utils.net.Address;
 import java.util.Objects;
-import java.util.Properties;
 
 /** Default cluster node. */
 public final class StatefulMember extends Member {
@@ -29,15 +26,14 @@ public final class StatefulMember extends Member {
   private volatile boolean active;
   private volatile boolean reachable;
 
-  public StatefulMember(
-      final MemberId id,
-      final Address address,
-      final String zone,
-      final String rack,
-      final String host,
-      final Properties properties,
-      final Version version) {
-    super(id, address, zone, rack, host, properties);
+  public StatefulMember(final Member member, final Version version) {
+    super(
+        member.id(),
+        member.address(),
+        member.zone(),
+        member.rack(),
+        member.host(),
+        member.properties());
     this.version = version;
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/cluster/impl/StatefulMember.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/impl/StatefulMember.java
@@ -20,21 +20,16 @@ import io.atomix.cluster.Member;
 import io.atomix.cluster.MemberId;
 import io.atomix.utils.Version;
 import io.atomix.utils.net.Address;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicLong;
 
 /** Default cluster node. */
-public class StatefulMember extends Member {
+public final class StatefulMember extends Member {
   private final Version version;
   private final AtomicLong timestamp = new AtomicLong();
   private volatile boolean active;
   private volatile boolean reachable;
-
-  public StatefulMember(final MemberId id, final Address address) {
-    super(id, address);
-    version = null;
-    timestamp.set(0);
-  }
 
   public StatefulMember(
       final MemberId id,
@@ -70,6 +65,29 @@ public class StatefulMember extends Member {
   /** Increments the member's timestamp. */
   void incrementTimestamp() {
     timestamp.incrementAndGet();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), version, timestamp);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    final StatefulMember that = (StatefulMember) o;
+    return version.equals(that.version) && timestamp.get() == that.timestamp.get();
   }
 
   @Override

--- a/atomix/cluster/src/test/java/io/atomix/cluster/TestGroupMembershipProtocol.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/TestGroupMembershipProtocol.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster;
+
+import io.atomix.cluster.discovery.NodeDiscoveryService;
+import io.atomix.cluster.protocol.GroupMembershipEvent;
+import io.atomix.cluster.protocol.GroupMembershipEventListener;
+import io.atomix.cluster.protocol.GroupMembershipProtocol;
+import io.atomix.cluster.protocol.GroupMembershipProtocolConfig;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+public final class TestGroupMembershipProtocol implements GroupMembershipProtocol {
+
+  private final Set<Member> members = new CopyOnWriteArraySet<>();
+  private final GroupMembershipProtocolConfig config;
+  private final Set<GroupMembershipEventListener> listeners = new CopyOnWriteArraySet<>();
+
+  public TestGroupMembershipProtocol() {
+    this(new Config());
+  }
+
+  public TestGroupMembershipProtocol(final GroupMembershipProtocolConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public Set<Member> getMembers() {
+    return members;
+  }
+
+  @Override
+  public Member getMember(final MemberId memberId) {
+    return members.stream().filter(m -> m.id().equals(memberId)).findFirst().orElse(null);
+  }
+
+  @Override
+  public CompletableFuture<Void> join(
+      final BootstrapService bootstrap,
+      final NodeDiscoveryService discovery,
+      final Member localMember) {
+    members.add(localMember);
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<Void> leave(final Member localMember) {
+    members.remove(localMember);
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public GroupMembershipProtocolConfig config() {
+    return config;
+  }
+
+  @Override
+  public void addListener(final GroupMembershipEventListener listener) {
+    listeners.add(listener);
+  }
+
+  @Override
+  public void removeListener(final GroupMembershipEventListener listener) {
+    listeners.remove(listener);
+  }
+
+  public void sendEvent(final GroupMembershipEvent event) {
+    listeners.forEach(listener -> listener.event(event));
+  }
+
+  public static class Config extends GroupMembershipProtocolConfig implements Type<Config> {
+
+    @Override
+    public Type getType() {
+      return this;
+    }
+
+    @Override
+    public GroupMembershipProtocol newProtocol(final Config config) {
+      return new TestGroupMembershipProtocol(config);
+    }
+
+    @Override
+    public Config newConfig() {
+      return new Config();
+    }
+
+    @Override
+    public String name() {
+      return getClass().getCanonicalName();
+    }
+  }
+}

--- a/atomix/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMembershipServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMembershipServiceTest.java
@@ -146,9 +146,9 @@ public class DefaultClusterMembershipServiceTest {
     assertTrue(clusterService1.getMember(MemberId.from("2")).isActive());
     assertTrue(clusterService1.getMember(MemberId.from("3")).isActive());
 
-    assertEquals("1.0.0", clusterService1.getMember("1").version().toString());
-    assertEquals("1.0.0", clusterService1.getMember("2").version().toString());
-    assertEquals("1.0.1", clusterService1.getMember("3").version().toString());
+    assertEquals("1.0.0", clusterService1.getMember(MemberId.from("1")).version().toString());
+    assertEquals("1.0.0", clusterService1.getMember(MemberId.from("2")).version().toString());
+    assertEquals("1.0.1", clusterService1.getMember(MemberId.from("3")).version().toString());
 
     final Member anonymousMember = buildMember(4);
     final BootstrapService ephemeralBootstrapService =
@@ -184,10 +184,10 @@ public class DefaultClusterMembershipServiceTest {
     assertEquals(4, clusterService3.getMembers().size());
     assertEquals(4, ephemeralClusterService.getMembers().size());
 
-    assertEquals("1.0.0", clusterService1.getMember("1").version().toString());
-    assertEquals("1.0.0", clusterService1.getMember("2").version().toString());
-    assertEquals("1.0.1", clusterService1.getMember("3").version().toString());
-    assertEquals("1.1.0", clusterService1.getMember("4").version().toString());
+    assertEquals("1.0.0", clusterService1.getMember(MemberId.from("1")).version().toString());
+    assertEquals("1.0.0", clusterService1.getMember(MemberId.from("2")).version().toString());
+    assertEquals("1.0.1", clusterService1.getMember(MemberId.from("3")).version().toString());
+    assertEquals("1.1.0", clusterService1.getMember(MemberId.from("4")).version().toString());
 
     clusterService1.stop().join();
 

--- a/atomix/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMembershipServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMembershipServiceTest.java
@@ -16,249 +16,177 @@
  */
 package io.atomix.cluster.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.BootstrapService;
 import io.atomix.cluster.ClusterMembershipEvent;
-import io.atomix.cluster.ClusterMembershipEventListener;
-import io.atomix.cluster.ManagedClusterMembershipService;
 import io.atomix.cluster.Member;
-import io.atomix.cluster.MemberId;
-import io.atomix.cluster.Node;
 import io.atomix.cluster.TestBootstrapService;
+import io.atomix.cluster.TestGroupMembershipProtocol;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
+import io.atomix.cluster.discovery.ManagedNodeDiscoveryService;
 import io.atomix.cluster.messaging.impl.TestMessagingServiceFactory;
 import io.atomix.cluster.messaging.impl.TestUnicastServiceFactory;
-import io.atomix.cluster.protocol.HeartbeatMembershipProtocol;
-import io.atomix.cluster.protocol.HeartbeatMembershipProtocolConfig;
+import io.atomix.cluster.protocol.GroupMembershipEvent;
 import io.atomix.utils.Version;
-import io.atomix.utils.net.Address;
-import java.time.Duration;
-import java.util.Collection;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import org.junit.Test;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
-/** Default cluster service test. */
-public class DefaultClusterMembershipServiceTest {
+@Execution(ExecutionMode.CONCURRENT)
+final class DefaultClusterMembershipServiceTest {
 
-  private Member buildMember(final int memberId) {
-    return Member.builder(String.valueOf(memberId))
-        .withHost("localhost")
-        .withPort(memberId)
-        .build();
-  }
+  private final TestMessagingServiceFactory messagingServiceFactory =
+      new TestMessagingServiceFactory();
+  private final TestUnicastServiceFactory unicastServiceFactory = new TestUnicastServiceFactory();
+  private final Member localMember = Member.member("0", "localhost:5000");
+  private final Version version = Version.from("1.0.0");
+  private final BootstrapService bootstrapService =
+      new TestBootstrapService(
+          messagingServiceFactory.newMessagingService(localMember.address()),
+          unicastServiceFactory.newUnicastService(localMember.address()));
+  private final ManagedNodeDiscoveryService discoveryService =
+      new DefaultNodeDiscoveryService(
+          bootstrapService, localMember, BootstrapDiscoveryProvider.builder().build());
 
-  private Collection<Node> buildBootstrapNodes(final int nodes) {
-    return IntStream.range(1, nodes + 1)
-        .mapToObj(
-            id ->
-                Node.builder()
-                    .withId(String.valueOf(id))
-                    .withAddress(Address.from("localhost", id))
-                    .build())
-        .collect(Collectors.toList());
+  // keep the type as a test type so we can use its test utilities
+  private final TestGroupMembershipProtocol protocol = new TestGroupMembershipProtocol();
+
+  @Test
+  void shouldManageDiscoveryService() {
+    // given
+    final var membershipService =
+        new DefaultClusterMembershipService(
+            localMember, version, discoveryService, bootstrapService, protocol);
+
+    // when - then
+    membershipService.start().join();
+    assertThat(discoveryService.isRunning()).as("the discovery service is now running").isTrue();
+
+    // when - then
+    membershipService.stop().join();
+    assertThat(discoveryService.isRunning())
+        .as("the discovery service is not running anymore")
+        .isFalse();
   }
 
   @Test
-  public void testClusterService() throws Exception {
-    final TestMessagingServiceFactory messagingServiceFactory = new TestMessagingServiceFactory();
-    final TestUnicastServiceFactory unicastServiceFactory = new TestUnicastServiceFactory();
-
-    final Collection<Node> bootstrapLocations = buildBootstrapNodes(3);
-
-    final Member localMember1 = buildMember(1);
-    final BootstrapService bootstrapService1 =
-        new TestBootstrapService(
-            messagingServiceFactory.newMessagingService(localMember1.address()).start().join(),
-            unicastServiceFactory.newUnicastService(localMember1.address()).start().join());
-    final ManagedClusterMembershipService clusterService1 =
+  void shouldGetLocalMember() {
+    // given
+    final var membershipService =
         new DefaultClusterMembershipService(
-            localMember1,
-            Version.from("1.0.0"),
-            new DefaultNodeDiscoveryService(
-                bootstrapService1,
-                localMember1,
-                new BootstrapDiscoveryProvider(bootstrapLocations)),
-            bootstrapService1,
-            new HeartbeatMembershipProtocol(
-                new HeartbeatMembershipProtocolConfig().setFailureTimeout(Duration.ofSeconds(2))));
+            localMember, version, discoveryService, bootstrapService, protocol);
 
-    final Member localMember2 = buildMember(2);
-    final BootstrapService bootstrapService2 =
-        new TestBootstrapService(
-            messagingServiceFactory.newMessagingService(localMember2.address()).start().join(),
-            unicastServiceFactory.newUnicastService(localMember2.address()).start().join());
-    final ManagedClusterMembershipService clusterService2 =
-        new DefaultClusterMembershipService(
-            localMember2,
-            Version.from("1.0.0"),
-            new DefaultNodeDiscoveryService(
-                bootstrapService2,
-                localMember2,
-                new BootstrapDiscoveryProvider(bootstrapLocations)),
-            bootstrapService2,
-            new HeartbeatMembershipProtocol(
-                new HeartbeatMembershipProtocolConfig().setFailureTimeout(Duration.ofSeconds(2))));
+    // when
+    membershipService.start().join();
 
-    final Member localMember3 = buildMember(3);
-    final BootstrapService bootstrapService3 =
-        new TestBootstrapService(
-            messagingServiceFactory.newMessagingService(localMember3.address()).start().join(),
-            unicastServiceFactory.newUnicastService(localMember3.address()).start().join());
-    final ManagedClusterMembershipService clusterService3 =
-        new DefaultClusterMembershipService(
-            localMember3,
-            Version.from("1.0.1"),
-            new DefaultNodeDiscoveryService(
-                bootstrapService3,
-                localMember3,
-                new BootstrapDiscoveryProvider(bootstrapLocations)),
-            bootstrapService3,
-            new HeartbeatMembershipProtocol(
-                new HeartbeatMembershipProtocolConfig().setFailureTimeout(Duration.ofSeconds(2))));
-
-    assertNull(clusterService1.getMember(MemberId.from("1")));
-    assertNull(clusterService1.getMember(MemberId.from("2")));
-    assertNull(clusterService1.getMember(MemberId.from("3")));
-
-    CompletableFuture.allOf(
-            new CompletableFuture[] {
-              clusterService1.start(), clusterService2.start(), clusterService3.start()
-            })
-        .join();
-
-    Thread.sleep(5000);
-
-    assertEquals(3, clusterService1.getMembers().size());
-    assertEquals(3, clusterService2.getMembers().size());
-    assertEquals(3, clusterService3.getMembers().size());
-
-    assertTrue(clusterService1.getLocalMember().isActive());
-    assertTrue(clusterService1.getMember(MemberId.from("1")).isActive());
-    assertTrue(clusterService1.getMember(MemberId.from("2")).isActive());
-    assertTrue(clusterService1.getMember(MemberId.from("3")).isActive());
-
-    assertEquals("1.0.0", clusterService1.getMember(MemberId.from("1")).version().toString());
-    assertEquals("1.0.0", clusterService1.getMember(MemberId.from("2")).version().toString());
-    assertEquals("1.0.1", clusterService1.getMember(MemberId.from("3")).version().toString());
-
-    final Member anonymousMember = buildMember(4);
-    final BootstrapService ephemeralBootstrapService =
-        new TestBootstrapService(
-            messagingServiceFactory.newMessagingService(anonymousMember.address()).start().join(),
-            unicastServiceFactory.newUnicastService(anonymousMember.address()).start().join());
-    final ManagedClusterMembershipService ephemeralClusterService =
-        new DefaultClusterMembershipService(
-            anonymousMember,
-            Version.from("1.1.0"),
-            new DefaultNodeDiscoveryService(
-                ephemeralBootstrapService,
-                anonymousMember,
-                new BootstrapDiscoveryProvider(bootstrapLocations)),
-            ephemeralBootstrapService,
-            new HeartbeatMembershipProtocol(
-                new HeartbeatMembershipProtocolConfig().setFailureTimeout(Duration.ofSeconds(2))));
-
-    assertFalse(ephemeralClusterService.getLocalMember().isActive());
-
-    assertNull(ephemeralClusterService.getMember(MemberId.from("1")));
-    assertNull(ephemeralClusterService.getMember(MemberId.from("2")));
-    assertNull(ephemeralClusterService.getMember(MemberId.from("3")));
-    assertNull(ephemeralClusterService.getMember(MemberId.from("4")));
-    assertNull(ephemeralClusterService.getMember(MemberId.from("5")));
-
-    ephemeralClusterService.start().join();
-
-    Thread.sleep(1000);
-
-    assertEquals(4, clusterService1.getMembers().size());
-    assertEquals(4, clusterService2.getMembers().size());
-    assertEquals(4, clusterService3.getMembers().size());
-    assertEquals(4, ephemeralClusterService.getMembers().size());
-
-    assertEquals("1.0.0", clusterService1.getMember(MemberId.from("1")).version().toString());
-    assertEquals("1.0.0", clusterService1.getMember(MemberId.from("2")).version().toString());
-    assertEquals("1.0.1", clusterService1.getMember(MemberId.from("3")).version().toString());
-    assertEquals("1.1.0", clusterService1.getMember(MemberId.from("4")).version().toString());
-
-    clusterService1.stop().join();
-
-    Thread.sleep(5000);
-
-    assertEquals(3, clusterService2.getMembers().size());
-
-    assertNull(clusterService2.getMember(MemberId.from("1")));
-    assertTrue(clusterService2.getMember(MemberId.from("2")).isActive());
-    assertTrue(clusterService2.getMember(MemberId.from("3")).isActive());
-    assertTrue(clusterService2.getMember(MemberId.from("4")).isActive());
-
-    ephemeralClusterService.stop().join();
-
-    Thread.sleep(5000);
-
-    assertEquals(2, clusterService2.getMembers().size());
-    assertNull(clusterService2.getMember(MemberId.from("1")));
-    assertTrue(clusterService2.getMember(MemberId.from("2")).isActive());
-    assertTrue(clusterService2.getMember(MemberId.from("3")).isActive());
-    assertNull(clusterService2.getMember(MemberId.from("4")));
-
-    Thread.sleep(2500);
-
-    assertEquals(2, clusterService2.getMembers().size());
-
-    assertNull(clusterService2.getMember(MemberId.from("1")));
-    assertTrue(clusterService2.getMember(MemberId.from("2")).isActive());
-    assertTrue(clusterService2.getMember(MemberId.from("3")).isActive());
-    assertNull(clusterService2.getMember(MemberId.from("4")));
-
-    final TestClusterMembershipEventListener eventListener =
-        new TestClusterMembershipEventListener();
-    clusterService2.addListener(eventListener);
-
-    ClusterMembershipEvent event;
-    clusterService3.getLocalMember().properties().put("foo", "bar");
-
-    event = eventListener.nextEvent();
-    assertEquals(ClusterMembershipEvent.Type.METADATA_CHANGED, event.type());
-    assertEquals("bar", event.subject().properties().get("foo"));
-
-    clusterService3.getLocalMember().properties().put("foo", "baz");
-
-    event = eventListener.nextEvent();
-    assertEquals(ClusterMembershipEvent.Type.METADATA_CHANGED, event.type());
-    assertEquals("baz", event.subject().properties().get("foo"));
-
-    CompletableFuture.allOf(
-            new CompletableFuture[] {
-              clusterService1.stop(), clusterService2.stop(), clusterService3.stop()
-            })
-        .join();
+    // then
+    final var expectedMember = new StatefulMember(localMember, version);
+    assertThat(membershipService.getLocalMember())
+        .as("the local member is member 0")
+        .isEqualTo(expectedMember);
   }
 
-  private class TestClusterMembershipEventListener implements ClusterMembershipEventListener {
+  @Test
+  void shouldGetMembers() {
+    // given
+    final var membershipService =
+        new DefaultClusterMembershipService(
+            localMember, version, discoveryService, bootstrapService, protocol);
 
-    private final BlockingQueue<ClusterMembershipEvent> queue =
-        new ArrayBlockingQueue<ClusterMembershipEvent>(10);
+    // when
+    protocol.getMembers().add(Member.member("1", "localhost:5001"));
+    membershipService.start().join();
 
-    @Override
-    public void event(final ClusterMembershipEvent event) {
-      queue.add(event);
-    }
+    // then
+    assertThat(membershipService.getMembers())
+        .as("there should be at least one member")
+        .isNotEmpty()
+        .as("the reported members are exactly the same as the protocol's")
+        .containsExactlyInAnyOrderElementsOf(protocol.getMembers());
+  }
 
-    ClusterMembershipEvent nextEvent() {
-      try {
-        return queue.poll(5, TimeUnit.SECONDS);
-      } catch (final InterruptedException e) {
-        return null;
-      }
-    }
+  @Test
+  void shouldTrackLocalMemberReachability() {
+    // given
+    final var membershipService =
+        new DefaultClusterMembershipService(
+            localMember, version, discoveryService, bootstrapService, protocol);
+
+    // when - then
+    membershipService.start().join();
+    assertThat(membershipService.getLocalMember().isActive())
+        .as("local member is active after starting")
+        .isTrue();
+
+    // when - then
+    membershipService.stop().join();
+    assertThat(membershipService.getLocalMember().isActive())
+        .as("local member is not active after stopping")
+        .isFalse();
+  }
+
+  @Test
+  void shouldTrackReachabilityOfLocalMember() {
+    // given
+    final var membershipService =
+        new DefaultClusterMembershipService(
+            localMember, version, discoveryService, bootstrapService, protocol);
+
+    // when - then
+    membershipService.start().join();
+    assertThat(membershipService.getLocalMember().isReachable())
+        .as("local member is reachable after starting")
+        .isTrue();
+
+    // when - then
+    membershipService.stop().join();
+    assertThat(membershipService.getLocalMember().isReachable())
+        .as("local member is not reachable after stopping")
+        .isFalse();
+  }
+
+  @Test
+  void shouldManageGroupMembershipOfLocalMember() {
+    // given
+    final var membershipService =
+        new DefaultClusterMembershipService(
+            localMember, version, discoveryService, bootstrapService, protocol);
+
+    // when - then
+    membershipService.start().join();
+    assertThat(protocol.getMembers())
+        .as("local member has joined the group protocol")
+        .containsExactly(membershipService.getLocalMember());
+
+    // when - then
+    membershipService.stop().join();
+    assertThat(protocol.getMembers()).as("local member has left the group protocol").isEmpty();
+  }
+
+  @Test
+  void shouldForwardGroupEvents() {
+    // given
+    final var membershipService =
+        new DefaultClusterMembershipService(
+            localMember, version, discoveryService, bootstrapService, protocol);
+    membershipService.start().join();
+
+    // when
+    final var event =
+        new GroupMembershipEvent(
+            GroupMembershipEvent.Type.MEMBER_REMOVED, Member.member("1", "localhost:5001"));
+    final var receivedEvent = new AtomicReference<ClusterMembershipEvent>();
+    membershipService.addListener(receivedEvent::set);
+    protocol.sendEvent(event);
+
+    // then
+    final var expectedEvent =
+        new ClusterMembershipEvent(
+            ClusterMembershipEvent.Type.MEMBER_REMOVED, event.member(), event.time());
+    assertThat(receivedEvent)
+        .as("the received event is the same as the one sent")
+        .hasValue(expectedEvent);
   }
 }


### PR DESCRIPTION
## Description

This PR's primary goal is to refactor the `DefaultClusterMembershipServiceTest`, and actually test that class and not indirectly the `HeartbeatGroupMembershipProtocol` class. Previously, it was mostly testing that behavior - this is not only already tested, but it's not even used in production with Zeebe.

Instead, we now test the class behavior, which is:

- Glue together the discovery protocol and the group membership protocol
- Report members accurately from these
- Keep track of its local member's reachability status
- Manage the lifecycle of the discovery service
- Listen to and forward group membership events

To do this, a new stub implementation of the `GroupMembershipProtocol` was introduced - this simplifies testing and removes any asynchronous behavior related to group events.

I also did a bit of drive-by refactoring, mostly removing dead code and updating classes to Zeebe conventions. I recommend you review commit by commit - the last few commits are the important ones, the rest is just small refactoring.

## Related issues

closes #7176 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
