### PR TITLE
7536 startup base classes actor style

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -49,8 +49,8 @@ import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.PartitionBoostrapAndTransitionContextImpl;
-import io.camunda.zeebe.broker.system.partitions.PartitionBootstrapStep;
 import io.camunda.zeebe.broker.system.partitions.PartitionHealthBroadcaster;
+import io.camunda.zeebe.broker.system.partitions.PartitionStartupStep;
 import io.camunda.zeebe.broker.system.partitions.PartitionStep;
 import io.camunda.zeebe.broker.system.partitions.PartitionStepMigrationHelper;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
@@ -64,7 +64,7 @@ import io.camunda.zeebe.broker.system.partitions.impl.steps.LogDeletionPartition
 import io.camunda.zeebe.broker.system.partitions.impl.steps.LogStreamPartitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.RocksDbMetricExporterPartitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.SnapshotDirectorPartitionStep;
-import io.camunda.zeebe.broker.system.partitions.impl.steps.SnapshotReplicationPartitionBootstrapStep;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.SnapshotReplicationPartitionStartupStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.StateControllerPartitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.StoragePartitionTransitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.StreamProcessorPartitionStep;
@@ -105,8 +105,8 @@ public final class Broker implements AutoCloseable {
 
   // preparation for future steps
   // will be executed in the order they are defined in this list
-  private static final List<PartitionBootstrapStep> BOOTSTRAP_STEPS =
-      List.of(new SnapshotReplicationPartitionBootstrapStep());
+  private static final List<PartitionStartupStep> BOOTSTRAP_STEPS =
+      List.of(new SnapshotReplicationPartitionStartupStep());
 
   // will probably be executed in parallel
   private static final List<PartitionTransitionStep> TRANSITION_STEPS =
@@ -116,7 +116,7 @@ public final class Broker implements AutoCloseable {
   private static final List<PartitionStep> LEADER_STEPS =
       List.of(
           PartitionStepMigrationHelper.fromBootstrapStep(
-              new SnapshotReplicationPartitionBootstrapStep()),
+              new SnapshotReplicationPartitionStartupStep()),
           new StateControllerPartitionStep(),
           PartitionStepMigrationHelper.fromTransitionStep(new StoragePartitionTransitionStep()),
           new LogDeletionPartitionStep(),
@@ -129,7 +129,7 @@ public final class Broker implements AutoCloseable {
   private static final List<PartitionStep> FOLLOWER_STEPS =
       List.of(
           PartitionStepMigrationHelper.fromBootstrapStep(
-              new SnapshotReplicationPartitionBootstrapStep()),
+              new SnapshotReplicationPartitionStartupStep()),
           new StateControllerPartitionStep(),
           PartitionStepMigrationHelper.fromTransitionStep(new StoragePartitionTransitionStep()),
           new LogDeletionPartitionStep());

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionBoostrapAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionBoostrapAndTransitionContextImpl.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
  */
 @Deprecated // will be split up according to interfaces
 public class PartitionBoostrapAndTransitionContextImpl
-    implements PartitionContext, PartitionBootstrapContext, PartitionTransitionContext {
+    implements PartitionContext, PartitionStartupContext, PartitionTransitionContext {
 
   private final int nodeId;
   private final List<PartitionListener> partitionListeners;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupContext.java
@@ -30,7 +30,7 @@ import io.camunda.zeebe.util.sched.ScheduledTimer;
 import java.util.List;
 import java.util.function.Consumer;
 
-public interface PartitionBootstrapContext {
+public interface PartitionStartupContext {
 
   // provided by application-wide dependencies
   BrokerCfg getBrokerCfg();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupStep.java
@@ -14,27 +14,27 @@ import io.camunda.zeebe.util.sched.future.ActorFuture;
  * opening/closing a component of the partition). The steps are opened in a pre-defined order and
  * will be closed in the reverse order.
  */
-public interface PartitionBootstrapStep {
+public interface PartitionStartupStep {
   /**
    * Performs some action required for the partition to function. This may include opening
-   * components (e.g., logstream), setting their values in {@link PartitionBootstrapContext}, etc.
-   * The subsequent partition steps will only be opened after the returned future is completed.
+   * components (e.g., logstream), setting their values in {@link PartitionStartupContext}, etc. The
+   * subsequent partition steps will only be opened after the returned future is completed.
    *
    * @param context the partition boostrap context
    * @return future
    */
-  ActorFuture<PartitionBootstrapContext> open(final PartitionBootstrapContext context);
+  ActorFuture<PartitionStartupContext> open(final PartitionStartupContext context);
 
   /**
    * Perform tear-down actions to clear the partition and prepare for another one to be installed.
-   * This includes closing components, clearing their values from {@link PartitionBootstrapContext}
-   * so they may be garbage-collected, etc. The subsequent partition steps will only be closed after
+   * This includes closing components, clearing their values from {@link PartitionStartupContext} so
+   * they may be garbage-collected, etc. The subsequent partition steps will only be closed after
    * the returned future is completed.
    *
    * @param context the partition bootstrap context
    * @return future
    */
-  ActorFuture<PartitionBootstrapContext> close(final PartitionBootstrapContext context);
+  ActorFuture<PartitionStartupContext> close(final PartitionStartupContext context);
 
   /** @return A log-friendly identification of the PartitionBootstrapStep. */
   String getName();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupStep.java
@@ -7,35 +7,11 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
-import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.startup.StartupStep;
 
 /**
  * A PartitionBoostrapStep is an action to be taken while opening or closing a partition (e.g.,
  * opening/closing a component of the partition). The steps are opened in a pre-defined order and
  * will be closed in the reverse order.
  */
-public interface PartitionStartupStep {
-  /**
-   * Performs some action required for the partition to function. This may include opening
-   * components (e.g., logstream), setting their values in {@link PartitionStartupContext}, etc. The
-   * subsequent partition steps will only be opened after the returned future is completed.
-   *
-   * @param context the partition boostrap context
-   * @return future
-   */
-  ActorFuture<PartitionStartupContext> open(final PartitionStartupContext context);
-
-  /**
-   * Perform tear-down actions to clear the partition and prepare for another one to be installed.
-   * This includes closing components, clearing their values from {@link PartitionStartupContext} so
-   * they may be garbage-collected, etc. The subsequent partition steps will only be closed after
-   * the returned future is completed.
-   *
-   * @param context the partition bootstrap context
-   * @return future
-   */
-  ActorFuture<PartitionStartupContext> close(final PartitionStartupContext context);
-
-  /** @return A log-friendly identification of the PartitionBootstrapStep. */
-  String getName();
-}
+public interface PartitionStartupStep extends StartupStep<PartitionStartupContext> {}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStepMigrationHelper.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStepMigrationHelper.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 @Deprecated
 public class PartitionStepMigrationHelper {
 
-  public static PartitionStep fromBootstrapStep(final PartitionBootstrapStep bootstrapStep) {
+  public static PartitionStep fromBootstrapStep(final PartitionStartupStep bootstrapStep) {
     return new WrappedPartitionBootstrapStep(bootstrapStep);
   }
 
@@ -24,9 +24,9 @@ public class PartitionStepMigrationHelper {
 
   private static class WrappedPartitionBootstrapStep implements PartitionStep {
 
-    private final PartitionBootstrapStep bootstrapStep;
+    private final PartitionStartupStep bootstrapStep;
 
-    public WrappedPartitionBootstrapStep(final PartitionBootstrapStep bootstrapStep) {
+    public WrappedPartitionBootstrapStep(final PartitionStartupStep bootstrapStep) {
       this.bootstrapStep = bootstrapStep;
     }
 
@@ -41,8 +41,13 @@ public class PartitionStepMigrationHelper {
       return wrapInVoidFuture(bootstrapStep.close(context));
     }
 
+    @Override
+    public String getName() {
+      return bootstrapStep.getName();
+    }
+
     private ActorFuture<Void> wrapInVoidFuture(
-        final ActorFuture<PartitionBootstrapContext> wrappable) {
+        final ActorFuture<PartitionStartupContext> wrappable) {
       final var result = new CompletableActorFuture<Void>();
 
       wrappable.onComplete(
@@ -55,11 +60,6 @@ public class PartitionStepMigrationHelper {
           });
 
       return result;
-    }
-
-    @Override
-    public String getName() {
-      return bootstrapStep.getName();
     }
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotReplicationPartitionStartupStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotReplicationPartitionStartupStep.java
@@ -8,18 +8,18 @@
 package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
 import io.camunda.zeebe.broker.Loggers;
-import io.camunda.zeebe.broker.system.partitions.PartitionBootstrapContext;
-import io.camunda.zeebe.broker.system.partitions.PartitionBootstrapStep;
+import io.camunda.zeebe.broker.system.partitions.PartitionStartupContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionStartupStep;
 import io.camunda.zeebe.broker.system.partitions.SnapshotReplication;
 import io.camunda.zeebe.broker.system.partitions.impl.NoneSnapshotReplication;
 import io.camunda.zeebe.broker.system.partitions.impl.StateReplication;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 
-public class SnapshotReplicationPartitionBootstrapStep implements PartitionBootstrapStep {
+public class SnapshotReplicationPartitionStartupStep implements PartitionStartupStep {
 
   @Override
-  public ActorFuture<PartitionBootstrapContext> open(final PartitionBootstrapContext context) {
+  public ActorFuture<PartitionStartupContext> open(final PartitionStartupContext context) {
     final SnapshotReplication replication =
         shouldReplicateSnapshots(context)
             ? new StateReplication(
@@ -31,7 +31,7 @@ public class SnapshotReplicationPartitionBootstrapStep implements PartitionBoots
   }
 
   @Override
-  public ActorFuture<PartitionBootstrapContext> close(final PartitionBootstrapContext context) {
+  public ActorFuture<PartitionStartupContext> close(final PartitionStartupContext context) {
     try {
       if (context.getSnapshotReplication() != null) {
         context.getSnapshotReplication().close();
@@ -53,7 +53,7 @@ public class SnapshotReplicationPartitionBootstrapStep implements PartitionBoots
     return "SnapshotReplication";
   }
 
-  private boolean shouldReplicateSnapshots(final PartitionBootstrapContext state) {
+  private boolean shouldReplicateSnapshots(final PartitionStartupContext state) {
     return state.getBrokerCfg().getCluster().getReplicationFactor() > 1;
   }
 }

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -106,6 +106,12 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -107,11 +107,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/util/src/main/java/io/camunda/zeebe/util/StartupStep.java
+++ b/util/src/main/java/io/camunda/zeebe/util/StartupStep.java
@@ -1,0 +1,52 @@
+package io.camunda.zeebe.util;
+
+import java.util.function.Consumer;
+
+/**
+ * Base interface for startup (and shutdown) steps. Each step implements the startup logic in {@code
+ * startup(...)}, as well as, the corresponding shutdown logic in {@code shutdown(...)}. Both
+ * methods take a context object as argument and return a future of the same context object.<br>
+ * Typically, a startup step will create resources and call setters on the context object, whereas a
+ * shutdown step will shutdown resources and remove them from the context by setting them to {@code
+ * null}. <br>
+ * Contract:
+ *
+ * <ul>
+ *   <li>Shutdown will never be called before startup
+ *   <li>Startup will be called at most once
+ *   <li>Shutdown may be called more than once with the expectation that the first call will trigger
+ *       the shutdown and any subsequent calls shall do nothing
+ *   <li>Shutdown may be called before the future of startup has completed with the expectation that
+ *       it will either cancel the startup process, or it will wait until it terminates and then
+ *       immediately begin the shutdown
+ * </ul>
+ *
+ * @param <CONTEXT> context object for the startup and shutdown steps. During startup this context
+ *     is used to collect the resources created during startup; during shutdown it is used to set
+ *     resources that have been shut down to {@code null}
+ */
+public interface StartupStep<CONTEXT> {
+
+  /**
+   * Returns name for logging purposes
+   *
+   * @return name for logging purposes
+   */
+  String getName();
+
+  /**
+   * Executes the startup logic
+   *
+   * @param context the startup context at the start of this step
+   * @param callback callback that receives the modified startup context at the end of this step
+   */
+  void startup(final CONTEXT context, Consumer<Either<Throwable, CONTEXT>> callback);
+
+  /**
+   * Executes the shutdown logic
+   *
+   * @param context the shutdown context at the start of this step
+   * @param callback callback that receives the modified shutdown context at the end of this step
+   */
+  void shutdown(final CONTEXT context, Consumer<Either<Throwable, CONTEXT>> callback);
+}

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorControl.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorControl.java
@@ -24,7 +24,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public class ActorControl {
+public class ActorControl implements ActorTaskSchedulingService {
   final ActorTask task;
   private final Actor actor;
 

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorTaskSchedulingService.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorTaskSchedulingService.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util.sched;
+
+public interface ActorTaskSchedulingService {
+  void submit(final Runnable action);
+}

--- a/util/src/main/java/io/camunda/zeebe/util/startup/StartupProcess.java
+++ b/util/src/main/java/io/camunda/zeebe/util/startup/StartupProcess.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util.startup;
+
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.sched.ActorTaskSchedulingService;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.Set;
+import java.util.Stack;
+import java.util.concurrent.CancellationException;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Executes a number of steps in a startup/shutdown process.
+ *
+ * <p>On startup, steps are executed in the given order. If any step completes exceptionally, then
+ * the subsequent steps are not executed and the startup completes exceptionally. However, no
+ * shutdown is triggered by this class. This can be done by the caller.
+ *
+ * <p>On shutdown, steps are executed in reverse order. If any shutdown step completes
+ * exceptionally, subsequent steps will be executed and the exceptions of all steps are collected as
+ * suppressed exceptions
+ *
+ * <p>Callers of this class must obey the following contract:
+ *
+ * <ul>
+ *   <li>Shutdown must not be called before startup
+ *   <li>Startup must be called at most once
+ *   <li>Shutdown may be called more than once. The first call will trigger the shutdown and any
+ *       subsequent calls do nothing
+ *   <li>Shutdown may be called before the future of startup has completed. In that case, it will
+ *       complete the current running startup step, cancel all subsequent startup step, complete the
+ *       startup future with an exception and start the shutdown from the step that last completed
+ * </ul>
+ *
+ * @param <CONTEXT> the startup/shutdown context
+ */
+public final class StartupProcess<CONTEXT> {
+
+  private final Logger logger;
+  private final ActorTaskSchedulingService actorTaskSchedulingService;
+  private final Deque<StartupStep<CONTEXT>> steps;
+
+  private final Stack<StartupStep<CONTEXT>> startedSteps = new Stack<>();
+  private boolean startupCalled = false;
+  private boolean shutdownCalled = false;
+  private AggregateConsumer<Either<Throwable, CONTEXT>> startupCallbackAggregate;
+  private AggregateConsumer<Either<Throwable, CONTEXT>> shutdownCallbackAggregate;
+
+  /**
+   * Constructs the startup process
+   *
+   * @param steps the steps to execute; must not be {@code null}
+   */
+  public StartupProcess(
+      final ActorTaskSchedulingService actorTaskSchedulingService,
+      final List<StartupStep<CONTEXT>> steps) {
+    this(
+        LoggerFactory.getLogger("io.camunda.zeebe.util.startup"),
+        actorTaskSchedulingService,
+        steps);
+  }
+
+  /**
+   * Constructs the startup process
+   *
+   * @param logger the logger to use for messages related to the startup process; must not be {@code
+   *     null}
+   * @param steps the steps to execute; must not be {@code null}
+   */
+  public StartupProcess(
+      final Logger logger,
+      final ActorTaskSchedulingService actorTaskSchedulingService,
+      final List<StartupStep<CONTEXT>> steps) {
+    this.logger = Objects.requireNonNull(logger);
+    this.actorTaskSchedulingService = Objects.requireNonNull(actorTaskSchedulingService);
+    this.steps = new ArrayDeque<>(Objects.requireNonNull(steps));
+  }
+
+  public void shutdown(final CONTEXT context, final Consumer<Either<Throwable, CONTEXT>> callback) {
+    actorTaskSchedulingService.submit(() -> shutdownSynchronized(context, callback));
+  }
+
+  private void shutdownSynchronized(
+      final CONTEXT context, final Consumer<Either<Throwable, CONTEXT>> callback) {
+    logger.debug("Shutdown was called with context: " + context);
+
+    /* signal that shutdown was called; this is read by the startup process to abort a concurrent
+    startup process*/
+    shutdownCalled = true;
+
+    if (shutdownCallbackAggregate == null) {
+      logger.info("Starting shutdown process");
+
+      // check if startup is concurrently running
+      if (startupCallbackAggregate != null) {
+        // if it is, trigger the shutdown after the current startup step has completed
+        startupCallbackAggregate.addConsumer(
+            (either) ->
+                actorTaskSchedulingService.submit(
+                    () -> {
+                      final var contextToUse = either.isRight() ? either.get() : context;
+                      startShutdownSynchronized(contextToUse, callback);
+                    }));
+      } else {
+        startShutdownSynchronized(context, callback);
+      }
+    } else {
+      logger.info("Shutdown already in progress");
+      shutdownCallbackAggregate.addConsumer(callback);
+    }
+  }
+
+  private void startShutdownSynchronized(
+      final CONTEXT context, final Consumer<Either<Throwable, CONTEXT>> callback) {
+    shutdownCallbackAggregate = new AggregateConsumer<>();
+    shutdownCallbackAggregate.addConsumer(callback);
+
+    proceedWithShutdownSynchronized(context, shutdownCallbackAggregate, new ArrayList<>());
+  }
+
+  public void startup(final CONTEXT context, final Consumer<Either<Throwable, CONTEXT>> callback) {
+    actorTaskSchedulingService.submit(() -> startupSynchronized(context, callback));
+  }
+
+  private void startupSynchronized(
+      final CONTEXT context, final Consumer<Either<Throwable, CONTEXT>> callback) {
+    logger.debug("Startup was called with context: " + context);
+    if (startupCalled) {
+      throw new IllegalStateException("startup(...) must only be called once");
+    }
+    startupCalled = true;
+
+    // when startup is complete
+    startupCallbackAggregate = new AggregateConsumer<>();
+    // call the original consumer
+    startupCallbackAggregate.addConsumer(callback);
+    /* and reset the callback in this class; the presence of the field is an indicator for the
+    shutdown process that startup has not completed yet*/
+    startupCallbackAggregate.addConsumer(
+        (either) -> actorTaskSchedulingService.submit(() -> startupCallbackAggregate = null));
+
+    final var stepsToStart = new ArrayDeque<>(steps);
+
+    logger.info("Starting startup process");
+    proceedWithStartupSynchronized(stepsToStart, context, startupCallbackAggregate);
+  }
+
+  private void proceedWithStartupSynchronized(
+      final Queue<StartupStep<CONTEXT>> stepsToStart,
+      final CONTEXT context,
+      final Consumer<Either<Throwable, CONTEXT>> callback) {
+    if (shutdownCalled) {
+      logger.info("Aborting startup process because shutdown was called");
+      callback.accept(
+          Either.left(
+              new CancellationException("Aborting startup process because shutdown was called")));
+    } else if (stepsToStart.isEmpty()) {
+      callback.accept(Either.right(context));
+      logger.info("Finished startup process");
+    } else {
+      final var stepToStart = stepsToStart.poll();
+      startedSteps.push(stepToStart);
+
+      logCurrentStep("Startup", stepToStart);
+      stepToStart.startup(
+          context,
+          (either) ->
+              actorTaskSchedulingService.submit(
+                  () ->
+                      onStartupStepCompletedSynchronized(
+                          either, stepsToStart, stepToStart, callback)));
+    }
+  }
+
+  private void onStartupStepCompletedSynchronized(
+      final Either<Throwable, CONTEXT> result,
+      final Queue<StartupStep<CONTEXT>> stepsToStart,
+      final StartupStep<CONTEXT> startedStep,
+      final Consumer<Either<Throwable, CONTEXT>> callback) {
+    result.ifRightOrLeft(
+        context -> proceedWithStartupSynchronized(stepsToStart, context, callback),
+        error -> {
+          logger.warn(
+              "Aborting startup process due to exception during stage " + startedStep.getName(),
+              error);
+          callback.accept(Either.left(error));
+        });
+  }
+
+  private void proceedWithShutdownSynchronized(
+      final CONTEXT context,
+      final Consumer<Either<Throwable, CONTEXT>> callback,
+      final List<ShutdownExceptionRecord> collectedExceptions) {
+    if (startedSteps.isEmpty()) {
+      completeShutdownFutureSynchronized(context, callback, collectedExceptions);
+    } else {
+      final var stepToShutdown = startedSteps.pop();
+
+      logCurrentStep("Shutdown", stepToShutdown);
+      stepToShutdown.shutdown(
+          context,
+          (either) ->
+              actorTaskSchedulingService.submit(
+                  () ->
+                      onShutdownStepCompletedSynchronized(
+                          context, either, stepToShutdown, callback, collectedExceptions)));
+    }
+  }
+
+  private void onShutdownStepCompletedSynchronized(
+      final CONTEXT lastShutdownContext,
+      final Either<Throwable, CONTEXT> result,
+      final StartupStep<CONTEXT> currentStep,
+      final Consumer<Either<Throwable, CONTEXT>> callback,
+      final List<ShutdownExceptionRecord> collectedExceptions) {
+    result.ifRightOrLeft(
+        context -> proceedWithShutdownSynchronized(context, callback, collectedExceptions),
+        error -> {
+          collectedExceptions.add(new ShutdownExceptionRecord(currentStep, error));
+
+          logger.warn(
+              "Aborting startup process due to exception during stage " + currentStep.getName(),
+              error);
+          proceedWithShutdownSynchronized(lastShutdownContext, callback, collectedExceptions);
+        });
+  }
+
+  private void completeShutdownFutureSynchronized(
+      final CONTEXT context,
+      final Consumer<Either<Throwable, CONTEXT>> callback,
+      final List<ShutdownExceptionRecord> collectedExceptions) {
+    if (collectedExceptions.isEmpty()) {
+      callback.accept(Either.right(context));
+      logger.info("Finished shutdown process");
+    } else {
+      final Throwable exception;
+      if (collectedExceptions.size() == 1) {
+        exception = collectedExceptions.get(0).getException();
+      } else {
+        final var details =
+            collectedExceptions.stream()
+                .map(entry -> entry.getStep().getName() + " " + entry.getException().getMessage())
+                .collect(Collectors.joining("\n"));
+        exception =
+            new Exception(
+                "Exceptions occurred during shutdown: \n"
+                    + details
+                    + "\nSee suppressed exceptions for more detail.");
+        collectedExceptions.stream()
+            .map(ShutdownExceptionRecord::getException)
+            .forEach(exception::addSuppressed);
+      }
+      callback.accept(Either.left(exception));
+      logger.warn("Finished shutdown process with exception:", exception);
+    }
+  }
+
+  private void logCurrentStep(final String process, final StartupStep<CONTEXT> step) {
+    logger.info(process + " " + step.getName());
+  }
+
+  private static final class ShutdownExceptionRecord {
+    private final StartupStep<?> step;
+    private final Throwable exception;
+
+    private ShutdownExceptionRecord(final StartupStep<?> step, final Throwable exception) {
+      this.step = step;
+      this.exception = exception;
+    }
+
+    private StartupStep<?> getStep() {
+      return step;
+    }
+
+    public Throwable getException() {
+      return exception;
+    }
+  }
+
+  private static final class AggregateConsumer<TYPE> implements Consumer<TYPE> {
+
+    private final Set<Consumer<TYPE>> delegates = new HashSet<>();
+    private TYPE capturedResult;
+
+    @Override
+    public void accept(final TYPE result) {
+      delegates.forEach(consumer -> consumer.accept(result));
+
+      capturedResult = result;
+    }
+
+    private void addConsumer(final Consumer<TYPE> consumer) {
+      delegates.add(consumer);
+
+      if (capturedResult != null) {
+        consumer.accept(capturedResult);
+      }
+    }
+  }
+}

--- a/util/src/main/java/io/camunda/zeebe/util/startup/StartupStep.java
+++ b/util/src/main/java/io/camunda/zeebe/util/startup/StartupStep.java
@@ -1,5 +1,13 @@
-package io.camunda.zeebe.util;
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util.startup;
 
+import io.camunda.zeebe.util.Either;
 import java.util.function.Consumer;
 
 /**
@@ -40,7 +48,7 @@ public interface StartupStep<CONTEXT> {
    * @param context the startup context at the start of this step
    * @param callback callback that receives the modified startup context at the end of this step
    */
-  void startup(final CONTEXT context, Consumer<Either<Throwable, CONTEXT>> callback);
+  void startup(final CONTEXT context, final Consumer<Either<Throwable, CONTEXT>> callback);
 
   /**
    * Executes the shutdown logic
@@ -48,5 +56,5 @@ public interface StartupStep<CONTEXT> {
    * @param context the shutdown context at the start of this step
    * @param callback callback that receives the modified shutdown context at the end of this step
    */
-  void shutdown(final CONTEXT context, Consumer<Either<Throwable, CONTEXT>> callback);
+  void shutdown(final CONTEXT context, final Consumer<Either<Throwable, CONTEXT>> callback);
 }

--- a/util/src/main/java/io/camunda/zeebe/util/startup/actor/BootstrapException.java
+++ b/util/src/main/java/io/camunda/zeebe/util/startup/actor/BootstrapException.java
@@ -1,0 +1,8 @@
+package io.camunda.zeebe.util.startup.actor;
+
+public class BootstrapException extends Exception {
+
+  public BootstrapException(final String message) {
+    super(message);
+  }
+}

--- a/util/src/main/java/io/camunda/zeebe/util/startup/actor/BootstrapProcess.java
+++ b/util/src/main/java/io/camunda/zeebe/util/startup/actor/BootstrapProcess.java
@@ -1,0 +1,221 @@
+package io.camunda.zeebe.util.startup.actor;
+
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Queue;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+
+/**
+ * Executes a number of steps in a startup/shutdown process.
+ *
+ * <p>On startup, steps are executed in the given order. If any step completes exceptionally, then
+ * the subsequent steps are not executed and the startup completes exceptionally. However, no
+ * shutdown is triggered by this class. This can be done by the caller.
+ *
+ * <p>On shutdown, steps are executed in reverse order. If any shutdown step completes
+ * exceptionally, subsequent steps will be executed and the exceptions of all steps are collected as
+ * suppressed exceptions
+ *
+ * <p>Callers of this class must obey the following contract:
+ *
+ * <ul>
+ *   <li>An actor <em>must</em> own the instance of {@link BootstrapProcess}
+ *   <li>{@link #startup(Object)} MUST be called from that actor's context
+ *   <li>{@link #shutdown(Object)} MUST be called from that actor's context
+ *   <li>{@link #shutdown(Object)} must not be called before startup
+ *   <li>@link #startup(Object)} must be called at most once
+ *   <li>{@link #shutdown(Object)} may be called more than once. The first call will trigger the
+ *       shutdown and any subsequent calls do nothing
+ *   <li>{@link #shutdown(Object)} may be called before the future of startup has completed. In that
+ *       case, it will complete the current running startup step, cancel all subsequent startup
+ *       step, complete the startup future with an exception and start the shutdown from the step
+ *       that last completed
+ * </ul>
+ *
+ * @param <CONTEXT> the startup/shutdown context
+ */
+public final class BootstrapProcess<CONTEXT> {
+  private final String name;
+  private final Logger logger;
+  private final Queue<BootstrapStep<CONTEXT>> steps;
+
+  private final Deque<BootstrapStep<CONTEXT>> startedSteps = new ArrayDeque<>();
+  private final CompletableActorFuture<CONTEXT> startupFuture = new CompletableActorFuture<>();
+  private final CompletableActorFuture<CONTEXT> shutdownFuture = new CompletableActorFuture<>();
+
+  private boolean startupRequested = false;
+  private boolean shutdownRequested = false;
+
+  public BootstrapProcess(
+      final String name, final List<BootstrapStep<CONTEXT>> steps, final Logger logger) {
+    this.name = name;
+    // copy the steps to avoid mutating the given list
+    this.steps = new ArrayDeque<>(steps);
+    this.logger = logger;
+  }
+
+  /** Must be called from within the host actor context. */
+  public ActorFuture<CONTEXT> startup(final CONTEXT context) {
+    if (shutdownRequested) {
+      throw new IllegalStateException(
+          String.format("Shutdown of bootstrap process %s was already requested", name));
+    }
+
+    if (startupRequested) {
+      throw new IllegalStateException(
+          String.format(
+              "Startup of bootstrap process %s should only be requested once, and was already requested",
+              name));
+    }
+
+    if (logger.isInfoEnabled()) {
+      logger.info("{} - Bootstrap startup started with {} steps", name, steps.size());
+    } else if (logger.isDebugEnabled()) {
+      final var stepNames = steps.stream().map(BootstrapStep::getName).collect(Collectors.toList());
+      logger.debug(
+          "{} - Bootstrap startup started with #{} steps: {}", name, steps.size(), stepNames);
+    }
+
+    startupRequested = true;
+    proceedWithStartup(context);
+    return startupFuture;
+  }
+
+  /** Must be called from within the host actor context. */
+  public ActorFuture<CONTEXT> shutdown(final CONTEXT context) {
+    if (shutdownRequested) {
+      logger.debug("{} - Shutdown already in progress", name);
+      return shutdownFuture;
+    }
+
+    if (logger.isInfoEnabled()) {
+      logger.info("{} - Bootstrap shutdown started with {} steps", name, startedSteps.size());
+    } else if (logger.isDebugEnabled()) {
+      final var stepNames =
+          startedSteps.stream().map(BootstrapStep::getName).collect(Collectors.toList());
+      logger.debug(
+          "{} - Bootstrap shutdown started with #{} steps: {}",
+          name,
+          startedSteps.size(),
+          stepNames);
+    }
+
+    // signal that shutdown was called; this is read by the startup process to abort a concurrent
+    // startup process
+    shutdownRequested = true;
+
+    if (startupRequested) {
+      // wait until the current startup step finishes and then complete it
+      // TODO: how to propagate the fact that startup was cancelled?
+      startupFuture.onComplete(
+          (latestContext, error) -> {
+            // if all startup steps were completed, then error is null and we can use ctxt
+            // if there was an error in the last step, then error is not null and we should use the
+            //  shutdown context
+            final CONTEXT contextToUse = error == null ? latestContext : context;
+            proceedWithShutdown(contextToUse, new ArrayList<>());
+          });
+    } else {
+      proceedWithShutdown(context, new ArrayList<>());
+    }
+
+    return shutdownFuture;
+  }
+
+  private void proceedWithStartup(final CONTEXT context) {
+    if (shutdownRequested) {
+      logger.info("{} - Interrupting startup process due to shutdown request", name);
+      startupFuture.complete(context);
+      return;
+    }
+
+    if (steps.isEmpty()) {
+      startupFuture.complete(context);
+      return;
+    }
+
+    final var currentStep = steps.poll();
+    // TODO: should we push it as started before or after it finishes?
+    startedSteps.push(currentStep);
+
+    logger.debug("{} - Proceeding to next startup step {}", name, currentStep.getName());
+    logger.trace(
+        "{} - Invoking startup of step {} with context {}", name, currentStep.getName(), context);
+    currentStep
+        .startup(context)
+        .onComplete((newContext, error) -> onCompleteStartupStep(currentStep, newContext, error));
+  }
+
+  private void onCompleteStartupStep(
+      final BootstrapStep<CONTEXT> currentStep, final CONTEXT newContext, final Throwable error) {
+    if (error == null) {
+      proceedWithStartup(newContext);
+      return;
+    }
+
+    logger.warn(
+        "{} - Aborting startup process due to exception during stage {}",
+        name,
+        currentStep.getName());
+    startupFuture.completeExceptionally(error);
+  }
+
+  private void proceedWithShutdown(
+      final CONTEXT context, final List<BootstrapStepException> exceptions) {
+
+    if (startedSteps.isEmpty()) {
+      if (exceptions.isEmpty()) {
+        shutdownFuture.complete(context);
+      } else {
+        shutdownFuture.completeExceptionally(aggregateExceptions(exceptions));
+      }
+
+      return;
+    }
+
+    final var currentStep = startedSteps.pop();
+    logger.debug("{} - Proceeding to next shutdown step {}", name, currentStep.getName());
+    logger.trace(
+        "{} - Invoking shutdown of step {} with context {}", name, currentStep.getName(), context);
+    currentStep
+        .shutdown(context)
+        .onComplete(
+            (newContext, error) ->
+                onCompleteShutdownStep(context, exceptions, currentStep, newContext, error));
+  }
+
+  private void onCompleteShutdownStep(
+      final CONTEXT context,
+      final List<BootstrapStepException> exceptions,
+      final BootstrapStep<CONTEXT> currentStep,
+      final CONTEXT newContext,
+      final Throwable error) {
+    if (error == null) {
+      proceedWithShutdown(newContext, exceptions);
+      return;
+    }
+
+    exceptions.add(new BootstrapStepException(error, currentStep.getName()));
+    logger.warn(
+        "Aborting startup process due to exception during stage " + currentStep.getName(), error);
+    proceedWithShutdown(context, exceptions);
+  }
+
+  private Throwable aggregateExceptions(final List<BootstrapStepException> exceptions) {
+    final var failedSteps =
+        exceptions.stream().map(BootstrapStepException::getStepName).collect(Collectors.toList());
+    final var message =
+        String.format(
+            "Bootstrap %s failed in the following steps: %s. See suppressed exceptions for details.",
+            name, failedSteps);
+
+    final var exception = new BootstrapException(message);
+    exceptions.forEach(exception::addSuppressed);
+    return exception;
+  }
+}

--- a/util/src/main/java/io/camunda/zeebe/util/startup/actor/BootstrapStep.java
+++ b/util/src/main/java/io/camunda/zeebe/util/startup/actor/BootstrapStep.java
@@ -1,0 +1,49 @@
+package io.camunda.zeebe.util.startup.actor;
+
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+
+/**
+ * Base interface for bootstrap steps. Each step implements the startup logic in {@code
+ * startup(...)}, as well as, the corresponding shutdown logic in {@code shutdown(...)}. Both
+ * methods take a context object as argument and return a future of the same context object.<br>
+ * Typically, a startup step will create resources and call setters on the context object, whereas a
+ * shutdown step will shutdown resources and remove them from the context by setting them to {@code
+ * null}. <br>
+ * Contract:
+ *
+ * <ul>
+ *   <li>{@link #shutdown(Object)} will never be called before {@link #startup(Object)}
+ *   <li>{@link #startup(Object)} will be called at most once
+ *   <li>@link #shutdown(Object)} may be called more than once with the expectation that the first
+ *       call will trigger the shutdown and any subsequent calls shall do nothing
+ *   <li>@link #shutdown(Object)} may be called before the future of startup has completed with the
+ *       expectation that it will either cancel the startup process, or it will wait until it
+ *       terminates and then immediately begin the shutdown
+ * </ul>
+ *
+ * @param <CONTEXT> context object for the startup and shutdown steps. During startup this context
+ *     is used to collect the resources created during startup; during shutdown it is used to set
+ *     resources that have been shut down to {@code null}
+ */
+public interface BootstrapStep<CONTEXT> {
+  /**
+   * Returns name for observability
+   *
+   * @return name for observability
+   */
+  String getName();
+
+  /**
+   * Executes the startup logic
+   *
+   * @param context the startup context at the start of this step
+   */
+  ActorFuture<CONTEXT> startup(final CONTEXT context);
+
+  /**
+   * Executes the shutdown logic
+   *
+   * @param context the shutdown context at the start of this step
+   */
+  ActorFuture<CONTEXT> shutdown(final CONTEXT context);
+}

--- a/util/src/main/java/io/camunda/zeebe/util/startup/actor/BootstrapStepException.java
+++ b/util/src/main/java/io/camunda/zeebe/util/startup/actor/BootstrapStepException.java
@@ -1,0 +1,14 @@
+package io.camunda.zeebe.util.startup.actor;
+
+public class BootstrapStepException extends Exception {
+  private final String stepName;
+
+  public BootstrapStepException(final Throwable cause, final String stepName) {
+    super(String.format("Bootstrap step %s failed", stepName), cause);
+    this.stepName = stepName;
+  }
+
+  public String getStepName() {
+    return stepName;
+  }
+}

--- a/util/src/test/java/io/camunda/zeebe/util/startup/StartupProcessTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/startup/StartupProcessTest.java
@@ -1,0 +1,527 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util.startup;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.sched.ActorTaskSchedulingService;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+@SuppressWarnings({"unchecked"})
+// TODO (probably impossible) test whether the task scheduler is called at the right time with the
+// right values
+class StartupProcessTest {
+
+  private static final Object STARTUP_CONTEXT =
+      new Object() {
+        @Override
+        public String toString() {
+          return "startupContext";
+        }
+      };
+
+  private static final Object SHUTDOWN_CONTEXT =
+      new Object() {
+        @Override
+        public String toString() {
+          return "shutdownContext";
+        }
+      };
+
+  private static final ActorTaskSchedulingService TEST_SCHEDULING_SERVICE =
+      new TestActorTaskSchedulingService();
+
+  static final class TestActorTaskSchedulingService implements ActorTaskSchedulingService {
+
+    @Override
+    public void submit(final Runnable action) {
+      action.run();
+    }
+  }
+
+  static class NoopStartupStep implements StartupStep<Object> {
+
+    @Override
+    public String getName() {
+      return "NoopStartupStep";
+    }
+
+    @Override
+    public void startup(final Object o, final Consumer<Either<Throwable, Object>> callback) {
+      callback.accept(Either.right(o));
+    }
+
+    @Override
+    public void shutdown(final Object o, final Consumer<Either<Throwable, Object>> callback) {
+      callback.accept(Either.right(o));
+    }
+  }
+
+  static class TestStartupStep implements StartupStep<Object> {
+
+    private final Object expectedStartupContext;
+    private final Either<Throwable, Object> resultOfStartupContext;
+    private final Object expectedShutdownContext;
+    private final Either<Throwable, Object> resultOfShutdownContext;
+
+    TestStartupStep(
+        final Object expectedStartupContext,
+        final Either<Throwable, Object> resultOfStartupContext,
+        final Object expectedShutdownContext,
+        final Either<Throwable, Object> resultOfShutdownContext) {
+      this.expectedStartupContext = expectedStartupContext;
+      this.resultOfStartupContext = resultOfStartupContext;
+      this.expectedShutdownContext = expectedShutdownContext;
+      this.resultOfShutdownContext = resultOfShutdownContext;
+    }
+
+    @Override
+    public String getName() {
+      return "NoopStartupStep";
+    }
+
+    @Override
+    public void startup(final Object o, final Consumer<Either<Throwable, Object>> callback) {
+      if (expectedStartupContext.equals(o)) {
+        callback.accept(resultOfStartupContext);
+      } else {
+        throw new IllegalArgumentException(
+            "Expected input to be" + expectedStartupContext + " but was called with " + o);
+      }
+    }
+
+    @Override
+    public void shutdown(final Object o, final Consumer<Either<Throwable, Object>> callback) {
+      if (expectedShutdownContext.equals(o)) {
+        callback.accept(resultOfShutdownContext);
+      } else {
+        throw new IllegalArgumentException(
+            "Expected input to be" + expectedShutdownContext + " but was called with " + o);
+      }
+    }
+  }
+
+  static final class InvocationCountingStartupStep implements StartupStep<Object> {
+
+    private int startupInvocationCounter = 0;
+    private int shutdownInvocationCounter = 0;
+
+    int getStartupInvocationCounter() {
+      return startupInvocationCounter;
+    }
+
+    int getShutdownInvocationCounter() {
+      return shutdownInvocationCounter;
+    }
+
+    @Override
+    public String getName() {
+      return "InvocationCountingStartupStep";
+    }
+
+    @Override
+    public void startup(final Object o, final Consumer<Either<Throwable, Object>> callback) {
+      startupInvocationCounter++;
+      callback.accept(Either.right(o));
+    }
+
+    @Override
+    public void shutdown(final Object o, final Consumer<Either<Throwable, Object>> callback) {
+      shutdownInvocationCounter++;
+      callback.accept(Either.right(o));
+    }
+  }
+
+  static final class WaitingStartupStep implements StartupStep<Object> {
+
+    private final CountDownLatch startupCountdownLatch;
+    private final boolean completeWithException;
+
+    WaitingStartupStep(
+        final CountDownLatch startupCountdownLatch, final boolean completeWithException) {
+      this.startupCountdownLatch = startupCountdownLatch;
+      this.completeWithException = completeWithException;
+    }
+
+    @Override
+    public String getName() {
+      return "WaitingStartupStep";
+    }
+
+    @Override
+    public void startup(final Object o, final Consumer<Either<Throwable, Object>> callback) {
+
+      final var startupThread =
+          new Thread(
+              () -> {
+                try {
+                  startupCountdownLatch.await();
+                } catch (final InterruptedException e) {
+                  e.printStackTrace();
+                } finally {
+                  if (!completeWithException) {
+                    callback.accept(Either.right(o));
+                  } else {
+                    callback.accept(Either.left(new Throwable("completed exceptionally")));
+                  }
+                }
+              });
+      startupThread.start();
+    }
+
+    @Override
+    public void shutdown(final Object o, final Consumer<Either<Throwable, Object>> callback) {
+      callback.accept(Either.right(o));
+    }
+  }
+
+  @Nested
+  class MainUseCase {
+
+    private static final String INPUT_STEP1 = "inputStep1";
+    private static final String INPUT_STEP2 = "inputStep2";
+    private static final String RESULT_STEP1 = "resultStep1";
+    private static final String RESULT_STEP2 = "resultStep2";
+
+    private final Exception testException1 = new Exception("TEST_EXCEPTION1");
+    private final Exception testException2 = new Exception("TEST_EXCEPTION1");
+
+    private StartupStep<Object> spyStep1;
+    private StartupStep<Object> spyStep2;
+
+    @BeforeEach
+    void setup() {
+      final var step1 = new NoopStartupStep();
+      final var step2 = new NoopStartupStep();
+
+      spyStep1 = spy(step1);
+      spyStep2 = spy(step2);
+
+      when(spyStep1.getName()).thenReturn("step1");
+      when(spyStep2.getName()).thenReturn("step2");
+    }
+
+    @Test
+    void shouldCallStartupStepsInOrder() {
+      // given
+      final var sut = new StartupProcess<>(TEST_SCHEDULING_SERVICE, List.of(spyStep1, spyStep2));
+
+      // when
+      sut.startup(STARTUP_CONTEXT, (result) -> {});
+
+      // then
+      final var invocationRecorder = inOrder(spyStep1, spyStep2);
+      invocationRecorder.verify(spyStep1).startup(eq(STARTUP_CONTEXT), any());
+      invocationRecorder.verify(spyStep2).startup(eq(STARTUP_CONTEXT), any());
+    }
+
+    @Test
+    void shouldCallShutdownStepsInReverseOrder() {
+      // given
+      final var sut = new StartupProcess<>(TEST_SCHEDULING_SERVICE, List.of(spyStep1, spyStep2));
+      sut.startup(STARTUP_CONTEXT, (result) -> {});
+
+      // when
+      sut.shutdown(SHUTDOWN_CONTEXT, (result) -> {});
+
+      // then
+      final var invocationRecorder = inOrder(spyStep1, spyStep2);
+      invocationRecorder.verify(spyStep2).shutdown(eq(SHUTDOWN_CONTEXT), any());
+      invocationRecorder.verify(spyStep1).shutdown(eq(SHUTDOWN_CONTEXT), any());
+    }
+
+    @Test
+    void shouldCallSubsequentStartupStepWithResultOfPreviousStep() {
+      // given
+      final var step1 = new TestStartupStep(INPUT_STEP1, Either.right(RESULT_STEP1), null, null);
+      final var step2 = new TestStartupStep(RESULT_STEP1, Either.right(RESULT_STEP2), null, null);
+
+      spyStep1 = spy(step1);
+      spyStep2 = spy(step2);
+
+      when(spyStep1.getName()).thenReturn("step1");
+      when(spyStep2.getName()).thenReturn("step2");
+
+      final var sut = new StartupProcess<>(TEST_SCHEDULING_SERVICE, List.of(spyStep1, spyStep2));
+
+      final var mockCallback = Mockito.mock(Consumer.class);
+
+      // when
+      sut.startup(INPUT_STEP1, mockCallback);
+
+      // then
+      final var invocationRecorder = inOrder(spyStep1, spyStep2);
+      invocationRecorder.verify(spyStep1).startup(eq(INPUT_STEP1), any());
+      invocationRecorder.verify(spyStep2).startup(eq(RESULT_STEP1), any());
+
+      final var argumentCaptor = ArgumentCaptor.forClass(Either.class);
+      verify(mockCallback).accept(argumentCaptor.capture());
+
+      assertThat(argumentCaptor.getValue().get()).isSameAs(RESULT_STEP2);
+    }
+
+    @Test
+    void shouldCallSubsequentShutdownStepWithResultOfPreviousStep() {
+      // given
+      final var step1 =
+          new TestStartupStep(
+              INPUT_STEP1, Either.right(RESULT_STEP1), RESULT_STEP2, Either.right(RESULT_STEP1));
+      final var step2 =
+          new TestStartupStep(
+              RESULT_STEP1, Either.right(RESULT_STEP2), INPUT_STEP2, Either.right(RESULT_STEP2));
+
+      spyStep1 = spy(step1);
+      spyStep2 = spy(step2);
+
+      when(spyStep1.getName()).thenReturn("step1");
+      when(spyStep2.getName()).thenReturn("step2");
+
+      final var sut = new StartupProcess<>(TEST_SCHEDULING_SERVICE, List.of(spyStep1, spyStep2));
+
+      final var mockCallback = Mockito.mock(Consumer.class);
+
+      sut.startup(INPUT_STEP1, (result) -> {});
+
+      // when
+      sut.shutdown(INPUT_STEP2, mockCallback);
+
+      // then
+      final var invocationRecorder = inOrder(spyStep1, spyStep2);
+      invocationRecorder.verify(spyStep2).shutdown(eq(INPUT_STEP2), any());
+      invocationRecorder.verify(spyStep1).shutdown(eq(RESULT_STEP2), any());
+
+      final var argumentCaptor = ArgumentCaptor.forClass(Either.class);
+      verify(mockCallback).accept(argumentCaptor.capture());
+
+      assertThat(argumentCaptor.getValue().get()).isSameAs(RESULT_STEP1);
+    }
+
+    @Test
+    void shouldAbortStartupIfOneStepThrewAnException() {
+      // given
+      final var testException = new Exception("TEST_EXCEPTION");
+
+      final var step1 =
+          new TestStartupStep(
+              STARTUP_CONTEXT,
+              Either.left(testException),
+              RESULT_STEP2,
+              Either.right(RESULT_STEP1));
+
+      spyStep1 = spy(step1);
+      when(spyStep1.getName()).thenReturn("step1");
+
+      final var sut = new StartupProcess<>(TEST_SCHEDULING_SERVICE, List.of(spyStep1, spyStep2));
+
+      final var mockCallback = Mockito.mock(Consumer.class);
+
+      // when
+      sut.startup(STARTUP_CONTEXT, mockCallback);
+
+      // then
+      verify(spyStep2, never()).startup(eq(STARTUP_CONTEXT), any());
+
+      final var argumentCaptor = ArgumentCaptor.forClass(Either.class);
+      verify(mockCallback).accept(argumentCaptor.capture());
+
+      assertThat(argumentCaptor.getValue().getLeft()).isSameAs(testException);
+    }
+
+    @Test
+    void shouldContinueShutdownEvenIfStepsThrowExceptions() {
+      // given
+      final var step1 =
+          new TestStartupStep(
+              STARTUP_CONTEXT,
+              Either.right(STARTUP_CONTEXT),
+              SHUTDOWN_CONTEXT,
+              Either.left(testException1));
+      final var step2 =
+          new TestStartupStep(
+              STARTUP_CONTEXT,
+              Either.right(STARTUP_CONTEXT),
+              SHUTDOWN_CONTEXT,
+              Either.left(testException2));
+
+      spyStep1 = spy(step1);
+      spyStep2 = spy(step2);
+
+      when(spyStep1.getName()).thenReturn("step1");
+      when(spyStep2.getName()).thenReturn("step2");
+
+      final var sut = new StartupProcess<>(TEST_SCHEDULING_SERVICE, List.of(spyStep1, spyStep2));
+
+      sut.startup(STARTUP_CONTEXT, (result) -> {});
+
+      final var mockCallback = Mockito.mock(Consumer.class);
+
+      // when
+      sut.shutdown(SHUTDOWN_CONTEXT, mockCallback);
+
+      // then
+      verify(spyStep2).shutdown(eq(SHUTDOWN_CONTEXT), any());
+      verify(spyStep1).shutdown(eq(SHUTDOWN_CONTEXT), any());
+
+      final var argumentCaptor = ArgumentCaptor.forClass(Either.class);
+      verify(mockCallback).accept(argumentCaptor.capture());
+
+      assertThat(argumentCaptor.getValue().getLeft()).isInstanceOf(Exception.class);
+
+      final var exception = (Throwable) argumentCaptor.getValue().getLeft();
+
+      assertThat(exception)
+          .hasSuppressedException(testException1)
+          .hasSuppressedException(testException2);
+    }
+
+    @Test
+    void shouldAbortOngoingStartupWhenShutdownIsCalled() {
+      // given
+      final var step1CountdownLatch = new CountDownLatch(1);
+      final var step1 = new WaitingStartupStep(step1CountdownLatch, false);
+
+      final var sut = new StartupProcess<>(TEST_SCHEDULING_SERVICE, List.of(step1, spyStep2));
+
+      final var mockStartupCallback = Mockito.mock(Consumer.class);
+      final var mockShutdownCallback = Mockito.mock(Consumer.class);
+
+      // when
+      sut.startup(STARTUP_CONTEXT, mockStartupCallback);
+      sut.shutdown(SHUTDOWN_CONTEXT, mockShutdownCallback);
+
+      step1CountdownLatch.countDown();
+
+      // then
+      verifyNoInteractions(spyStep2);
+
+      final var startupArgumentCaptor = ArgumentCaptor.forClass(Either.class);
+      verify(mockStartupCallback, timeout(100)).accept(startupArgumentCaptor.capture());
+
+      assertThat(startupArgumentCaptor.getValue().isLeft())
+          .describedAs("Startup completed with exception")
+          .isTrue();
+
+      final var shutdownArgumentCaptor = ArgumentCaptor.forClass(Either.class);
+      verify(mockShutdownCallback).accept(shutdownArgumentCaptor.capture());
+
+      assertThat(shutdownArgumentCaptor.getValue().get()).isSameAs(SHUTDOWN_CONTEXT);
+    }
+  }
+
+  @Nested
+  class IllegalStatesAndArguments {
+
+    @Test
+    void shouldThrowNPEWhenCalledWithNoSteps() {
+      // when + then
+      assertThatThrownBy(() -> new StartupProcess<>(TEST_SCHEDULING_SERVICE, null))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNPEWhenCalledWithNoScheduler() {
+      // when + then
+      assertThatThrownBy(() -> new StartupProcess<>(null, Collections.emptyList()))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNPEWhenCalledWithNoLogger() {
+      // when + then
+      assertThatThrownBy(
+              () -> new StartupProcess<>(null, TEST_SCHEDULING_SERVICE, Collections.emptyList()))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowIllegalStateIfStartupIsCalledMoreThanOnce() {
+      // given
+      final var sut = new StartupProcess<>(TEST_SCHEDULING_SERVICE, Collections.emptyList());
+
+      // when + then
+      sut.startup(STARTUP_CONTEXT, (result) -> {});
+
+      assertThatThrownBy(() -> sut.startup(STARTUP_CONTEXT, (result) -> {}))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("startup(...) must only be called once");
+    }
+
+    @Test
+    void shouldPerformShutdownOnlyOnceIfShutdownIsCalledMultipleTimes() {
+      // given
+      final var step = new InvocationCountingStartupStep();
+      final var sut = new StartupProcess<>(TEST_SCHEDULING_SERVICE, singletonList(step));
+
+      // when
+      sut.startup(STARTUP_CONTEXT, (result) -> {});
+      sut.shutdown(SHUTDOWN_CONTEXT, (result) -> {});
+      sut.shutdown(SHUTDOWN_CONTEXT, (result) -> {});
+
+      // then
+      assertThat(step.getShutdownInvocationCounter()).isEqualTo(1);
+    }
+  }
+
+  @Nested
+  class EmptyList {
+
+    private final StartupProcess<Object> sut =
+        new StartupProcess<>(TEST_SCHEDULING_SERVICE, Collections.emptyList());
+
+    @Test
+    void shouldReturnContextImmediatelyOnStartup() {
+      final var mockCallback = Mockito.mock(Consumer.class);
+
+      // when
+      sut.startup(STARTUP_CONTEXT, mockCallback);
+
+      // then
+      final var argumentCaptor = ArgumentCaptor.forClass(Either.class);
+      verify(mockCallback).accept(argumentCaptor.capture());
+
+      assertThat(argumentCaptor.getValue().get()).isSameAs(STARTUP_CONTEXT);
+    }
+
+    @Test
+    void shouldReturnContextImmediatelyOnShutdown() {
+      // given
+      sut.startup(STARTUP_CONTEXT, (result) -> {});
+
+      final var mockCallback = Mockito.mock(Consumer.class);
+
+      // when
+      sut.shutdown(SHUTDOWN_CONTEXT, mockCallback);
+
+      // then
+      final var argumentCaptor = ArgumentCaptor.forClass(Either.class);
+      verify(mockCallback).accept(argumentCaptor.capture());
+
+      assertThat(argumentCaptor.getValue().get()).isSameAs(SHUTDOWN_CONTEXT);
+    }
+  }
+}

--- a/util/src/test/java/io/camunda/zeebe/util/startup/actor/Application.java
+++ b/util/src/test/java/io/camunda/zeebe/util/startup/actor/Application.java
@@ -1,0 +1,62 @@
+package io.camunda.zeebe.util.startup.actor;
+
+import io.camunda.zeebe.util.sched.Actor;
+import io.camunda.zeebe.util.sched.ActorScheduler;
+import java.util.List;
+import org.agrona.concurrent.ShutdownSignalBarrier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class Application extends Actor {
+  private static final Logger LOGGER = LoggerFactory.getLogger(Application.class);
+
+  private final BootstrapProcess<SampleContext> bootstrap =
+      new BootstrapProcess<>("sample", List.of(new StepA(), new StepB()), LOGGER);
+
+  private SampleContext context = new SampleContext();
+
+  private Application() {}
+
+  public static void main(final String[] args) throws Exception {
+    final var shutdownBarrier = new ShutdownSignalBarrier();
+    final var application = new Application();
+
+    try (final var scheduler = ActorScheduler.newActorScheduler().build()) {
+      scheduler.start();
+      scheduler.submitActor(application).join();
+      shutdownBarrier.await();
+      application.close();
+    }
+  }
+
+  @Override
+  public String getName() {
+    return "application";
+  }
+
+  @Override
+  protected void onActorStarted() {
+    bootstrap.startup(context).onComplete(this::onStartupComplete);
+  }
+
+  @Override
+  protected void onActorClosing() {
+    bootstrap.shutdown(context).onComplete(this::onShutdownComplete);
+  }
+
+  private void onShutdownComplete(final SampleContext newContext, final Throwable error) {
+    if (error == null) {
+      LOGGER.info("sample bootstrap shutdown completed with context: {}", newContext);
+    } else {
+      LOGGER.error("sample bootstrap shutdown failed with latest context: {}", context, error);
+    }
+  }
+
+  private void onStartupComplete(final SampleContext newContext, final Throwable error) {
+    if (error == null) {
+      LOGGER.info("sample bootstrap startup completed with context: {}", newContext);
+    } else {
+      LOGGER.error("sample bootstrap startup failed with latest context: {}", context, error);
+    }
+  }
+}

--- a/util/src/test/java/io/camunda/zeebe/util/startup/actor/SampleContext.java
+++ b/util/src/test/java/io/camunda/zeebe/util/startup/actor/SampleContext.java
@@ -1,0 +1,54 @@
+package io.camunda.zeebe.util.startup.actor;
+
+import java.util.Objects;
+
+final class SampleContext {
+  private String propertyA = "defaultA";
+  private String propertyB = "defaultB";
+
+  String getPropertyA() {
+    return propertyA;
+  }
+
+  void setPropertyA(final String propertyA) {
+    this.propertyA = propertyA;
+  }
+
+  String getPropertyB() {
+    return propertyB;
+  }
+
+  void setPropertyB(final String propertyB) {
+    this.propertyB = propertyB;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getPropertyA(), getPropertyB());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SampleContext)) {
+      return false;
+    }
+    final SampleContext that = (SampleContext) o;
+    return Objects.equals(getPropertyA(), that.getPropertyA())
+        && Objects.equals(getPropertyB(), that.getPropertyB());
+  }
+
+  @Override
+  public String toString() {
+    return "SampleContext{"
+        + "propertyA='"
+        + propertyA
+        + '\''
+        + ", propertyB='"
+        + propertyB
+        + '\''
+        + '}';
+  }
+}

--- a/util/src/test/java/io/camunda/zeebe/util/startup/actor/StepA.java
+++ b/util/src/test/java/io/camunda/zeebe/util/startup/actor/StepA.java
@@ -1,0 +1,36 @@
+package io.camunda.zeebe.util.startup.actor;
+
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
+
+final class StepA implements BootstrapStep<SampleContext> {
+  private String initialPropertyA;
+
+  @Override
+  public String getName() {
+    return "set property A to foo";
+  }
+
+  @Override
+  public ActorFuture<SampleContext> startup(final SampleContext context) {
+    initialPropertyA = context.getPropertyA();
+    if (initialPropertyA.equals("foo")) {
+      return CompletableActorFuture.completedExceptionally(
+          new IllegalStateException("Expected to set propertyA to foo, but it's already foo!"));
+    }
+
+    context.setPropertyA("foo");
+    return CompletableActorFuture.completed(context);
+  }
+
+  @Override
+  public ActorFuture<SampleContext> shutdown(final SampleContext context) {
+    if (!context.getPropertyA().equals("foo")) {
+      return CompletableActorFuture.completedExceptionally(
+          new IllegalStateException("Expected to rollback propertyA from foo, but it's not foo!"));
+    }
+
+    context.setPropertyA(initialPropertyA);
+    return CompletableActorFuture.completed(context);
+  }
+}

--- a/util/src/test/java/io/camunda/zeebe/util/startup/actor/StepB.java
+++ b/util/src/test/java/io/camunda/zeebe/util/startup/actor/StepB.java
@@ -1,0 +1,36 @@
+package io.camunda.zeebe.util.startup.actor;
+
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
+
+final class StepB implements BootstrapStep<SampleContext> {
+  private String initialPropertyB;
+
+  @Override
+  public String getName() {
+    return "set property B to bar";
+  }
+
+  @Override
+  public ActorFuture<SampleContext> startup(final SampleContext context) {
+    initialPropertyB = context.getPropertyB();
+    if (initialPropertyB.equals("bar")) {
+      return CompletableActorFuture.completedExceptionally(
+          new IllegalStateException("Expected to set propertyB to bar, but it's already bar!"));
+    }
+
+    context.setPropertyB("baz");
+    return CompletableActorFuture.completed(context);
+  }
+
+  @Override
+  public ActorFuture<SampleContext> shutdown(final SampleContext context) {
+    if (!context.getPropertyB().equals("bar")) {
+      return CompletableActorFuture.completedExceptionally(
+          new IllegalStateException("Expected to rollback propertyB from bar, but it's not bar!"));
+    }
+
+    context.setPropertyB(initialPropertyB);
+    return CompletableActorFuture.completed(context);
+  }
+}


### PR DESCRIPTION
## Description

Startup base classes actor style. 

This is one proposal to implement #7536. The other proposal is #7557 

The two proposals exist to compare actor style and  completable future style. Otherwise, they are pretty much equivalent.

## Related issues

closes #7536

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
