### PR TITLE
Reenable SonarCloud analysis on all PRs

### DIFF
--- a/.ci/scripts/distribution/analyse-java.sh
+++ b/.ci/scripts/distribution/analyse-java.sh
@@ -23,12 +23,12 @@ else
   fi
 
   if [ "${GIT_BRANCH}" == "master" ] || [ "${GIT_BRANCH}" == "develop" ]; then
-    TARGET_BRANCH="master"
+    TARGET_BRANCH="${GIT_BRANCH}"
   else
     TARGET_BRANCH="develop"
+    PROPERTIES+=("-Dsonar.branch.target=${TARGET_BRANCH}")
   fi
 
-  PROPERTIES+=("-Dsonar.branch.target=${TARGET_BRANCH}")
   git fetch --no-tags "${GIT_URL}" "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
 fi
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -132,7 +132,6 @@ pipeline {
             when { not { expression { params.SKIP_VERIFY } } }
             parallel {
                 stage('Analyse') {
-                    when { expression { return false } } // disable SonarCloud until new artifact id is linked to project
                     steps {
                         timeout(time: longTimeoutMinutes, unit: 'MINUTES') {
                             runMavenContainerCommand('.ci/scripts/distribution/analyse-java.sh')

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1570,7 +1570,7 @@
         <!-- sonarscanner integration -->
         <!-- sonar.login token must be passed at runtime to avoid sharing token -->
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.organization>zeebe-io</sonar.organization>
+        <sonar.organization>camunda-cloud</sonar.organization>
         <sonar.login>${env.SONARCLOUD_TOKEN}</sonar.login>
         <sonar.links.issue>${project.scm.url}/issues</sonar.links.issue>
         <sonar.cpd.exclusions>


### PR DESCRIPTION
## Description

This PR re-enables SonarCloud analysis on all pull requests. I updated the organization since we've now changed it, and also changed it so that develop and master both act as "base" branches, i.e. they aren't compared against a different branch.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
