### PR TITLE
Improve logging on election timeout

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RandomizedElectionTimer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RandomizedElectionTimer.java
@@ -21,12 +21,14 @@ import io.atomix.utils.concurrent.ThreadContext;
 import java.time.Duration;
 import java.util.Random;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An implementation of the default election in raft. It uses a randomized timeout to prevent
  * multiple nodes from starting the election at the same time.
  */
 public class RandomizedElectionTimer implements ElectionTimer {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RandomizedElectionTimer.class);
 
   private Scheduled electionTimer;
   private final Duration electionTimeout;
@@ -54,6 +56,7 @@ public class RandomizedElectionTimer implements ElectionTimer {
     final Duration delay =
         electionTimeout.plus(Duration.ofMillis(random.nextInt((int) electionTimeout.toMillis())));
     electionTimer = threadContext.schedule(delay, this::onElectionTimeout);
+    LOGGER.trace("Election timeout scheduled for {}", delay);
   }
 
   @Override

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractRole.java
@@ -55,17 +55,18 @@ public abstract class AbstractRole implements RaftRole {
    *
    * @return The Raft state represented by this state.
    */
+  @Override
   public abstract RaftServer.Role role();
 
   /** Logs a request. */
   protected final <R extends RaftRequest> R logRequest(final R request) {
-    log.debug("Received {}", request);
+    log.trace("Received {}", request);
     return request;
   }
 
   /** Logs a response. */
   protected final <R extends RaftResponse> R logResponse(final R response) {
-    log.debug("Sending {}", response);
+    log.trace("Sending {}", response);
     return response;
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -38,6 +38,7 @@ import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.utils.Quorum;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -46,9 +47,10 @@ import java.util.stream.Collectors;
 /** Follower state. */
 public final class FollowerRole extends ActiveRole {
 
-  private long lastHeartbeat;
   private final ElectionTimer electionTimer;
   private final ClusterMembershipEventListener clusterListener = this::handleClusterEvent;
+
+  private long lastHeartbeat;
 
   public FollowerRole(final RaftContext context, final ElectionTimerFactory electionTimerFactory) {
     super(context);
@@ -65,6 +67,7 @@ public final class FollowerRole extends ActiveRole {
     }
 
     raft.getMembershipService().addListener(clusterListener);
+    lastHeartbeat = System.currentTimeMillis();
     return super.start().thenRun(electionTimer::reset).thenApply(v -> this);
   }
 
@@ -122,9 +125,12 @@ public final class FollowerRole extends ActiveRole {
 
     // If there are no other members in the cluster, immediately transition to leader.
     if (votingMembers.isEmpty()) {
+      log.info("Transitioning to candidate as there are no known other active members");
       raft.transition(RaftServer.Role.CANDIDATE);
       return;
     }
+
+    log.info("Sending poll requests to all active members: {}", votingMembers);
 
     final Quorum quorum =
         new Quorum(
@@ -150,8 +156,6 @@ public final class FollowerRole extends ActiveRole {
     } else {
       lastTerm = 0;
     }
-
-    log.debug("Polling members {}", votingMembers);
 
     // Once we got the last log term, iterate through each current member
     // of the cluster and vote each member for a vote.
@@ -243,11 +247,14 @@ public final class FollowerRole extends ActiveRole {
     }
 
     if (raft.getFirstCommitIndex() == 0 || raft.getState() == RaftContext.State.READY) {
-      final long missTime = System.currentTimeMillis() - lastHeartbeat;
-      log.info(
-          "No heartbeat from {} in the last {}ms, sending poll requests",
-          raft.getLeader(),
-          missTime);
+      final var timeSinceLastHeartbeatMs = System.currentTimeMillis() - lastHeartbeat;
+      final var leader =
+          Optional.ofNullable(raft.getLeader())
+              .map(DefaultRaftMember::memberId)
+              .map(MemberId::id)
+              .orElse("a known leader");
+
+      log.info("No heartbeat from {} since {}ms", leader, timeSinceLastHeartbeatMs);
       raft.getRaftRoleMetrics().countHeartbeatMiss();
 
       raft.setLeader(null);


### PR DESCRIPTION
## Description

This PR improves logging when an election occurs due to missing heartbeats. This fixes the issue of having very high "time since last heartbeat" due when there are no heartbeats, and it also shows that there is no known leader instead of just showing null.

This also exposes the election timeout to display it, making a difference between the time out and when the last heartbeat was received.

Previously, the log message would look like this when there was no leader and no heartbeat had ever been sent:

```
2021-06-20 14:53:50.739 [] [raft-server-2-raft-partition-partition-1] INFO 
      io.atomix.raft.roles.FollowerRole - RaftServer{raft-partition-partition-1}{role=FOLLOWER} - No heartbeat from null in the last 1624200830739ms, sending poll requests
```

Now it will look like this:

```
2021-06-20 14:53:50.739 [] [raft-server-2-raft-partition-partition-1] INFO 
      io.atomix.raft.roles.FollowerRole - RaftServer{raft-partition-partition-1}{role=FOLLOWER} - No heartbeat from a known leader since 2603ms
```

Additionally, the sending poll requests part was split off, and when we send poll requests we will now log the following. If there are other known active members to poll:

```
10:59:21.175 [] [raft-server-1-raft-partition-partition-1] INFO
      io.atomix.raft.roles.FollowerRole - RaftServer{raft-partition-partition-1}{role=FOLLOWER} - Sending poll requests to all active members: [DefaultRaftMember{id=0, type=ACTIVE, updated=2021-06-23T08:59:18.475Z}, DefaultRaftMember{id=2, type=ACTIVE, updated=2021-06-23T08:59:18.475Z}]
```

If there are no other known active members to poll:

```
2021-06-20 14:53:50.739 [] [raft-server-2-raft-partition-partition-1] INFO 
      io.atomix.raft.roles.FollowerRole - RaftServer{raft-partition-partition-1}{role=FOLLOWER} - Transitioning to candidate as there are no known other active members
```

Finally, in Raft, we log every single request/response sent as debug. This creates tons of noise as we are sending lots and lots of requests. This PR lowers the log level of this to trace. We already log relevant debug information when handling polls/appends/etc., so it's pretty redundant.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
