### PR TITLE
feat(broker): followers re-install services when new snapshot is received

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.partitions;
 
 import io.atomix.raft.RaftRoleChangeListener;
 import io.atomix.raft.RaftServer.Role;
+import io.atomix.raft.SnapshotReplicationListener;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
@@ -31,7 +32,11 @@ import java.util.Optional;
 import org.slf4j.Logger;
 
 public final class ZeebePartition extends Actor
-    implements RaftRoleChangeListener, HealthMonitorable, FailureListener, DiskSpaceUsageListener {
+    implements RaftRoleChangeListener,
+        HealthMonitorable,
+        FailureListener,
+        DiskSpaceUsageListener,
+        SnapshotReplicationListener {
 
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
   private Role raftRole;
@@ -174,6 +179,7 @@ public final class ZeebePartition extends Actor
     context.getRaftPartition().addRoleChangeListener(this);
     context.getComponentHealthMonitor().addFailureListener(this);
     onRoleChange(context.getRaftPartition().getRole(), context.getRaftPartition().term());
+    context.getRaftPartition().getServer().addSnapshotReplicationListener(this);
   }
 
   @Override
@@ -192,11 +198,12 @@ public final class ZeebePartition extends Actor
 
   @Override
   protected void onActorClosing() {
+    context.getRaftPartition().getServer().removeSnapshotReplicationListener(this);
+    context.getRaftPartition().removeRoleChangeListener(this);
+
     transitionToInactive()
         .onComplete(
             (nothing, err) -> {
-              context.getRaftPartition().removeRoleChangeListener(this);
-
               context
                   .getComponentHealthMonitor()
                   .removeComponent(context.getRaftPartition().name());
@@ -460,5 +467,21 @@ public final class ZeebePartition extends Actor
             LOG.error("Could not resume exporting", e);
           }
         });
+  }
+
+  @Override
+  public void onSnapshotReplicationStarted() {
+    // When a snapshot is received, the follower stream processor and exporter should
+    // restart from a new state. So we transition to Inactive to close existing services. The
+    // services will be reinstalled when snapshot replication is completed.
+    // We do not want to mark it as unhealthy, hence we don't reuse transitionToInactive()
+    actor.run(() -> currentTransitionFuture = transition.toInactive());
+  }
+
+  @Override
+  public void onSnapshotReplicationCompleted(final long term) {
+    // Snapshot is received only by the followers. Hence we can safely assume that we have to
+    // re-install follower services.
+    actor.run(() -> currentTransitionFuture = followerTransition(term));
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
+import io.atomix.raft.partition.impl.RaftPartitionServer;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.health.CriticalComponentsHealthMonitor;
 import io.camunda.zeebe.util.health.FailureListener;
@@ -52,6 +53,7 @@ public class ZeebePartitionTest {
     raft = mock(RaftPartition.class);
     when(raft.id()).thenReturn(new PartitionId("", 0));
     when(raft.getRole()).thenReturn(Role.INACTIVE);
+    when(raft.getServer()).thenReturn(mock(RaftPartitionServer.class));
 
     healthMonitor = mock(CriticalComponentsHealthMonitor.class);
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTransitionIntegrationTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTransitionIntegrationTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
+import io.atomix.raft.partition.impl.RaftPartitionServer;
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionTransitionImpl;
 import io.camunda.zeebe.broker.system.partitions.impl.TestPartitionStep;
 import io.camunda.zeebe.util.health.CriticalComponentsHealthMonitor;
@@ -43,6 +44,7 @@ public class ZeebePartitionTransitionIntegrationTest {
     final RaftPartition raftPartition = mock(RaftPartition.class);
     when(raftPartition.id()).thenReturn(new PartitionId("", 0));
     when(raftPartition.getRole()).thenReturn(Role.INACTIVE);
+    when(raftPartition.getServer()).thenReturn(mock(RaftPartitionServer.class));
 
     final CriticalComponentsHealthMonitor healthMonitor =
         mock(CriticalComponentsHealthMonitor.class);


### PR DESCRIPTION
## Description

ZeebePartition implements `SnapshotReplicationListener` and re-installs follower services when new snapshot is received via raft replication.

There is no test for this yet. I think it would make sense to add a test after #7513 is done.

## Related issues

closes #7481 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
