### PR TITLE
Add metrics for election latency

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -122,6 +122,8 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private PersistedSnapshot currentSnapshot;
   private volatile HealthStatus health = HealthStatus.HEALTHY;
 
+  private long lastHeartbeat;
+
   public RaftContext(
       final String name,
       final MemberId localMemberId,
@@ -1003,6 +1005,18 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
   public Random getRandom() {
     return random;
+  }
+
+  public long getLastHeartbeat() {
+    return lastHeartbeat;
+  }
+
+  public void setLastHeartbeat(final long lastHeartbeat) {
+    this.lastHeartbeat = lastHeartbeat;
+  }
+
+  public void resetLastHeartbeat() {
+    setLastHeartbeat(System.currentTimeMillis());
   }
 
   /** Raft server state. */

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -195,6 +195,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     raftRoleMetrics = new RaftRoleMetrics(name);
     replicationMetrics = new RaftReplicationMetrics(name);
     replicationMetrics.setAppendIndex(raftLog.getLastIndex());
+    lastHeartbeat = System.currentTimeMillis();
     started = true;
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRoleMetrics.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRoleMetrics.java
@@ -45,6 +45,13 @@ public class RaftRoleMetrics extends RaftMetrics {
           .help("Time between heartbeats")
           .labelNames("partitionGroupName", "partition")
           .register();
+  private static final Gauge ELECTION_LATENCY =
+      Gauge.build()
+          .namespace("atomix")
+          .name("election_latency_in_ms")
+          .help("Duration for election")
+          .labelNames("partitionGroupName", "partition")
+          .register();
 
   public RaftRoleMetrics(final String partitionName) {
     super(partitionName);
@@ -72,5 +79,9 @@ public class RaftRoleMetrics extends RaftMetrics {
 
   public static double getHeartbeatMissCount(final String partition) {
     return HEARTBEAT_MISS.labels(partition, partition).get();
+  }
+
+  public void setElectionLatency(final long latencyMs) {
+    ELECTION_LATENCY.labels(partitionGroupName, partition).set(latencyMs);
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -72,6 +72,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
   public LeaderRole(final RaftContext context) {
     super(context);
     appender = new LeaderAppender(this);
+    final var electionLatency = System.currentTimeMillis() - raft.getLastHeartbeat();
   }
 
   @Override
@@ -93,6 +94,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
 
   @Override
   public synchronized CompletableFuture<Void> stop() {
+    raft.resetLastHeartbeat();
     return super.stop()
         .thenRun(appender::close)
         .thenRun(this::cancelTimers)

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -72,11 +72,13 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
   public LeaderRole(final RaftContext context) {
     super(context);
     appender = new LeaderAppender(this);
-    final var electionLatency = System.currentTimeMillis() - raft.getLastHeartbeat();
   }
 
   @Override
   public synchronized CompletableFuture<RaftRole> start() {
+    raft.getRaftRoleMetrics()
+        .setElectionLatency(System.currentTimeMillis() - raft.getLastHeartbeat());
+
     // Reset state for the leader.
     takeLeadership();
 


### PR DESCRIPTION
## Description

The metrics is calculated at the leader node. The election latency = the time between the current leader received the last heartbeat from the previous leader until the current leader role is started.

## Related issues

closes #7288 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
