### PR TITLE
Build ad-hoc test image when running locally

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Add files not required to build the docker image here to avoid rebuilding when modifying them
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+.git
+.worktree
+.idea
+.github
+docs
+**/target
+# make sure modifying tests doesn't force us to rebuild the image
+**/src/test
+**/*.md
+.dockerignore
+.editorconfig
+.gitignore
+.lgtm.yml
+bors.toml
+createBenchmark.sh
+Jenkinsfile
+**/*.iml
+
+
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,6 +44,9 @@ pipeline {
     environment {
         NEXUS = credentials("camunda-nexus")
         SONARCLOUD_TOKEN = credentials('zeebe-sonarcloud-token')
+
+        // ensure tests always use the pre-built Docker image instead of rebuilding it every time
+        ZEEBE_USE_EXISTING_DOCKER_IMAGE = "true"
     }
 
     triggers {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/ZeebeTestContainerDefaults.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/ZeebeTestContainerDefaults.java
@@ -7,15 +7,60 @@
  */
 package io.camunda.zeebe.test.util.testcontainers;
 
+import io.camunda.zeebe.util.Environment;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.utility.DockerImageName;
 
 public final class ZeebeTestContainerDefaults {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZeebeTestContainerDefaults.class);
   private static final DockerImageName DEFAULT_TEST_IMAGE =
       DockerImageName.parse("camunda/zeebe:current-test");
+  private static final boolean SHOULD_USE_EXISTING_IMAGE =
+      new Environment().getBool("ZEEBE_USE_EXISTING_DOCKER_IMAGE").orElse(false);
+  private static boolean builtLocalImage = false;
 
   private ZeebeTestContainerDefaults() {}
 
+  /**
+   * Returns the default Zeebe image to use for integration tests. If {@link
+   * #SHOULD_USE_EXISTING_IMAGE} is false (the default), it will build a fresh image from the code
+   * at most once.
+   */
   public static DockerImageName defaultTestImage() {
+    if (!SHOULD_USE_EXISTING_IMAGE) {
+      buildLocaLImage();
+    }
+
     return DEFAULT_TEST_IMAGE;
+  }
+
+  private static synchronized void buildLocaLImage() {
+    if (builtLocalImage) {
+      return;
+    }
+
+    final var dockerfile = Path.of("/home/nicolas/src/github.com/camunda-cloud/zeebe/Dockerfile");
+    final var image =
+        new ImageFromDockerfile(DEFAULT_TEST_IMAGE.asCanonicalNameString())
+            .withDockerfile(dockerfile)
+            .withBuildArg("BASE", "maven")
+            .withBuildArg("APP_ENV", "dev");
+
+    LOGGER.info("Building test image {} from {}", DEFAULT_TEST_IMAGE, dockerfile);
+
+    try {
+      image.get(10, TimeUnit.MINUTES);
+      builtLocalImage = true;
+    } catch (final TimeoutException e) {
+      LOGGER.warn(
+          "Timed out waiting to build the test Docker image {}; it may not exist",
+          DEFAULT_TEST_IMAGE,
+          e);
+    }
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7249 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
