### PR TITLE
Logstreams in both leader and follower will be notified when new records are committed

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftCommitListener.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftCommitListener.java
@@ -16,10 +16,8 @@
  */
 package io.atomix.raft;
 
-import io.atomix.raft.storage.log.entry.RaftLogEntry;
-
 @FunctionalInterface
 public interface RaftCommitListener {
 
-  <T extends RaftLogEntry> void onCommit(long index);
+  void onCommit(long index);
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -351,6 +351,15 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   /**
+   * Removes registered commit listener
+   *
+   * @param commitListener the listenere to remove
+   */
+  public void removeCommitListener(final RaftCommitListener commitListener) {
+    commitListeners.remove(commitListener);
+  }
+
+  /**
    * Adds a new committed entry listener, which will be notified when the Leader commits a new
    * entry. If RAFT runs currently in a Follower role this listeners are not called.
    *

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -247,6 +247,11 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
     server.getContext().addCommitListener(commitListener);
   }
 
+  /** @see io.atomix.raft.impl.RaftContext#removeCommitListener(RaftCommitListener) */
+  public void removeCommitListener(final RaftCommitListener commitListener) {
+    server.getContext().removeCommitListener(commitListener);
+  }
+
   /** @see io.atomix.raft.impl.RaftContext#addCommittedEntryListener(RaftCommittedEntryListener) */
   public void addCommittedEntryListener(final RaftCommittedEntryListener commitListener) {
     server.getContext().addCommittedEntryListener(commitListener);

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -32,7 +32,6 @@ import io.atomix.raft.snapshot.InMemorySnapshot;
 import io.atomix.raft.snapshot.TestSnapshotStore;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
-import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.raft.zeebe.NoopEntryValidator;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
@@ -360,7 +359,7 @@ public final class RaftRule extends ExternalResource {
         .addCommitListener(
             new RaftCommitListener() {
               @Override
-              public <T extends RaftLogEntry> void onCommit(final long index) {
+              public void onCommit(final long index) {
                 final var currentIndex = index;
 
                 memberLog.put(raftServer.name(), currentIndex);

--- a/atomix/cluster/src/test/java/io/atomix/raft/zeebe/ZeebeTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/zeebe/ZeebeTest.java
@@ -25,7 +25,6 @@ import com.google.common.base.Stopwatch;
 import io.atomix.raft.RaftCommitListener;
 import io.atomix.raft.partition.impl.RaftPartitionServer;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
-import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.zeebe.util.TestAppender;
 import io.atomix.raft.zeebe.util.ZeebeTestHelper;
 import io.atomix.raft.zeebe.util.ZeebeTestNode;
@@ -285,7 +284,7 @@ public class ZeebeTest {
     private final AtomicInteger calledCount = new AtomicInteger(0);
 
     @Override
-    public <T extends RaftLogEntry> void onCommit(final long index) {
+    public void onCommit(final long index) {
       lastCommitted.set(index);
       calledCount.incrementAndGet();
     }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ListLogStorage.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ListLogStorage.java
@@ -10,10 +10,12 @@ package io.camunda.zeebe.engine.util;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.camunda.zeebe.logstreams.storage.LogStorageReader;
 import java.nio.ByteBuffer;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -26,6 +28,7 @@ public class ListLogStorage implements LogStorage {
   private final ConcurrentNavigableMap<Long, Integer> positionIndexMapping;
   private final List<Entry> entries;
   private LongConsumer positionListener;
+  private final Set<CommitListener> commitListeners = new HashSet<>();
 
   public ListLogStorage() {
     entries = new CopyOnWriteArrayList<>();
@@ -58,9 +61,20 @@ public class ListLogStorage implements LogStorage {
         positionListener.accept(entry.getHighestPosition());
       }
       listener.onCommit(index);
+      commitListeners.forEach(CommitListener::onCommit);
     } catch (final Exception e) {
       listener.onWriteError(e);
     }
+  }
+
+  @Override
+  public void addCommitListener(final CommitListener listener) {
+    commitListeners.add(listener);
+  }
+
+  @Override
+  public void removeCommitListener(final CommitListener listener) {
+    commitListeners.remove(listener);
   }
 
   private static final class Entry {

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
@@ -55,17 +55,14 @@ public class LogStorageAppender extends Actor implements HealthMonitorable {
   private final AppenderMetrics appenderMetrics;
   private final Set<FailureListener> failureListeners = new HashSet<>();
   private final ActorFuture<Void> closeFuture;
-  private final Runnable commitListener;
 
   public LogStorageAppender(
       final String name,
       final int partitionId,
       final LogStorage logStorage,
       final Subscription writeBufferSubscription,
-      final int maxBlockSize,
-      final Runnable commitListener) {
+      final int maxBlockSize) {
     appenderMetrics = new AppenderMetrics(Integer.toString(partitionId));
-    this.commitListener = commitListener;
     env = new Environment();
     this.name = name;
     this.logStorage = logStorage;
@@ -231,7 +228,6 @@ public class LogStorageAppender extends Actor implements HealthMonitorable {
   void notifyCommitPosition(final long highestPosition, final long startTime) {
     actor.run(
         () -> {
-          commitListener.run();
           appenderMetrics.setLastCommittedPosition(highestPosition);
           appenderMetrics.commitLatency(startTime, ActorClock.currentTimeMillis());
         });

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
@@ -47,6 +47,20 @@ public interface LogStorage {
       long lowestPosition, long highestPosition, ByteBuffer blockBuffer, AppendListener listener);
 
   /**
+   * Register a commit listener
+   *
+   * @param listener the listener which will be notified when a new record is committed.
+   */
+  void addCommitListener(CommitListener listener);
+
+  /**
+   * Remove a commit listener
+   *
+   * @param listener the listener to remove
+   */
+  void removeCommitListener(CommitListener listener);
+
+  /**
    * An append listener can be added to an append call to be notified of different events that can
    * occur during the append operation.
    */
@@ -80,5 +94,18 @@ public interface LogStorage {
      * @param error the error that occurred
      */
     default void onCommitError(final long address, final Throwable error) {}
+  }
+
+  /**
+   * Consumers of LogStorage can use this listener to get notified when new records are committed.
+   * The difference between this and {@link AppendListener} is that {@link AppendListener} can only
+   * be used by the writer of a record. {@link CommitListener} can be used by any consumers of
+   * LogStorage, and get notified of new records committed even if it did not write the record
+   * itself.
+   */
+  interface CommitListener {
+
+    /** Called when a new record is committed in the storage */
+    void onCommit();
   }
 }

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/atomix/AtomixLogStorage.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/atomix/AtomixLogStorage.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.logstreams.storage.atomix;
 
 import io.atomix.raft.RaftCommitListener;
-import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import java.nio.ByteBuffer;
@@ -65,7 +64,7 @@ public class AtomixLogStorage implements LogStorage, RaftCommitListener {
   }
 
   @Override
-  public <T extends RaftLogEntry> void onCommit(final long index) {
+  public void onCommit(final long index) {
     commitListeners.forEach(CommitListener::onCommit);
   }
 }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
@@ -53,7 +53,7 @@ public final class LogStorageAppenderHealthTest {
 
     appender =
         new LogStorageAppender(
-            "appender", PARTITION_ID, failingLogStorage, subscription, MAX_FRAGMENT_SIZE, () -> {});
+            "appender", PARTITION_ID, failingLogStorage, subscription, MAX_FRAGMENT_SIZE);
     writer = new LogStreamWriterImpl(PARTITION_ID, dispatcher);
   }
 

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
@@ -138,6 +138,16 @@ public final class LogStorageAppenderHealthTest {
     }
 
     @Override
+    public void addCommitListener(final CommitListener listener) {
+      throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public void removeCommitListener(final CommitListener listener) {
+      throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
     public void close() {
       actor.close();
     }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
@@ -82,7 +82,7 @@ public final class LogStorageAppenderTest {
 
     appender =
         new LogStorageAppender(
-            "appender", PARTITION_ID, logStorage, subscription, MAX_FRAGMENT_SIZE, () -> {});
+            "appender", PARTITION_ID, logStorage, subscription, MAX_FRAGMENT_SIZE);
     writer = new LogStreamWriterImpl(PARTITION_ID, dispatcher);
     reader = new LogStreamReaderImpl(logStorage.newReader());
   }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/AtomixLogStorageRule.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/AtomixLogStorageRule.java
@@ -131,6 +131,7 @@ public final class AtomixLogStorageRule extends ExternalResource
     raftLog.setCommitIndex(entry.index());
 
     listener.onCommit(entry);
+    storage.onCommit(entry.index());
     if (positionListener != null) {
       positionListener.accept(highestPosition);
     }


### PR DESCRIPTION
## Description

With this PR, logStreams get notified of new committed records via logStorage instead of LogStorageAppender. When using LogStorageAppender to notify commits, only leader gets notified. With the new listener logStreams running on follower can also get notified when new records are committed by raft.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7455 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
