### PR TITLE
Extract and rethrow JsonParseException

### DIFF
--- a/gateway/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import org.junit.jupiter.api.Test;
+
+public class RequestMapperTest {
+
+  @Test
+  public void shouldThrowHelpfulExceptionIfJsonIsInvalid() {
+    // given
+    final var invalidJson = "{ \"test\": \"value\", \"error\": \"errorrvalue }";
+    // closing quote missing in second value
+
+    // when + then
+    assertThatThrownBy(() -> RequestMapper.ensureJsonSet(invalidJson))
+        .isInstanceOf(JsonParseException.class)
+        .hasMessageContaining("Invalid JSON", invalidJson)
+        .getCause()
+        .isInstanceOf(JsonParseException.class);
+  }
+}


### PR DESCRIPTION
## Description

Catches the `RuntimeException` thrown by underlying converter. If the cause was a `JsonParseException` a new runtime exception is thrown, which contains the original content for reference.

An alternative to this implementation would be to move this logic into the `MsgPackConverter` class. However, I wasn't sure about that. The converter seems to assume that the data is valid. 

But I am happy to change that, if you think that would be better

## Related issues

closes #7025

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
