### PR TITLE
Introduce new protocol Record and RecordValue implementations with Jackson bindings

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -102,6 +102,12 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>zeebe-protocol-jackson</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>zeebe-transport</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -196,16 +202,19 @@
         <groupId>io.camunda</groupId>
         <version>${project.version}</version>
       </dependency>
+
       <dependency>
         <artifactId>zeebe-atomix-storage</artifactId>
         <groupId>io.camunda</groupId>
         <version>${project.version}</version>
       </dependency>
+
       <dependency>
         <artifactId>zeebe-atomix-utils</artifactId>
         <groupId>io.camunda</groupId>
         <version>${project.version}</version>
       </dependency>
+
       <dependency>
         <artifactId>zeebe-atomix</artifactId>
         <groupId>io.camunda</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -102,6 +102,7 @@
     <version.byte-buddy>1.11.12</version.byte-buddy>
     <version.revapi>0.24.4</version.revapi>
     <version.commons-io>2.11.0</version.commons-io>
+    <version.immutables>2.8.8</version.immutables>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.0.0</plugin.version.antrun>
@@ -570,6 +571,13 @@
             <artifactId>grpc-all</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <!-- Interface based code generation -->
+      <dependency>
+        <groupId>org.immutables</groupId>
+        <artifactId>value</artifactId>
+        <version>${version.immutables}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <module>protocol-asserts</module>
     <module>exporters/elasticsearch-exporter</module>
     <module>protocol-impl</module>
+    <module>protocol-jackson</module>
     <module>zb-db</module>
     <module>expression-language</module>
     <module>snapshot</module>

--- a/protocol-jackson/README.md
+++ b/protocol-jackson/README.md
@@ -1,0 +1,209 @@
+# Jackson bindings for Zeebe protocol records
+
+The goal of this module is to provide a basic implementation of the [Zeebe protocol](/protocol)
+`Record` interface and its possible values, e.g. `VariableRecordValue`, `IncidentRecordValue`, etc.
+
+This implementation can be used to (de)serialize these objects using Jackson (and therefore any
+format supported by Jackson). Use cases here are mostly for exporters and Java applications that are
+built around exporters, such as Operate, Tasklist, and Optimize.
+
+Additionally, the module provides builders for each of these values, allowing them to be used as
+standalone `Record` implementations. The main use case here is for testing, where it may be useful
+to specific records.
+
+## How it works
+
+The module provides a set of abstract types and uses [Immutables](https://immutables.github.io) to
+generate the actual implementation. To reduce API surface, the generated immutable classes are
+hidden, and instead only the generated builders and the abstract stubs are exposed.
+
+> NOTE: hiding the implementation classes is achieved via configuration in the `ZeebeStyle`
+> annotation. See there for more comments on which options control what.
+
+Serialization to and from the hidden generated types still work, as users can use the abstract
+types, e.g. `AbstractVariableRecordValue`, as the type reference in Jackson. These abstract types
+are annotated to tell Jackson what concrete type should be used for deserialization.
+
+Serializing an immutable record would just be like serializing any POJO with Jackson:
+
+```java
+// assume a pre-defined Record<?> record object
+final ObjectMapper mapper = new ObjectMapper();
+final String myJson = mapper.writeValueAsString(record);
+```
+
+To deserialize the record back, you simply need to specify the abstract type, either as a class or
+as a type reference.
+
+```java
+// assume a myJson string containing the JSON
+final ObjectMapper mapper = new ObjectMapper();
+final Record<?> record = mapper.readValue(myJson,AbstractRecord.class);
+
+// record will be correctly deserialized with the right parametric type
+```
+
+### Polymorphic deserialization
+
+Since the main `Record` interface is parameterized over the value property, this means we have to
+figure out concrete type of the `value` object at deserialization time. The protocol defines this
+via the `valueType` property. This is an enum which defines the expected type of the `value` at
+runtime.
+
+To achieve this, the first step is telling Jackson that the concrete type of the `value` property is
+resolved by its sibling property, `valueType`. This is achieved via the `JsonTypeInfo` annotation.
+Then we provide a custom `TypeIdResolver` (`ValueTypeIdResolver` and `IntentTypeIdResolver`) which
+provide Jackson with the concrete type from the given value type during deserialization.
+
+To support this and avoid having to map the value type multiple times, we have a central mapping in
+`ValueTypes`, which maps a `ValueType` constant to a pair of `Intent` sub class and an appropriate
+`RecordValue` sub class.
+
+## Using the builders
+
+As mentioned, one use case is in testing. It can be useful to manually create a series of records as
+input for some test. You can use the generated builders to do so. Builders are named after their
+abstract type, minus the `Abstract` prefix. This means `AbstractRecord` generates `RecordBuilder`,
+`AbstractVariableRecordValue` generates `VariableRecordValueBuilder`, and so on.
+
+The generated builders are plain old builders for beans. To use them, simply instantiate them, fill
+out the attributes, and build the object.
+
+```java
+final VariableDocumentRecordValue value = new VariableDocumentRecordValueBuilder()
+  .scopeKey(1)
+  .semantics(VariableDocumentUpdateSemantic.PROPAGATE)
+  .putVariables(Map.of())
+  .build();
+final RecordBuilder<?> builder = new RecordBuilder<>()
+  .value(value)
+  .valueType(ValueType.VARIABLE_DOCUMENT)
+  .intent(VariableDocumentIntent.UPDATE)
+  .recordType(RecordType.COMMAND)
+  .key(1);
+
+// apply more properties
+final Record<?> record = builder.build();
+```
+
+> NOTE: some attributes are required and do not have a default value. The `#build` method will fail
+> in this case with an appropriate error. This isn't fixed in stone, and if we want we can always
+> add more sane defaults, but it was decided to go with this for now to simplify the initial
+> iteration.
+
+Also note that builders have a `#from` method generated which accepts all super types of the
+abstract type. So for `VariableRecordValueBuilder`, there would be a `#from(VariableRecordValue)`
+method generated which can accept any implementations of the interface. This only performs shallow
+copying of values, meaning that when copying a `Record<?>`, it will simply set its value to the
+reference of `Record#getValue()`, and will copy that into an immutable object itself. If you need
+deep copy, you will have to manually copy all objects - or open an issue for it!
+
+## Development
+
+There are some unfortunate downsides to this approach when it comes to developing for Zeebe.
+
+### Setup
+
+While the Maven setup has already been taken care of, you may want to make sure that your IDE is
+also correctly set up to work with annotation processors. See this
+[page](https://immutables.github.io/apt.html) for more.
+
+### Adding a new record value
+
+If the `ValueType` enum is modified, then this has an impact on this module.
+
+When adding a new `ValueType`, you will need to go through the following steps, in order.
+
+First, add a new appropriate `Abstract*` value class which implements the equivalent interface. e.g.
+you add `ValueType.ULTRA`, and the interface `UltraRecordValue`, then you need to add a new
+`AbstractUltraRecordValue` to this module, with the following template:
+
+```java
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.UltraRecordValueBuilder.ImmutableUltraRecordValue;
+import io.camunda.zeebe.protocol.record.value.UltraRecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableUltraRecordValue.class)
+public abstract class AbstractUltraRecordValue
+  implements UltraRecordValue, DefaultJsonSerializable {
+
+}
+```
+
+The annotation `@Value.Immutable` tells the generator that a new immutable class should be generated
+from this abstract type. The `@ZeebeStyle` annotation configures the generation of that class. We
+use a centralized configuration annotation to ensure all generated types are aligned. Finally, the
+abstract class has to implement the correct interface, and we also implement
+`DefaultJsonSerializable` to provide a default implementation of `toJson`.
+
+After this, you need to add a new mapping in the `ValueTypes#TYPES` map, mapping the new `ValueType`
+constant with its intent class and the new immutable value class, e.g.:
+
+```java
+final class ValueTypes {
+
+  private static final Map<ValueType, ValueTypeInfo<?>> TYPES;
+
+  static {
+    final Map<ValueType, ValueTypeInfo<?>> mapping = new EnumMap<>(ValueType.class);
+
+    mapping.put(
+      ValueType.DEPLOYMENT,
+      new ValueTypeInfo<>(ImmutableDeploymentRecordValue.class, DeploymentIntent.class));
+
+    // ... more mappings
+    mapping.put(
+      ValueType.ULTRA,
+      new ValueTypeInfo<>(ImmutableUltraRecordValue.class, UltraIntent.class));
+  }
+}
+```
+
+> NOTE: there are two smoke tests which will ensure that we can map all `ValueType` constants to a
+> concrete `Intent` sub-class and a concrete `RecordValue` sub-class, just to be safe.
+
+This is the basic step, and what you most likely will have to do in most cases. There is one
+exception to this case: if you have nested abstract types which also need to be generated. In order
+for Jackson to properly deserialize these abstract types (whether abstract classes or interfaces),
+we need to specify to Jackson the concrete type it should use.
+
+Let's take a look at two existing types with nested types: the `JobBatchRecordValue`, and the
+`DeploymentRecordValue`.
+
+The `JobBatchRecordValue` has a list of `JobRecordValue`. `JobRecordValue` is also one of the types
+that we generate, and in order for deserialization to work, we need to tell Jackson the type into
+which it should be deserialized. In this case, there is no polymorphism, so this is simpler than
+with the `Record` interface: we can simply use
+`JsonDeserialize(contentAs = ImmutableJobRecordValue.class)`.
+
+> NOTE: we use `contentAs` and not `as`, since we specify the type of the list entries, not of the
+> list itself.
+
+We do the same for the `DeploymentRecordValue`. Here we even had to create custom abstract types for
+the `DeploymentResource`. We do the same as with any other type that we want to generate, except
+this time it doesn't need to implement `DefaultJsonSerializable`, and we don't need to provide a
+value type mapping for it (as `DeploymentResource` is not a value type).
+
+### Default values
+
+At times, you may want to specify sane defaults for your generated types. You can do so by
+annotating abstract methods with `@Value.Default`. These values are set in the generated builders
+on `#build()` if and only if no other value was provided - meaning, if the user provides `null` as a
+value, then the default value is not used but `null` is used instead.
+
+You can see an example of its usage in `AbstractRecord`, where specify some sane defaults for enums.
+As a rule of thumb, avoid providing a default value unless there is an obvious one.
+
+> NOTE: you do _not_ need to provide defaults for collections. These receive by default an
+> appropriate empty collection and will not be null.
+
+### Further reading
+
+If you want to do something that isn't covered here, I suggest reading the
+[Immutables](https://immutables.github.io/immutable.html) documentation, which is pretty thorough.
+The library has even more features we aren't touching here.

--- a/protocol-jackson/pom.xml
+++ b/protocol-jackson/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <name>Zeebe Protocol Jackson</name>
+  <artifactId>zeebe-protocol-jackson</artifactId>
+  <version>1.2.0-SNAPSHOT</version>
+
+  <parent>
+    <artifactId>zeebe-parent</artifactId>
+    <groupId>io.camunda</groupId>
+    <version>1.2.0-SNAPSHOT</version>
+    <relativePath>../parent/pom.xml</relativePath>
+  </parent>
+
+  <dependencies>
+    <!--
+      scoped as provided since the annotations are not retained at runtime and therefore it can be
+      omitted entirely
+      -->
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-test-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!--
+      there is a dependency on the DebugHttpExporter; the integration tests will simply fail if the
+      exporter is not present, or if its interface is changed.
+      -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-broker</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractDeploymentDistributionRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractDeploymentDistributionRecordValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.DeploymentDistributionRecordValueBuilder.ImmutableDeploymentDistributionRecordValue;
+import io.camunda.zeebe.protocol.record.value.DeploymentDistributionRecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableDeploymentDistributionRecordValue.class)
+public abstract class AbstractDeploymentDistributionRecordValue
+    implements DeploymentDistributionRecordValue, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractDeploymentRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractDeploymentRecordValue.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.DeploymentRecordValueBuilder.ImmutableDeploymentRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.DeploymentResourceBuilder.ImmutableDeploymentResource;
+import io.camunda.zeebe.protocol.jackson.record.ProcessMetadataValueBuilder.ImmutableProcessMetadataValue;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource;
+import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
+import java.util.List;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableDeploymentRecordValue.class)
+public abstract class AbstractDeploymentRecordValue
+    implements DeploymentRecordValue, DefaultJsonSerializable {
+  @JsonDeserialize(contentAs = ImmutableDeploymentResource.class)
+  @Override
+  public abstract List<DeploymentResource> getResources();
+
+  @JsonDeserialize(contentAs = ImmutableProcessMetadataValue.class)
+  @Override
+  public abstract List<ProcessMetadataValue> getProcessesMetadata();
+}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractDeploymentResource.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractDeploymentResource.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.DeploymentResourceBuilder.ImmutableDeploymentResource;
+import io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableDeploymentResource.class)
+public abstract class AbstractDeploymentResource
+    implements DeploymentResource, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractErrorRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractErrorRecordValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.ErrorRecordValueBuilder.ImmutableErrorRecordValue;
+import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableErrorRecordValue.class)
+public abstract class AbstractErrorRecordValue
+    implements ErrorRecordValue, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractIncidentRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractIncidentRecordValue.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.IncidentRecordValueBuilder.ImmutableIncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import org.immutables.value.Value;
+import org.immutables.value.Value.Default;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableIncidentRecordValue.class)
+public abstract class AbstractIncidentRecordValue
+    implements IncidentRecordValue, DefaultJsonSerializable {
+  @Default
+  @Override
+  public ErrorType getErrorType() {
+    return ErrorType.UNKNOWN;
+  }
+}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractJobBatchRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractJobBatchRecordValue.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.JobBatchRecordValueBuilder.ImmutableJobBatchRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.JobRecordValueBuilder.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import java.util.List;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableJobBatchRecordValue.class)
+public abstract class AbstractJobBatchRecordValue
+    implements JobBatchRecordValue, DefaultJsonSerializable {
+
+  @JsonDeserialize(contentAs = ImmutableJobRecordValue.class)
+  @Override
+  public abstract List<JobRecordValue> getJobs();
+}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractJobRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractJobRecordValue.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.JobRecordValueBuilder.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.record.ErrorCode;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import org.immutables.value.Value;
+import org.immutables.value.Value.Default;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableJobRecordValue.class)
+public abstract class AbstractJobRecordValue implements JobRecordValue, DefaultJsonSerializable {
+  @Default
+  @Override
+  public String getErrorCode() {
+    return ErrorCode.NULL_VAL.name();
+  }
+}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractMessageRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractMessageRecordValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.MessageRecordValueBuilder.ImmutableMessageRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableMessageRecordValue.class)
+public abstract class AbstractMessageRecordValue
+    implements MessageRecordValue, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractMessageStartEventSubscriptionRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractMessageStartEventSubscriptionRecordValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.MessageStartEventSubscriptionRecordValueBuilder.ImmutableMessageStartEventSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableMessageStartEventSubscriptionRecordValue.class)
+public abstract class AbstractMessageStartEventSubscriptionRecordValue
+    implements MessageStartEventSubscriptionRecordValue, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractMessageSubscriptionRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractMessageSubscriptionRecordValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.MessageSubscriptionRecordValueBuilder.ImmutableMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableMessageSubscriptionRecordValue.class)
+public abstract class AbstractMessageSubscriptionRecordValue
+    implements MessageSubscriptionRecordValue, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractProcess.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractProcess.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.ProcessBuilder.ImmutableProcess;
+import io.camunda.zeebe.protocol.record.value.deployment.Process;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableProcess.class)
+public abstract class AbstractProcess implements Process, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractProcessEventRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractProcessEventRecordValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.ProcessEventRecordValueBuilder.ImmutableProcessEventRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessEventRecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableProcessEventRecordValue.class)
+public abstract class AbstractProcessEventRecordValue
+    implements ProcessEventRecordValue, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractProcessInstanceCreationRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractProcessInstanceCreationRecordValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.ProcessInstanceCreationRecordValueBuilder.ImmutableProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableProcessInstanceCreationRecordValue.class)
+public abstract class AbstractProcessInstanceCreationRecordValue
+    implements ProcessInstanceCreationRecordValue, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractProcessInstanceRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractProcessInstanceRecordValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.ProcessInstanceRecordValueBuilder.ImmutableProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableProcessInstanceRecordValue.class)
+public abstract class AbstractProcessInstanceRecordValue
+    implements ProcessInstanceRecordValue, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractProcessInstanceResultRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractProcessInstanceResultRecordValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.ProcessInstanceResultRecordValueBuilder.ImmutableProcessInstanceResultRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableProcessInstanceResultRecordValue.class)
+public abstract class AbstractProcessInstanceResultRecordValue
+    implements ProcessInstanceResultRecordValue, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractProcessMessageSubscriptionRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractProcessMessageSubscriptionRecordValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.ProcessMessageSubscriptionRecordValueBuilder.ImmutableProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableProcessMessageSubscriptionRecordValue.class)
+public abstract class AbstractProcessMessageSubscriptionRecordValue
+    implements ProcessMessageSubscriptionRecordValue, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractProcessMetadataValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractProcessMetadataValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.ProcessMetadataValueBuilder.ImmutableProcessMetadataValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableProcessMetadataValue.class)
+public abstract class AbstractProcessMetadataValue
+    implements ProcessMetadataValue, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractRecord.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractRecord.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+import io.camunda.zeebe.protocol.jackson.record.RecordBuilder.ImmutableRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableRecord.class)
+public abstract class AbstractRecord<T extends RecordValue>
+    implements Record<T>, DefaultJsonSerializable {
+  @Value.Default
+  @JsonTypeInfo(use = Id.CUSTOM, include = As.EXTERNAL_PROPERTY, property = "valueType")
+  @JsonTypeIdResolver(IntentTypeIdResolver.class)
+  @Override
+  public Intent getIntent() {
+    return Intent.UNKNOWN;
+  }
+
+  @Value.Default
+  @Override
+  public RecordType getRecordType() {
+    return RecordType.NULL_VAL;
+  }
+
+  @Value.Default
+  @Override
+  public RejectionType getRejectionType() {
+    return RejectionType.NULL_VAL;
+  }
+
+  @JsonTypeInfo(use = Id.CUSTOM, include = As.EXTERNAL_PROPERTY, property = "valueType")
+  @JsonTypeIdResolver(ValueTypeIdResolver.class)
+  @Override
+  public abstract T getValue();
+
+  /** @return itself as the object is immutable and can be used as is */
+  @SuppressWarnings({"MethodDoesntCallSuperMethod", "squid:S2975", "squid:S1182"})
+  @Override
+  public Record<T> clone() {
+    return this;
+  }
+}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractTimerRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractTimerRecordValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.TimerRecordValueBuilder.ImmutableTimerRecordValue;
+import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableTimerRecordValue.class)
+public abstract class AbstractTimerRecordValue
+    implements TimerRecordValue, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractVariableDocumentRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractVariableDocumentRecordValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.VariableDocumentRecordValueBuilder.ImmutableVariableDocumentRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableVariableDocumentRecordValue.class)
+public abstract class AbstractVariableDocumentRecordValue
+    implements VariableDocumentRecordValue, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractVariableRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractVariableRecordValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.VariableRecordValueBuilder.ImmutableVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableVariableRecordValue.class)
+public abstract class AbstractVariableRecordValue
+    implements VariableRecordValue, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/DefaultJsonSerializable.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/DefaultJsonSerializable.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.protocol.record.JsonSerializable;
+import java.io.UncheckedIOException;
+
+/**
+ * Overshadow {@link JsonSerializable} to prevent toJson from being detected as an attribute; it
+ * should instead be re-computed every time.
+ */
+interface DefaultJsonSerializable extends JsonSerializable {
+  /** @deprecated use your own {@link ObjectMapper} instead of relying on this one */
+  @Deprecated(since = "1.2.0")
+  ObjectMapper JSON_WRITER = new ObjectMapper();
+
+  /** @deprecated use a {@link ObjectMapper} directly instead of calling this method */
+  @Override
+  @Deprecated(since = "1.2.0")
+  default String toJson() {
+    try {
+      return JSON_WRITER.writeValueAsString(this);
+    } catch (final JsonProcessingException e) {
+      throw new UncheckedIOException(String.format("Failed to serialize %s to JSON", this), e);
+    }
+  }
+}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/IntentTypeIdResolver.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/IntentTypeIdResolver.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+
+/**
+ * A {@link com.fasterxml.jackson.databind.jsontype.TypeIdResolver} that maps a serialized {@link
+ * Intent} value to a concrete implementation enum, e.g. {@link
+ * io.camunda.zeebe.protocol.record.intent.VariableIntent}, based on the value type of the record.
+ */
+final class IntentTypeIdResolver extends TypeIdResolverBase {
+  @Override
+  public String idFromValue(final Object value) {
+    return ((ValueType) value).name();
+  }
+
+  @Override
+  public String idFromValueAndType(final Object value, final Class<?> suggestedType) {
+    return idFromValue(value);
+  }
+
+  @Override
+  public Id getMechanism() {
+    return Id.CUSTOM;
+  }
+
+  @Override
+  public JavaType typeFromId(final DatabindContext context, final String id) {
+    final var valueType = ValueType.valueOf(id);
+    final var typeFactory = context.getTypeFactory();
+    return typeFactory.constructType(mapValueTypeToIntentClass(valueType));
+  }
+
+  private Class<? extends Intent> mapValueTypeToIntentClass(final ValueType valueType) {
+    final var typeInfo = ValueTypes.getTypeInfoOrNull(valueType);
+    if (typeInfo == null) {
+      return Intent.UNKNOWN.getClass();
+    }
+
+    return typeInfo.getIntentClass();
+  }
+}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/ValueTypeIdResolver.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/ValueTypeIdResolver.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+
+/**
+ * A {@link com.fasterxml.jackson.databind.jsontype.TypeIdResolver} that maps a serialized {@link
+ * RecordValue} value to a concrete implementation enum, e.g. {@link ImmutableVariableRecordValue},
+ * based on the value type of the record.
+ */
+final class ValueTypeIdResolver extends TypeIdResolverBase {
+
+  @Override
+  public String idFromValue(final Object value) {
+    return ((ValueType) value).name();
+  }
+
+  @Override
+  public String idFromValueAndType(final Object value, final Class<?> suggestedType) {
+    return idFromValue(value);
+  }
+
+  @Override
+  public Id getMechanism() {
+    return Id.CUSTOM;
+  }
+
+  @Override
+  public JavaType typeFromId(final DatabindContext context, final String id) {
+    final var valueType = ValueType.valueOf(id);
+    final var typeFactory = context.getTypeFactory();
+    return typeFactory.constructType(mapValueTypeToRecordValue(valueType));
+  }
+
+  private Class<? extends RecordValue> mapValueTypeToRecordValue(final ValueType valueType) {
+    return ValueTypes.getTypeInfo(valueType).getValueClass();
+  }
+}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/ValueTypeInfo.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/ValueTypeInfo.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+
+/**
+ * Provides mapping info between a value type and various constructs. Can be extended in the future
+ * to include mapping between a base value class (as defined in the protocol module) and a concrete
+ * implementation class (as generated here) for safe copying.
+ *
+ * @param <T> the immutable implementation class, e.g. {@link
+ *     io.camunda.zeebe.protocol.jackson.record.VariableRecordValueBuilder.ImmutableVariableRecordValue}
+ */
+final class ValueTypeInfo<T extends RecordValue> {
+  private final Class<T> valueClass;
+
+  private final Class<? extends Intent> intentClass;
+
+  ValueTypeInfo(final Class<T> valueClass, final Class<? extends Intent> intentClass) {
+    this.valueClass = valueClass;
+    this.intentClass = intentClass;
+  }
+
+  Class<T> getValueClass() {
+    return valueClass;
+  }
+
+  Class<? extends Intent> getIntentClass() {
+    return intentClass;
+  }
+}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/ValueTypes.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/ValueTypes.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import io.camunda.zeebe.protocol.jackson.record.DeploymentDistributionRecordValueBuilder.ImmutableDeploymentDistributionRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.DeploymentRecordValueBuilder.ImmutableDeploymentRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.ErrorRecordValueBuilder.ImmutableErrorRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.IncidentRecordValueBuilder.ImmutableIncidentRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.JobBatchRecordValueBuilder.ImmutableJobBatchRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.JobRecordValueBuilder.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.MessageRecordValueBuilder.ImmutableMessageRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.MessageStartEventSubscriptionRecordValueBuilder.ImmutableMessageStartEventSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.MessageSubscriptionRecordValueBuilder.ImmutableMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.ProcessBuilder.ImmutableProcess;
+import io.camunda.zeebe.protocol.jackson.record.ProcessEventRecordValueBuilder.ImmutableProcessEventRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.ProcessInstanceCreationRecordValueBuilder.ImmutableProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.ProcessInstanceRecordValueBuilder.ImmutableProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.ProcessInstanceResultRecordValueBuilder.ImmutableProcessInstanceResultRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.ProcessMessageSubscriptionRecordValueBuilder.ImmutableProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.TimerRecordValueBuilder.ImmutableTimerRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.VariableDocumentRecordValueBuilder.ImmutableVariableDocumentRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.VariableRecordValueBuilder.ImmutableVariableRecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Provides a mapping of all {@link ValueType} to their concrete implementations. It should be an
+ * exhaustive map of all possible {@link ValueType}, so if you add one, make sure to update the
+ * mapping here as well.
+ */
+@SuppressWarnings("java:S1452")
+final class ValueTypes {
+  private static final Map<ValueType, ValueTypeInfo<?>> TYPES;
+
+  static {
+    final Map<ValueType, ValueTypeInfo<?>> mapping = new EnumMap<>(ValueType.class);
+
+    mapping.put(
+        ValueType.DEPLOYMENT,
+        new ValueTypeInfo<>(ImmutableDeploymentRecordValue.class, DeploymentIntent.class));
+    mapping.put(
+        ValueType.DEPLOYMENT_DISTRIBUTION,
+        new ValueTypeInfo<>(
+            ImmutableDeploymentDistributionRecordValue.class, DeploymentDistributionIntent.class));
+    mapping.put(
+        ValueType.ERROR, new ValueTypeInfo<>(ImmutableErrorRecordValue.class, ErrorIntent.class));
+    mapping.put(
+        ValueType.INCIDENT,
+        new ValueTypeInfo<>(ImmutableIncidentRecordValue.class, IncidentIntent.class));
+    mapping.put(ValueType.JOB, new ValueTypeInfo<>(ImmutableJobRecordValue.class, JobIntent.class));
+    mapping.put(
+        ValueType.JOB_BATCH,
+        new ValueTypeInfo<>(ImmutableJobBatchRecordValue.class, JobBatchIntent.class));
+    mapping.put(
+        ValueType.MESSAGE,
+        new ValueTypeInfo<>(ImmutableMessageRecordValue.class, MessageIntent.class));
+    mapping.put(
+        ValueType.MESSAGE_START_EVENT_SUBSCRIPTION,
+        new ValueTypeInfo<>(
+            ImmutableMessageStartEventSubscriptionRecordValue.class,
+            MessageStartEventSubscriptionIntent.class));
+    mapping.put(
+        ValueType.MESSAGE_SUBSCRIPTION,
+        new ValueTypeInfo<>(
+            ImmutableMessageSubscriptionRecordValue.class, MessageSubscriptionIntent.class));
+    mapping.put(
+        ValueType.PROCESS, new ValueTypeInfo<>(ImmutableProcess.class, ProcessIntent.class));
+    mapping.put(
+        ValueType.PROCESS_EVENT,
+        new ValueTypeInfo<>(ImmutableProcessEventRecordValue.class, ProcessEventIntent.class));
+    mapping.put(
+        ValueType.PROCESS_INSTANCE,
+        new ValueTypeInfo<>(
+            ImmutableProcessInstanceRecordValue.class, ProcessInstanceIntent.class));
+    mapping.put(
+        ValueType.PROCESS_INSTANCE_CREATION,
+        new ValueTypeInfo<>(
+            ImmutableProcessInstanceCreationRecordValue.class,
+            ProcessInstanceCreationIntent.class));
+    mapping.put(
+        ValueType.PROCESS_INSTANCE_RESULT,
+        new ValueTypeInfo<>(
+            ImmutableProcessInstanceResultRecordValue.class, ProcessInstanceResultIntent.class));
+    mapping.put(
+        ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
+        new ValueTypeInfo<>(
+            ImmutableProcessMessageSubscriptionRecordValue.class,
+            ProcessMessageSubscriptionIntent.class));
+    mapping.put(
+        ValueType.TIMER, new ValueTypeInfo<>(ImmutableTimerRecordValue.class, TimerIntent.class));
+    mapping.put(
+        ValueType.VARIABLE,
+        new ValueTypeInfo<>(ImmutableVariableRecordValue.class, VariableIntent.class));
+    mapping.put(
+        ValueType.VARIABLE_DOCUMENT,
+        new ValueTypeInfo<>(
+            ImmutableVariableDocumentRecordValue.class, VariableDocumentIntent.class));
+
+    TYPES = mapping;
+  }
+
+  private ValueTypes() {}
+
+  static ValueTypeInfo<?> getTypeInfo(final ValueType valueType) {
+    final var typeInfo = TYPES.get(valueType);
+    if (typeInfo == null) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected value type to be one of %s, but was %s", TYPES.keySet(), valueType));
+    }
+
+    return typeInfo;
+  }
+
+  static ValueTypeInfo<?> getTypeInfoOrNull(final ValueType valueType) {
+    return TYPES.get(valueType);
+  }
+}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/ZeebeStyle.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/ZeebeStyle.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.immutables.value.Value;
+import org.immutables.value.Value.Style.BuilderVisibility;
+import org.immutables.value.Value.Style.ImplementationVisibility;
+import org.immutables.value.Value.Style.ValidationMethod;
+
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+@Retention(RetentionPolicy.CLASS)
+@Value.Style(
+    // standardize to mimic Java beans
+    get = {"is*", "get*"},
+    // hide the implementation class to reduce the API surface, instead only exposing the builder
+    // and abstract classes
+    visibility = ImplementationVisibility.PACKAGE,
+    builderVisibility = BuilderVisibility.PUBLIC,
+    implementationNestedInBuilder = true,
+    overshadowImplementation = true,
+    // do not generate code which relies on Guava or other libraries
+    jdkOnly = true,
+    // do not pre-compute the hash, instead compute it once the first time it's required and memoize
+    // it; further, disable generation of copy methods which will only target the `Abstract*` type
+    // and not the interface type, as these become rather pointless
+    defaults = @Value.Immutable(lazyhash = true, copy = false),
+    validationMethod = ValidationMethod.NONE,
+    headerComments = true,
+    clearBuilder = true,
+    attributeBuilderDetection = true)
+@JsonSerialize
+@interface ZeebeStyle {}

--- a/protocol-jackson/src/test/java/io/camunda/zeebe/protocol/jackson/ExporterSerializationIT.java
+++ b/protocol-jackson/src/test/java/io/camunda/zeebe/protocol/jackson/ExporterSerializationIT.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.broker.exporter.debug.DebugHttpExporter;
+import io.camunda.zeebe.protocol.jackson.record.AbstractRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.test.exporter.ExporterIntegrationRule;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class ExporterSerializationIT {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final ExporterIntegrationRule testHarness = new ExporterIntegrationRule();
+  private int debugExporterPort;
+
+  @BeforeEach
+  void beforeEach() {
+    debugExporterPort = SocketUtil.getNextAddress().getPort();
+    testHarness.configure(
+        "debug", DebugHttpExporter.class, Map.of("port", debugExporterPort, "limit", 3000));
+  }
+
+  @AfterEach
+  void afterEach() {
+    testHarness.stop();
+  }
+
+  @Test
+  void shouldDeserializeExportedRecords() throws IOException {
+    // given
+    testHarness.start();
+
+    // when
+    testHarness.performSampleWorkload();
+
+    // then
+    // collecting all exported records will wait up to 2 seconds before returning, giving us some
+    // assumption for now that everything has been exported
+    RecordingExporter.setMaximumWaitTime(2_000);
+    final var exportedRecords = RecordingExporter.records().collect(Collectors.toList());
+    final var exportedCount = exportedRecords.size();
+    final var deserializedRecords = fetchJsonRecords(exportedCount);
+    assertThat(deserializedRecords).hasSameSizeAs(exportedRecords);
+
+    // since the DebugHttpExporter reverses the order, flip it again to compare against the
+    // RecordingExporter
+    Collections.reverse(deserializedRecords);
+
+    // convert the exported record to an immutable equivalent so we can make use of equality instead
+    // of having to write logical comparators for each generated value; a recursive bean comparator
+    // would also work, but unfortunately there is none that I know of
+    assertThat(deserializedRecords)
+        .zipSatisfy(exportedRecords, this::assertRecordIsLogicallyEquivalent);
+  }
+
+  private List<AbstractRecord<?>> fetchJsonRecords(final int expectedCount) throws IOException {
+    final var url = new URL("http://localhost:" + debugExporterPort + "/records.json");
+
+    return Awaitility.await("until we have at least " + expectedCount + " records")
+        .pollInSameThread()
+        .until(
+            () -> MAPPER.readerFor(new TypeReference<List<AbstractRecord<?>>>() {}).readValue(url),
+            records -> records.size() >= expectedCount);
+  }
+
+  // TODO: this is a hacky way to logically compare two beans, as when serialized to JSON they
+  //  should produce logically equivalent objects; this should be replaced by a proper logical equal
+  //  and/or copy method in the future
+  private void assertRecordIsLogicallyEquivalent(
+      final AbstractRecord<?> actual, final Record<?> expected) {
+    final var actualJson = MAPPER.valueToTree(actual);
+    final var expectedJson = MAPPER.valueToTree(expected);
+
+    assertThat(actualJson).isEqualTo(expectedJson);
+  }
+}

--- a/protocol-jackson/src/test/java/io/camunda/zeebe/protocol/jackson/record/IntentTypeIdResolverTest.java
+++ b/protocol-jackson/src/test/java/io/camunda/zeebe/protocol/jackson/record/IntentTypeIdResolverTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerFactory;
+import com.fasterxml.jackson.databind.deser.DefaultDeserializationContext;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.io.IOException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+
+final class IntentTypeIdResolverTest {
+
+  /**
+   * This test checks that every known intent type is handled. It doesn't validate the correctness
+   * of the result - its goal is to be a smoke test to make sure no intents are forgotten
+   *
+   * @deprecated to be removed when intent classes are directly mapped via the {@link ValueType}
+   *     enum
+   */
+  @EnumSource(
+      value = ValueType.class,
+      names = {"NULL_VAL", "SBE_UNKNOWN"},
+      mode = Mode.EXCLUDE)
+  @ParameterizedTest
+  void shouldHandleEveryKnownValueType(final ValueType type) throws IOException {
+    // given
+    final var mapper = new ObjectMapper();
+    final var baseContext =
+        new DefaultDeserializationContext.Impl(BeanDeserializerFactory.instance);
+    final var context =
+        baseContext.createInstance(
+            mapper.getDeserializationConfig(),
+            mapper.createParser("{}"),
+            mapper.getInjectableValues());
+    final var resolver = new IntentTypeIdResolver();
+    final var resolvedType = resolver.typeFromId(context, resolver.idFromValue(type));
+
+    assertThat(Intent.class).isAssignableFrom(resolvedType.getRawClass());
+  }
+}

--- a/protocol-jackson/src/test/java/io/camunda/zeebe/protocol/jackson/record/ValueTypeIdResolveTest.java
+++ b/protocol-jackson/src/test/java/io/camunda/zeebe/protocol/jackson/record/ValueTypeIdResolveTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerFactory;
+import com.fasterxml.jackson.databind.deser.DefaultDeserializationContext;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.io.IOException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+
+final class ValueTypeIdResolveTest {
+  /**
+   * This test checks that every known record value type is handled. It doesn't validate the
+   * correctness of the result - its goal is to be a smoke test to make sure no value types are
+   * forgotten. It does NOT check that the value type is mapped to the right value implementation.
+   */
+  @EnumSource(
+      value = ValueType.class,
+      names = {"NULL_VAL", "SBE_UNKNOWN"},
+      mode = Mode.EXCLUDE)
+  @ParameterizedTest
+  void shouldHandleEveryKnownValueType(final ValueType type) throws IOException {
+    // given
+    final var mapper = new ObjectMapper();
+    final var baseContext =
+        new DefaultDeserializationContext.Impl(BeanDeserializerFactory.instance);
+    final var context =
+        baseContext.createInstance(
+            mapper.getDeserializationConfig(),
+            mapper.createParser("{}"),
+            mapper.getInjectableValues());
+    final var resolver = new ValueTypeIdResolver();
+    final var resolvedType = resolver.typeFromId(context, resolver.idFromValue(type));
+
+    assertThat(RecordValue.class).isAssignableFrom(resolvedType.getRawClass());
+  }
+}

--- a/protocol-jackson/src/test/resources/log4j2-test.xml
+++ b/protocol-jackson/src/test/resources/log4j2-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout
+        pattern="%d{HH:mm:ss.SSS} [%t] [%X{actor-name}] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
## Description

This PR introduces a new module, `protocol-jackson`, which provides [Immutables](https://immutables.org) generated implementations for `Record<T>`, and all known `RecordValue` derived interfaces (e.g. `VariableRecordValue`, `TimerRecordValue`, etc.) at the time of writing. The primary goal here is to provide implementations which can be serialized and deserialized easily via Jackson, while being backwards compatible for deserialization with the JSON produced by the `Record#toJson` method and its current implementations in `protocol-impl`.

The actual generated implementations are not exposed via the public API to reduce the API surface, and reduce coupling with the code generator. Instead, we introduced new abstract types which implement the required interfaces (e.g. `AbstractRecord` implements `Record`, `AbstractVariableRecordValue` implements `VariableRecordValue`, etc.). These types are annotated with the appropriate Jackson annotations to ensure (de)serialization works as expected, including polymorphic (de)serialization via `Record#getValueType()`, e.g. the record's value and its concrete `Intent` type. What is exposed are these abstract types, and the generated builders.

The polymorphic (de)serialization is achieved by using Jackson's `TypeIdResolver` facilities. Implementations of this interface tell Jackson what is the concrete type to use when deserializing an object. So in our case, we have two: the `ValueTypeIdResolver` and the `IntentTypeIdResolver`, respectively for the record's `value` and the `intent`. Since in our protocol, we resolve types via the `valueType` property, we can use the `JsonTypeInfo` annotation to specify this. This means our `TypeIdResolver` implementations take in as input the actual `valueType` (already deserialized), and just need to return the correct Java class. This mapping is done in the package-private `ValueTypes` class, which is a thin wrapper around a constant `EnumMap`.

The abstract types are obviously exposed as they are what users are expected to tell Jackson is the type of their objects, either when creating readers/writers (e.g. `objectMapper.readerFor(AbstractRecord.class)` or `objectMapper.writerFor(AbstractRecord.class)`) or just reading/writing values (e.g. `objectMapper.readValue(myJson, AbstractRecord.class)` or `objectMapper.readValue(myJson, AbstractTimerRecordValue.class)`).

The builders are exposed primarily to allow users to build standalone records and values for unit testing. I'm not aware of any other production usage, so I'm happy to challenge this use case. It's also a bit of a long term one, as I would hope it can replace the `MockRecord` and eventually `CopiedRecord` and `CopiedRecords` functionalities. For example, a `new RecordBuilder().from(record).build()` would completely replace the `CopiedRecords` and `CopiedRecord` classes, as it would provide an immutable copy of the given record, regardless of its concrete implementation class. This may be a bit slower however and would need to be tested, especially regarding the serialization of these objects in the `ElasticsearchExporter`.

There are some known downsides to this PR. First of all, it slightly increases the maintenance burden when adding/removing record value types. Every time you add one, you need to also:

- Add a new abstract class for the value in the `protocol-jackson` implementation.
- Add a new mapping entry from the `ValueType` to its corresponding `Intent` and generated immutable class in `ValueTypes`. This is done for the polymorphic (de)serialization as mentioned above.

When removing a new value type, you'd have to reverse the above. This is a bit more than before, but it's considerably less than if we had to hand write all the new implementations, so I think it's acceptable. There are smoke tests - `IntentTypeIdResolverTest` and `ValueTypeIdResolverTest` - which ensure that we don't forget to map new `ValueType`.

Testing is done primarily via integration tests. As our main use case initially is being able to deserialize exported records, we have an integration test `ExporterSerializationIT` which starts a broker, runs the standard exporter workload (as defined in `ExporterIntegrationRule` of the `test` module), and fetches the JSON records from the `DebugHttpExporter`. They are deserialized, and then compared to the records from `RecordingExporter` to check that they are logically equivalent.

> I had some issues with logical equivalence of records: I've asked the AssertJ project about this and the Immutables project, I hope they can provide better insight. In the mean time, I went with a "hacky" solution. You can convert your `Record` objects to `JsonNode` - essentially an intermediate tree representation of the object. Since in JSON equivalence is basically just checking all the properties are the same, regardless of order and so on, this should work. It does seem strange, however.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7545 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
