### PR TITLE
A user can deploy a process definition with a send task

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractFlowNodeBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractFlowNodeBuilder.java
@@ -194,6 +194,12 @@ public abstract class AbstractFlowNodeBuilder<
     return createTargetBuilder(SendTask.class, id);
   }
 
+  public SendTaskBuilder sendTask(final String id, final Consumer<SendTaskBuilder> consumer) {
+    final SendTaskBuilder builder = createTargetBuilder(SendTask.class, id);
+    consumer.accept(builder);
+    return builder;
+  }
+
   public UserTaskBuilder userTask() {
     return createTargetBuilder(UserTask.class);
   }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractSendTaskBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractSendTaskBuilder.java
@@ -23,7 +23,7 @@ import io.camunda.zeebe.model.bpmn.instance.SendTask;
 
 /** @author Sebastian Menski */
 public abstract class AbstractSendTaskBuilder<B extends AbstractSendTaskBuilder<B>>
-    extends AbstractTaskBuilder<B, SendTask> {
+    extends AbstractJobWorkerTaskBuilder<B, SendTask> {
 
   protected AbstractSendTaskBuilder(
       final BpmnModelInstance modelInstance, final SendTask element, final Class<?> selfType) {

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.model.bpmn.instance.IntermediateCatchEvent;
 import io.camunda.zeebe.model.bpmn.instance.ParallelGateway;
 import io.camunda.zeebe.model.bpmn.instance.ReceiveTask;
 import io.camunda.zeebe.model.bpmn.instance.ScriptTask;
+import io.camunda.zeebe.model.bpmn.instance.SendTask;
 import io.camunda.zeebe.model.bpmn.instance.SequenceFlow;
 import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
@@ -56,6 +57,7 @@ public class FlowElementValidator implements ModelElementValidator<FlowElement> 
     SUPPORTED_ELEMENT_TYPES.add(ReceiveTask.class);
     SUPPORTED_ELEMENT_TYPES.add(ScriptTask.class);
     SUPPORTED_ELEMENT_TYPES.add(SequenceFlow.class);
+    SUPPORTED_ELEMENT_TYPES.add(SendTask.class);
     SUPPORTED_ELEMENT_TYPES.add(ServiceTask.class);
     SUPPORTED_ELEMENT_TYPES.add(StartEvent.class);
     SUPPORTED_ELEMENT_TYPES.add(SubProcess.class);

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
 import io.camunda.zeebe.model.bpmn.instance.CallActivity;
 import io.camunda.zeebe.model.bpmn.instance.MultiInstanceLoopCharacteristics;
 import io.camunda.zeebe.model.bpmn.instance.ScriptTask;
+import io.camunda.zeebe.model.bpmn.instance.SendTask;
 import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
@@ -67,6 +68,10 @@ public final class ZeebeDesignTimeValidators {
             .hasSingleExtensionElement(
                 ZeebeTaskDefinition.class, ZeebeConstants.ELEMENT_TASK_DEFINITION));
     validators.add(new SequenceFlowValidator());
+    validators.add(
+        ExtensionElementsValidator.verifyThat(SendTask.class)
+            .hasSingleExtensionElement(
+                ZeebeTaskDefinition.class, ZeebeConstants.ELEMENT_TASK_DEFINITION));
     validators.add(
         ExtensionElementsValidator.verifyThat(ServiceTask.class)
             .hasSingleExtensionElement(

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeJobWorkerTaskValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeJobWorkerTaskValidationTest.java
@@ -106,7 +106,8 @@ public class ZeebeJobWorkerTaskValidationTest {
     return Stream.of(
         JobWorkerTaskBuilder.of("serviceTask", AbstractFlowNodeBuilder::serviceTask),
         JobWorkerTaskBuilder.of("businessRuleTask", AbstractFlowNodeBuilder::businessRuleTask),
-        JobWorkerTaskBuilder.of("scriptTask", AbstractFlowNodeBuilder::scriptTask));
+        JobWorkerTaskBuilder.of("scriptTask", AbstractFlowNodeBuilder::scriptTask),
+        JobWorkerTaskBuilder.of("sendTask", AbstractFlowNodeBuilder::sendTask));
   }
 
   private static final class JobWorkerTaskBuilder {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
@@ -37,6 +37,7 @@ public final class BpmnElementProcessors {
     processors.put(BpmnElementType.SERVICE_TASK, new JobWorkerTaskProcessor(bpmnBehaviors));
     processors.put(BpmnElementType.BUSINESS_RULE_TASK, new JobWorkerTaskProcessor(bpmnBehaviors));
     processors.put(BpmnElementType.SCRIPT_TASK, new JobWorkerTaskProcessor(bpmnBehaviors));
+    processors.put(BpmnElementType.SEND_TASK, new JobWorkerTaskProcessor(bpmnBehaviors));
     processors.put(BpmnElementType.USER_TASK, new JobWorkerTaskProcessor(bpmnBehaviors));
     processors.put(BpmnElementType.RECEIVE_TASK, new ReceiveTaskProcessor(bpmnBehaviors));
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
@@ -32,6 +32,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.transformer.UserTaskT
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
 import io.camunda.zeebe.model.bpmn.instance.ScriptTask;
+import io.camunda.zeebe.model.bpmn.instance.SendTask;
 import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.traversal.ModelWalker;
 import java.util.List;
@@ -80,6 +81,7 @@ public final class BpmnTransformer {
     step2Visitor.registerHandler(new JobWorkerTaskTransformer<>(ServiceTask.class));
     step2Visitor.registerHandler(new JobWorkerTaskTransformer<>(BusinessRuleTask.class));
     step2Visitor.registerHandler(new JobWorkerTaskTransformer<>(ScriptTask.class));
+    step2Visitor.registerHandler(new JobWorkerTaskTransformer<>(SendTask.class));
     step2Visitor.registerHandler(new ReceiveTaskTransformer());
     step2Visitor.registerHandler(new UserTaskTransformer());
     step2Visitor.registerHandler(new StartEventTransformer());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowElementInstantiationTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowElementInstantiationTransformer.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.model.bpmn.instance.IntermediateCatchEvent;
 import io.camunda.zeebe.model.bpmn.instance.ParallelGateway;
 import io.camunda.zeebe.model.bpmn.instance.ReceiveTask;
 import io.camunda.zeebe.model.bpmn.instance.ScriptTask;
+import io.camunda.zeebe.model.bpmn.instance.SendTask;
 import io.camunda.zeebe.model.bpmn.instance.SequenceFlow;
 import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
@@ -65,6 +66,7 @@ public final class FlowElementInstantiationTransformer
     ELEMENT_FACTORIES.put(ParallelGateway.class, ExecutableFlowNode::new);
     ELEMENT_FACTORIES.put(ReceiveTask.class, ExecutableReceiveTask::new);
     ELEMENT_FACTORIES.put(ScriptTask.class, ExecutableJobWorkerTask::new);
+    ELEMENT_FACTORIES.put(SendTask.class, ExecutableJobWorkerTask::new);
     ELEMENT_FACTORIES.put(SequenceFlow.class, ExecutableSequenceFlow::new);
     ELEMENT_FACTORIES.put(ServiceTask.class, ExecutableJobWorkerTask::new);
     ELEMENT_FACTORIES.put(StartEvent.class, ExecutableStartEvent::new);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -53,6 +53,7 @@ public final class MigratedStreamProcessors {
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.SEQUENCE_FLOW);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.BUSINESS_RULE_TASK);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.SCRIPT_TASK);
+    MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.SEND_TASK);
 
     MIGRATED_VALUE_TYPES.put(ValueType.JOB, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.JOB_BATCH, MIGRATED);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementTypeTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementTypeTest.java
@@ -232,6 +232,21 @@ public final class BpmnElementTypeTest {
               ENGINE.job().ofInstance(processInstanceKey).withType(taskType()).complete();
             }
           },
+          new BpmnElementTypeScenario("Send Task", BpmnElementType.SEND_TASK) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .sendTask(elementId(), b -> b.zeebeJobType(taskType()))
+                  .done();
+            }
+
+            @Override
+            void test() {
+              final long processInstanceKey = super.executeInstance();
+              ENGINE.job().ofInstance(processInstanceKey).withType(taskType()).complete();
+            }
+          },
           new BpmnElementTypeScenario("User Task", BpmnElementType.USER_TASK) {
             @Override
             BpmnModelInstance modelInstance() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/JobWorkerTaskBuilderProvider.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/JobWorkerTaskBuilderProvider.java
@@ -34,7 +34,8 @@ public final class JobWorkerTaskBuilderProvider implements ArgumentsProvider {
         JobWorkerTaskBuilder.of(BpmnElementType.SERVICE_TASK, AbstractFlowNodeBuilder::serviceTask),
         JobWorkerTaskBuilder.of(
             BpmnElementType.BUSINESS_RULE_TASK, AbstractFlowNodeBuilder::businessRuleTask),
-        JobWorkerTaskBuilder.of(BpmnElementType.SCRIPT_TASK, AbstractFlowNodeBuilder::scriptTask));
+        JobWorkerTaskBuilder.of(BpmnElementType.SCRIPT_TASK, AbstractFlowNodeBuilder::scriptTask),
+        JobWorkerTaskBuilder.of(BpmnElementType.SEND_TASK, AbstractFlowNodeBuilder::sendTask));
   }
 
   public static Collection<Object[]> buildersAsParameters() {

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BpmnElementType.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BpmnElementType.java
@@ -50,7 +50,8 @@ public enum BpmnElementType {
   TESTING_ONLY,
 
   BUSINESS_RULE_TASK,
-  SCRIPT_TASK;
+  SCRIPT_TASK,
+  SEND_TASK;
 
   public static BpmnElementType bpmnElementTypeFor(final String elementTypeName) {
     switch (elementTypeName) {
@@ -86,6 +87,8 @@ public enum BpmnElementType {
         return BpmnElementType.BUSINESS_RULE_TASK;
       case "scriptTask":
         return BpmnElementType.SCRIPT_TASK;
+      case "sendTask":
+        return BpmnElementType.SEND_TASK;
       default:
         throw new RuntimeException("Unsupported BPMN element of type " + elementTypeName);
     }


### PR DESCRIPTION
## Description

* allow processes with send tasks
* send tasks behave exactly like service tasks

## Related issues

closes #7156 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
