### PR TITLE
Allow zbctl errors in Jenkins QA

### DIFF
--- a/.ci/scripts/distribution/qa-testbench.sh
+++ b/.ci/scripts/distribution/qa-testbench.sh
@@ -12,7 +12,8 @@ echo "Waiting for result of $businessKey"
 jobKey=""
 
 while true; do
-    "${zbctl}" activate jobs "$businessKey" > activationresponse.txt 2>/dev/null
+    # activate jobs non-zero exits can be ignored with `<command> || true`
+    "${zbctl}" activate jobs "$businessKey" > activationresponse.txt 2>/dev/null || true
     jobKey=$(jq -r '.jobs[0].key' < activationresponse.txt)
 
     if [[ -z "$jobKey" || "$jobKey" == "null" ]]; then


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Any error (including common problems like connection issues) in zbctl
result in a non-zero exit code. This resulted in the QA step of Jenkins
prematurely stopping with a FAILURE. However, it was just checking
whether testbench had already completed.

This change uses `<command> || true` to avoid stopping the process on a
non-zero exit code (due to running bash with -e flag).

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7521 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
