### PR TITLE
refactor(broker): use set instead of list for listeners

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/DiskSpaceUsageMonitor.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/DiskSpaceUsageMonitor.java
@@ -13,13 +13,13 @@ import io.camunda.zeebe.broker.system.configuration.DataCfg;
 import io.camunda.zeebe.util.sched.Actor;
 import java.io.File;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.LongSupplier;
 
 public class DiskSpaceUsageMonitor extends Actor {
 
-  private final List<DiskSpaceUsageListener> diskSpaceUsageListeners = new ArrayList<>();
+  private final Set<DiskSpaceUsageListener> diskSpaceUsageListeners = new HashSet<>();
   private boolean currentDiskAvailableStatus = true;
   private LongSupplier freeDiskSpaceSupplier;
   private final Duration monitoringDelay;


### PR DESCRIPTION
## Description

Previously, it was possible for listeners to register more than once. This would also lead to listeners getting notified more than once.


<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
