### PR TITLE
fix(zeebe-client-java): return this in builder methods

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -95,6 +95,7 @@ public class ZeebeClientCloudBuilderImpl
     if (properties.containsKey(ClientProperties.CLOUD_CLIENT_SECRET)) {
       withClientSecret(properties.getProperty(ClientProperties.CLOUD_CLIENT_SECRET));
     }
+    innerBuilder.withProperties(properties);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -21,7 +21,6 @@ import static io.camunda.zeebe.client.impl.command.ArgumentUtil.ensureNotNull;
 import io.camunda.zeebe.client.ClientProperties;
 import io.camunda.zeebe.client.CredentialsProvider;
 import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1;
 import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2;
 import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3;
@@ -67,22 +66,26 @@ public class ZeebeClientCloudBuilderImpl
   }
 
   @Override
-  public ZeebeClientBuilder gatewayAddress(final String gatewayAddress) {
-    return innerBuilder.gatewayAddress(gatewayAddress);
+  public ZeebeClientCloudBuilderStep4 gatewayAddress(final String gatewayAddress) {
+    innerBuilder.gatewayAddress(gatewayAddress);
+    return this;
   }
 
   @Override
-  public ZeebeClientBuilder usePlaintext() {
-    return innerBuilder.usePlaintext();
+  public ZeebeClientCloudBuilderStep4 usePlaintext() {
+    innerBuilder.usePlaintext();
+    return this;
   }
 
   @Override
-  public ZeebeClientBuilder credentialsProvider(final CredentialsProvider credentialsProvider) {
-    return innerBuilder.credentialsProvider(credentialsProvider);
+  public ZeebeClientCloudBuilderStep4 credentialsProvider(
+      final CredentialsProvider credentialsProvider) {
+    innerBuilder.credentialsProvider(credentialsProvider);
+    return this;
   }
 
   @Override
-  public ZeebeClientBuilder withProperties(final Properties properties) {
+  public ZeebeClientCloudBuilderStep4 withProperties(final Properties properties) {
     if (properties.containsKey(ClientProperties.CLOUD_CLUSTER_ID)) {
       withClusterId(properties.getProperty(ClientProperties.CLOUD_CLUSTER_ID));
     }
@@ -92,62 +95,73 @@ public class ZeebeClientCloudBuilderImpl
     if (properties.containsKey(ClientProperties.CLOUD_CLIENT_SECRET)) {
       withClientSecret(properties.getProperty(ClientProperties.CLOUD_CLIENT_SECRET));
     }
-    return innerBuilder.withProperties(properties);
+    return this;
   }
 
   @Override
-  public ZeebeClientBuilder defaultJobWorkerMaxJobsActive(final int maxJobsActive) {
-    return innerBuilder.defaultJobWorkerMaxJobsActive(maxJobsActive);
+  public ZeebeClientCloudBuilderStep4 defaultJobWorkerMaxJobsActive(final int maxJobsActive) {
+    innerBuilder.defaultJobWorkerMaxJobsActive(maxJobsActive);
+    return this;
   }
 
   @Override
-  public ZeebeClientBuilder numJobWorkerExecutionThreads(final int numThreads) {
-    return innerBuilder.numJobWorkerExecutionThreads(numThreads);
+  public ZeebeClientCloudBuilderStep4 numJobWorkerExecutionThreads(final int numThreads) {
+    innerBuilder.numJobWorkerExecutionThreads(numThreads);
+    return this;
   }
 
   @Override
-  public ZeebeClientBuilder defaultJobWorkerName(final String workerName) {
-    return innerBuilder.defaultJobWorkerName(workerName);
+  public ZeebeClientCloudBuilderStep4 defaultJobWorkerName(final String workerName) {
+    innerBuilder.defaultJobWorkerName(workerName);
+    return this;
   }
 
   @Override
-  public ZeebeClientBuilder defaultJobTimeout(final Duration timeout) {
-    return innerBuilder.defaultJobTimeout(timeout);
+  public ZeebeClientCloudBuilderStep4 defaultJobTimeout(final Duration timeout) {
+    innerBuilder.defaultJobTimeout(timeout);
+    return this;
   }
 
   @Override
-  public ZeebeClientBuilder defaultJobPollInterval(final Duration pollInterval) {
-    return innerBuilder.defaultJobPollInterval(pollInterval);
+  public ZeebeClientCloudBuilderStep4 defaultJobPollInterval(final Duration pollInterval) {
+    innerBuilder.defaultJobPollInterval(pollInterval);
+    return this;
   }
 
   @Override
-  public ZeebeClientBuilder defaultMessageTimeToLive(final Duration timeToLive) {
-    return innerBuilder.defaultMessageTimeToLive(timeToLive);
+  public ZeebeClientCloudBuilderStep4 defaultMessageTimeToLive(final Duration timeToLive) {
+    innerBuilder.defaultMessageTimeToLive(timeToLive);
+    return this;
   }
 
   @Override
-  public ZeebeClientBuilder defaultRequestTimeout(final Duration requestTimeout) {
-    return innerBuilder.defaultRequestTimeout(requestTimeout);
+  public ZeebeClientCloudBuilderStep4 defaultRequestTimeout(final Duration requestTimeout) {
+    innerBuilder.defaultRequestTimeout(requestTimeout);
+    return this;
   }
 
   @Override
-  public ZeebeClientBuilder caCertificatePath(final String certificatePath) {
-    return innerBuilder.caCertificatePath(certificatePath);
+  public ZeebeClientCloudBuilderStep4 caCertificatePath(final String certificatePath) {
+    innerBuilder.caCertificatePath(certificatePath);
+    return this;
   }
 
   @Override
-  public ZeebeClientBuilder keepAlive(final Duration keepAlive) {
-    return innerBuilder.keepAlive(keepAlive);
+  public ZeebeClientCloudBuilderStep4 keepAlive(final Duration keepAlive) {
+    innerBuilder.keepAlive(keepAlive);
+    return this;
   }
 
   @Override
-  public ZeebeClientBuilder withInterceptors(final ClientInterceptor... interceptor) {
-    return innerBuilder.withInterceptors(interceptor);
+  public ZeebeClientCloudBuilderStep4 withInterceptors(final ClientInterceptor... interceptor) {
+    innerBuilder.withInterceptors(interceptor);
+    return this;
   }
 
   @Override
-  public ZeebeClientBuilder withJsonMapper(final JsonMapper jsonMapper) {
-    return innerBuilder.withJsonMapper(jsonMapper);
+  public ZeebeClientCloudBuilderStep4 withJsonMapper(final JsonMapper jsonMapper) {
+    innerBuilder.withJsonMapper(jsonMapper);
+    return this;
   }
 
   @Override
@@ -177,6 +191,10 @@ public class ZeebeClientCloudBuilderImpl
       ensureNotNull("client id", clientId);
       ensureNotNull("client secret", clientSecret);
       final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
+
+      if (innerBuilder.isPlaintextConnectionEnabled()) {
+        Loggers.LOGGER.debug("Expected setting 'usePlaintext' to be 'false', but found 'true'.");
+      }
       return builder
           .audience(String.format("%s.%s", clusterId, BASE_ADDRESS))
           .clientId(clientId)


### PR DESCRIPTION
## Description

Makes sure that all builder methods return this.

## Related issues

closes #7169 

<!-- Cut-off marker
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
