### PR TITLE
Fix flakiness in AdvertisedAddressTest

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -632,22 +632,13 @@
         <version>${version.asm}</version>
       </dependency>
 
+      <!-- Testcontainers & Docker for container based integration tests -->
       <dependency>
         <groupId>org.testcontainers</groupId>
-        <artifactId>testcontainers</artifactId>
+        <artifactId>testcontainers-bom</artifactId>
         <version>${version.testcontainers}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>elasticsearch</artifactId>
-        <version>${version.testcontainers}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>toxiproxy</artifactId>
-        <version>${version.testcontainers}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
 
       <dependency>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -165,6 +165,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol-asserts</artifactId>
       <scope>test</scope>

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/network/AdvertisedAddressTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/network/AdvertisedAddressTest.java
@@ -9,8 +9,6 @@ package io.camunda.zeebe.broker.it.network;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.client.api.response.Topology;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import io.camunda.zeebe.test.util.testcontainers.ZeebeTestContainerDefaults;
@@ -21,7 +19,6 @@ import io.zeebe.containers.ZeebePort;
 import io.zeebe.containers.cluster.ZeebeCluster;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.agrona.CloseHelper;
@@ -94,7 +91,7 @@ final class AdvertisedAddressTest {
 
     // when - send a message to verify the gateway can talk to the broker directly not just via
     // gossip
-    try (final var client = newClientBuilder().build()) {
+    try (final var client = cluster.newClientBuilder().build()) {
       final Topology topology = client.newTopologyRequest().send().join(5, TimeUnit.SECONDS);
       final var messageSend =
           client
@@ -174,21 +171,5 @@ final class AdvertisedAddressTest {
         TOXIPROXY_NETWORK_ALIAS + ":" + contactPointProxy.getOriginalProxyPort());
     gateway.setDockerImageName(
         ZeebeTestContainerDefaults.defaultTestImage().asCanonicalNameString());
-  }
-
-  // TODO(menski): replace with test container after update to new package names
-  private ZeebeClientBuilder newClientBuilder() {
-    final ZeebeGatewayNode<?> gateway =
-        cluster.getGateways().values().stream()
-            .filter(ZeebeNode::isStarted)
-            .findAny()
-            .orElseThrow(
-                () ->
-                    new NoSuchElementException(
-                        "Expected at least one gateway for the client to connect to, but there is none"));
-
-    return ZeebeClient.newClientBuilder()
-        .gatewayAddress(gateway.getExternalGatewayAddress())
-        .usePlaintext();
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/network/AdvertisedAddressTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/network/AdvertisedAddressTest.java
@@ -68,6 +68,18 @@ final class AdvertisedAddressTest {
   void beforeEach() {
     cluster.getBrokers().values().forEach(this::configureBroker);
     cluster.getGateways().values().forEach(this::configureGateway);
+
+    // the first pass of configureBroker builds up the initial contact points; this has to be done
+    // as we're also creating the proxies. we use a second pass such that all nodes known about all
+    // others during bootstrapping.
+    cluster
+        .getBrokers()
+        .values()
+        .forEach(
+            broker ->
+                broker.withEnv(
+                    "ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS",
+                    String.join(",", initialContactPoints)));
   }
 
   @AfterEach
@@ -132,8 +144,6 @@ final class AdvertisedAddressTest {
     broker.setDockerImageName(
         ZeebeTestContainerDefaults.defaultTestImage().asCanonicalNameString());
     broker
-        .withEnv(
-            "ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS", String.join(",", initialContactPoints))
         .withEnv("ZEEBE_LOG_LEVEL", "DEBUG")
         .withEnv("ATOMIX_LOG_LEVEL", "INFO")
         .withEnv("ZEEBE_BROKER_NETWORK_COMMANDAPI_ADVERTISEDHOST", TOXIPROXY_NETWORK_ALIAS)


### PR DESCRIPTION
## Description

This PR fixes flakiness with the `AdvertisedAddressTest` by ensuring all nodes know about each other. While it doesn't fix the underlying problem of the timeout being scheduled post handshake, since all nodes know each other, even if one node fails to probe the other, we can now guarantee that it will receive probe requests from other nodes in the cluster, which should prevent flakiness here as it will be able to discover other nodes.

I will create a follow up issue to deal with the time out and handshake issues.

## Related issues

closes #6856 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
