### PR TITLE
fix(snapshots): flush snapshot to disk

### DIFF
--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
@@ -16,6 +16,8 @@ import io.camunda.zeebe.util.sched.ActorControl;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -29,6 +31,7 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
   private static final Logger LOGGER = LoggerFactory.getLogger(FileBasedReceivedSnapshot.class);
   private static final boolean FAILED = false;
   private static final boolean SUCCESS = true;
+  private static final int BLOCK_SIZE = 512 * 1024;
 
   private final Path directory;
   private final ActorControl actor;
@@ -169,12 +172,23 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
   }
 
   private boolean writeReceivedSnapshotChunk(
-      final SnapshotChunk snapshotChunk, final Path snapshotFile) throws IOException {
-    Files.write(
-        snapshotFile,
-        snapshotChunk.getContent(),
-        StandardOpenOption.CREATE_NEW,
-        StandardOpenOption.WRITE);
+      final SnapshotChunk snapshotChunk, final Path snapshotFile) {
+    try (var channel =
+        FileChannel.open(snapshotFile, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
+      final ByteBuffer buffer = ByteBuffer.wrap(snapshotChunk.getContent());
+
+      while (buffer.hasRemaining()) {
+        final int newLimit = Math.min(buffer.capacity(), buffer.position() + BLOCK_SIZE);
+        channel.write(buffer.limit(newLimit));
+        buffer.limit(buffer.capacity());
+      }
+
+      channel.force(true);
+    } catch (IOException e) {
+      LOGGER.warn("Failed to write snapshot chunk {}", snapshotChunk, e);
+      return FAILED;
+    }
+
     LOGGER.trace("Wrote replicated snapshot chunk to file {}", snapshotFile);
     return SUCCESS;
   }

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.channels.FileChannel;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -40,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 public final class FileBasedSnapshotStore extends Actor
     implements ConstructableSnapshotStore, ReceivableSnapshotStore {
+
   // first is the metadata and the second the the received snapshot count
   private static final String RECEIVING_DIR_FORMAT = "%s-%d";
 
@@ -504,6 +506,10 @@ public final class FileBasedSnapshotStore extends Actor
     } catch (final AtomicMoveNotSupportedException e) {
       LOGGER.warn("Atomic move not supported. Moving the snapshot files non-atomically.");
       Files.move(directory, destination);
+    }
+
+    try (var channel = FileChannel.open(destination)) {
+      channel.force(true);
     }
   }
 


### PR DESCRIPTION
## Description

Flushes snapshot changes to disk before acknowledging the snapshot as valid. Also ensure that metadata changes are persisted.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7136

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
