### PR TITLE
Increase role change granularity in Grafana

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -89,7 +89,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1622104691851,
+  "iteration": 1623398951904,
   "links": [],
   "panels": [
     {
@@ -6593,6 +6593,7 @@
           },
           "hiddenSeries": false,
           "id": 95,
+          "interval": "1s",
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -6885,7 +6886,7 @@
           "pluginVersion": "6.7.1",
           "repeat": null,
           "repeatDirection": "h",
-          "repeatIteration": 1622104691826,
+          "repeatIteration": 1623398951903,
           "repeatPanelId": 205,
           "scopedVars": {
             "partition": {
@@ -6970,7 +6971,7 @@
           "pluginVersion": "6.7.1",
           "repeat": null,
           "repeatDirection": "h",
-          "repeatIteration": 1622104691826,
+          "repeatIteration": 1623398951903,
           "repeatPanelId": 205,
           "scopedVars": {
             "partition": {
@@ -7138,7 +7139,7 @@
           "pluginVersion": "6.7.1",
           "repeat": null,
           "repeatDirection": "h",
-          "repeatIteration": 1622104691826,
+          "repeatIteration": 1623398951903,
           "repeatPanelId": 209,
           "scopedVars": {
             "partition": {
@@ -7223,7 +7224,7 @@
           "pluginVersion": "6.7.1",
           "repeat": null,
           "repeatDirection": "h",
-          "repeatIteration": 1622104691826,
+          "repeatIteration": 1623398951903,
           "repeatPanelId": 209,
           "scopedVars": {
             "partition": {
@@ -9990,5 +9991,5 @@
   "timezone": "",
   "title": "Zeebe",
   "uid": "I4lo7_EZk",
-  "version": 10
+  "version": 12
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

In some cases, the role change happens so fast and changes back to the
previous state (in less than 15s). When that happens, grafana was unable
to show the election cycle. By reducing the query interval for the
datasource we can increase the granularity and show these role changes.
The interval is only changed for the role change panel, to not impact
performance.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #7218

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
