### PR TITLE
use correct logical predecessor

### DIFF
--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/ExecutionPathSegment.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/ExecutionPathSegment.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.test.util.bpmn.random;
 
+import static io.camunda.zeebe.test.util.bpmn.random.steps.AbstractExecutionStep.VIRTUALLY_NO_TIME;
+
 import io.camunda.zeebe.test.util.bpmn.random.steps.AbstractExecutionStep;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -183,9 +185,19 @@ public final class ExecutionPathSegment {
    * the right. The related ScheduledSteps which are before and come immediately after are updated.
    *
    * @param random used to pseudo-randomly chose where the step should be inserted
-   * @param executionStep the step which should be inserted
+   * @param executionStep the step which should be inserted. Must be a time that takes almost no
+   *     time. Otherwise, the scheduling information for steps behind the insertion point will be
+   *     inaccurate
    */
   public void insertExecutionStep(final Random random, final AbstractExecutionStep executionStep) {
+    if (executionStep.getDeltaTime().toMillis() > VIRTUALLY_NO_TIME.toMillis()) {
+      throw new RuntimeException(
+          "Not yet implemented. This insert logic only works if the step that is inserted takes almost no time.");
+      /* For a step that takes time, one needs to recalculate the scheduled times
+       * for all steps after the insertion point
+       */
+    }
+
     final var index = findCutOffPoint(random);
 
     final var successor = scheduledSteps.remove(index);
@@ -198,7 +210,10 @@ public final class ExecutionPathSegment {
     }
 
     // add at index will move all elements to the right, including the object on the given index
-    scheduledSteps.add(index, new ScheduledExecutionStep(newStep, newStep, successor.getStep()));
+    scheduledSteps.add(
+        index,
+        new ScheduledExecutionStep(
+            successor.getLogicalPredecessor(), newStep, successor.getStep()));
     scheduledSteps.add(index, newStep);
   }
 


### PR DESCRIPTION
## Description

Previously the logical predecessor of the successor was overwritten to be the inserted step.
This was incorrect and led to wrong calculations for scheduled time and timeouts (see e.g. #7108 for a root cause analysis)

This fix sets the correct logical predecessor correctly.
It also adds a check at the begin of the insertion method to make sure the inserted step doesn't change the timeline.

## Related issues

closes #7108

The flaky test can be reproduced quite good. Locally, I used the seeds from the failing test and set Idea to run the tests to failure. It failed on average once in 10 times. After the fix it ran for >30 mins without failure.

<!-- Cut-off marker
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
