### PR TITLE
feat(raft): assign priorities for nodes for priority election

### DIFF
--- a/atomix/cluster/pom.xml
+++ b/atomix/cluster/pom.xml
@@ -176,6 +176,11 @@
       <version>${project.parent.version}</version>
       <type>test-jar</type>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <modelVersion>4.0.0</modelVersion>

--- a/atomix/cluster/src/main/java/io/atomix/primitive/partition/PartitionMetadata.java
+++ b/atomix/cluster/src/main/java/io/atomix/primitive/partition/PartitionMetadata.java
@@ -16,11 +16,10 @@
  */
 package io.atomix.primitive.partition;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-
 import io.atomix.cluster.MemberId;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -30,10 +29,18 @@ import java.util.Objects;
 public class PartitionMetadata {
   private final PartitionId id;
   private final List<MemberId> members;
+  private final Map<MemberId, Integer> priority;
+  private final int targetPriority;
 
-  public PartitionMetadata(final PartitionId id, final List<MemberId> members) {
+  public PartitionMetadata(
+      final PartitionId id,
+      final List<MemberId> members,
+      final Map<MemberId, Integer> priority,
+      final int targetPriority) {
     this.id = id;
     this.members = members;
+    this.priority = priority;
+    this.targetPriority = targetPriority;
   }
 
   /**
@@ -54,6 +61,21 @@ public class PartitionMetadata {
     return members;
   }
 
+  /**
+   * Return the priority of the node if the node is a member of the replication group for this
+   * partition. Otherwise return -1.
+   *
+   * @param member
+   * @return the priority of the member
+   */
+  public int getPriority(final MemberId member) {
+    return priority.getOrDefault(member, -1);
+  }
+
+  public int getTargetPriority() {
+    return targetPriority;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(id, members);
@@ -70,6 +92,15 @@ public class PartitionMetadata {
 
   @Override
   public String toString() {
-    return toStringHelper(this).add("id", id).add("members", members).toString();
+    return "PartitionMetadata{"
+        + "id="
+        + id
+        + ", members="
+        + members
+        + ", priority="
+        + priority
+        + ", targetPriority="
+        + targetPriority
+        + '}';
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/PartitionDistributor.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/PartitionDistributor.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.partition;
+
+import com.google.common.collect.Sets;
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Generates the partition distribution based on the cluster size, partition count and replication
+ * factor
+ */
+public class PartitionDistributor {
+
+  public Collection<PartitionMetadata> generatePartitionDistribution(
+      final Collection<MemberId> clusterMembers,
+      final List<PartitionId> sortedPartitionIds,
+      final int replicationFactor) {
+    final List<MemberId> sorted = new ArrayList<>(clusterMembers);
+    Collections.sort(sorted);
+
+    final int length = sorted.size();
+    final int count = Math.min(replicationFactor, length);
+
+    final Set<PartitionMetadata> metadata = Sets.newHashSet();
+    for (int i = 0; i < sortedPartitionIds.size(); i++) {
+      final PartitionId partitionId = sortedPartitionIds.get(i);
+      final List<MemberId> membersForPartition = new ArrayList<>(count);
+      for (int j = 0; j < count; j++) {
+        membersForPartition.add(sorted.get((i + j) % length));
+      }
+      final var primary = sorted.get(i % length);
+      final var priorities =
+          getPriorities(
+              partitionId, membersForPartition, primary, sorted.size(), replicationFactor);
+      metadata.add(
+          new PartitionMetadata(
+              partitionId, membersForPartition, priorities, priorities.get(primary)));
+    }
+    return metadata;
+  }
+
+  private Map<MemberId, Integer> getPriorities(
+      final PartitionId partitionId,
+      final List<MemberId> membersForPartition,
+      final MemberId primary,
+      final int clusterSize,
+      final int replicationFactor) {
+    final Map<MemberId, Integer> priority = new HashMap<>();
+    final int lowestPriority = 1;
+
+    priority.put(primary, replicationFactor);
+    // To ensure that secondary priorities are distributed evenly, we alternate the nodes for which
+    // second priority is assigned. Example, clusterSize = 3 partitionCount = 12. Node 0 has highest
+    // priority (=3) for partition 1,4,7 and 10. For partition 1 and 7, node 1 gets priority 2. For
+    // partition 4 and 10, node 2 gets priority 2. This is done so that if node 0 dies, the
+    // leadership is evenly distributed on the rest of the followers.
+    if ((partitionId.id() - 1) / clusterSize % 2 == 0) {
+      int nextPriority = replicationFactor - 1;
+      for (final MemberId member : membersForPartition) {
+        if (!member.equals(primary)) {
+          priority.put(member, nextPriority);
+          nextPriority--;
+        }
+      }
+    } else {
+      int nextPriority = lowestPriority;
+      for (final MemberId member : membersForPartition) {
+        if (!member.equals(primary)) {
+          priority.put(member, nextPriority);
+          nextPriority++;
+        }
+      }
+    }
+    return priority;
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -48,7 +48,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -63,7 +62,7 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
   private static final Duration SNAPSHOT_TIMEOUT = Duration.ofSeconds(15);
   private final String name;
   private final RaftPartitionGroupConfig config;
-  private final int partitionSize;
+  private final int replicationFactor;
   private final Map<PartitionId, RaftPartition> partitions = Maps.newConcurrentMap();
   private final List<PartitionId> sortedPartitionIds = Lists.newCopyOnWriteArrayList();
   private final String snapshotSubject;
@@ -77,7 +76,7 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
             LoggerContext.builder(RaftPartitionGroup.class).addValue(config.getName()).build());
     name = config.getName();
     this.config = config;
-    partitionSize = config.getPartitionSize();
+    replicationFactor = config.getPartitionSize();
 
     final int threadPoolSize =
         Math.max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 16), 4);
@@ -179,15 +178,20 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
 
     // We expect to bootstrap partitions where leadership is equally distributed.
     // First member of a PartitionMetadata is the bootstrap leader
-    metadata = buildPartitions();
+    final var members =
+        config.getMembers().stream().map(MemberId::from).collect(Collectors.toSet());
+    metadata =
+        new PartitionDistributor()
+            .generatePartitionDistribution(members, sortedPartitionIds, replicationFactor);
+    // Example distribution with priority, clusterSize=4, partitionCount=5, replicationFactor=3
     // +------------------+----+----+----+---+
     // | Partition \ Node | 0  | 1  | 2  | 3 |
     // +------------------+----+----+----+---+
-    // |                1 | L  | F  | F  |   |
-    // |                2 |    | L  | F  | F |
-    // |                3 | F  |    | L  | F |
-    // |                4 | F  | F  |    | L |
-    // |                5 | L  | F  | F  |   |
+    // |                1 | 3  | 2  | 1  |   |
+    // |                2 |    | 3  | 2  | 1 |
+    // |                3 | 1  |    | 3  | 2 |
+    // |                4 | 2  | 1  |    | 3 |
+    // |                5 | 3  | 1  | 2  |   |
     // +------------------+----+----+----+---+
 
     communicationService = managementService.getMessagingService();
@@ -227,32 +231,6 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
 
               LOGGER.info("Stopped");
             });
-  }
-
-  private Collection<PartitionMetadata> buildPartitions() {
-    final List<MemberId> sorted =
-        new ArrayList<>(
-            config.getMembers().stream().map(MemberId::from).collect(Collectors.toSet()));
-    Collections.sort(sorted);
-
-    int partitionSize = this.partitionSize;
-    if (partitionSize == 0) {
-      partitionSize = sorted.size();
-    }
-
-    final int length = sorted.size();
-    final int count = Math.min(partitionSize, length);
-
-    final Set<PartitionMetadata> metadata = Sets.newHashSet();
-    for (int i = 0; i < partitions.size(); i++) {
-      final PartitionId partitionId = sortedPartitionIds.get(i);
-      final List<MemberId> membersForPartition = new ArrayList<>(count);
-      for (int j = 0; j < count; j++) {
-        membersForPartition.add(sorted.get((i + j) % length));
-      }
-      metadata.add(new PartitionMetadata(partitionId, membersForPartition));
-    }
-    return metadata;
   }
 
   /** Raft partition group type. */

--- a/atomix/cluster/src/test/java/io/atomix/raft/partition/PartitionDistributorTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/partition/PartitionDistributorTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.partition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class PartitionDistributorTest {
+
+  @ParameterizedTest(name = "[{index}] {0} {1} {2}")
+  @MethodSource("clusterConfig")
+  void shouldAssignPrioritiesCorrectly(
+      final int clusterSize,
+      final int partitionCount,
+      final int replicationFactor,
+      final int[][] expected) {
+    // when
+    final var partitionMetadata =
+        new PartitionDistributor()
+            .generatePartitionDistribution(
+                getMembers(clusterSize), getSortedPartitionIds(partitionCount), replicationFactor);
+
+    // then
+    assertThat(partitionMetadata).isNotEmpty();
+    partitionMetadata.forEach(
+        metadata -> {
+          final int partitionId = metadata.id().id();
+          metadata
+              .members()
+              .forEach(
+                  member -> {
+                    final int nodeId = Integer.parseInt(member.id());
+                    assertThat(metadata.getPriority(member))
+                        .describedAs(
+                            "Priority calculated wrong for nodeId %d, partition %d. Observed metadata is %s",
+                            nodeId, partitionId, metadata)
+                        .isEqualTo(expected[nodeId][partitionId - 1]);
+                  });
+        });
+  }
+
+  static Stream<Arguments> clusterConfig() {
+    return Stream.of(
+        Arguments.of(
+            3, // clusterSize
+            3, // partitionCount
+            3, // replicationFactor
+            // Expected partitionDistribution matrix row = nodes, column = partitions
+            new int[][] {
+              {3, 1, 2},
+              {2, 3, 1},
+              {1, 2, 3},
+            }),
+        Arguments.of(
+            3,
+            6,
+            3,
+            new int[][] {
+              {3, 1, 2, 3, 2, 1},
+              {2, 3, 1, 1, 3, 2},
+              {1, 2, 3, 2, 1, 3},
+            }),
+        Arguments.of(
+            6,
+            3,
+            3,
+            new int[][] {
+              {3, 0, 0},
+              {2, 3, 0},
+              {1, 2, 3},
+              {0, 1, 2},
+              {0, 0, 1},
+              {0, 0, 0},
+            }),
+        Arguments.of(
+            4,
+            12,
+            3,
+            new int[][] {
+              {3, 0, 1, 2, 3, 0, 2, 1, 3, 0, 1, 2},
+              {2, 3, 0, 1, 1, 3, 0, 2, 2, 3, 0, 1},
+              {1, 2, 3, 0, 2, 1, 3, 0, 1, 2, 3, 0},
+              {0, 1, 2, 3, 0, 2, 1, 3, 0, 1, 2, 3},
+            }));
+  }
+
+  private Collection<MemberId> getMembers(final int nodeCount) {
+    final Set<MemberId> members = new HashSet<>();
+    for (int i = 0; i < nodeCount; i++) {
+      members.add(MemberId.from(String.valueOf(i)));
+    }
+    return members;
+  }
+
+  private List<PartitionId> getSortedPartitionIds(final int partitionCount) {
+    final List<PartitionId> partitionIds = new ArrayList<>(partitionCount);
+    for (int i = 1; i <= partitionCount; i++) {
+      partitionIds.add(PartitionId.from("test", i));
+    }
+    return partitionIds;
+  }
+}


### PR DESCRIPTION
## Description

Priorities for nodes are calculated and assigned when the partition distribution is calculated. When priority election is enabled, this priority will be used. Otherwise the priority has no effect.

This PR is in preparation to #7285 

## Related issues

Related #7285 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
