### PR TITLE
Fix ES container memory to 1Gb

### DIFF
--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/util/ElasticsearchContainer.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/util/ElasticsearchContainer.java
@@ -141,7 +141,7 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
         .withEnv("cluster.name", "zeebe")
         .withEnv("ELASTIC_PASSWORD", "changeme")
         .withNetworkAliases("elasticsearch-" + Base58.randomString(6))
-        .withEnv("discovery.type", "single-node");
+        .withEnv("ES_JAVA_OPTS", "-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1073741824");
 
     addExposedPorts(DEFAULT_HTTP_PORT, DEFAULT_TCP_PORT);
     setWaitStrategy(waitStrategy);


### PR DESCRIPTION
## Description

It seems the default configuration for the ElasticsearchContainer is to use all the heap available, even as initial heap. This is unnecessary for our tests and can cause issues with other tests running in parallel on the same machine. 

This PR fixes the max heap size to 1Gb and the max direct memory to 1Gb as well. This hopefully fixes the following errors:

```
14:58:50.621 [] [main] ERROR 🐳 [docker.elastic.co/elasticsearch/elasticsearch:7.13.1] - Log output from the failed container:
Exception in thread "main" java.lang.RuntimeException: starting java failed with [1]
output:
#
# There is insufficient memory for the Java Runtime Environment to continue.
# Native memory allocation (mmap) failed to map 32212254720 bytes for committing reserved memory.
# An error report file with more information is saved as:
# logs/hs_err_pid181.log
error:
OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x0000000080000000, 32212254720, 0) failed; error='Not enough space' (errno=12)
	at org.elasticsearch.tools.launchers.JvmOption.flagsFinal(JvmOption.java:119)
	at org.elasticsearch.tools.launchers.JvmOption.findFinalOptions(JvmOption.java:81)
```

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
