### PR TITLE
Add logs dumper extension for container tests

### DIFF
--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -79,6 +79,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
     </dependency>

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/ContainerLogsDumper.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/ContainerLogsDumper.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.testcontainers;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Container;
+
+/** A utility class to dump the logs of a set of containers. */
+@SuppressWarnings("java:S1452")
+public final class ContainerLogsDumper implements AfterTestExecutionCallback {
+  private static final Logger DEFAULT_LOGGER = LoggerFactory.getLogger(ContainerLogsDumper.class);
+  private static final Pattern DOUBLE_NEWLINE = Pattern.compile("\n\n");
+
+  private final Supplier<Map<?, ? extends Container<?>>> containersSupplier;
+  private final Logger logger;
+
+  @SuppressWarnings("unused")
+  public ContainerLogsDumper(final Supplier<Map<?, ? extends Container<?>>> containersSupplier) {
+    this(containersSupplier, DEFAULT_LOGGER);
+  }
+
+  public ContainerLogsDumper(
+      final Supplier<Map<?, ? extends Container<?>>> containers, final Logger logger) {
+    this.containersSupplier = containers;
+    this.logger = logger;
+  }
+
+  @Override
+  public void afterTestExecution(final ExtensionContext context) {
+    final var testFailed = context.getExecutionException().isPresent();
+    if (!testFailed) {
+      return;
+    }
+
+    final var containers = containersSupplier.get();
+    for (final var container : containers.entrySet()) {
+      final var id = container.getKey();
+
+      try {
+        dumpContainerLogs(id, container.getValue());
+      } catch (final Exception e) {
+        logger.warn("Failed to extract logs from container {}", id, e);
+      }
+    }
+  }
+
+  private void dumpContainerLogs(final Object id, final Container<?> container) {
+    if (!container.isRunning()) {
+      logger.info("No logs to dump for stopped container {}", id);
+      return;
+    }
+
+    if (logger.isErrorEnabled()) {
+      final var logs = container.getLogs().replaceAll(DOUBLE_NEWLINE.pattern(), "\n");
+      logger.error(
+          "{}==============================================={}{} logs{}==============================================={}{}",
+          System.lineSeparator(),
+          System.lineSeparator(),
+          id,
+          System.lineSeparator(),
+          System.lineSeparator(),
+          logs);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a junit 5 extension which will dump all the logs of a set of containers on test failure. This can be useful when running container tests, especially clustered tests where debugging is not possible. The extension must be registered programatically as the set of containers is not known at initialization time, and it supports a `Supplier` as input
instead of just a plain map to support asynchronous cases. See the javadoc on how to use it.

## Related issues

related to #6266 in preparation

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
