### PR TITLE
add deprecated annotations

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/PartitionListener.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/PartitionListener.java
@@ -37,7 +37,10 @@ public interface PartitionListener {
    * @param logStream the corresponding log stream
    * @return future that should be completed by the listener
    */
-  ActorFuture<Void> onBecomingLeader(int partitionId, long term, LogStream logStream);
+  ActorFuture<Void> onBecomingLeader(
+      int partitionId,
+      long term,
+      @Deprecated LogStream logStream); // lookup of log stream will be changed in the future
 
   /**
    * Is called by the {@link io.camunda.zeebe.broker.system.partitions.ZeebePartition} on becoming

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
@@ -26,10 +26,13 @@ public interface PartitionContext {
 
   RaftPartition getRaftPartition();
 
+  @Deprecated // will be moved to transition logic and happen automatically
   List<ActorFuture<Void>> notifyListenersOfBecomingLeader(final long newTerm);
 
+  @Deprecated // will be moved to transition logic and happen automatically
   List<ActorFuture<Void>> notifyListenersOfBecomingFollower(final long newTerm);
 
+  @Deprecated // will be moved to transition logic and happen automatically
   void notifyListenersOfBecomingInactive();
 
   Role getCurrentRole();
@@ -40,21 +43,30 @@ public interface PartitionContext {
 
   StreamProcessor getStreamProcessor();
 
+  @Deprecated // will be moved into some kind of controller class
   void triggerSnapshot();
 
   ExporterDirector getExporterDirector();
 
+  @Deprecated // currently the implementation forwards this to other components inside the
+  // partition; these components will be directly registered as listeners in the future
   void setDiskSpaceAvailable(boolean b);
 
+  @Deprecated // will be moved into some kind of controller class
   boolean shouldProcess();
 
+  @Deprecated // will be moved into some kind of controller class
   void pauseProcessing() throws IOException;
 
+  @Deprecated // will be moved into some kind of controller class
   void resumeProcessing() throws IOException;
 
+  @Deprecated // will be moved into some kind of controller class
   boolean shouldExport();
 
+  @Deprecated // will be moved into some kind of controller class
   boolean pauseExporting() throws IOException;
 
+  @Deprecated // will be moved into some kind of controller class
   boolean resumeExporting() throws IOException;
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -69,6 +69,7 @@ public final class ZeebePartition extends Actor
    * @param newRole the new role of the raft partition
    */
   @Override
+  @Deprecated // will be removed from public API of ZeebePartition
   public void onNewRole(final Role newRole, final long newTerm) {
     actor.run(() -> onRoleChange(newRole, newTerm));
   }
@@ -228,6 +229,7 @@ public final class ZeebePartition extends Actor
   }
 
   @Override
+  @Deprecated // will be removed from public API of ZeebePartition
   public void onFailure() {
     actor.run(
         () -> {
@@ -237,6 +239,7 @@ public final class ZeebePartition extends Actor
   }
 
   @Override
+  @Deprecated // will be removed from public API of ZeebePartition
   public void onRecovered() {
     actor.run(
         () -> {
@@ -246,6 +249,7 @@ public final class ZeebePartition extends Actor
   }
 
   @Override
+  @Deprecated // will be removed from public API of ZeebePartition
   public void onUnrecoverableFailure() {
     actor.run(this::handleUnrecoverableFailure);
   }
@@ -326,6 +330,8 @@ public final class ZeebePartition extends Actor
   }
 
   @Override
+  @Deprecated // currently the implementation forwards this to other components inside the
+  // partition; these components will be directly registered as listeners in the future
   public void onDiskSpaceNotAvailable() {
     actor.call(
         () -> {
@@ -339,6 +345,8 @@ public final class ZeebePartition extends Actor
   }
 
   @Override
+  @Deprecated // currently the implementation forwards this to other components inside the
+  // partition; these components will be directly registered as listeners in the future
   public void onDiskSpaceAvailable() {
     actor.call(
         () -> {
@@ -351,6 +359,7 @@ public final class ZeebePartition extends Actor
         });
   }
 
+  @Deprecated // will be removed from public API of ZeebePartition
   public ActorFuture<Void> pauseProcessing() {
     final CompletableActorFuture<Void> completed = new CompletableActorFuture<>();
     actor.call(
@@ -371,6 +380,7 @@ public final class ZeebePartition extends Actor
     return completed;
   }
 
+  @Deprecated // will be removed from public API of ZeebePartition
   public void resumeProcessing() {
     actor.call(
         () -> {
@@ -393,6 +403,7 @@ public final class ZeebePartition extends Actor
     return context.getRaftPartition().getServer().getPersistedSnapshotStore();
   }
 
+  @Deprecated // will be removed from public API of ZeebePartition
   public void triggerSnapshot() {
     actor.call(
         () -> {
@@ -408,6 +419,7 @@ public final class ZeebePartition extends Actor
     return actor.call(() -> Optional.ofNullable(context.getExporterDirector()));
   }
 
+  @Deprecated // will be removed from public API of ZeebePartition
   public ActorFuture<Void> pauseExporting() {
     final CompletableActorFuture<Void> completed = new CompletableActorFuture<>();
     actor.call(
@@ -428,6 +440,7 @@ public final class ZeebePartition extends Actor
     return completed;
   }
 
+  @Deprecated // will be removed from public API of ZeebePartition
   public void resumeExporting() {
     actor.call(
         () -> {


### PR DESCRIPTION
## Description

This commit adds deprecated annotations to all methods related to the interface between application-wide components and per-partition components. This is to indicate which things will change during the bootstrap refactoring.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7412

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
