### PR TITLE
Defer deleting journal segments to ensure safe concurrent access

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
@@ -73,6 +73,9 @@ public interface Journal extends AutoCloseable {
    * Delete all records in the journal and reset the next index to nextIndex. The following calls to
    * {@link Journal#append(long, DirectBuffer)} will append at index nextIndex.
    *
+   * <p>After this operation, all readers must be reset explicitly. The readers that are not reset
+   * will return false for {@link JournalReader#hasNext()}, cannot read any record.
+   *
    * @param nextIndex the next index of the journal.
    */
   void reset(long nextIndex);

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/JournalSegment.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/JournalSegment.java
@@ -217,6 +217,9 @@ class JournalSegment implements AutoCloseable {
   }
 
   private void markForDeletion() {
+    if (markedForDeletion) {
+      return;
+    }
     writer.close();
     final var target = file.getFileMarkedForDeletion();
     try {

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/JournalSegment.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/JournalSegment.java
@@ -145,8 +145,11 @@ class JournalSegment implements AutoCloseable {
    */
   MappedJournalSegmentReader createReader() {
     checkOpen();
-    return new MappedJournalSegmentReader(
-        buffer.asReadOnlyBuffer().position(0).order(ENDIANNESS), this, index);
+    final MappedJournalSegmentReader reader =
+        new MappedJournalSegmentReader(
+            buffer.asReadOnlyBuffer().position(0).order(ENDIANNESS), this, index);
+    readers.add(reader);
+    return reader;
   }
 
   private MappedJournalSegmentWriter createWriter(final long lastWrittenIndex) {

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/JournalSegment.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/JournalSegment.java
@@ -230,6 +230,7 @@ class JournalSegment implements AutoCloseable {
     if (markedForDeletion) {
       return;
     }
+
     writer.close();
     final var target = file.getFileMarkedForDeletion();
     try {

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/MappedJournalSegmentReader.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/MappedJournalSegmentReader.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.zeebe.journal.file;
 
+import com.google.common.base.Preconditions;
 import io.camunda.zeebe.journal.JournalRecord;
 import io.camunda.zeebe.journal.file.record.JournalRecordReaderUtil;
 import io.camunda.zeebe.journal.file.record.SBESerializer;
@@ -43,11 +44,18 @@ class MappedJournalSegmentReader {
   }
 
   public boolean hasNext() {
+    checkSegmentOpen();
     // if the next entry exists the version would be non-zero
     return FrameUtil.hasValidVersion(buffer);
   }
 
+  private void checkSegmentOpen() {
+    Preconditions.checkState(
+        segment.isOpen(), "Segment is already closed. Reader must reset to a valid index.");
+  }
+
   public JournalRecord next() {
+    checkSegmentOpen();
     if (!hasNext()) {
       throw new NoSuchElementException();
     }
@@ -62,11 +70,13 @@ class MappedJournalSegmentReader {
   }
 
   public void reset() {
+    checkSegmentOpen();
     buffer.position(descriptorLength);
     currentIndex = segment.index() - 1;
   }
 
   public void seek(final long index) {
+    checkSegmentOpen();
     final long firstIndex = segment.index();
     final long lastIndex = segment.lastIndex();
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -529,21 +529,22 @@ public final class SegmentedJournal implements Journal {
         Files.newDirectoryStream(
             directory.toPath(),
             path -> JournalSegmentFile.isDeletedSegmentFile(name, path.getFileName().toString()))) {
-      segmentsToDelete.forEach(
-          segmentFileToDelete -> {
-            try {
-              Files.deleteIfExists(segmentFileToDelete);
-            } catch (final IOException e) {
-              log.warn(
-                  "Could not delete file {} which is marked for deletion. This can result in unnecessary disk usage.",
-                  segmentFileToDelete,
-                  e);
-            }
-          });
+      segmentsToDelete.forEach(this::deleteDeferredFile);
     } catch (final IOException e) {
       log.warn(
           "Could not delete segment files marked for deletion in {}. This can result in unnecessary disk usage.",
           directory.toPath(),
+          e);
+    }
+  }
+
+  private void deleteDeferredFile(final Path segmentFileToDelete) {
+    try {
+      Files.deleteIfExists(segmentFileToDelete);
+    } catch (final IOException e) {
+      log.warn(
+          "Could not delete file {} which is marked for deletion. This can result in unnecessary disk usage.",
+          segmentFileToDelete,
           e);
     }
   }

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/JournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/JournalTest.java
@@ -191,7 +191,7 @@ class JournalTest {
   }
 
   @Test
-  void shouldResetWhileReading() {
+  void shouldThrowExceptionWhenResetWhileReading() {
     // given
     final var reader = journal.openReader();
     long asqn = 1;
@@ -210,10 +210,7 @@ class JournalTest {
     assertThat(record.index()).isEqualTo(2);
 
     // then
-    assertThat(reader.hasNext()).isTrue();
-    final var record2 = reader.next();
-    assertThat(record2.index()).isEqualTo(2);
-    assertThat(record2.asqn()).isEqualTo(record.asqn());
+    assertThatThrownBy(() -> reader.hasNext()).isInstanceOf(IllegalStateException.class);
   }
 
   @Test

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/JournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/JournalTest.java
@@ -191,7 +191,7 @@ class JournalTest {
   }
 
   @Test
-  void shouldThrowExceptionWhenResetWhileReading() {
+  void shouldNotReadAfterJournalResetWithoutReaderReset() {
     // given
     final var reader = journal.openReader();
     long asqn = 1;
@@ -203,14 +203,10 @@ class JournalTest {
 
     // when
     journal.reset(2);
+    journal.append(asqn++, data);
 
     // then
-    assertThat(journal.getLastIndex()).isEqualTo(1);
-    final var record = journal.append(asqn, data);
-    assertThat(record.index()).isEqualTo(2);
-
-    // then
-    assertThatThrownBy(() -> reader.hasNext()).isInstanceOf(IllegalStateException.class);
+    assertThat(reader.hasNext()).isFalse();
   }
 
   @Test

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
@@ -108,6 +108,35 @@ class SegmentedJournalReaderTest {
     }
   }
 
+  @Test
+  void shouldNotReadWhenAccessingDeletedSegment() {
+    // given
+    journal.append(data);
+    final var reader = journal.openReader();
+
+    // when
+    journal.reset(100);
+
+    // then
+    assertThat(reader.hasNext()).isFalse();
+  }
+
+  @Test
+  void shouldReadAfterReset() {
+    // given
+    journal.append(data);
+    final var reader = journal.openReader();
+    final int resetIndex = 100;
+    journal.reset(resetIndex);
+    journal.append(data);
+
+    // when
+    reader.seekToFirst();
+
+    // then
+    assertThat(reader.next().index()).isEqualTo(resetIndex);
+  }
+
   private int getSerializedSize(final DirectBuffer data) {
     final var record = new RecordData(Long.MAX_VALUE, Long.MAX_VALUE, data);
     final var serializer = new SBESerializer();

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -540,18 +540,6 @@ class SegmentedJournalTest {
   }
 
   @Test
-  void shouldReaderThrowExceptionWhenAccessingDeletedSegment() {
-    // given
-    final var journal = openJournal(2);
-    journal.append(data);
-    final var reader = journal.openReader();
-    journal.reset(100);
-
-    // when - then
-    assertThatThrownBy(reader::next).isInstanceOf(IllegalStateException.class);
-  }
-
-  @Test
   void shouldBeAbleToResetAgainWhileThePreviousFileIsNotDeleted() {
     // given
     final var journal = openJournal(2);

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -500,6 +500,24 @@ class SegmentedJournalTest {
   }
 
   @Test
+  void shouldDeleteSegmentFileImmediatelyWhenThereAreNoReaders() {
+    // given
+    final var journal = openJournal(2);
+    journal.append(data);
+
+    // when
+    journal.reset(100);
+
+    // then
+    final File logDirectory = directory.resolve("data").toFile();
+    assertThat(logDirectory)
+        .isDirectoryNotContaining(
+            file -> JournalSegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
+        .isDirectoryContaining(
+            file -> JournalSegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
+  }
+
+  @Test
   void shouldDeleteFilesMarkedForDeletionsOnLoad() {
     // given
     final var journal = openJournal(2);


### PR DESCRIPTION
## Description

This PR is in preparation to #7481 
When the journal is reset, StreamProcessor is concurrently reading from the deleted segments. If we unmap the segment buffer, it can lead to Segmentation fault when the reader is trying to access it. To prevent this, this PR defers the deletion of the segments until all readers are closed. This PR also removes the automatic reset of readers when the segments are deleted. 

## Related issues

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
