### PR TITLE
Remove commitPosition from LogStream interface

### DIFF
--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -98,16 +98,6 @@ public final class LogStreamImpl extends Actor implements LogStream, FailureList
   }
 
   @Override
-  public ActorFuture<Long> getCommitPositionAsync() {
-    return actor.call(() -> commitPosition);
-  }
-
-  @Override
-  public void setCommitPosition(final long commitPosition) {
-    actor.call(() -> internalSetCommitPosition(commitPosition));
-  }
-
-  @Override
   public ActorFuture<LogStreamReader> newLogStreamReader() {
     return actor.call(this::createLogStreamReader);
   }
@@ -144,6 +134,10 @@ public final class LogStreamImpl extends Actor implements LogStream, FailureList
   @Override
   public void removeOnCommitPositionUpdatedCondition(final ActorCondition condition) {
     actor.call(() -> onCommitPositionUpdatedConditions.removeConsumer(condition));
+  }
+
+  public void setCommitPosition(final long commitPosition) {
+    actor.call(() -> internalSetCommitPosition(commitPosition));
   }
 
   @Override

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
@@ -37,15 +37,6 @@ public interface LogStream extends AsyncClosable, AutoCloseable, HealthMonitorab
    */
   String getLogName();
 
-  /**
-   * @return a future, when successfully completed it returns the current commit position, or a
-   *     negative value if no entry is committed
-   */
-  ActorFuture<Long> getCommitPositionAsync();
-
-  /** sets the new commit position * */
-  void setCommitPosition(long position);
-
   /** @return a future, when successfully completed it returns a newly created log stream reader */
   ActorFuture<LogStreamReader> newLogStreamReader();
 

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
@@ -53,7 +53,7 @@ public final class LogStorageAppenderHealthTest {
 
     appender =
         new LogStorageAppender(
-            "appender", PARTITION_ID, failingLogStorage, subscription, MAX_FRAGMENT_SIZE, l -> {});
+            "appender", PARTITION_ID, failingLogStorage, subscription, MAX_FRAGMENT_SIZE, () -> {});
     writer = new LogStreamWriterImpl(PARTITION_ID, dispatcher);
   }
 

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
@@ -82,7 +82,7 @@ public final class LogStorageAppenderTest {
 
     appender =
         new LogStorageAppender(
-            "appender", PARTITION_ID, logStorage, subscription, MAX_FRAGMENT_SIZE, l -> {});
+            "appender", PARTITION_ID, logStorage, subscription, MAX_FRAGMENT_SIZE, () -> {});
     writer = new LogStreamWriterImpl(PARTITION_ID, dispatcher);
     reader = new LogStreamReaderImpl(logStorage.newReader());
   }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamTest.java
@@ -48,7 +48,6 @@ public final class LogStreamTest {
     // then
     assertThat(logStream.getPartitionId()).isEqualTo(PARTITION_ID);
     assertThat(logStream.getLogName()).isEqualTo("0");
-    assertThat(logStream.getCommitPosition()).isEqualTo(-1L);
 
     assertThat(logStream.newLogStreamReader()).isNotNull();
     assertThat(logStream.newLogStreamBatchWriter()).isNotNull();

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStream.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStream.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
 public class SyncLogStream implements SynchronousLogStream {
 
   private final LogStream logStream;
+  private long commitPosition = -1;
 
   public SyncLogStream(final LogStream logStream) {
     this.logStream = logStream;
@@ -51,12 +52,12 @@ public class SyncLogStream implements SynchronousLogStream {
 
   @Override
   public long getCommitPosition() {
-    return logStream.getCommitPositionAsync().join();
+    return commitPosition;
   }
 
   @Override
   public void setCommitPosition(final long position) {
-    logStream.setCommitPosition(position);
+    commitPosition = position;
   }
 
   @Override

--- a/test/revapi.json
+++ b/test/revapi.json
@@ -30,5 +30,40 @@
         ]
       }
     }
+  },
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "justification": "LogStream is an internal api. Changes to this interface is acceptable.",
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.util.sched.future.ActorFuture<java.lang.Long> io.camunda.zeebe.logstreams.log.LogStream::getCommitPositionAsync()",
+          "justification": "LogStream is an internal api. Changes to this interface is acceptable.",
+          "package": "io.camunda.zeebe.logstreams.log",
+          "classQualifiedName": "io.camunda.zeebe.logstreams.log.LogStream",
+          "classSimpleName": "LogStream",
+          "methodName": "getCommitPositionAsync",
+          "elementKind": "method",
+          "oldArchive": "io.camunda:zeebe-logstreams:jar:1.0.0",
+          "oldArchiveRole": "supplementary",
+          "breaksSemanticVersioning": "true"
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method void io.camunda.zeebe.logstreams.log.LogStream::setCommitPosition(long)",
+          "justification": "LogStream is an internal api. Changes to this interface is acceptable.",
+          "package": "io.camunda.zeebe.logstreams.log",
+          "classQualifiedName": "io.camunda.zeebe.logstreams.log.LogStream",
+          "classSimpleName": "LogStream",
+          "methodName": "setCommitPosition",
+          "elementKind": "method",
+          "oldArchive": "io.camunda:zeebe-logstreams:jar:1.0.0",
+          "oldArchiveRole": "supplementary",
+          "breaksSemanticVersioning": "true"
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Description

There are no listeners using commit position from logstream. Hence the api for accessing commit position is removed from LogStream interface.

## Related issues

closes #7453 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
