### PR TITLE
Remove dependency of partition components on CommdApiService

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorPartitionStep.java
@@ -69,9 +69,8 @@ public class StreamProcessorPartitionStep implements PartitionStep {
         .zeebeDb(state.getZeebeDb())
         .eventApplierFactory(EventAppliers::new)
         .nodeId(state.getNodeId())
-        .commandResponseWriter(state.getCommandApiService().newCommandResponseWriter())
-        .onProcessedListener(
-            state.getCommandApiService().getOnProcessedListener(state.getPartitionId()))
+        .commandResponseWriter(state.getCommandResponseWriter())
+        .onProcessedListener(state.getOnProcessedListener())
         .streamProcessorFactory(
             processingContext -> {
               final ActorControl actor = processingContext.getActor();


### PR DESCRIPTION
## Description

This removes the dependency of the partition components on the `CommandApiService`. I first thought about defining an interface with the methods of `CommandApiService` that the partition depends upon. But then I could not find a good name for that interface. So it is now two small things that the partition depends upon.

## Related issues
related to (but not closing #7410 

<!-- Cut-off marker
## Definition of Ready
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
