### PR TITLE
Avoid NPE in RaftPartitionServer.stop()

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -149,7 +149,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
 
   @Override
   public CompletableFuture<Void> stop() {
-    return server.shutdown();
+    return server != null ? server.shutdown() : CompletableFuture.completedFuture(null);
   }
 
   private void initServer() {
@@ -232,6 +232,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
     }
   }
 
+  @Override
   public void removeFailureListener(final FailureListener listener) {
     deferredFailureListeners.remove(listener);
     server.removeFailureListener(listener);


### PR DESCRIPTION
## Description

NPE did occur when stop was called before server was initialized (see https://github.com/camunda-cloud/zeebe/issues/5645)

## Related issues

related to #5645

<!-- Cut-off marker
## Definition of Ready
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done
Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
