### PR TITLE
refactor(raft): extract election timer logic

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/ElectionTimer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/ElectionTimer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+/** An election timer controls when a node triggers an election. */
+public interface ElectionTimer {
+
+  /**
+   * Reset the timer
+   *
+   * <p>When `reset` is called, the previous timer is cancelled and a new timer will be started.
+   * After a specific duration, depending on the implementation, the election will be triggered.
+   */
+  void reset();
+
+  /** Cancel the timer */
+  void cancel();
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/ElectionTimerFactory.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/ElectionTimerFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import org.slf4j.Logger;
+
+@FunctionalInterface
+public interface ElectionTimerFactory {
+
+  /**
+   * Creates a new ElectionTimer
+   *
+   * @param triggerElection - A runnable which start election by sending the poll requests.
+   * @param logger - A logger for logging
+   * @return an ElectionTimer
+   */
+  ElectionTimer create(Runnable triggerElection, Logger logger);
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RandomizedElectionTimer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RandomizedElectionTimer.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.impl;
+
+import io.atomix.raft.ElectionTimer;
+import io.atomix.utils.concurrent.Scheduled;
+import io.atomix.utils.concurrent.ThreadContext;
+import java.time.Duration;
+import java.util.Random;
+import org.slf4j.Logger;
+
+/**
+ * An implementation of the default election in raft. It uses a randomized timeout to prevent
+ * multiple nodes from starting the election at the same time.
+ */
+public class RandomizedElectionTimer implements ElectionTimer {
+
+  private Scheduled electionTimer;
+  private final Duration electionTimeout;
+  private final ThreadContext threadContext;
+  private final Random random;
+  private final Runnable triggerElection;
+  private final Logger log;
+
+  public RandomizedElectionTimer(
+      final Duration electionTimeout,
+      final ThreadContext threadContext,
+      final Random random,
+      final Runnable triggerElection,
+      final Logger log) {
+    this.electionTimeout = electionTimeout;
+    this.threadContext = threadContext;
+    this.random = random;
+    this.triggerElection = triggerElection;
+    this.log = log;
+  }
+
+  @Override
+  public void reset() {
+    cancel();
+    final Duration delay =
+        electionTimeout.plus(Duration.ofMillis(random.nextInt((int) electionTimeout.toMillis())));
+    electionTimer = threadContext.schedule(delay, this::onElectionTimeout);
+  }
+
+  @Override
+  public void cancel() {
+    if (electionTimer != null) {
+      electionTimer.cancel();
+      electionTimer = null;
+    }
+  }
+
+  private void onElectionTimeout() {
+    electionTimer =
+        threadContext.schedule(
+            electionTimeout,
+            () -> {
+              log.debug("Failed to poll a majority of the cluster in {}", electionTimeout);
+              reset();
+            });
+    triggerElection.run();
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -19,6 +19,8 @@ package io.atomix.raft.roles;
 import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.ClusterMembershipEventListener;
 import io.atomix.cluster.MemberId;
+import io.atomix.raft.ElectionTimer;
+import io.atomix.raft.ElectionTimerFactory;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
@@ -36,8 +38,6 @@ import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.utils.Quorum;
-import io.atomix.utils.concurrent.Scheduled;
-import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -46,12 +46,13 @@ import java.util.stream.Collectors;
 /** Follower state. */
 public final class FollowerRole extends ActiveRole {
 
-  private Scheduled heartbeatTimer;
-  private final ClusterMembershipEventListener clusterListener = this::handleClusterEvent;
   private long lastHeartbeat;
+  private final ElectionTimer electionTimer;
+  private final ClusterMembershipEventListener clusterListener = this::handleClusterEvent;
 
-  public FollowerRole(final RaftContext context) {
+  public FollowerRole(final RaftContext context, final ElectionTimerFactory electionTimerFactory) {
     super(context);
+    electionTimer = electionTimerFactory.create(this::schedulePollRequests, log);
   }
 
   @Override
@@ -64,13 +65,13 @@ public final class FollowerRole extends ActiveRole {
     }
 
     raft.getMembershipService().addListener(clusterListener);
-    return super.start().thenRun(this::resetHeartbeatTimeout).thenApply(v -> this);
+    return super.start().thenRun(electionTimer::reset).thenApply(v -> this);
   }
 
   @Override
   public synchronized CompletableFuture<Void> stop() {
     raft.getMembershipService().removeListener(clusterListener);
-    cancelHeartbeatTimer();
+    electionTimer.cancel();
 
     return super.stop();
   }
@@ -84,18 +85,9 @@ public final class FollowerRole extends ActiveRole {
   public CompletableFuture<InstallResponse> onInstall(final InstallRequest request) {
     final CompletableFuture<InstallResponse> future = super.onInstall(request);
     if (isRequestFromCurrentLeader(request.currentTerm(), request.leader())) {
-      resetHeartbeatTimeout();
+      onHeartbeatFromLeader();
     }
     return future;
-  }
-
-  /** Cancels the heartbeat timer. */
-  private void cancelHeartbeatTimer() {
-    if (heartbeatTimer != null) {
-      log.trace("Cancelling heartbeat timer");
-      heartbeatTimer.cancel();
-      heartbeatTimer = null;
-    }
   }
 
   /** Handles a cluster event. */
@@ -144,7 +136,7 @@ public final class FollowerRole extends ActiveRole {
               if (raft.getLeader() == null && elected) {
                 raft.transition(RaftServer.Role.CANDIDATE);
               } else {
-                resetHeartbeatTimeout();
+                electionTimer.reset();
               }
             });
 
@@ -184,7 +176,7 @@ public final class FollowerRole extends ActiveRole {
   public CompletableFuture<ConfigureResponse> onConfigure(final ConfigureRequest request) {
     final CompletableFuture<ConfigureResponse> future = super.onConfigure(request);
     if (isRequestFromCurrentLeader(request.term(), request.leader())) {
-      resetHeartbeatTimeout();
+      onHeartbeatFromLeader();
     }
     return future;
   }
@@ -193,7 +185,7 @@ public final class FollowerRole extends ActiveRole {
   public CompletableFuture<AppendResponse> onAppend(final AppendRequest request) {
     final CompletableFuture<AppendResponse> future = super.onAppend(request);
     if (isRequestFromCurrentLeader(request.term(), request.leader())) {
-      resetHeartbeatTimeout();
+      onHeartbeatFromLeader();
     }
     return future;
   }
@@ -203,7 +195,7 @@ public final class FollowerRole extends ActiveRole {
     // Reset the heartbeat timeout if we voted for another candidate.
     final VoteResponse response = super.handleVote(request);
     if (response.voted()) {
-      resetHeartbeatTimeout();
+      onHeartbeatFromLeader();
     }
     return response;
   }
@@ -225,23 +217,14 @@ public final class FollowerRole extends ActiveRole {
     return true;
   }
 
-  private void resetHeartbeatTimeout() {
+  private void onHeartbeatFromLeader() {
     raft.checkThread();
     if (!isRunning()) {
       return;
     }
 
-    cancelHeartbeatTimer();
     updateHeartbeat(System.currentTimeMillis());
-
-    // Set the election timeout in a semi-random fashion with the random range
-    // being election timeout and 2 * election timeout.
-    final Duration delay =
-        raft.getElectionTimeout()
-            .plus(
-                Duration.ofMillis(
-                    raft.getRandom().nextInt((int) raft.getElectionTimeout().toMillis())));
-    heartbeatTimer = raft.getThreadContext().schedule(delay, () -> onHeartbeatTimeout(delay));
+    electionTimer.reset();
   }
 
   private void updateHeartbeat(final long currentTimestamp) {
@@ -252,7 +235,7 @@ public final class FollowerRole extends ActiveRole {
     lastHeartbeat = currentTimestamp;
   }
 
-  private void schedulePollRequests(final Duration delay) {
+  private void schedulePollRequests() {
     raft.checkThread();
 
     if (!isRunning()) {
@@ -262,34 +245,14 @@ public final class FollowerRole extends ActiveRole {
     if (raft.getFirstCommitIndex() == 0 || raft.getState() == RaftContext.State.READY) {
       final long missTime = System.currentTimeMillis() - lastHeartbeat;
       log.info(
-          "No heartbeat from {} in the last {} (calculated from last {} ms), sending poll requests",
+          "No heartbeat from {} in the last {}ms, sending poll requests",
           raft.getLeader(),
-          delay,
           missTime);
       raft.getRaftRoleMetrics().countHeartbeatMiss();
 
       raft.setLeader(null);
       sendPollRequests();
     }
-  }
-
-  private void onHeartbeatTimeout(final Duration delay) {
-    if (!isRunning()) {
-      return;
-    }
-
-    final Duration pollTimeout = raft.getElectionTimeout();
-
-    heartbeatTimer =
-        raft.getThreadContext()
-            .schedule(
-                pollTimeout,
-                () -> {
-                  log.debug("Failed to poll a majority of the cluster in {}", pollTimeout);
-                  resetHeartbeatTimeout();
-                });
-
-    schedulePollRequests(delay);
   }
 
   private void handlePollResponse(


### PR DESCRIPTION
## Description

This PR is in preparation to implement priority election in #7258. By extracting the election logic, it will be easier to chose between default election and priority election.

## Related issues

Related #7258 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioral changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
