### PR TITLE
chore(ci): use github app as git user.name instead of camunda-jenkins

### DIFF
--- a/.ci/scripts/release/prepare-go.sh
+++ b/.ci/scripts/release/prepare-go.sh
@@ -2,7 +2,7 @@
 
 # configure Jenkins GitHub user for GO container
 git config --global user.email "ci@camunda.com"
-git config --global user.name "camunda-jenkins"
+git config --global user.name "${GITHUB_TOKEN_USR}"
 
 GOCOMPAT_VERSION="v0.2.0"
 

--- a/.ci/scripts/release/prepare.sh
+++ b/.ci/scripts/release/prepare.sh
@@ -6,11 +6,7 @@ git remote add origin https://${GITHUB_TOKEN_USR}:${GITHUB_TOKEN_PSW}@github.com
 
 # configure Jenkins GitHub user for Maven container
 git config --global user.email "ci@camunda.com"
-git config --global user.name "camunda-jenkins"
-
-# trust github ssh key
-mkdir -p ~/.ssh/
-ssh-keyscan github.com >> ~/.ssh/known_hosts
+git config --global user.name "${GITHUB_TOKEN_USR}"
 
 # setup maven central gpg keys
 gpg -q --allow-secret-key-import --import --no-tty --batch --yes ${GPG_SEC_KEY}


### PR DESCRIPTION
## Description

The Github user "camunda-jenkins" is used as git `user.name` even though the user is not really used for auth (Github app is used).

Also since the app is used, then ssh not used anymore to access Github.

Related to: NFRA-2661