### PR TITLE
Ensure journal segments are durably created

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/file/JournalSegment.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/JournalSegment.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.journal.JournalException;
 import java.io.IOException;
 import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
-import java.nio.channels.FileChannel.MapMode;
 import java.nio.file.Files;
 import java.util.Set;
 import org.agrona.IoUtil;
@@ -49,15 +48,14 @@ class JournalSegment implements AutoCloseable {
   public JournalSegment(
       final JournalSegmentFile file,
       final JournalSegmentDescriptor descriptor,
+      final MappedByteBuffer buffer,
       final long maxWrittenIndex,
-      final JournalIndex journalIndex) {
+      final JournalIndex index) {
     this.file = file;
     this.descriptor = descriptor;
-    index = journalIndex;
-    buffer =
-        IoUtil.mapExistingFile(
-            file.file(), MapMode.READ_WRITE, file.name(), 0, descriptor.maxSegmentSize());
-    buffer.order(ENDIANNESS);
+    this.buffer = buffer;
+    this.index = index;
+
     writer = createWriter(maxWrittenIndex);
   }
 

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.channels.FileChannel;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -502,14 +501,10 @@ public final class FileBasedSnapshotStore extends Actor
   private void tryAtomicDirectoryMove(final Path directory, final Path destination)
       throws IOException {
     try {
-      Files.move(directory, destination, StandardCopyOption.ATOMIC_MOVE);
+      FileUtil.moveDurably(directory, destination, StandardCopyOption.ATOMIC_MOVE);
     } catch (final AtomicMoveNotSupportedException e) {
-      LOGGER.warn("Atomic move not supported. Moving the snapshot files non-atomically.");
-      Files.move(directory, destination);
-    }
-
-    try (var channel = FileChannel.open(destination)) {
-      channel.force(true);
+      LOGGER.warn("Atomic move not supported. Moving the snapshot files non-atomically", e);
+      FileUtil.moveDurably(directory, destination);
     }
   }
 


### PR DESCRIPTION
## Description

This PR fixes an edge case where a segment may be created, and flushed to disc, but on crash recovery its directory entry was not flushed and as such the file is not visible to the file system. The data is on disc, but not directly accessible, resulting in us effectively "missing" data in a way that is most likely not detectable. 

Unfortunately I wasn't sure how to reproduce this case in a reliable fashion, and as such there's no test for it. Part of the PR is also cleaning up a bit how we create segment. Next steps are outlined in https://github.com/camunda-cloud/zeebe/issues/6221#issuecomment-879810357, but I thought it was out of scope here (e.g. extract the loading/creating segment logic into a specific class, extract the descriptor serialization/deserialization, etc.).

I recommend reviewing commit by commit since I also explain the changes I did in these commits.

## Related issues

closes #7158 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
