### PR TITLE
Add Continuously Replay Mode 

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingContext.java
@@ -132,8 +132,8 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
     return this;
   }
 
-  public ProcessingContext replayContinuously() {
-    replayMode = ReplayMode.CONTINUOUSLY;
+  public ProcessingContext replayMode(final ReplayMode replayMode) {
+    this.replayMode = replayMode;
     return this;
   }
 
@@ -224,7 +224,7 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
     streamWriterProxy.wrap(noopTypedStreamWriter);
   }
 
-  public boolean shouldReplayContinuously() {
-    return replayMode == ReplayMode.CONTINUOUSLY;
+  public ReplayMode getReplayMode() {
+    return replayMode;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingContext.java
@@ -49,6 +49,7 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
   private Consumer<TypedRecord<?>> onProcessedListener = record -> {};
   private Consumer<LoggedEvent> onSkippedListener = record -> {};
   private int maxFragmentSize;
+  private ReplayMode replayMode = ReplayMode.UNTIL_END;
 
   public ProcessingContext() {
     streamWriterProxy.wrap(logStreamWriter);
@@ -128,6 +129,11 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
 
   public ProcessingContext eventApplier(final EventApplier eventApplier) {
     this.eventApplier = eventApplier;
+    return this;
+  }
+
+  public ProcessingContext replayContinuously() {
+    replayMode = ReplayMode.CONTINUOUSLY;
     return this;
   }
 
@@ -216,5 +222,9 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
 
   public void disableLogStreamWriter() {
     streamWriterProxy.wrap(noopTypedStreamWriter);
+  }
+
+  public boolean shouldReplayContinuously() {
+    return replayMode == ReplayMode.CONTINUOUSLY;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayMode.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayMode.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+public enum ReplayMode {
+  /**
+   * Normal replay mode, which is used on Leader side. After the replay the processing normally
+   * starts.
+   */
+  UNTIL_END,
+
+  /**
+   * Continuously means it will never stop the replay mode, all new events are replayed and commands
+   * are ignored.
+   */
+  CONTINUOUSLY
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
@@ -77,6 +77,11 @@ public final class StreamProcessorBuilder {
     return this;
   }
 
+  public StreamProcessorBuilder replayContinuously() {
+    processingContext.replayContinuously();
+    return this;
+  }
+
   public TypedRecordProcessorFactory getTypedRecordProcessorFactory() {
     return typedRecordProcessorFactory;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
@@ -77,8 +77,8 @@ public final class StreamProcessorBuilder {
     return this;
   }
 
-  public StreamProcessorBuilder replayContinuously() {
-    processingContext.replayContinuously();
+  public StreamProcessorBuilder replayMode(final ReplayMode replayMode) {
+    processingContext.replayMode(replayMode);
     return this;
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ContinuouslyReplayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ContinuouslyReplayTest.java
@@ -18,13 +18,13 @@ import org.junit.Test;
 
 public class ContinuouslyReplayTest {
 
-  private final ListLogStorage listLogStorage = new ListLogStorage();
+  private final ListLogStorage sharedStorage = new ListLogStorage();
 
   @Rule
   public final EngineRule replay =
-      EngineRule.withSharedStorage(listLogStorage).withContinuouslyReplay();
+      EngineRule.withSharedStorage(sharedStorage).withReplayMode(ReplayMode.CONTINUOUSLY);
 
-  @Rule public final EngineRule processing = EngineRule.withSharedStorage(listLogStorage);
+  @Rule public final EngineRule processing = EngineRule.withSharedStorage(sharedStorage);
 
   @Test
   public void shouldEndUpWithTheSameState() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ContinuouslyReplayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ContinuouslyReplayTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+import io.camunda.zeebe.engine.state.ZbColumnFamilies;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.ListLogStorage;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import org.assertj.core.api.SoftAssertions;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ContinuouslyReplayTest {
+
+  private final ListLogStorage listLogStorage = new ListLogStorage();
+
+  @Rule
+  public final EngineRule replay =
+      EngineRule.withSharedStorage(listLogStorage).withContinuouslyReplay();
+
+  @Rule public final EngineRule processing = EngineRule.withSharedStorage(listLogStorage);
+
+  @Test
+  public void shouldEndUpWithTheSameState() {
+    // given
+
+    // when
+    processing
+        .deployment()
+        .withXmlResource(Bpmn.createExecutableProcess().startEvent().endEvent().done())
+        .deploy();
+
+    // then
+    assertStates();
+  }
+
+  private void assertStates() {
+    Awaitility.await("await that the replay state is equal to the processing state")
+        .untilAsserted(
+            () -> {
+              final var replayState = replay.collectState();
+              final var processingState = processing.collectState();
+
+              final var softly = new SoftAssertions();
+
+              processingState.entrySet().stream()
+                  .filter(entry -> entry.getKey() != ZbColumnFamilies.DEFAULT)
+                  // ignores transient states
+                  .filter(entry -> entry.getKey() != ZbColumnFamilies.KEY)
+                  // on followers we don't need to reset the key
+                  // this will happen anyway then on leader replay
+                  .forEach(
+                      entry -> {
+                        final var column = entry.getKey();
+                        final var processingEntries = entry.getValue();
+                        final var replayEntries = replayState.get(column);
+
+                        if (processingEntries.isEmpty()) {
+                          softly
+                              .assertThat(replayEntries)
+                              .describedAs(
+                                  "The state column '%s' should be empty after replay", column)
+                              .isEmpty();
+                        } else {
+                          softly
+                              .assertThat(replayEntries)
+                              .describedAs(
+                                  "The state column '%s' has different entries after replay",
+                                  column)
+                              .containsExactlyInAnyOrderEntriesOf(processingEntries);
+                        }
+                      });
+
+              softly.assertAll();
+            });
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorReplayModeTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorReplayModeTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+import static io.camunda.zeebe.engine.util.RecordToWrite.command;
+import static io.camunda.zeebe.engine.util.RecordToWrite.event;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor.Phase;
+import io.camunda.zeebe.engine.state.EventApplier;
+import io.camunda.zeebe.engine.util.Records;
+import io.camunda.zeebe.engine.util.StreamProcessorRule;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.verification.VerificationWithTimeout;
+
+public final class StreamProcessorReplayModeTest {
+
+  private static final long TIMEOUT_MILLIS = 2_000L;
+  private static final VerificationWithTimeout TIMEOUT = timeout(TIMEOUT_MILLIS);
+
+  private static final int PARTITION_ID = 1;
+
+  private static final ProcessInstanceRecord RECORD = Records.processInstance(1);
+
+  @Rule
+  public final StreamProcessorRule replayUntilEnd =
+      new StreamProcessorRule(PARTITION_ID).withReplayMode(ReplayMode.UNTIL_END);
+
+  @Rule
+  public final StreamProcessorRule replayContinuously =
+      new StreamProcessorRule(PARTITION_ID).withReplayMode(ReplayMode.CONTINUOUSLY);
+
+  @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock private TypedRecordProcessor<?> typedRecordProcessor;
+  @Mock private EventApplier eventApplier;
+
+  @Test
+  public void shouldReplayUntilEnd() {
+    // given
+    replayUntilEnd.writeBatch(
+        command().processInstance(ACTIVATE_ELEMENT, RECORD),
+        event().processInstance(ELEMENT_ACTIVATING, RECORD).causedBy(0));
+
+    // when
+    startStreamProcessor(replayUntilEnd);
+
+    replayUntilEnd.writeBatch(
+        command().processInstance(ACTIVATE_ELEMENT, RECORD),
+        event().processInstance(ELEMENT_ACTIVATING, RECORD).causedBy(0));
+
+    // then
+    final InOrder inOrder = inOrder(typedRecordProcessor, eventApplier);
+    inOrder.verify(eventApplier, TIMEOUT).applyState(anyLong(), eq(ELEMENT_ACTIVATING), any());
+    inOrder.verify(typedRecordProcessor, TIMEOUT.times(1)).onRecovered(any());
+    inOrder
+        .verify(typedRecordProcessor, TIMEOUT)
+        .processRecord(anyLong(), any(), any(), any(), any());
+    inOrder.verifyNoMoreInteractions();
+
+    assertThat(getCurrentPhase(replayUntilEnd)).isEqualTo(Phase.PROCESSING);
+  }
+
+  @Test
+  public void shouldReplayContinuously() {
+    // given
+    replayContinuously.writeBatch(
+        command().processInstance(ACTIVATE_ELEMENT, RECORD),
+        event().processInstance(ELEMENT_ACTIVATING, RECORD).causedBy(0));
+
+    // when
+    startStreamProcessor(replayContinuously);
+
+    replayContinuously.writeBatch(
+        command().processInstance(ACTIVATE_ELEMENT, RECORD),
+        event().processInstance(ELEMENT_ACTIVATING, RECORD).causedBy(0));
+
+    // then
+    final InOrder inOrder = inOrder(typedRecordProcessor, eventApplier);
+    inOrder
+        .verify(eventApplier, TIMEOUT.times(2))
+        .applyState(anyLong(), eq(ELEMENT_ACTIVATING), any());
+    inOrder.verify(typedRecordProcessor, never()).onRecovered(any());
+    inOrder.verifyNoMoreInteractions();
+
+    assertThat(getCurrentPhase(replayContinuously)).isEqualTo(Phase.REPROCESSING);
+  }
+
+  private void startStreamProcessor(final StreamProcessorRule streamProcessorRule) {
+    streamProcessorRule
+        .withEventApplierFactory(zeebeState -> eventApplier)
+        .startTypedStreamProcessor(
+            (processors, context) ->
+                processors.onCommand(
+                    ValueType.PROCESS_INSTANCE, ACTIVATE_ELEMENT, typedRecordProcessor));
+  }
+
+  private Phase getCurrentPhase(final StreamProcessorRule streamProcessorRule) {
+    return streamProcessorRule.getStreamProcessor(PARTITION_ID).getCurrentPhase().join();
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -101,7 +101,6 @@ public final class EngineRule extends ExternalResource {
       new Int2ObjectHashMap<>();
 
   private long lastProcessedPosition = -1L;
-  private ReplayMode replayMode;
 
   private EngineRule(final int partitionCount) {
     this(partitionCount, null);
@@ -176,7 +175,7 @@ public final class EngineRule extends ExternalResource {
   }
 
   public EngineRule withReplayMode(final ReplayMode replayMode) {
-    this.replayMode = replayMode;
+    environmentRule.withReplayMode(replayMode);
     return this;
   }
 
@@ -194,7 +193,6 @@ public final class EngineRule extends ExternalResource {
               (processingContext) ->
                   EngineProcessors.createEngineProcessors(
                           processingContext
-                              .replayMode(replayMode)
                               .onProcessedListener(
                                   record -> {
                                     lastProcessedPosition = record.getPosition();

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ListLogStorage.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ListLogStorage.java
@@ -51,14 +51,14 @@ public class ListLogStorage implements LogStorage {
       final ByteBuffer blockBuffer,
       final AppendListener listener) {
     try {
-      final var entry = new Entry(lowestPosition, highestPosition, blockBuffer);
+      final var entry = new Entry(blockBuffer);
       entries.add(entry);
       final var index = entries.size();
       positionIndexMapping.put(lowestPosition, index);
       listener.onWrite(index);
 
       if (positionListener != null) {
-        positionListener.accept(entry.getHighestPosition());
+        positionListener.accept(highestPosition);
       }
       listener.onCommit(index);
       commitListeners.forEach(CommitListener::onCommit);
@@ -78,22 +78,10 @@ public class ListLogStorage implements LogStorage {
   }
 
   private static final class Entry {
-    private final long lowestPosition;
-    private final long highestPosition;
     private final ByteBuffer data;
 
-    public Entry(final long lowestPosition, final long highestPosition, final ByteBuffer data) {
-      this.lowestPosition = lowestPosition;
-      this.highestPosition = highestPosition;
+    public Entry(final ByteBuffer data) {
       this.data = data;
-    }
-
-    public long getLowestPosition() {
-      return lowestPosition;
-    }
-
-    public long getHighestPosition() {
-      return highestPosition;
     }
 
     public ByteBuffer getData() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.util;
 import static io.camunda.zeebe.engine.util.StreamProcessingComposite.getLogName;
 
 import io.camunda.zeebe.db.ZeebeDbFactory;
+import io.camunda.zeebe.engine.processing.streamprocessor.ReplayMode;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
@@ -64,6 +65,7 @@ public final class StreamProcessorRule implements TestRule {
   private TestStreams streams;
   private StreamProcessingComposite streamProcessingComposite;
   private ListLogStorage sharedStorage = null;
+  private ReplayMode replayMode = ReplayMode.UNTIL_END;
 
   public StreamProcessorRule() {
     this(new TemporaryFolder());
@@ -122,6 +124,11 @@ public final class StreamProcessorRule implements TestRule {
   public StreamProcessorRule withEventApplierFactory(
       final Function<MutableZeebeState, EventApplier> eventApplierFactory) {
     streams.withEventApplierFactory(eventApplierFactory);
+    return this;
+  }
+
+  public StreamProcessorRule withReplayMode(final ReplayMode replayMode) {
+    this.replayMode = replayMode;
     return this;
   }
 
@@ -317,6 +324,7 @@ public final class StreamProcessorRule implements TestRule {
     @Override
     protected void before() {
       streams = new TestStreams(tempFolder, closeables, actorSchedulerRule.get());
+      streams.withReplayMode(replayMode);
 
       int partitionId = startPartitionId;
       for (int i = 0; i < partitionCount; i++) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -85,9 +85,9 @@ public final class StreamProcessorRule implements TestRule {
       final int startPartitionId,
       final int partitionCount,
       final ZeebeDbFactory dbFactory,
-      final ListLogStorage listLogStorage) {
+      final ListLogStorage sharedStorage) {
     this(startPartitionId, partitionCount, dbFactory, new TemporaryFolder());
-    sharedStorage = listLogStorage;
+    this.sharedStorage = sharedStorage;
   }
 
   public StreamProcessorRule(

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbFactory;
+import io.camunda.zeebe.engine.processing.streamprocessor.ReplayMode;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedEventRegistry;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
@@ -79,6 +80,7 @@ public final class TestStreams {
   private boolean snapshotWasTaken = false;
 
   private Function<MutableZeebeState, EventApplier> eventApplierFactory = EventAppliers::new;
+  private ReplayMode replayMode = ReplayMode.UNTIL_END;
 
   public TestStreams(
       final TemporaryFolder dataDirectory,
@@ -105,6 +107,10 @@ public final class TestStreams {
   public void withEventApplierFactory(
       final Function<MutableZeebeState, EventApplier> eventApplierFactory) {
     this.eventApplierFactory = eventApplierFactory;
+  }
+
+  public void withReplayMode(final ReplayMode replayMode) {
+    this.replayMode = replayMode;
   }
 
   public CommandResponseWriter getMockedResponseWriter() {
@@ -252,6 +258,7 @@ public final class TestStreams {
             .onProcessedListener(mockOnProcessedListener)
             .streamProcessorFactory(factory)
             .eventApplierFactory(eventApplierFactory)
+            .replayMode(replayMode)
             .build();
     final var openFuture = streamProcessor.openAsync(false);
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -129,12 +129,12 @@ public final class TestStreams {
   }
 
   public SynchronousLogStream createLogStream(
-      final String name, final int partitionId, final ListLogStorage listLogStorage) {
+      final String name, final int partitionId, final ListLogStorage sharedStorage) {
     return createLogStream(
         name,
         partitionId,
-        listLogStorage,
-        logStream -> listLogStorage.setPositionListener(logStream::setLastWrittenPosition));
+        sharedStorage,
+        logStream -> sharedStorage.setPositionListener(logStream::setLastWrittenPosition));
   }
 
   private SynchronousLogStream createLogStream(


### PR DESCRIPTION
## Description

 * Add different replay mode on StreamProcessorBuilder, in order to create processor in different modes
 * Adds support for continuously replay mode on the StreamProcessor and ReplayStateMachine
 * Add simple test which verifies that same state is created on replay and processing

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7457 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
