### PR TITLE
Separate build from runtime dependencies

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -398,7 +398,7 @@ public final class Broker implements AutoCloseable {
                     clusterServices.getMembershipService(),
                     owningPartition.members());
 
-            final PartitionTransitionContext context =
+            final PartitionTransitionContext transitionContext =
                 new PartitionTransitionContext(
                     localBroker.getNodeId(),
                     owningPartition,
@@ -417,8 +417,9 @@ public final class Broker implements AutoCloseable {
                     buildExporterRepository(brokerCfg),
                     new PartitionProcessingState(owningPartition));
             final PartitionTransitionImpl transitionBehavior =
-                new PartitionTransitionImpl(context, LEADER_STEPS, FOLLOWER_STEPS);
-            final ZeebePartition zeebePartition = new ZeebePartition(context, transitionBehavior);
+                new PartitionTransitionImpl(transitionContext, LEADER_STEPS, FOLLOWER_STEPS);
+            final ZeebePartition zeebePartition =
+                new ZeebePartition(transitionContext, transitionBehavior);
             scheduleActor(zeebePartition);
             zeebePartition.addFailureListener(
                 new PartitionHealthBroadcaster(partitionId, topologyManager::onHealthChanged));

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -45,9 +45,9 @@ import io.camunda.zeebe.broker.system.management.deployment.PushDeploymentReques
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
-import io.camunda.zeebe.broker.system.partitions.PartitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionHealthBroadcaster;
 import io.camunda.zeebe.broker.system.partitions.PartitionStep;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.TypedRecordProcessorsFactory;
 import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.broker.system.partitions.impl.AtomixPartitionMessagingService;
@@ -398,8 +398,8 @@ public final class Broker implements AutoCloseable {
                     clusterServices.getMembershipService(),
                     owningPartition.members());
 
-            final PartitionContext context =
-                new PartitionContext(
+            final PartitionTransitionContext context =
+                new PartitionTransitionContext(
                     localBroker.getNodeId(),
                     owningPartition,
                     partitionListeners,

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
@@ -9,12 +9,11 @@ package io.camunda.zeebe.broker.system.partitions;
 
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
-import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
-import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.util.health.HealthMonitor;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
 import java.io.IOException;
 import java.util.List;
 
@@ -28,13 +27,15 @@ public interface PartitionContext {
 
   RaftPartition getRaftPartition();
 
-  List<PartitionListener> getPartitionListeners();
+  List<ActorFuture<Void>> notifyListenersOfBecomingLeader(final long newTerm);
+
+  List<ActorFuture<Void>> notifyListenersOfBecomingFollower(final long newTerm);
+
+  void notifyListenersOfBecomingInactive();
 
   Role getCurrentRole();
 
   long getCurrentTerm();
-
-  LogStream getLogStream();
 
   HealthMonitor getComponentHealthMonitor();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions;
+
+import io.atomix.raft.RaftServer.Role;
+import io.atomix.raft.partition.RaftPartition;
+import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
+import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
+import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.util.health.HealthMonitor;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Interface encapsulating all the information about a partition that are needed at runtime (i.e.
+ * after the transition to the current role has completed)
+ */
+public interface PartitionContext {
+
+  int getPartitionId();
+
+  RaftPartition getRaftPartition();
+
+  List<PartitionListener> getPartitionListeners();
+
+  Role getCurrentRole();
+
+  long getCurrentTerm();
+
+  LogStream getLogStream();
+
+  HealthMonitor getComponentHealthMonitor();
+
+  StreamProcessor getStreamProcessor();
+
+  AsyncSnapshotDirector getSnapshotDirector();
+
+  ExporterDirector getExporterDirector();
+
+  void setDiskSpaceAvailable(boolean b);
+
+  boolean shouldProcess();
+
+  void pauseProcessing() throws IOException;
+
+  void resumeProcessing() throws IOException;
+
+  boolean shouldExport();
+
+  boolean pauseExporting() throws IOException;
+
+  boolean resumeExporting() throws IOException;
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.broker.system.partitions;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
-import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
@@ -41,7 +40,7 @@ public interface PartitionContext {
 
   StreamProcessor getStreamProcessor();
 
-  AsyncSnapshotDirector getSnapshotDirector();
+  void triggerSnapshot();
 
   ExporterDirector getExporterDirector();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStep.java
@@ -18,26 +18,26 @@ import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 public interface PartitionStep {
   /**
    * Performs some action required for the partition to function. This may include opening
-   * components (e.g., logstream), setting their values in {@link PartitionContext}, etc. The
-   * subsequent partition steps will only be opened after the returned future is completed.
+   * components (e.g., logstream), setting their values in {@link PartitionTransitionContext}, etc.
+   * The subsequent partition steps will only be opened after the returned future is completed.
    *
    * @param context the partition context
    * @return future
    */
-  default ActorFuture<Void> open(final PartitionContext context) {
+  default ActorFuture<Void> open(final PartitionTransitionContext context) {
     return CompletableActorFuture.completed(null);
   }
 
   /**
    * Perform tear-down actions to clear the partition and prepare for another one to be installed.
-   * This includes closing components, clearing their values from {@link PartitionContext} so they
-   * may be garbage-collected, etc. The subsequent partition steps will only be closed after the
-   * returned future is completed.
+   * This includes closing components, clearing their values from {@link PartitionTransitionContext}
+   * so they may be garbage-collected, etc. The subsequent partition steps will only be closed after
+   * the returned future is completed.
    *
    * @param context the partition context
    * @return future
    */
-  ActorFuture<Void> close(final PartitionContext context);
+  ActorFuture<Void> close(final PartitionTransitionContext context);
 
   /** @return A log-friendly identification of the PartitionStep. */
   String getName();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -30,7 +30,15 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-public class PartitionTransitionContext {
+/**
+ * Interface encapsulating all the information about a partition that are needed during transition
+ * to the role of the partition
+ *
+ * <p><strong>Note:</strong> Currently this class implements {@code PartitionConcept}. This is for
+ * legacy reasons to keep the change set small. In the future the transition should be the process
+ * by which the partition context is created.
+ */
+public class PartitionTransitionContext implements PartitionContext {
 
   private final int nodeId;
   private final List<PartitionListener> partitionListeners;
@@ -90,6 +98,7 @@ public class PartitionTransitionContext {
     this.partitionProcessingState = partitionProcessingState;
   }
 
+  @Override
   public ExporterDirector getExporterDirector() {
     return exporterDirector;
   }
@@ -122,6 +131,7 @@ public class PartitionTransitionContext {
     this.zeebeDb = zeebeDb;
   }
 
+  @Override
   public HealthMonitor getComponentHealthMonitor() {
     return criticalComponentsHealthMonitor;
   }
@@ -130,6 +140,7 @@ public class PartitionTransitionContext {
     this.criticalComponentsHealthMonitor = criticalComponentsHealthMonitor;
   }
 
+  @Override
   public AsyncSnapshotDirector getSnapshotDirector() {
     return snapshotDirector;
   }
@@ -170,6 +181,7 @@ public class PartitionTransitionContext {
     this.deferredCommitPosition = deferredCommitPosition;
   }
 
+  @Override
   public StreamProcessor getStreamProcessor() {
     return streamProcessor;
   }
@@ -178,6 +190,7 @@ public class PartitionTransitionContext {
     this.streamProcessor = streamProcessor;
   }
 
+  @Override
   public LogStream getLogStream() {
     return logStream;
   }
@@ -190,10 +203,12 @@ public class PartitionTransitionContext {
     return nodeId;
   }
 
+  @Override
   public int getPartitionId() {
     return partitionId;
   }
 
+  @Override
   public List<PartitionListener> getPartitionListeners() {
     return partitionListeners;
   }
@@ -214,6 +229,7 @@ public class PartitionTransitionContext {
     return snapshotStoreSupplier;
   }
 
+  @Override
   public RaftPartition getRaftPartition() {
     return raftPartition;
   }
@@ -234,34 +250,42 @@ public class PartitionTransitionContext {
     return exporterRepository;
   }
 
+  @Override
   public void setDiskSpaceAvailable(final boolean diskSpaceAvailable) {
     partitionProcessingState.setDiskSpaceAvailable(diskSpaceAvailable);
   }
 
+  @Override
   public boolean shouldProcess() {
     return partitionProcessingState.shouldProcess();
   }
 
+  @Override
   public boolean shouldExport() {
     return !partitionProcessingState.isExportingPaused();
   }
 
+  @Override
   public void pauseProcessing() throws IOException {
     partitionProcessingState.pauseProcessing();
   }
 
+  @Override
   public void resumeProcessing() throws IOException {
     partitionProcessingState.resumeProcessing();
   }
 
+  @Override
   public boolean pauseExporting() throws IOException {
     return partitionProcessingState.pauseExporting();
   }
 
+  @Override
   public boolean resumeExporting() throws IOException {
     return partitionProcessingState.resumeExporting();
   }
 
+  @Override
   public long getCurrentTerm() {
     return currentTerm;
   }
@@ -270,11 +294,16 @@ public class PartitionTransitionContext {
     this.currentTerm = currentTerm;
   }
 
+  @Override
   public Role getCurrentRole() {
     return currentRole;
   }
 
   public void setCurrentRole(final Role currentRole) {
     this.currentRole = currentRole;
+  }
+
+  public PartitionContext toPartitionContext() {
+    return this;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -33,8 +33,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Interface encapsulating all the information about a partition that are needed during transition
- * to the role of the partition
+ * Class encapsulating all the information about a partition that are needed during transition to
+ * the role of the partition
  *
  * <p><strong>Note:</strong> Currently this class implements {@code PartitionConcept}. This is for
  * legacy reasons to keep the change set small. In the future the transition should be the process
@@ -142,7 +142,6 @@ public class PartitionTransitionContext implements PartitionContext {
     this.criticalComponentsHealthMonitor = criticalComponentsHealthMonitor;
   }
 
-  @Override
   public AsyncSnapshotDirector getSnapshotDirector() {
     return snapshotDirector;
   }
@@ -320,5 +319,12 @@ public class PartitionTransitionContext implements PartitionContext {
   @Override
   public void notifyListenersOfBecomingInactive() {
     partitionListeners.forEach(l -> l.onBecomingInactive(getPartitionId(), getCurrentTerm()));
+  }
+
+  @Override
+  public void triggerSnapshot() {
+    if (getSnapshotDirector() != null) {
+      getSnapshotDirector().forceSnapshot();
+    }
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-public class PartitionContext {
+public class PartitionTransitionContext {
 
   private final int nodeId;
   private final List<PartitionListener> partitionListeners;
@@ -63,7 +63,7 @@ public class PartitionContext {
   private long currentTerm;
   private Role currentRole;
 
-  public PartitionContext(
+  public PartitionTransitionContext(
       final int nodeId,
       final RaftPartition raftPartition,
       final List<PartitionListener> partitionListeners,

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -41,12 +41,13 @@ public final class ZeebePartition extends Actor
   private final HealthMetrics healthMetrics;
   private final ZeebePartitionHealth zeebePartitionHealth;
 
-  private final PartitionContext context;
+  private final PartitionTransitionContext context;
   private final PartitionTransition transition;
   private CompletableActorFuture<Void> closeFuture;
   private ActorFuture<Void> currentTransitionFuture;
 
-  public ZeebePartition(final PartitionContext context, final PartitionTransition transition) {
+  public ZeebePartition(
+      final PartitionTransitionContext context, final PartitionTransition transition) {
     this.context = context;
     this.transition = transition;
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -396,9 +396,7 @@ public final class ZeebePartition extends Actor
   public void triggerSnapshot() {
     actor.call(
         () -> {
-          if (context.getSnapshotDirector() != null) {
-            context.getSnapshotDirector().forceSnapshot();
-          }
+          context.triggerSnapshot();
         });
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -41,23 +41,25 @@ public final class ZeebePartition extends Actor
   private final HealthMetrics healthMetrics;
   private final ZeebePartitionHealth zeebePartitionHealth;
 
-  private final PartitionTransitionContext context;
+  private final PartitionContext context;
   private final PartitionTransition transition;
   private CompletableActorFuture<Void> closeFuture;
   private ActorFuture<Void> currentTransitionFuture;
 
   public ZeebePartition(
-      final PartitionTransitionContext context, final PartitionTransition transition) {
-    this.context = context;
+      final PartitionTransitionContext transitionContext, final PartitionTransition transition) {
+    context = transitionContext.toPartitionContext();
     this.transition = transition;
 
-    context.setActor(actor);
-    context.setDiskSpaceAvailable(true);
+    transitionContext.setActor(actor);
+    transitionContext.setDiskSpaceAvailable(true);
 
-    actorName = buildActorName(context.getNodeId(), "ZeebePartition", context.getPartitionId());
-    context.setComponentHealthMonitor(new CriticalComponentsHealthMonitor(actor, LOG));
-    zeebePartitionHealth = new ZeebePartitionHealth(context.getPartitionId());
-    healthMetrics = new HealthMetrics(context.getPartitionId());
+    actorName =
+        buildActorName(
+            transitionContext.getNodeId(), "ZeebePartition", transitionContext.getPartitionId());
+    transitionContext.setComponentHealthMonitor(new CriticalComponentsHealthMonitor(actor, LOG));
+    zeebePartitionHealth = new ZeebePartitionHealth(transitionContext.getPartitionId());
+    healthMetrics = new HealthMetrics(transitionContext.getPartitionId());
     healthMetrics.setUnhealthy();
     failureListeners = new ArrayList<>();
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
@@ -9,9 +9,9 @@ package io.camunda.zeebe.broker.system.partitions.impl;
 
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.Loggers;
-import io.camunda.zeebe.broker.system.partitions.PartitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionStep;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransition;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
@@ -26,14 +26,14 @@ public class PartitionTransitionImpl implements PartitionTransition {
   private static final List<PartitionStep> EMPTY_LIST = Collections.emptyList();
   private static final int INACTIVE_TERM = -1;
 
-  private final PartitionContext context;
+  private final PartitionTransitionContext context;
   private final List<PartitionStep> leaderSteps;
   private final List<PartitionStep> followerSteps;
   private final List<PartitionStep> openedSteps = new ArrayList<>();
   private CompletableActorFuture<Void> currentTransition = CompletableActorFuture.completed(null);
 
   public PartitionTransitionImpl(
-      final PartitionContext context,
+      final PartitionTransitionContext context,
       final List<PartitionStep> leaderSteps,
       final List<PartitionStep> followerSteps) {
     this.context = context;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionStep.java
@@ -9,8 +9,8 @@ package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext;
-import io.camunda.zeebe.broker.system.partitions.PartitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionStep;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.util.sched.Actor;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 
@@ -19,7 +19,7 @@ public class ExporterDirectorPartitionStep implements PartitionStep {
   private static final int EXPORTER_PROCESSOR_ID = 1003;
 
   @Override
-  public ActorFuture<Void> open(final PartitionContext context) {
+  public ActorFuture<Void> open(final PartitionTransitionContext context) {
     final var exporterDescriptors = context.getExporterRepository().getExporters().values();
 
     final ExporterDirectorContext exporterCtx =
@@ -50,7 +50,7 @@ public class ExporterDirectorPartitionStep implements PartitionStep {
   }
 
   @Override
-  public ActorFuture<Void> close(final PartitionContext context) {
+  public ActorFuture<Void> close(final PartitionTransitionContext context) {
     final var director = context.getExporterDirector();
     context.getComponentHealthMonitor().removeComponent(director.getName());
     final ActorFuture<Void> future = director.closeAsync();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/FollowerPostStoragePartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/FollowerPostStoragePartitionStep.java
@@ -7,21 +7,21 @@
  */
 package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
-import io.camunda.zeebe.broker.system.partitions.PartitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionStep;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 
 public class FollowerPostStoragePartitionStep implements PartitionStep {
 
   @Override
-  public ActorFuture<Void> open(final PartitionContext context) {
+  public ActorFuture<Void> open(final PartitionTransitionContext context) {
     context.getSnapshotController().consumeReplicatedSnapshots();
     return CompletableActorFuture.completed(null);
   }
 
   @Override
-  public ActorFuture<Void> close(final PartitionContext context) {
+  public ActorFuture<Void> close(final PartitionTransitionContext context) {
     return CompletableActorFuture.completed(null);
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LeaderPostStoragePartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LeaderPostStoragePartitionStep.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
-import io.camunda.zeebe.broker.system.partitions.PartitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionStep;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 
 public class LeaderPostStoragePartitionStep implements PartitionStep {
 
   @Override
-  public ActorFuture<Void> open(final PartitionContext context) {
+  public ActorFuture<Void> open(final PartitionTransitionContext context) {
     context
         .getSnapshotStoreSupplier()
         .getPersistedSnapshotStore(context.getRaftPartition().id().id())
@@ -25,7 +25,7 @@ public class LeaderPostStoragePartitionStep implements PartitionStep {
   }
 
   @Override
-  public ActorFuture<Void> close(final PartitionContext context) {
+  public ActorFuture<Void> close(final PartitionTransitionContext context) {
     context
         .getSnapshotStoreSupplier()
         .getPersistedSnapshotStore(context.getRaftPartition().id().id())

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogDeletionPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogDeletionPartitionStep.java
@@ -10,14 +10,14 @@ package io.camunda.zeebe.broker.system.partitions.impl.steps;
 import io.camunda.zeebe.broker.logstreams.AtomixLogCompactor;
 import io.camunda.zeebe.broker.logstreams.LogCompactor;
 import io.camunda.zeebe.broker.logstreams.LogDeletionService;
-import io.camunda.zeebe.broker.system.partitions.PartitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionStep;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 
 public class LogDeletionPartitionStep implements PartitionStep {
 
   @Override
-  public ActorFuture<Void> open(final PartitionContext context) {
+  public ActorFuture<Void> open(final PartitionTransitionContext context) {
     final LogCompactor logCompactor =
         new AtomixLogCompactor(context.getRaftPartition().getServer());
     final LogDeletionService deletionService =
@@ -34,7 +34,7 @@ public class LogDeletionPartitionStep implements PartitionStep {
   }
 
   @Override
-  public ActorFuture<Void> close(final PartitionContext context) {
+  public ActorFuture<Void> close(final PartitionTransitionContext context) {
     final ActorFuture<Void> future = context.getLogDeletionService().closeAsync();
     context.setLogDeletionService(null);
     return future;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/RocksDbMetricExporterPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/RocksDbMetricExporterPartitionStep.java
@@ -9,8 +9,8 @@ package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
 import static io.camunda.zeebe.engine.state.DefaultZeebeDbFactory.DEFAULT_DB_METRIC_EXPORTER_FACTORY;
 
-import io.camunda.zeebe.broker.system.partitions.PartitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionStep;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.time.Duration;
@@ -18,7 +18,7 @@ import java.time.Duration;
 public class RocksDbMetricExporterPartitionStep implements PartitionStep {
 
   @Override
-  public ActorFuture<Void> open(final PartitionContext context) {
+  public ActorFuture<Void> open(final PartitionTransitionContext context) {
     final var metricExporter =
         DEFAULT_DB_METRIC_EXPORTER_FACTORY.apply(
             Integer.toString(context.getPartitionId()), context.getZeebeDb());
@@ -38,7 +38,7 @@ public class RocksDbMetricExporterPartitionStep implements PartitionStep {
   }
 
   @Override
-  public ActorFuture<Void> close(final PartitionContext context) {
+  public ActorFuture<Void> close(final PartitionTransitionContext context) {
     context.getMetricsTimer().cancel();
     context.setMetricsTimer(null);
     return CompletableActorFuture.completed(null);

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionStep.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
-import io.camunda.zeebe.broker.system.partitions.PartitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionStep;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import java.time.Duration;
@@ -16,7 +16,7 @@ import java.time.Duration;
 public class SnapshotDirectorPartitionStep implements PartitionStep {
 
   @Override
-  public ActorFuture<Void> open(final PartitionContext context) {
+  public ActorFuture<Void> open(final PartitionTransitionContext context) {
     final Duration snapshotPeriod = context.getBrokerCfg().getData().getSnapshotPeriod();
     final AsyncSnapshotDirector director =
         new AsyncSnapshotDirector(
@@ -32,7 +32,7 @@ public class SnapshotDirectorPartitionStep implements PartitionStep {
   }
 
   @Override
-  public ActorFuture<Void> close(final PartitionContext context) {
+  public ActorFuture<Void> close(final PartitionTransitionContext context) {
     final var director = context.getSnapshotDirector();
     context.getComponentHealthMonitor().removeComponent(director.getName());
     final ActorFuture<Void> future = director.closeAsync();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotReplicationPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotReplicationPartitionStep.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
 import io.camunda.zeebe.broker.Loggers;
-import io.camunda.zeebe.broker.system.partitions.PartitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionStep;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.SnapshotReplication;
 import io.camunda.zeebe.broker.system.partitions.impl.NoneSnapshotReplication;
 import io.camunda.zeebe.broker.system.partitions.impl.StateReplication;
@@ -19,7 +19,7 @@ import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 public class SnapshotReplicationPartitionStep implements PartitionStep {
 
   @Override
-  public ActorFuture<Void> open(final PartitionContext context) {
+  public ActorFuture<Void> open(final PartitionTransitionContext context) {
     final SnapshotReplication replication =
         shouldReplicateSnapshots(context)
             ? new StateReplication(
@@ -31,7 +31,7 @@ public class SnapshotReplicationPartitionStep implements PartitionStep {
   }
 
   @Override
-  public ActorFuture<Void> close(final PartitionContext context) {
+  public ActorFuture<Void> close(final PartitionTransitionContext context) {
     try {
       if (context.getSnapshotReplication() != null) {
         context.getSnapshotReplication().close();
@@ -53,7 +53,7 @@ public class SnapshotReplicationPartitionStep implements PartitionStep {
     return "SnapshotReplication";
   }
 
-  private boolean shouldReplicateSnapshots(final PartitionContext state) {
+  private boolean shouldReplicateSnapshots(final PartitionTransitionContext state) {
     return state.getBrokerCfg().getCluster().getReplicationFactor() > 1;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
@@ -10,8 +10,8 @@ package io.camunda.zeebe.broker.system.partitions.impl.steps;
 import io.atomix.raft.storage.log.RaftLogReader.Mode;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.logstreams.state.StatePositionSupplier;
-import io.camunda.zeebe.broker.system.partitions.PartitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionStep;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.impl.AtomixRecordEntrySupplierImpl;
 import io.camunda.zeebe.broker.system.partitions.impl.StateControllerImpl;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
@@ -21,7 +21,7 @@ import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 public class StateControllerPartitionStep implements PartitionStep {
 
   @Override
-  public ActorFuture<Void> open(final PartitionContext context) {
+  public ActorFuture<Void> open(final PartitionTransitionContext context) {
     final var runtimeDirectory =
         context.getRaftPartition().dataDirectory().toPath().resolve("runtime");
     final var databaseCfg = context.getBrokerCfg().getExperimental().getRocksdb();
@@ -45,7 +45,7 @@ public class StateControllerPartitionStep implements PartitionStep {
   }
 
   @Override
-  public ActorFuture<Void> close(final PartitionContext context) {
+  public ActorFuture<Void> close(final PartitionTransitionContext context) {
     try {
       context.getSnapshotController().close();
     } catch (final Exception e) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorPartitionStep.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
-import io.camunda.zeebe.broker.system.partitions.PartitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionStep;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
@@ -19,7 +19,7 @@ import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 public class StreamProcessorPartitionStep implements PartitionStep {
 
   @Override
-  public ActorFuture<Void> open(final PartitionContext context) {
+  public ActorFuture<Void> open(final PartitionTransitionContext context) {
     final StreamProcessor streamProcessor = createStreamProcessor(context);
     final ActorFuture<Void> openFuture = streamProcessor.openAsync(!context.shouldProcess());
     final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
@@ -50,7 +50,7 @@ public class StreamProcessorPartitionStep implements PartitionStep {
   }
 
   @Override
-  public ActorFuture<Void> close(final PartitionContext context) {
+  public ActorFuture<Void> close(final PartitionTransitionContext context) {
     context.getComponentHealthMonitor().removeComponent(context.getStreamProcessor().getName());
     final ActorFuture<Void> future = context.getStreamProcessor().closeAsync();
     context.setStreamProcessor(null);
@@ -62,7 +62,7 @@ public class StreamProcessorPartitionStep implements PartitionStep {
     return "StreamProcessor";
   }
 
-  private StreamProcessor createStreamProcessor(final PartitionContext state) {
+  private StreamProcessor createStreamProcessor(final PartitionTransitionContext state) {
     return StreamProcessor.builder()
         .logStream(state.getLogStream())
         .actorScheduler(state.getScheduler())

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ZeebeDbPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ZeebeDbPartitionStep.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
 import io.camunda.zeebe.broker.Loggers;
-import io.camunda.zeebe.broker.system.partitions.PartitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionStep;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
@@ -17,7 +17,7 @@ import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 public class ZeebeDbPartitionStep implements PartitionStep {
 
   @Override
-  public ActorFuture<Void> open(final PartitionContext context) {
+  public ActorFuture<Void> open(final PartitionTransitionContext context) {
     context
         .getSnapshotStoreSupplier()
         .getPersistedSnapshotStore(context.getRaftPartition().id().id())
@@ -43,7 +43,7 @@ public class ZeebeDbPartitionStep implements PartitionStep {
   }
 
   @Override
-  public ActorFuture<Void> close(final PartitionContext context) {
+  public ActorFuture<Void> close(final PartitionTransitionContext context) {
     // ZeebeDb is closed in the StateController's close()
     context.setZeebeDb(null);
     return CompletableActorFuture.completed(null);

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -56,6 +56,7 @@ public class ZeebePartitionTest {
     healthMonitor = mock(CriticalComponentsHealthMonitor.class);
 
     when(ctx.getRaftPartition()).thenReturn(raft);
+    when(ctx.toPartitionContext()).thenReturn(ctx);
     when(ctx.getComponentHealthMonitor()).thenReturn(healthMonitor);
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -39,14 +39,14 @@ public class ZeebePartitionTest {
 
   @Rule public ControlledActorSchedulerRule schedulerRule = new ControlledActorSchedulerRule();
 
-  private PartitionContext ctx;
+  private PartitionTransitionContext ctx;
   private PartitionTransition transition;
   private CriticalComponentsHealthMonitor healthMonitor;
   private RaftPartition raft;
 
   @Before
   public void setup() {
-    ctx = mock(PartitionContext.class);
+    ctx = mock(PartitionTransitionContext.class);
     transition = spy(new NoopTransition());
 
     raft = mock(RaftPartition.class);

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTransitionIntegrationTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTransitionIntegrationTest.java
@@ -29,12 +29,12 @@ public class ZeebePartitionTransitionIntegrationTest {
 
   @Rule public ActorSchedulerRule schedulerRule = new ActorSchedulerRule();
 
-  private PartitionContext ctx;
+  private PartitionTransitionContext ctx;
   private PartitionTransition transition;
 
   @Before
   public void setup() {
-    ctx = mock(PartitionContext.class);
+    ctx = mock(PartitionTransitionContext.class);
     final TestPartitionStep firstComponent = spy(TestPartitionStep.builder().build());
     final TestPartitionStep secondComponent = spy(TestPartitionStep.builder().build());
     transition =

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTransitionIntegrationTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTransitionIntegrationTest.java
@@ -48,6 +48,7 @@ public class ZeebePartitionTransitionIntegrationTest {
         mock(CriticalComponentsHealthMonitor.class);
 
     when(ctx.getRaftPartition()).thenReturn(raftPartition);
+    when(ctx.toPartitionContext()).thenReturn(ctx);
     when(ctx.getComponentHealthMonitor()).thenReturn(healthMonitor);
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionTest.java
@@ -33,8 +33,7 @@ public class PartitionTransitionTest {
   private final ControlledActorSchedulerRule schedulerRule = new ControlledActorSchedulerRule();
   private final Timeout testTimeout = Timeout.seconds(30);
 
-  @Rule public final RuleChain chain = RuleChain.outerRule(testTimeout).around(
-      schedulerRule);
+  @Rule public final RuleChain chain = RuleChain.outerRule(testTimeout).around(schedulerRule);
 
   private PartitionTransitionContext ctx;
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.raft.RaftServer.Role;
-import io.camunda.zeebe.broker.system.partitions.PartitionContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.sched.Actor;
 import io.camunda.zeebe.util.sched.testing.ControlledActorSchedulerRule;
@@ -33,13 +33,14 @@ public class PartitionTransitionTest {
   private final ControlledActorSchedulerRule schedulerRule = new ControlledActorSchedulerRule();
   private final Timeout testTimeout = Timeout.seconds(30);
 
-  @Rule public final RuleChain chain = RuleChain.outerRule(testTimeout).around(schedulerRule);
+  @Rule public final RuleChain chain = RuleChain.outerRule(testTimeout).around(
+      schedulerRule);
 
-  private PartitionContext ctx;
+  private PartitionTransitionContext ctx;
 
   @Before
   public void setup() {
-    ctx = mock(PartitionContext.class);
+    ctx = mock(PartitionTransitionContext.class);
     when(ctx.getPartitionId()).thenReturn(0);
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/TestPartitionStep.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/TestPartitionStep.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.broker.system.partitions.impl;
 
-import io.camunda.zeebe.broker.system.partitions.PartitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionStep;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 
@@ -30,7 +30,7 @@ public final class TestPartitionStep implements PartitionStep {
   }
 
   @Override
-  public ActorFuture<Void> open(final PartitionContext context) {
+  public ActorFuture<Void> open(final PartitionTransitionContext context) {
     if (throwOnOpen != null) {
       throw throwOnOpen;
     }
@@ -41,7 +41,7 @@ public final class TestPartitionStep implements PartitionStep {
   }
 
   @Override
-  public ActorFuture<Void> close(final PartitionContext context) {
+  public ActorFuture<Void> close(final PartitionTransitionContext context) {
     if (throwOnClose != null) {
       throw throwOnClose;
     }
@@ -87,7 +87,8 @@ public final class TestPartitionStep implements PartitionStep {
     }
 
     public TestPartitionStep build() {
-      return new TestPartitionStep(failOpen, failClose, throwOnOpen, throwOnClose);
+      return new TestPartitionStep(failOpen, failClose, throwOnOpen,
+          throwOnClose);
     }
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/TestPartitionStep.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/TestPartitionStep.java
@@ -87,8 +87,7 @@ public final class TestPartitionStep implements PartitionStep {
     }
 
     public TestPartitionStep build() {
-      return new TestPartitionStep(failOpen, failClose, throwOnOpen,
-          throwOnClose);
+      return new TestPartitionStep(failOpen, failClose, throwOnOpen, throwOnClose);
     }
   }
 }


### PR DESCRIPTION
## Description

This change contains several intermediate steps to better define the partition context and which dependencies are needed at runtime.

Looking at the existing `PartitionContext` it is clear that much of the stuff inside it is only needed during the transition, but not after the transition has completed.

This PR:
* Renames `PartitionContext` to `PartitionTransitionContext` 
* Introduces a new interface `PartitionContext` which only exposes those components and methods that are needed by `ZeebePartition` at runtime
* Refactors the way the notification of listeners is done to keep the `PartitionContext` interface smaller

There is more that could be done here, but I think it is a small step in the right direction.


<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
