### PR TITLE
Introduce ActorSchedulingService interface

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -29,7 +29,7 @@ import io.camunda.zeebe.util.retry.EndlessRetryStrategy;
 import io.camunda.zeebe.util.retry.RetryStrategy;
 import io.camunda.zeebe.util.sched.Actor;
 import io.camunda.zeebe.util.sched.ActorCondition;
-import io.camunda.zeebe.util.sched.ActorScheduler;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import io.camunda.zeebe.util.sched.SchedulingHints;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
@@ -89,8 +89,8 @@ public final class ExporterDirector extends Actor implements HealthMonitorable {
     isPaused = shouldPauseOnStart;
   }
 
-  public ActorFuture<Void> startAsync(final ActorScheduler actorScheduler) {
-    return actorScheduler.submitActor(this, SchedulingHints.ioBound());
+  public ActorFuture<Void> startAsync(final ActorSchedulingService actorSchedulingService) {
+    return actorSchedulingService.submitActor(this, SchedulingHints.ioBound());
   }
 
   public ActorFuture<Void> stopAsync() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -24,7 +24,7 @@ import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.snapshots.SnapshotStoreSupplier;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import io.camunda.zeebe.util.sched.ActorControl;
-import io.camunda.zeebe.util.sched.ActorScheduler;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import io.camunda.zeebe.util.sched.ScheduledTimer;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import java.io.IOException;
@@ -45,7 +45,7 @@ public class PartitionTransitionContext implements PartitionContext {
   private final int nodeId;
   private final List<PartitionListener> partitionListeners;
   private final PartitionMessagingService messagingService;
-  private final ActorScheduler scheduler;
+  private final ActorSchedulingService actorSchedulingService;
   private final BrokerCfg brokerCfg;
 
   private final SnapshotStoreSupplier snapshotStoreSupplier;
@@ -78,7 +78,7 @@ public class PartitionTransitionContext implements PartitionContext {
       final RaftPartition raftPartition,
       final List<PartitionListener> partitionListeners,
       final PartitionMessagingService messagingService,
-      final ActorScheduler actorScheduler,
+      final ActorSchedulingService actorSchedulingService,
       final BrokerCfg brokerCfg,
       final CommandApiService commandApiService,
       final SnapshotStoreSupplier snapshotStoreSupplier,
@@ -94,7 +94,7 @@ public class PartitionTransitionContext implements PartitionContext {
     this.commandApiService = commandApiService;
     this.partitionListeners = Collections.unmodifiableList(partitionListeners);
     partitionId = raftPartition.id().id();
-    scheduler = actorScheduler;
+    this.actorSchedulingService = actorSchedulingService;
     maxFragmentSize = (int) brokerCfg.getNetwork().getMaxMessageSizeInBytes();
     this.exporterRepository = exporterRepository;
     this.partitionProcessingState = partitionProcessingState;
@@ -212,8 +212,8 @@ public class PartitionTransitionContext implements PartitionContext {
     return messagingService;
   }
 
-  public ActorScheduler getScheduler() {
-    return scheduler;
+  public ActorSchedulingService getActorSchedulingService() {
+    return actorSchedulingService;
   }
 
   public BrokerCfg getBrokerCfg() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionStep.java
@@ -34,7 +34,7 @@ public class ExporterDirectorPartitionStep implements PartitionStep {
     context.setExporterDirector(director);
     context.getComponentHealthMonitor().registerComponent(director.getName(), director);
 
-    final var startFuture = director.startAsync(context.getScheduler());
+    final var startFuture = director.startAsync(context.getActorSchedulingService());
     startFuture.onComplete(
         (nothing, error) -> {
           if (error == null) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogDeletionPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogDeletionPartitionStep.java
@@ -30,7 +30,7 @@ public class LogDeletionPartitionStep implements PartitionStep {
                 .getPersistedSnapshotStore(context.getRaftPartition().id().id()));
 
     context.setLogDeletionService(deletionService);
-    return context.getScheduler().submitActor(deletionService);
+    return context.getActorSchedulingService().submitActor(deletionService);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionStep.java
@@ -108,7 +108,7 @@ public class LogStreamPartitionStep implements PartitionStep {
         .withNodeId(context.getNodeId())
         .withPartitionId(context.getRaftPartition().id().id())
         .withMaxFragmentSize(context.getMaxFragmentSize())
-        .withActorScheduler(context.getScheduler())
+        .withActorSchedulingService(context.getActorSchedulingService())
         .buildAsync();
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionStep.java
@@ -28,7 +28,7 @@ public class SnapshotDirectorPartitionStep implements PartitionStep {
 
     context.setSnapshotDirector(director);
     context.getComponentHealthMonitor().registerComponent(director.getName(), director);
-    return context.getScheduler().submitActor(director);
+    return context.getActorSchedulingService().submitActor(director);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorPartitionStep.java
@@ -65,7 +65,7 @@ public class StreamProcessorPartitionStep implements PartitionStep {
   private StreamProcessor createStreamProcessor(final PartitionTransitionContext state) {
     return StreamProcessor.builder()
         .logStream(state.getLogStream())
-        .actorScheduler(state.getScheduler())
+        .actorSchedulingService(state.getActorSchedulingService())
         .zeebeDb(state.getZeebeDb())
         .eventApplierFactory(EventAppliers::new)
         .nodeId(state.getNodeId())

--- a/dispatcher/src/main/java/io/camunda/zeebe/dispatcher/DispatcherBuilder.java
+++ b/dispatcher/src/main/java/io/camunda/zeebe/dispatcher/DispatcherBuilder.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.util.ByteValue;
 import io.camunda.zeebe.util.EnsureUtil;
 import io.camunda.zeebe.util.allocation.AllocatedBuffer;
 import io.camunda.zeebe.util.allocation.BufferAllocators;
-import io.camunda.zeebe.util.sched.ActorScheduler;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import java.util.Objects;
 import org.agrona.BitUtil;
 
@@ -30,7 +30,7 @@ public final class DispatcherBuilder {
 
   private String dispatcherName;
 
-  private ActorScheduler actorScheduler;
+  private ActorSchedulingService actorSchedulingService;
 
   private String[] subscriptionNames;
 
@@ -53,8 +53,9 @@ public final class DispatcherBuilder {
     return this;
   }
 
-  public DispatcherBuilder actorScheduler(final ActorScheduler actorScheduler) {
-    this.actorScheduler = actorScheduler;
+  public DispatcherBuilder actorSchedulingService(
+      final ActorSchedulingService actorSchedulingService) {
+    this.actorSchedulingService = actorSchedulingService;
     return this;
   }
 
@@ -79,7 +80,7 @@ public final class DispatcherBuilder {
   }
 
   public Dispatcher build() {
-    Objects.requireNonNull(actorScheduler, "Actor scheduler cannot be null.");
+    Objects.requireNonNull(actorSchedulingService, "Actor scheduling service must not be null.");
 
     bufferSize = calculateBufferSize();
     final int partitionSize = BitUtil.align(bufferSize / PARTITION_COUNT, 8);
@@ -114,7 +115,7 @@ public final class DispatcherBuilder {
     dispatcher.updatePublisherLimit(); // make subscription initially writable without waiting for
     // conductor to do this
 
-    actorScheduler.submitActor(dispatcher);
+    actorSchedulingService.submitActor(dispatcher);
 
     return dispatcher;
   }

--- a/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/ActorFrameworkIntegrationTest.java
+++ b/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/ActorFrameworkIntegrationTest.java
@@ -30,7 +30,7 @@ public final class ActorFrameworkIntegrationTest {
   public void testClaim() throws InterruptedException {
     final Dispatcher dispatcher =
         Dispatchers.create("default")
-            .actorScheduler(actorSchedulerRule.get())
+            .actorSchedulingService(actorSchedulerRule.get())
             .bufferSize((int) ByteValue.ofMegabytes(10))
             .build();
 
@@ -46,7 +46,7 @@ public final class ActorFrameworkIntegrationTest {
   public void testClaimAndPeek() throws InterruptedException {
     final Dispatcher dispatcher =
         Dispatchers.create("default")
-            .actorScheduler(actorSchedulerRule.get())
+            .actorSchedulingService(actorSchedulerRule.get())
             .bufferSize((int) ByteValue.ofMegabytes(10))
             .build();
 

--- a/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/DispatcherIntegrationTest.java
+++ b/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/DispatcherIntegrationTest.java
@@ -39,7 +39,7 @@ public final class DispatcherIntegrationTest {
 
     final Dispatcher dispatcher =
         Dispatchers.create("default")
-            .actorScheduler(actorSchedulerRule.get())
+            .actorSchedulingService(actorSchedulerRule.get())
             .bufferSize((int) ByteValue.ofMegabytes(10))
             .build();
 
@@ -70,7 +70,7 @@ public final class DispatcherIntegrationTest {
 
     final Dispatcher dispatcher =
         Dispatchers.create("default")
-            .actorScheduler(actorSchedulerRule.get())
+            .actorSchedulingService(actorSchedulerRule.get())
             .bufferSize((int) ByteValue.ofMegabytes(10))
             .build();
 
@@ -107,7 +107,7 @@ public final class DispatcherIntegrationTest {
 
     final Dispatcher dispatcher =
         Dispatchers.create("default")
-            .actorScheduler(actorSchedulerRule.get())
+            .actorSchedulingService(actorSchedulerRule.get())
             .bufferSize((int) ByteValue.ofMegabytes(10))
             .build();
 
@@ -151,7 +151,7 @@ public final class DispatcherIntegrationTest {
     // given
     final Dispatcher dispatcher =
         Dispatchers.create("default")
-            .actorScheduler(actorSchedulerRule.get())
+            .actorSchedulingService(actorSchedulerRule.get())
             .bufferSize((int) ByteValue.ofKilobytes(10))
             .build();
 
@@ -170,7 +170,7 @@ public final class DispatcherIntegrationTest {
 
     final var builder =
         Dispatchers.create("test")
-            .actorScheduler(actorSchedulerRule.get())
+            .actorSchedulingService(actorSchedulerRule.get())
             .maxFragmentLength(frameLength)
             .bufferSize(frameLength);
 
@@ -188,7 +188,7 @@ public final class DispatcherIntegrationTest {
 
     final Dispatcher dispatcher =
         Dispatchers.create("test")
-            .actorScheduler(actorSchedulerRule.get())
+            .actorSchedulingService(actorSchedulerRule.get())
             .maxFragmentLength(frameLength)
             .build();
 
@@ -203,7 +203,7 @@ public final class DispatcherIntegrationTest {
     final int maxFragmentLength = (int) ByteValue.ofKilobytes(1);
     final Dispatcher dispatcher =
         Dispatchers.create("default")
-            .actorScheduler(actorSchedulerRule.get())
+            .actorSchedulingService(actorSchedulerRule.get())
             .maxFragmentLength(maxFragmentLength)
             .build();
 

--- a/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/FragmentBatchIntegrationTest.java
+++ b/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/FragmentBatchIntegrationTest.java
@@ -46,7 +46,7 @@ public final class FragmentBatchIntegrationTest {
     dispatcher =
         Dispatchers.create("default")
             .bufferSize((int) ByteValue.ofKilobytes(32))
-            .actorScheduler(actorSchedulerRule.get())
+            .actorSchedulingService(actorSchedulerRule.get())
             .build();
 
     subscription = dispatcher.openSubscription("test");

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -24,7 +24,7 @@ import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthStatus;
 import io.camunda.zeebe.util.sched.Actor;
 import io.camunda.zeebe.util.sched.ActorCondition;
-import io.camunda.zeebe.util.sched.ActorScheduler;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import io.camunda.zeebe.util.sched.clock.ActorClock;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
@@ -44,7 +44,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
   private static final String ERROR_MESSAGE_RECOVER_FROM_SNAPSHOT_FAILED =
       "Expected to find event with the snapshot position %s in log stream, but nothing was found. Failed to recover '%s'.";
   private static final Logger LOG = Loggers.LOGSTREAMS_LOGGER;
-  private final ActorScheduler actorScheduler;
+  private final ActorSchedulingService actorSchedulingService;
   private final AtomicBoolean isOpened = new AtomicBoolean(false);
   private final List<StreamProcessorLifecycleAware> lifecycleAwareListeners;
   private final Function<MutableZeebeState, EventApplier> eventApplierFactory;
@@ -74,7 +74,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
   private ActorFuture<Long> recoverFuture;
 
   protected StreamProcessor(final StreamProcessorBuilder processorBuilder) {
-    actorScheduler = processorBuilder.getActorScheduler();
+    actorSchedulingService = processorBuilder.getActorSchedulingService();
     lifecycleAwareListeners = processorBuilder.getLifecycleListeners();
 
     typedRecordProcessorFactory = processorBuilder.getTypedRecordProcessorFactory();
@@ -239,7 +239,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
     if (isOpened.compareAndSet(false, true)) {
       shouldProcess = !pauseOnStart;
       openFuture = new CompletableActorFuture<>();
-      actorScheduler.submitActor(this);
+      actorSchedulingService.submitActor(this);
     }
     return openFuture;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandRespons
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.logstreams.log.LogStream;
-import io.camunda.zeebe.util.sched.ActorScheduler;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -24,7 +24,7 @@ public final class StreamProcessorBuilder {
   private final ProcessingContext processingContext;
   private final List<StreamProcessorLifecycleAware> lifecycleListeners = new ArrayList<>();
   private TypedRecordProcessorFactory typedRecordProcessorFactory;
-  private ActorScheduler actorScheduler;
+  private ActorSchedulingService actorSchedulingService;
   private ZeebeDb zeebeDb;
   private Function<MutableZeebeState, EventApplier> eventApplierFactory;
   private int nodeId;
@@ -39,8 +39,9 @@ public final class StreamProcessorBuilder {
     return this;
   }
 
-  public StreamProcessorBuilder actorScheduler(final ActorScheduler actorScheduler) {
-    this.actorScheduler = actorScheduler;
+  public StreamProcessorBuilder actorSchedulingService(
+      final ActorSchedulingService actorSchedulingService) {
+    this.actorSchedulingService = actorSchedulingService;
     return this;
   }
 
@@ -84,8 +85,8 @@ public final class StreamProcessorBuilder {
     return processingContext;
   }
 
-  public ActorScheduler getActorScheduler() {
-    return actorScheduler;
+  public ActorSchedulingService getActorSchedulingService() {
+    return actorSchedulingService;
   }
 
   public List<StreamProcessorLifecycleAware> getLifecycleListeners() {
@@ -112,7 +113,7 @@ public final class StreamProcessorBuilder {
 
   private void validate() {
     Objects.requireNonNull(typedRecordProcessorFactory, "No stream processor factory provided.");
-    Objects.requireNonNull(actorScheduler, "No task scheduler provided.");
+    Objects.requireNonNull(actorSchedulingService, "No task scheduler provided.");
     Objects.requireNonNull(processingContext.getLogStream(), "No log stream provided.");
     Objects.requireNonNull(
         processingContext.getWriters().response(), "No command response writer provided.");

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -147,7 +147,7 @@ public final class TestStreams {
             .withLogName(name)
             .withLogStorage(logStorage)
             .withPartitionId(partitionId)
-            .withActorScheduler(actorScheduler)
+            .withActorSchedulingService(actorScheduler)
             .build();
 
     logStreamConsumer.accept(logStream);
@@ -239,7 +239,7 @@ public final class TestStreams {
         StreamProcessor.builder()
             .logStream(stream.getAsyncLogStream())
             .zeebeDb(zeebeDb)
-            .actorScheduler(actorScheduler)
+            .actorSchedulingService(actorScheduler)
             .commandResponseWriter(mockCommandResponseWriter)
             .onProcessedListener(mockOnProcessedListener)
             .streamProcessorFactory(factory)

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.RoundRobinActivateJobsHandler;
 import io.camunda.zeebe.util.VersionUtil;
-import io.camunda.zeebe.util.sched.ActorScheduler;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptors;
@@ -42,7 +42,7 @@ public final class Gateway {
   private final Function<GatewayCfg, ServerBuilder> serverBuilderFactory;
   private final Function<GatewayCfg, BrokerClient> brokerClientFactory;
   private final GatewayCfg gatewayCfg;
-  private final ActorScheduler actorScheduler;
+  private final ActorSchedulingService actorSchedulingService;
 
   private Server server;
   private BrokerClient brokerClient;
@@ -54,30 +54,30 @@ public final class Gateway {
       final MessagingService messagingService,
       final ClusterMembershipService membershipService,
       final ClusterEventService eventService,
-      final ActorScheduler actorScheduler) {
+      final ActorSchedulingService actorSchedulingService) {
     this(
         gatewayCfg,
         cfg -> new BrokerClientImpl(cfg, messagingService, membershipService, eventService),
         DEFAULT_SERVER_BUILDER_FACTORY,
-        actorScheduler);
+        actorSchedulingService);
   }
 
   public Gateway(
       final GatewayCfg gatewayCfg,
       final Function<GatewayCfg, BrokerClient> brokerClientFactory,
-      final ActorScheduler actorScheduler) {
-    this(gatewayCfg, brokerClientFactory, DEFAULT_SERVER_BUILDER_FACTORY, actorScheduler);
+      final ActorSchedulingService actorSchedulingService) {
+    this(gatewayCfg, brokerClientFactory, DEFAULT_SERVER_BUILDER_FACTORY, actorSchedulingService);
   }
 
   public Gateway(
       final GatewayCfg gatewayCfg,
       final Function<GatewayCfg, BrokerClient> brokerClientFactory,
       final Function<GatewayCfg, ServerBuilder> serverBuilderFactory,
-      final ActorScheduler actorScheduler) {
+      final ActorSchedulingService actorSchedulingService) {
     this.gatewayCfg = gatewayCfg;
     this.brokerClientFactory = brokerClientFactory;
     this.serverBuilderFactory = serverBuilderFactory;
-    this.actorScheduler = actorScheduler;
+    this.actorSchedulingService = actorSchedulingService;
   }
 
   public GatewayCfg getGatewayCfg() {
@@ -105,7 +105,7 @@ public final class Gateway {
     if (gatewayCfg.getLongPolling().isEnabled()) {
       final LongPollingActivateJobsHandler longPollingHandler =
           buildLongPollingHandler(brokerClient);
-      actorScheduler.submitActor(longPollingHandler);
+      actorSchedulingService.submitActor(longPollingHandler);
       activateJobsHandler = longPollingHandler;
     } else {
       activateJobsHandler = new RoundRobinActivateJobsHandler(brokerClient);

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBuilder.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBuilder.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.logstreams.log;
 
 import io.camunda.zeebe.logstreams.storage.LogStorage;
-import io.camunda.zeebe.util.sched.ActorScheduler;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 
 /** Builder pattern for the {@link LogStream} */
@@ -17,10 +17,10 @@ public interface LogStreamBuilder {
   /**
    * The actor scheduler to use for the {@link LogStream} and its child actors
    *
-   * @param actorScheduler the scheduler to use
+   * @param actorSchedulingService the scheduler to use
    * @return this builder
    */
-  LogStreamBuilder withActorScheduler(ActorScheduler actorScheduler);
+  LogStreamBuilder withActorSchedulingService(ActorSchedulingService actorSchedulingService);
 
   /**
    * The maximum fragment size read from the shared write buffer; this should be aligned with the

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
@@ -45,7 +45,7 @@ public final class LogStorageAppenderHealthTest {
 
     dispatcher =
         Dispatchers.create("0")
-            .actorScheduler(schedulerRule.get())
+            .actorSchedulingService(schedulerRule.get())
             .bufferSize((int) ByteValue.ofMegabytes(100 * MAX_FRAGMENT_SIZE))
             .maxFragmentLength(MAX_FRAGMENT_SIZE)
             .build();

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
@@ -73,7 +73,7 @@ public final class LogStorageAppenderTest {
 
     dispatcher =
         Dispatchers.create("0")
-            .actorScheduler(schedulerRule.get())
+            .actorSchedulingService(schedulerRule.get())
             .bufferSize((int) ByteValue.ofMegabytes(100 * MAX_FRAGMENT_SIZE))
             .maxFragmentLength(MAX_FRAGMENT_SIZE)
             .initialPosition(INITIAL_POSITION)

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamRule.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamRule.java
@@ -88,7 +88,7 @@ public final class LogStreamRule extends ExternalResource {
 
     builder =
         LogStream.builder()
-            .withActorScheduler(actorScheduler)
+            .withActorSchedulingService(actorScheduler)
             .withPartitionId(0)
             .withLogName("0")
             .withLogStorage(logStorageRule.getStorage());
@@ -116,7 +116,8 @@ public final class LogStreamRule extends ExternalResource {
   }
 
   private void openLogStream() {
-    logStream = SyncLogStream.builder(builder).withActorScheduler(actorSchedulerRule.get()).build();
+    logStream =
+        SyncLogStream.builder(builder).withActorSchedulingService(actorSchedulerRule.get()).build();
     logStorageRule.setPositionListener(logStream::setCommitPosition);
   }
 

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStreamBuilder.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStreamBuilder.java
@@ -11,14 +11,14 @@ import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamBuilder;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.camunda.zeebe.util.sched.Actor;
-import io.camunda.zeebe.util.sched.ActorScheduler;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.util.Objects;
 
 public final class SyncLogStreamBuilder implements LogStreamBuilder {
   private final LogStreamBuilder delegate;
-  private ActorScheduler actorScheduler;
+  private ActorSchedulingService actorSchedulingService;
 
   SyncLogStreamBuilder() {
     this(LogStream.builder());
@@ -29,9 +29,10 @@ public final class SyncLogStreamBuilder implements LogStreamBuilder {
   }
 
   @Override
-  public SyncLogStreamBuilder withActorScheduler(final ActorScheduler actorScheduler) {
-    this.actorScheduler = actorScheduler;
-    delegate.withActorScheduler(actorScheduler);
+  public SyncLogStreamBuilder withActorSchedulingService(
+      final ActorSchedulingService actorSchedulingService) {
+    this.actorSchedulingService = actorSchedulingService;
+    delegate.withActorSchedulingService(actorSchedulingService);
     return this;
   }
 
@@ -73,8 +74,8 @@ public final class SyncLogStreamBuilder implements LogStreamBuilder {
   public SyncLogStream build() {
     final var scheduler =
         Objects.requireNonNull(
-            actorScheduler,
-            "must provide an actor scheduler through SyncLogStreamBuilder#withActorScheduler");
+            actorSchedulingService,
+            "must provide an actor scheduling service through SyncLogStreamBuilder#withActorSchedulingService");
 
     final var buildFuture = new CompletableActorFuture<SyncLogStream>();
     scheduler.submitActor(

--- a/test/ignored-changes.json
+++ b/test/ignored-changes.json
@@ -50,6 +50,12 @@
         {
           "code": "java.method.removed",
           "old": "method io.camunda.zeebe.broker.Broker io.camunda.zeebe.test.EmbeddedBrokerRule::getBroker()"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.logstreams.log.LogStreamBuilder io.camunda.zeebe.logstreams.log.LogStreamBuilder::withActorScheduler(io.camunda.zeebe.util.sched.ActorScheduler)",
+          "justification": "Reduces dependency surface and makes some tests easier to implement"
         }
       ]
     }

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorScheduler.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorScheduler.java
@@ -14,7 +14,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-public final class ActorScheduler implements AutoCloseable {
+public final class ActorScheduler implements AutoCloseable, ActorSchedulingService {
   private final AtomicReference<SchedulerState> state = new AtomicReference<>();
   private final ActorExecutor actorTaskExecutor;
 
@@ -28,6 +28,7 @@ public final class ActorScheduler implements AutoCloseable {
    *
    * @param actor the actor to submit
    */
+  @Override
   public ActorFuture<Void> submitActor(final Actor actor) {
     return actorTaskExecutor.submitCpuBound(actor.actor.task);
   }

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorSchedulingService.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorSchedulingService.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util.sched;
+
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+
+/**
+ * Service interface to schedule an actor (without exposing the full interface of {@code
+ * ActorScheduler}
+ */
+public interface ActorSchedulingService {
+  ActorFuture<Void> submitActor(final Actor actor);
+
+  ActorFuture<Void> submitActor(final Actor actor, int schedulingHints);
+}


### PR DESCRIPTION
## Description

This interface contains the methods to submit a new Actor. Call sites that reference ActorScheduler were updated if the smaller interface suffices. This reduces the dependency surface and will make some tests easier to implement.

## Related issues
related to (but does not close): #7410

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
