### PR TITLE
Remove unnecessary threads

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
@@ -90,7 +90,6 @@ import org.slf4j.LoggerFactory;
  */
 public class AtomixCluster implements BootstrapService, Managed<Void> {
 
-  private static final String[] DEFAULT_RESOURCES = new String[] {"cluster"};
   private static final Logger LOGGER = LoggerFactory.getLogger(AtomixCluster.class);
   protected final ManagedMessagingService messagingService;
   protected final ManagedUnicastService unicastService;
@@ -101,7 +100,7 @@ public class AtomixCluster implements BootstrapService, Managed<Void> {
   protected final ManagedClusterEventService eventService;
   protected volatile CompletableFuture<Void> openFuture;
   protected volatile CompletableFuture<Void> closeFuture;
-  private final ThreadContext threadContext = new SingleThreadContext("atomix-cluster-%d");
+  protected final ThreadContext threadContext = new SingleThreadContext("atomix-cluster-%d");
   private final AtomicBoolean started = new AtomicBoolean();
 
   public AtomixCluster(final ClusterConfig config, final Version version) {

--- a/atomix/core/pom.xml
+++ b/atomix/core/pom.xml
@@ -49,11 +49,6 @@
     </dependency>
 
     <dependency>
-      <artifactId>slf4j-api</artifactId>
-      <groupId>org.slf4j</groupId>
-    </dependency>
-
-    <dependency>
       <artifactId>guava</artifactId>
       <groupId>com.google.guava</groupId>
     </dependency>

--- a/atomix/core/src/main/java/io/atomix/core/Atomix.java
+++ b/atomix/core/src/main/java/io/atomix/core/Atomix.java
@@ -34,8 +34,6 @@ import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.concurrent.Threads;
 import io.camunda.zeebe.util.VersionUtil;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,9 +67,7 @@ import org.slf4j.LoggerFactory;
 public class Atomix extends AtomixCluster {
   private static final Logger LOGGER = LoggerFactory.getLogger(Atomix.class);
 
-  private final ScheduledExecutorService executorService;
   private final ManagedPartitionService partitions;
-  private final ThreadContext threadContext = new SingleThreadContext("atomix-%d");
   private final ManagedPartitionGroup partitionGroup;
 
   protected Atomix(final AtomixConfig config) {
@@ -87,11 +83,6 @@ public class Atomix extends AtomixCluster {
         Version.from(VersionUtil.getVersion()),
         messagingService,
         unicastService);
-    executorService =
-        Executors.newScheduledThreadPool(
-            Math.max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 8), 4),
-            Threads.namedThreads("atomix-primitive-%d", LOGGER));
-
     final PartitionGroupConfig<?> partitionGroupConfig = config.getPartitionGroup();
 
     partitionGroup =
@@ -99,7 +90,7 @@ public class Atomix extends AtomixCluster {
             ? partitionGroupConfig.getType().newPartitionGroup(partitionGroupConfig)
             : null;
 
-    partitions = buildPartitionService(config, getMembershipService(), getCommunicationService());
+    partitions = buildPartitionService(getMembershipService(), getCommunicationService());
   }
 
   /**
@@ -166,20 +157,12 @@ public class Atomix extends AtomixCluster {
   }
 
   @Override
-  protected CompletableFuture<Void> completeShutdown() {
-    executorService.shutdownNow();
-    threadContext.close();
-    return super.completeShutdown();
-  }
-
-  @Override
   public String toString() {
     return toStringHelper(this).add("partitionGroup", partitionGroup).toString();
   }
 
   /** Builds a partition service. */
   private ManagedPartitionService buildPartitionService(
-      final AtomixConfig config,
       final ClusterMembershipService clusterMembershipService,
       final ClusterCommunicationService messagingService) {
 

--- a/atomix/core/src/main/java/io/atomix/core/Atomix.java
+++ b/atomix/core/src/main/java/io/atomix/core/Atomix.java
@@ -29,13 +29,8 @@ import io.atomix.primitive.partition.PartitionGroupConfig;
 import io.atomix.primitive.partition.impl.DefaultPartitionService;
 import io.atomix.utils.Version;
 import io.atomix.utils.concurrent.Futures;
-import io.atomix.utils.concurrent.SingleThreadContext;
-import io.atomix.utils.concurrent.ThreadContext;
-import io.atomix.utils.concurrent.Threads;
 import io.camunda.zeebe.util.VersionUtil;
 import java.util.concurrent.CompletableFuture;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Primary interface for managing Atomix clusters and operating on distributed primitives.
@@ -65,8 +60,6 @@ import org.slf4j.LoggerFactory;
  * all services are available.
  */
 public class Atomix extends AtomixCluster {
-  private static final Logger LOGGER = LoggerFactory.getLogger(Atomix.class);
-
   private final ManagedPartitionService partitions;
   private final ManagedPartitionGroup partitionGroup;
 


### PR DESCRIPTION
## Description

Small clean up of Atomix, primarily removing the spawning of unnecessary threads which were simply not used anywhere (the Atomix executor for primitives), or weren't necessary (the thread context from the Atomix class for startup, when we can use the parent class's thread context). 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
