### PR TITLE
Fix ES memory usage

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/health/DiskSpaceRecoveryITTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/health/DiskSpaceRecoveryITTest.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
 
 public class DiskSpaceRecoveryITTest {
   private static final Logger LOG = LoggerFactory.getLogger(DiskSpaceRecoveryITTest.class);
@@ -144,12 +145,13 @@ public class DiskSpaceRecoveryITTest {
   }
 
   private ElasticsearchContainer createElastic() {
-    final String image =
-        "docker.elastic.co/elasticsearch/elasticsearch:"
-            + RestClient.class.getPackage().getImplementationVersion();
+    final var version = RestClient.class.getPackage().getImplementationVersion();
+    final var image =
+        DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch").withTag(version);
 
     return new ElasticsearchContainer(image)
         .withEnv("discovery.type", "single-node")
+        .withEnv("ES_JAVA_OPTS", "-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1073741824")
         .withNetworkAliases(ELASTIC_HOSTNAME);
   }
 }


### PR DESCRIPTION
## Description

Elasticsearch will automatically grab all available memory as its initial and max heap size on start up. When starting it as a container with no particular limits, it will then use up all the host's heap, which causes problems for other processes running on the same node.

This was already fixed in the ES exporter tests, but I missed this case here. This is new in ES 7 I believe, and may explain some increased flakiness we noticed since a few months (which could coincide with the upgrade to ES 7?), but I didn't double check. At any rate, you can test it locally by running the test and see your memory gobbled up when you start ES without this fix :smile: 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
