### PR TITLE
Fix minimal development support on Windows

### DIFF
--- a/.github/workflows/os-smoke-test.yml
+++ b/.github/workflows/os-smoke-test.yml
@@ -1,0 +1,34 @@
+name: OS Support Smoke Test
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build:
+    name: Run smoke tests on ${{ matrix.os }}
+    timeout-minutes: 10
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ macos-latest, windows-latest, ubuntu-latest ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Cache Maven packages
+        uses: actions/cache@v2.1.6
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build with Maven
+        run: mvn -B -pl qa/integration-tests -am install -DskipTests -DskipChecks
+      - name: Run smoke test
+        run: mvn -B -pl qa/integration-tests verify -P smoke-test -DskipUTs -DskipChecks

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -253,6 +253,5 @@
       </plugin>
     </plugins>
   </build>
-
 </project>
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -675,7 +675,7 @@ public final class SegmentedJournal implements Journal {
     // necessary to flush the directory to ensure that the file itself is visible as an entry of
     // that directory after recovery
     try {
-      FileUtil.flush(directory.toPath());
+      FileUtil.flushDirectory(directory.toPath());
     } catch (final IOException e) {
       throw new JournalException(
           String.format("Failed to flush journal directory after creating segment %s", segmentFile),

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -273,5 +273,28 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <!--
+      this profile will run all tests annotated with @SmokeTest. the profile is mainly used to
+      ensure that we can run basic tests on Windows, macOS, and Linux, thereby ensuring minimal
+      multi-platform support for development.
+      -->
+    <profile>
+      <id>smoke-test</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <failIfNoTests>false</failIfNoTests>
+              <groups>smoke-test</groups>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/SmokeTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/SmokeTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.smoke;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("smoke-test")
+@Test
+public @interface SmokeTest {}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/StandaloneBrokerIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/StandaloneBrokerIT.java
@@ -23,7 +23,6 @@ import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 import java.util.Objects;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -49,7 +48,7 @@ final class StandaloneBrokerIT {
   }
 
   /** A simple smoke test to ensure the broker starts and can perform basic functionality. */
-  @Test
+  @SmokeTest
   void smokeTest() {
     // given
     final var processId = Strings.newRandomValidBpmnId();

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/StandaloneGatewayIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/StandaloneGatewayIT.java
@@ -46,7 +46,7 @@ final class StandaloneGatewayIT {
   private GatewayCfg config;
 
   /** A simple smoke test which checks that the gateway can start and accept requests. */
-  @Test
+  @SmokeTest
   void smokeTest() {
     // given
     try (final var client =

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -16,7 +16,6 @@
     <dependency>
       <groupId>org.agrona</groupId>
       <artifactId>agrona</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -38,10 +37,12 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>
+
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>

--- a/util/src/main/java/io/camunda/zeebe/util/FileUtil.java
+++ b/util/src/main/java/io/camunda/zeebe/util/FileUtil.java
@@ -25,6 +25,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Objects;
+import org.agrona.SystemUtil;
 import org.slf4j.Logger;
 
 public final class FileUtil {
@@ -34,10 +35,9 @@ public final class FileUtil {
 
   /**
    * Ensures updates to the given path are flushed to disk, with the same guarantees as {@link
-   * FileChannel#force(boolean)}. This can be used for both directory and files. Note that if you
-   * already have a file channel open, then use the {@link FileChannel#force(boolean)} method
-   * directly. This method is mostly useful when flushing directories after file creation and/or
-   * file rename operations.
+   * FileChannel#force(boolean)}. This can be used for files only; for directories, call {@link
+   * #flushDirectory(Path)}. Note that if you already have a file channel open, then use the {@link
+   * FileChannel#force(boolean)} method directly.
    *
    * @param path the path to synchronize
    * @throws IOException can be thrown on opening and on flushing the file
@@ -46,6 +46,27 @@ public final class FileUtil {
     try (final var channel = FileChannel.open(path, StandardOpenOption.READ)) {
       channel.force(true);
     }
+  }
+
+  /**
+   * This method flushes the given directory. Note that on Windows this is a no-op, as Windows does
+   * not allow to flush directories except when opening the sys handle with a specific backup flag,
+   * which is not possible to do without custom JNI code. However, as the main use case here is for
+   * durability to sync the parent directory after creating a new file or renaming it, this is safe
+   * to do as Windows (or rather NTFS) does not need this.
+   *
+   * @param path the path to synchronize
+   * @throws IOException can be thrown on opening and on flushing the file
+   */
+  public static void flushDirectory(final Path path) throws IOException {
+    // Windows does not allow flushing a directory except under very specific conditions which are
+    // not possible to produce with the standard JDK; it's also not necessary to flush a directory
+    // in Windows
+    if (SystemUtil.isWindows()) {
+      return;
+    }
+
+    flush(path);
   }
 
   /**
@@ -61,7 +82,7 @@ public final class FileUtil {
   public static void moveDurably(final Path source, final Path target, final CopyOption... options)
       throws IOException {
     Files.move(source, target, options);
-    flush(target.getParent());
+    flushDirectory(target.getParent());
   }
 
   public static void deleteFolder(final String path) throws IOException {


### PR DESCRIPTION
## Description

This PR adds smoke tests to run some basic sanity checks on the broker and gateway on Linux, Windows, and macOS. The tests ensure that both artifacts launch and can do basic things, like bind to ports, create a process instance, take a snapshot, etc.

Additionally, it fixes the bug with flushing directories on Windows by making it a no-op. This is safe to do on Windows as flushing the parent directory after creating a file or renaming it is only required on specific Unix file systems (namely ext and btrfs).

## Related issues

closes #7600

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
