### PR TITLE
Split RaftLogReader into CommittedReader and UncommittedReader

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -85,7 +85,7 @@ public final class RaftMemberContext {
         break;
       case PROMOTABLE:
       case ACTIVE:
-        reader = log.openReader();
+        reader = log.openUncommittedReader();
         resetReaderAtEndOfLog(reader);
         break;
       default:

--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -95,7 +95,7 @@ public final class RaftMemberContext {
   }
 
   private void openReaderAtEndOfLog(final RaftLog log, final Mode all) {
-    reader = log.openReader(all);
+    reader = log.openReader();
     reader.seekToLast();
     if (reader.hasNext()) {
       currentEntry = reader.next();

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -55,7 +55,6 @@ import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.StorageException;
 import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.storage.log.RaftLogReader;
-import io.atomix.raft.storage.log.RaftLogReader.Mode;
 import io.atomix.raft.storage.system.MetaStore;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.utils.concurrent.ComposableFuture;
@@ -171,7 +170,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
     // Construct the core log, reader, writer, and compactor.
     raftLog = storage.openLog();
-    logReader = raftLog.openReader(Mode.ALL);
+    logReader = raftLog.openReader();
 
     // Open the snapshot store.
     persistedSnapshotStore = storage.getPersistedSnapshotStore();

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -170,7 +170,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
     // Construct the core log, reader, writer, and compactor.
     raftLog = storage.openLog();
-    logReader = raftLog.openReader();
+    logReader = raftLog.openUncommittedReader();
 
     // Open the snapshot store.
     persistedSnapshotStore = storage.getPersistedSnapshotStore();

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -206,8 +206,8 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
     server.getContext().getLogCompactor().setCompactableIndex(index);
   }
 
-  public RaftLogReader openReader(final Mode mode) {
-    return server.getContext().getLog().openReader(mode);
+  public RaftLogReader openReader() {
+    return server.getContext().getLog().openReader(Mode.COMMITS);
   }
 
   public void addRoleChangeListener(final RaftRoleChangeListener listener) {

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -34,7 +34,6 @@ import io.atomix.raft.roles.RaftRole;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.StorageException;
 import io.atomix.raft.storage.log.RaftLogReader;
-import io.atomix.raft.storage.log.RaftLogReader.Mode;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
 import io.atomix.utils.Managed;
 import io.atomix.utils.concurrent.Futures;
@@ -207,7 +206,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
   }
 
   public RaftLogReader openReader() {
-    return server.getContext().getLog().openReader(Mode.COMMITS);
+    return server.getContext().getLog().openCommittedReader();
   }
 
   public void addRoleChangeListener(final RaftRoleChangeListener listener) {

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -16,7 +16,6 @@
  */
 package io.atomix.raft.storage.log;
 
-import io.atomix.raft.storage.log.RaftLogReader.Mode;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.ConfigurationEntry;
 import io.atomix.raft.storage.log.entry.InitialEntry;
@@ -62,7 +61,7 @@ public final class RaftLog implements Closeable {
    * @return the reader
    */
   public RaftLogReader openReader() {
-    return new RaftLogReader(this, journal.openReader(), Mode.ALL);
+    return new RaftLogUncommittedReader(journal.openReader());
   }
 
   /**
@@ -71,7 +70,7 @@ public final class RaftLog implements Closeable {
    * @return the reader
    */
   public RaftLogReader openCommittedReader() {
-    return new RaftLogReader(this, journal.openReader(), Mode.COMMITS);
+    return new RaftLogCommittedReader(this);
   }
 
   public boolean isOpen() {

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -57,23 +57,21 @@ public final class RaftLog implements Closeable {
   }
 
   /**
-   * Opens the reader with {@link Mode} ALL.
+   * Opens the reader that can read both committed and uncommitted entries.
    *
    * @return the reader
    */
   public RaftLogReader openReader() {
-    return openReader(Mode.ALL);
+    return new RaftLogReader(this, journal.openReader(), Mode.ALL);
   }
 
   /**
-   * Opens the reader with given {@link Mode}.
+   * Opens the reader that can only read committed entries.
    *
-   * @param mode the mode of the reader
    * @return the reader
    */
-  public RaftLogReader openReader(final Mode mode) {
-    final RaftLogReader reader = new RaftLogReader(this, journal.openReader(), mode);
-    return reader;
+  public RaftLogReader openCommittedReader() {
+    return new RaftLogReader(this, journal.openReader(), Mode.COMMITS);
   }
 
   public boolean isOpen() {

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -60,7 +60,7 @@ public final class RaftLog implements Closeable {
    *
    * @return the reader
    */
-  public RaftLogReader openReader() {
+  public RaftLogReader openUncommittedReader() {
     return new RaftLogUncommittedReader(journal.openReader());
   }
 
@@ -70,7 +70,7 @@ public final class RaftLog implements Closeable {
    * @return the reader
    */
   public RaftLogReader openCommittedReader() {
-    return new RaftLogCommittedReader(this);
+    return new RaftLogCommittedReader(this, new RaftLogUncommittedReader(journal.openReader()));
   }
 
   public boolean isOpen() {
@@ -127,7 +127,7 @@ public final class RaftLog implements Closeable {
   }
 
   private void readLastEntry() {
-    try (final var reader = openReader()) {
+    try (final var reader = openUncommittedReader()) {
       reader.seekToLast();
       if (reader.hasNext()) {
         lastAppendedEntry = reader.next();

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogCommittedReader.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogCommittedReader.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.storage.log;
+
+import io.atomix.raft.storage.serializer.RaftEntrySBESerializer;
+import io.atomix.raft.storage.serializer.RaftEntrySerializer;
+import java.util.NoSuchElementException;
+
+/** Raft log reader that reads only committed entries. */
+public class RaftLogCommittedReader implements RaftLogReader {
+  private final RaftLog log;
+  private final RaftEntrySerializer serializer = new RaftEntrySBESerializer();
+
+  // NOTE: nextIndex is only used if the reader is in commit mode, hence why it's not subject to
+  // inconsistencies when the log is truncated/compacted/etc.
+  private long nextIndex;
+  private final RaftLogReader reader;
+
+  RaftLogCommittedReader(final RaftLog log) {
+    this.log = log;
+    reader = log.openReader();
+    nextIndex = log.getFirstIndex();
+  }
+
+  @Override
+  public boolean hasNext() {
+    return nextIndex <= log.getCommitIndex() && reader.hasNext();
+  }
+
+  @Override
+  public IndexedRaftLogEntry next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+
+    final IndexedRaftLogEntry entry = reader.next();
+
+    nextIndex = entry.index() + 1;
+    return entry;
+  }
+
+  public long reset() {
+    nextIndex = reader.reset();
+    return nextIndex;
+  }
+
+  public long seek(final long index) {
+    // allow seeking one past the commit index to simulate being at the end of the log
+    final long upperBoundIndex = log.getCommitIndex() + 1;
+    final long boundIndex = Math.min(index, upperBoundIndex);
+
+    nextIndex = reader.seek(boundIndex);
+    return nextIndex;
+  }
+
+  public long seekToLast() {
+    seek(log.getCommitIndex());
+    return nextIndex;
+  }
+
+  public long seekToAsqn(final long asqn) {
+    nextIndex = reader.seekToAsqn(asqn, log.getCommitIndex());
+    return nextIndex;
+  }
+
+  @Override
+  public long seekToAsqn(final long asqn, final long indexUpperBound) {
+    nextIndex = reader.seekToAsqn(asqn, Math.min(indexUpperBound, log.getCommitIndex()));
+    return nextIndex;
+  }
+
+  @Override
+  public void close() {
+    reader.close();
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogCommittedReader.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogCommittedReader.java
@@ -28,11 +28,11 @@ public class RaftLogCommittedReader implements RaftLogReader {
   // NOTE: nextIndex is only used if the reader is in commit mode, hence why it's not subject to
   // inconsistencies when the log is truncated/compacted/etc.
   private long nextIndex;
-  private final RaftLogReader reader;
+  private final RaftLogUncommittedReader reader;
 
-  RaftLogCommittedReader(final RaftLog log) {
+  RaftLogCommittedReader(final RaftLog log, final RaftLogUncommittedReader reader) {
     this.log = log;
-    reader = log.openReader();
+    this.reader = reader;
     nextIndex = log.getFirstIndex();
   }
 
@@ -74,12 +74,6 @@ public class RaftLogCommittedReader implements RaftLogReader {
 
   public long seekToAsqn(final long asqn) {
     nextIndex = reader.seekToAsqn(asqn, log.getCommitIndex());
-    return nextIndex;
-  }
-
-  @Override
-  public long seekToAsqn(final long asqn, final long indexUpperBound) {
-    nextIndex = reader.seekToAsqn(asqn, Math.min(indexUpperBound, log.getCommitIndex()));
     return nextIndex;
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogReader.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogReader.java
@@ -47,17 +47,6 @@ public interface RaftLogReader extends java.util.Iterator<IndexedRaftLogEntry>, 
    */
   long seekToAsqn(final long asqn);
 
-  /**
-   * Seek to a record with the highest ASQN less than or equal to the given asqn, with the
-   * restriction that it seeks to a record with index less than or equal to the given
-   * indexUpperBound.
-   *
-   * @param asqn the asqn to seek to
-   * @param indexUpperBound the index until which it seeks
-   * @return the index of the record that will be returned by {@link #next()}
-   */
-  long seekToAsqn(final long asqn, final long indexUpperBound);
-
   @Override
   void close();
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogReader.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogReader.java
@@ -1,12 +1,11 @@
 /*
- * Copyright 2017-present Open Networking Foundation
  * Copyright © 2020 camunda services GmbH (info@camunda.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,100 +15,49 @@
  */
 package io.atomix.raft.storage.log;
 
-import io.atomix.raft.storage.log.entry.RaftLogEntry;
-import io.atomix.raft.storage.serializer.RaftEntrySBESerializer;
-import io.atomix.raft.storage.serializer.RaftEntrySerializer;
-import io.camunda.zeebe.journal.JournalReader;
-import io.camunda.zeebe.journal.JournalRecord;
-import java.util.NoSuchElementException;
+public interface RaftLogReader extends java.util.Iterator<IndexedRaftLogEntry>, AutoCloseable {
 
-/** Raft log reader. */
-public class RaftLogReader implements java.util.Iterator<IndexedRaftLogEntry>, AutoCloseable {
-  private final RaftLog log;
-  private final JournalReader journalReader;
-  private final RaftLogReader.Mode mode;
-  private final RaftEntrySerializer serializer = new RaftEntrySBESerializer();
+  /**
+   * Reset the reader to the first index of the log.
+   *
+   * @return return the first index
+   */
+  long reset();
 
-  // NOTE: nextIndex is only used if the reader is in commit mode, hence why it's not subject to
-  // inconsistencies when the log is truncated/compacted/etc.
-  private long nextIndex;
+  /**
+   * Seeks to the given index.
+   *
+   * @param index the index to seeks to
+   * @return the index of the next record to be read
+   */
+  long seek(long index);
 
-  RaftLogReader(
-      final RaftLog log, final JournalReader journalReader, final RaftLogReader.Mode mode) {
-    this.log = log;
-    this.journalReader = journalReader;
-    this.mode = mode;
+  /**
+   * Seeks to the last index
+   *
+   * @return the index of the next record to be read
+   */
+  long seekToLast();
 
-    nextIndex = log.getFirstIndex();
-  }
+  /**
+   * Seek to a record with the highest ASQN less than or equal to the given asqn.
+   *
+   * @param asqn the asqn to seek to
+   * @return the index of the record that will be returned by {@link #next()}
+   */
+  long seekToAsqn(final long asqn);
 
-  @Override
-  public boolean hasNext() {
-    return (mode == Mode.ALL || nextIndex <= log.getCommitIndex()) && journalReader.hasNext();
-  }
-
-  @Override
-  public IndexedRaftLogEntry next() {
-    if (!hasNext()) {
-      throw new NoSuchElementException();
-    }
-
-    final JournalRecord journalRecord = journalReader.next();
-    final RaftLogEntry entry = serializer.readRaftLogEntry(journalRecord.data());
-
-    nextIndex = journalRecord.index() + 1;
-    return new IndexedRaftLogEntryImpl(entry.term(), entry.entry(), journalRecord);
-  }
-
-  public long reset() {
-    nextIndex = journalReader.seekToFirst();
-    return nextIndex;
-  }
-
-  public long seek(final long index) {
-    long boundedIndex = index;
-
-    if (mode == Mode.COMMITS) {
-      // allow seeking one past the commit index to simulate being at the end of the log
-      final long upperBoundIndex = log.getCommitIndex() + 1;
-      boundedIndex = Math.min(index, upperBoundIndex);
-    }
-
-    nextIndex = journalReader.seek(boundedIndex);
-    return nextIndex;
-  }
-
-  public long seekToLast() {
-    if (mode == Mode.ALL) {
-      nextIndex = journalReader.seekToLast();
-    } else {
-      seek(log.getCommitIndex());
-    }
-
-    return nextIndex;
-  }
-
-  public long seekToAsqn(final long asqn) {
-    if (mode == Mode.COMMITS) {
-      nextIndex = journalReader.seekToAsqn(asqn, log.getCommitIndex());
-    } else {
-      nextIndex = journalReader.seekToAsqn(asqn);
-    }
-    return nextIndex;
-  }
+  /**
+   * Seek to a record with the highest ASQN less than or equal to the given asqn, with the
+   * restriction that it seeks to a record with index less than or equal to the given
+   * indexUpperBound.
+   *
+   * @param asqn the asqn to seek to
+   * @param indexUpperBound the index until which it seeks
+   * @return the index of the record that will be returned by {@link #next()}
+   */
+  long seekToAsqn(final long asqn, final long indexUpperBound);
 
   @Override
-  public void close() {
-    journalReader.close();
-  }
-
-  /** Raft log reader mode. */
-  public enum Mode {
-
-    /** Reads all entries from the log. */
-    ALL,
-
-    /** Reads committed entries from the log. */
-    COMMITS,
-  }
+  void close();
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogUncommittedReader.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogUncommittedReader.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.storage.log;
+
+import io.atomix.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.raft.storage.serializer.RaftEntrySBESerializer;
+import io.atomix.raft.storage.serializer.RaftEntrySerializer;
+import io.camunda.zeebe.journal.JournalReader;
+import io.camunda.zeebe.journal.JournalRecord;
+import java.util.NoSuchElementException;
+
+/**
+ * Raft log reader that reads both committed and uncommitted entries. This reader is supposed to be
+ * only used internally in raft. The reader is not thread safe with a concurrent writer.
+ */
+public class RaftLogUncommittedReader implements RaftLogReader {
+  private final JournalReader journalReader;
+  private final RaftEntrySerializer serializer = new RaftEntrySBESerializer();
+
+  RaftLogUncommittedReader(final JournalReader journalReader) {
+    this.journalReader = journalReader;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return journalReader.hasNext();
+  }
+
+  @Override
+  public IndexedRaftLogEntry next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+
+    final JournalRecord journalRecord = journalReader.next();
+    final RaftLogEntry entry = serializer.readRaftLogEntry(journalRecord.data());
+
+    return new IndexedRaftLogEntryImpl(entry.term(), entry.entry(), journalRecord);
+  }
+
+  @Override
+  public long reset() {
+    return journalReader.seekToFirst();
+  }
+
+  @Override
+  public long seek(final long index) {
+    return journalReader.seek(index);
+  }
+
+  @Override
+  public long seekToLast() {
+    return journalReader.seekToLast();
+  }
+
+  @Override
+  public long seekToAsqn(final long asqn) {
+    return journalReader.seekToAsqn(asqn);
+  }
+
+  @Override
+  public long seekToAsqn(final long asqn, final long indexUpperBound) {
+    return journalReader.seekToAsqn(asqn, indexUpperBound);
+  }
+
+  @Override
+  public void close() {
+    journalReader.close();
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogUncommittedReader.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogUncommittedReader.java
@@ -73,12 +73,11 @@ public class RaftLogUncommittedReader implements RaftLogReader {
   }
 
   @Override
-  public long seekToAsqn(final long asqn, final long indexUpperBound) {
-    return journalReader.seekToAsqn(asqn, indexUpperBound);
-  }
-
-  @Override
   public void close() {
     journalReader.close();
+  }
+
+  public long seekToAsqn(final long asqn, final long indexUpperBound) {
+    return journalReader.seekToAsqn(asqn, indexUpperBound);
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -28,7 +28,6 @@ import io.atomix.raft.roles.LeaderRole;
 import io.atomix.raft.snapshot.TestSnapshotStore;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.RaftLogReader;
-import io.atomix.raft.storage.log.RaftLogReader.Mode;
 import io.atomix.raft.zeebe.NoopEntryValidator;
 import io.atomix.raft.zeebe.ZeebeLogAppender.AppendListener;
 import io.camunda.zeebe.util.collection.Tuple;
@@ -300,8 +299,7 @@ public final class ControllableRaftContexts {
   public void assertAllLogsEqual() {
     final var readers =
         raftServers.values().stream()
-            .collect(
-                Collectors.toMap(Function.identity(), s -> s.getLog().openReader(Mode.COMMITS)));
+            .collect(Collectors.toMap(Function.identity(), s -> s.getLog().openCommittedReader()));
     long index = 0;
     while (true) {
       final var entries =

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -385,7 +385,7 @@ public final class RaftRule extends ExternalResource {
 
         final var log = server.getContext().getLog();
         final List<IndexedRaftLogEntry> entryList = new ArrayList<>();
-        try (final var raftLogReader = log.openReader()) {
+        try (final var raftLogReader = log.openUncommittedReader()) {
           while (raftLogReader.hasNext()) {
             final var indexedEntry = raftLogReader.next();
             entryList.add(indexedEntry);

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -32,7 +32,6 @@ import io.atomix.raft.snapshot.InMemorySnapshot;
 import io.atomix.raft.snapshot.TestSnapshotStore;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
-import io.atomix.raft.storage.log.RaftLogReader.Mode;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.raft.zeebe.NoopEntryValidator;
@@ -386,7 +385,7 @@ public final class RaftRule extends ExternalResource {
 
         final var log = server.getContext().getLog();
         final List<IndexedRaftLogEntry> entryList = new ArrayList<>();
-        try (final var raftLogReader = log.openReader(Mode.ALL)) {
+        try (final var raftLogReader = log.openReader()) {
           while (raftLogReader.hasNext()) {
             final var indexedEntry = raftLogReader.next();
             entryList.add(indexedEntry);

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -46,7 +46,6 @@ import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.storage.log.RaftLogReader;
-import io.atomix.raft.storage.log.RaftLogReader.Mode;
 import io.atomix.raft.storage.log.entry.InitialEntry;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
 import io.atomix.utils.concurrent.SingleThreadContext;
@@ -374,7 +373,7 @@ public class RaftTest extends ConcurrentTestCase {
       final CountDownLatch transitionCompleted) {
     if (role == Role.LEADER) {
       final RaftLog raftLog = server.getContext().getLog();
-      final RaftLogReader raftLogReader = raftLog.openReader(Mode.COMMITS);
+      final RaftLogReader raftLogReader = raftLog.openCommittedReader();
       raftLogReader.seek(raftLog.getLastIndex());
       final IndexedRaftLogEntry entry = raftLogReader.next();
 
@@ -526,7 +525,7 @@ public class RaftTest extends ConcurrentTestCase {
 
     // then
     final RaftLog raftLog = leader.getContext().getLog();
-    final RaftLogReader raftLogReader = raftLog.openReader(Mode.ALL);
+    final RaftLogReader raftLogReader = raftLog.openReader();
 
     assertThat(raftLog.getLastIndex()).isEqualTo(index - 1);
     raftLogReader.seek(raftLog.getLastIndex());

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -525,7 +525,7 @@ public class RaftTest extends ConcurrentTestCase {
 
     // then
     final RaftLog raftLog = leader.getContext().getLog();
-    final RaftLogReader raftLogReader = raftLog.openReader();
+    final RaftLogReader raftLogReader = raftLog.openUncommittedReader();
 
     assertThat(raftLog.getLastIndex()).isEqualTo(index - 1);
     raftLogReader.seek(raftLog.getLastIndex());

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogCommittedReaderTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogCommittedReaderTest.java
@@ -17,7 +17,6 @@ package io.atomix.raft.storage.log;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.atomix.raft.storage.log.RaftLogReader.Mode;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import java.io.File;
@@ -39,7 +38,7 @@ class RaftLogCommittedReaderTest {
   @BeforeEach
   void setup(@TempDir final File directory) {
     raftlog = RaftLog.builder().withDirectory(directory).withName("test").build();
-    committedReader = raftlog.openReader(Mode.COMMITS);
+    committedReader = raftlog.openCommittedReader();
   }
 
   @AfterEach

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
@@ -57,7 +57,7 @@ class RaftLogTest {
   @BeforeEach
   void setup(@TempDir final File directory) {
     raftlog = RaftLog.builder().withDirectory(directory).withName("test").build();
-    reader = raftlog.openReader();
+    reader = raftlog.openUncommittedReader();
   }
 
   @AfterEach

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogUncommittedReaderTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogUncommittedReaderTest.java
@@ -17,7 +17,6 @@ package io.atomix.raft.storage.log;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.atomix.raft.storage.log.RaftLogReader.Mode;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import java.io.File;
@@ -39,7 +38,7 @@ class RaftLogUncommittedReaderTest {
   @BeforeEach
   void setup(@TempDir final File directory) {
     raftlog = RaftLog.builder().withDirectory(directory).withName("test").build();
-    uncommittedReader = raftlog.openReader(Mode.ALL);
+    uncommittedReader = raftlog.openReader();
     data.order(ByteOrder.LITTLE_ENDIAN).putInt(123456);
   }
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogUncommittedReaderTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogUncommittedReaderTest.java
@@ -38,7 +38,7 @@ class RaftLogUncommittedReaderTest {
   @BeforeEach
   void setup(@TempDir final File directory) {
     raftlog = RaftLog.builder().withDirectory(directory).withName("test").build();
-    uncommittedReader = raftlog.openReader();
+    uncommittedReader = raftlog.openUncommittedReader();
     data.order(ByteOrder.LITTLE_ENDIAN).putInt(123456);
   }
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestHelper.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestHelper.java
@@ -21,7 +21,6 @@ import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.impl.RaftPartitionServer;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLogReader;
-import io.atomix.raft.storage.log.RaftLogReader.Mode;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
 import java.time.Duration;
 import java.util.Collection;
@@ -89,7 +88,7 @@ public class ZeebeTestHelper {
 
   public boolean containsIndexed(
       final RaftPartitionServer partition, final IndexedRaftLogEntry indexed) {
-    try (final RaftLogReader reader = partition.openReader(Mode.COMMITS)) {
+    try (final RaftLogReader reader = partition.openReader()) {
       reader.seek(indexed.index());
 
       if (reader.hasNext()) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/AtomixRecordEntrySupplier.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/AtomixRecordEntrySupplier.java
@@ -17,9 +17,6 @@ import java.util.Optional;
  * position.
  */
 @FunctionalInterface
-public interface AtomixRecordEntrySupplier extends AutoCloseable {
+public interface AtomixRecordEntrySupplier {
   Optional<IndexedRaftLogEntry> getPreviousIndexedEntry(long position);
-
-  @Override
-  default void close() {}
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.broker.system.partitions.impl;
 
-import static io.camunda.zeebe.broker.Loggers.SYSTEM_LOGGER;
-
 import io.camunda.zeebe.broker.system.partitions.AtomixRecordEntrySupplier;
 import io.camunda.zeebe.broker.system.partitions.SnapshotReplication;
 import io.camunda.zeebe.broker.system.partitions.StateController;
@@ -160,12 +158,6 @@ public class StateControllerImpl implements StateController, PersistedSnapshotLi
       db.close();
       db = null;
       LOG.debug("Closed database from '{}'.", runtimeDirectory);
-    }
-
-    try {
-      entrySupplier.close();
-    } catch (final Exception e) {
-      SYSTEM_LOGGER.error("Unexpected error closing log reader for partition {}", partitionId, e);
     }
 
     FileUtil.deleteFolderIfExists(runtimeDirectory);

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
@@ -33,7 +33,7 @@ public class StateControllerPartitionStep implements PartitionStep {
             context.getReceivableSnapshotStore(),
             runtimeDirectory,
             context.getSnapshotReplication(),
-            new AtomixRecordEntrySupplierImpl(context.getRaftPartition().getServer().openReader()),
+            new AtomixRecordEntrySupplierImpl(context.getRaftPartition().getServer()),
             StatePositionSupplier::getHighestExportedPosition);
 
     context.setSnapshotController(stateController);

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
-import io.atomix.raft.storage.log.RaftLogReader.Mode;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.logstreams.state.StatePositionSupplier;
 import io.camunda.zeebe.broker.system.partitions.PartitionStep;
@@ -34,8 +33,7 @@ public class StateControllerPartitionStep implements PartitionStep {
             context.getReceivableSnapshotStore(),
             runtimeDirectory,
             context.getSnapshotReplication(),
-            new AtomixRecordEntrySupplierImpl(
-                context.getRaftPartition().getServer().openReader(Mode.COMMITS)),
+            new AtomixRecordEntrySupplierImpl(context.getRaftPartition().getServer().openReader()),
             StatePositionSupplier::getHighestExportedPosition);
 
     context.setSnapshotController(stateController);

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerSnapshotTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerSnapshotTest.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.raft.partition.RaftPartition;
 import io.atomix.raft.storage.log.RaftLogReader;
-import io.atomix.raft.storage.log.RaftLogReader.Mode;
 import io.camunda.zeebe.broker.clustering.atomix.AtomixFactory;
 import io.camunda.zeebe.broker.system.management.BrokerAdminService;
 import io.camunda.zeebe.broker.system.management.PartitionStatus;
@@ -49,7 +48,7 @@ public class BrokerSnapshotTest {
                 .getClusterServices()
                 .getPartitionGroup()
                 .getPartition(PartitionId.from(AtomixFactory.GROUP_NAME, PARTITION_ID));
-    journalReader = raftPartition.getServer().openReader(Mode.COMMITS);
+    journalReader = raftPartition.getServer().openReader();
     brokerAdminService = brokerRule.getBroker().getBrokerAdminService();
 
     final String contactPoint = NetUtil.toSocketAddressString(brokerRule.getGatewayAddress());

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/atomix/AtomixReaderFactory.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/atomix/AtomixReaderFactory.java
@@ -8,13 +8,8 @@
 package io.camunda.zeebe.logstreams.storage.atomix;
 
 import io.atomix.raft.storage.log.RaftLogReader;
-import io.atomix.raft.storage.log.RaftLogReader.Mode;
 
 @FunctionalInterface
 public interface AtomixReaderFactory {
-  RaftLogReader create(Mode mode);
-
-  default RaftLogReader create() {
-    return create(Mode.COMMITS);
-  }
+  RaftLogReader create();
 }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/storage/atomix/AtomixLogStorageReaderTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/storage/atomix/AtomixLogStorageReaderTest.java
@@ -35,7 +35,7 @@ final class AtomixLogStorageReaderTest {
   void beforeEach(final @TempDir File tempDir) {
     log = RaftLog.builder().withDirectory(tempDir).build();
     final Appender appender = new Appender();
-    logStorage = new AtomixLogStorage(log::openReader, appender);
+    logStorage = new AtomixLogStorage(log::openUncommittedReader, appender);
     reader = logStorage.newReader();
   }
 

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/AtomixLogStorageRule.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/AtomixLogStorageRule.java
@@ -13,7 +13,6 @@ import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.storage.log.RaftLogReader;
-import io.atomix.raft.storage.log.RaftLogReader.Mode;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.system.MetaStore;
@@ -161,8 +160,8 @@ public final class AtomixLogStorageRule extends ExternalResource
   }
 
   @Override
-  public RaftLogReader create(final Mode mode) {
-    return raftLog.openReader(mode);
+  public RaftLogReader create() {
+    return raftLog.openReader();
   }
 
   public void setPositionListener(final LongConsumer positionListener) {

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/AtomixLogStorageRule.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/AtomixLogStorageRule.java
@@ -161,7 +161,7 @@ public final class AtomixLogStorageRule extends ExternalResource
 
   @Override
   public RaftLogReader create() {
-    return raftLog.openReader();
+    return raftLog.openUncommittedReader();
   }
 
   public void setPositionListener(final LongConsumer positionListener) {


### PR DESCRIPTION
## Description

This PR splits the RaftLogReader into two - RaftLogCommittedReader, RaftLogUncommittedReader. The initial commits are refactoring necessary for the main change. 
In addition there is also a minor refactoring to make Sonarlint check passes. In this change, the reader in AtomixRecordEntrySupplier is changed to a volatile reader instead of a long living one. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6308 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
