### PR TITLE
feat(bpmn elements): allow conversion of BpmnElementTypes back to String

### DIFF
--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BpmnElementType.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BpmnElementType.java
@@ -15,82 +15,65 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import java.util.Arrays;
+import java.util.Optional;
+
 public enum BpmnElementType {
 
   // Default
-  UNSPECIFIED,
+  UNSPECIFIED(null),
 
   // Containers
-  PROCESS,
-  SUB_PROCESS,
-  EVENT_SUB_PROCESS,
+  PROCESS("process"),
+  SUB_PROCESS("subProcess"),
+  EVENT_SUB_PROCESS(null),
 
   // Events
-  START_EVENT,
-  INTERMEDIATE_CATCH_EVENT,
-  BOUNDARY_EVENT,
-  END_EVENT,
+  START_EVENT("startEvent"),
+  INTERMEDIATE_CATCH_EVENT("intermediateCatchEvent"),
+  BOUNDARY_EVENT("boundaryEvent"),
+  END_EVENT("endEvent"),
 
   // Tasks
-  SERVICE_TASK,
-  RECEIVE_TASK,
-  USER_TASK,
+  SERVICE_TASK("serviceTask"),
+  RECEIVE_TASK("receiveTask"),
+  USER_TASK("userTask"),
 
   // Gateways
-  EXCLUSIVE_GATEWAY,
-  PARALLEL_GATEWAY,
-  EVENT_BASED_GATEWAY,
+  EXCLUSIVE_GATEWAY("exclusiveGateway"),
+  PARALLEL_GATEWAY("parallelGateway"),
+  EVENT_BASED_GATEWAY("eventBasedGateway"),
 
   // Other
-  SEQUENCE_FLOW,
-  MULTI_INSTANCE_BODY,
-  CALL_ACTIVITY,
+  SEQUENCE_FLOW("sequenceFlow"),
+  MULTI_INSTANCE_BODY(null),
+  CALL_ACTIVITY("callActivity"),
 
   // TODO (saig0): remove element type for testing - #6202
-  TESTING_ONLY,
+  TESTING_ONLY(null),
 
-  BUSINESS_RULE_TASK,
-  SCRIPT_TASK,
-  SEND_TASK;
+  BUSINESS_RULE_TASK("businessRuleTask"),
+  SCRIPT_TASK("scriptTask"),
+  SEND_TASK("sendTask");
+
+  private final String elementTypeName;
+
+  BpmnElementType(final String elementTypeName) {
+    this.elementTypeName = elementTypeName;
+  }
+
+  public Optional<String> getElementTypeName() {
+    return Optional.of(elementTypeName);
+  }
 
   public static BpmnElementType bpmnElementTypeFor(final String elementTypeName) {
-    switch (elementTypeName) {
-      case "process":
-        return BpmnElementType.PROCESS;
-      case "subProcess":
-        return BpmnElementType.SUB_PROCESS;
-      case "startEvent":
-        return BpmnElementType.START_EVENT;
-      case "intermediateCatchEvent":
-        return BpmnElementType.INTERMEDIATE_CATCH_EVENT;
-      case "boundaryEvent":
-        return BpmnElementType.BOUNDARY_EVENT;
-      case "endEvent":
-        return BpmnElementType.END_EVENT;
-      case "serviceTask":
-        return BpmnElementType.SERVICE_TASK;
-      case "receiveTask":
-        return BpmnElementType.RECEIVE_TASK;
-      case "exclusiveGateway":
-        return BpmnElementType.EXCLUSIVE_GATEWAY;
-      case "eventBasedGateway":
-        return BpmnElementType.EVENT_BASED_GATEWAY;
-      case "parallelGateway":
-        return BpmnElementType.PARALLEL_GATEWAY;
-      case "sequenceFlow":
-        return BpmnElementType.SEQUENCE_FLOW;
-      case "callActivity":
-        return BpmnElementType.CALL_ACTIVITY;
-      case "userTask":
-        return BpmnElementType.USER_TASK;
-      case "businessRuleTask":
-        return BpmnElementType.BUSINESS_RULE_TASK;
-      case "scriptTask":
-        return BpmnElementType.SCRIPT_TASK;
-      case "sendTask":
-        return BpmnElementType.SEND_TASK;
-      default:
-        throw new RuntimeException("Unsupported BPMN element of type " + elementTypeName);
-    }
+    return Arrays.stream(values())
+        .filter(
+            bpmnElementType ->
+                bpmnElementType.elementTypeName != null
+                    && bpmnElementType.elementTypeName.equals(elementTypeName))
+        .findFirst()
+        .orElseThrow(
+            () -> new RuntimeException("Unsupported BPMN element of type " + elementTypeName));
   }
 }


### PR DESCRIPTION
Returns the optional BpmnModelConstant String representation of each BpmnElementType to allow Optimize to convert them to compatible types consistent with their model constant

## Description

closes #7506

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
