### PR TITLE
Add metrics to track leader transition time

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/RoleMetrics.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/RoleMetrics.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions;
+
+import io.prometheus.client.Gauge;
+
+public class RoleMetrics {
+  private static final Gauge LEADER_TRANSITION_LATENCY =
+      Gauge.build()
+          .namespace("zeebe")
+          .name("leader_transition_latency")
+          .help(
+              "The time (in ms) needed for the engine services to transition to leader and be ready to process new requests.")
+          .labelNames("partition")
+          .register();
+
+  private final String partitionIdLabel;
+
+  public RoleMetrics(final int partitionId) {
+    partitionIdLabel = String.valueOf(partitionId);
+  }
+
+  public void setLeaderTransitionLatency(final long latencyInMs) {
+    LEADER_TRANSITION_LATENCY.labels(partitionIdLabel).set(latencyInMs);
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthStatus;
 import io.camunda.zeebe.util.sched.Actor;
+import io.camunda.zeebe.util.sched.clock.ActorClock;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.io.IOException;
@@ -38,6 +39,7 @@ public final class ZeebePartition extends Actor
   private final String actorName;
   private final List<FailureListener> failureListeners;
   private final HealthMetrics healthMetrics;
+  private final RoleMetrics roleMetrics;
   private final ZeebePartitionHealth zeebePartitionHealth;
 
   private final PartitionContext context;
@@ -61,6 +63,7 @@ public final class ZeebePartition extends Actor
     healthMetrics = new HealthMetrics(transitionContext.getPartitionId());
     healthMetrics.setUnhealthy();
     failureListeners = new ArrayList<>();
+    roleMetrics = new RoleMetrics(transitionContext.getPartitionId());
   }
 
   /**
@@ -104,10 +107,13 @@ public final class ZeebePartition extends Actor
   }
 
   private ActorFuture<Void> leaderTransition(final long newTerm) {
+    final var installStartTime = ActorClock.currentTimeMillis();
     final var leaderTransitionFuture = transition.toLeader(newTerm);
     leaderTransitionFuture.onComplete(
         (success, error) -> {
           if (error == null) {
+            final var leaderTransitionLatency = ActorClock.currentTimeMillis() - installStartTime;
+            roleMetrics.setLeaderTransitionLatency(leaderTransitionLatency);
             final List<ActorFuture<Void>> listenerFutures =
                 context.notifyListenersOfBecomingLeader(newTerm);
             actor.runOnCompletion(

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -89,7 +89,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1625146815175,
+  "iteration": 1625552874210,
   "links": [],
   "panels": [
     {
@@ -9525,7 +9525,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 48
+            "y": 13
           },
           "id": 170,
           "maxPerRow": 6,
@@ -9539,16 +9539,17 @@
               "fields": "",
               "values": false
             },
-            "showUnfilled": true
+            "showUnfilled": true,
+            "text": {}
           },
-          "pluginVersion": "7.0.3",
+          "pluginVersion": "7.4.5",
           "repeat": "pod",
           "repeatDirection": "h",
           "scopedVars": {
             "pod": {
               "selected": false,
-              "text": "medic-cw-20-f8b1a83e1-benchmark-zeebe-0",
-              "value": "medic-cw-20-f8b1a83e1-benchmark-zeebe-0"
+              "text": "dd-leader-latency-zeebe-0",
+              "value": "dd-leader-latency-zeebe-0"
             }
           },
           "targets": [
@@ -9603,9 +9604,9 @@
             "h": 6,
             "w": 8,
             "x": 8,
-            "y": 48
+            "y": 13
           },
-          "id": 248,
+          "id": 262,
           "maxPerRow": 6,
           "options": {
             "displayMode": "basic",
@@ -9617,18 +9618,18 @@
               "fields": "",
               "values": false
             },
-            "showUnfilled": true
+            "showUnfilled": true,
+            "text": {}
           },
-          "pluginVersion": "7.0.3",
-          "repeat": null,
+          "pluginVersion": "7.4.5",
           "repeatDirection": "h",
-          "repeatIteration": 1621341468031,
+          "repeatIteration": 1625552874204,
           "repeatPanelId": 170,
           "scopedVars": {
             "pod": {
               "selected": false,
-              "text": "medic-cw-20-f8b1a83e1-benchmark-zeebe-1",
-              "value": "medic-cw-20-f8b1a83e1-benchmark-zeebe-1"
+              "text": "dd-leader-latency-zeebe-1",
+              "value": "dd-leader-latency-zeebe-1"
             }
           },
           "targets": [
@@ -9683,9 +9684,9 @@
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 48
+            "y": 13
           },
-          "id": 249,
+          "id": 263,
           "maxPerRow": 6,
           "options": {
             "displayMode": "basic",
@@ -9697,18 +9698,18 @@
               "fields": "",
               "values": false
             },
-            "showUnfilled": true
+            "showUnfilled": true,
+            "text": {}
           },
-          "pluginVersion": "7.0.3",
-          "repeat": null,
+          "pluginVersion": "7.4.5",
           "repeatDirection": "h",
-          "repeatIteration": 1621341468031,
+          "repeatIteration": 1625552874204,
           "repeatPanelId": 170,
           "scopedVars": {
             "pod": {
               "selected": false,
-              "text": "medic-cw-20-f8b1a83e1-benchmark-zeebe-2",
-              "value": "medic-cw-20-f8b1a83e1-benchmark-zeebe-2"
+              "text": "dd-leader-latency-zeebe-2",
+              "value": "dd-leader-latency-zeebe-2"
             }
           },
           "targets": [
@@ -9735,6 +9736,9 @@
           "description": "Time taken to recover and reprocess events",
           "fieldConfig": {
             "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
               "custom": {},
               "mappings": [],
               "min": 0,
@@ -9751,15 +9755,15 @@
                   }
                 ]
               },
-              "unit": "dtdurationms"
+              "unit": "ms"
             },
             "overrides": []
           },
           "gridPos": {
-            "h": 5,
-            "w": 24,
+            "h": 6,
+            "w": 12,
             "x": 0,
-            "y": 54
+            "y": 19
           },
           "id": 174,
           "options": {
@@ -9772,20 +9776,82 @@
               "fields": "",
               "values": false
             },
-            "showUnfilled": true
+            "showUnfilled": true,
+            "text": {}
           },
-          "pluginVersion": "7.0.3",
+          "pluginVersion": "7.4.5",
           "targets": [
             {
               "expr": "zeebe_stream_processor_startup_recovery_time{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}",
               "interval": "",
-              "legendFormat": "{{pod}} p{{partition}}",
+              "legendFormat": "{{pod}}:Partition {{partition}}",
               "refId": "A"
             }
           ],
           "timeFrom": null,
           "timeShift": null,
           "title": "Streamprocessor Recovery Time",
+          "type": "bargauge"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "The time needed to install all leader services on a newly elected leader until it is ready to process new requests.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {},
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 60000
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 12,
+            "y": 19
+          },
+          "id": 265,
+          "options": {
+            "displayMode": "basic",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "7.4.5",
+          "targets": [
+            {
+              "expr": "zeebe_leader_transition_latency{namespace=~\"$namespace\", partition=~\"$partition\", pod=~\"$pod\"}",
+              "interval": "",
+              "legendFormat": "{{pod}}: Partition {{ partition }}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Leader transition duration",
           "type": "bargauge"
         }
       ],
@@ -9933,5 +9999,5 @@
   "timezone": "",
   "title": "Zeebe",
   "uid": "I4lo7_EZk",
-  "version": 14
+  "version": 15
 }


### PR DESCRIPTION
## Description

The new metrics calculates the duration from when ZeebePartition receives the leader role change event from raft, until all the services for the leader is installed. Only after the services are installed the commandApi starts accepting requests for that partition. The metrics covers the duration until this point.

## Related issues

closes #7433 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
