### PR TITLE
[Backports stable/1.0] Fix flaky test analysis with integration tests

### DIFF
--- a/.ci/scripts/distribution/it-java.sh
+++ b/.ci/scripts/distribution/it-java.sh
@@ -12,6 +12,7 @@ MAVEN_PROPERTIES=(
   -DskipChecks
   -DtestMavenId=2
   -Dfailsafe.rerunFailingTestsCount=7
+  -Dflaky.test.reportDir=failsafe-reports
 )
 tmpfile=$(mktemp)
 
@@ -25,7 +26,9 @@ if [ ! -z "$JUNIT_THREAD_COUNT" ]; then
   MAVEN_PROPERTIES+=("-DjunitThreadCount=$JUNIT_THREAD_COUNT")
 fi
 
-mvn -o -B --fail-never -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} verify -P parallel-tests "${MAVEN_PROPERTIES[@]}" | tee ${tmpfile}
+mvn -o -B --fail-never -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} \
+  -P parallel-tests,extract-flaky-tests "${MAVEN_PROPERTIES[@]}" \
+  verify | tee ${tmpfile}
 status=${PIPESTATUS[0]}
 
 # delay checking the maven status after we've analysed flaky tests

--- a/.ci/scripts/distribution/test-java.sh
+++ b/.ci/scripts/distribution/test-java.sh
@@ -25,7 +25,9 @@ if [ ! -z "$JUNIT_THREAD_COUNT" ]; then
   MAVEN_PROPERTIES+=("-DjunitThreadCount=$JUNIT_THREAD_COUNT")
 fi
 
-mvn -o -B --fail-never -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} test -P skip-random-tests,parallel-tests "${MAVEN_PROPERTIES[@]}" | tee ${tmpfile}
+mvn -o -B --fail-never -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} \
+  -P skip-random-tests,parallel-tests,extract-flaky-tests "${MAVEN_PROPERTIES[@]}" \
+  verify | tee ${tmpfile}
 status=${PIPESTATUS[0]}
 
 # delay checking the maven status after we've analysed flaky tests

--- a/.ci/scripts/distribution/test-java8.sh
+++ b/.ci/scripts/distribution/test-java8.sh
@@ -7,6 +7,7 @@ LIMITS_CPU=${LIMITS_CPU:-$(getconf _NPROCESSORS_ONLN)}
 MAVEN_PARALLELISM=${MAVEN_PARALLELISM:-$LIMITS_CPU}
 SUREFIRE_FORK_COUNT=${SUREFIRE_FORK_COUNT:-}
 MAVEN_PROPERTIES=(
+  -DskipITs
   -DskipChecks
   -DtestMavenId=3
   -Dsurefire.rerunFailingTestsCount=7
@@ -19,7 +20,9 @@ if [ ! -z "$SUREFIRE_FORK_COUNT" ]; then
   export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -XX:MaxRAMPercentage=$((100 / ($MAVEN_PARALLELISM * $SUREFIRE_FORK_COUNT)))"
 fi
 
-mvn -o -B --fail-never -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} test -pl clients/java "${MAVEN_PROPERTIES[@]}" | tee ${tmpfile}
+mvn -o -B --fail-never -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} -pl clients/java \
+ -P parallel-tests,extract-flaky-tests "${MAVEN_PROPERTIES[@]}" \
+ verify | tee ${tmpfile}
 status=${PIPESTATUS[0]}
 
 # delay checking the maven status after we've analysed flaky tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -412,7 +412,7 @@ pipeline {
                         org.camunda.helper.CIAnalytics.trackBuildStatus(this, 'flaky-tests', flakyTestCase)
                     }
                 } else {
-                    org.camunda.helper.CIAnalytics.trackBuildStatus(this, currentBuild.currentResult)
+                    org.camunda.helper.CIAnalytics.trackBuildStatus(this, currentBuild.result)
                 }
             }
         }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1552,6 +1552,9 @@
                   <goal>resolve-plugins</goal>
                   <goal>go-offline</goal>
                 </goals>
+                <configuration>
+                  <silent>true</silent>
+                </configuration>
               </execution>
               <execution>
                 <id>analyze-dependencies</id>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -128,6 +128,7 @@
     <plugin.version.dependency-analyzer>1.11.1</plugin.version.dependency-analyzer>
     <plugin.version.jacoco>0.8.7</plugin.version.jacoco>
     <plugin.version.revapi>0.14.2</plugin.version.revapi>
+    <plugin.version.flaky-tests>2.0.3</plugin.version.flaky-tests>
 
     <!-- maven extensions -->
     <extension.version.os-maven-plugin>1.7.0</extension.version.os-maven-plugin>
@@ -1294,18 +1295,11 @@
           </executions>
         </plugin>
 
+        <!-- extracts flaky test results into separate test cases; meant to be use in CI -->
         <plugin>
           <groupId>io.zeebe</groupId>
           <artifactId>flaky-test-extractor-maven-plugin</artifactId>
-          <version>2.0.3</version>
-          <executions>
-            <execution>
-              <phase>post-integration-test</phase>
-              <goals>
-                <goal>extract-flaky-tests</goal>
-              </goals>
-            </execution>
-          </executions>
+          <version>${plugin.version.flaky-tests}</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -1534,6 +1528,12 @@
           <artifactId>revapi-java</artifactId>
           <version>${version.revapi}</version>
         </dependency>
+        <dependency>
+          <groupId>io.zeebe</groupId>
+          <artifactId>flaky-test-extractor-maven-plugin</artifactId>
+          <version>${plugin.version.flaky-tests}</version>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
       <build>
         <plugins>
@@ -1558,6 +1558,7 @@
                 <configuration>
                   <ignoredUnusedDeclaredDependencies combine.children="append">
                     <dep>org.revapi:revapi-java</dep>
+                    <dep>io.zeebe:flaky-test-extractor-maven-plugin</dep>
                   </ignoredUnusedDeclaredDependencies>
                 </configuration>
               </execution>
@@ -1662,20 +1663,34 @@
       </build>
     </profile>
 
-    <!-- profile to skip flaky test extraction when tests are skipped -->
+    <!--
+      profile to enable flaky test analysis/extraction; running this module will extract flaky runs
+      from your failed test cases as their own test case, such that the failed results can be viewed
+      in Jenkins
+      -->
     <profile>
       <id>extract-flaky-tests</id>
-      <activation>
-        <property>
-          <name>skipTests</name>
-          <value>!true</value>
-        </property>
-      </activation>
+
+      <properties>
+        <flaky.test.reportDir>surefire-reports</flaky.test.reportDir>
+      </properties>
+
       <build>
         <plugins>
           <plugin>
             <groupId>io.zeebe</groupId>
             <artifactId>flaky-test-extractor-maven-plugin</artifactId>
+            <configuration>
+              <reportDir>${project.build.directory}/${flaky.test.reportDir}</reportDir>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>extract-flaky-tests</goal>
+                </goals>
+                <phase>post-integration-test</phase>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -100,6 +100,7 @@
     <version.json-smart>2.4.7</version.json-smart>
     <version.byte-buddy>1.11.0</version.byte-buddy>
     <version.revapi>0.24.1</version.revapi>
+    <version.commons-io>2.9.0</version.commons-io>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.0.0</plugin.version.antrun>
@@ -742,6 +743,12 @@
         <groupId>com.esotericsoftware</groupId>
         <artifactId>minlog</artifactId>
         <version>${version.minlog}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${version.commons-io}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1484,6 +1484,9 @@
       with mvn dependency:go-offline and then run the tests in offline mode. But the plugin misses
       to download the surefire-junit dependency, therefore define an explicit dependency while downloading.
 
+      NOTE: make sure to specify the scope as test for all dependencies, otherwise they will get
+            added to the distribution!
+
       Usage: mvn install -Pprepare-offline
     -->
     <profile>
@@ -1527,6 +1530,7 @@
           <groupId>org.revapi</groupId>
           <artifactId>revapi-java</artifactId>
           <version>${version.revapi}</version>
+          <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>io.zeebe</groupId>


### PR DESCRIPTION
## Description

This PR backports #7413 to stable/1.0. The merge conflicts were all in the `parent/pom.xml` and related to versions which have been updated on develop, but not here. I've kept the original versions to resolve them.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
