### PR TITLE
Reduce backport triggers

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,8 +7,18 @@ on:
 jobs:
   build:
     name: Create backport PRs
-    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/backport')) }}
     runs-on: ubuntu-latest
+    # Only run when pull request is merged
+    # or when a comment containing `/backport` is created
+    if: >
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.merged
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '/backport')
+      )
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,9 +1,9 @@
 name: Backport labeled merged pull requests
 on:
   pull_request:
-    types: [ closed ]
+    types: [closed]
   issue_comment:
-    types: [ created ]
+    types: [created]
 jobs:
   build:
     name: Create backport PRs
@@ -22,11 +22,27 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          # required to find all branches
+          # Required to find all branches
           fetch-depth: 0
       - name: Create backport PRs
-        uses: zeebe-io/backport-action@master
+        # Should be kept in sync with `version`
+        uses: zeebe-io/backport-action@0.0.4
         with:
+          # Required
+          # Version of the backport-action
+          # Must equal the version in `uses`
+          # Recommended: latest tag or `master`
+          version: 0.0.4
+
+          # Required
+          # Token to authenticate requests to GitHub
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Required
+          # Working directory for the backport script
           github_workspace: ${{ github.workspace }}
-          version: master
+
+          # Optional
+          # Regex pattern to match github labels
+          # Must contain a capture group for target branchname
+          # label_pattern: ^backport ([^ ]+)$


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

We've had multiple times that a PR was commented on by the backport-action that the pull request was not backported because it was not yet merged. This can happen when the PR is closed without merging. This pull request, changes that by restricting when the backport-action triggers for 'pull_request' events: only on 'merged' pull requests.

It also applies yaml folding to make the conditions more readable, and aligns the backport action with version 0.0.4.

## Related issues

<!-- Which issues are closed by this PR or are related -->

example case: https://github.com/camunda-cloud/zeebe/pull/7192#issuecomment-855686139

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
