### PR TITLE
[Backports stable/1.0] Ensure requests are always completed

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/ClusterCommunicationService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/ClusterCommunicationService.java
@@ -40,8 +40,8 @@ import java.util.function.Function;
  *   <li>{@link #multicast(String, Object, Set)} sends the message to all provided members
  *   <li>{@link #unicast(String, Object, MemberId)} sends a unicast message directly to the given
  *       member
- *   <li>{@link #send(String, Object, MemberId)} sends a message directly to the given member and
- *       awaits a reply
+ *   <li>{@link #send(String, Object, MemberId, Duration)} sends a message directly to the given
+ *       member and awaits a reply
  * </ul>
  *
  * To register to listen for messages, use one of the {@link #subscribe(String, Consumer, Executor)}
@@ -153,71 +153,6 @@ public interface ClusterCommunicationService {
       String subject, M message, Function<M, byte[]> encoder, boolean reliable);
 
   /**
-   * Sends a message to the specified member over TCP.
-   *
-   * @param subject message subject
-   * @param message message to send
-   * @param toMemberId destination node identifier
-   * @param <M> message type
-   * @return future that is completed when the message is sent
-   */
-  default <M> CompletableFuture<Void> unicast(
-      final String subject, final M message, final MemberId toMemberId) {
-    return unicast(subject, message, BASIC::encode, toMemberId, true);
-  }
-
-  /**
-   * Sends a message to the specified member.
-   *
-   * @param subject message subject
-   * @param message message to send
-   * @param toMemberId destination node identifier
-   * @param reliable whether to perform a reliable (TCP) unicast
-   * @param <M> message type
-   * @return future that is completed when the message is sent
-   */
-  default <M> CompletableFuture<Void> unicast(
-      final String subject, final M message, final MemberId toMemberId, final boolean reliable) {
-    return unicast(subject, message, BASIC::encode, toMemberId, reliable);
-  }
-
-  /**
-   * Sends a message to the specified member over TCP.
-   *
-   * @param subject message subject
-   * @param message message to send
-   * @param encoder function for encoding message to byte[]
-   * @param toMemberId destination node identifier
-   * @param <M> message type
-   * @return future that is completed when the message is sent
-   */
-  default <M> CompletableFuture<Void> unicast(
-      final String subject,
-      final M message,
-      final Function<M, byte[]> encoder,
-      final MemberId toMemberId) {
-    return unicast(subject, message, encoder, toMemberId, true);
-  }
-
-  /**
-   * Sends a message to the specified member.
-   *
-   * @param subject message subject
-   * @param message message to send
-   * @param encoder function for encoding message to byte[]
-   * @param toMemberId destination node identifier
-   * @param reliable whether to perform a reliable (TCP) unicast
-   * @param <M> message type
-   * @return future that is completed when the message is sent
-   */
-  <M> CompletableFuture<Void> unicast(
-      String subject,
-      M message,
-      Function<M, byte[]> encoder,
-      MemberId toMemberId,
-      boolean reliable);
-
-  /**
    * Multicasts a message to a set of members over TCP.
    *
    * @param subject message subject
@@ -281,19 +216,29 @@ public interface ClusterCommunicationService {
       boolean reliable);
 
   /**
-   * Sends a message and expects a reply.
+   * Sends a message to a member over TCP.
    *
    * @param subject message subject
    * @param message message to send
-   * @param toMemberId recipient node identifier
-   * @param <M> request type
-   * @param <R> reply type
-   * @return reply future
+   * @param memberId recipient node identifier
+   * @param <M> message type
    */
-  default <M, R> CompletableFuture<R> send(
-      final String subject, final M message, final MemberId toMemberId) {
-    return send(subject, message, BASIC::encode, BASIC::decode, toMemberId, null);
+  default <M> void unicast(final String subject, final M message, final MemberId memberId) {
+    unicast(subject, message, BASIC::encode, memberId, true);
   }
+
+  /**
+   * Sends a message to a member.
+   *
+   * @param subject message subject
+   * @param message message to send
+   * @param encoder function for encoding message to byte[]
+   * @param memberId recipient node identifier
+   * @param reliable whether to perform a reliable (TCP) unicast
+   * @param <M> message type
+   */
+  <M> void unicast(
+      String subject, M message, Function<M, byte[]> encoder, MemberId memberId, boolean reliable);
 
   /**
    * Sends a message and expects a reply.
@@ -309,27 +254,6 @@ public interface ClusterCommunicationService {
   default <M, R> CompletableFuture<R> send(
       final String subject, final M message, final MemberId toMemberId, final Duration timeout) {
     return send(subject, message, BASIC::encode, BASIC::decode, toMemberId, timeout);
-  }
-
-  /**
-   * Sends a message and expects a reply.
-   *
-   * @param subject message subject
-   * @param message message to send
-   * @param encoder function for encoding request to byte[]
-   * @param decoder function for decoding response from byte[]
-   * @param toMemberId recipient node identifier
-   * @param <M> request type
-   * @param <R> reply type
-   * @return reply future
-   */
-  default <M, R> CompletableFuture<R> send(
-      final String subject,
-      final M message,
-      final Function<M, byte[]> encoder,
-      final Function<byte[], R> decoder,
-      final MemberId toMemberId) {
-    return send(subject, message, encoder, decoder, toMemberId, null);
   }
 
   /**

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
@@ -23,10 +23,12 @@ import java.util.List;
 
 /** Messaging configuration. */
 public class MessagingConfig implements Config {
+  private int connectionPoolSize = 8;
   private List<String> interfaces = new ArrayList<>();
   private Integer port;
-  private int connectionPoolSize = 8;
   private Duration connectTimeout = Duration.ofSeconds(10);
+  private Duration shutdownQuietPeriod = Duration.ofSeconds(2); // taken from Netty's default value
+  private Duration shutdownTimeout = Duration.ofSeconds(15); // taken from Netty's default value
 
   /**
    * Returns the local interfaces to which to bind the node.
@@ -106,5 +108,37 @@ public class MessagingConfig implements Config {
   public MessagingConfig setConnectTimeout(final Duration connectTimeout) {
     this.connectTimeout = connectTimeout;
     return this;
+  }
+
+  /** @return the configured shutdown quiet period */
+  public Duration getShutdownQuietPeriod() {
+    return shutdownQuietPeriod;
+  }
+
+  /**
+   * Sets the shutdown quiet period. This is mostly useful to set a small value when testing,
+   * otherwise every tests takes an additional 2 second just to shutdown the executor.
+   *
+   * @param shutdownQuietPeriod the quiet period on shutdown
+   * @return this config
+   */
+  public MessagingConfig setShutdownQuietPeriod(final Duration shutdownQuietPeriod) {
+    this.shutdownQuietPeriod = shutdownQuietPeriod;
+    return this;
+  }
+
+  /** @return the configured shutdown timeout */
+  public Duration getShutdownTimeout() {
+    return shutdownTimeout;
+  }
+
+  /**
+   * Sets the shutdown timeout.
+   *
+   * @param shutdownTimeout the time to wait for an orderly shutdown of the messaging service
+   * @return this config
+   */
+  public void setShutdownTimeout(final Duration shutdownTimeout) {
+    this.shutdownTimeout = shutdownTimeout;
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/AbstractClientConnection.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/AbstractClientConnection.java
@@ -19,40 +19,17 @@ package io.atomix.cluster.messaging.impl;
 import com.google.common.collect.Maps;
 import io.atomix.cluster.messaging.MessagingException;
 import java.net.ConnectException;
-import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
-import org.apache.commons.math3.stat.descriptive.SynchronizedDescriptiveStatistics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Base class for client-side connections. Manages request futures and timeouts. */
 abstract class AbstractClientConnection implements ClientConnection {
-  private static final int WINDOW_SIZE = 10;
-  private static final int MIN_SAMPLES = 50;
-  private static final int TIMEOUT_FACTOR = 5;
-  private static final long MIN_TIMEOUT_MILLIS = 100;
-  private static final long MAX_TIMEOUT_MILLIS = 5000;
-
   private final Logger log = LoggerFactory.getLogger(getClass());
-
-  private final ScheduledExecutorService executorService;
   private final Map<Long, Callback> callbacks = Maps.newConcurrentMap();
-
-  private final Map<String, DescriptiveStatistics> replySamples = new ConcurrentHashMap<>();
-
   private final AtomicBoolean closed = new AtomicBoolean(false);
-
-  AbstractClientConnection(final ScheduledExecutorService executorService) {
-    this.executorService = executorService;
-  }
 
   @Override
   public void dispatch(final ProtocolReply message) {
@@ -74,48 +51,6 @@ abstract class AbstractClientConnection implements ClientConnection {
     }
   }
 
-  /**
-   * Adds a reply time to the history.
-   *
-   * @param type the message type
-   * @param replyTime the reply time to add to the history
-   */
-  private void addReplyTime(final String type, final long replyTime) {
-    DescriptiveStatistics samples = replySamples.get(type);
-    if (samples == null) {
-      samples =
-          replySamples.computeIfAbsent(
-              type, t -> new SynchronizedDescriptiveStatistics(WINDOW_SIZE));
-    }
-    samples.addValue(replyTime);
-  }
-
-  /**
-   * Returns the timeout in milliseconds for the given timeout duration
-   *
-   * @param type the message type
-   * @param timeout the timeout duration or {@code null} if the timeout is dynamic
-   * @return the timeout in milliseconds
-   */
-  private long getTimeoutMillis(final String type, final Duration timeout) {
-    return timeout != null ? timeout.toMillis() : computeTimeoutMillis(type);
-  }
-
-  /**
-   * Computes the timeout for the next request.
-   *
-   * @param type the message type
-   * @return the computed timeout for the next request
-   */
-  private long computeTimeoutMillis(final String type) {
-    final DescriptiveStatistics samples = replySamples.get(type);
-    if (samples == null || samples.getN() < MIN_SAMPLES) {
-      return MAX_TIMEOUT_MILLIS;
-    }
-    return Math.min(
-        Math.max((long) samples.getMax() * TIMEOUT_FACTOR, MIN_TIMEOUT_MILLIS), MAX_TIMEOUT_MILLIS);
-  }
-
   @Override
   public void close() {
     if (closed.compareAndSet(false, true)) {
@@ -128,42 +63,12 @@ abstract class AbstractClientConnection implements ClientConnection {
   /** Client connection callback. */
   final class Callback {
     private final long id;
-    private final String type;
-    private final long time = System.currentTimeMillis();
-    private final long timeout;
-    private final ScheduledFuture<?> scheduledFuture;
     private final CompletableFuture<byte[]> replyFuture;
 
-    Callback(
-        final long id,
-        final String type,
-        final Duration timeout,
-        final CompletableFuture<byte[]> future) {
+    Callback(final long id, final CompletableFuture<byte[]> future) {
       this.id = id;
-      this.type = type;
-      this.timeout = getTimeoutMillis(type, timeout);
-      scheduledFuture =
-          executorService.schedule(this::timeout, this.timeout, TimeUnit.MILLISECONDS);
       replyFuture = future;
-      future.thenRun(() -> addReplyTime(type, System.currentTimeMillis() - time));
       callbacks.put(id, this);
-    }
-
-    /**
-     * Returns the callback message type.
-     *
-     * @return the message type
-     */
-    String type() {
-      return type;
-    }
-
-    /** Fails the callback future with a timeout exception. */
-    private void timeout() {
-      replyFuture.completeExceptionally(
-          new TimeoutException(
-              "Request type " + type + " timed out in " + timeout + " milliseconds"));
-      callbacks.remove(id);
     }
 
     /**
@@ -172,7 +77,6 @@ abstract class AbstractClientConnection implements ClientConnection {
      * @param value the value with which to complete the callback
      */
     void complete(final byte[] value) {
-      scheduledFuture.cancel(false);
       replyFuture.complete(value);
     }
 
@@ -182,7 +86,6 @@ abstract class AbstractClientConnection implements ClientConnection {
      * @param error the callback exception
      */
     void completeExceptionally(final Throwable error) {
-      scheduledFuture.cancel(false);
       replyFuture.completeExceptionally(error);
       callbacks.remove(id);
     }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ClientConnection.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/ClientConnection.java
@@ -16,7 +16,6 @@
  */
 package io.atomix.cluster.messaging.impl;
 
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
 /** Client-side connection interface which handles sending messages. */
@@ -34,11 +33,11 @@ interface ClientConnection extends Connection<ProtocolReply> {
    * Sends a message to the other side of the connection, awaiting a reply.
    *
    * @param message the message to send
-   * @param timeout the response timeout
    * @return a completable future to be completed once a reply is received or the request times out
    */
-  CompletableFuture<byte[]> sendAndReceive(ProtocolRequest message, Duration timeout);
+  CompletableFuture<byte[]> sendAndReceive(ProtocolRequest message);
 
   /** Closes the connection. */
+  @Override
   default void close() {}
 }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterCommunicationService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterCommunicationService.java
@@ -95,20 +95,6 @@ public class DefaultClusterCommunicationService implements ManagedClusterCommuni
   }
 
   @Override
-  public <M> CompletableFuture<Void> unicast(
-      final String subject,
-      final M message,
-      final Function<M, byte[]> encoder,
-      final MemberId toMemberId,
-      final boolean reliable) {
-    try {
-      return doUnicast(subject, encoder.apply(message), toMemberId, reliable);
-    } catch (final Exception e) {
-      return Futures.exceptionalFuture(e);
-    }
-  }
-
-  @Override
   public <M> void multicast(
       final String subject,
       final M message,
@@ -117,6 +103,17 @@ public class DefaultClusterCommunicationService implements ManagedClusterCommuni
       final boolean reliable) {
     final byte[] payload = encoder.apply(message);
     nodes.forEach(memberId -> doUnicast(subject, payload, memberId, reliable));
+  }
+
+  @Override
+  public <M> void unicast(
+      final String subject,
+      final M message,
+      final Function<M, byte[]> encoder,
+      final MemberId memberId,
+      final boolean reliable) {
+    final byte[] payload = encoder.apply(message);
+    doUnicast(subject, payload, memberId, reliable);
   }
 
   @Override

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/LocalClientConnection.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/LocalClientConnection.java
@@ -18,15 +18,12 @@ package io.atomix.cluster.messaging.impl;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
 
 /** Local client-side connection. */
 final class LocalClientConnection extends AbstractClientConnection {
   private final LocalServerConnection serverConnection;
 
-  LocalClientConnection(
-      final ScheduledExecutorService executorService, final HandlerRegistry handlers) {
-    super(executorService);
+  LocalClientConnection(final HandlerRegistry handlers) {
     serverConnection = new LocalServerConnection(handlers, this);
   }
 
@@ -40,7 +37,7 @@ final class LocalClientConnection extends AbstractClientConnection {
   public CompletableFuture<byte[]> sendAndReceive(
       final ProtocolRequest message, final Duration timeout) {
     final CompletableFuture<byte[]> future = new CompletableFuture<>();
-    new Callback(message.id(), message.subject(), timeout, future);
+    new Callback(message.id(), future);
     serverConnection.dispatch(message);
     return future;
   }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/LocalClientConnection.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/LocalClientConnection.java
@@ -16,7 +16,6 @@
  */
 package io.atomix.cluster.messaging.impl;
 
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
 /** Local client-side connection. */
@@ -34,10 +33,8 @@ final class LocalClientConnection extends AbstractClientConnection {
   }
 
   @Override
-  public CompletableFuture<byte[]> sendAndReceive(
-      final ProtocolRequest message, final Duration timeout) {
-    final CompletableFuture<byte[]> future = new CompletableFuture<>();
-    new Callback(message.id(), future);
+  public CompletableFuture<byte[]> sendAndReceive(final ProtocolRequest message) {
+    final CompletableFuture<byte[]> future = awaitResponseForRequestWithId(message.id());
     serverConnection.dispatch(message);
     return future;
   }
@@ -46,5 +43,10 @@ final class LocalClientConnection extends AbstractClientConnection {
   public void close() {
     super.close();
     serverConnection.close();
+  }
+
+  @Override
+  public String toString() {
+    return "LocalClientConnection{}";
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -200,11 +200,10 @@ public final class NettyMessagingService implements ManagedMessagingService {
     final CompletableFuture<byte[]> responseFuture;
     if (keepAlive) {
       responseFuture =
-          executeOnPooledConnection(
-              address, type, c -> c.sendAndReceive(message, timeout), executor);
+          executeOnPooledConnection(address, type, c -> c.sendAndReceive(message), executor);
     } else {
       responseFuture =
-          executeOnTransientConnection(address, c -> c.sendAndReceive(message, timeout), executor);
+          executeOnTransientConnection(address, c -> c.sendAndReceive(message), executor);
     }
 
     final var timeoutFuture =

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/RemoteClientConnection.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/RemoteClientConnection.java
@@ -19,14 +19,12 @@ package io.atomix.cluster.messaging.impl;
 import io.netty.channel.Channel;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
 
 /** Client-side Netty remote connection. */
 final class RemoteClientConnection extends AbstractClientConnection {
   private final Channel channel;
 
-  RemoteClientConnection(final ScheduledExecutorService executorService, final Channel channel) {
-    super(executorService);
+  RemoteClientConnection(final Channel channel) {
     this.channel = channel;
   }
 
@@ -50,7 +48,7 @@ final class RemoteClientConnection extends AbstractClientConnection {
   public CompletableFuture<byte[]> sendAndReceive(
       final ProtocolRequest message, final Duration timeout) {
     final CompletableFuture<byte[]> future = new CompletableFuture<>();
-    final Callback callback = new Callback(message.id(), message.subject(), timeout, future);
+    final Callback callback = new Callback(message.id(), future);
     channel
         .writeAndFlush(message)
         .addListener(

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/RemoteClientConnection.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/RemoteClientConnection.java
@@ -17,7 +17,6 @@
 package io.atomix.cluster.messaging.impl;
 
 import io.netty.channel.Channel;
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
 /** Client-side Netty remote connection. */
@@ -45,18 +44,21 @@ final class RemoteClientConnection extends AbstractClientConnection {
   }
 
   @Override
-  public CompletableFuture<byte[]> sendAndReceive(
-      final ProtocolRequest message, final Duration timeout) {
-    final CompletableFuture<byte[]> future = new CompletableFuture<>();
-    final Callback callback = new Callback(message.id(), future);
+  public CompletableFuture<byte[]> sendAndReceive(final ProtocolRequest message) {
+    final CompletableFuture<byte[]> responseFuture = awaitResponseForRequestWithId(message.id());
     channel
         .writeAndFlush(message)
         .addListener(
             channelFuture -> {
               if (!channelFuture.isSuccess()) {
-                callback.completeExceptionally(channelFuture.cause());
+                responseFuture.completeExceptionally(channelFuture.cause());
               }
             });
-    return future;
+    return responseFuture;
+  }
+
+  @Override
+  public String toString() {
+    return "RemoteClientConnection{channel=" + channel + "}";
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
@@ -37,12 +37,14 @@ import io.atomix.raft.protocol.TransferResponse;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.utils.serializer.Serializer;
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 /** Raft server protocol that uses a {@link ClusterCommunicationService}. */
 public class RaftServerCommunicator implements RaftServerProtocol {
 
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
   private final RaftMessageContext context;
   private final Serializer serializer;
   private final ClusterCommunicationService clusterCommunicator;
@@ -210,7 +212,12 @@ public class RaftServerCommunicator implements RaftServerProtocol {
       final String subject, final T request, final MemberId memberId) {
     metrics.sendMessage(memberId.id(), request.getClass().getSimpleName());
     return clusterCommunicator.send(
-        subject, request, serializer::encode, serializer::decode, MemberId.from(memberId.id()));
+        subject,
+        request,
+        serializer::encode,
+        serializer::decode,
+        MemberId.from(memberId.id()),
+        REQUEST_TIMEOUT);
   }
 
   private <T extends RaftMessage> T recordReceivedMetrics(final T m) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/PartitionCommandSenderImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/PartitionCommandSenderImpl.java
@@ -31,6 +31,7 @@ public final class PartitionCommandSenderImpl implements PartitionCommandSender 
     topologyManager.addTopologyPartitionListener(partitionListener);
   }
 
+  @Override
   public boolean sendCommand(final int receiverPartitionId, final BufferWriter command) {
 
     final Int2IntHashMap partitionLeaders = partitionListener.getPartitionLeaders();
@@ -45,7 +46,7 @@ public final class PartitionCommandSenderImpl implements PartitionCommandSender 
 
     atomix
         .getCommunicationService()
-        .send("subscription", bytes, MemberId.from("" + partitionLeader));
+        .unicast("subscription", bytes, MemberId.from("" + partitionLeader));
     return true;
   }
 }


### PR DESCRIPTION
## Description

This PR backports #7362. The only conflicts were with the PartitionCommandSenderImpl, where we still use the Atomix object directly in 1.0.x, but have replaced it with using the communication service directly in 1.1.x.

## Related issues

relates to #7360 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [x] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
