### PR TITLE
wip: draft interfaces for partition manager

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/ClusterPartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/ClusterPartition.java
@@ -1,0 +1,8 @@
+package io.camunda.zeebe.broker.partitioning;
+
+/**
+ * Representation of a cluster-wide view of a partition. Calls against this object may be rerouted
+ * to another node on the cluster (e.g. calls to write to the partition will be rerouted to the
+ * leader node; calls to query the partition will be rerouted to a node which hosts the partition
+ */
+public interface ClusterPartition extends Partition {}

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/ClusterPartitionManager.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/ClusterPartitionManager.java
@@ -1,0 +1,12 @@
+package io.camunda.zeebe.broker.partitioning;
+
+import java.util.List;
+
+public interface ClusterPartitionManager {
+
+  List<ClusterPartition> getPartitions();
+
+  ClusterPartition getPartition(int partitionId);
+
+  // ??? Topology getTopology()
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/LocalPartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/LocalPartition.java
@@ -1,0 +1,8 @@
+package io.camunda.zeebe.broker.partitioning;
+
+/**
+ * Representation of a locally available partition. Calls to this object will never be rerouted to
+ * other brokers. But calls may fail, e.g. if a write operation is attempted, but the current broker
+ * is not leader
+ */
+public interface LocalPartition extends Partition {}

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/LocalPartitionManager.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/LocalPartitionManager.java
@@ -1,0 +1,10 @@
+package io.camunda.zeebe.broker.partitioning;
+
+import java.util.List;
+
+public interface LocalPartitionManager {
+
+  List<LocalPartition> getLocalPartitions();
+
+  LocalPartition getLocalPartition(int partitionId);
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/Partition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/Partition.java
@@ -1,0 +1,8 @@
+package io.camunda.zeebe.broker.partitioning;
+
+public interface Partition {
+
+  PartitionWriteAccess writeAccess();
+
+  PartitionQueryAccess queryAccess();
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
@@ -7,10 +7,17 @@
  */
 package io.camunda.zeebe.broker.partitioning;
 
-import io.atomix.primitive.partition.ManagedPartitionGroup;
+import java.util.concurrent.CompletableFuture;
 
-public interface PartitionManager {
+public interface PartitionAdminAccess {
 
-  @Deprecated
-  ManagedPartitionGroup getPartitionGroup();
+  CompletableFuture<Void> takeSnapshots();
+
+  CompletableFuture<Void> pauseExporting();
+
+  CompletableFuture<Void> resumeExporting();
+
+  CompletableFuture<Void> pauseProcessing();
+
+  CompletableFuture<Void> resumeProcessing();
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionQueryAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionQueryAccess.java
@@ -1,0 +1,8 @@
+package io.camunda.zeebe.broker.partitioning;
+
+import java.util.function.BiConsumer;
+
+public interface PartitionQueryAccess {
+
+  void runQuery(Query query, BiConsumer<QueryResponse, Exception> callback);
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionWriteAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionWriteAccess.java
@@ -1,0 +1,10 @@
+package io.camunda.zeebe.broker.partitioning;
+
+import java.util.function.BiConsumer;
+
+public interface PartitionWriteAccess {
+
+  void sendMessage(Message message);
+
+  void writeCommandToPartition(Command command, BiConsumer<Response, Exception> callback);
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
