### PR TITLE
Unhandled error incident on job can be resolved

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.IncidentState;
-import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
@@ -36,8 +35,6 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
 
   public static final String NO_INCIDENT_FOUND_MSG =
       "Expected to resolve incident with key '%d', but no such incident was found";
-  private static final String RESOLVE_UNHANDLED_ERROR_INCIDENT_MESSAGE =
-      "Expected to resolve incident of unhandled error for job %d, but such incidents cannot be resolved. See issue #6000";
   private static final String ELEMENT_NOT_IN_SUPPORTED_STATE_MSG =
       "Expected incident to refer to element in state ELEMENT_ACTIVATING or ELEMENT_COMPLETING, but element is in state %s";
 
@@ -51,7 +48,6 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
 
   private final IncidentState incidentState;
   private final ElementInstanceState elementInstanceState;
-  private final JobState jobState;
   private final KeyGenerator keyGenerator;
 
   public ResolveIncidentProcessor(
@@ -64,7 +60,6 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
     rejectionWriter = writers.rejection();
     incidentState = zeebeState.getIncidentState();
     elementInstanceState = zeebeState.getElementInstanceState();
-    jobState = zeebeState.getJobState();
     this.keyGenerator = keyGenerator;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -195,7 +195,8 @@ public final class EventAppliers implements EventApplier {
         new IncidentCreatedApplier(state.getIncidentState(), state.getJobState()));
     register(
         IncidentIntent.RESOLVED,
-        new IncidentResolvedApplier(state.getIncidentState(), state.getJobState()));
+        new IncidentResolvedApplier(
+            state.getIncidentState(), state.getJobState(), state.getElementInstanceState()));
   }
 
   private void registerProcessMessageSubscriptionEventAppliers(final MutableZeebeState state) {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

When an error is thrown for a job and uncaught, an incident is raised. Previously, this incident could not be resolved. This PR adds support for resolving this type of incident by making the job activatable again.

Specifically, it removes the resolve incident command rejection for this incident type, and makes the job activatable when the incident is resolved.

Note that the `job.elementId` was already updated to `NO_CATCH_EVENT_FOUND` for incident's created on older versions, as well as for newly created incidents of this type. The event applier can simply reset this state through a lookup, which does not affect the backwards compatibility.

Reviewer: These changes are backwards compatible, because incidents related to jobs in error_thrown state cannot have been resolved. However, there is something to say about checking the version of the record in the event applier. Please consider whether we need this now, since the event appliers lack knowledge of a record's version at this time.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6000 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
