### PR TITLE
Do not write unnecessary VariableRecord.UPDATED if the variable remains unchanged

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
@@ -123,7 +123,7 @@ public final class VariableBehavior {
         final VariableInstance variableInstance =
             variableState.getVariableInstanceLocal(currentScope, entry.getName());
 
-        if (variableInstance != null) {
+        if (variableInstance != null && !variableInstance.getValue().equals(entry.getValue())) {
           applyEntryToRecord(entry);
           stateWriter.appendFollowUpEvent(
               variableInstance.getKey(), VariableIntent.UPDATED, variableRecord);
@@ -182,7 +182,7 @@ public final class VariableBehavior {
     if (variableInstance == null) {
       final long key = keyGenerator.nextKey();
       stateWriter.appendFollowUpEvent(key, VariableIntent.CREATED, record);
-    } else {
+    } else if (!variableInstance.getValue().equals(record.getValueBuffer())) {
       stateWriter.appendFollowUpEvent(variableInstance.getKey(), VariableIntent.UPDATED, record);
     }
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ProcessInstanceVariableTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ProcessInstanceVariableTest.java
@@ -312,9 +312,11 @@ public final class ProcessInstanceVariableTest {
 
     // then
     assertThat(
-            RecordingExporter.variableRecords(VariableIntent.UPDATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .limit(2))
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .variableRecords()
+                .withIntent(VariableIntent.UPDATED)
+                .withProcessInstanceKey(processInstanceKey))
         .extracting(Record::getValue)
         .extracting(v -> tuple(v.getName(), v.getValue()))
         .hasSize(2)

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
@@ -355,7 +355,7 @@ final class VariableBehaviorTest {
   }
 
   @Test
-  void shouldOnlyUpdateModifiedVariables() {
+  void shouldNotUpdateUnmodifiedVariables() {
     // given
     final long processDefinitionKey = 1;
     final long parentScopeKey = 1;

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingTypedEventWriter.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingTypedEventWriter.java
@@ -42,5 +42,10 @@ public final class RecordingTypedEventWriter implements TypedEventWriter {
       this.intent = intent;
       this.value = (T) Records.cloneValue(value);
     }
+
+    @Override
+    public String toString() {
+      return "RecordedEvent{" + "key=" + key + ", intent=" + intent + ", value=" + value + '}';
+    }
   }
 }


### PR DESCRIPTION
## Description

This PR fixes a bug introduced during the engine refactoring, where we now write `VariableRecord.UPDATED` even if the variable remains unchanged. The fix removes this unnecessary follow up event. This is technically a breaking change, insofar as applications relying on this record being produced would not find it anymore. However, there is no loss of information - the variable CREATED still exist, and the command which would have produced the unnecessary `VariableRecord.UPDATED` is still exported and has all the info required, so I think it's a change we can accept.

## Related issues

closes #7295 
closes #7273

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
