### PR TITLE
Priority election in raft

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -26,6 +26,7 @@ import io.atomix.raft.cluster.RaftCluster;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.impl.DefaultRaftServer;
 import io.atomix.raft.impl.RaftContext;
+import io.atomix.raft.partition.RaftElectionConfig;
 import io.atomix.raft.protocol.RaftServerProtocol;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.RaftLog;
@@ -422,6 +423,7 @@ public interface RaftServer {
     protected EntryValidator entryValidator = new NoopEntryValidator();
     protected int maxAppendsPerFollower = 2;
     protected int maxAppendBatchSize = 32 * 1024;
+    protected RaftElectionConfig electionConfig = RaftElectionConfig.ofDefaultElection();
 
     protected Builder(final MemberId localMemberId) {
       this.localMemberId = checkNotNull(localMemberId, "localMemberId cannot be null");
@@ -553,6 +555,11 @@ public interface RaftServer {
 
     public Builder withEntryValidator(final EntryValidator entryValidator) {
       this.entryValidator = entryValidator;
+      return this;
+    }
+
+    public Builder withElectionConfig(final RaftElectionConfig electionConfig) {
+      this.electionConfig = electionConfig;
       return this;
     }
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -265,7 +265,8 @@ public class DefaultRaftServer implements RaftServer {
               singleThreadFactory,
               maxAppendBatchSize,
               maxAppendsPerFollower,
-              randomSupplier);
+              randomSupplier,
+              electionConfig);
       raft.setElectionTimeout(electionTimeout);
       raft.setHeartbeatInterval(heartbeatInterval);
       raft.setEntryValidator(entryValidator);

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/PriorityElectionTimer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/PriorityElectionTimer.java
@@ -75,6 +75,10 @@ public class PriorityElectionTimer implements ElectionTimer {
               });
       triggerElection.run();
     } else {
+      log.debug(
+          "Node priority {} < target priority {}. Not triggering election.",
+          nodePriority,
+          targetPriority);
       electionTimer =
           threadContext.schedule(
               pollTimeout,

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/PriorityElectionTimer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/PriorityElectionTimer.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.impl;
+
+import io.atomix.raft.ElectionTimer;
+import io.atomix.utils.concurrent.Scheduled;
+import io.atomix.utils.concurrent.ThreadContext;
+import java.time.Duration;
+import org.slf4j.Logger;
+
+public class PriorityElectionTimer implements ElectionTimer {
+
+  private Scheduled electionTimer;
+  private final Duration electionTimeout;
+  private final ThreadContext threadContext;
+  private final Runnable triggerElection;
+  private final Logger log;
+  private final int initialTargetPriority;
+  private final int nodePriority;
+  private int targetPriority;
+
+  public PriorityElectionTimer(
+      final Duration electionTimeout,
+      final ThreadContext threadContext,
+      final Runnable triggerElection,
+      final Logger log,
+      final int initialTargetPriority,
+      final int nodePriority) {
+    this.electionTimeout = electionTimeout;
+    this.threadContext = threadContext;
+    this.triggerElection = triggerElection;
+    this.log = log;
+    this.initialTargetPriority = initialTargetPriority;
+    this.nodePriority = nodePriority;
+    targetPriority = initialTargetPriority;
+  }
+
+  @Override
+  public void reset() {
+    cancel();
+    electionTimer = threadContext.schedule(electionTimeout, this::onElectionTimeout);
+    targetPriority = initialTargetPriority;
+  }
+
+  @Override
+  public void cancel() {
+    if (electionTimer != null) {
+      electionTimer.cancel();
+    }
+  }
+
+  private void onElectionTimeout() {
+    final Duration pollTimeout = electionTimeout;
+
+    if (nodePriority >= targetPriority) {
+      electionTimer =
+          threadContext.schedule(
+              pollTimeout,
+              () -> {
+                log.debug("Failed to poll a majority of the cluster in {}", pollTimeout);
+                reset();
+              });
+      triggerElection.run();
+    } else {
+      electionTimer =
+          threadContext.schedule(
+              pollTimeout,
+              () -> {
+                targetPriority = targetPriority - 1;
+                onElectionTimeout();
+              });
+    }
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -142,6 +142,12 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
         ContextualLoggerFactory.getLogger(
             getClass(), LoggerContext.builder(RaftServer.class).addValue(name).build());
     this.electionConfig = electionConfig;
+    if (electionConfig.isPriorityElectionEnabled()) {
+      log.debug(
+          "Priority election is enabled with target priority {} and node priority {}",
+          electionConfig.getInitialTargetPriority(),
+          electionConfig.getNodePriority());
+    }
 
     // Lock the storage directory.
     if (!storage.lock(localMemberId.id())) {

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -36,6 +36,7 @@ import io.atomix.raft.cluster.impl.RaftClusterContext;
 import io.atomix.raft.impl.zeebe.LogCompactor;
 import io.atomix.raft.metrics.RaftReplicationMetrics;
 import io.atomix.raft.metrics.RaftRoleMetrics;
+import io.atomix.raft.partition.RaftElectionConfig;
 import io.atomix.raft.protocol.RaftResponse;
 import io.atomix.raft.protocol.RaftServerProtocol;
 import io.atomix.raft.protocol.TransferRequest;
@@ -90,6 +91,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   protected final RaftServerProtocol protocol;
   protected final RaftStorage storage;
   private final Logger log;
+  private final RaftElectionConfig electionConfig;
   private final Set<RaftRoleChangeListener> roleChangeListeners = new CopyOnWriteArraySet<>();
   private final Set<Consumer<State>> stateChangeListeners = new CopyOnWriteArraySet<>();
   private final Set<Consumer<RaftMember>> electionListeners = new CopyOnWriteArraySet<>();
@@ -129,7 +131,8 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
       final RaftThreadContextFactory threadContextFactory,
       final int maxAppendBatchSize,
       final int maxAppendsPerFollower,
-      final Supplier<Random> randomFactory) {
+      final Supplier<Random> randomFactory,
+      final RaftElectionConfig electionConfig) {
     this.name = checkNotNull(name, "name cannot be null");
     this.membershipService = checkNotNull(membershipService, "membershipService cannot be null");
     this.protocol = checkNotNull(protocol, "protocol cannot be null");
@@ -138,6 +141,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     log =
         ContextualLoggerFactory.getLogger(
             getClass(), LoggerContext.builder(RaftServer.class).addValue(name).build());
+    this.electionConfig = electionConfig;
 
     // Lock the storage directory.
     if (!storage.lock(localMemberId.id())) {
@@ -582,8 +586,18 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   private ElectionTimer createElectionTimer(final Runnable triggerElection, final Logger log) {
-    return new RandomizedElectionTimer(
-        electionTimeout, threadContext, random, triggerElection, log);
+    if (electionConfig.isPriorityElectionEnabled()) {
+      return new PriorityElectionTimer(
+          electionTimeout,
+          threadContext,
+          triggerElection,
+          log,
+          electionConfig.getInitialTargetPriority(),
+          electionConfig.getNodePriority());
+    } else {
+      return new RandomizedElectionTimer(
+          electionTimeout, threadContext, random, triggerElection, log);
+    }
   }
 
   /** Transitions the server to the base state for the given member type. */

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftElectionConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftElectionConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.partition;
+
+public final class RaftElectionConfig {
+
+  private final boolean priorityElectionEnabled;
+  private final int initialTargetPriority;
+  private final int nodePriority;
+
+  private RaftElectionConfig(
+      final boolean priorityElectionEnabled,
+      final int initialTargetPriority,
+      final int nodePriority) {
+    this.priorityElectionEnabled = priorityElectionEnabled;
+    this.initialTargetPriority = initialTargetPriority;
+    this.nodePriority = nodePriority;
+  }
+
+  public static RaftElectionConfig ofPriorityElection(
+      final int initialTargetPriority, final int nodePriority) {
+    return new RaftElectionConfig(true, initialTargetPriority, nodePriority);
+  }
+
+  public static RaftElectionConfig ofDefaultElection() {
+    return new RaftElectionConfig(false, -1, -1);
+  }
+
+  public boolean isPriorityElectionEnabled() {
+    return priorityElectionEnabled;
+  }
+
+  public int getInitialTargetPriority() {
+    return initialTargetPriority;
+  }
+
+  public int getNodePriority() {
+    return nodePriority;
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -138,7 +138,8 @@ public class RaftPartition implements Partition, HealthMonitorable {
         config,
         managementService.getMembershipService().getLocalMember().id(),
         managementService.getMembershipService(),
-        managementService.getMessagingService());
+        managementService.getMessagingService(),
+        partitionMetadata);
   }
 
   /**

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -421,6 +421,11 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
       return this;
     }
 
+    public Builder withPriorityElection(final boolean enable) {
+      config.setPriorityElectionEnabled(enable);
+      return this;
+    }
+
     @Override
     public RaftPartitionGroup build() {
       return new RaftPartitionGroup(config);

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroupConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroupConfig.java
@@ -31,6 +31,7 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
   private static final int DEFAULT_PARTITIONS = 7;
   private static final Duration DEFAULT_ELECTION_TIMEOUT = Duration.ofMillis(2500);
   private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(250);
+  private static final boolean DEFAULT_PRIORITY_ELECTION = false;
 
   private Set<String> members = new HashSet<>();
   private int partitionSize;
@@ -39,6 +40,7 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
   private RaftStorageConfig storageConfig = new RaftStorageConfig();
   private int maxAppendsPerFollower = 2;
   private int maxAppendBatchSize = 32 * 1024;
+  private boolean priorityElectionEnabled = DEFAULT_PRIORITY_ELECTION;
 
   @Optional("EntryValidator")
   private EntryValidator entryValidator = new NoopEntryValidator();
@@ -187,5 +189,13 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
   @Override
   public PartitionGroup.Type getType() {
     return RaftPartitionGroup.TYPE;
+  }
+
+  public boolean isPriorityElectionEnabled() {
+    return priorityElectionEnabled;
+  }
+
+  public void setPriorityElectionEnabled(final boolean enable) {
+    priorityElectionEnabled = enable;
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.impl.RaftContext;
+import io.atomix.raft.partition.RaftElectionConfig;
 import io.atomix.raft.protocol.ControllableRaftServerProtocol;
 import io.atomix.raft.roles.LeaderRole;
 import io.atomix.raft.snapshot.TestSnapshotStore;
@@ -159,7 +160,8 @@ public final class ControllableRaftContexts {
             getRaftThreadContextFactory(memberId),
             32 * 1024, // Copied from defaults
             2, // Copied from defaults
-            () -> random);
+            () -> random,
+            RaftElectionConfig.ofDefaultElection());
     raft.setEntryValidator(new NoopEntryValidator());
     return raft;
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftPriorityElectionTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftPriorityElectionTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import io.atomix.raft.partition.RaftElectionConfig;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class RaftPriorityElectionTest {
+
+  @Rule @Parameter public RaftRule raftRule;
+
+  @Parameters(name = "{index}: {0}")
+  public static Object[][] raftConfigurations() {
+    return new Object[][] {
+      new Object[] {
+        RaftRule.withBootstrappedNodes(
+            3,
+            (member, builder) ->
+                // Assign node priority as the same value as nodeId
+                builder.withElectionConfig(
+                    RaftElectionConfig.ofPriorityElection(3, Integer.parseInt(member.id()) + 1)))
+      },
+      new Object[] {
+        RaftRule.withBootstrappedNodes(
+            4,
+            (member, builder) ->
+                builder.withElectionConfig(
+                    RaftElectionConfig.ofPriorityElection(4, Integer.parseInt(member.id()) + 1)))
+      },
+      new Object[] {
+        RaftRule.withBootstrappedNodes(
+            5,
+            (member, builder) ->
+                builder.withElectionConfig(
+                    RaftElectionConfig.ofPriorityElection(5, Integer.parseInt(member.id()) + 1)))
+      }
+    };
+  }
+
+  // Note: Priority election is not deterministic hence we cannot deterministically test if leaders
+  // are elected according to the priority. Instead here we only test that leader election succeeds.
+  @Test
+  public void shouldElectNewLeadersWhenLeaderUnavailable() throws Throwable {
+    // given
+    final int failureTolerance = (raftRule.getMemberIds().size() - 1) / 2;
+
+    for (int i = 0; i < failureTolerance; i++) {
+      raftRule.appendEntries(1);
+      // when
+      raftRule.shutdownLeader();
+
+      // then
+      raftRule.awaitNewLeader();
+    }
+  }
+}

--- a/atomix/cluster/src/test/java/io/atomix/raft/impl/PriorityElectionTimerTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/impl/PriorityElectionTimerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.impl;
+
+import io.atomix.utils.concurrent.SingleThreadContext;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PriorityElectionTimerTest {
+
+  private final Logger log = LoggerFactory.getLogger(PriorityElectionTimerTest.class);
+  private final SingleThreadContext threadContext = new SingleThreadContext("priorityElectionTest");
+
+  @After
+  public void after() {
+    threadContext.close();
+  }
+
+  @Test
+  public void shouldLowerPriorityNodeEventuallyStartsAnElection() {
+    // given
+    final AtomicInteger triggerCount = new AtomicInteger();
+
+    final PriorityElectionTimer timer =
+        new PriorityElectionTimer(
+            Duration.ofMillis(100), threadContext, triggerCount::getAndIncrement, log, 4, 1);
+
+    // when
+    timer.reset();
+
+    // then
+    Awaitility.await().until(() -> triggerCount.get() >= 1);
+  }
+
+  @Test
+  public void shouldHighPriorityNodeStartElectionFirst() {
+    // given
+    final AtomicBoolean highPrioElectionTriggered = new AtomicBoolean();
+    final int targetPriority = 4;
+    final PriorityElectionTimer timerHighPrio =
+        new PriorityElectionTimer(
+            Duration.ofMillis(100),
+            threadContext,
+            () -> highPrioElectionTriggered.set(true),
+            log,
+            targetPriority,
+            targetPriority);
+
+    final PriorityElectionTimer timerLowPrio =
+        new PriorityElectionTimer(
+            Duration.ofMillis(100), threadContext, timerHighPrio::cancel, log, targetPriority, 1);
+
+    // when
+    timerLowPrio.reset();
+    timerHighPrio.reset();
+
+    // then
+    Awaitility.await().until(highPrioElectionTriggered::get);
+  }
+}


### PR DESCRIPTION
## Description

* Implement priority election in raft
* Default is disabled
* Configurations to enable it would be done in a follow up PR

## Related issues

closes #7285 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
