### PR TITLE
Fix partition status when building state on followers

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/management/PartitionStatus.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/management/PartitionStatus.java
@@ -55,8 +55,10 @@ public final class PartitionStatus {
         exportedPosition);
   }
 
-  public static PartitionStatus ofFollower(final String snapshotId) {
-    return new PartitionStatus(Role.FOLLOWER, null, snapshotId, null, null, null, null);
+  public static PartitionStatus ofFollower(
+      final String snapshotId, final Long processedPositionInSnapshot) {
+    return new PartitionStatus(
+        Role.FOLLOWER, null, snapshotId, processedPositionInSnapshot, null, null, null);
   }
 
   public Role getRole() {
@@ -85,5 +87,26 @@ public final class PartitionStatus {
 
   public Long getExportedPosition() {
     return exportedPosition;
+  }
+
+  @Override
+  public String toString() {
+    return "PartitionStatus{"
+        + "role="
+        + role
+        + ", snapshotId='"
+        + snapshotId
+        + '\''
+        + ", processedPosition="
+        + processedPosition
+        + ", processedPositionInSnapshot="
+        + processedPositionInSnapshot
+        + ", streamProcessorPhase="
+        + streamProcessorPhase
+        + ", exporterPhase="
+        + exporterPhase
+        + ", exportedPosition="
+        + exportedPosition
+        + '}';
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -484,4 +484,8 @@ public final class ZeebePartition extends Actor
     // re-install follower services.
     actor.run(() -> currentTransitionFuture = followerTransition(term));
   }
+
+  public ActorFuture<Role> getCurrentRole() {
+    return actor.call(() -> context.getCurrentRole());
+  }
 }

--- a/util/src/main/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitor.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitor.java
@@ -46,8 +46,10 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
     actor.run(
         () -> {
           final var monitoredComponent = monitoredComponents.remove(componentName);
-          componentHealth.remove(componentName);
-          monitoredComponent.component.removeFailureListener(monitoredComponent);
+          if (monitoredComponent != null) {
+            componentHealth.remove(componentName);
+            monitoredComponent.component.removeFailureListener(monitoredComponent);
+          }
         });
   }
 


### PR DESCRIPTION
## Description

Previously adminService check if streamprocessor exists to determine if it is a follower or leader. This is not true anymore when follower starts building state. Now it retreives the role from ZeebePArtition.

In addition, also updated the BrokerAdminServiceTest to not verify if snapshots on follower and leaders are equal. Snapshot won't be same once #7513 is done.

## Related issues

This  PR is preparation to #7513 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
