### PR TITLE
Simiplify dependencies

### DIFF
--- a/atomix/core/src/main/java/io/atomix/core/Atomix.java
+++ b/atomix/core/src/main/java/io/atomix/core/Atomix.java
@@ -25,9 +25,9 @@ import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.atomix.cluster.messaging.ManagedUnicastService;
+import io.atomix.primitive.partition.ManagedPartitionGroup;
 import io.atomix.primitive.partition.ManagedPartitionService;
 import io.atomix.primitive.partition.PartitionGroupConfig;
-import io.atomix.primitive.partition.PartitionService;
 import io.atomix.primitive.partition.impl.DefaultPartitionService;
 import io.atomix.utils.Version;
 import io.atomix.utils.concurrent.Futures;
@@ -94,6 +94,7 @@ public class Atomix extends AtomixCluster {
   private final ScheduledExecutorService executorService;
   private final ManagedPartitionService partitions;
   private final ThreadContext threadContext = new SingleThreadContext("atomix-%d");
+  private final ManagedPartitionGroup partitionGroup;
 
   protected Atomix(final AtomixConfig config) {
     this(config, null, null);
@@ -108,6 +109,14 @@ public class Atomix extends AtomixCluster {
         Executors.newScheduledThreadPool(
             Math.max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 8), 4),
             Threads.namedThreads("atomix-primitive-%d", LOGGER));
+
+    final PartitionGroupConfig<?> partitionGroupConfig = config.getPartitionGroup();
+
+    partitionGroup =
+        partitionGroupConfig != null
+            ? partitionGroupConfig.getType().newPartitionGroup(partitionGroupConfig)
+            : null;
+
     partitions = buildPartitionService(config, getMembershipService(), getCommunicationService());
   }
 
@@ -135,16 +144,8 @@ public class Atomix extends AtomixCluster {
     return new AtomixBuilder(config);
   }
 
-  /**
-   * Returns the partition service.
-   *
-   * <p>The partition service is responsible for managing the lifecycle of primitive partitions and
-   * can provide information about active partition groups and partitions in the cluster.
-   *
-   * @return the partition service
-   */
-  public PartitionService getPartitionService() {
-    return partitions;
+  public ManagedPartitionGroup getPartitionGroup() {
+    return partitionGroup;
   }
 
   /**
@@ -192,21 +193,14 @@ public class Atomix extends AtomixCluster {
 
   @Override
   public String toString() {
-    return toStringHelper(this).add("partitions", getPartitionService()).toString();
+    return toStringHelper(this).add("partitionGroup", partitionGroup).toString();
   }
 
   /** Builds a partition service. */
-  private static ManagedPartitionService buildPartitionService(
+  private ManagedPartitionService buildPartitionService(
       final AtomixConfig config,
       final ClusterMembershipService clusterMembershipService,
       final ClusterCommunicationService messagingService) {
-
-    final PartitionGroupConfig<?> partitionGroupConfig = config.getPartitionGroup();
-
-    final var partitionGroup =
-        partitionGroupConfig != null
-            ? partitionGroupConfig.getType().newPartitionGroup(partitionGroupConfig)
-            : null;
 
     return new DefaultPartitionService(clusterMembershipService, messagingService, partitionGroup);
   }

--- a/atomix/core/src/test/java/io/atomix/core/RaftRolesTest.java
+++ b/atomix/core/src/test/java/io/atomix/core/RaftRolesTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import io.atomix.primitive.partition.Partition;
-import io.atomix.primitive.partition.impl.DefaultPartitionService;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
@@ -276,10 +275,7 @@ public final class RaftRolesTest {
 
           final Atomix atomix = builder.withPartitionGroup(partitionGroup).build();
 
-          final DefaultPartitionService partitionService =
-              (DefaultPartitionService) atomix.getPartitionService();
-
-          partitionService.getPartitionGroup().getPartitions().forEach(partitionConsumer);
+          atomix.getPartitionGroup().getPartitions().forEach(partitionConsumer);
           return atomix;
         });
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -349,8 +349,7 @@ public final class Broker implements AutoCloseable {
   }
 
   private AutoCloseable monitoringServerStep(final BrokerInfo localBroker) {
-    healthCheckService =
-        new BrokerHealthCheckService(localBroker, atomix.getPartitionService().getPartitionGroup());
+    healthCheckService = new BrokerHealthCheckService(localBroker, atomix.getPartitionGroup());
     springBrokerBridge.registerBrokerHealthCheckServiceSupplier(() -> healthCheckService);
     partitionListeners.add(healthCheckService);
     scheduleActor(healthCheckService);
@@ -381,7 +380,7 @@ public final class Broker implements AutoCloseable {
 
   private AutoCloseable partitionsStep(final BrokerCfg brokerCfg, final BrokerInfo localBroker)
       throws Exception {
-    final ManagedPartitionGroup partitionGroup = atomix.getPartitionService().getPartitionGroup();
+    final ManagedPartitionGroup partitionGroup = clusterServices.getPartitionService().getPartitionGroup();
 
     final MemberId nodeId = atomix.getMembershipService().getLocalMember().id();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -19,6 +19,7 @@ import io.atomix.raft.partition.RaftPartition;
 import io.atomix.utils.net.Address;
 import io.camunda.zeebe.broker.bootstrap.CloseProcess;
 import io.camunda.zeebe.broker.bootstrap.StartProcess;
+import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.clustering.atomix.AtomixFactory;
 import io.camunda.zeebe.broker.clustering.topology.TopologyManagerImpl;
 import io.camunda.zeebe.broker.clustering.topology.TopologyPartitionListenerImpl;
@@ -119,7 +120,8 @@ public final class Broker implements AutoCloseable {
   private final SystemContext brokerContext;
   private final List<PartitionListener> partitionListeners;
   private boolean isClosed = false;
-  private Atomix atomix;
+
+  private ClusterServices clusterServices;
   private CompletableFuture<Broker> startFuture;
   private TopologyManagerImpl topologyManager;
   private LeaderManagementRequestHandler managementRequestHandler;
@@ -135,6 +137,8 @@ public final class Broker implements AutoCloseable {
   private SnapshotStoreSupplier snapshotStoreSupplier;
   private final List<ZeebePartition> partitions = new ArrayList<>();
   private BrokerAdminService brokerAdminService;
+
+  private final TestCompanionClass testCompanionObject = new TestCompanionClass();
 
   public Broker(final SystemContext systemContext, final SpringBrokerBridge springBrokerBridge) {
     brokerContext = systemContext;
@@ -218,7 +222,7 @@ public final class Broker implements AutoCloseable {
         "command api handler", () -> commandApiHandlerStep(brokerCfg, localBroker));
     startContext.addStep("subscription api", () -> subscriptionAPIStep(localBroker));
 
-    startContext.addStep("cluster services", () -> atomix.start().join());
+    startContext.addStep("cluster services", () -> clusterServices.start().join());
     startContext.addStep("topology manager", () -> topologyManagerStep(clusterCfg, localBroker));
     if (brokerCfg.getGateway().isEnable()) {
       startContext.addStep(
@@ -228,9 +232,9 @@ public final class Broker implements AutoCloseable {
                 new EmbeddedGatewayService(
                     brokerCfg,
                     scheduler,
-                    atomix.getMessagingService(),
-                    atomix.getMembershipService(),
-                    atomix.getEventService());
+                    clusterServices.getMessagingService(),
+                    clusterServices.getMembershipService(),
+                    clusterServices.getEventService());
             return embeddedGatewayService;
           });
     }
@@ -264,10 +268,14 @@ public final class Broker implements AutoCloseable {
     final var snapshotStoreFactory =
         new FileBasedSnapshotStoreFactory(scheduler, localBroker.getNodeId());
     snapshotStoreSupplier = snapshotStoreFactory;
-    atomix = AtomixFactory.fromConfiguration(brokerCfg, snapshotStoreFactory);
+    final var atomix = AtomixFactory.fromConfiguration(brokerCfg, snapshotStoreFactory);
+    testCompanionObject.atomix = atomix;
+    clusterServices = new ClusterServices(atomix);
 
     return () ->
-        atomix.stop().get(brokerContext.getStepTimeout().toMillis(), TimeUnit.MILLISECONDS);
+        clusterServices
+            .stop()
+            .get(brokerContext.getStepTimeout().toMillis(), TimeUnit.MILLISECONDS);
   }
 
   private AutoCloseable commandApiTransportStep(
@@ -321,7 +329,7 @@ public final class Broker implements AutoCloseable {
   private AutoCloseable subscriptionAPIStep(final BrokerInfo localBroker) {
     final SubscriptionApiCommandMessageHandlerService messageHandlerService =
         new SubscriptionApiCommandMessageHandlerService(
-            localBroker, atomix.getCommunicationService());
+            localBroker, clusterServices.getCommunicationService());
     partitionListeners.add(messageHandlerService);
     scheduleActor(messageHandlerService);
     diskSpaceUsageListeners.add(messageHandlerService);
@@ -342,14 +350,15 @@ public final class Broker implements AutoCloseable {
   private AutoCloseable topologyManagerStep(
       final ClusterCfg clusterCfg, final BrokerInfo localBroker) {
     topologyManager =
-        new TopologyManagerImpl(atomix.getMembershipService(), localBroker, clusterCfg);
+        new TopologyManagerImpl(clusterServices.getMembershipService(), localBroker, clusterCfg);
     partitionListeners.add(topologyManager);
     scheduleActor(topologyManager);
     return topologyManager;
   }
 
   private AutoCloseable monitoringServerStep(final BrokerInfo localBroker) {
-    healthCheckService = new BrokerHealthCheckService(localBroker, atomix.getPartitionGroup());
+    healthCheckService =
+        new BrokerHealthCheckService(localBroker, clusterServices.getPartitionGroup());
     springBrokerBridge.registerBrokerHealthCheckServiceSupplier(() -> healthCheckService);
     partitionListeners.add(healthCheckService);
     scheduleActor(healthCheckService);
@@ -371,7 +380,9 @@ public final class Broker implements AutoCloseable {
   private AutoCloseable managementRequestStep(final BrokerInfo localBroker) {
     managementRequestHandler =
         new LeaderManagementRequestHandler(
-            localBroker, atomix.getCommunicationService(), atomix.getEventService());
+            localBroker,
+            clusterServices.getCommunicationService(),
+            clusterServices.getEventService());
     scheduleActor(managementRequestHandler);
     partitionListeners.add(managementRequestHandler);
     diskSpaceUsageListeners.add(managementRequestHandler);
@@ -380,9 +391,9 @@ public final class Broker implements AutoCloseable {
 
   private AutoCloseable partitionsStep(final BrokerCfg brokerCfg, final BrokerInfo localBroker)
       throws Exception {
-    final ManagedPartitionGroup partitionGroup = clusterServices.getPartitionService().getPartitionGroup();
+    final ManagedPartitionGroup partitionGroup = clusterServices.getPartitionGroup();
 
-    final MemberId nodeId = atomix.getMembershipService().getLocalMember().id();
+    final MemberId nodeId = clusterServices.getMembershipService().getLocalMember().id();
 
     final List<RaftPartition> owningPartitions =
         partitionGroup.getPartitionsWithMember(nodeId).stream()
@@ -398,8 +409,8 @@ public final class Broker implements AutoCloseable {
           () -> {
             final var messagingService =
                 new AtomixPartitionMessagingService(
-                    atomix.getCommunicationService(),
-                    atomix.getMembershipService(),
+                    clusterServices.getCommunicationService(),
+                    clusterServices.getMembershipService(),
                     owningPartition.members());
 
             final PartitionContext context =
@@ -415,8 +426,8 @@ public final class Broker implements AutoCloseable {
                     createFactory(
                         topologyManager,
                         brokerCfg.getCluster(),
-                        atomix.getCommunicationService(),
-                        atomix.getEventService(),
+                        clusterServices.getCommunicationService(),
+                        clusterServices.getEventService(),
                         managementRequestHandler),
                     buildExporterRepository(brokerCfg),
                     new PartitionProcessingState(owningPartition));
@@ -486,7 +497,7 @@ public final class Broker implements AutoCloseable {
           requestHandler.getPushDeploymentRequestHandler();
 
       final LongPollingJobNotification jobsAvailableNotification =
-          new LongPollingJobNotification(atomix.getEventService());
+          new LongPollingJobNotification(clusterServices.getEventService());
 
       return EngineProcessors.createEngineProcessors(
           processingContext,
@@ -527,7 +538,11 @@ public final class Broker implements AutoCloseable {
   // only used for tests
   @Deprecated
   public Atomix getAtomix() {
-    return atomix;
+    return testCompanionObject.atomix;
+  }
+
+  public ClusterServices getClusterServices() {
+    return clusterServices;
   }
 
   public DiskSpaceUsageMonitor getDiskSpaceUsageMonitor() {
@@ -540,5 +555,10 @@ public final class Broker implements AutoCloseable {
 
   public SystemContext getBrokerContext() {
     return brokerContext;
+  }
+
+  @Deprecated // only used for test; temporary work around
+  private static final class TestCompanionClass {
+    private Atomix atomix;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterServices.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterServices.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.clustering;
+
+import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.cluster.messaging.ClusterEventService;
+import io.atomix.cluster.messaging.MessagingService;
+import io.atomix.core.Atomix;
+import io.atomix.primitive.partition.ManagedPartitionGroup;
+import java.util.concurrent.CompletableFuture;
+
+public final class ClusterServices {
+
+  private final Atomix atomix;
+
+  public ClusterServices(final Atomix atomix) {
+    this.atomix = atomix;
+  }
+
+  public CompletableFuture<Void> start() {
+    return atomix.start();
+  }
+
+  public CompletableFuture<Void> stop() {
+    return atomix.stop();
+  }
+
+  public MessagingService getMessagingService() {
+    return atomix.getMessagingService();
+  }
+
+  public ClusterMembershipService getMembershipService() {
+    return atomix.getMembershipService();
+  }
+
+  public ClusterEventService getEventService() {
+    return atomix.getEventService();
+  }
+
+  public ClusterCommunicationService getCommunicationService() {
+    return atomix.getCommunicationService();
+  }
+
+  public ManagedPartitionGroup getPartitionGroup() {
+    return atomix.getPartitionGroup();
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/clustering/atomix/AtomixFactoryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/clustering/atomix/AtomixFactoryTest.java
@@ -61,7 +61,7 @@ public final class AtomixFactoryTest {
   }
 
   private ManagedPartitionGroup getPartitionGroup(final Atomix atomix) {
-    return atomix.getPartitionService().getPartitionGroup();
+    return atomix.getPartitionGroup();
   }
 
   private RaftPartitionGroupConfig getPartitionGroupConfig(final Atomix atomix) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerSnapshotTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerSnapshotTest.java
@@ -46,7 +46,7 @@ public class BrokerSnapshotTest {
         (RaftPartition)
             brokerRule
                 .getBroker()
-                .getAtomix()
+                .getClusterServices()
                 .getPartitionGroup()
                 .getPartition(PartitionId.from(AtomixFactory.GROUP_NAME, PARTITION_ID));
     journalReader = raftPartition.getServer().openReader(Mode.COMMITS);

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerSnapshotTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerSnapshotTest.java
@@ -47,7 +47,6 @@ public class BrokerSnapshotTest {
             brokerRule
                 .getBroker()
                 .getAtomix()
-                .getPartitionService()
                 .getPartitionGroup()
                 .getPartition(PartitionId.from(AtomixFactory.GROUP_NAME, PARTITION_ID));
     journalReader = raftPartition.getServer().openReader(Mode.COMMITS);

--- a/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.TestLoggers;
+import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
@@ -162,6 +163,10 @@ public final class EmbeddedBrokerRule extends ExternalResource {
 
   public SpringBrokerBridge getSpringBrokerBridge() {
     return springBrokerBridge;
+  }
+
+  public ClusterServices getClusterServices() {
+    return broker.getClusterServices();
   }
 
   public Atomix getAtomix() {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/clustering/ClusteringRule.java
@@ -581,11 +581,11 @@ public final class ClusteringRule extends ExternalResource {
   }
 
   public void stepDown(final Broker broker, final int partitionId) {
-    final var atomix = broker.getAtomix();
+    final var atomix = broker.getClusterServices();
     final MemberId nodeId = atomix.getMembershipService().getLocalMember().id();
 
     final var raftPartition =
-        atomix.getPartitionService().getPartitionGroup().getPartitions().stream()
+        atomix.getPartitionGroup().getPartitions().stream()
             .filter(partition -> partition.members().contains(nodeId))
             .filter(partition -> partition.id().id() == partitionId)
             .map(RaftPartition.class::cast)

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/gateway/GatewayIntegrationTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/gateway/GatewayIntegrationTest.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.broker.it.gateway;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.atomix.cluster.AtomixCluster;
+import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
 import io.camunda.zeebe.gateway.cmd.BrokerRejectionException;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
@@ -52,13 +52,13 @@ public final class GatewayIntegrationTest {
     configuration.init();
 
     final ControlledActorClock clock = new ControlledActorClock();
-    final AtomixCluster atomixCluster = broker.getAtomix();
+    final ClusterServices clusterServices = broker.getClusterServices();
     client =
         new BrokerClientImpl(
             configuration,
-            atomixCluster.getMessagingService(),
-            atomixCluster.getMembershipService(),
-            atomixCluster.getEventService(),
+            clusterServices.getMessagingService(),
+            clusterServices.getMembershipService(),
+            clusterServices.getEventService(),
             clock);
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/health/HealthMonitoringTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/health/HealthMonitoringTest.java
@@ -39,8 +39,7 @@ public class HealthMonitoringTest {
     final var raftPartition =
         (RaftPartition)
             leader
-                .getAtomix()
-                .getPartitionService()
+                .getClusterServices()
                 .getPartitionGroup()
                 .getPartition(PartitionId.from(GROUP_NAME, START_PARTITION_ID));
     raftPartition.getServer().stop();


### PR DESCRIPTION
## Description

This hides the `PartitionService` so that other services cannot depend on it. All those places only used it to get hold of the partition group, which only depends on config. So all dependencies can be satisfied in an easier way

It also removes all access to the Atomix class in production code. Instead, a new class `ClusterServices` is introduced that delegates all access to the `Atomix` class. The benefit of having this indirection is that `ClusterServices` has only a minimal interface, whereas `Atomix` has a large interface. For test classes a reference to the underlying `Atomix` class is still provided.

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
