### PR TITLE
Decouple Snapshot Director from Logstream

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftCommittedEntryListener.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftCommittedEntryListener.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import io.atomix.raft.storage.log.IndexedRaftLogEntry;
+
+/**
+ * This listener will only be called by the Leader, when it commits an entry. If RAFT is currently
+ * running in a follower role, it will not call this listener.
+ */
+@FunctionalInterface
+public interface RaftCommittedEntryListener {
+
+  /** @param indexedRaftLogEntry the new committed entry */
+  void onCommit(IndexedRaftLogEntry indexedRaftLogEntry);
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -25,6 +25,7 @@ import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.ElectionTimer;
 import io.atomix.raft.RaftCommitListener;
+import io.atomix.raft.RaftCommittedEntryListener;
 import io.atomix.raft.RaftException.ProtocolException;
 import io.atomix.raft.RaftRoleChangeListener;
 import io.atomix.raft.RaftServer;
@@ -53,6 +54,7 @@ import io.atomix.raft.roles.PromotableRole;
 import io.atomix.raft.roles.RaftRole;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.StorageException;
+import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.storage.log.RaftLogReader;
 import io.atomix.raft.storage.log.RaftLogReader.Mode;
@@ -100,6 +102,8 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private final Set<Consumer<State>> stateChangeListeners = new CopyOnWriteArraySet<>();
   private final Set<Consumer<RaftMember>> electionListeners = new CopyOnWriteArraySet<>();
   private final Set<RaftCommitListener> commitListeners = new CopyOnWriteArraySet<>();
+  private final Set<RaftCommittedEntryListener> committedEntryListeners =
+      new CopyOnWriteArraySet<>();
   private final Set<FailureListener> failureListeners = new CopyOnWriteArraySet<>();
   private final RaftRoleMetrics raftRoleMetrics;
   private final RaftReplicationMetrics replicationMetrics;
@@ -348,12 +352,36 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   /**
+   * Adds a new committed entry listener, which will be notified when the Leader commits a new
+   * entry. If RAFT runs currently in a Follower role this listeners are not called.
+   *
+   * <p>Note that it will be called on the Raft thread, and as such should not perform any heavy
+   * computation.
+   *
+   * @param raftCommittedEntryListener the listener to add
+   */
+  public void addCommittedEntryListener(
+      final RaftCommittedEntryListener raftCommittedEntryListener) {
+    committedEntryListeners.add(raftCommittedEntryListener);
+  }
+
+  /**
    * Notifies all listeners of the latest entry.
    *
    * @param lastCommitIndex index of the most recently committed entry
    */
   public void notifyCommitListeners(final long lastCommitIndex) {
     commitListeners.forEach(listener -> listener.onCommit(lastCommitIndex));
+  }
+
+  /**
+   * Notifies all listeners of the latest entry.
+   *
+   * @param committedEntry the most recently committed entry
+   */
+  public void notifyCommitListeners(final IndexedRaftLogEntry committedEntry) {
+    commitListeners.forEach(listener -> listener.onCommit(committedEntry.index()));
+    committedEntryListeners.forEach(listener -> listener.onCommit(committedEntry));
   }
 
   /**

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -22,6 +22,7 @@ import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.primitive.partition.Partition;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.RaftCommitListener;
+import io.atomix.raft.RaftCommittedEntryListener;
 import io.atomix.raft.RaftRoleChangeListener;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.RaftServer.Role;
@@ -245,6 +246,11 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
   /** @see io.atomix.raft.impl.RaftContext#addCommitListener(RaftCommitListener) */
   public void addCommitListener(final RaftCommitListener commitListener) {
     server.getContext().addCommitListener(commitListener);
+  }
+
+  /** @see io.atomix.raft.impl.RaftContext#addCommittedEntryListener(RaftCommittedEntryListener) */
+  public void addCommittedEntryListener(final RaftCommittedEntryListener commitListener) {
+    server.getContext().addCommittedEntryListener(commitListener);
   }
 
   public PersistedSnapshotStore getPersistedSnapshotStore() {

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -602,7 +602,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
               // entries properly on fail over
               if (commitError == null) {
                 appendListener.onCommit(indexed);
-                raft.notifyCommitListeners(indexed.index());
+                raft.notifyCommitListeners(indexed);
               } else {
                 appendListener.onCommitError(indexed, commitError);
                 // replicating the entry will be retried on the next append request

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -575,6 +575,16 @@ public final class RaftRule extends ExternalResource {
     return servers.get(followerB).getContext().getPersistedSnapshotStore();
   }
 
+  public void addCommitListener(final RaftCommitListener raftCommitListener) {
+    servers.forEach((id, raft) -> raft.getContext().addCommitListener(raftCommitListener));
+  }
+
+  public void addCommittedEntryListener(
+      final RaftCommittedEntryListener raftCommittedEntryListener) {
+    servers.forEach(
+        (id, raft) -> raft.getContext().addCommittedEntryListener(raftCommittedEntryListener));
+  }
+
   private static final class CommitAwaiter {
 
     private final long awaitedIndex;


### PR DESCRIPTION
## Description

 * Introduces new RaftCommittedEntryListener
 
>   The new comitted entry listener is called only in a Leader role, and
> serves only one purpose, to make it possible to have access of the last
> committed entry (without an explicit reader).
> 
> This is useful for leader services to resolve the last committed position without
> creating a mapping nor having a separate reader. The Snasphot director
> of a leader will use that to make sure that the snapshots are valid.

* SnapshotDirector decouple from LogStream

> SnapshotDirector uses new Leader RaftCommittedEntryListener to resolve
> committed position. No longer rely on LogStream, which makes it possible
> to remove the commit position from LogStream in future PR's.
> 
> Thought about a separate CommitPositionService (separate Actor), but this would make it again more complex then useful. Currently the SnapshotDirector is the only component which really consumes the committed position. Later for building state on follower, we will have a separate SnapshotDirector, which doesn't care about commit positions, since he only consumes committed entries.


After this PR is merged, we can remove the commit position from the LogStream and replace the listener there with something like notify for new records.

FYI @deepthidevaki @saig0 

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->
Related to https://github.com/zeebe-io/enhancements/pull/16

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
