### PR TITLE
Replace usages of IoUtil.ensureDirectoryExists

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -24,11 +24,12 @@ import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.storage.system.MetaStore;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
+import io.camunda.zeebe.util.FileUtil;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
-import org.agrona.IoUtil;
 
 /**
  * Immutable log configuration and {@link RaftLog} factory.
@@ -73,7 +74,12 @@ public final class RaftStorage {
     this.persistedSnapshotStore = persistedSnapshotStore;
     this.journalIndexDensity = journalIndexDensity;
 
-    IoUtil.ensureDirectoryExists(directory, prefix + " raft partition storage");
+    try {
+      FileUtil.ensureDirectoryExists(directory.toPath());
+    } catch (final IOException e) {
+      throw new UncheckedIOException(
+          String.format("Failed to create partition's directory %s", directory.toPath()), e);
+    }
   }
 
   /**

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -27,10 +27,12 @@ import io.camunda.zeebe.broker.system.configuration.MembershipCfg;
 import io.camunda.zeebe.broker.system.configuration.NetworkCfg;
 import io.camunda.zeebe.logstreams.impl.log.ZeebeEntryValidator;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStoreFactory;
+import io.camunda.zeebe.util.FileUtil;
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
-import org.agrona.IoUtil;
 import org.slf4j.Logger;
 
 public final class AtomixFactory {
@@ -81,7 +83,11 @@ public final class AtomixFactory {
 
     final DataCfg dataConfiguration = configuration.getData();
     final String rootDirectory = dataConfiguration.getDirectory();
-    IoUtil.ensureDirectoryExists(new File(rootDirectory), "Zeebe data directory");
+    try {
+      FileUtil.ensureDirectoryExists(new File(rootDirectory).toPath());
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to create data directory", e);
+    }
 
     final RaftPartitionGroup partitionGroup =
         createRaftPartitionGroup(configuration, rootDirectory, snapshotStoreFactory);
@@ -95,7 +101,11 @@ public final class AtomixFactory {
       final ReceivableSnapshotStoreFactory snapshotStoreFactory) {
 
     final File raftDirectory = new File(rootDirectory, AtomixFactory.GROUP_NAME);
-    IoUtil.ensureDirectoryExists(raftDirectory, "Raft data directory");
+    try {
+      FileUtil.ensureDirectoryExists(raftDirectory.toPath());
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to create raft directory", e);
+    }
 
     final ClusterCfg clusterCfg = configuration.getCluster();
     final var experimentalCfg = configuration.getExperimental();

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreFactory.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreFactory.java
@@ -11,10 +11,12 @@ import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStoreFactory;
+import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.sched.ActorScheduler;
 import io.camunda.zeebe.util.sched.SchedulingHints;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
-import org.agrona.IoUtil;
 import org.agrona.collections.Int2ObjectHashMap;
 
 /**
@@ -47,8 +49,12 @@ public final class FileBasedSnapshotStoreFactory implements ReceivableSnapshotSt
     final var snapshotDirectory = root.resolve(SNAPSHOTS_DIRECTORY);
     final var pendingDirectory = root.resolve(PENDING_DIRECTORY);
 
-    IoUtil.ensureDirectoryExists(snapshotDirectory.toFile(), "Snapshot directory");
-    IoUtil.ensureDirectoryExists(pendingDirectory.toFile(), "Pending snapshot directory");
+    try {
+      FileUtil.ensureDirectoryExists(snapshotDirectory);
+      FileUtil.ensureDirectoryExists(pendingDirectory);
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to create snapshot directories", e);
+    }
 
     return partitionSnapshotStores.computeIfAbsent(
         partitionId,

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -28,7 +28,6 @@ import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-import org.agrona.IoUtil;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Rule;
@@ -359,7 +358,7 @@ public class FileBasedReceivedSnapshotTest {
   }
 
   private FileBasedSnapshotStore createStore(
-      final int nodeId, final Path snapshotDir, final Path pendingDir) {
+      final int nodeId, final Path snapshotDir, final Path pendingDir) throws IOException {
     final var store =
         new FileBasedSnapshotStore(
             nodeId,
@@ -368,8 +367,8 @@ public class FileBasedReceivedSnapshotTest {
             snapshotDir,
             pendingDir);
 
-    IoUtil.ensureDirectoryExists(snapshotDir.toFile(), "snapshots directory");
-    IoUtil.ensureDirectoryExists(pendingDir.toFile(), "pending directory");
+    FileUtil.ensureDirectoryExists(snapshotDir);
+    FileUtil.ensureDirectoryExists(pendingDir);
     scheduler.submitActor(store);
 
     return store;

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -19,7 +19,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import org.agrona.IoUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -59,7 +58,7 @@ public class FileBasedSnapshotStoreTest {
   }
 
   @Test
-  public void shouldLoadExistingSnapshot() {
+  public void shouldLoadExistingSnapshot() throws IOException {
     // given
     final var persistedSnapshot = takeTransientSnapshot().persist().join();
 
@@ -73,7 +72,7 @@ public class FileBasedSnapshotStoreTest {
   }
 
   @Test
-  public void shouldLoadLatestSnapshotWhenMoreThanOneExistsAndDeleteOlder() {
+  public void shouldLoadLatestSnapshotWhenMoreThanOneExistsAndDeleteOlder() throws IOException {
     // given
     final FileBasedSnapshotStore otherStore = createStore(snapshotsDir, pendingSnapshotsDir);
     final var olderSnapshot = takeTransientSnapshot(1L, otherStore).persist().join();
@@ -162,11 +161,12 @@ public class FileBasedSnapshotStoreTest {
     return transientSnapshot;
   }
 
-  private FileBasedSnapshotStore createStore(final Path snapshotDir, final Path pendingDir) {
+  private FileBasedSnapshotStore createStore(final Path snapshotDir, final Path pendingDir)
+      throws IOException {
     final var store =
         new FileBasedSnapshotStore(1, 1, new SnapshotMetrics(1 + "-" + 1), snapshotDir, pendingDir);
-    IoUtil.ensureDirectoryExists(snapshotDir.toFile(), "Snapshot directory");
-    IoUtil.ensureDirectoryExists(pendingSnapshotsDir.toFile(), "Pending snapshot directory");
+    FileUtil.ensureDirectoryExists(snapshotDir);
+    FileUtil.ensureDirectoryExists(pendingSnapshotsDir);
     scheduler.submitActor(store).join();
 
     return store;


### PR DESCRIPTION
## Description

Replace use of `IoUtil.ensureDirectoryExists` with `FileUtil.ensureDirectoryExists`. IoUtil hides the actual exception which makes it difficult to debug. 

All uses replaced in this PR is happening in the startup phase. Hence the exception is not handled, but simply rethrown. As a result the startup will fail.

## Related issues

closes #7311

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
