### PR TITLE
Unpack atomix dependencies

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/primitive/partition/PartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/primitive/partition/PartitionGroup.java
@@ -17,12 +17,14 @@
 package io.atomix.primitive.partition;
 
 import com.google.common.hash.Hashing;
+import io.atomix.cluster.MemberId;
 import io.atomix.utils.NamedType;
 import io.atomix.utils.config.Configured;
 import io.atomix.utils.serializer.Namespace;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /** Primitive partition group. */
 public interface PartitionGroup extends Configured<PartitionGroupConfig> {
@@ -67,6 +69,12 @@ public interface PartitionGroup extends Configured<PartitionGroupConfig> {
    * @return a sorted list of partition IDs
    */
   List<PartitionId> getPartitionIds();
+
+  default List<Partition> getPartitionsWithMember(final MemberId memberId) {
+    return getPartitions().stream()
+        .filter(partition -> partition.members().contains(memberId))
+        .collect(Collectors.toList());
+  }
 
   /** Partition group builder. */
   abstract class Builder<C extends PartitionGroupConfig<C>>

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -222,7 +222,13 @@ public final class Broker implements AutoCloseable {
       startContext.addStep(
           "embedded gateway",
           () -> {
-            embeddedGatewayService = new EmbeddedGatewayService(brokerCfg, scheduler, atomix);
+            embeddedGatewayService =
+                new EmbeddedGatewayService(
+                    brokerCfg,
+                    scheduler,
+                    atomix.getMessagingService(),
+                    atomix.getMembershipService(),
+                    atomix.getEventService());
             return embeddedGatewayService;
           });
     }

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -348,8 +348,7 @@ public final class Broker implements AutoCloseable {
 
   private AutoCloseable monitoringServerStep(final BrokerInfo localBroker) {
     healthCheckService =
-        new BrokerHealthCheckService(localBroker,
-            atomix.getPartitionService().getPartitionGroup());
+        new BrokerHealthCheckService(localBroker, atomix.getPartitionService().getPartitionGroup());
     springBrokerBridge.registerBrokerHealthCheckServiceSupplier(() -> healthCheckService);
     partitionListeners.add(healthCheckService);
     scheduleActor(healthCheckService);
@@ -414,8 +413,7 @@ public final class Broker implements AutoCloseable {
                     commandHandler,
                     snapshotStoreSupplier,
                     createFactory(
-                        topologyManager, brokerCfg.getCluster(), atomix,
-                        managementRequestHandler),
+                        topologyManager, brokerCfg.getCluster(), atomix, managementRequestHandler),
                     buildExporterRepository(brokerCfg),
                     new PartitionProcessingState(owningPartition));
             final PartitionTransitionImpl transitionBehavior =
@@ -472,7 +470,7 @@ public final class Broker implements AutoCloseable {
 
       final DeploymentDistributorImpl deploymentDistributor =
           new DeploymentDistributorImpl(
-              atomix, partitionListener, zeebeState.getDeploymentState(), actor);
+              atomix.getCommunicationService(), atomix.getEventService(), partitionListener, actor);
 
       final PartitionCommandSenderImpl partitionCommandSender =
           new PartitionCommandSenderImpl(atomix, topologyManager, actor);

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -348,7 +348,8 @@ public final class Broker implements AutoCloseable {
 
   private AutoCloseable monitoringServerStep(final BrokerInfo localBroker) {
     healthCheckService =
-        new BrokerHealthCheckService(localBroker, atomix.getPartitionService().getPartitionGroup());
+        new BrokerHealthCheckService(localBroker,
+            atomix.getPartitionService().getPartitionGroup());
     springBrokerBridge.registerBrokerHealthCheckServiceSupplier(() -> healthCheckService);
     partitionListeners.add(healthCheckService);
     scheduleActor(healthCheckService);
@@ -413,7 +414,8 @@ public final class Broker implements AutoCloseable {
                     commandHandler,
                     snapshotStoreSupplier,
                     createFactory(
-                        topologyManager, brokerCfg.getCluster(), atomix, managementRequestHandler),
+                        topologyManager, brokerCfg.getCluster(), atomix,
+                        managementRequestHandler),
                     buildExporterRepository(brokerCfg),
                     new PartitionProcessingState(owningPartition));
             final PartitionTransitionImpl transitionBehavior =
@@ -519,6 +521,8 @@ public final class Broker implements AutoCloseable {
     return embeddedGatewayService;
   }
 
+  // only used for tests
+  @Deprecated
   public Atomix getAtomix() {
     return atomix;
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -348,8 +348,7 @@ public final class Broker implements AutoCloseable {
 
   private AutoCloseable monitoringServerStep(final BrokerInfo localBroker) {
     healthCheckService =
-        new BrokerHealthCheckService(localBroker,
-            atomix.getPartitionService().getPartitionGroup());
+        new BrokerHealthCheckService(localBroker, atomix.getPartitionService().getPartitionGroup());
     springBrokerBridge.registerBrokerHealthCheckServiceSupplier(() -> healthCheckService);
     partitionListeners.add(healthCheckService);
     scheduleActor(healthCheckService);
@@ -384,9 +383,9 @@ public final class Broker implements AutoCloseable {
         (RaftPartitionGroup) atomix.getPartitionService().getPartitionGroup();
 
     final MemberId nodeId = atomix.getMembershipService().getLocalMember().id();
+
     final List<RaftPartition> owningPartitions =
-        partitionGroup.getPartitions().stream()
-            .filter(partition -> partition.members().contains(nodeId))
+        partitionGroup.getPartitionsWithMember(nodeId).stream()
             .map(RaftPartition.class::cast)
             .collect(Collectors.toList());
 
@@ -414,8 +413,7 @@ public final class Broker implements AutoCloseable {
                     commandHandler,
                     snapshotStoreSupplier,
                     createFactory(
-                        topologyManager, brokerCfg.getCluster(), atomix,
-                        managementRequestHandler),
+                        topologyManager, brokerCfg.getCluster(), atomix, managementRequestHandler),
                     buildExporterRepository(brokerCfg),
                     new PartitionProcessingState(owningPartition));
             final PartitionTransitionImpl transitionBehavior =

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -349,7 +349,8 @@ public final class Broker implements AutoCloseable {
 
   private AutoCloseable monitoringServerStep(final BrokerInfo localBroker) {
     healthCheckService =
-        new BrokerHealthCheckService(localBroker, atomix.getPartitionService().getPartitionGroup());
+        new BrokerHealthCheckService(localBroker,
+            atomix.getPartitionService().getPartitionGroup());
     springBrokerBridge.registerBrokerHealthCheckServiceSupplier(() -> healthCheckService);
     partitionListeners.add(healthCheckService);
     scheduleActor(healthCheckService);
@@ -369,7 +370,9 @@ public final class Broker implements AutoCloseable {
   }
 
   private AutoCloseable managementRequestStep(final BrokerInfo localBroker) {
-    managementRequestHandler = new LeaderManagementRequestHandler(localBroker, atomix);
+    managementRequestHandler =
+        new LeaderManagementRequestHandler(
+            localBroker, atomix.getCommunicationService(), atomix.getEventService());
     scheduleActor(managementRequestHandler);
     partitionListeners.add(managementRequestHandler);
     diskSpaceUsageListeners.add(managementRequestHandler);
@@ -412,7 +415,8 @@ public final class Broker implements AutoCloseable {
                     brokerCfg,
                     commandHandler,
                     snapshotStoreSupplier,
-                    createFactory(topologyManager, clusterCfg, atomix, managementRequestHandler),
+                    createFactory(topologyManager, clusterCfg, atomix,
+                        managementRequestHandler),
                     buildExporterRepository(brokerCfg),
                     new PartitionProcessingState(owningPartition));
             final PartitionTransitionImpl transitionBehavior =

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -473,7 +473,7 @@ public final class Broker implements AutoCloseable {
               atomix.getCommunicationService(), atomix.getEventService(), partitionListener, actor);
 
       final PartitionCommandSenderImpl partitionCommandSender =
-          new PartitionCommandSenderImpl(atomix, topologyManager, actor);
+          new PartitionCommandSenderImpl(atomix.getCommunicationService(), topologyManager, actor);
       final SubscriptionCommandSender subscriptionCommandSender =
           new SubscriptionCommandSender(stream.getPartitionId(), partitionCommandSender);
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -348,7 +348,8 @@ public final class Broker implements AutoCloseable {
   }
 
   private AutoCloseable monitoringServerStep(final BrokerInfo localBroker) {
-    healthCheckService = new BrokerHealthCheckService(localBroker, atomix);
+    healthCheckService =
+        new BrokerHealthCheckService(localBroker, atomix.getPartitionService().getPartitionGroup());
     springBrokerBridge.registerBrokerHealthCheckServiceSupplier(() -> healthCheckService);
     partitionListeners.add(healthCheckService);
     scheduleActor(healthCheckService);

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -340,7 +340,8 @@ public final class Broker implements AutoCloseable {
 
   private AutoCloseable topologyManagerStep(
       final ClusterCfg clusterCfg, final BrokerInfo localBroker) {
-    topologyManager = new TopologyManagerImpl(atomix, localBroker, clusterCfg);
+    topologyManager =
+        new TopologyManagerImpl(atomix.getMembershipService(), localBroker, clusterCfg);
     partitionListeners.add(topologyManager);
     scheduleActor(topologyManager);
     return topologyManager;

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -319,7 +319,8 @@ public final class Broker implements AutoCloseable {
 
   private AutoCloseable subscriptionAPIStep(final BrokerInfo localBroker) {
     final SubscriptionApiCommandMessageHandlerService messageHandlerService =
-        new SubscriptionApiCommandMessageHandlerService(localBroker, atomix);
+        new SubscriptionApiCommandMessageHandlerService(
+            localBroker, atomix.getCommunicationService());
     partitionListeners.add(messageHandlerService);
     scheduleActor(messageHandlerService);
     diskSpaceUsageListeners.add(messageHandlerService);

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -236,8 +236,7 @@ public final class Broker implements AutoCloseable {
     startContext.addStep("disk space monitor", () -> diskSpaceMonitorStep(brokerCfg.getData()));
     startContext.addStep(
         "leader management request handler", () -> managementRequestStep(localBroker));
-    startContext.addStep(
-        "zeebe partitions", () -> partitionsStep(brokerCfg, clusterCfg, localBroker));
+    startContext.addStep("zeebe partitions", () -> partitionsStep(brokerCfg, localBroker));
     startContext.addStep("register diskspace usage listeners", this::addDiskSpaceUsageListeners);
     startContext.addStep("upgrade manager", this::addBrokerAdminService);
 
@@ -379,8 +378,7 @@ public final class Broker implements AutoCloseable {
     return managementRequestHandler;
   }
 
-  private AutoCloseable partitionsStep(
-      final BrokerCfg brokerCfg, final ClusterCfg clusterCfg, final BrokerInfo localBroker)
+  private AutoCloseable partitionsStep(final BrokerCfg brokerCfg, final BrokerInfo localBroker)
       throws Exception {
     final RaftPartitionGroup partitionGroup =
         (RaftPartitionGroup) atomix.getPartitionService().getPartitionGroup();
@@ -415,7 +413,8 @@ public final class Broker implements AutoCloseable {
                     brokerCfg,
                     commandHandler,
                     snapshotStoreSupplier,
-                    createFactory(topologyManager, clusterCfg, atomix,
+                    createFactory(
+                        topologyManager, brokerCfg.getCluster(), atomix,
                         managementRequestHandler),
                     buildExporterRepository(brokerCfg),
                     new PartitionProcessingState(owningPartition));

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
@@ -24,7 +24,14 @@ public final class EmbeddedGatewayService implements AutoCloseable {
   public EmbeddedGatewayService(
       final BrokerCfg configuration, final ActorScheduler actorScheduler, final Atomix atomix) {
     final Function<GatewayCfg, BrokerClient> brokerClientFactory =
-        cfg -> new BrokerClientImpl(cfg, atomix, actorScheduler, false);
+        cfg ->
+            new BrokerClientImpl(
+                cfg,
+                atomix.getMessagingService(),
+                atomix.getMembershipService(),
+                atomix.getEventService(),
+                actorScheduler,
+                false);
     gateway = new Gateway(configuration.getGateway(), brokerClientFactory, actorScheduler);
     startGateway();
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.broker.system;
 
-import io.atomix.core.Atomix;
+import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.cluster.messaging.ClusterEventService;
+import io.atomix.cluster.messaging.MessagingService;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.gateway.Gateway;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
@@ -22,16 +24,15 @@ public final class EmbeddedGatewayService implements AutoCloseable {
   private final Gateway gateway;
 
   public EmbeddedGatewayService(
-      final BrokerCfg configuration, final ActorScheduler actorScheduler, final Atomix atomix) {
+      final BrokerCfg configuration,
+      final ActorScheduler actorScheduler,
+      final MessagingService messagingService,
+      final ClusterMembershipService membershipService,
+      final ClusterEventService eventService) {
     final Function<GatewayCfg, BrokerClient> brokerClientFactory =
         cfg ->
             new BrokerClientImpl(
-                cfg,
-                atomix.getMessagingService(),
-                atomix.getMembershipService(),
-                atomix.getEventService(),
-                actorScheduler,
-                false);
+                cfg, messagingService, membershipService, eventService, actorScheduler, false);
     gateway = new Gateway(configuration.getGateway(), brokerClientFactory, actorScheduler);
     startGateway();
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/management/deployment/PushDeploymentRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/management/deployment/PushDeploymentRequestHandler.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.management.deployment;
 
-import io.atomix.core.Atomix;
+import io.atomix.cluster.messaging.ClusterEventService;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.engine.impl.DeploymentDistributorImpl;
 import io.camunda.zeebe.clustering.management.MessageHeaderDecoder;
@@ -43,15 +43,15 @@ public final class PushDeploymentRequestHandler
 
   private final Int2ObjectHashMap<LogStreamRecordWriter> leaderPartitions;
   private final ActorControl actor;
-  private final Atomix atomix;
+  private final ClusterEventService eventService;
 
   public PushDeploymentRequestHandler(
       final Int2ObjectHashMap<LogStreamRecordWriter> leaderPartitions,
       final ActorControl actor,
-      final Atomix atomix) {
+      final ClusterEventService eventService) {
     this.leaderPartitions = leaderPartitions;
     this.actor = actor;
-    this.atomix = atomix;
+    this.eventService = eventService;
   }
 
   @Override
@@ -96,7 +96,7 @@ public final class PushDeploymentRequestHandler
     final String topic =
         DeploymentDistributorImpl.getDeploymentResponseTopic(deploymentKey, partitionId);
 
-    atomix.getEventService().broadcast(topic, deploymentResponse.toBytes());
+    eventService.broadcast(topic, deploymentResponse.toBytes());
     LOG.trace("Send deployment response on topic {} for partition {}", topic, partitionId);
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -8,8 +8,7 @@
 package io.camunda.zeebe.broker.system.monitoring;
 
 import io.atomix.cluster.MemberId;
-import io.atomix.core.Atomix;
-import io.atomix.primitive.partition.ManagedPartitionGroup;
+import io.atomix.primitive.partition.PartitionGroup;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.logstreams.log.LogStream;
@@ -93,7 +92,6 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
 
   private static final String PARTITION_COMPONENT_NAME_FORMAT = "Partition-%d";
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
-  private final Atomix atomix;
   private final String actorName;
   private Map<Integer, Boolean> partitionInstallStatus;
   /* set to true when all partitions are installed. Once set to true, it is never
@@ -101,19 +99,20 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
   private volatile boolean allPartitionsInstalled = false;
   private volatile boolean brokerStarted = false;
   private final HealthMonitor healthMonitor;
+  private final MemberId nodeId;
+  private final PartitionGroup partitionGroup;
 
-  public BrokerHealthCheckService(final BrokerInfo localBroker, final Atomix atomix) {
-    this.atomix = atomix;
+  public BrokerHealthCheckService(
+      final BrokerInfo localBroker, final PartitionGroup partitionGroup) {
+    this.partitionGroup = partitionGroup;
     actorName = buildActorName(localBroker.getNodeId(), "HealthCheckService");
+    nodeId = MemberId.from(String.valueOf(localBroker.getNodeId()));
     healthMonitor = new CriticalComponentsHealthMonitor(actor, LOG);
     initializePartitionInstallStatus();
     initializePartitionHealthStatus();
   }
 
   private void initializePartitionHealthStatus() {
-    final ManagedPartitionGroup partitionGroup = atomix.getPartitionService().getPartitionGroup();
-    final MemberId nodeId = atomix.getMembershipService().getLocalMember().id();
-
     partitionGroup.getPartitions().stream()
         .filter(partition -> partition.members().contains(nodeId))
         .map(partition -> partition.id().id())
@@ -158,9 +157,6 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
   }
 
   private void initializePartitionInstallStatus() {
-    final ManagedPartitionGroup partitionGroup = atomix.getPartitionService().getPartitionGroup();
-    final MemberId nodeId = atomix.getMembershipService().getLocalMember().id();
-
     partitionInstallStatus =
         partitionGroup.getPartitions().stream()
             .filter(partition -> partition.members().contains(nodeId))

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -113,8 +113,7 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
   }
 
   private void initializePartitionHealthStatus() {
-    partitionGroup.getPartitions().stream()
-        .filter(partition -> partition.members().contains(nodeId))
+    partitionGroup.getPartitionsWithMember(nodeId).stream()
         .map(partition -> partition.id().id())
         .forEach(
             partitionId ->

--- a/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
@@ -46,7 +46,14 @@ public class StandaloneGateway {
     atomixCluster = createAtomixCluster(gatewayCfg.getCluster());
     actorScheduler = createActorScheduler(gatewayCfg);
     final Function<GatewayCfg, BrokerClient> brokerClientFactory =
-        cfg -> new BrokerClientImpl(cfg, atomixCluster, actorScheduler, false);
+        cfg ->
+            new BrokerClientImpl(
+                cfg,
+                atomixCluster.getMessagingService(),
+                atomixCluster.getMembershipService(),
+                atomixCluster.getEventService(),
+                actorScheduler,
+                false);
     gateway = new Gateway(gatewayCfg, brokerClientFactory, actorScheduler);
 
     springGatewayBridge.registerGatewayStatusSupplier(gateway::getStatus);

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.gateway;
 
-import io.atomix.cluster.AtomixCluster;
+import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.cluster.messaging.ClusterEventService;
+import io.atomix.cluster.messaging.MessagingService;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
@@ -49,16 +51,13 @@ public final class Gateway {
 
   public Gateway(
       final GatewayCfg gatewayCfg,
-      final AtomixCluster atomixCluster,
+      final MessagingService messagingService,
+      final ClusterMembershipService membershipService,
+      final ClusterEventService eventService,
       final ActorScheduler actorScheduler) {
     this(
         gatewayCfg,
-        cfg ->
-            new BrokerClientImpl(
-                cfg,
-                atomixCluster.getMessagingService(),
-                atomixCluster.getMembershipService(),
-                atomixCluster.getEventService()),
+        cfg -> new BrokerClientImpl(cfg, messagingService, membershipService, eventService),
         DEFAULT_SERVER_BUILDER_FACTORY,
         actorScheduler);
   }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -45,7 +45,6 @@ public final class Gateway {
   private Server server;
   private BrokerClient brokerClient;
 
-  @SuppressWarnings("squid:S3077")
   private volatile Status status = Status.INITIAL;
 
   public Gateway(
@@ -54,7 +53,12 @@ public final class Gateway {
       final ActorScheduler actorScheduler) {
     this(
         gatewayCfg,
-        cfg -> new BrokerClientImpl(cfg, atomixCluster),
+        cfg ->
+            new BrokerClientImpl(
+                cfg,
+                atomixCluster.getMessagingService(),
+                atomixCluster.getMembershipService(),
+                atomixCluster.getEventService()),
         DEFAULT_SERVER_BUILDER_FACTORY,
         actorScheduler);
   }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
@@ -54,7 +54,13 @@ class UnavailableBrokersTest {
     actorScheduler = ActorScheduler.newActorScheduler().build();
     actorScheduler.start();
 
-    gateway = new Gateway(new GatewayCfg().setNetwork(networkCfg), cluster, actorScheduler);
+    gateway =
+        new Gateway(
+            new GatewayCfg().setNetwork(networkCfg),
+            cluster.getMessagingService(),
+            cluster.getMembershipService(),
+            cluster.getEventService(),
+            actorScheduler);
     gateway.start();
 
     final String gatewayAddress = NetUtil.toSocketAddressString(networkCfg.toSocketAddress());

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/broker/BrokerClientTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/broker/BrokerClientTest.java
@@ -93,7 +93,13 @@ public final class BrokerClientTest {
             .build();
     atomixCluster.start().join();
 
-    client = new BrokerClientImpl(configuration, atomixCluster, clock);
+    client =
+        new BrokerClientImpl(
+            configuration,
+            atomixCluster.getMessagingService(),
+            atomixCluster.getMembershipService(),
+            atomixCluster.getEventService(),
+            clock);
 
     final BrokerClusterStateImpl topology = new BrokerClusterStateImpl();
     topology.addPartitionIfAbsent(START_PARTITION_ID);

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
@@ -47,9 +47,7 @@ public final class SecurityTest {
             cfg.getSecurity().getCertificateChainPath()));
 
     // when
-    gateway =
-        new Gateway(
-            cfg, AtomixCluster.builder().build(), ActorScheduler.newActorScheduler().build());
+    gateway = buildGateway(cfg);
     gateway.start();
   }
 
@@ -69,9 +67,7 @@ public final class SecurityTest {
             cfg.getSecurity().getPrivateKeyPath()));
 
     // when
-    gateway =
-        new Gateway(
-            cfg, AtomixCluster.builder().build(), ActorScheduler.newActorScheduler().build());
+    gateway = buildGateway(cfg);
     gateway.start();
   }
 
@@ -88,9 +84,7 @@ public final class SecurityTest {
             + "Edit the gateway configuration file to provide one or to disable TLS.");
 
     // when
-    gateway =
-        new Gateway(
-            cfg, AtomixCluster.builder().build(), ActorScheduler.newActorScheduler().build());
+    gateway = buildGateway(cfg);
     gateway.start();
   }
 
@@ -107,9 +101,7 @@ public final class SecurityTest {
             + "Edit the gateway configuration file to provide one or to disable TLS.");
 
     // when
-    gateway =
-        new Gateway(
-            cfg, AtomixCluster.builder().build(), ActorScheduler.newActorScheduler().build());
+    gateway = buildGateway(cfg);
     gateway.start();
   }
 
@@ -129,5 +121,15 @@ public final class SecurityTest {
                         .getClassLoader()
                         .getResource("security/test-server.key.pem")
                         .getPath()));
+  }
+
+  private Gateway buildGateway(final GatewayCfg gatewayCfg) {
+    final var atomix = AtomixCluster.builder().build();
+    return new Gateway(
+        gatewayCfg,
+        atomix.getMessagingService(),
+        atomix.getMembershipService(),
+        atomix.getEventService(),
+        ActorScheduler.newActorScheduler().build());
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -50,7 +50,6 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 
 // TODO: This will be fixed in the https://github.com/zeebe-io/zeebe/issues/5640
-@SuppressWarnings({"squid:S1200", "squid:S1448"})
 public final class BrokerInfo implements BufferReader, BufferWriter {
 
   private static final String BROKER_INFO_PROPERTY_NAME = "brokerInfo";
@@ -234,7 +233,6 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   }
 
   // TODO: This will be fixed in the https://github.com/zeebe-io/zeebe/issues/5640
-  @SuppressWarnings("squid:S138")
   @Override
   public void wrap(final DirectBuffer buffer, int offset, final int length) {
     reset();
@@ -330,7 +328,6 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   }
 
   // TODO: This will be fixed in the https://github.com/zeebe-io/zeebe/issues/5640
-  @SuppressWarnings("squid:S138")
   @Override
   public void write(final MutableDirectBuffer buffer, int offset) {
     headerEncoder

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/clustering/ClusteringRule.java
@@ -376,7 +376,13 @@ public final class ClusteringRule extends ExternalResource {
 
     actorScheduler.start();
 
-    final Gateway gateway = new Gateway(gatewayCfg, atomixCluster, actorScheduler);
+    final Gateway gateway =
+        new Gateway(
+            gatewayCfg,
+            atomixCluster.getMessagingService(),
+            atomixCluster.getMembershipService(),
+            atomixCluster.getEventService(),
+            actorScheduler);
     closeables.manage(gateway::stop);
     closeables.manage(atomixCluster::stop);
     closeables.manage(actorScheduler::stop);

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/gateway/GatewayIntegrationTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/gateway/GatewayIntegrationTest.java
@@ -53,7 +53,13 @@ public final class GatewayIntegrationTest {
 
     final ControlledActorClock clock = new ControlledActorClock();
     final AtomixCluster atomixCluster = broker.getAtomix();
-    client = new BrokerClientImpl(configuration, atomixCluster, clock);
+    client =
+        new BrokerClientImpl(
+            configuration,
+            atomixCluster.getMessagingService(),
+            atomixCluster.getMembershipService(),
+            atomixCluster.getEventService(),
+            clock);
   }
 
   @After


### PR DESCRIPTION
## Description

So basically, this PR unpacks any dependency to atomix in the broker and gateway modules. Whenever there was a dependency on Atomix, I looked at which bits of Atomix are actually needed and lifted those out. The purpose is to get a clearer picture of the dependencies between components, and ultimate to untangle the bootstrap sequence.

Review hints:
We do not need to merge this PR. We can also keep it as a separate branch and the whole exercise was just to gain more insight into the dependencies.

However, having gone through the exercise, I quite like this level of granularity of dependencies for a time being. I also think it is a good first step toward better testability and dependency injection through constructor injection.

<!-- Cut-off marker
## Definition of Ready

* [ ] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
