### PR TITLE
fix(broker): fix race condition in exporter tests

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/logstreams/state/StatePositionSupplier.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/logstreams/state/StatePositionSupplier.java
@@ -10,9 +10,11 @@ package io.camunda.zeebe.broker.logstreams.state;
 import io.camunda.zeebe.broker.exporter.stream.ExportersState;
 import io.camunda.zeebe.db.ZeebeDb;
 
-public class StatePositionSupplier {
+public final class StatePositionSupplier {
+  private StatePositionSupplier() {}
+
   public static long getHighestExportedPosition(final ZeebeDb zeebeDb) {
-    final ExportersState exporterState = new ExportersState(zeebeDb, zeebeDb.createContext());
+    final var exporterState = new ExportersState(zeebeDb, zeebeDb.createContext());
     if (exporterState.hasExporters()) {
       return exporterState.getLowestPosition();
     } else {

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -177,7 +177,7 @@ public final class ExporterDirectorTest {
   }
 
   @Test
-  public void shouldUpdateIfRecordSkipsSingleUpToDateExporter() throws InterruptedException {
+  public void shouldUpdateIfRecordSkipsSingleUpToDateExporter() {
     final ControlledTestExporter filteringExporter = exporters.get(0);
     final ControlledTestExporter tailingExporter = exporters.get(1);
     tailingExporter
@@ -297,13 +297,13 @@ public final class ExporterDirectorTest {
         .onConfigure(
             withFilter(
                 Arrays.asList(RecordType.COMMAND, RecordType.EVENT),
-                Arrays.asList(ValueType.DEPLOYMENT)));
+                Collections.singletonList(ValueType.DEPLOYMENT)));
 
     exporters
         .get(1)
         .onConfigure(
             withFilter(
-                Arrays.asList(RecordType.EVENT),
+                Collections.singletonList(RecordType.EVENT),
                 Arrays.asList(ValueType.DEPLOYMENT, ValueType.JOB)));
 
     startExporterDirector(exporterDescriptors);
@@ -381,7 +381,7 @@ public final class ExporterDirectorTest {
 
     writeEvent();
 
-    timerScheduledLatch.await(5, TimeUnit.SECONDS);
+    assertThat(timerScheduledLatch.await(5, TimeUnit.SECONDS)).isTrue();
 
     rule.getClock().addTime(delay);
 
@@ -408,7 +408,7 @@ public final class ExporterDirectorTest {
 
     writeEvent();
 
-    timerScheduledLatch.await(5, TimeUnit.SECONDS);
+    assertThat(timerScheduledLatch.await(5, TimeUnit.SECONDS)).isTrue();
 
     rule.getClock().addTime(delay);
 
@@ -441,7 +441,7 @@ public final class ExporterDirectorTest {
 
     writeEvent();
 
-    timerScheduledLatch.await(5, TimeUnit.SECONDS);
+    assertThat(timerScheduledLatch.await(5, TimeUnit.SECONDS)).isTrue();
 
     rule.getClock().addTime(delay);
 
@@ -473,7 +473,7 @@ public final class ExporterDirectorTest {
 
     // then
     waitUntil(() -> exporters.get(1).getExportedRecords().size() >= 1);
-    assertThat(exporters.get(0).getExportedRecords()).hasSize(0);
+    assertThat(exporters.get(0).getExportedRecords()).isEmpty();
     assertThat(exporters.get(1).getExportedRecords())
         .extracting(Record::getPosition)
         .hasSize(1)
@@ -594,19 +594,18 @@ public final class ExporterDirectorTest {
 
   private Consumer<Context> withFilter(
       final List<RecordType> acceptedTypes, final List<ValueType> valueTypes) {
-    return context -> {
-      context.setFilter(
-          new Context.RecordFilter() {
-            @Override
-            public boolean acceptType(final RecordType recordType) {
-              return acceptedTypes.contains(recordType);
-            }
+    return context ->
+        context.setFilter(
+            new Context.RecordFilter() {
+              @Override
+              public boolean acceptType(final RecordType recordType) {
+                return acceptedTypes.contains(recordType);
+              }
 
-            @Override
-            public boolean acceptValue(final ValueType valueType) {
-              return valueTypes.contains(valueType);
-            }
-          });
-    };
+              @Override
+              public boolean acceptValue(final ValueType valueType) {
+                return valueTypes.contains(valueType);
+              }
+            });
   }
 }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.db.impl.rocksdb.transaction.ZeebeTransactionDb;
 import java.io.File;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
@@ -60,7 +61,7 @@ public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamil
   @Override
   public ZeebeTransactionDb<ColumnFamilyType> createDb(final File pathName) {
     final ZeebeTransactionDb<ColumnFamilyType> db;
-    final List<AutoCloseable> closeables = new ArrayList<>();
+    final List<AutoCloseable> closeables = Collections.synchronizedList(new ArrayList<>());
     try {
       // column family options have to be closed as last
       final var columnFamilyOptions = createColumnFamilyOptions(closeables);


### PR DESCRIPTION
## Description

I couldn't reproduce the test failure but looking at the stack trace and code, we can see that an IndexOutOfBounds exception is thrown when adding an element to a list. I think that a concurrent access caused two threads to pass the array size check with one index to spare and then one of them succeeded and the other tried to write out of bounds. The tests get the exporter states, which adds a context to the closeables list, shortly after it starts an ExporterDirector, which also adds a context to the closeables list asynchronously while starting. This PR fixes the race condition by making the tests wait until the ExporterDirector has started.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6029 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
