### PR TITLE
Expose configs for  electiontimeout and heartbeatInterval

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -338,6 +338,31 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
     }
 
     /**
+     * Sets the heartbeatInterval. The leader will send heartbeats to a follower at this interval.
+     *
+     * @param heartbeatInterval the delay between two heartbeats
+     * @return the Raft partition group builder
+     */
+    public Builder withHeartbeatInterval(final Duration heartbeatInterval) {
+      checkArgument(heartbeatInterval.toMillis() > 0, "heartbeatInterval must be atleast 1ms");
+      config.setHeartbeatInterval(heartbeatInterval);
+      return this;
+    }
+
+    /**
+     * Sets the election timeout. If a follower does not receive a heartbeat from the leader within
+     * election timeout, it can start a new leader election.
+     *
+     * @param electionTimeout the election timeout
+     * @return the Raft partition group builder
+     */
+    public Builder withElectionTimeout(final Duration electionTimeout) {
+      checkArgument(electionTimeout.toMillis() > 0, "heartbeatInterval must be atleast 1ms");
+      config.setElectionTimeout(electionTimeout);
+      return this;
+    }
+
+    /**
      * Sets the path to the data directory.
      *
      * @param dataDir the path to the replica's data directory

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -111,6 +111,8 @@ public final class AtomixFactory {
             .withSnapshotStoreFactory(snapshotStoreFactory)
             .withMaxAppendBatchSize((int) experimentalCfg.getMaxAppendBatchSizeInBytes())
             .withMaxAppendsPerFollower(experimentalCfg.getMaxAppendsPerFollower())
+            .withHeartbeatInterval(clusterCfg.getHeartbeatInterval())
+            .withElectionTimeout(clusterCfg.getElectionTimeout())
             .withEntryValidator(new ZeebeEntryValidator())
             .withFlushExplicitly(!experimentalCfg.isDisableExplicitRaftFlush())
             .withFreeDiskSpace(dataCfg.getFreeDiskSpaceReplicationWatermark())

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -126,6 +126,23 @@ public final class SystemContext {
     if (experimental.isDisableExplicitRaftFlush()) {
       LOG.warn(REPLICATION_WITH_DISABLED_FLUSH_WARNING);
     }
+
+    final var heartbeatInterval = cluster.getHeartbeatInterval();
+    final var electionTimeout = cluster.getElectionTimeout();
+    if (heartbeatInterval.toMillis() < 1) {
+      throw new IllegalArgumentException(
+          String.format("heartbeatInterval %s must be at least 1ms", heartbeatInterval));
+    }
+    if (electionTimeout.toMillis() < 1) {
+      throw new IllegalArgumentException(
+          String.format("electionTimeout %s must be at least 1ms", electionTimeout));
+    }
+    if (electionTimeout.compareTo(heartbeatInterval) < 1) {
+      throw new IllegalArgumentException(
+          String.format(
+              "electionTimeout %s must be greater than heartbeatInterval %s",
+              electionTimeout, heartbeatInterval));
+    }
   }
 
   private ActorScheduler initScheduler(final ActorClock clock, final String brokerId) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.system.configuration;
 import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
 import static io.camunda.zeebe.util.StringUtil.LIST_SANITIZER;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,6 +24,8 @@ public final class ClusterCfg implements ConfigurationEntry {
   public static final int DEFAULT_REPLICATION_FACTOR = 1;
   public static final int DEFAULT_CLUSTER_SIZE = 1;
   public static final String DEFAULT_CLUSTER_NAME = "zeebe-cluster";
+  private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(250);
+  private static final Duration DEFAULT_ELECTION_TIMEOUT = Duration.ofMillis(2500);
 
   private List<String> initialContactPoints = DEFAULT_CONTACT_POINTS;
 
@@ -32,6 +35,8 @@ public final class ClusterCfg implements ConfigurationEntry {
   private int replicationFactor = DEFAULT_REPLICATION_FACTOR;
   private int clusterSize = DEFAULT_CLUSTER_SIZE;
   private String clusterName = DEFAULT_CLUSTER_NAME;
+  private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
+  private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private MembershipCfg membership = new MembershipCfg();
 
   @Override
@@ -106,6 +111,14 @@ public final class ClusterCfg implements ConfigurationEntry {
     this.membership = membership;
   }
 
+  public Duration getHeartbeatInterval() {
+    return heartbeatInterval;
+  }
+
+  public void setHeartbeatInterval(final Duration heartbeatInterval) {
+    this.heartbeatInterval = heartbeatInterval;
+  }
+
   @Override
   public String toString() {
     return "ClusterCfg{"
@@ -126,6 +139,18 @@ public final class ClusterCfg implements ConfigurationEntry {
         + '\''
         + ", membership="
         + membership
+        + ", heartbeatInterval="
+        + heartbeatInterval
+        + ", electionTimeout="
+        + electionTimeout
         + '}';
+  }
+
+  public Duration getElectionTimeout() {
+    return electionTimeout;
+  }
+
+  public void setElectionTimeout(final Duration electionTimeout) {
+    this.electionTimeout = electionTimeout;
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -161,6 +161,47 @@ public final class SystemContextTest {
         .isEqualTo(Duration.ofMinutes(1));
   }
 
+  @Test
+  public void shouldThrowExceptionIfHeartbeatIntervalIsSmallerThanOneMs() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.getCluster().setHeartbeatInterval(Duration.ofMillis(0));
+
+    // expect
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("heartbeatInterval PT0S must be at least 1ms");
+
+    initSystemContext(brokerCfg);
+  }
+
+  @Test
+  public void shouldThrowExceptionIfElectionTimeoutIsSmallerThanOneMs() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.getCluster().setElectionTimeout(Duration.ofMillis(0));
+
+    // expect
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("electionTimeout PT0S must be at least 1ms");
+
+    initSystemContext(brokerCfg);
+  }
+
+  @Test
+  public void shouldThrowExceptionIfElectionTimeoutIsSmallerThanHeartbeatInterval() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.getCluster().setElectionTimeout(Duration.ofSeconds(1));
+    brokerCfg.getCluster().setHeartbeatInterval(Duration.ofSeconds(2));
+
+    // expect
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage(
+        "electionTimeout PT1S must be greater than heartbeatInterval PT2S");
+
+    initSystemContext(brokerCfg);
+  }
+
   private SystemContext initSystemContext(final BrokerCfg brokerCfg) {
     return new SystemContext(brokerCfg, "test", new ControlledActorClock());
   }

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -241,6 +241,20 @@
       # Example:
       # clusterName: zeebe-cluster
 
+      # Configure heartbeatInterval. The leader sends a heartbeat to a follower every heartbeatInterval.
+      # Note: This is an advanced setting.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_HEARTBEATINTERVAL.
+      # heartbeatInterval: 250ms
+
+      # Configure electionTimeout. If a follower does not receive a heartbeat from the leader with in an election timeout,
+      # it can start a new leader election. electionTimeout should be greater than configured heartbeatInterval.
+      # When the electionTimeout is large, there will be delay in detecting a leader failure.
+      # When the electionTimeout is small, it can lead to false positives when detecting leader failures and thus leading to unnecessary leader changes.
+      # If the network latency between the nodes is high, it is recommended to have a higher election latency.
+      # Note: This is an advanced setting.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_ELECTIONTIMEOUT.
+      # electionTimeout: 2500ms
+
       # Configure parameters for SWIM protocol which is used to propagate cluster membership
       # information among brokers and gateways
       # membership:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -200,6 +200,20 @@
       # Example:
       # clusterName: zeebe-cluster
 
+      # Configure heartbeatInterval. The leader sends a heartbeat to a follower every heartbeatInterval.
+      # Note: This is an advanced setting.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_HEARTBEATINTERVAL.
+      # heartbeatInterval: 250ms
+
+      # Configure electionTimeout. If a follower does not receive a heartbeat from the leader with in an election timeout,
+      # it can start a new leader election. electionTimeout should be greater than configured heartbeatInterval.
+      # When the electionTimeout is large, there will be delay in detecting a leader failure.
+      # When the electionTimeout is small, it can lead to false positives when detecting leader failures and thus leading to unnecessary leader changes.
+      # If the network latency between the nodes is high, it is recommended to have a higher election latency.
+      # Note: This is an advanced setting.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_ELECTIONTIMEOUT.
+      # electionTimeout: 2500ms
+
       # Configure parameters for SWIM protocol which is used to propagate cluster membership
       # information among brokers and gateways
       # membership:


### PR DESCRIPTION
## Description

Expose configuration parameters for raft `electionTimeout` and `heartbeatInterval`.

## Related issues

closes #7393 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
