### PR TITLE
Improve stability of SuccessfulDeploymentTest

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SuccessfulDeploymentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SuccessfulDeploymentTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.deployment.model.validation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.zeebe.engine.util.EngineRule;
@@ -22,6 +23,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Function;
@@ -31,9 +33,13 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+import org.mockito.verification.VerificationWithTimeout;
 
 @RunWith(Parameterized.class)
 public final class SuccessfulDeploymentTest {
+
+  private static final VerificationWithTimeout VERIFICATION_TIMEOUT =
+      timeout(Duration.ofSeconds(10).toMillis());
 
   @Rule public final EngineRule engine = EngineRule.singlePartition();
 
@@ -95,7 +101,8 @@ public final class SuccessfulDeploymentTest {
     verify(engine.getCommandResponseWriter()).valueType(ValueType.DEPLOYMENT);
     verify(engine.getCommandResponseWriter()).intent(DeploymentIntent.CREATED);
     verify(engine.getCommandResponseWriter()).key(deployment.getKey());
-    verify(engine.getCommandResponseWriter()).tryWriteResponse(anyInt(), anyLong());
+    verify(engine.getCommandResponseWriter(), VERIFICATION_TIMEOUT)
+        .tryWriteResponse(anyInt(), anyLong());
   }
 
   private static Function<DeploymentClient, Record<DeploymentRecordValue>> deploy(


### PR DESCRIPTION
## Description

* the command response is sent asynchronously in the background and can be delayed
* use a timeout for the verification to make the test more stable (especially for CI)
 
## Related issues

closes #7211 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
