### PR TITLE
Minor fixes to the revapi config

### DIFF
--- a/build-tools/src/main/resources/revapi/revapi.json
+++ b/build-tools/src/main/resources/revapi/revapi.json
@@ -12,5 +12,12 @@
         "java.class.nonPublicPartOfAPI"
       ]
     }
+  },
+  {
+    "extension": "revapi.java",
+    "configuration": {
+      "reportUsesFor": "all-differences",
+      "matchOverloads": false
+    }
   }
 ]

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -811,7 +811,6 @@
               different branches which need to compare to different versions
               -->
             <oldVersion>${backwards.compat.version}</oldVersion>
-            <skip>${skipChecks}</skip>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
## Description

This PR updates the Revapi configuration to always show the use-chain that led to a change being marked as breaking. For example, for the logstreams changes made in #7461, the use chain would now be:

```
"exampleUseChainInOldApi": "io.camunda.zeebe.logstreams.log.LogStream is used as parameter in method io.camunda.zeebe.util.sched.future.ActorFuture<java.lang.Void> io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService::onBecomingLeader(int, long, io.camunda.zeebe.logstreams.log.LogStream) <- io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService is used as a type parameter or type variable bound on method void io.camunda.zeebe.broker.SpringBrokerBridge::registerBrokerHealthCheckServiceSupplier(java.util.function.Supplier<io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService>) <- io.camunda.zeebe.broker.SpringBrokerBridge is used as parameter in method void io.camunda.zeebe.broker.Broker::<init>(io.camunda.zeebe.broker.system.configuration.BrokerCfg, java.lang.String, io.camunda.zeebe.util.sched.clock.ActorClock, io.camunda.zeebe.broker.SpringBrokerBridge) <- field io.camunda.zeebe.test.EmbeddedBrokerRule.broker has the type io.camunda.zeebe.broker.Broker (field io.camunda.zeebe.test.EmbeddedBrokerRule.broker is part of the API)",
```

This slows down analysis a little, but it's worth it to understand why a change is marked as breaking. Additionally, I realized we configured the `skip` parameter of the revapi plugin twice - it should only be once in the parent pom's properties, and not on the plugin config itself, since we want to use `skipChecks` as a default, but still allow to individually skip the plugin by specifying `revapi.skip` if you want.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
