### PR TITLE
Rename SyncLogStream#getCommitPosition

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateRandomizedPropertyTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateRandomizedPropertyTest.java
@@ -157,6 +157,9 @@ public class ReplayStateRandomizedPropertyTest {
         .untilAsserted(
             () ->
                 assertThat(engineRule.getLastProcessedPosition())
+                    .describedAs(
+                        "Last written %d has to be processed %d",
+                        engineRule.getLastWrittenPosition(1), engineRule.getLastProcessedPosition())
                     .isEqualTo(engineRule.getLastWrittenPosition(1)));
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -160,7 +160,7 @@ public final class TestStreams {
   }
 
   public long getLastWrittenPosition(final String name) {
-    return getStreamProcessor(name).getLastWrittenPositionAsync().join();
+    return getLogStream(name).getLastWrittenPosition();
   }
 
   public SynchronousLogStream getLogStream(final String name) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -125,7 +125,7 @@ public final class TestStreams {
         name,
         partitionId,
         listLogStorage,
-        logStream -> listLogStorage.setPositionListener(logStream::setCommitPosition));
+        logStream -> listLogStorage.setPositionListener(logStream::setLastWrittenPosition));
   }
 
   public SynchronousLogStream createLogStream(
@@ -134,7 +134,7 @@ public final class TestStreams {
         name,
         partitionId,
         listLogStorage,
-        logStream -> listLogStorage.setPositionListener(logStream::setCommitPosition));
+        logStream -> listLogStorage.setPositionListener(logStream::setLastWrittenPosition));
   }
 
   private SynchronousLogStream createLogStream(
@@ -160,8 +160,7 @@ public final class TestStreams {
   }
 
   public long getLastWrittenPosition(final String name) {
-    // the position of a written record is directly committed, we can use it as a synonym
-    return getLogStream(name).getCommitPosition();
+    return getStreamProcessor(name).getLastWrittenPositionAsync().join();
   }
 
   public SynchronousLogStream getLogStream(final String name) {

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamBatchWriterTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamBatchWriterTest.java
@@ -71,7 +71,7 @@ public final class LogStreamBatchWriterTest {
 
     assertThat(position).isGreaterThan(0);
 
-    writerRule.waitForPositionToBeCommitted(position);
+    writerRule.waitForPositionToBeWritten(position);
 
     long eventPosition = -1L;
 

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamTest.java
@@ -100,7 +100,7 @@ public final class LogStreamTest {
     writer.value(wrapString("value")).tryWrite();
     writer.value(wrapString("value")).tryWrite();
     final long positionBeforeClose = writer.value(wrapString("value")).tryWrite();
-    TestUtil.waitUntil(() -> logStream.getCommitPosition() >= positionBeforeClose);
+    TestUtil.waitUntil(() -> logStream.getLastWrittenPosition() >= positionBeforeClose);
 
     // when
     logStream.close();
@@ -126,7 +126,7 @@ public final class LogStreamTest {
     }
 
     final long writtenEventPosition = position;
-    waitUntil(() -> logStream.getCommitPosition() >= writtenEventPosition);
+    waitUntil(() -> logStream.getLastWrittenPosition() >= writtenEventPosition);
 
     return position;
   }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamWriterTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamWriterTest.java
@@ -68,7 +68,7 @@ public final class LogStreamWriterTest {
   private LoggedEvent getWrittenEvent(final long position) {
     assertThat(position).isGreaterThan(0);
 
-    writerRule.waitForPositionToBeCommitted(position);
+    writerRule.waitForPositionToBeWritten(position);
 
     final LoggedEvent event = readerRule.readEventAtPosition(position);
 
@@ -208,7 +208,7 @@ public final class LogStreamWriterTest {
   public void shouldCloseAllWritersAndWriteAgain() {
     // given
     final long firstPosition = writer.key(123L).value(EVENT_VALUE).tryWrite();
-    writerRule.waitForPositionToBeCommitted(firstPosition);
+    writerRule.waitForPositionToBeWritten(firstPosition);
 
     // when
     writerRule.closeWriter();

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamRule.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamRule.java
@@ -118,7 +118,7 @@ public final class LogStreamRule extends ExternalResource {
   private void openLogStream() {
     logStream =
         SyncLogStream.builder(builder).withActorSchedulingService(actorSchedulerRule.get()).build();
-    logStorageRule.setPositionListener(logStream::setCommitPosition);
+    logStorageRule.setPositionListener(logStream::setLastWrittenPosition);
   }
 
   public LogStreamReader newLogStreamReader() {

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamWriterRule.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamWriterRule.java
@@ -66,7 +66,7 @@ public final class LogStreamWriterRule extends ExternalResource {
               .until(logStreamWriter::tryWrite, position -> position >= 0);
     }
 
-    waitForPositionToBeCommitted(lastPosition);
+    waitForPositionToBeWritten(lastPosition);
     return lastPosition;
   }
 
@@ -77,7 +77,7 @@ public final class LogStreamWriterRule extends ExternalResource {
   public long writeEvent(final Consumer<LogEntryBuilder> writer) {
     final long position = writeEventInternal(writer);
 
-    waitForPositionToBeCommitted(position);
+    waitForPositionToBeWritten(position);
 
     return position;
   }
@@ -99,11 +99,11 @@ public final class LogStreamWriterRule extends ExternalResource {
     return logStreamWriter.tryWrite();
   }
 
-  public void waitForPositionToBeCommitted(final long position) {
+  public void waitForPositionToBeWritten(final long position) {
     Awaitility.await("until position " + position + " is committed")
         .atMost(Duration.ofSeconds(5))
         .pollDelay(Duration.ofNanos(0))
         .pollInSameThread()
-        .until(() -> logStream.getCommitPosition() >= position);
+        .until(() -> logStream.getLastWrittenPosition() >= position);
   }
 }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStream.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStream.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
 public class SyncLogStream implements SynchronousLogStream {
 
   private final LogStream logStream;
-  private long commitPosition = -1;
+  private long lastWrittenPosition = -1;
 
   public SyncLogStream(final LogStream logStream) {
     this.logStream = logStream;
@@ -51,13 +51,13 @@ public class SyncLogStream implements SynchronousLogStream {
   }
 
   @Override
-  public long getCommitPosition() {
-    return commitPosition;
+  public long getLastWrittenPosition() {
+    return lastWrittenPosition;
   }
 
   @Override
-  public void setCommitPosition(final long position) {
-    commitPosition = position;
+  public void setLastWrittenPosition(final long position) {
+    lastWrittenPosition = position;
   }
 
   @Override

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SynchronousLogStream.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SynchronousLogStream.java
@@ -40,10 +40,10 @@ public interface SynchronousLogStream extends AutoCloseable {
   void close();
 
   /** @return the current commit position, or a negative value if no entry is committed. */
-  long getCommitPosition();
+  long getLastWrittenPosition();
 
   /** sets the new commit position * */
-  void setCommitPosition(long position);
+  void setLastWrittenPosition(long position);
 
   LogStreamReader newLogStreamReader();
 


### PR DESCRIPTION
## Description

* In engine module use stream processor last written pos
* rename getCommitPosition to lastWrittenPosition
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7453 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
