### PR TITLE
refactor(atomix): remove obsolete casts

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionService.java
+++ b/atomix/cluster/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionService.java
@@ -22,7 +22,6 @@ import io.atomix.primitive.partition.ManagedPartitionGroup;
 import io.atomix.primitive.partition.ManagedPartitionService;
 import io.atomix.primitive.partition.PartitionManagementService;
 import io.atomix.primitive.partition.PartitionService;
-import io.atomix.raft.partition.RaftPartitionGroup;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
@@ -41,7 +40,7 @@ public class DefaultPartitionService implements ManagedPartitionService {
   public DefaultPartitionService(
       final ClusterMembershipService membershipService,
       final ClusterCommunicationService messagingService,
-      final RaftPartitionGroup group) {
+      final ManagedPartitionGroup group) {
     clusterMembershipService = membershipService;
     communicationService = messagingService;
     this.group = group;

--- a/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestNode.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestNode.java
@@ -23,6 +23,7 @@ import io.atomix.cluster.Node;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.cluster.discovery.NodeDiscoveryProvider;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.primitive.partition.ManagedPartitionGroup;
 import io.atomix.primitive.partition.ManagedPartitionService;
 import io.atomix.primitive.partition.impl.DefaultPartitionService;
 import io.atomix.raft.partition.RaftPartition;
@@ -66,8 +67,8 @@ public class ZeebeTestNode {
     return (RaftPartition) getDataPartitionGroup().getPartition(String.valueOf(id));
   }
 
-  private RaftPartitionGroup getDataPartitionGroup() {
-    return (RaftPartitionGroup) partitionService.getPartitionGroup();
+  private ManagedPartitionGroup getDataPartitionGroup() {
+    return partitionService.getPartitionGroup();
   }
 
   public CompletableFuture<Void> start(final Collection<ZeebeTestNode> nodes) {

--- a/atomix/core/src/main/java/io/atomix/core/Atomix.java
+++ b/atomix/core/src/main/java/io/atomix/core/Atomix.java
@@ -29,7 +29,6 @@ import io.atomix.primitive.partition.ManagedPartitionService;
 import io.atomix.primitive.partition.PartitionGroupConfig;
 import io.atomix.primitive.partition.PartitionService;
 import io.atomix.primitive.partition.impl.DefaultPartitionService;
-import io.atomix.raft.partition.RaftPartitionGroup;
 import io.atomix.utils.Version;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.concurrent.SingleThreadContext;
@@ -209,7 +208,6 @@ public class Atomix extends AtomixCluster {
             ? partitionGroupConfig.getType().newPartitionGroup(partitionGroupConfig)
             : null;
 
-    return new DefaultPartitionService(
-        clusterMembershipService, messagingService, (RaftPartitionGroup) partitionGroup);
+    return new DefaultPartitionService(clusterMembershipService, messagingService, partitionGroup);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -12,8 +12,8 @@ import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.atomix.cluster.messaging.MessagingConfig;
 import io.atomix.cluster.messaging.impl.NettyMessagingService;
 import io.atomix.core.Atomix;
+import io.atomix.primitive.partition.ManagedPartitionGroup;
 import io.atomix.raft.partition.RaftPartition;
-import io.atomix.raft.partition.RaftPartitionGroup;
 import io.atomix.utils.net.Address;
 import io.camunda.zeebe.broker.bootstrap.CloseProcess;
 import io.camunda.zeebe.broker.bootstrap.StartProcess;
@@ -370,8 +370,7 @@ public final class Broker implements AutoCloseable {
   private AutoCloseable partitionsStep(
       final BrokerCfg brokerCfg, final ClusterCfg clusterCfg, final BrokerInfo localBroker)
       throws Exception {
-    final RaftPartitionGroup partitionGroup =
-        (RaftPartitionGroup) atomix.getPartitionService().getPartitionGroup();
+    final ManagedPartitionGroup partitionGroup = atomix.getPartitionService().getPartitionGroup();
 
     final MemberId nodeId = atomix.getMembershipService().getLocalMember().id();
     final List<RaftPartition> owningPartitions =


### PR DESCRIPTION
This removes casts to `RaftPartitionGroup` in places where the cast is not needed.

This was a bit motivated by your idea to merge these classes. I also looked further into merging `Partition` and `RaftPartition`, but I stopped there. 

There are a couple of concepts that the interface partition does not yet have:
* folder for storage
* ability to register `RaftRoleChangeListeners`

In the end, I preferred to keep the change set small, so I just reduced unnecessary casts to `RaftPartitionGroup`

<!-- Cut-off marker
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
