### PR TITLE
Mark StreamProcessor as open later

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -120,7 +120,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
           new ProcessingStateMachine(processingContext, this::shouldProcessNext);
 
       healthCheckTick();
-      openFuture.complete(null);
 
       final ReProcessingStateMachine reProcessingStateMachine =
           new ReProcessingStateMachine(processingContext);
@@ -302,6 +301,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
     if (!shouldProcess) {
       setStateToPausedAndNotifyListeners();
     }
+
+    openFuture.complete(null);
   }
 
   private void onFailure(final Throwable throwable) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -345,7 +345,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
       return HealthStatus.UNHEALTHY;
     }
 
-    if (!processingStateMachine.isMakingProgress()) {
+    if (processingStateMachine == null || !processingStateMachine.isMakingProgress()) {
       return HealthStatus.UNHEALTHY;
     }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
@@ -178,7 +178,7 @@ public class StreamProcessorHealthTest {
 
   private StreamProcessor getErrorProneStreamProcessor() {
     streamProcessor =
-        streamProcessorRule.startTypedStreamProcessor(
+        streamProcessorRule.startTypedStreamProcessorNotAwaitOpening(
             processingContext -> {
               final MutableZeebeState zeebeState = processingContext.getZeebeState();
               mockedLogStreamWriter = new WrappedStreamWriter();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorInconsistentPositionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorInconsistentPositionTest.java
@@ -100,7 +100,7 @@ public final class StreamProcessorInconsistentPositionTest {
     // when
     final TypedRecordProcessor typedRecordProcessor = mock(TypedRecordProcessor.class);
     final var streamProcessor =
-        firstStreamProcessorComposite.startTypedStreamProcessor(
+        firstStreamProcessorComposite.startTypedStreamProcessorNotAwaitOpening(
             (processors, context) ->
                 processors
                     .onEvent(ValueType.PROCESS_INSTANCE, ELEMENT_ACTIVATING, typedRecordProcessor)

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
@@ -93,10 +93,11 @@ public final class StreamProcessorTest {
   public void shouldCallStreamProcessorLifecycleOnFail() throws InterruptedException {
     // given
     final CountDownLatch failedLatch = new CountDownLatch(1);
-    streamProcessorRule.startTypedStreamProcessor(
+    streamProcessorRule.startTypedStreamProcessorNotAwaitOpening(
         (processors, state) ->
             processors.withListener(
                 new StreamProcessorLifecycleAware() {
+
                   @Override
                   public void onRecovered(final ReadonlyProcessingContext context) {
                     throw new RuntimeException("force fail");

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -137,6 +137,17 @@ public final class StreamProcessorRule implements TestRule {
     return startTypedStreamProcessor(startPartitionId, factory);
   }
 
+  public StreamProcessor startTypedStreamProcessorNotAwaitOpening(
+      final StreamProcessorTestFactory factory) {
+    return streamProcessingComposite.startTypedStreamProcessorNotAwaitOpening(factory, r -> {});
+  }
+
+  public StreamProcessor startTypedStreamProcessorNotAwaitOpening(
+      final TypedRecordProcessorFactory factory) {
+    return streamProcessingComposite.startTypedStreamProcessorNotAwaitOpening(
+        startPartitionId, factory);
+  }
+
   public StreamProcessor startTypedStreamProcessor(
       final int partitionId, final TypedRecordProcessorFactory factory) {
     return streamProcessingComposite.startTypedStreamProcessor(partitionId, factory);


### PR DESCRIPTION
## Description

The StreamProcessor was marked as open to early, before the Reprocessing was done. This can cause issues like opening the CommandAPI too early, which fill already the command queue and return a lot of resources exhausted responses to the clients. It is not useful to accept already commands, if we are not able to process them

<!-- Please explain the changes you made here. -->

## Benchmark

With the changes we see that exporting and processing starts at the same time.
![chg-general](https://user-images.githubusercontent.com/2758593/122716501-9dc17600-d26a-11eb-8701-0e67317af885.png)

With our base (current develop) we can see that it normally happened that exporting already started, while the StreamProcessor was in replay mode. 

![base-general](https://user-images.githubusercontent.com/2758593/122716554-afa31900-d26a-11eb-9627-0dfa7cd20272.png)



## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7308 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
