### PR TITLE
Allow configuring raft request timeout

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -451,6 +451,17 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
       return this;
     }
 
+    /**
+     * Sets the timeout for all messages sent between raft replicas.
+     *
+     * @param requestTimeout the timeout
+     * @return the Raft Partition group builder
+     */
+    public Builder withRequestTimeout(final Duration requestTimeout) {
+      config.setRequestTimeout(requestTimeout);
+      return this;
+    }
+
     @Override
     public RaftPartitionGroup build() {
       return new RaftPartitionGroup(config);

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroupConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroupConfig.java
@@ -17,7 +17,7 @@
 package io.atomix.raft.partition;
 
 import com.esotericsoftware.kryo.serializers.FieldSerializer.Optional;
-import io.atomix.primitive.partition.PartitionGroup;
+import io.atomix.primitive.partition.PartitionGroup.Type;
 import io.atomix.primitive.partition.PartitionGroupConfig;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.raft.zeebe.NoopEntryValidator;
@@ -32,6 +32,7 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
   private static final Duration DEFAULT_ELECTION_TIMEOUT = Duration.ofMillis(2500);
   private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(250);
   private static final boolean DEFAULT_PRIORITY_ELECTION = false;
+  private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(5);
 
   private Set<String> members = new HashSet<>();
   private int partitionSize;
@@ -41,6 +42,7 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
   private int maxAppendsPerFollower = 2;
   private int maxAppendBatchSize = 32 * 1024;
   private boolean priorityElectionEnabled = DEFAULT_PRIORITY_ELECTION;
+  private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
 
   @Optional("EntryValidator")
   private EntryValidator entryValidator = new NoopEntryValidator();
@@ -187,7 +189,7 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
   }
 
   @Override
-  public PartitionGroup.Type getType() {
+  public Type getType() {
     return RaftPartitionGroup.TYPE;
   }
 
@@ -197,5 +199,13 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
 
   public void setPriorityElectionEnabled(final boolean enable) {
     priorityElectionEnabled = enable;
+  }
+
+  public Duration getRequestTimeout() {
+    return requestTimeout;
+  }
+
+  public void setRequestTimeout(final Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
@@ -44,22 +44,24 @@ import java.util.function.Function;
 /** Raft server protocol that uses a {@link ClusterCommunicationService}. */
 public class RaftServerCommunicator implements RaftServerProtocol {
 
-  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
   private final RaftMessageContext context;
   private final Serializer serializer;
   private final ClusterCommunicationService clusterCommunicator;
   private final String partitionName;
   private final RaftRequestMetrics metrics;
+  private final Duration requestTimeout;
 
   public RaftServerCommunicator(
       final String prefix,
       final Serializer serializer,
-      final ClusterCommunicationService clusterCommunicator) {
+      final ClusterCommunicationService clusterCommunicator,
+      final Duration requestTimeout) {
     context = new RaftMessageContext(prefix);
     partitionName = prefix;
     this.serializer = Preconditions.checkNotNull(serializer, "serializer cannot be null");
     this.clusterCommunicator =
         Preconditions.checkNotNull(clusterCommunicator, "clusterCommunicator cannot be null");
+    this.requestTimeout = requestTimeout;
     metrics = new RaftRequestMetrics(partitionName);
   }
 
@@ -217,7 +219,7 @@ public class RaftServerCommunicator implements RaftServerProtocol {
         serializer::encode,
         serializer::decode,
         MemberId.from(memberId.id()),
-        REQUEST_TIMEOUT);
+        requestTimeout);
   }
 
   private <T extends RaftMessage> T recordReceivedMetrics(final T m) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -117,7 +117,8 @@ public final class AtomixFactory {
             .withFlushExplicitly(!experimentalCfg.isDisableExplicitRaftFlush())
             .withFreeDiskSpace(dataCfg.getFreeDiskSpaceReplicationWatermark())
             .withJournalIndexDensity(dataCfg.getLogIndexDensity())
-            .withPriorityElection(experimentalCfg.isEnablePriorityElection());
+            .withPriorityElection(experimentalCfg.isEnablePriorityElection())
+            .withRequestTimeout(experimentalCfg.getRaft().getRequestTimeout());
 
     final int maxMessageSize = (int) networkCfg.getMaxMessageSizeInBytes();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -27,10 +27,12 @@ public class ExperimentalCfg implements ConfigurationEntry {
   private boolean disableExplicitRaftFlush = DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH;
   private boolean enablePriorityElection = DEFAULT_ENABLE_PRIORITY_ELECTION;
   private RocksdbCfg rocksdb = new RocksdbCfg();
+  private RaftCfg raft = new RaftCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
     rocksdb.init(globalConfig, brokerBase);
+    raft.init(globalConfig, brokerBase);
   }
 
   public int getMaxAppendsPerFollower() {
@@ -89,5 +91,13 @@ public class ExperimentalCfg implements ConfigurationEntry {
         + ", rocksdb="
         + rocksdb
         + '}';
+  }
+
+  public RaftCfg getRaft() {
+    return raft;
+  }
+
+  public void setRaft(final RaftCfg raft) {
+    this.raft = raft;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+import java.time.Duration;
+
+public final class RaftCfg implements ConfigurationEntry {
+
+  private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+  private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+
+  public Duration getRequestTimeout() {
+    return requestTimeout;
+  }
+
+  public void setRequestTimeout(final Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfgTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class ExperimentalCfgTest {
+
+  public final Map<String, String> environment = new HashMap<>();
+
+  @Test
+  public void shouldSetRaftRequestTimeoutFromConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
+    final var raft = cfg.getExperimental().getRaft();
+
+    // then
+    assertThat(raft.getRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
+  }
+
+  @Test
+  public void shouldSetRaftRequestTimeoutFromEnv() {
+    // given
+    environment.put("zeebe.broker.experimental.raft.requestTimeout", "15s");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
+    final var raft = cfg.getExperimental().getRaft();
+
+    // then
+    assertThat(raft.getRequestTimeout()).isEqualTo(Duration.ofSeconds(15));
+  }
+}

--- a/broker/src/test/resources/system/experimental-cfg.yaml
+++ b/broker/src/test/resources/system/experimental-cfg.yaml
@@ -2,3 +2,5 @@ zeebe:
   broker:
     experimental:
       enablePriorityElection: true
+      raft:
+        requestTimeout: 10s

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -518,6 +518,12 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENABLEPRIORITYELECTION
       # enablePriorityElection = false;
 
+      # Allows to configure specific raft properties
+      # raft:
+        # Sets the timeout for all requests send by raft leaders and followers.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_REQUESTTIMEOUT
+        # requestTimeout = 5s
+
       # Allows to configure RocksDB properties, which is used for state management.
       # rocksdb:
         # Specify custom column family options overwriting Zeebe's own defaults.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -479,6 +479,13 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENABLEPRIORITYELECTION
       # enablePriorityElection = false;
 
+      # Allows to configure specific raft properties
+      # raft:
+        # Sets the timeout for all requests send by raft leaders and followers.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_REQUESTTIMEOUT
+        # requestTimeout = 5s
+
+
       # Allows to configure RocksDB properties, which is used for state management.
       # rocksdb:
         # Specify custom column family options overwriting Zeebe's own defaults.

--- a/test/revapi.json
+++ b/test/revapi.json
@@ -8,6 +8,10 @@
           {
             "matcher": "java-package",
             "match": "/org\\.assertj(\\..*)?/"
+          },
+          {
+            "matcher": "java-package",
+            "match": "io.camunda.zeebe.broker.system.configuration"
           }
         ]
       }


### PR DESCRIPTION
## Description

Expose raft requestTimeout as a configuration parameter. The default value is the same as before.

## Related issues

This PR only adds one parameter specified in the issue.
relates to #6320 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
