### PR TITLE
Expose raft failure timeouts in configuration

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/primitive/partition/PartitionGroupConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/primitive/partition/PartitionGroupConfig.java
@@ -23,7 +23,7 @@ import io.atomix.utils.config.TypedConfig;
 public abstract class PartitionGroupConfig<C extends PartitionGroupConfig<C>>
     implements TypedConfig<PartitionGroup.Type>, NamedConfig<C> {
   private String name;
-  private int partitions = getDefaultPartitions();
+  private int partitionCount = getDefaultPartitions();
 
   @Override
   public String getName() {
@@ -42,19 +42,19 @@ public abstract class PartitionGroupConfig<C extends PartitionGroupConfig<C>>
    *
    * @return the number of partitions in the group.
    */
-  public int getPartitions() {
-    return partitions;
+  public int getPartitionCount() {
+    return partitionCount;
   }
 
   /**
    * Sets the number of partitions in the group.
    *
-   * @param partitions the number of partitions in the group
+   * @param partitionCount the number of partitions in the group
    * @return the partition group configuration
    */
   @SuppressWarnings("unchecked")
-  public C setPartitions(final int partitions) {
-    this.partitions = partitions;
+  public C setPartitionCount(final int partitionCount) {
+    this.partitionCount = partitionCount;
     return (C) this;
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -16,7 +16,6 @@
  */
 package io.atomix.raft;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.atomix.raft.RaftException.ConfigurationException;
 
@@ -27,6 +26,7 @@ import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.impl.DefaultRaftServer;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.partition.RaftElectionConfig;
+import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.protocol.RaftServerProtocol;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.RaftLog;
@@ -417,13 +417,10 @@ public interface RaftServer {
     protected RaftServerProtocol protocol;
     protected RaftStorage storage;
     protected RaftThreadContextFactory threadContextFactory;
-    protected Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
-    protected Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
     protected Supplier<Random> randomFactory;
     protected EntryValidator entryValidator = new NoopEntryValidator();
-    protected int maxAppendsPerFollower = 2;
-    protected int maxAppendBatchSize = 32 * 1024;
     protected RaftElectionConfig electionConfig = RaftElectionConfig.ofDefaultElection();
+    protected RaftPartitionConfig partitionConfig = new RaftPartitionConfig();
 
     protected Builder(final MemberId localMemberId) {
       this.localMemberId = checkNotNull(localMemberId, "localMemberId cannot be null");
@@ -489,70 +486,6 @@ public interface RaftServer {
       return this;
     }
 
-    /**
-     * Sets the Raft election timeout, returning the Raft configuration for method chaining.
-     *
-     * @param electionTimeout The Raft election timeout duration.
-     * @return The Raft configuration.
-     * @throws IllegalArgumentException If the election timeout is not positive
-     * @throws NullPointerException if {@code electionTimeout} is null
-     */
-    public Builder withElectionTimeout(final Duration electionTimeout) {
-      checkNotNull(electionTimeout, "electionTimeout cannot be null");
-      checkArgument(
-          !electionTimeout.isNegative() && !electionTimeout.isZero(),
-          "electionTimeout must be positive");
-      checkArgument(
-          electionTimeout.toMillis() > heartbeatInterval.toMillis(),
-          "electionTimeout must be greater than heartbeatInterval");
-      this.electionTimeout = electionTimeout;
-      return this;
-    }
-
-    /**
-     * Sets the Raft heartbeat interval, returning the Raft configuration for method chaining.
-     *
-     * @param heartbeatInterval The Raft heartbeat interval duration.
-     * @return The Raft configuration.
-     * @throws IllegalArgumentException If the heartbeat interval is not positive
-     * @throws NullPointerException if {@code heartbeatInterval} is null
-     */
-    public Builder withHeartbeatInterval(final Duration heartbeatInterval) {
-      checkNotNull(heartbeatInterval, "heartbeatInterval cannot be null");
-      checkArgument(
-          !heartbeatInterval.isNegative() && !heartbeatInterval.isZero(),
-          "sessionTimeout must be positive");
-      checkArgument(
-          heartbeatInterval.toMillis() < electionTimeout.toMillis(),
-          "heartbeatInterval must be less than electionTimeout");
-      this.heartbeatInterval = heartbeatInterval;
-      return this;
-    }
-
-    /**
-     * Sets the maximum append requests which are sent per follower at once. Default is 2.
-     *
-     * @param maxAppendsPerFollower the maximum appends send per follower
-     * @return The server builder.
-     */
-    public Builder withMaxAppendsPerFollower(final int maxAppendsPerFollower) {
-      checkArgument(maxAppendsPerFollower > 0, "maxAppendsPerFollower must be positive");
-      this.maxAppendsPerFollower = maxAppendsPerFollower;
-      return this;
-    }
-
-    /**
-     * Sets the maximum batch size, which is sent per append request. Default size is 32 KB.
-     *
-     * @param maxAppendBatchSize the maximum batch size per append
-     * @return The server builder.
-     */
-    public Builder withMaxAppendBatchSize(final int maxAppendBatchSize) {
-      checkArgument(maxAppendBatchSize > 0, "maxAppendBatchSize must be positive");
-      this.maxAppendBatchSize = maxAppendBatchSize;
-      return this;
-    }
-
     public Builder withEntryValidator(final EntryValidator entryValidator) {
       this.entryValidator = entryValidator;
       return this;
@@ -560,6 +493,11 @@ public interface RaftServer {
 
     public Builder withElectionConfig(final RaftElectionConfig electionConfig) {
       this.electionConfig = electionConfig;
+      return this;
+    }
+
+    public Builder withPartitionConfig(final RaftPartitionConfig partitionConfig) {
+      this.partitionConfig = partitionConfig;
       return this;
     }
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -263,12 +263,9 @@ public class DefaultRaftServer implements RaftServer {
               protocol,
               storage,
               singleThreadFactory,
-              maxAppendBatchSize,
-              maxAppendsPerFollower,
               randomSupplier,
-              electionConfig);
-      raft.setElectionTimeout(electionTimeout);
-      raft.setHeartbeatInterval(heartbeatInterval);
+              electionConfig,
+              partitionConfig);
       raft.setEntryValidator(entryValidator);
 
       return new DefaultRaftServer(raft);

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -25,12 +25,13 @@ import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.ElectionTimer;
 import io.atomix.raft.RaftCommitListener;
-import io.atomix.raft.RaftException;
+import io.atomix.raft.RaftException.ProtocolException;
 import io.atomix.raft.RaftRoleChangeListener;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.RaftThreadContextFactory;
 import io.atomix.raft.cluster.RaftMember;
+import io.atomix.raft.cluster.RaftMember.Type;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.cluster.impl.RaftClusterContext;
 import io.atomix.raft.impl.zeebe.LogCompactor;
@@ -39,6 +40,7 @@ import io.atomix.raft.metrics.RaftRoleMetrics;
 import io.atomix.raft.partition.RaftElectionConfig;
 import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.protocol.RaftResponse;
+import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.RaftServerProtocol;
 import io.atomix.raft.protocol.TransferRequest;
 import io.atomix.raft.roles.ActiveRole;
@@ -53,6 +55,7 @@ import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.StorageException;
 import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.storage.log.RaftLogReader;
+import io.atomix.raft.storage.log.RaftLogReader.Mode;
 import io.atomix.raft.storage.system.MetaStore;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.utils.concurrent.ComposableFuture;
@@ -107,8 +110,6 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private final LogCompactor logCompactor;
   private volatile State state = State.ACTIVE;
   private RaftRole role = new InactiveRole(this);
-  private final Duration electionTimeout;
-  private final Duration heartbeatInterval;
   private volatile MemberId leader;
   private volatile long term;
   private MemberId lastVotedFor;
@@ -116,14 +117,13 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private volatile long firstCommitIndex;
   private volatile boolean started;
   private EntryValidator entryValidator;
-  private final int maxAppendBatchSize;
-  private final int maxAppendsPerFollower;
   // Used for randomizing election timeout
   private final Random random;
   private PersistedSnapshot currentSnapshot;
   private volatile HealthStatus health = HealthStatus.HEALTHY;
 
   private long lastHeartbeat;
+  private final RaftPartitionConfig partitionConfig;
 
   public RaftContext(
       final String name,
@@ -171,7 +171,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
     // Construct the core log, reader, writer, and compactor.
     raftLog = storage.openLog();
-    logReader = raftLog.openReader(RaftLogReader.Mode.ALL);
+    logReader = raftLog.openReader(Mode.ALL);
 
     // Open the snapshot store.
     persistedSnapshotStore = storage.getPersistedSnapshotStore();
@@ -185,10 +185,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
     logCompactor = new LogCompactor(this);
 
-    maxAppendBatchSize = partitionConfig.getMaxAppendBatchSize();
-    maxAppendsPerFollower = partitionConfig.getMaxAppendsPerFollower();
-    heartbeatInterval = partitionConfig.getHeartbeatInterval();
-    electionTimeout = partitionConfig.getElectionTimeout();
+    this.partitionConfig = partitionConfig;
     cluster = new RaftClusterContext(localMemberId, this);
 
     // Register protocol listeners.
@@ -275,11 +272,11 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   public int getMaxAppendBatchSize() {
-    return maxAppendBatchSize;
+    return partitionConfig.getMaxAppendBatchSize();
   }
 
   public int getMaxAppendsPerFollower() {
-    return maxAppendsPerFollower;
+    return partitionConfig.getMaxAppendsPerFollower();
   }
 
   /**
@@ -405,7 +402,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
   /** Attempts to become the leader. */
   public CompletableFuture<Void> anoint() {
-    if (role.role() == RaftServer.Role.LEADER) {
+    if (role.role() == Role.LEADER) {
       return CompletableFuture.completedFuture(null);
     }
 
@@ -422,7 +419,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
                     future.complete(null);
                   } else {
                     future.completeExceptionally(
-                        new RaftException.ProtocolException("Failed to transfer leadership"));
+                        new ProtocolException("Failed to transfer leadership"));
                   }
                   removeLeaderElectionListener(this);
                 }
@@ -443,15 +440,15 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
                     (response, error) -> {
                       if (error != null) {
                         future.completeExceptionally(error);
-                      } else if (response.status() == RaftResponse.Status.ERROR) {
+                      } else if (response.status() == Status.ERROR) {
                         future.completeExceptionally(response.error().createException());
                       } else {
-                        transition(RaftServer.Role.CANDIDATE);
+                        transition(Role.CANDIDATE);
                       }
                     },
                     threadContext);
           } else {
-            transition(RaftServer.Role.CANDIDATE);
+            transition(Role.CANDIDATE);
           }
         });
     return future;
@@ -496,7 +493,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   /** Transition handler. */
-  public void transition(final RaftServer.Role role) {
+  public void transition(final Role role) {
     checkThread();
     checkNotNull(role);
 
@@ -574,7 +571,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   /** Creates an internal state for the given state type. */
-  private RaftRole createRole(final RaftServer.Role role) {
+  private RaftRole createRole(final Role role) {
     switch (role) {
       case INACTIVE:
         return new InactiveRole(this);
@@ -599,7 +596,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private ElectionTimer createElectionTimer(final Runnable triggerElection, final Logger log) {
     if (electionConfig.isPriorityElectionEnabled()) {
       return new PriorityElectionTimer(
-          electionTimeout,
+          partitionConfig.getElectionTimeout(),
           threadContext,
           triggerElection,
           log,
@@ -607,31 +604,31 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
           electionConfig.getNodePriority());
     } else {
       return new RandomizedElectionTimer(
-          electionTimeout, threadContext, random, triggerElection, log);
+          partitionConfig.getElectionTimeout(), threadContext, random, triggerElection, log);
     }
   }
 
   /** Transitions the server to the base state for the given member type. */
-  public void transition(final RaftMember.Type type) {
+  public void transition(final Type type) {
     switch (type) {
       case ACTIVE:
         if (!(role instanceof ActiveRole)) {
-          transition(RaftServer.Role.FOLLOWER);
+          transition(Role.FOLLOWER);
         }
         break;
       case PROMOTABLE:
-        if (role.role() != RaftServer.Role.PROMOTABLE) {
-          transition(RaftServer.Role.PROMOTABLE);
+        if (role.role() != Role.PROMOTABLE) {
+          transition(Role.PROMOTABLE);
         }
         break;
       case PASSIVE:
-        if (role.role() != RaftServer.Role.PASSIVE) {
-          transition(RaftServer.Role.PASSIVE);
+        if (role.role() != Role.PASSIVE) {
+          transition(Role.PASSIVE);
         }
         break;
       default:
-        if (role.role() != RaftServer.Role.INACTIVE) {
-          transition(RaftServer.Role.INACTIVE);
+        if (role.role() != Role.INACTIVE) {
+          transition(Role.INACTIVE);
         }
         break;
     }
@@ -701,7 +698,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
    * @return The election timeout.
    */
   public Duration getElectionTimeout() {
-    return electionTimeout;
+    return partitionConfig.getElectionTimeout();
   }
 
   /**
@@ -733,7 +730,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
    * @return The heartbeat interval.
    */
   public Duration getHeartbeatInterval() {
-    return heartbeatInterval;
+    return partitionConfig.getHeartbeatInterval();
   }
 
   /**
@@ -856,7 +853,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
    *
    * @return The current server role.
    */
-  public RaftServer.Role getRole() {
+  public Role getRole() {
     return role.role();
   }
 
@@ -1002,6 +999,14 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
   public void resetLastHeartbeat() {
     setLastHeartbeat(System.currentTimeMillis());
+  }
+
+  public int getMinStepDownFailureCount() {
+    return partitionConfig.getMinStepDownFailureCount();
+  }
+
+  public Duration getMaxQuorumResponseTimeout() {
+    return partitionConfig.getMaxQuorumResponseTimeout();
   }
 
   /** Raft server state. */

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -16,12 +16,9 @@
  */
 package io.atomix.raft.partition;
 
-import com.esotericsoftware.kryo.serializers.FieldSerializer.Optional;
-import io.atomix.raft.zeebe.EntryValidator;
-import io.atomix.raft.zeebe.NoopEntryValidator;
 import java.time.Duration;
 
-/** Raft partition group configuration. */
+/** Configurations for a single partition. */
 public class RaftPartitionConfig {
 
   private static final Duration DEFAULT_ELECTION_TIMEOUT = Duration.ofMillis(2500);
@@ -35,9 +32,6 @@ public class RaftPartitionConfig {
   private int maxAppendBatchSize = 32 * 1024;
   private boolean priorityElectionEnabled = DEFAULT_PRIORITY_ELECTION;
   private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
-
-  @Optional("EntryValidator")
-  private EntryValidator entryValidator = new NoopEntryValidator();
 
   /**
    * Returns the Raft leader election timeout.
@@ -76,26 +70,6 @@ public class RaftPartitionConfig {
    */
   public RaftPartitionConfig setHeartbeatInterval(final Duration heartbeatInterval) {
     this.heartbeatInterval = heartbeatInterval;
-    return this;
-  }
-
-  /**
-   * Returns the entry validator to be called when an entry is appended.
-   *
-   * @return the entry validator
-   */
-  public EntryValidator getEntryValidator() {
-    return entryValidator;
-  }
-
-  /**
-   * Sets the entry validator to be called when an entry is appended.
-   *
-   * @param entryValidator the entry validator
-   * @return the Raft Partition group builder
-   */
-  public RaftPartitionConfig setEntryValidator(final EntryValidator entryValidator) {
-    this.entryValidator = entryValidator;
     return this;
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.partition;
+
+import com.esotericsoftware.kryo.serializers.FieldSerializer.Optional;
+import io.atomix.raft.zeebe.EntryValidator;
+import io.atomix.raft.zeebe.NoopEntryValidator;
+import java.time.Duration;
+
+/** Raft partition group configuration. */
+public class RaftPartitionConfig {
+
+  private static final Duration DEFAULT_ELECTION_TIMEOUT = Duration.ofMillis(2500);
+  private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(250);
+  private static final boolean DEFAULT_PRIORITY_ELECTION = false;
+  private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+  private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
+  private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
+  private int maxAppendsPerFollower = 2;
+  private int maxAppendBatchSize = 32 * 1024;
+  private boolean priorityElectionEnabled = DEFAULT_PRIORITY_ELECTION;
+  private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+
+  @Optional("EntryValidator")
+  private EntryValidator entryValidator = new NoopEntryValidator();
+
+  /**
+   * Returns the Raft leader election timeout.
+   *
+   * @return the Raft leader election timeout
+   */
+  public Duration getElectionTimeout() {
+    return electionTimeout;
+  }
+
+  /**
+   * Sets the leader election timeout.
+   *
+   * @param electionTimeout the leader election timeout
+   * @return the Raft partition group configuration
+   */
+  public RaftPartitionConfig setElectionTimeout(final Duration electionTimeout) {
+    this.electionTimeout = electionTimeout;
+    return this;
+  }
+
+  /**
+   * Returns the heartbeat interval.
+   *
+   * @return the heartbeat interval
+   */
+  public Duration getHeartbeatInterval() {
+    return heartbeatInterval;
+  }
+
+  /**
+   * Sets the heartbeat interval.
+   *
+   * @param heartbeatInterval the heartbeat interval
+   * @return the Raft partition group configuration
+   */
+  public RaftPartitionConfig setHeartbeatInterval(final Duration heartbeatInterval) {
+    this.heartbeatInterval = heartbeatInterval;
+    return this;
+  }
+
+  /**
+   * Returns the entry validator to be called when an entry is appended.
+   *
+   * @return the entry validator
+   */
+  public EntryValidator getEntryValidator() {
+    return entryValidator;
+  }
+
+  /**
+   * Sets the entry validator to be called when an entry is appended.
+   *
+   * @param entryValidator the entry validator
+   * @return the Raft Partition group builder
+   */
+  public RaftPartitionConfig setEntryValidator(final EntryValidator entryValidator) {
+    this.entryValidator = entryValidator;
+    return this;
+  }
+
+  public int getMaxAppendsPerFollower() {
+    return maxAppendsPerFollower;
+  }
+
+  public void setMaxAppendsPerFollower(final int maxAppendsPerFollower) {
+    this.maxAppendsPerFollower = maxAppendsPerFollower;
+  }
+
+  public int getMaxAppendBatchSize() {
+    return maxAppendBatchSize;
+  }
+
+  public void setMaxAppendBatchSize(final int maxAppendBatchSize) {
+    this.maxAppendBatchSize = maxAppendBatchSize;
+  }
+
+  public boolean isPriorityElectionEnabled() {
+    return priorityElectionEnabled;
+  }
+
+  public void setPriorityElectionEnabled(final boolean enable) {
+    priorityElectionEnabled = enable;
+  }
+
+  public Duration getRequestTimeout() {
+    return requestTimeout;
+  }
+
+  public void setRequestTimeout(final Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -26,8 +26,7 @@ public class RaftPartitionConfig {
   private static final boolean DEFAULT_PRIORITY_ELECTION = false;
   private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(5);
   private static final int DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT = 3;
-  private static final Duration DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT =
-      DEFAULT_ELECTION_TIMEOUT.multipliedBy(2);
+  private static final Duration DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT = Duration.ofSeconds(0);
 
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
@@ -139,6 +138,8 @@ public class RaftPartitionConfig {
    * If the leader is not able to reach the quorum, the leader may step down. This is triggered
    * after minStepDownFailureCount number of requests fails to get a response from the quorum of
    * followers as well as if the last response was received before maxQuorumResponseTime.
+   *
+   * <p>When this value is zero, it uses a default value of electionTimeout * 2
    *
    * @param maxQuorumResponseTimeout the quorum response time out to trigger leader step down
    */

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -25,6 +25,9 @@ public class RaftPartitionConfig {
   private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(250);
   private static final boolean DEFAULT_PRIORITY_ELECTION = false;
   private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(5);
+  private static final int DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT = 3;
+  private static final Duration DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT =
+      DEFAULT_ELECTION_TIMEOUT.multipliedBy(2);
 
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
@@ -32,6 +35,8 @@ public class RaftPartitionConfig {
   private int maxAppendBatchSize = 32 * 1024;
   private boolean priorityElectionEnabled = DEFAULT_PRIORITY_ELECTION;
   private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+  private int minStepDownFailureCount = DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT;
+  private Duration maxQuorumResponseTimeout = DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT;
 
   /**
    * Returns the Raft leader election timeout.
@@ -101,7 +106,43 @@ public class RaftPartitionConfig {
     return requestTimeout;
   }
 
+  /**
+   * Sets the timeout for every requests send between the replicas.
+   *
+   * @param requestTimeout the request timeout
+   */
   public void setRequestTimeout(final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;
+  }
+
+  public int getMinStepDownFailureCount() {
+    return minStepDownFailureCount;
+  }
+
+  /**
+   * If the leader is not able to reach the quorum, the leader may step down. This is triggered
+   * after minStepDownFailureCount number of requests fails to get a response from the quorum of
+   * followers as well as if the last response was received before maxQuorumResponseTime.
+   *
+   * @param minStepDownFailureCount The number of failures after which a leader considers stepping
+   *     down.
+   */
+  public void setMinStepDownFailureCount(final int minStepDownFailureCount) {
+    this.minStepDownFailureCount = minStepDownFailureCount;
+  }
+
+  public Duration getMaxQuorumResponseTimeout() {
+    return maxQuorumResponseTimeout;
+  }
+
+  /**
+   * If the leader is not able to reach the quorum, the leader may step down. This is triggered
+   * after minStepDownFailureCount number of requests fails to get a response from the quorum of
+   * followers as well as if the last response was received before maxQuorumResponseTime.
+   *
+   * @param maxQuorumResponseTimeout the quorum response time out to trigger leader step down
+   */
+  public void setMaxQuorumResponseTimeout(final Duration maxQuorumResponseTimeout) {
+    this.maxQuorumResponseTimeout = maxQuorumResponseTimeout;
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -462,6 +462,35 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
       return this;
     }
 
+    /**
+     * If the leader is not able to reach the quorum, the leader may step down. This is triggered
+     * after minStepDownFailureCount number of requests fails to get a response from the quorum of
+     * followers as well as if the last response was received before maxQuorumResponseTime.
+     *
+     * @param minStepDownFailureCount The number of failures after which a leader considers stepping
+     *     down.
+     * @return the Raft Partition group builder
+     */
+    public Builder withMinStepDownFailureCount(final int minStepDownFailureCount) {
+      config.getPartitionConfig().setMinStepDownFailureCount(minStepDownFailureCount);
+      return this;
+    }
+
+    /**
+     * If the leader is not able to reach the quorum, the leader may step down. This is triggered *
+     * after minStepDownFailureCount number of requests fails to get a response from the quorum of *
+     * followers as well as if the last response was received before maxQuorumResponseTime.
+     *
+     * <p>When this value is 0, it will use a default value of electionTimeout * 2.
+     *
+     * @param maxQuorumResponseTimeout the quorum response timeout
+     * @return the Raft Partition group builder
+     */
+    public Builder withMaxQuorumResponseTimeout(final Duration maxQuorumResponseTimeout) {
+      config.getPartitionConfig().setMaxQuorumResponseTimeout(maxQuorumResponseTimeout);
+      return this;
+    }
+
     @Override
     public RaftPartitionGroup build() {
       return new RaftPartitionGroup(config);

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -76,7 +76,7 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
             LoggerContext.builder(RaftPartitionGroup.class).addValue(config.getName()).build());
     name = config.getName();
     this.config = config;
-    replicationFactor = config.getPartitionSize();
+    replicationFactor = config.getReplicationFactor();
 
     final int threadPoolSize =
         Math.max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 16), 4);
@@ -94,8 +94,8 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
   private static Collection<RaftPartition> buildPartitions(final RaftPartitionGroupConfig config) {
     final File partitionsDir =
         new File(config.getStorageConfig().getDirectory(config.getName()), "partitions");
-    final List<RaftPartition> partitions = new ArrayList<>(config.getPartitions());
-    for (int i = 0; i < config.getPartitions(); i++) {
+    final List<RaftPartition> partitions = new ArrayList<>(config.getPartitionCount());
+    for (int i = 0; i < config.getPartitionCount(); i++) {
       partitions.add(
           new RaftPartition(
               PartitionId.from(config.getName(), i + 1),
@@ -297,7 +297,7 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
      * @throws IllegalArgumentException if the number of partitions is not positive
      */
     public Builder withNumPartitions(final int numPartitions) {
-      config.setPartitions(numPartitions);
+      config.setPartitionCount(numPartitions);
       return this;
     }
 
@@ -309,7 +309,7 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
      * @throws IllegalArgumentException if the partition size is not positive
      */
     public Builder withPartitionSize(final int partitionSize) {
-      config.setPartitionSize(partitionSize);
+      config.setReplicationFactor(partitionSize);
       return this;
     }
 
@@ -321,7 +321,7 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
      */
     public Builder withMaxAppendsPerFollower(final int maxAppendsPerFollower) {
       checkArgument(maxAppendsPerFollower > 0, "maxAppendsPerFollower must be positive");
-      config.setMaxAppendsPerFollower(maxAppendsPerFollower);
+      config.getPartitionConfig().setMaxAppendsPerFollower(maxAppendsPerFollower);
       return this;
     }
 
@@ -333,7 +333,7 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
      */
     public Builder withMaxAppendBatchSize(final int maxAppendBatchSize) {
       checkArgument(maxAppendBatchSize > 0, "maxAppendBatchSize must be positive");
-      config.setMaxAppendBatchSize(maxAppendBatchSize);
+      config.getPartitionConfig().setMaxAppendBatchSize(maxAppendBatchSize);
       return this;
     }
 
@@ -345,7 +345,7 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
      */
     public Builder withHeartbeatInterval(final Duration heartbeatInterval) {
       checkArgument(heartbeatInterval.toMillis() > 0, "heartbeatInterval must be atleast 1ms");
-      config.setHeartbeatInterval(heartbeatInterval);
+      config.getPartitionConfig().setHeartbeatInterval(heartbeatInterval);
       return this;
     }
 
@@ -358,7 +358,7 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
      */
     public Builder withElectionTimeout(final Duration electionTimeout) {
       checkArgument(electionTimeout.toMillis() > 0, "heartbeatInterval must be atleast 1ms");
-      config.setElectionTimeout(electionTimeout);
+      config.getPartitionConfig().setElectionTimeout(electionTimeout);
       return this;
     }
 
@@ -447,7 +447,7 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
     }
 
     public Builder withPriorityElection(final boolean enable) {
-      config.setPriorityElectionEnabled(enable);
+      config.getPartitionConfig().setPriorityElectionEnabled(enable);
       return this;
     }
 
@@ -458,7 +458,7 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
      * @return the Raft Partition group builder
      */
     public Builder withRequestTimeout(final Duration requestTimeout) {
-      config.setRequestTimeout(requestTimeout);
+      config.getPartitionConfig().setRequestTimeout(requestTimeout);
       return this;
     }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroupConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroupConfig.java
@@ -21,7 +21,6 @@ import io.atomix.primitive.partition.PartitionGroup.Type;
 import io.atomix.primitive.partition.PartitionGroupConfig;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.raft.zeebe.NoopEntryValidator;
-import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -29,20 +28,11 @@ import java.util.Set;
 public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartitionGroupConfig> {
 
   private static final int DEFAULT_PARTITIONS = 7;
-  private static final Duration DEFAULT_ELECTION_TIMEOUT = Duration.ofMillis(2500);
-  private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(250);
-  private static final boolean DEFAULT_PRIORITY_ELECTION = false;
-  private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(5);
 
   private Set<String> members = new HashSet<>();
-  private int partitionSize;
-  private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
-  private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
+  private int replicationFactor;
   private RaftStorageConfig storageConfig = new RaftStorageConfig();
-  private int maxAppendsPerFollower = 2;
-  private int maxAppendBatchSize = 32 * 1024;
-  private boolean priorityElectionEnabled = DEFAULT_PRIORITY_ELECTION;
-  private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+  private RaftPartitionConfig partitionConfig = new RaftPartitionConfig();
 
   @Optional("EntryValidator")
   private EntryValidator entryValidator = new NoopEntryValidator();
@@ -50,46 +40,6 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
   @Override
   protected int getDefaultPartitions() {
     return DEFAULT_PARTITIONS;
-  }
-
-  /**
-   * Returns the Raft leader election timeout.
-   *
-   * @return the Raft leader election timeout
-   */
-  public Duration getElectionTimeout() {
-    return electionTimeout;
-  }
-
-  /**
-   * Sets the leader election timeout.
-   *
-   * @param electionTimeout the leader election timeout
-   * @return the Raft partition group configuration
-   */
-  public RaftPartitionGroupConfig setElectionTimeout(final Duration electionTimeout) {
-    this.electionTimeout = electionTimeout;
-    return this;
-  }
-
-  /**
-   * Returns the heartbeat interval.
-   *
-   * @return the heartbeat interval
-   */
-  public Duration getHeartbeatInterval() {
-    return heartbeatInterval;
-  }
-
-  /**
-   * Sets the heartbeat interval.
-   *
-   * @param heartbeatInterval the heartbeat interval
-   * @return the Raft partition group configuration
-   */
-  public RaftPartitionGroupConfig setHeartbeatInterval(final Duration heartbeatInterval) {
-    this.heartbeatInterval = heartbeatInterval;
-    return this;
   }
 
   /**
@@ -117,18 +67,18 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
    *
    * @return the partition size
    */
-  public int getPartitionSize() {
-    return partitionSize;
+  public int getReplicationFactor() {
+    return replicationFactor;
   }
 
   /**
    * Sets the partition size.
    *
-   * @param partitionSize the partition size
+   * @param replicationFactor the partition size
    * @return the Raft partition group configuration
    */
-  public RaftPartitionGroupConfig setPartitionSize(final int partitionSize) {
-    this.partitionSize = partitionSize;
+  public RaftPartitionGroupConfig setReplicationFactor(final int replicationFactor) {
+    this.replicationFactor = replicationFactor;
     return this;
   }
 
@@ -172,40 +122,17 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
     return this;
   }
 
-  public int getMaxAppendsPerFollower() {
-    return maxAppendsPerFollower;
-  }
-
-  public void setMaxAppendsPerFollower(final int maxAppendsPerFollower) {
-    this.maxAppendsPerFollower = maxAppendsPerFollower;
-  }
-
-  public int getMaxAppendBatchSize() {
-    return maxAppendBatchSize;
-  }
-
-  public void setMaxAppendBatchSize(final int maxAppendBatchSize) {
-    this.maxAppendBatchSize = maxAppendBatchSize;
-  }
-
   @Override
   public Type getType() {
     return RaftPartitionGroup.TYPE;
   }
 
-  public boolean isPriorityElectionEnabled() {
-    return priorityElectionEnabled;
+  public RaftPartitionConfig getPartitionConfig() {
+    return partitionConfig;
   }
 
-  public void setPriorityElectionEnabled(final boolean enable) {
-    priorityElectionEnabled = enable;
-  }
-
-  public Duration getRequestTimeout() {
-    return requestTimeout;
-  }
-
-  public void setRequestTimeout(final Duration requestTimeout) {
-    this.requestTimeout = requestTimeout;
+  public RaftPartitionGroupConfig setPartitionConfig(final RaftPartitionConfig partitionConfig) {
+    this.partitionConfig = partitionConfig;
+    return this;
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -95,7 +95,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
             getClass(),
             LoggerContext.builder(RaftPartitionServer.class).addValue(partition.name()).build());
     this.partitionMetadata = partitionMetadata;
-    requestTimeout = config.getRequestTimeout();
+    requestTimeout = config.getPartitionConfig().getRequestTimeout();
   }
 
   @Override
@@ -170,8 +170,10 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
             .getPersistedSnapshotStoreFactory()
             .createReceivableSnapshotStore(partition.dataDirectory().toPath(), partitionId);
 
+    final var partitionConfig = config.getPartitionConfig();
+
     final var electionConfig =
-        config.isPriorityElectionEnabled()
+        partitionConfig.isPriorityElectionEnabled()
             ? RaftElectionConfig.ofPriorityElection(
                 partitionMetadata.getTargetPriority(), partitionMetadata.getPriority(localMemberId))
             : RaftElectionConfig.ofDefaultElection();
@@ -180,12 +182,12 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
         .withName(partition.name())
         .withMembershipService(membershipService)
         .withProtocol(createServerProtocol())
-        .withHeartbeatInterval(config.getHeartbeatInterval())
-        .withElectionTimeout(config.getElectionTimeout())
-        .withMaxAppendBatchSize(config.getMaxAppendBatchSize())
-        .withMaxAppendsPerFollower(config.getMaxAppendsPerFollower())
+        .withHeartbeatInterval(partitionConfig.getHeartbeatInterval())
+        .withElectionTimeout(partitionConfig.getElectionTimeout())
+        .withMaxAppendBatchSize(partitionConfig.getMaxAppendBatchSize())
+        .withMaxAppendsPerFollower(partitionConfig.getMaxAppendsPerFollower())
         .withStorage(createRaftStorage())
-        .withEntryValidator(config.getEntryValidator())
+        .withEntryValidator(partitionConfig.getEntryValidator())
         .withElectionConfig(electionConfig)
         .build();
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -182,12 +182,9 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
         .withName(partition.name())
         .withMembershipService(membershipService)
         .withProtocol(createServerProtocol())
-        .withHeartbeatInterval(partitionConfig.getHeartbeatInterval())
-        .withElectionTimeout(partitionConfig.getElectionTimeout())
-        .withMaxAppendBatchSize(partitionConfig.getMaxAppendBatchSize())
-        .withMaxAppendsPerFollower(partitionConfig.getMaxAppendsPerFollower())
+        .withPartitionConfig(partitionConfig)
         .withStorage(createRaftStorage())
-        .withEntryValidator(partitionConfig.getEntryValidator())
+        .withEntryValidator(config.getEntryValidator())
         .withElectionConfig(electionConfig)
         .build();
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -42,7 +42,6 @@ final class LeaderAppender extends AbstractAppender {
 
   private static final long MAX_HEARTBEAT_WAIT = 60000;
   private static final int MIN_BACKOFF_FAILURE_COUNT = 5;
-  private static final int MIN_STEP_DOWN_FAILURE_COUNT = 3;
 
   private final long leaderTime;
   private final long leaderIndex;
@@ -51,6 +50,8 @@ final class LeaderAppender extends AbstractAppender {
   private final Map<Long, CompletableFuture<Long>> appendFutures = new HashMap<>();
   private final List<TimestampedFuture<Long>> heartbeatFutures = new ArrayList<>();
   private final long heartbeatTime;
+  private final int minStepDownFailureCount;
+  private final long maxQuorumResponseTimeout;
 
   LeaderAppender(final LeaderRole leader) {
     super(leader.raft);
@@ -60,6 +61,9 @@ final class LeaderAppender extends AbstractAppender {
     heartbeatTime = leaderTime;
     electionTimeout = raft.getElectionTimeout().toMillis();
     heartbeatInterval = raft.getHeartbeatInterval().toMillis();
+    minStepDownFailureCount = raft.getMinStepDownFailureCount();
+    maxQuorumResponseTimeout =
+        Math.max(electionTimeout * 2, raft.getMaxQuorumResponseTimeout().toMillis());
   }
 
   /**
@@ -165,8 +169,7 @@ final class LeaderAppender extends AbstractAppender {
     // that a partition occurred and transition back to the FOLLOWER state.
     final long quorumResponseTime =
         System.currentTimeMillis() - Math.max(computeResponseTime(), leaderTime);
-    final long maxQuorumResponseTimeout = electionTimeout * 2;
-    if (member.getFailureCount() >= MIN_STEP_DOWN_FAILURE_COUNT
+    if (member.getFailureCount() >= minStepDownFailureCount
         && quorumResponseTime > maxQuorumResponseTimeout) {
       log.warn(
           "Suspected network partition after {} failures from {} over a period of time {} > {}, stepping down",

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -63,7 +63,9 @@ final class LeaderAppender extends AbstractAppender {
     heartbeatInterval = raft.getHeartbeatInterval().toMillis();
     minStepDownFailureCount = raft.getMinStepDownFailureCount();
     maxQuorumResponseTimeout =
-        Math.max(electionTimeout * 2, raft.getMaxQuorumResponseTimeout().toMillis());
+        raft.getMaxQuorumResponseTimeout().isZero()
+            ? electionTimeout * 2
+            : raft.getMaxQuorumResponseTimeout().toMillis();
   }
 
   /**

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -22,6 +22,7 @@ import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.partition.RaftElectionConfig;
+import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.protocol.ControllableRaftServerProtocol;
 import io.atomix.raft.roles.LeaderRole;
 import io.atomix.raft.snapshot.TestSnapshotStore;
@@ -158,10 +159,9 @@ public final class ControllableRaftContexts {
             new ControllableRaftServerProtocol(memberId, serverProtocols, messageQueue),
             createStorage(memberId),
             getRaftThreadContextFactory(memberId),
-            32 * 1024, // Copied from defaults
-            2, // Copied from defaults
             () -> random,
-            RaftElectionConfig.ofDefaultElection());
+            RaftElectionConfig.ofDefaultElection(),
+            new RaftPartitionConfig());
     raft.setEntryValidator(new NoopEntryValidator());
     return raft;
   }

--- a/atomix/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/atomix/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -50,8 +50,8 @@ public class AtomixTest {
                   final var groupConfig =
                       new RaftPartitionGroupConfig()
                           .setName("raft")
-                          .setPartitionSize(3)
-                          .setPartitions(7)
+                          .setReplicationFactor(3)
+                          .setPartitionCount(7)
                           .setMembers(Set.of("1"))
                           .setStorageConfig(
                               new RaftStorageConfig()

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -118,7 +118,9 @@ public final class AtomixFactory {
             .withFreeDiskSpace(dataCfg.getFreeDiskSpaceReplicationWatermark())
             .withJournalIndexDensity(dataCfg.getLogIndexDensity())
             .withPriorityElection(experimentalCfg.isEnablePriorityElection())
-            .withRequestTimeout(experimentalCfg.getRaft().getRequestTimeout());
+            .withRequestTimeout(experimentalCfg.getRaft().getRequestTimeout())
+            .withMaxQuorumResponseTimeout(experimentalCfg.getRaft().getMaxQuorumResponseTimeout())
+            .withMinStepDownFailureCount(experimentalCfg.getRaft().getMinStepDownFailureCount());
 
     final int maxMessageSize = (int) networkCfg.getMaxMessageSizeInBytes();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
@@ -12,8 +12,12 @@ import java.time.Duration;
 public final class RaftCfg implements ConfigurationEntry {
 
   private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(5);
+  private static final Duration DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT = Duration.ofSeconds(0);
+  private static final int DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT = 3;
 
   private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+  private Duration maxQuorumResponseTimeout = DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT;
+  private int minStepDownFailureCount = DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT;
 
   public Duration getRequestTimeout() {
     return requestTimeout;
@@ -21,5 +25,21 @@ public final class RaftCfg implements ConfigurationEntry {
 
   public void setRequestTimeout(final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;
+  }
+
+  public Duration getMaxQuorumResponseTimeout() {
+    return maxQuorumResponseTimeout;
+  }
+
+  public void setMaxQuorumResponseTimeout(final Duration maxQuorumResponseTimeout) {
+    this.maxQuorumResponseTimeout = maxQuorumResponseTimeout;
+  }
+
+  public int getMinStepDownFailureCount() {
+    return minStepDownFailureCount;
+  }
+
+  public void setMinStepDownFailureCount(final int minStepDownFailureCount) {
+    this.minStepDownFailureCount = minStepDownFailureCount;
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfgTest.java
@@ -40,4 +40,50 @@ public class ExperimentalCfgTest {
     // then
     assertThat(raft.getRequestTimeout()).isEqualTo(Duration.ofSeconds(15));
   }
+
+  @Test
+  public void shouldSetRaftMaxQuorumResponseTimeoutFromConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
+    final var raft = cfg.getExperimental().getRaft();
+
+    // then
+    assertThat(raft.getMaxQuorumResponseTimeout()).isEqualTo(Duration.ofSeconds(8));
+  }
+
+  @Test
+  public void shouldSetRaftMaxQuorumResponseTimeoutFromEnv() {
+    // given
+    environment.put("zeebe.broker.experimental.raft.maxQuorumResponseTimeout", "15s");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
+    final var raft = cfg.getExperimental().getRaft();
+
+    // then
+    assertThat(raft.getMaxQuorumResponseTimeout()).isEqualTo(Duration.ofSeconds(15));
+  }
+
+  @Test
+  public void shouldSetRaftMinStepDownFailureCountFromConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
+    final var raft = cfg.getExperimental().getRaft();
+
+    // then
+    assertThat(raft.getMinStepDownFailureCount()).isEqualTo(5);
+  }
+
+  @Test
+  public void shouldSetRaftMinStepDownFailureCountFromEnv() {
+    // given
+    environment.put("zeebe.broker.experimental.raft.minStepDownFailureCount", "10");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
+    final var raft = cfg.getExperimental().getRaft();
+
+    // then
+    assertThat(raft.getMinStepDownFailureCount()).isEqualTo(10);
+  }
 }

--- a/broker/src/test/resources/system/experimental-cfg.yaml
+++ b/broker/src/test/resources/system/experimental-cfg.yaml
@@ -4,3 +4,5 @@ zeebe:
       enablePriorityElection: true
       raft:
         requestTimeout: 10s
+        maxQuorumResponseTimeout: 8s
+        minStepDownFailureCount: 5

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -524,6 +524,19 @@
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_REQUESTTIMEOUT
         # requestTimeout = 5s
 
+        # If the leader is not able to reach the quorum, the leader may step down.
+        # This is triggered after minStepDownFailureCount number of requests fails to get a response from the quorum of
+        # followers as well as if the last response was received before maxQuorumResponseTime.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_MINSTEPDOWNFAILURECOUNT
+        # minStepDownFailureCount = 3
+
+        # If the leader is not able to reach the quorum, the leader may step down.
+        # This is triggered after minStepDownFailureCount number of requests fails to get a response from the quorum of
+        # followers as well as if the last response was received before maxQuorumResponseTime.
+        # When this value is 0, it will use a default value of electionTimeout * 2.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_MAXQUORUMRESPONSETIMEOUT
+        # maxQuorumResponseTimeout = 0ms
+
       # Allows to configure RocksDB properties, which is used for state management.
       # rocksdb:
         # Specify custom column family options overwriting Zeebe's own defaults.

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -525,14 +525,16 @@
         # requestTimeout = 5s
 
         # If the leader is not able to reach the quorum, the leader may step down.
-        # This is triggered after minStepDownFailureCount number of requests fails to get a response from the quorum of
-        # followers as well as if the last response was received before maxQuorumResponseTime.
+        # This is triggered after a number of requests, to a quorum of followers, has failed, and the number of failures
+        # reached minStepDownFailureCount. The maxQuorumResponseTime also influences when the leader step down.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_MINSTEPDOWNFAILURECOUNT
         # minStepDownFailureCount = 3
 
         # If the leader is not able to reach the quorum, the leader may step down.
-        # This is triggered after minStepDownFailureCount number of requests fails to get a response from the quorum of
-        # followers as well as if the last response was received before maxQuorumResponseTime.
+        # This is triggered if the leader is not able to reach the quorum of the followers for maxQuorumResponseTimeout.
+        # The minStepDownFailureCount also influences when the leader step down.
+        # Higher the timeout, slower the leader reacts to a partial network partition.
+        # When the timeout is lower, there might be false positives, and the leader might step down too quickly.
         # When this value is 0, it will use a default value of electionTimeout * 2.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_MAXQUORUMRESPONSETIMEOUT
         # maxQuorumResponseTimeout = 0ms

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -486,14 +486,16 @@
         # requestTimeout = 5s
 
         # If the leader is not able to reach the quorum, the leader may step down.
-        # This is triggered after minStepDownFailureCount number of requests fails to get a response from the quorum of
-        # followers as well as if the last response was received before maxQuorumResponseTime.
+        # This is triggered after a number of requests, to a quorum of followers, has failed, and the number of failures
+        # reached minStepDownFailureCount. The maxQuorumResponseTime also influences when the leader step down.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_MINSTEPDOWNFAILURECOUNT
         # minStepDownFailureCount = 3
 
         # If the leader is not able to reach the quorum, the leader may step down.
-        # This is triggered after minStepDownFailureCount number of requests fails to get a response from the quorum of
-        # followers as well as if the last response was received before maxQuorumResponseTime.
+        # This is triggered if the leader is not able to reach the quorum of the followers for maxQuorumResponseTimeout.
+        # The minStepDownFailureCount also influences when the leader step down.
+        # Higher the timeout, slower the leader reacts to a partial network partition.
+        # When the timeout is lower, there might be false positives, and the leader might step down too quickly.
         # When this value is 0, it will use a default value of electionTimeout * 2.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_MAXQUORUMRESPONSETIMEOUT
         # maxQuorumResponseTimeout = 0ms

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -485,6 +485,18 @@
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_REQUESTTIMEOUT
         # requestTimeout = 5s
 
+        # If the leader is not able to reach the quorum, the leader may step down.
+        # This is triggered after minStepDownFailureCount number of requests fails to get a response from the quorum of
+        # followers as well as if the last response was received before maxQuorumResponseTime.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_MINSTEPDOWNFAILURECOUNT
+        # minStepDownFailureCount = 3
+
+        # If the leader is not able to reach the quorum, the leader may step down.
+        # This is triggered after minStepDownFailureCount number of requests fails to get a response from the quorum of
+        # followers as well as if the last response was received before maxQuorumResponseTime.
+        # When this value is 0, it will use a default value of electionTimeout * 2.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_MAXQUORUMRESPONSETIMEOUT
+        # maxQuorumResponseTimeout = 0ms
 
       # Allows to configure RocksDB properties, which is used for state management.
       # rocksdb:


### PR DESCRIPTION
## Description

* Expose two more raft parameters - minStepDownFailureCount, maxQuorumResponseTime
* Refactor how we pass configuration to raft context

## Related issues

closes #6320 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
