### PR TITLE
Simplify partition service

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/primitive/partition/PartitionService.java
+++ b/atomix/cluster/src/main/java/io/atomix/primitive/partition/PartitionService.java
@@ -16,23 +16,13 @@
  */
 package io.atomix.primitive.partition;
 
-import java.util.Collection;
-
 /** Partition service. */
 public interface PartitionService {
 
   /**
    * Returns a partition group by name.
    *
-   * @param name the name of the partition group
    * @return the partition group
    */
-  PartitionGroup getPartitionGroup(String name);
-
-  /**
-   * Returns a collection of all partition groups.
-   *
-   * @return a collection of all partition groups
-   */
-  Collection<PartitionGroup> getPartitionGroups();
+  ManagedPartitionGroup getPartitionGroup();
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestNode.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestNode.java
@@ -23,7 +23,6 @@ import io.atomix.cluster.Node;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.cluster.discovery.NodeDiscoveryProvider;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
-import io.atomix.primitive.partition.ManagedPartitionGroup;
 import io.atomix.primitive.partition.ManagedPartitionService;
 import io.atomix.primitive.partition.impl.DefaultPartitionService;
 import io.atomix.raft.partition.RaftPartition;
@@ -32,8 +31,6 @@ import io.atomix.raft.partition.impl.RaftPartitionServer;
 import io.atomix.raft.snapshot.TestSnapshotStore;
 import java.io.File;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
@@ -70,7 +67,7 @@ public class ZeebeTestNode {
   }
 
   private RaftPartitionGroup getDataPartitionGroup() {
-    return (RaftPartitionGroup) partitionService.getPartitionGroup(DATA_PARTITION_GROUP_NAME);
+    return (RaftPartitionGroup) partitionService.getPartitionGroup();
   }
 
   public CompletableFuture<Void> start(final Collection<ZeebeTestNode> nodes) {
@@ -130,10 +127,8 @@ public class ZeebeTestNode {
   private ManagedPartitionService buildPartitionService(
       final ClusterMembershipService clusterMembershipService,
       final ClusterCommunicationService messagingService) {
-    final List<ManagedPartitionGroup> partitionGroups =
-        Collections.singletonList(dataPartitionGroup);
-
-    return new DefaultPartitionService(clusterMembershipService, messagingService, partitionGroups);
+    return new DefaultPartitionService(
+        clusterMembershipService, messagingService, dataPartitionGroup);
   }
 
   public CompletableFuture<Void> stop() {

--- a/atomix/core/src/main/java/io/atomix/core/AtomixBuilder.java
+++ b/atomix/core/src/main/java/io/atomix/core/AtomixBuilder.java
@@ -24,7 +24,6 @@ import io.atomix.cluster.discovery.NodeDiscoveryProvider;
 import io.atomix.cluster.protocol.GroupMembershipProtocol;
 import io.atomix.primitive.partition.ManagedPartitionGroup;
 import io.atomix.utils.net.Address;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Properties;
 
@@ -90,49 +89,12 @@ public class AtomixBuilder extends AtomixClusterBuilder {
    * <p>The partition groups can also be configured in {@code atomix.conf} under the {@code
    * partition-groups} key.
    *
-   * @param partitionGroups the partition groups
+   * @param partitionGroup the partition group
    * @return the Atomix builder
    * @throws NullPointerException if the partition groups are null
    */
-  public AtomixBuilder withPartitionGroups(final ManagedPartitionGroup... partitionGroups) {
-    return withPartitionGroups(
-        Arrays.asList(checkNotNull(partitionGroups, "partitionGroups cannot be null")));
-  }
-
-  /**
-   * Sets the primitive partition groups.
-   *
-   * <p>The primitive partition groups represent partitions that are directly accessible to
-   * distributed primitives. To use partitioned primitives, at least one node must be configured
-   * with at least one data partition group.
-   *
-   * <pre>{@code
-   * Atomix atomix = Atomix.builder()
-   *   .withPartitionGroups(PrimaryBackupPartitionGroup.builder("data")
-   *     .withNumPartitions(32)
-   *     .build())
-   *   .build();
-   *
-   * }</pre>
-   *
-   * The partition group name is used to uniquely identify the group when constructing primitive
-   * instances. Partitioned primitives will reference a specific protocol and partition group within
-   * which to replicate the primitive.
-   *
-   * <p>The configured partition groups are replicated on whichever nodes define them in this
-   * configuration. That is, this node will participate in whichever partition groups are provided
-   * to this method.
-   *
-   * <p>The partition groups can also be configured in {@code atomix.conf} under the {@code
-   * partition-groups} key.
-   *
-   * @param partitionGroups the partition groups
-   * @return the Atomix builder
-   * @throws NullPointerException if the partition groups are null
-   */
-  public AtomixBuilder withPartitionGroups(
-      final Collection<ManagedPartitionGroup> partitionGroups) {
-    partitionGroups.forEach(group -> atomixConfig.addPartitionGroup(group.config()));
+  public AtomixBuilder withPartitionGroup(final ManagedPartitionGroup partitionGroup) {
+    atomixConfig.setPartitionGroup(partitionGroup.config());
     return this;
   }
 

--- a/atomix/core/src/main/java/io/atomix/core/AtomixConfig.java
+++ b/atomix/core/src/main/java/io/atomix/core/AtomixConfig.java
@@ -19,14 +19,12 @@ package io.atomix.core;
 import io.atomix.cluster.ClusterConfig;
 import io.atomix.primitive.partition.PartitionGroupConfig;
 import io.atomix.utils.config.Config;
-import java.util.HashMap;
-import java.util.Map;
 
 /** Atomix configuration. */
 public class AtomixConfig implements Config {
 
   private final ClusterConfig cluster = new ClusterConfig();
-  private final Map<String, PartitionGroupConfig<?>> partitionGroups = new HashMap<>();
+  private PartitionGroupConfig<?> partitionGroup;
 
   /**
    * Returns the cluster configuration.
@@ -42,8 +40,8 @@ public class AtomixConfig implements Config {
    *
    * @return the partition group configurations
    */
-  Map<String, PartitionGroupConfig<?>> getPartitionGroups() {
-    return partitionGroups;
+  PartitionGroupConfig<?> getPartitionGroup() {
+    return partitionGroup;
   }
 
   /**
@@ -52,8 +50,8 @@ public class AtomixConfig implements Config {
    * @param partitionGroup the partition group configuration to add
    * @return the Atomix configuration
    */
-  AtomixConfig addPartitionGroup(final PartitionGroupConfig partitionGroup) {
-    partitionGroups.put(partitionGroup.getName(), partitionGroup);
+  AtomixConfig setPartitionGroup(final PartitionGroupConfig partitionGroup) {
+    this.partitionGroup = partitionGroup;
     return this;
   }
 }

--- a/atomix/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/atomix/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -62,7 +62,7 @@ public class AtomixTest {
                                       new NoopSnapshotStoreFactory()));
 
                   final var raftPartitionGroup = new RaftPartitionGroup(groupConfig);
-                  return builder.withPartitionGroups(raftPartitionGroup).build();
+                  return builder.withPartitionGroup(raftPartitionGroup).build();
                 })
             .get(TIMEOUT_IN_S, TimeUnit.SECONDS);
 

--- a/atomix/core/src/test/java/io/atomix/core/RaftRolesTest.java
+++ b/atomix/core/src/test/java/io/atomix/core/RaftRolesTest.java
@@ -274,16 +274,12 @@ public final class RaftRolesTest {
                   .withSnapshotStoreFactory(new NoopSnapshotStoreFactory())
                   .build();
 
-          final Atomix atomix = builder.withPartitionGroups(partitionGroup).build();
+          final Atomix atomix = builder.withPartitionGroup(partitionGroup).build();
 
           final DefaultPartitionService partitionService =
               (DefaultPartitionService) atomix.getPartitionService();
 
-          partitionService.getPartitionGroups().stream()
-              .findFirst()
-              .ifPresent(
-                  raftPartitionGroup ->
-                      raftPartitionGroup.getPartitions().forEach(partitionConsumer));
+          partitionService.getPartitionGroup().getPartitions().forEach(partitionConsumer);
           return atomix;
         });
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -371,8 +371,7 @@ public final class Broker implements AutoCloseable {
       final BrokerCfg brokerCfg, final ClusterCfg clusterCfg, final BrokerInfo localBroker)
       throws Exception {
     final RaftPartitionGroup partitionGroup =
-        (RaftPartitionGroup)
-            atomix.getPartitionService().getPartitionGroup(AtomixFactory.GROUP_NAME);
+        (RaftPartitionGroup) atomix.getPartitionService().getPartitionGroup();
 
     final MemberId nodeId = atomix.getMembershipService().getLocalMember().id();
     final List<RaftPartition> owningPartitions =

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -86,7 +86,7 @@ public final class AtomixFactory {
     final RaftPartitionGroup partitionGroup =
         createRaftPartitionGroup(configuration, rootDirectory, snapshotStoreFactory);
 
-    return atomixBuilder.withPartitionGroups(partitionGroup).build();
+    return atomixBuilder.withPartitionGroup(partitionGroup).build();
   }
 
   private static RaftPartitionGroup createRaftPartitionGroup(

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -7,11 +7,9 @@
  */
 package io.camunda.zeebe.broker.system.monitoring;
 
-import static io.camunda.zeebe.broker.clustering.atomix.AtomixFactory.GROUP_NAME;
-
 import io.atomix.cluster.MemberId;
 import io.atomix.core.Atomix;
-import io.atomix.raft.partition.RaftPartitionGroup;
+import io.atomix.primitive.partition.ManagedPartitionGroup;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.logstreams.log.LogStream;
@@ -113,8 +111,7 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
   }
 
   private void initializePartitionHealthStatus() {
-    final RaftPartitionGroup partitionGroup =
-        (RaftPartitionGroup) atomix.getPartitionService().getPartitionGroup(GROUP_NAME);
+    final ManagedPartitionGroup partitionGroup = atomix.getPartitionService().getPartitionGroup();
     final MemberId nodeId = atomix.getMembershipService().getLocalMember().id();
 
     partitionGroup.getPartitions().stream()
@@ -161,8 +158,7 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
   }
 
   private void initializePartitionInstallStatus() {
-    final RaftPartitionGroup partitionGroup =
-        (RaftPartitionGroup) atomix.getPartitionService().getPartitionGroup(GROUP_NAME);
+    final ManagedPartitionGroup partitionGroup = atomix.getPartitionService().getPartitionGroup();
     final MemberId nodeId = atomix.getMembershipService().getLocalMember().id();
 
     partitionInstallStatus =

--- a/broker/src/test/java/io/camunda/zeebe/broker/clustering/atomix/AtomixFactoryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/clustering/atomix/AtomixFactoryTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import io.atomix.core.Atomix;
-import io.atomix.raft.partition.RaftPartitionGroup;
+import io.atomix.primitive.partition.ManagedPartitionGroup;
 import io.atomix.raft.partition.RaftPartitionGroupConfig;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
@@ -60,9 +60,8 @@ public final class AtomixFactoryTest {
     assertThat(config.getStorageConfig().shouldFlushExplicitly()).isTrue();
   }
 
-  private RaftPartitionGroup getPartitionGroup(final Atomix atomix) {
-    return (RaftPartitionGroup)
-        atomix.getPartitionService().getPartitionGroup(AtomixFactory.GROUP_NAME);
+  private ManagedPartitionGroup getPartitionGroup(final Atomix atomix) {
+    return atomix.getPartitionService().getPartitionGroup();
   }
 
   private RaftPartitionGroupConfig getPartitionGroupConfig(final Atomix atomix) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerSnapshotTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerSnapshotTest.java
@@ -48,7 +48,7 @@ public class BrokerSnapshotTest {
                 .getBroker()
                 .getAtomix()
                 .getPartitionService()
-                .getPartitionGroup(AtomixFactory.GROUP_NAME)
+                .getPartitionGroup()
                 .getPartition(PartitionId.from(AtomixFactory.GROUP_NAME, PARTITION_ID));
     journalReader = raftPartition.getServer().openReader(Mode.COMMITS);
     brokerAdminService = brokerRule.getBroker().getBrokerAdminService();

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/clustering/ClusteringRule.java
@@ -579,11 +579,7 @@ public final class ClusteringRule extends ExternalResource {
     final MemberId nodeId = atomix.getMembershipService().getLocalMember().id();
 
     final var raftPartition =
-        atomix
-            .getPartitionService()
-            .getPartitionGroup(AtomixFactory.GROUP_NAME)
-            .getPartitions()
-            .stream()
+        atomix.getPartitionService().getPartitionGroup().getPartitions().stream()
             .filter(partition -> partition.members().contains(nodeId))
             .filter(partition -> partition.id().id() == partitionId)
             .map(RaftPartition.class::cast)

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/health/HealthMonitoringTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/health/HealthMonitoringTest.java
@@ -41,7 +41,7 @@ public class HealthMonitoringTest {
             leader
                 .getAtomix()
                 .getPartitionService()
-                .getPartitionGroup(GROUP_NAME)
+                .getPartitionGroup()
                 .getPartition(PartitionId.from(GROUP_NAME, START_PARTITION_ID));
     raftPartition.getServer().stop();
 


### PR DESCRIPTION
## Description

This simplifies the partition service. It gets rid of the map of partition groups and instead uses one partition group.

Review comments:
I would love to hear your opinion on the second commit. The second commit is to fix the failing tests. I am of two minds about the change.

On the one hand the behavior of `DefaultPartitionService` is very similar to the original behavior in the sense that both an empty list of partition groups and a partition group which is `null` is essentially a NOP. On the other hand, in productive code I expect this partition group to never be null. So in order to move the code forward, we could also require it to be not null.

Then we would have to provide a partition group in all the tests that were failing. Here again, on the one hand, I am reluctant to do that because we want to make the tests smaller and reduce test dependencies. But on the other hand the failing tests are precisely integration tests, where I think it is prudent to provide a full configuration.

In the end, I went back and forth on this, and decided to implement the small change set in `DefaultPartitionService` for now. I still want to look at the tests and how to improve them as I get deeper into the topic. 

Still, interested in your thoughts on the matter.

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
