### PR TITLE
feat(clients/java): add the default region using the camunda cloud builder

### DIFF
--- a/clients/java/revapi.json
+++ b/clients/java/revapi.json
@@ -26,5 +26,17 @@
         ]
       }
     }
+  },
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "justification": "Ignore new methods on all types, as these are not meant to be implemented but simply consumed; as such, new methods are perfectly fine to add",
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.method.addedToInterface"
+        }
+      ]
+    }
   }
 ]

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientCloudBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientCloudBuilderStep1.java
@@ -44,7 +44,15 @@ public interface ZeebeClientCloudBuilderStep1 {
        */
       ZeebeClientCloudBuilderStep4 withClientSecret(String clientSecret);
 
-      interface ZeebeClientCloudBuilderStep4 extends ZeebeClientBuilder {}
+      interface ZeebeClientCloudBuilderStep4 extends ZeebeClientBuilder {
+
+        /**
+         * Sets the region of the Camunda Cloud cluster. Default is 'bru-2'.
+         *
+         * @param region region of the Camunda Cloud cluster
+         */
+        ZeebeClientCloudBuilderStep4 withRegion(String region);
+      }
     }
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -41,11 +41,14 @@ public class ZeebeClientCloudBuilderImpl
   private static final String BASE_ADDRESS = "zeebe.camunda.io";
   private static final String BASE_AUTH_URL = "https://login.cloud.camunda.io/oauth/token";
 
+  private static final String DEFAULT_REGION = "bru-2";
+
   private final ZeebeClientBuilderImpl innerBuilder = new ZeebeClientBuilderImpl();
 
   private String clusterId;
   private String clientId;
   private String clientSecret;
+  private String region = DEFAULT_REGION;
 
   @Override
   public ZeebeClientCloudBuilderStep2 withClusterId(final String clusterId) {
@@ -62,6 +65,12 @@ public class ZeebeClientCloudBuilderImpl
   @Override
   public ZeebeClientCloudBuilderStep4 withClientSecret(final String clientSecret) {
     this.clientSecret = clientSecret;
+    return this;
+  }
+
+  @Override
+  public ZeebeClientCloudBuilderStep4 withRegion(final String region) {
+    this.region = region;
     return this;
   }
 
@@ -175,7 +184,7 @@ public class ZeebeClientCloudBuilderImpl
   private String determineGatewayAddress() {
     if (isNeedToSetCloudGatewayAddress()) {
       ensureNotNull("cluster id", clusterId);
-      return String.format("%s.%s:443", clusterId, BASE_ADDRESS);
+      return String.format("%s.%s.%s:443", clusterId, region, BASE_ADDRESS);
     } else {
       Loggers.LOGGER.debug(
           "Expected to use 'cluster id' to set gateway address in the client cloud builder, "
@@ -197,7 +206,7 @@ public class ZeebeClientCloudBuilderImpl
         Loggers.LOGGER.debug("Expected setting 'usePlaintext' to be 'false', but found 'true'.");
       }
       return builder
-          .audience(String.format("%s.%s", clusterId, BASE_ADDRESS))
+          .audience(String.format("%s.%s.%s", clusterId, region, BASE_ADDRESS))
           .clientId(clientId)
           .clientSecret(clientSecret)
           .authorizationServerUrl(BASE_AUTH_URL)
@@ -221,6 +230,7 @@ public class ZeebeClientCloudBuilderImpl
     final StringBuilder sb = new StringBuilder(innerBuilder.toString());
     appendProperty(sb, "clusterId", clusterId);
     appendProperty(sb, "clientId", clientId);
+    appendProperty(sb, "region", region);
     return sb.toString();
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -179,6 +179,29 @@ public final class ZeebeClientTest extends ClientTest {
   public void shouldCloudBuilderBuildProperClient() {
     // given
     final String clusterId = "clusterId";
+    final String region = "asdf-123";
+
+    try (final ZeebeClient client =
+        ZeebeClient.newCloudClientBuilder()
+            .withClusterId(clusterId)
+            .withClientId("clientId")
+            .withClientSecret("clientSecret")
+            .withRegion(region)
+            .build()) {
+      // when
+      final ZeebeClientConfiguration clientConfiguration = client.getConfiguration();
+      // then
+      assertThat(clientConfiguration.getCredentialsProvider())
+          .isInstanceOf(OAuthCredentialsProvider.class);
+      assertThat(clientConfiguration.getGatewayAddress())
+          .isEqualTo(String.format("%s.%s.zeebe.camunda.io:443", clusterId, region));
+    }
+  }
+
+  @Test
+  public void shouldCloudBuilderBuildProperClientWithDefaultRegion() {
+    // given
+    final String clusterId = "clusterId";
     try (final ZeebeClient client =
         ZeebeClient.newCloudClientBuilder()
             .withClusterId(clusterId)
@@ -191,7 +214,7 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(clientConfiguration.getCredentialsProvider())
           .isInstanceOf(OAuthCredentialsProvider.class);
       assertThat(clientConfiguration.getGatewayAddress())
-          .isEqualTo(String.format("%s.zeebe.camunda.io:443", clusterId));
+          .isEqualTo(String.format("%s.bru-2.zeebe.camunda.io:443", clusterId));
     }
   }
 

--- a/test/revapi.json
+++ b/test/revapi.json
@@ -12,5 +12,19 @@
         ]
       }
     }
+  },
+  {
+    "extension": "revapi.filter",
+    "configuration": {
+      "justification": "The client API is already checked in the module itself.",
+      "elements": {
+        "exclude": [
+          {
+            "matcher": "java-package",
+            "match": "io.camunda.zeebe.client"
+          }
+        ]
+      }
+    }
   }
 ]


### PR DESCRIPTION
## Description

- Adds `bru-2` as the default region to URLs build using the Camunda Cloud builder
- Adds a new method `withRegion` to the Camunda Cloud builder to allow users to override the region, i.e. if we have multiple region support
- Adds the region to the audience as it is used in the credentials cache

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7391 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
