### PR TITLE
Read event from the log stream in batches

### DIFF
--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderImpl.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.logstreams.impl.log;
+
+import io.camunda.zeebe.logstreams.log.LogStreamBatchReader;
+import io.camunda.zeebe.logstreams.log.LogStreamReader;
+import io.camunda.zeebe.logstreams.log.LoggedEvent;
+import java.util.NoSuchElementException;
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.collections.IntArrayList;
+
+public class LogStreamBatchReaderImpl implements LogStreamBatchReader {
+
+  private final LogStreamBatchImpl batch = new LogStreamBatchImpl();
+
+  private final MutableDirectBuffer eventBuffer = new ExpandableArrayBuffer();
+  private final IntArrayList bufferOffsets = new IntArrayList();
+
+  private final LogStreamReader logStreamReader;
+
+  public LogStreamBatchReaderImpl(final LogStreamReader logStreamReader) {
+    this.logStreamReader = logStreamReader;
+  }
+
+  @Override
+  public boolean seekToNextBatch(final long position) {
+    return logStreamReader.seekToNextEvent(position);
+  }
+
+  @Override
+  public boolean hasNext() {
+    return logStreamReader.hasNext();
+  }
+
+  @Override
+  public Batch next() {
+    if (!logStreamReader.hasNext()) {
+      throw new NoSuchElementException();
+    }
+
+    bufferOffsets.clear();
+    int bufferOffset = 0;
+    long sourceEventPosition;
+
+    do {
+      final LoggedEvent event = logStreamReader.next();
+      sourceEventPosition = event.getSourceEventPosition();
+
+      event.write(eventBuffer, bufferOffset);
+
+      bufferOffsets.addInt(bufferOffset);
+
+      bufferOffset += event.getLength();
+
+    } while (logStreamReader.hasNext()
+        && sourceEventPosition > 0
+        && sourceEventPosition == logStreamReader.peekNext().getSourceEventPosition());
+
+    batch.wrap(eventBuffer, bufferOffsets);
+    return batch;
+  }
+
+  @Override
+  public void close() {
+    logStreamReader.close();
+    bufferOffsets.clear();
+  }
+
+  static class LogStreamBatchImpl implements LogStreamBatchReader.Batch {
+
+    private final LoggedEventImpl event = new LoggedEventImpl();
+
+    private DirectBuffer buffer;
+    private IntArrayList offsets;
+
+    private int currentIndex = 0;
+
+    private void wrap(final DirectBuffer buffer, final IntArrayList offsets) {
+      this.buffer = buffer;
+      this.offsets = offsets;
+
+      head();
+    }
+
+    @Override
+    public void head() {
+      currentIndex = 0;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return currentIndex < offsets.size();
+    }
+
+    @Override
+    public LoggedEvent next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+
+      final var offset = offsets.get(currentIndex);
+      event.wrap(buffer, offset);
+
+      currentIndex += 1;
+
+      return event;
+    }
+  }
+}

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
@@ -168,6 +168,14 @@ public final class LogStreamReaderImpl implements LogStreamReader {
     return -1;
   }
 
+  @Override
+  public LoggedEvent peekNext() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    return nextEvent;
+  }
+
   private void reset() {
     currentEventBuffer.wrap(0, 0);
     currentEvent.wrap(currentEventBuffer, 0);

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBatchReader.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBatchReader.java
@@ -13,7 +13,7 @@ import java.util.Iterator;
 
 /**
  * Reads the log stream in batches. Similar to {@link LogStreamReader} but groups events with the
- * same source event position in batches. Can be used to read all follow-up events atomically.
+ * same source event position in batches. Can be used to read all follow-up events at once.
  *
  * <pre>
  * <code>

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBatchReader.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBatchReader.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.logstreams.log;
+
+import io.camunda.zeebe.logstreams.log.LogStreamBatchReader.Batch;
+import io.camunda.zeebe.util.CloseableSilently;
+import java.util.Iterator;
+
+/**
+ * Reads the log stream in batches. Similar to {@link LogStreamReader} but groups events with the
+ * same source event position in batches. Can be used to read all follow-up events atomically.
+ *
+ * <pre>
+ * <code>
+ *
+ * // optionally
+ * reader.seekToNextBatch(position);
+ *
+ * while (reader.hasNext()) {
+ *     final Batch batch = reader.next();
+ *     while (batch.hasNext()) {
+ *         final LoggedEvent event = batch.next();
+ *         // ...
+ *     }
+ * }
+ * </code>
+ * </pre>
+ */
+public interface LogStreamBatchReader extends Iterator<Batch>, CloseableSilently {
+
+  /**
+   * Seeks to the next event after the given position. If the position is negative then it seeks to
+   * the first event.
+   *
+   * @param position the position to seek for the next event
+   * @return <code>true</code>, if the given position exists, or if it is negative
+   */
+  boolean seekToNextBatch(long position);
+
+  /**
+   * A batch of events that share the same source record position. Events with no source event
+   * position are in a singleton batch.
+   *
+   * <pre>
+   * <code>
+   *
+   * while (batch.hasNext()) {
+   *     final LoggedEvent event = batch.next();
+   *     // ...
+   * }
+   * </code>
+   * </pre>
+   */
+  interface Batch extends Iterator<LoggedEvent> {
+
+    /**
+     * Move to the head of the batch. Reads the first event of the batch next. Can be used to read
+     * the whole batch again.
+     */
+    void head();
+  }
+}

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBatchReader.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBatchReader.java
@@ -34,7 +34,7 @@ import java.util.Iterator;
 public interface LogStreamBatchReader extends Iterator<Batch>, CloseableSilently {
 
   /**
-   * Seeks to the next event after the given position. If the position is negative then it seeks to
+   * Seeks to the next batch after the given position. If the position is negative then it seeks to
    * the first event.
    *
    * @param position the position to seek for the next event

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamReader.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamReader.java
@@ -62,4 +62,13 @@ public interface LogStreamReader extends Iterator<LoggedEvent>, CloseableSilentl
    * @return the current log position, or negative value if the log is empty or not initialized
    */
   long getPosition();
+
+  /**
+   * Peeks the next event on the log. It is similar to {@link #next()} but it doesn't move the
+   * iterator. It should only be called if {@link #hasNext()} returns {@code true}.
+   *
+   * @return return the next event on the log
+   * @throws java.util.NoSuchElementException if there is no next event on the log
+   */
+  LoggedEvent peekNext();
 }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderTest.java
@@ -259,8 +259,8 @@ public class LogStreamBatchReaderTest {
   public void shouldSeekToNextEventWithinBatch() {
     // given
     final long eventPosition1 = writerRule.sourceEventPosition(1L).writeEvent(EVENT_VALUE);
-    final long eventPosition2 = writerRule.sourceEventPosition(1L).writeEvent(EVENT_VALUE);
-    writerRule.sourceEventPosition(2L).writeEvent(EVENT_VALUE);
+    writerRule.sourceEventPosition(1L).writeEvent(EVENT_VALUE);
+    final long eventPosition3 = writerRule.sourceEventPosition(2L).writeEvent(EVENT_VALUE);
 
     // when
     final var found = batchReader.seekToNextBatch(eventPosition1);
@@ -271,7 +271,7 @@ public class LogStreamBatchReaderTest {
 
     final var batch = batchReader.next();
     assertThat(batch.hasNext()).isTrue();
-    assertThat(batch.next().getPosition()).isEqualTo(eventPosition2);
+    assertThat(batch.next().getPosition()).isEqualTo(eventPosition3);
   }
 
   @Test

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderTest.java
@@ -325,11 +325,13 @@ public class LogStreamBatchReaderTest {
     writerRule.writeEvent(w -> w.key(1L).value(EVENT_VALUE));
 
     assertThat(batchReader.hasNext()).isTrue();
-    batchReader.next();
 
-    assertThat(batchReader.hasNext()).isFalse();
+    final var batch = batchReader.next();
+    batch.next();
+
+    assertThat(batch.hasNext()).isFalse();
 
     // when / then
-    assertThatThrownBy(batchReader::next).isInstanceOf(NoSuchElementException.class);
+    assertThatThrownBy(batch::next).isInstanceOf(NoSuchElementException.class);
   }
 }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderTest.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.logstreams.impl.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.logstreams.log.LogStreamBatchReader;
+import io.camunda.zeebe.logstreams.util.LogStreamReaderRule;
+import io.camunda.zeebe.logstreams.util.LogStreamRule;
+import io.camunda.zeebe.logstreams.util.LogStreamWriterRule;
+import io.camunda.zeebe.util.ByteValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.NoSuchElementException;
+import org.agrona.DirectBuffer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+
+public class LogStreamBatchReaderTest {
+
+  private static final DirectBuffer EVENT_VALUE = BufferUtil.wrapString("test");
+  private static final int LOG_SEGMENT_SIZE = (int) ByteValue.ofMegabytes(4);
+
+  private final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private final LogStreamRule logStreamRule =
+      LogStreamRule.startByDefault(
+          temporaryFolder,
+          builder -> builder.withMaxFragmentSize(LOG_SEGMENT_SIZE),
+          builder -> builder);
+
+  private final LogStreamWriterRule writerRule = new LogStreamWriterRule(logStreamRule);
+  private final LogStreamReaderRule readerRule = new LogStreamReaderRule(logStreamRule);
+
+  @Rule
+  public final RuleChain ruleChain =
+      RuleChain.outerRule(temporaryFolder)
+          .around(logStreamRule)
+          .around(readerRule)
+          .around(writerRule);
+
+  private LogStreamBatchReader batchReader;
+
+  @Before
+  public void setUp() {
+    final var logStreamReader = readerRule.getLogStreamReader();
+    batchReader = new LogStreamBatchReaderImpl(logStreamReader);
+  }
+
+  @Test
+  public void shouldNotHaveNextIfEmpty() {
+    assertThat(batchReader.hasNext()).isFalse();
+  }
+
+  @Test
+  public void shouldReadEventsInBatch() {
+    // given
+    final long eventPosition1 =
+        writerRule.sourceEventPosition(1L).writeEvent(w -> w.key(1L).value(EVENT_VALUE));
+    final long eventPosition2 =
+        writerRule.sourceEventPosition(1L).writeEvent(w -> w.key(2L).value(EVENT_VALUE));
+
+    // then
+    assertThat(batchReader.hasNext()).isTrue();
+
+    final var batch = batchReader.next();
+    assertThat(batch).isNotNull();
+
+    assertThat(batch.hasNext()).isTrue();
+    final var event1 = batch.next();
+    assertThat(event1.getKey()).isEqualTo(1L);
+    assertThat(event1.getPosition()).isEqualTo(eventPosition1);
+
+    assertThat(batch.hasNext()).isTrue();
+    final var event2 = batch.next();
+    assertThat(event2.getKey()).isEqualTo(2L);
+    assertThat(event2.getPosition()).isEqualTo(eventPosition2);
+
+    assertThat(batch.hasNext()).isFalse();
+    assertThat(batchReader.hasNext()).isFalse();
+  }
+
+  @Test
+  public void shouldReadNextBatch() {
+    // given
+    final long eventPosition1 =
+        writerRule.sourceEventPosition(1L).writeEvent(w -> w.key(1L).value(EVENT_VALUE));
+    final long eventPosition2 =
+        writerRule.sourceEventPosition(2L).writeEvent(w -> w.key(2L).value(EVENT_VALUE));
+
+    // then
+    assertThat(batchReader.hasNext()).isTrue();
+    final var batch1 = batchReader.next();
+
+    assertThat(batch1.hasNext()).isTrue();
+    final var event1 = batch1.next();
+    assertThat(event1.getKey()).isEqualTo(1L);
+    assertThat(event1.getPosition()).isEqualTo(eventPosition1);
+
+    assertThat(batch1.hasNext()).isFalse();
+    assertThat(batchReader.hasNext()).isTrue();
+
+    final var batch2 = batchReader.next();
+    assertThat(batch2.hasNext()).isTrue();
+    final var event2 = batch2.next();
+    assertThat(event2.getKey()).isEqualTo(2L);
+    assertThat(event2.getPosition()).isEqualTo(eventPosition2);
+
+    assertThat(batch2.hasNext()).isFalse();
+    assertThat(batchReader.hasNext()).isFalse();
+  }
+
+  @Test
+  public void shouldReadEventsWithoutSourceEventPosition() {
+    // given
+    final long eventPosition1 = writerRule.writeEvent(EVENT_VALUE);
+    final long eventPosition2 = writerRule.writeEvent(EVENT_VALUE);
+
+    // then
+    assertThat(batchReader.hasNext()).isTrue();
+
+    final var batch1 = batchReader.next();
+    assertThat(batch1.hasNext()).isTrue();
+    assertThat(batch1.next().getPosition()).isEqualTo(eventPosition1);
+
+    assertThat(batch1.hasNext()).isFalse();
+    assertThat(batchReader.hasNext()).isTrue();
+
+    final var batch2 = batchReader.next();
+    assertThat(batch2.hasNext()).isTrue();
+    assertThat(batch2.next().getPosition()).isEqualTo(eventPosition2);
+  }
+
+  @Test
+  public void shouldNotIncludeEventsWithoutSourceEventPosition() {
+    // given
+    final long eventPosition1 = writerRule.sourceEventPosition(1L).writeEvent(EVENT_VALUE);
+    final long eventPosition2 = writerRule.writeEvent(EVENT_VALUE);
+    final long eventPosition3 = writerRule.sourceEventPosition(2L).writeEvent(EVENT_VALUE);
+
+    // then
+    assertThat(batchReader.hasNext()).isTrue();
+
+    final var batch1 = batchReader.next();
+    assertThat(batch1.hasNext()).isTrue();
+    assertThat(batch1.next().getPosition()).isEqualTo(eventPosition1);
+
+    assertThat(batch1.hasNext()).isFalse();
+    assertThat(batchReader.hasNext()).isTrue();
+
+    final var batch2 = batchReader.next();
+    assertThat(batch2.hasNext()).isTrue();
+    assertThat(batch2.next().getPosition()).isEqualTo(eventPosition2);
+
+    assertThat(batch2.hasNext()).isFalse();
+    assertThat(batchReader.hasNext()).isTrue();
+
+    final var batch3 = batchReader.next();
+    assertThat(batch3.hasNext()).isTrue();
+    assertThat(batch3.next().getPosition()).isEqualTo(eventPosition3);
+  }
+
+  @Test
+  public void shouldMoveBatchToHead() {
+    // given
+    final long eventPosition1 = writerRule.sourceEventPosition(1L).writeEvent(EVENT_VALUE);
+    final long eventPosition2 = writerRule.sourceEventPosition(1L).writeEvent(EVENT_VALUE);
+    final long eventPosition3 = writerRule.sourceEventPosition(2L).writeEvent(EVENT_VALUE);
+
+    assertThat(batchReader.hasNext()).isTrue();
+
+    final var batch1 = batchReader.next();
+    assertThat(batch1.hasNext()).isTrue();
+    assertThat(batch1.next().getPosition()).isEqualTo(eventPosition1);
+
+    // when
+    batch1.head();
+
+    // then
+    assertThat(batch1.hasNext()).isTrue();
+    assertThat(batch1.next().getPosition()).isEqualTo(eventPosition1);
+
+    assertThat(batch1.hasNext()).isTrue();
+    assertThat(batch1.next().getPosition()).isEqualTo(eventPosition2);
+
+    assertThat(batch1.hasNext()).isFalse();
+
+    final var batch2 = batchReader.next();
+    assertThat(batch2.hasNext()).isTrue();
+    assertThat(batch2.next().getPosition()).isEqualTo(eventPosition3);
+  }
+
+  @Test
+  public void shouldSkipEventsInBatch() {
+    // given
+    final long eventPosition1 = writerRule.sourceEventPosition(1L).writeEvent(EVENT_VALUE);
+    writerRule.sourceEventPosition(1L).writeEvent(EVENT_VALUE);
+    final long eventPosition3 = writerRule.sourceEventPosition(2L).writeEvent(EVENT_VALUE);
+
+    assertThat(batchReader.hasNext()).isTrue();
+
+    final var batch1 = batchReader.next();
+    assertThat(batch1.hasNext()).isTrue();
+    assertThat(batch1.next().getPosition()).isEqualTo(eventPosition1);
+
+    // when
+    assertThat(batchReader.hasNext()).isTrue();
+
+    final var batch2 = batchReader.next();
+    assertThat(batch2.hasNext()).isTrue();
+    assertThat(batch2.next().getPosition()).isEqualTo(eventPosition3);
+  }
+
+  @Test
+  public void shouldSeekToHeadIfNegative() {
+    // given
+    final long eventPosition1 = writerRule.sourceEventPosition(1L).writeEvent(EVENT_VALUE);
+    writerRule.sourceEventPosition(1L).writeEvent(EVENT_VALUE);
+
+    // when
+    final var found = batchReader.seekToNextBatch(-1L);
+
+    // then
+    assertThat(found).isTrue();
+    assertThat(batchReader.hasNext()).isTrue();
+
+    final var batch = batchReader.next();
+    assertThat(batch.hasNext()).isTrue();
+    assertThat(batch.next().getPosition()).isEqualTo(eventPosition1);
+  }
+
+  @Test
+  public void shouldSeekToNextBatch() {
+    // given
+    writerRule.sourceEventPosition(1L).writeEvent(EVENT_VALUE);
+    final long eventPosition2 = writerRule.sourceEventPosition(1L).writeEvent(EVENT_VALUE);
+    final long eventPosition3 = writerRule.sourceEventPosition(2L).writeEvent(EVENT_VALUE);
+
+    // when
+    final var found = batchReader.seekToNextBatch(eventPosition2);
+
+    // then
+    assertThat(found).isTrue();
+    assertThat(batchReader.hasNext()).isTrue();
+
+    final var batch = batchReader.next();
+    assertThat(batch.hasNext()).isTrue();
+    assertThat(batch.next().getPosition()).isEqualTo(eventPosition3);
+  }
+
+  @Test
+  public void shouldSeekToNextEventWithinBatch() {
+    // given
+    final long eventPosition1 = writerRule.sourceEventPosition(1L).writeEvent(EVENT_VALUE);
+    final long eventPosition2 = writerRule.sourceEventPosition(1L).writeEvent(EVENT_VALUE);
+    writerRule.sourceEventPosition(2L).writeEvent(EVENT_VALUE);
+
+    // when
+    final var found = batchReader.seekToNextBatch(eventPosition1);
+
+    // then
+    assertThat(found).isTrue();
+    assertThat(batchReader.hasNext()).isTrue();
+
+    final var batch = batchReader.next();
+    assertThat(batch.hasNext()).isTrue();
+    assertThat(batch.next().getPosition()).isEqualTo(eventPosition2);
+  }
+
+  @Test
+  public void shouldSeekToTailIfLastEvent() {
+    // given
+    writerRule.sourceEventPosition(1L).writeEvent(EVENT_VALUE);
+    final long eventPosition2 = writerRule.sourceEventPosition(1L).writeEvent(EVENT_VALUE);
+
+    // when
+    final var found = batchReader.seekToNextBatch(eventPosition2);
+
+    // then
+    assertThat(found).isTrue();
+    assertThat(batchReader.hasNext()).isFalse();
+  }
+
+  @Test
+  public void shouldSeekToNotExistingPosition() {
+    // given
+    final var eventPosition = writerRule.sourceEventPosition(1L).writeEvent(EVENT_VALUE);
+
+    // when
+    final var found = batchReader.seekToNextBatch(eventPosition + 1);
+
+    // then
+    assertThat(found).isFalse();
+    assertThat(batchReader.hasNext()).isFalse();
+  }
+
+  @Test
+  public void shouldNotHaveNextIfClosed() {
+    // given
+    batchReader.close();
+
+    // when - then
+    assertThat(batchReader.hasNext()).isFalse();
+  }
+
+  @Test
+  public void shouldThrowNoSuchElementExceptionOnNextBatch() {
+    // given
+    assertThat(batchReader.hasNext()).isFalse();
+
+    // when / then
+    assertThatThrownBy(batchReader::next).isInstanceOf(NoSuchElementException.class);
+  }
+
+  @Test
+  public void shouldThrowNoSuchElementExceptionOnNextEvent() {
+    // given
+    writerRule.writeEvent(w -> w.key(1L).value(EVENT_VALUE));
+
+    assertThat(batchReader.hasNext()).isTrue();
+    batchReader.next();
+
+    assertThat(batchReader.hasNext()).isFalse();
+
+    // when / then
+    assertThatThrownBy(batchReader::next).isInstanceOf(NoSuchElementException.class);
+  }
+}

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamWriterRule.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamWriterRule.java
@@ -82,6 +82,11 @@ public final class LogStreamWriterRule extends ExternalResource {
     return position;
   }
 
+  public LogStreamWriterRule sourceEventPosition(final long sourceEventPosition) {
+    logStreamWriter.sourceRecordPosition(sourceEventPosition);
+    return this;
+  }
+
   private long writeEventInternal(final Consumer<LogEntryBuilder> writer) {
     long position;
     do {


### PR DESCRIPTION
## Description

* introduce a new log stream reader that reads a batch of event 
* all events in the batch shares the same source event position
* add a new `peekNext()` method to the existing reader to look at the next event without moving the iterator
* the new batch reader will be used by the replay state machine to ensure that all follow-up events are applied atomically #7597 (will be implemented in a follow-up PR) 

## Related issues

contributes to #7597 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
