### PR TITLE
Replace onCommitPositionUpdateCondition in LogStream

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -53,7 +53,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
-import io.camunda.zeebe.util.sched.ActorCondition;
 import io.camunda.zeebe.util.sched.ActorControl;
 import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
@@ -429,10 +428,8 @@ public final class EngineRule extends ExternalResource {
       typedEvent = new TypedEventImpl(partitionId);
       final ActorControl actor = context.getActor();
 
-      final ActorCondition onCommitCondition =
-          actor.onCondition("on-commit", this::onNewEventCommitted);
       final LogStream logStream = context.getLogStream();
-      logStream.registerOnCommitPositionUpdatedCondition(onCommitCondition);
+      logStream.registerRecordAvailableListener(() -> actor.run(this::onNewEventCommitted));
       logStream
           .newLogStreamReader()
           .onComplete(

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBuilderImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBuilderImpl.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamBuilder;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.camunda.zeebe.util.sched.ActorSchedulingService;
-import io.camunda.zeebe.util.sched.channel.ActorConditions;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.util.Objects;
@@ -68,13 +67,7 @@ public final class LogStreamBuilderImpl implements LogStreamBuilder {
 
     final var logStreamService =
         new LogStreamImpl(
-            actorSchedulingService,
-            new ActorConditions(),
-            logName,
-            partitionId,
-            nodeId,
-            maxFragmentSize,
-            logStorage);
+            actorSchedulingService, logName, partitionId, nodeId, maxFragmentSize, logStorage);
 
     final var logstreamInstallFuture = new CompletableActorFuture<LogStream>();
     actorSchedulingService

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogRecordAwaiter.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogRecordAwaiter.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+
+package io.camunda.zeebe.logstreams.log;
+
+/** Listener invoked by {@link LogStream} when new records are available to read. */
+@FunctionalInterface
+public interface LogRecordAwaiter {
+
+  /** Will be invoked when new records are available in LogStream. */
+  void onRecordAvailable();
+}

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
@@ -65,4 +65,8 @@ public interface LogStream extends AsyncClosable, AutoCloseable, HealthMonitorab
    * @param condition the condition which should be removed
    */
   void removeOnCommitPositionUpdatedCondition(ActorCondition condition);
+
+  void registerRecordAvailableListener(LogRecordAwaiter recordAwaiter);
+
+  void removeRecordAvailableListener(LogRecordAwaiter recordAwaiter);
 }

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.logstreams.log;
 
 import io.camunda.zeebe.logstreams.impl.log.LogStreamBuilderImpl;
 import io.camunda.zeebe.util.health.HealthMonitorable;
-import io.camunda.zeebe.util.sched.ActorCondition;
 import io.camunda.zeebe.util.sched.AsyncClosable;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 
@@ -53,20 +52,17 @@ public interface LogStream extends AsyncClosable, AutoCloseable, HealthMonitorab
   ActorFuture<LogStreamBatchWriter> newLogStreamBatchWriter();
 
   /**
-   * Registers for on commit updates.
+   * Registers a listener that will be notified when new records are available to read from the
+   * logstream.
    *
-   * @param condition the condition which should be signalled.
+   * @param recordAwaiter the listener to be notified
    */
-  void registerOnCommitPositionUpdatedCondition(ActorCondition condition);
-
-  /**
-   * Removes the registered condition.
-   *
-   * @param condition the condition which should be removed
-   */
-  void removeOnCommitPositionUpdatedCondition(ActorCondition condition);
-
   void registerRecordAvailableListener(LogRecordAwaiter recordAwaiter);
 
+  /**
+   * Removes the listener.
+   *
+   * @param recordAwaiter the listener to remove
+   */
   void removeRecordAvailableListener(LogRecordAwaiter recordAwaiter);
 }

--- a/test/revapi.json
+++ b/test/revapi.json
@@ -62,6 +62,32 @@
           "oldArchive": "io.camunda:zeebe-logstreams:jar:1.0.0",
           "oldArchiveRole": "supplementary",
           "breaksSemanticVersioning": "true"
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method void io.camunda.zeebe.logstreams.log.LogStream::registerOnCommitPositionUpdatedCondition(io.camunda.zeebe.util.sched.ActorCondition)",
+          "justification": "LogStream is an internal api. Changes to this interface is acceptable.",
+          "package": "io.camunda.zeebe.logstreams.log",
+          "classQualifiedName": "io.camunda.zeebe.logstreams.log.LogStream",
+          "classSimpleName": "LogStream",
+          "methodName": "registerOnCommitPositionUpdatedCondition",
+          "elementKind": "method",
+          "oldArchive": "io.camunda:zeebe-logstreams:jar:1.0.0",
+          "oldArchiveRole": "supplementary",
+          "breaksSemanticVersioning": "true"
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method void io.camunda.zeebe.logstreams.log.LogStream::removeOnCommitPositionUpdatedCondition(io.camunda.zeebe.util.sched.ActorCondition)",
+          "justification": "LogStream is an internal api. Changes to this interface is acceptable.",
+          "package": "io.camunda.zeebe.logstreams.log",
+          "classQualifiedName": "io.camunda.zeebe.logstreams.log.LogStream",
+          "classSimpleName": "LogStream",
+          "methodName": "removeOnCommitPositionUpdatedCondition",
+          "elementKind": "method",
+          "oldArchive": "io.camunda:zeebe-logstreams:jar:1.0.0",
+          "oldArchiveRole": "supplementary",
+          "breaksSemanticVersioning": "true"
         }
       ]
     }


### PR DESCRIPTION
## Description

* Added a new interface LogRecordAwaiter used by LogStream to notify consumers when new records are available to read.
* Replace all uses of `onCommitPositionUpdatedCondition` with the new listener
* Removed `onCommitPositionUpdatedCondition` listener from LogStream interface.

## Related issues

closes #7454 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
