### PR TITLE
Allow follower to react on install requests

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/SnapshotReplicationListener.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/SnapshotReplicationListener.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import io.atomix.raft.RaftServer.Role;
+
+/**
+ * Listener which will be invoked when a new snapshot is received by this follower from a leader.
+ * When a new snapshot is received via raft replication, the log will be reset and all entries in
+ * the log is deleted and creates a new empty log. Hence any consumers of the log may have to reset
+ * its internal state so that it can start with a new log and a new snapshot.
+ *
+ * <p>The difference between this listener and {@link
+ * io.camunda.zeebe.snapshots.PersistedSnapshotListener} is that {@link
+ * io.camunda.zeebe.snapshots.PersistedSnapshotListener} notifies when a snapshot is taken locally
+ * and when a snapshot is received via replication. This listener only notifies when a snapshot is
+ * received via raft replication, which happens only when the follower's log is lagging behind the
+ * leader.
+ *
+ * <p>These listeners are invoked in the Raft thread. Hence it should not do any heavy computations.
+ * Any time consuming steps should be delegated to another thread/actor.
+ */
+public interface SnapshotReplicationListener {
+
+  /**
+   * Will be called when the snapshot receiving has started. This should close the consumers of the
+   * log.
+   */
+  void onSnapshotReplicationStarted();
+
+  /**
+   * Will be called after the snapshot replication is completed. The snapshot replication can //
+   * complete either a new snapshot is committed or the snapshot replication is aborted. // If a new
+   * snapshot has been committed, the log will be empty.
+   *
+   * @param role the current raft role of this member
+   * @param term the current term
+   */
+  void onSnapshotReplicationCompleted(Role role, long term);
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/SnapshotReplicationListener.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/SnapshotReplicationListener.java
@@ -16,8 +16,6 @@
  */
 package io.atomix.raft;
 
-import io.atomix.raft.RaftServer.Role;
-
 /**
  * Listener which will be invoked when a new snapshot is received by this follower from a leader.
  * When a new snapshot is received via raft replication, the log will be reset and all entries in
@@ -47,8 +45,7 @@ public interface SnapshotReplicationListener {
    * complete either a new snapshot is committed or the snapshot replication is aborted. // If a new
    * snapshot has been committed, the log will be empty.
    *
-   * @param role the current raft role of this member
    * @param term the current term
    */
-  void onSnapshotReplicationCompleted(Role role, long term);
+  void onSnapshotReplicationCompleted(long term);
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -455,7 +455,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   public void notifySnapshotReplicationCompleted() {
-    snapshotReplicationListeners.forEach(l -> l.onSnapshotReplicationCompleted(role.role(), term));
+    snapshotReplicationListeners.forEach(l -> l.onSnapshotReplicationCompleted(term));
   }
 
   /**

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -26,6 +26,7 @@ import io.atomix.raft.RaftCommittedEntryListener;
 import io.atomix.raft.RaftRoleChangeListener;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.RaftServer.Role;
+import io.atomix.raft.SnapshotReplicationListener;
 import io.atomix.raft.metrics.RaftStartupMetrics;
 import io.atomix.raft.partition.RaftElectionConfig;
 import io.atomix.raft.partition.RaftPartition;
@@ -255,6 +256,23 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
   /** @see io.atomix.raft.impl.RaftContext#addCommittedEntryListener(RaftCommittedEntryListener) */
   public void addCommittedEntryListener(final RaftCommittedEntryListener commitListener) {
     server.getContext().addCommittedEntryListener(commitListener);
+  }
+
+  /**
+   * @see
+   *     io.atomix.raft.impl.RaftContext#addSnapshotReplicationListener(SnapshotReplicationListener)
+   */
+  public void addSnapshotReplicationListener(final SnapshotReplicationListener logResetListener) {
+    server.getContext().addSnapshotReplicationListener(logResetListener);
+  }
+
+  /**
+   * @see
+   *     io.atomix.raft.impl.RaftContext#removeSnapshotReplicationListener(SnapshotReplicationListener)
+   */
+  public void removeSnapshotReplicationListener(
+      final SnapshotReplicationListener logResetListener) {
+    server.getContext().removeSnapshotReplicationListener(logResetListener);
   }
 
   public PersistedSnapshotStore getPersistedSnapshotStore() {

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -262,17 +262,16 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
    * @see
    *     io.atomix.raft.impl.RaftContext#addSnapshotReplicationListener(SnapshotReplicationListener)
    */
-  public void addSnapshotReplicationListener(final SnapshotReplicationListener logResetListener) {
-    server.getContext().addSnapshotReplicationListener(logResetListener);
+  public void addSnapshotReplicationListener(final SnapshotReplicationListener listener) {
+    server.getContext().addSnapshotReplicationListener(listener);
   }
 
   /**
    * @see
    *     io.atomix.raft.impl.RaftContext#removeSnapshotReplicationListener(SnapshotReplicationListener)
    */
-  public void removeSnapshotReplicationListener(
-      final SnapshotReplicationListener logResetListener) {
-    server.getContext().removeSnapshotReplicationListener(logResetListener);
+  public void removeSnapshotReplicationListener(final SnapshotReplicationListener listener) {
+    server.getContext().removeSnapshotReplicationListener(listener);
   }
 
   public PersistedSnapshotStore getPersistedSnapshotStore() {

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -51,13 +51,14 @@ import org.slf4j.Logger;
 /** Passive state. */
 public class PassiveRole extends InactiveRole {
 
-  private final SnapshotReplicationMetrics snapshotReplicationMetrics;
+  private static final Runnable NO_ONGOING_SNAPSHOT_REPLICATION = () -> {};
 
+  private final SnapshotReplicationMetrics snapshotReplicationMetrics;
   private long pendingSnapshotStartTimestamp;
   private ReceivedSnapshot pendingSnapshot;
   private PersistedSnapshotListener snapshotListener;
   private ByteBuffer nextPendingSnapshotChunkId;
-  private Runnable resetOngoingSnapshotReplication = () -> {};
+  private Runnable resetOngoingSnapshotReplication = NO_ONGOING_SNAPSHOT_REPLICATION;
 
   public PassiveRole(final RaftContext context) {
     super(context);
@@ -365,7 +366,7 @@ public class PassiveRole extends InactiveRole {
     // Listeners should be notified whether snapshot is committed or aborted. Otherwise they can
     // wait for ever.
     raft.notifySnapshotReplicationCompleted();
-    resetOngoingSnapshotReplication = () -> {};
+    resetOngoingSnapshotReplication = NO_ONGOING_SNAPSHOT_REPLICATION;
   }
 
   private void setNextExpected(final ByteBuffer nextChunkId) {

--- a/atomix/cluster/src/test/java/io/atomix/raft/SnapshotReplicationListenerTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/SnapshotReplicationListenerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+import io.atomix.raft.RaftServer.Role;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SnapshotReplicationListenerTest {
+
+  @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);
+
+  @Test
+  public void shouldNotifySnapshotReplicationListener() throws Throwable {
+    // given
+    final var snapshotReplicationListener = mock(SnapshotReplicationListener.class);
+    final var follower = raftRule.getFollower().orElseThrow();
+    follower.getContext().addSnapshotReplicationListener(snapshotReplicationListener);
+    raftRule.partition(follower);
+
+    final var commitIndex = raftRule.appendEntries(2); // awaits commit
+    final var leader = raftRule.getLeader().orElseThrow();
+    raftRule.doSnapshotOnMember(leader, commitIndex, 1);
+    raftRule.appendEntry();
+
+    // when
+    // leader appended new entries and took snapshot when the follower was disconnected. When
+    // follower reconnects, it should receive a new InstallRequest which resets the log.
+    raftRule.reconnect(follower);
+
+    // then
+    verify(snapshotReplicationListener, timeout(1000L).times(1)).onSnapshotReplicationStarted();
+    verify(snapshotReplicationListener, timeout(1000L).times(1))
+        .onSnapshotReplicationCompleted(Role.FOLLOWER, follower.getTerm());
+  }
+}

--- a/atomix/cluster/src/test/java/io/atomix/raft/SnapshotReplicationListenerTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/SnapshotReplicationListenerTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
-import io.atomix.raft.RaftServer.Role;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -48,6 +47,6 @@ public class SnapshotReplicationListenerTest {
     // then
     verify(snapshotReplicationListener, timeout(1000L).times(1)).onSnapshotReplicationStarted();
     verify(snapshotReplicationListener, timeout(1000L).times(1))
-        .onSnapshotReplicationCompleted(Role.FOLLOWER, follower.getTerm());
+        .onSnapshotReplicationCompleted(follower.getTerm());
   }
 }


### PR DESCRIPTION
## Description

This PR introduces listeners that allows a follower to react on install requests. Raft notifies `SnapshotReplicationListener`, when a snapshot replication starts and when completed. When snapshot replication is started, the follower can implement the listener to stop all the services that reads from the log (stream processor, exporter etc.) and when the snapshot replication completes, the follower can re-install the services with the new snapshot and log. 

The problem with concurrent log reset and readers is handled in PR #7569. Hence the listeners can be executed asynchronously. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

Related #7481 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
