### PR TITLE
Rename ReplayMode to StreamProcessorMode

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingContext.java
@@ -49,7 +49,7 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
   private Consumer<TypedRecord<?>> onProcessedListener = record -> {};
   private Consumer<LoggedEvent> onSkippedListener = record -> {};
   private int maxFragmentSize;
-  private ReplayMode replayMode = ReplayMode.UNTIL_END;
+  private StreamProcessorMode streamProcessorMode = StreamProcessorMode.PROCESSING;
 
   public ProcessingContext() {
     streamWriterProxy.wrap(logStreamWriter);
@@ -132,8 +132,8 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
     return this;
   }
 
-  public ProcessingContext replayMode(final ReplayMode replayMode) {
-    this.replayMode = replayMode;
+  public ProcessingContext processorMode(final StreamProcessorMode streamProcessorMode) {
+    this.streamProcessorMode = streamProcessorMode;
     return this;
   }
 
@@ -224,7 +224,7 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
     streamWriterProxy.wrap(noopTypedStreamWriter);
   }
 
-  public ReplayMode getReplayMode() {
-    return replayMode;
+  public StreamProcessorMode getProcessorMode() {
+    return streamProcessorMode;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -127,7 +127,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
       processingContext.disableLogStreamWriter();
 
       replayCompletedFuture = replayStateMachine.startRecover(snapshotPosition);
-      if (processingContext.getReplayMode() == ReplayMode.CONTINUOUSLY) {
+      if (processingContext.getProcessorMode() == StreamProcessorMode.REPLAY) {
         openFuture.complete(null);
         replayCompletedFuture.onComplete(
             (v, error) -> {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -334,7 +334,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   public ActorFuture<Long> getLastProcessedPositionAsync() {
     return actor.call(
         () -> {
-          if (processingContext.getReplayMode() == ReplayMode.CONTINUOUSLY) {
+          if (processingContext.getProcessorMode() == StreamProcessorMode.REPLAY) {
             return replayStateMachine.getLastSourceEventPosition();
           } else {
             return processingStateMachine.getLastSuccessfulProcessedEventPosition();
@@ -345,7 +345,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   public ActorFuture<Long> getLastWrittenPositionAsync() {
     return actor.call(
         () -> {
-          if (processingContext.getReplayMode() == ReplayMode.CONTINUOUSLY) {
+          if (processingContext.getProcessorMode() == StreamProcessorMode.REPLAY) {
             return replayStateMachine.getLastReplayedEventPosition();
           } else {
             return processingStateMachine.getLastWrittenEventPosition();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
@@ -77,7 +77,7 @@ public final class StreamProcessorBuilder {
     return this;
   }
 
-  public StreamProcessorBuilder replayMode(final StreamProcessorMode streamProcessorMode) {
+  public StreamProcessorBuilder streamProcessorMode(final StreamProcessorMode streamProcessorMode) {
     processingContext.processorMode(streamProcessorMode);
     return this;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
@@ -77,8 +77,8 @@ public final class StreamProcessorBuilder {
     return this;
   }
 
-  public StreamProcessorBuilder replayMode(final ReplayMode replayMode) {
-    processingContext.replayMode(replayMode);
+  public StreamProcessorBuilder replayMode(final StreamProcessorMode streamProcessorMode) {
+    processingContext.processorMode(streamProcessorMode);
     return this;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorMode.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorMode.java
@@ -7,16 +7,16 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
-public enum ReplayMode {
+public enum StreamProcessorMode {
   /**
-   * Normal replay mode, which is used on Leader side. After the replay the processing normally
-   * starts.
+   * When in PROCESSING mode, stream processor first replays existing events, and then switch to
+   * processing commands. This is the mode used by the leader.
    */
-  UNTIL_END,
+  PROCESSING,
 
   /**
-   * Continuously means it will never stop the replay mode, all new events are replayed and commands
-   * are ignored.
+   * When in REPLAY mode, all events are replayed and commands are never processed. This is the mode
+   * used in followers.
    */
-  CONTINUOUSLY
+  REPLAY
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ContinuouslyReplayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ContinuouslyReplayTest.java
@@ -25,7 +25,8 @@ public class ContinuouslyReplayTest {
 
   @Rule
   public final EngineRule replay =
-      EngineRule.withSharedStorage(sharedStorage).withReplayMode(StreamProcessorMode.REPLAY);
+      EngineRule.withSharedStorage(sharedStorage)
+          .withStreamProcessorMode(StreamProcessorMode.REPLAY);
 
   @Rule public final EngineRule processing = EngineRule.withSharedStorage(sharedStorage);
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ContinuouslyReplayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ContinuouslyReplayTest.java
@@ -25,7 +25,7 @@ public class ContinuouslyReplayTest {
 
   @Rule
   public final EngineRule replay =
-      EngineRule.withSharedStorage(sharedStorage).withReplayMode(ReplayMode.CONTINUOUSLY);
+      EngineRule.withSharedStorage(sharedStorage).withReplayMode(StreamProcessorMode.REPLAY);
 
   @Rule public final EngineRule processing = EngineRule.withSharedStorage(sharedStorage);
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorReplayModeTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorReplayModeTest.java
@@ -46,11 +46,11 @@ public final class StreamProcessorReplayModeTest {
 
   @Rule
   public final StreamProcessorRule replayUntilEnd =
-      new StreamProcessorRule(PARTITION_ID).withReplayMode(StreamProcessorMode.PROCESSING);
+      new StreamProcessorRule(PARTITION_ID).withStreamProcessorMode(StreamProcessorMode.PROCESSING);
 
   @Rule
   public final StreamProcessorRule replayContinuously =
-      new StreamProcessorRule(PARTITION_ID).withReplayMode(StreamProcessorMode.REPLAY);
+      new StreamProcessorRule(PARTITION_ID).withStreamProcessorMode(StreamProcessorMode.REPLAY);
 
   @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorReplayModeTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorReplayModeTest.java
@@ -46,11 +46,11 @@ public final class StreamProcessorReplayModeTest {
 
   @Rule
   public final StreamProcessorRule replayUntilEnd =
-      new StreamProcessorRule(PARTITION_ID).withReplayMode(ReplayMode.UNTIL_END);
+      new StreamProcessorRule(PARTITION_ID).withReplayMode(StreamProcessorMode.PROCESSING);
 
   @Rule
   public final StreamProcessorRule replayContinuously =
-      new StreamProcessorRule(PARTITION_ID).withReplayMode(ReplayMode.CONTINUOUSLY);
+      new StreamProcessorRule(PARTITION_ID).withReplayMode(StreamProcessorMode.REPLAY);
 
   @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -174,8 +174,8 @@ public final class EngineRule extends ExternalResource {
     return this;
   }
 
-  public EngineRule withReplayMode(final StreamProcessorMode streamProcessorMode) {
-    environmentRule.withReplayMode(streamProcessorMode);
+  public EngineRule withStreamProcessorMode(final StreamProcessorMode streamProcessorMode) {
+    environmentRule.withStreamProcessorMode(streamProcessorMode);
     return this;
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -19,9 +19,9 @@ import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandMes
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.ReadonlyProcessingContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.RecordValues;
-import io.camunda.zeebe.engine.processing.streamprocessor.ReplayMode;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorMode;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedEventImpl;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
@@ -174,8 +174,8 @@ public final class EngineRule extends ExternalResource {
     return this;
   }
 
-  public EngineRule withReplayMode(final ReplayMode replayMode) {
-    environmentRule.withReplayMode(replayMode);
+  public EngineRule withReplayMode(final StreamProcessorMode streamProcessorMode) {
+    environmentRule.withReplayMode(streamProcessorMode);
     return this;
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -127,7 +127,8 @@ public final class StreamProcessorRule implements TestRule {
     return this;
   }
 
-  public StreamProcessorRule withReplayMode(final StreamProcessorMode streamProcessorMode) {
+  public StreamProcessorRule withStreamProcessorMode(
+      final StreamProcessorMode streamProcessorMode) {
     this.streamProcessorMode = streamProcessorMode;
     return this;
   }
@@ -324,7 +325,7 @@ public final class StreamProcessorRule implements TestRule {
     @Override
     protected void before() {
       streams = new TestStreams(tempFolder, closeables, actorSchedulerRule.get());
-      streams.withReplayMode(streamProcessorMode);
+      streams.withStreamProcessorMode(streamProcessorMode);
 
       int partitionId = startPartitionId;
       for (int i = 0; i < partitionCount; i++) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -10,8 +10,8 @@ package io.camunda.zeebe.engine.util;
 import static io.camunda.zeebe.engine.util.StreamProcessingComposite.getLogName;
 
 import io.camunda.zeebe.db.ZeebeDbFactory;
-import io.camunda.zeebe.engine.processing.streamprocessor.ReplayMode;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorMode;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
@@ -65,7 +65,7 @@ public final class StreamProcessorRule implements TestRule {
   private TestStreams streams;
   private StreamProcessingComposite streamProcessingComposite;
   private ListLogStorage sharedStorage = null;
-  private ReplayMode replayMode = ReplayMode.UNTIL_END;
+  private StreamProcessorMode streamProcessorMode = StreamProcessorMode.PROCESSING;
 
   public StreamProcessorRule() {
     this(new TemporaryFolder());
@@ -127,8 +127,8 @@ public final class StreamProcessorRule implements TestRule {
     return this;
   }
 
-  public StreamProcessorRule withReplayMode(final ReplayMode replayMode) {
-    this.replayMode = replayMode;
+  public StreamProcessorRule withReplayMode(final StreamProcessorMode streamProcessorMode) {
+    this.streamProcessorMode = streamProcessorMode;
     return this;
   }
 
@@ -324,7 +324,7 @@ public final class StreamProcessorRule implements TestRule {
     @Override
     protected void before() {
       streams = new TestStreams(tempFolder, closeables, actorSchedulerRule.get());
-      streams.withReplayMode(replayMode);
+      streams.withReplayMode(streamProcessorMode);
 
       int partitionId = startPartitionId;
       for (int i = 0; i < partitionCount; i++) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -17,8 +17,8 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbFactory;
-import io.camunda.zeebe.engine.processing.streamprocessor.ReplayMode;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorMode;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedEventRegistry;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
@@ -80,7 +80,7 @@ public final class TestStreams {
   private boolean snapshotWasTaken = false;
 
   private Function<MutableZeebeState, EventApplier> eventApplierFactory = EventAppliers::new;
-  private ReplayMode replayMode = ReplayMode.UNTIL_END;
+  private StreamProcessorMode streamProcessorMode = StreamProcessorMode.PROCESSING;
 
   public TestStreams(
       final TemporaryFolder dataDirectory,
@@ -109,8 +109,8 @@ public final class TestStreams {
     this.eventApplierFactory = eventApplierFactory;
   }
 
-  public void withReplayMode(final ReplayMode replayMode) {
-    this.replayMode = replayMode;
+  public void withReplayMode(final StreamProcessorMode streamProcessorMode) {
+    this.streamProcessorMode = streamProcessorMode;
   }
 
   public CommandResponseWriter getMockedResponseWriter() {
@@ -258,7 +258,7 @@ public final class TestStreams {
             .onProcessedListener(mockOnProcessedListener)
             .streamProcessorFactory(factory)
             .eventApplierFactory(eventApplierFactory)
-            .replayMode(replayMode)
+            .replayMode(streamProcessorMode)
             .build();
     final var openFuture = streamProcessor.openAsync(false);
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -109,7 +109,7 @@ public final class TestStreams {
     this.eventApplierFactory = eventApplierFactory;
   }
 
-  public void withReplayMode(final StreamProcessorMode streamProcessorMode) {
+  public void withStreamProcessorMode(final StreamProcessorMode streamProcessorMode) {
     this.streamProcessorMode = streamProcessorMode;
   }
 
@@ -258,7 +258,7 @@ public final class TestStreams {
             .onProcessedListener(mockOnProcessedListener)
             .streamProcessorFactory(factory)
             .eventApplierFactory(eventApplierFactory)
-            .replayMode(streamProcessorMode)
+            .streamProcessorMode(streamProcessorMode)
             .build();
     final var openFuture = streamProcessor.openAsync(false);
 


### PR DESCRIPTION
## Description

* Rename ReplayMode to StreamProcessorMode. It reflects that the StreamProcessor can be either in processing mode or in replay mode.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x ] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
