### PR TITLE
Remove deferred commit position

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -65,7 +65,6 @@ public class PartitionTransitionContext implements PartitionContext {
 
   private StreamProcessor streamProcessor;
   private LogStream logStream;
-  private long deferredCommitPosition;
   private SnapshotReplication snapshotReplication;
   private StateControllerImpl stateController;
   private LogDeletionService logDeletionService;
@@ -182,14 +181,6 @@ public class PartitionTransitionContext implements PartitionContext {
 
   public void setSnapshotReplication(final SnapshotReplication snapshotReplication) {
     this.snapshotReplication = snapshotReplication;
-  }
-
-  public long getDeferredCommitPosition() {
-    return deferredCommitPosition;
-  }
-
-  public void setDeferredCommitPosition(final long deferredCommitPosition) {
-    this.deferredCommitPosition = deferredCommitPosition;
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionStep.java
@@ -35,10 +35,6 @@ public class LogStreamPartitionStep implements PartitionStep {
                 if (err == null) {
                   context.setLogStream(logStream);
 
-                  if (context.getDeferredCommitPosition() > 0) {
-                    context.getLogStream().setCommitPosition(context.getDeferredCommitPosition());
-                    context.setDeferredCommitPosition(-1);
-                  }
                   context
                       .getComponentHealthMonitor()
                       .registerComponent(logStream.getLogName(), logStream);


### PR DESCRIPTION
## Description
This removes the deferred commit position. It is no longer written in any meaningful way.

## Related issues

related to (but not closing) #7418 

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
