### PR TITLE
Resolve LogStorage concurrency bug

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionBoostrapAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionBoostrapAndTransitionContextImpl.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.logstreams.storage.atomix.AtomixLogStorage;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.util.health.HealthMonitor;
@@ -72,6 +73,7 @@ public class PartitionBoostrapAndTransitionContextImpl
   private ActorControl actorControl;
   private ScheduledTimer metricsTimer;
   private ExporterDirector exporterDirector;
+  private AtomixLogStorage logStorage;
 
   private long currentTerm;
   private Role currentRole;
@@ -311,6 +313,14 @@ public class PartitionBoostrapAndTransitionContextImpl
 
   public void setCurrentRole(final Role currentRole) {
     this.currentRole = currentRole;
+  }
+
+  public AtomixLogStorage getLogStorage() {
+    return logStorage;
+  }
+
+  public void setLogStorage(final AtomixLogStorage logStorage) {
+    this.logStorage = logStorage;
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionBoostrapAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionBoostrapAndTransitionContextImpl.java
@@ -108,48 +108,56 @@ public class PartitionBoostrapAndTransitionContextImpl
   }
 
   @Override
-  public ExporterDirector getExporterDirector() {
-    return exporterDirector;
+  public StateControllerImpl getSnapshotController() {
+    return stateController;
+  }
+
+  public void setSnapshotController(final StateControllerImpl controller) {
+    stateController = controller;
   }
 
   @Override
-  public void setExporterDirector(final ExporterDirector exporterDirector) {
-    this.exporterDirector = exporterDirector;
-  }
-
-  @Override
-  public PartitionBoostrapAndTransitionContextImpl createTransitionContext() {
+  public PartitionContext getPartitionContext() {
     return this;
   }
 
   @Override
-  public ScheduledTimer getMetricsTimer() {
-    return metricsTimer;
+  public int getPartitionId() {
+    return partitionId;
   }
 
   @Override
-  public void setMetricsTimer(final ScheduledTimer metricsTimer) {
-    this.metricsTimer = metricsTimer;
+  public RaftPartition getRaftPartition() {
+    return raftPartition;
   }
 
   @Override
-  public ActorControl getActorControl() {
-    return actorControl;
+  public List<ActorFuture<Void>> notifyListenersOfBecomingLeader(final long newTerm) {
+    return partitionListeners.stream()
+        .map(l -> l.onBecomingLeader(getPartitionId(), newTerm, getLogStream()))
+        .collect(Collectors.toList());
   }
 
   @Override
-  public void setActorControl(final ActorControl actorControl) {
-    this.actorControl = actorControl;
+  public List<ActorFuture<Void>> notifyListenersOfBecomingFollower(final long newTerm) {
+    return partitionListeners.stream()
+        .map(l -> l.onBecomingFollower(getPartitionId(), newTerm))
+        .collect(Collectors.toList());
   }
 
   @Override
-  public ZeebeDb getZeebeDb() {
-    return zeebeDb;
+  public void notifyListenersOfBecomingInactive() {
+    partitionListeners.forEach(l -> l.onBecomingInactive(getPartitionId(), getCurrentTerm()));
   }
 
   @Override
-  public void setZeebeDb(final ZeebeDb zeebeDb) {
-    this.zeebeDb = zeebeDb;
+  public Role getCurrentRole() {
+    return currentRole;
+  }
+
+  @Override
+  public long getCurrentTerm() {
+    return currentTerm;
   }
 
   @Override
@@ -160,35 +168,6 @@ public class PartitionBoostrapAndTransitionContextImpl
   @Override
   public void setComponentHealthMonitor(final HealthMonitor criticalComponentsHealthMonitor) {
     this.criticalComponentsHealthMonitor = criticalComponentsHealthMonitor;
-  }
-
-  @Override
-  public AsyncSnapshotDirector getSnapshotDirector() {
-    return snapshotDirector;
-  }
-
-  @Override
-  public void setSnapshotDirector(final AsyncSnapshotDirector snapshotDirector) {
-    this.snapshotDirector = snapshotDirector;
-  }
-
-  @Override
-  public LogDeletionService getLogDeletionService() {
-    return logDeletionService;
-  }
-
-  @Override
-  public void setLogDeletionService(final LogDeletionService logDeletionService) {
-    this.logDeletionService = logDeletionService;
-  }
-
-  @Override
-  public StateControllerImpl getSnapshotController() {
-    return stateController;
-  }
-
-  public void setSnapshotController(final StateControllerImpl controller) {
-    stateController = controller;
   }
 
   @Override
@@ -210,13 +189,13 @@ public class PartitionBoostrapAndTransitionContextImpl
   public void setStateController(final StateControllerImpl stateController) {}
 
   @Override
-  public StreamProcessor getStreamProcessor() {
-    return streamProcessor;
+  public LogDeletionService getLogDeletionService() {
+    return logDeletionService;
   }
 
   @Override
-  public void setStreamProcessor(final StreamProcessor streamProcessor) {
-    this.streamProcessor = streamProcessor;
+  public void setLogDeletionService(final LogDeletionService logDeletionService) {
+    this.logDeletionService = logDeletionService;
   }
 
   @Override
@@ -230,72 +209,65 @@ public class PartitionBoostrapAndTransitionContextImpl
   }
 
   @Override
-  public int getNodeId() {
-    return nodeId;
+  public ZeebeDb getZeebeDb() {
+    return zeebeDb;
   }
 
   @Override
-  public int getPartitionId() {
-    return partitionId;
+  public void setZeebeDb(final ZeebeDb zeebeDb) {
+    this.zeebeDb = zeebeDb;
   }
 
   @Override
-  public PartitionMessagingService getMessagingService() {
-    return messagingService;
+  public StreamProcessor getStreamProcessor() {
+    return streamProcessor;
   }
 
   @Override
-  public ActorSchedulingService getActorSchedulingService() {
-    return actorSchedulingService;
+  public void setStreamProcessor(final StreamProcessor streamProcessor) {
+    this.streamProcessor = streamProcessor;
   }
 
   @Override
-  public BrokerCfg getBrokerCfg() {
-    return brokerCfg;
+  public AsyncSnapshotDirector getSnapshotDirector() {
+    return snapshotDirector;
   }
 
   @Override
-  public ConstructableSnapshotStore getConstructableSnapshotStore() {
-    return constructableSnapshotStore;
+  public void setSnapshotDirector(final AsyncSnapshotDirector snapshotDirector) {
+    this.snapshotDirector = snapshotDirector;
   }
 
   @Override
-  public ReceivableSnapshotStore getReceivableSnapshotStore() {
-    return receivableSnapshotStore;
+  public ScheduledTimer getMetricsTimer() {
+    return metricsTimer;
   }
 
   @Override
-  public RaftPartition getRaftPartition() {
-    return raftPartition;
+  public void setMetricsTimer(final ScheduledTimer metricsTimer) {
+    this.metricsTimer = metricsTimer;
   }
 
   @Override
-  public TypedRecordProcessorsFactory getTypedRecordProcessorsFactory() {
-    return typedRecordProcessorsFactory;
-  }
-
-  public int getMaxFragmentSize() {
-    return maxFragmentSize;
-  }
-
-  @Override
-  public ExporterRepository getExporterRepository() {
-    return exporterRepository;
+  public void triggerSnapshot() {
+    if (getSnapshotDirector() != null) {
+      getSnapshotDirector().forceSnapshot();
+    }
   }
 
   @Override
-  public List<PartitionListener> getPartitionListeners() {
-    return partitionListeners;
+  public ExporterDirector getExporterDirector() {
+    return exporterDirector;
   }
 
   @Override
-  public PartitionContext getPartitionContext() {
+  public void setExporterDirector(final ExporterDirector exporterDirector) {
+    this.exporterDirector = exporterDirector;
+  }
+
+  @Override
+  public PartitionBoostrapAndTransitionContextImpl createTransitionContext() {
     return this;
-  }
-
-  @Override
-  public PartitionProcessingState getPartitionProcessingState() {
-    return partitionProcessingState;
   }
 
   @Override
@@ -309,11 +281,6 @@ public class PartitionBoostrapAndTransitionContextImpl
   }
 
   @Override
-  public boolean shouldExport() {
-    return !partitionProcessingState.isExportingPaused();
-  }
-
-  @Override
   public void pauseProcessing() throws IOException {
     partitionProcessingState.pauseProcessing();
   }
@@ -321,6 +288,11 @@ public class PartitionBoostrapAndTransitionContextImpl
   @Override
   public void resumeProcessing() throws IOException {
     partitionProcessingState.resumeProcessing();
+  }
+
+  @Override
+  public boolean shouldExport() {
+    return !partitionProcessingState.isExportingPaused();
   }
 
   @Override
@@ -333,18 +305,8 @@ public class PartitionBoostrapAndTransitionContextImpl
     return partitionProcessingState.resumeExporting();
   }
 
-  @Override
-  public long getCurrentTerm() {
-    return currentTerm;
-  }
-
   public void setCurrentTerm(final long currentTerm) {
     this.currentTerm = currentTerm;
-  }
-
-  @Override
-  public Role getCurrentRole() {
-    return currentRole;
   }
 
   public void setCurrentRole(final Role currentRole) {
@@ -352,29 +314,38 @@ public class PartitionBoostrapAndTransitionContextImpl
   }
 
   @Override
-  public List<ActorFuture<Void>> notifyListenersOfBecomingFollower(final long newTerm) {
-    return partitionListeners.stream()
-        .map(l -> l.onBecomingFollower(getPartitionId(), newTerm))
-        .collect(Collectors.toList());
+  public BrokerCfg getBrokerCfg() {
+    return brokerCfg;
   }
 
   @Override
-  public List<ActorFuture<Void>> notifyListenersOfBecomingLeader(final long newTerm) {
-    return partitionListeners.stream()
-        .map(l -> l.onBecomingLeader(getPartitionId(), newTerm, getLogStream()))
-        .collect(Collectors.toList());
+  public int getNodeId() {
+    return nodeId;
   }
 
   @Override
-  public void notifyListenersOfBecomingInactive() {
-    partitionListeners.forEach(l -> l.onBecomingInactive(getPartitionId(), getCurrentTerm()));
+  public ActorSchedulingService getActorSchedulingService() {
+    return actorSchedulingService;
   }
 
   @Override
-  public void triggerSnapshot() {
-    if (getSnapshotDirector() != null) {
-      getSnapshotDirector().forceSnapshot();
-    }
+  public PartitionMessagingService getMessagingService() {
+    return messagingService;
+  }
+
+  @Override
+  public ConstructableSnapshotStore getConstructableSnapshotStore() {
+    return constructableSnapshotStore;
+  }
+
+  @Override
+  public ReceivableSnapshotStore getReceivableSnapshotStore() {
+    return receivableSnapshotStore;
+  }
+
+  @Override
+  public CommandResponseWriter getCommandResponseWriter() {
+    return commandResponseWriterSupplier.get();
   }
 
   @Override
@@ -383,7 +354,36 @@ public class PartitionBoostrapAndTransitionContextImpl
   }
 
   @Override
-  public CommandResponseWriter getCommandResponseWriter() {
-    return commandResponseWriterSupplier.get();
+  public TypedRecordProcessorsFactory getTypedRecordProcessorsFactory() {
+    return typedRecordProcessorsFactory;
+  }
+
+  @Override
+  public ExporterRepository getExporterRepository() {
+    return exporterRepository;
+  }
+
+  @Override
+  public List<PartitionListener> getPartitionListeners() {
+    return partitionListeners;
+  }
+
+  @Override
+  public PartitionProcessingState getPartitionProcessingState() {
+    return partitionProcessingState;
+  }
+
+  @Override
+  public ActorControl getActorControl() {
+    return actorControl;
+  }
+
+  @Override
+  public void setActorControl(final ActorControl actorControl) {
+    this.actorControl = actorControl;
+  }
+
+  public int getMaxFragmentSize() {
+    return maxFragmentSize;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionStep.java
@@ -31,10 +31,12 @@ public class LogStreamPartitionStep implements PartitionStep {
     final var logStorageOrException = buildAtomixLogStorage(context);
 
     if (logStorageOrException.isRight()) {
-      buildLogstream(context, logStorageOrException.get())
+      final var logStorage = logStorageOrException.get();
+      buildLogstream(context, logStorage)
           .onComplete(
               ((logStream, err) -> {
                 if (err == null) {
+                  context.setLogStorage(logStorage);
                   context.setLogStream(logStream);
 
                   context
@@ -96,7 +98,6 @@ public class LogStreamPartitionStep implements PartitionStep {
     } else {
       final var logStorage = AtomixLogStorage.ofPartition(server::openReader, logAppender);
       server.addCommitListener(logStorage);
-      context.setLogStorage(logStorage);
 
       return right(logStorage);
     }


### PR DESCRIPTION
## Description

The logStorage was concurrently manipulated by different actors, since
the step was installed for each partition and the same object was in use. In order to avoid that the
storage is set into the partition context, which is an object for each partition.

I dont like to add more to the context, but it quickly solves the issue for now.
Alternative solution would be to have instead of one object for all partitions, separate
objects. Like defining only the classes for the Leader- and Follower-Steps.
Since we plan to refactor the bootstraping I don't think it makes sense to spent
more time on this.

Unfortunately I had to first reformat the context class, it seem to not align with our guidelines/settings ?
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7475

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
