### PR TITLE
Move topology manager into partition manager

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/PartitionCommandSenderImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/PartitionCommandSenderImpl.java
@@ -9,11 +9,12 @@ package io.camunda.zeebe.broker.engine.impl;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
-import io.camunda.zeebe.broker.partitioning.topology.TopologyManager;
+import io.camunda.zeebe.broker.partitioning.topology.TopologyPartitionListener;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyPartitionListenerImpl;
 import io.camunda.zeebe.engine.processing.message.command.PartitionCommandSender;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.camunda.zeebe.util.sched.ActorControl;
+import java.util.function.Consumer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Int2IntHashMap;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -26,11 +27,11 @@ public final class PartitionCommandSenderImpl implements PartitionCommandSender 
 
   public PartitionCommandSenderImpl(
       final ClusterCommunicationService communicationService,
-      final TopologyManager topologyManager,
+      final Consumer<TopologyPartitionListener> partitionListenerConsumer,
       final ActorControl actor) {
     this.communicationService = communicationService;
     partitionListener = new TopologyPartitionListenerImpl(actor);
-    topologyManager.addTopologyPartitionListener(partitionListener);
+    partitionListenerConsumer.accept(partitionListener);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerFactory.java
@@ -15,8 +15,10 @@ import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
 import io.camunda.zeebe.broker.system.configuration.DataCfg;
 import io.camunda.zeebe.broker.system.configuration.NetworkCfg;
 import io.camunda.zeebe.logstreams.impl.log.ZeebeEntryValidator;
+import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStoreFactory;
 import io.camunda.zeebe.util.FileUtil;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Paths;
@@ -28,13 +30,17 @@ public class PartitionManagerFactory {
   public static final String GROUP_NAME = "raft-partition";
 
   public static PartitionManagerImpl fromBrokerConfiguration(
+      final ActorSchedulingService actorSchedulingService,
       final BrokerCfg configuration,
+      final BrokerInfo localBroker,
       final ClusterServices clusterServices,
       final ReceivableSnapshotStoreFactory snapshotStoreFactory) {
 
     final var partitionGroup = buildRaftPartitionGroup(configuration, snapshotStoreFactory);
 
     return new PartitionManagerImpl(
+        actorSchedulingService,
+        localBroker,
         partitionGroup,
         clusterServices.getMembershipService(),
         clusterServices.getCommunicationService());

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -14,23 +14,41 @@ import io.atomix.primitive.partition.ManagedPartitionService;
 import io.atomix.primitive.partition.impl.DefaultPartitionService;
 import io.atomix.raft.partition.RaftPartitionGroup;
 import io.atomix.utils.concurrent.Futures;
+import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.partitioning.topology.TopologyManager;
+import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
+import io.camunda.zeebe.broker.partitioning.topology.TopologyPartitionListener;
+import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.camunda.zeebe.util.health.HealthStatus;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
-public final class PartitionManagerImpl implements PartitionManager {
+public final class PartitionManagerImpl
+    implements PartitionManager, TopologyManager, PartitionListener {
 
   protected volatile CompletableFuture<Void> closeFuture;
+  private final ActorSchedulingService actorSchedulingService;
   private ManagedPartitionService partitions;
   private ManagedPartitionGroup partitionGroup;
+  private TopologyManagerImpl topologyManager;
 
   public PartitionManagerImpl(
+      final ActorSchedulingService actorSchedulingService,
+      final BrokerInfo localBroker,
       final RaftPartitionGroup partitionGroup,
       final ClusterMembershipService membershipService,
       final ClusterCommunicationService communicationService) {
 
+    this.actorSchedulingService = actorSchedulingService;
+
     this.partitionGroup = Objects.requireNonNull(partitionGroup);
 
     partitions = buildPartitionService(membershipService, communicationService);
+
+    topologyManager = new TopologyManagerImpl(membershipService, localBroker);
   }
 
   @Override
@@ -45,6 +63,8 @@ public final class PartitionManagerImpl implements PartitionManager {
               "Atomix instance " + (closeFuture.isDone() ? "shutdown" : "shutting down")));
     }
 
+    actorSchedulingService.submitActor(topologyManager);
+
     return partitions.start().thenApply(ps -> null);
   }
 
@@ -58,6 +78,8 @@ public final class PartitionManagerImpl implements PartitionManager {
                     synchronized (this) {
                       partitionGroup = null;
                       partitions = null;
+                      topologyManager.close();
+                      topologyManager = null;
                     }
                     return null;
                   });
@@ -77,5 +99,35 @@ public final class PartitionManagerImpl implements PartitionManager {
   @Override
   public String toString() {
     return "PartitionManagerImpl{" + "partitionGroup=" + partitionGroup + '}';
+  }
+
+  @Override
+  public ActorFuture<Void> onBecomingFollower(final int partitionId, final long term) {
+    return topologyManager.onBecomingFollower(partitionId, term);
+  }
+
+  @Override
+  public ActorFuture<Void> onBecomingLeader(
+      final int partitionId, final long term, final LogStream logStream) {
+    return topologyManager.onBecomingLeader(partitionId, term, logStream);
+  }
+
+  @Override
+  public ActorFuture<Void> onBecomingInactive(final int partitionId, final long term) {
+    return topologyManager.onBecomingInactive(partitionId, term);
+  }
+
+  public void onHealthChanged(final int i, final HealthStatus healthStatus) {
+    topologyManager.onHealthChanged(i, healthStatus);
+  }
+
+  @Override
+  public void removeTopologyPartitionListener(final TopologyPartitionListener listener) {
+    topologyManager.removeTopologyPartitionListener(listener);
+  }
+
+  @Override
+  public void addTopologyPartitionListener(final TopologyPartitionListener listener) {
+    topologyManager.addTopologyPartitionListener(listener);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -14,11 +14,9 @@ import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.Member;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.PartitionListener;
-import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.util.LogUtil;
-import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.health.HealthStatus;
 import io.camunda.zeebe.util.sched.Actor;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
@@ -41,20 +39,9 @@ public final class TopologyManagerImpl extends Actor
   private final String actorName;
 
   public TopologyManagerImpl(
-      final ClusterMembershipService membershipService,
-      final BrokerInfo localBroker,
-      final ClusterCfg clusterCfg) {
+      final ClusterMembershipService membershipService, final BrokerInfo localBroker) {
     this.membershipService = membershipService;
     this.localBroker = localBroker;
-    localBroker
-        .setClusterSize(clusterCfg.getClusterSize())
-        .setPartitionsCount(clusterCfg.getPartitionsCount())
-        .setReplicationFactor(clusterCfg.getReplicationFactor());
-
-    final String version = VersionUtil.getVersion();
-    if (version != null && !version.isBlank()) {
-      localBroker.setVersion(version);
-    }
 
     actorName = buildActorName(localBroker.getNodeId(), "TopologyManager");
   }

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionManagerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionManagerTest.java
@@ -13,8 +13,10 @@ import static org.mockito.Mockito.mock;
 import io.atomix.raft.partition.RaftPartitionGroupConfig;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
 import io.camunda.zeebe.util.Environment;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,7 +40,9 @@ public final class PartitionManagerTest {
     // when
     final var partitionManager =
         PartitionManagerFactory.fromBrokerConfiguration(
+            mock(ActorSchedulingService.class),
             brokerConfig,
+            new BrokerInfo(1, "dummy"),
             mock(ClusterServicesImpl.class),
             mock(FileBasedSnapshotStoreFactory.class));
 
@@ -56,7 +60,9 @@ public final class PartitionManagerTest {
     // when
     final var partitionManager =
         PartitionManagerFactory.fromBrokerConfiguration(
+            mock(ActorSchedulingService.class),
             brokerConfig,
+            new BrokerInfo(1, "dummy"),
             mock(ClusterServicesImpl.class),
             mock(FileBasedSnapshotStoreFactory.class));
     // then

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftRolesTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftRolesTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.cluster.AtomixClusterBuilder;
@@ -21,6 +22,8 @@ import io.atomix.raft.RaftServer;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.atomix.raft.partition.RaftPartitionGroup;
+import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -277,7 +280,11 @@ public final class RaftRolesTest {
 
       final var partitionManager =
           new PartitionManagerImpl(
-              partitionGroup, atomix.getMembershipService(), atomix.getCommunicationService());
+              mock(ActorSchedulingService.class),
+              new BrokerInfo(0, "dummy"),
+              partitionGroup,
+              atomix.getMembershipService(),
+              atomix.getCommunicationService());
 
       partitionManager.getPartitionGroup().getPartitions().forEach(partitionConsumer);
 


### PR DESCRIPTION
## Description

This moves the `TopologyManager` inside the `PartitionManager`

This is part of a major refactoring of the bootstrapping processes. This refactoring aims at making the bootstrapping easier to understand and change. Part of the effort is to untangle complex sequences and dependencies between different components, by increasing cohesion within components.

The topology manager is such a case in point. Currently, it is a standalone component. Most of the dependencies are related to partitions.

In the future, the partition manager shall serve as the central hub for anything related to partition. Both local partitions on the same node, as well as, a way to talk to remote partitions on other nodes. Therefor, it make sens to move the topology manager into the partition manager. In doing that, it also simplifies the dependency graph.

## Related issues

closes #7564

<!-- Cut-off marker
## Definition of Ready
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)