### PR TITLE
Scan recursively for children when checking whether a Message is referenced

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/MessageValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/MessageValidator.java
@@ -26,8 +26,12 @@ import io.camunda.zeebe.model.bpmn.instance.StartEvent;
 import io.camunda.zeebe.model.bpmn.instance.SubProcess;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeSubscription;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.camunda.bpm.model.xml.impl.ModelInstanceImpl;
+import org.camunda.bpm.model.xml.impl.util.ModelUtil;
+import org.camunda.bpm.model.xml.instance.DomElement;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
@@ -134,7 +138,27 @@ public class MessageValidator implements ModelElementValidator<Message> {
   private <T extends ModelElementInstance> Collection<T> getAllElementsByType(
       final Message element, final Class<T> type) {
     return element.getParentElement().getChildElementsByType(Process.class).stream()
-        .flatMap(p -> p.getChildElementsByType(type).stream())
+        .flatMap(p -> getAllElementsByTypeRecursive(p, type).stream())
         .collect(Collectors.toList());
+  }
+
+  private <T extends ModelElementInstance> Collection<T> getAllElementsByTypeRecursive(
+      final ModelElementInstance element, final Class<T> type) {
+
+    // look for immediate children
+    final Collection<T> result = element.getChildElementsByType(type);
+
+    // look for children in subtree
+    final List<DomElement> childDomElements = element.getDomElement().getChildElements();
+    final Collection<ModelElementInstance> childModelElements =
+        ModelUtil.getModelElementCollection(
+            childDomElements, (ModelInstanceImpl) element.getModelInstance());
+
+    result.addAll(
+        childModelElements.stream()
+            .flatMap(child -> getAllElementsByTypeRecursive(child, type).stream())
+            .collect(Collectors.toList()));
+
+    return result;
   }
 }


### PR DESCRIPTION
## Description

The existing logic only did only a flat scan for children of a certain type. So it considered only
immediate children of the process. The change does a recursive search, so that nested children will
also be considered

Hints: 
* the one detail which is not ideal is the cast. I have not found any other way to get at the children. And since the library that is referenced there is quite stable, I though it would be ok for a time being.
* See #7131 for a discussion on why this change was necessary to fix the bug.

## Related issues

closes #7131 

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [X] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
