### PR TITLE
Update benchmark documentation with OAuth setup

### DIFF
--- a/benchmarks/docs/setup/README.md
+++ b/benchmarks/docs/setup/README.md
@@ -27,9 +27,43 @@ helm repo update
 ## Monitoring
 
 To monitor your cluster, we will set up a the [Prometheus Operator helm chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator),
-which will install the following components the operator and Grafana.
+which will install the following components the operator and Grafana. There are some pre-requisites for Grafana first.
 
-To do so, run:
+By default, Grafana is setup for Github OAuth, allowing users from the zeebe-io, camunda, and camunda-cloud organizations to login as editors. If you want to use it, you will need to deploy a secret which contains your Github OAuth Application's client ID and client secret, e.g.:
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: auth-github-oauth
+type: Opaque
+stringData:
+  client_id: <ID>
+  client_secret: <SECRET>
+```
+
+Save this to a file `oauth-secret.yml`, and apply via `kubectl apply -f oauth-secret.yml`.
+
+Additionally, the admin user will require a pre-defined secret for the username and password. Note that once this is set during the first run, changes to the secret will _not_ update the password - to do that, you need to either use the `grafana-cli` or the do it via the web interface.
+
+Here's an example of a secret you would need to deploy:
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-admin-password
+type: Opaque
+stringData:
+  admin-user: <ADMIN USER>
+  admin-password: <SUPER STRONG PASSWORD>
+```
+
+Save this to `admin.yml` and apply via `kubectl apply -f admin.yml`.
+
+Once these secrets exist, you can now install the operator. To do so, run:
 
 ```sh
 helm install metrics stable/prometheus-operator --atomic -f prometheus-operator-values.yml

--- a/benchmarks/docs/setup/prometheus-operator-values.yml
+++ b/benchmarks/docs/setup/prometheus-operator-values.yml
@@ -2,7 +2,30 @@ alertmanager:
   enabled: false
 
 grafana:
-  adminPassword: camunda
+  image:
+    tag: 7.4.5
+  admin:
+    existingSecret: grafana-admin-password
+    userKey: admin-user
+    passwordKey: admin-password
+  grafana.ini:
+    auth.github:
+      enabled: true
+      allow_sign_up: true
+      scopes: user:email,read:org
+      auth_url: https://github.com/login/oauth/authorize
+      token_url: https://github.com/login/oauth/access_token
+      api_url: https://api.github.com/user
+      allowed_organizations: zeebe-io camunda camunda-cloud
+      client_id: "$__file{/etc/secrets/auth-github-oauth/client_id}"
+      client_secret: "$__file{/etc/secrets/auth-github-oauth/client_secret}"
+      role_attribute_path: "editor"
+  extraSecretMounts:
+    - name: auth-github-oauth
+      secretName: auth-github-oauth
+      defaultMode: 0440
+      mountPath: /etc/secrets/auth-github-oauth
+      readOnly: true
   dashboardProviders:
     dashboardproviders.yaml:
       apiVersion: 1


### PR DESCRIPTION
## Description

This PR updates the documentation regarding how to setup one of our benchmark clusters, specifically how to turn on Github OAuth2 authentication for Grafana. This serves for further clusters that will need to be setup in the future, but also as documentation of the current settings deployed.

It removes the need for a shared admin password, and lets us use normal users, such that we can safely share Grafana URLs publicly.

Additionally bumps up the Grafana version since I needed to in order to use the configuration file provider (i.e. this `$__file` syntax to inject secrets).

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
