### PR TITLE
Fix flaky test analysis with integration tests

### DIFF
--- a/.ci/scripts/distribution/it-java.sh
+++ b/.ci/scripts/distribution/it-java.sh
@@ -12,6 +12,7 @@ MAVEN_PROPERTIES=(
   -DskipChecks
   -DtestMavenId=2
   -Dfailsafe.rerunFailingTestsCount=7
+  -Dflaky.test.reportDir=failsafe-reports
 )
 tmpfile=$(mktemp)
 
@@ -25,7 +26,9 @@ if [ ! -z "$JUNIT_THREAD_COUNT" ]; then
   MAVEN_PROPERTIES+=("-DjunitThreadCount=$JUNIT_THREAD_COUNT")
 fi
 
-mvn -o -B --fail-never -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} verify -P parallel-tests "${MAVEN_PROPERTIES[@]}" | tee ${tmpfile}
+mvn -o -B --fail-never -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} \
+  -P parallel-tests,extract-flaky-tests "${MAVEN_PROPERTIES[@]}" \
+  verify | tee ${tmpfile}
 status=${PIPESTATUS[0]}
 
 # delay checking the maven status after we've analysed flaky tests

--- a/.ci/scripts/distribution/test-java.sh
+++ b/.ci/scripts/distribution/test-java.sh
@@ -25,7 +25,9 @@ if [ ! -z "$JUNIT_THREAD_COUNT" ]; then
   MAVEN_PROPERTIES+=("-DjunitThreadCount=$JUNIT_THREAD_COUNT")
 fi
 
-mvn -o -B --fail-never -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} test -P skip-random-tests,parallel-tests "${MAVEN_PROPERTIES[@]}" | tee ${tmpfile}
+mvn -o -B --fail-never -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} \
+  -P skip-random-tests,parallel-tests,extract-flaky-tests "${MAVEN_PROPERTIES[@]}" \
+  verify | tee ${tmpfile}
 status=${PIPESTATUS[0]}
 
 # delay checking the maven status after we've analysed flaky tests

--- a/.ci/scripts/distribution/test-java8.sh
+++ b/.ci/scripts/distribution/test-java8.sh
@@ -7,6 +7,7 @@ LIMITS_CPU=${LIMITS_CPU:-$(getconf _NPROCESSORS_ONLN)}
 MAVEN_PARALLELISM=${MAVEN_PARALLELISM:-$LIMITS_CPU}
 SUREFIRE_FORK_COUNT=${SUREFIRE_FORK_COUNT:-}
 MAVEN_PROPERTIES=(
+  -DskipITs
   -DskipChecks
   -DtestMavenId=3
   -Dsurefire.rerunFailingTestsCount=7
@@ -19,7 +20,9 @@ if [ ! -z "$SUREFIRE_FORK_COUNT" ]; then
   export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -XX:MaxRAMPercentage=$((100 / ($MAVEN_PARALLELISM * $SUREFIRE_FORK_COUNT)))"
 fi
 
-mvn -o -B --fail-never -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} test -pl clients/java "${MAVEN_PROPERTIES[@]}" | tee ${tmpfile}
+mvn -o -B --fail-never -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} -pl clients/java \
+ -P parallel-tests,extract-flaky-tests "${MAVEN_PROPERTIES[@]}" \
+ verify | tee ${tmpfile}
 status=${PIPESTATUS[0]}
 
 # delay checking the maven status after we've analysed flaky tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -412,7 +412,7 @@ pipeline {
                         org.camunda.helper.CIAnalytics.trackBuildStatus(this, 'flaky-tests', flakyTestCase)
                     }
                 } else {
-                    org.camunda.helper.CIAnalytics.trackBuildStatus(this, currentBuild.currentResult)
+                    org.camunda.helper.CIAnalytics.trackBuildStatus(this, currentBuild.result)
                 }
             }
         }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -128,6 +128,7 @@
     <plugin.version.dependency-analyzer>1.11.1</plugin.version.dependency-analyzer>
     <plugin.version.jacoco>0.8.7</plugin.version.jacoco>
     <plugin.version.revapi>0.14.3</plugin.version.revapi>
+    <plugin.version.flaky-tests>2.0.3</plugin.version.flaky-tests>
 
     <!-- maven extensions -->
     <extension.version.os-maven-plugin>1.7.0</extension.version.os-maven-plugin>
@@ -1306,18 +1307,11 @@
           </executions>
         </plugin>
 
+        <!-- extracts flaky test results into separate test cases; meant to be use in CI -->
         <plugin>
           <groupId>io.zeebe</groupId>
           <artifactId>flaky-test-extractor-maven-plugin</artifactId>
-          <version>2.0.3</version>
-          <executions>
-            <execution>
-              <phase>post-integration-test</phase>
-              <goals>
-                <goal>extract-flaky-tests</goal>
-              </goals>
-            </execution>
-          </executions>
+          <version>${plugin.version.flaky-tests}</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -1546,6 +1540,12 @@
           <artifactId>revapi-java</artifactId>
           <version>${version.revapi}</version>
         </dependency>
+        <dependency>
+          <groupId>io.zeebe</groupId>
+          <artifactId>flaky-test-extractor-maven-plugin</artifactId>
+          <version>${plugin.version.flaky-tests}</version>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
       <build>
         <plugins>
@@ -1570,6 +1570,7 @@
                 <configuration>
                   <ignoredUnusedDeclaredDependencies combine.children="append">
                     <dep>org.revapi:revapi-java</dep>
+                    <dep>io.zeebe:flaky-test-extractor-maven-plugin</dep>
                   </ignoredUnusedDeclaredDependencies>
                 </configuration>
               </execution>
@@ -1674,20 +1675,34 @@
       </build>
     </profile>
 
-    <!-- profile to skip flaky test extraction when tests are skipped -->
+    <!--
+      profile to enable flaky test analysis/extraction; running this module will extract flaky runs
+      from your failed test cases as their own test case, such that the failed results can be viewed
+      in Jenkins
+      -->
     <profile>
       <id>extract-flaky-tests</id>
-      <activation>
-        <property>
-          <name>skipTests</name>
-          <value>!true</value>
-        </property>
-      </activation>
+
+      <properties>
+        <flaky.test.reportDir>surefire-reports</flaky.test.reportDir>
+      </properties>
+
       <build>
         <plugins>
           <plugin>
             <groupId>io.zeebe</groupId>
             <artifactId>flaky-test-extractor-maven-plugin</artifactId>
+            <configuration>
+              <reportDir>${project.build.directory}/${flaky.test.reportDir}</reportDir>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>extract-flaky-tests</goal>
+                </goals>
+                <phase>post-integration-test</phase>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -101,6 +101,7 @@
     <version.json-smart>2.4.7</version.json-smart>
     <version.byte-buddy>1.11.5</version.byte-buddy>
     <version.revapi>0.24.3</version.revapi>
+    <version.commons-io>2.9.0</version.commons-io>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.0.0</plugin.version.antrun>
@@ -749,6 +750,12 @@
         <groupId>net.minidev</groupId>
         <artifactId>json-smart</artifactId>
         <version>${version.json-smart}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${version.commons-io}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1496,6 +1496,9 @@
       with mvn dependency:go-offline and then run the tests in offline mode. But the plugin misses
       to download the surefire-junit dependency, therefore define an explicit dependency while downloading.
 
+      NOTE: make sure to specify the scope as test for all dependencies, otherwise they will get
+            added to the distribution!
+
       Usage: mvn install -Pprepare-offline
     -->
     <profile>
@@ -1539,6 +1542,7 @@
           <groupId>org.revapi</groupId>
           <artifactId>revapi-java</artifactId>
           <version>${version.revapi}</version>
+          <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>io.zeebe</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1564,6 +1564,9 @@
                   <goal>resolve-plugins</goal>
                   <goal>go-offline</goal>
                 </goals>
+                <configuration>
+                  <silent>true</silent>
+                </configuration>
               </execution>
               <execution>
                 <id>analyze-dependencies</id>


### PR DESCRIPTION
## Description

This PR fixes the flaky test analysis when used with `failsafe`. `Failsafe` writes reports not to `surefire-reports` but to `failsafe-reports`, so previously the analysis was not picking it up. Furthermore, when we switched the unit tests from running `verify` to simply running `test` (which is the usual for unit testing), the plugin was not ran anymore as it's bound to the `post-integration-test` lifecycle.

The PR works around this by having the script explicitly call the plugin after their phase. This avoids having to repackage in the unit test stage for no reason, and avoids having to keep a special profile which only enables the plugin for CI. Instead, the CI scripts will call the plugin if they need to.

I also added two small fixes to the CI, I hope that's not too much of an issue. One was to make sure dependencies added to the `prepare-offline` profile are test scope (two were not), otherwise they will be included in the distribution, the second was to silence the dependency resolving plugin when going offline. The plugin is very, very noisy, and most of the time we don't care. Making it silent will remove this but will still print warnings and errors, which is what we typically care about. It can always be set back to noisy if we're debugging something.

You can see an example build where I manually added flaky tests (but disabled all others to save time): https://ci.zeebe.camunda.cloud/job/camunda-cloud/job/zeebe/job/np-fix-flakytests/14/

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
