### PR TITLE
test(qa): improve flaky DiskSpaceMonitoringFailOverTest

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/health/DiskSpaceMonitoringFailOverTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/health/DiskSpaceMonitoringFailOverTest.java
@@ -50,13 +50,13 @@ public class DiskSpaceMonitoringFailOverTest {
         clusteringRule.getBrokers().stream()
             .filter(b -> b.getConfig().getCluster().getNodeId() != leaderId)
             .collect(Collectors.toList());
-    // Force rescan of healthcheck
-    clusteringRule.getClock().addTime(Duration.ofSeconds(60));
 
     followers.forEach(
         broker ->
             Awaitility.await()
-                .timeout(Duration.ofSeconds(30))
+                // If broker is not healthy, it can take upto one health check interval (60 seconds)
+                // to determine if it is healthy again
+                .timeout(Duration.ofSeconds(70))
                 .untilAsserted(
                     () ->
                         assertThat(


### PR DESCRIPTION
## Description

StreamProcessor health check is based on a health tick which checks if the last successful tick was with in a specified interval. When forcing the rescan of health check by advancing the clock, the streamprocessor is sometimes detected as unhealthy because the last health tick was before the clock was advanced artificially. The test fails as a result as it timesout waiting for the broker to be healthy. So it is not a good idea to advance the clock to rescan the health check. Instead we just wait for one health check interval until the broker is healthy.

## Related issues

<!-- Which issues are closed by this PR or are related -->


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
