### PR TITLE
Hard reject resolving incident with missing failed command

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
@@ -143,8 +143,13 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
 
               sideEffect.accept(sideEffects);
             },
-            failure ->
-                rejectResolveCommand(command, responseWriter, failure, RejectionType.NOT_FOUND));
+            failure -> {
+              final var message =
+                  String.format(
+                      "Expected to continue processing after incident %d resolved, but failed command not found",
+                      command.getKey());
+              throw new IllegalStateException(message, new IllegalStateException(failure));
+            });
   }
 
   private Either<String, TypedRecord<ProcessInstanceRecord>> getFailedCommand(
@@ -154,7 +159,7 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
     if (elementInstance == null) {
       return Either.left(
           String.format(
-              "Expected to resolve incident with element instance %d, but element instance not found",
+              "Expected to find failed command for element instance %d, but element instance not found",
               elementInstanceKey));
     }
     return getFailedCommandIntent(elementInstance)


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Throw an exception when we try to resolve an incident, but cannot find the failed command. This is an unrecoverable situation for that process instance.

The exception helps visibility of the problem to engineers (it pops up in the logs). The exception leads to a command rejection which is communicated to the client that sent the resolve command.

An alternative solution was to accept the resolved and recreate a new incident. This idea was challenged during the review.

Another solution was blacklisting the instance, which would stop all processing on the instance. This blocks more than necessary.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7127

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
