### PR TITLE
Cancel request if messaging service is not running

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingService.java
@@ -199,4 +199,11 @@ public interface MessagingService {
    * @param type message type
    */
   void unregisterHandler(String type);
+
+  /**
+   * Returns a boolean value indicating whether the managed object is running.
+   *
+   * @return Indicates whether the managed object is running.
+   */
+  boolean isRunning();
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixClientTransportAdapter.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixClientTransportAdapter.java
@@ -98,6 +98,15 @@ public final class AtomixClientTransportAdapter extends Actor implements ClientT
       return;
     }
 
+    if (!messagingService.isRunning()) {
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Messaging service is not running.");
+      }
+      requestContext.completeExceptionally(
+          new IllegalStateException("Messaging service is not running."));
+      return;
+    }
+
     final var calculateTimeout = requestContext.calculateTimeout();
     if (calculateTimeout.toMillis() <= 0L) {
       if (LOG.isTraceEnabled()) {


### PR DESCRIPTION
## Description

This change completes the request exceptionally if the messaging service is not running

## Related issues

closes #7026

<!-- Cut-off marker

## Definition of Ready
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
