### PR TITLE
[Backports stable/1.0] Fix intermittent build errors by removing buildnumber plugin

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
@@ -116,6 +116,7 @@ public class AtomixCluster implements BootstrapService, Managed<Void> {
     this.messagingService =
         messagingService != null ? messagingService : buildMessagingService(config);
     this.unicastService = unicastService != null ? unicastService : buildUnicastService(config);
+
     discoveryProvider = buildLocationProvider(config);
     membershipProtocol = buildMembershipProtocol(config);
     membershipService =

--- a/atomix/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
@@ -23,7 +23,9 @@ import io.atomix.cluster.discovery.NodeDiscoveryProvider;
 import io.atomix.cluster.protocol.GroupMembershipProtocol;
 import io.atomix.cluster.protocol.HeartbeatMembershipProtocol;
 import io.atomix.utils.Builder;
+import io.atomix.utils.Version;
 import io.atomix.utils.net.Address;
+import io.camunda.zeebe.util.VersionUtil;
 import java.util.Collection;
 import java.util.Properties;
 
@@ -222,6 +224,6 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
 
   @Override
   public AtomixCluster build() {
-    return new AtomixCluster(config, null);
+    return new AtomixCluster(config, Version.from(VersionUtil.getVersion()));
   }
 }

--- a/atomix/core/pom.xml
+++ b/atomix/core/pom.xml
@@ -31,10 +31,17 @@
       <artifactId>zeebe-atomix-cluster</artifactId>
       <groupId>io.camunda</groupId>
     </dependency>
+
     <dependency>
       <artifactId>zeebe-atomix-utils</artifactId>
       <groupId>io.camunda</groupId>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-snapshots</artifactId>
@@ -45,6 +52,7 @@
       <artifactId>slf4j-api</artifactId>
       <groupId>org.slf4j</groupId>
     </dependency>
+
     <dependency>
       <artifactId>guava</artifactId>
       <groupId>com.google.guava</groupId>
@@ -55,26 +63,25 @@
       <artifactId>netty-common</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <artifactId>hamcrest</artifactId>
       <groupId>org.hamcrest</groupId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <artifactId>junit</artifactId>
       <groupId>junit</groupId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-util</artifactId>
-      <scope>test</scope>
-    </dependency>
+
     <dependency>
       <artifactId>zeebe-test-util</artifactId>
       <groupId>io.camunda</groupId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>

--- a/atomix/core/pom.xml
+++ b/atomix/core/pom.xml
@@ -15,25 +15,16 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <name>Zeebe Atomix</name>
   <artifactId>zeebe-atomix</artifactId>
+  <packaging>jar</packaging>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>buildnumber-maven-plugin</artifactId>
-        <groupId>org.codehaus.mojo</groupId>
-      </plugin>
-    </plugins>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-      </resource>
-      <resource>
-        <directory>src/main/filtered-resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
-  </build>
+  <parent>
+    <artifactId>zeebe-atomix-parent</artifactId>
+    <groupId>io.camunda</groupId>
+    <version>1.0.2-SNAPSHOT</version>
+  </parent>
 
   <dependencies>
     <dependency>
@@ -90,14 +81,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <modelVersion>4.0.0</modelVersion>
-  <name>Zeebe Atomix</name>
-
-  <packaging>jar</packaging>
-
-  <parent>
-    <artifactId>zeebe-atomix-parent</artifactId>
-    <groupId>io.camunda</groupId>
-    <version>1.0.2-SNAPSHOT</version>
-  </parent>
 </project>

--- a/atomix/core/src/main/filtered-resources/VERSION
+++ b/atomix/core/src/main/filtered-resources/VERSION
@@ -1,1 +1,0 @@
-${buildNumber}

--- a/atomix/core/src/main/java/io/atomix/core/Atomix.java
+++ b/atomix/core/src/main/java/io/atomix/core/Atomix.java
@@ -33,6 +33,7 @@ import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.concurrent.SingleThreadContext;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.concurrent.Threads;
+import io.camunda.zeebe.util.VersionUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -86,7 +87,7 @@ public class Atomix extends AtomixCluster {
       final ManagedUnicastService unicastService) {
     super(
         config.getClusterConfig(),
-        Version.from("1.1.0-SNAPSHOT"),
+        Version.from(VersionUtil.getVersion()),
         messagingService,
         unicastService);
     executorService =

--- a/atomix/pom.xml
+++ b/atomix/pom.xml
@@ -50,36 +50,6 @@
   </properties>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>buildnumber-maven-plugin</artifactId>
-          <configuration>
-            <doCheck>false</doCheck>
-            <doUpdate>false</doUpdate>
-            <format>{0} (revision {1} built on {2,date,yyyy-MM-dd HH:mm:ss})</format>
-            <items>
-              <item>${project.version}</item>
-              <item>scmVersion</item>
-              <item>timestamp</item>
-            </items>
-            <revisionOnScmFailure>N/A</revisionOnScmFailure>
-            <shortRevisionLength>6</shortRevisionLength>
-          </configuration>
-          <executions>
-            <execution>
-              <goals>
-                <goal>create</goal>
-              </goals>
-              <id>configure-buildnumber</id>
-              <phase>validate</phase>
-            </execution>
-          </executions>
-          <groupId>org.codehaus.mojo</groupId>
-          <version>1.4</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <!-- LICENSE PLUGIN -->
       <plugin>
@@ -102,7 +72,6 @@
           <suppressionsLocation>src/main/resources/suppression.xml</suppressionsLocation>
         </configuration>
       </plugin>
-
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
## Description

This PR backports #7403 to stable/1.0. The only conflict was some import statements in `Atomix.java` since we simplified the partition groups in 1.1 but not in 1.0.

## Related issues

relates to #7294

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
