### PR TITLE
chore(go/zbctl): edit help text

### DIFF
--- a/clients/go/cmd/zbctl/internal/commands/root.go
+++ b/clients/go/cmd/zbctl/internal/commands/root.go
@@ -46,7 +46,7 @@ var clientCacheFlag string
 var rootCmd = &cobra.Command{
 	Use:   "zbctl",
 	Short: "zeebe command line interface",
-	Long: `zbctl is command line interface designed to create and read resources inside zeebe broker.
+	Long: `zbctl is a command line interface designed to create and read resources inside zeebe broker.
 It is designed for regular maintenance jobs such as:
 	* deploying processes,
 	* creating jobs and process instances

--- a/clients/go/cmd/zbctl/testdata/help.golden
+++ b/clients/go/cmd/zbctl/testdata/help.golden
@@ -1,4 +1,4 @@
-zbctl is command line interface designed to create and read resources inside zeebe broker.
+zbctl is a command line interface designed to create and read resources inside zeebe broker.
 It is designed for regular maintenance jobs such as:
 	* deploying processes,
 	* creating jobs and process instances


### PR DESCRIPTION
## Description

Small edit to the help text of `zbctl`: `zbctl is command line interface` -> `zbctl is a command line interface`.
