### PR TITLE
Introduce configurable PartitionDistributor component

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/PartitionDistributor.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/PartitionDistributor.java
@@ -15,84 +15,38 @@
  */
 package io.atomix.raft.partition;
 
-import com.google.common.collect.Sets;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
- * Generates the partition distribution based on the cluster size, partition count and replication
- * factor
+ * Maps a list of partitions to a set of members, based on the given replication factor.
+ * Implementations of this class must guarantee that the distribution is complete, that is:
+ *
+ * <ul>
+ *   <li>The number of members a partition belongs to is equal to the replication factor
+ *   <li>All partitions are replicated
+ * </ul>
+ *
+ * It's perfectly valid for an implementation to ignore some members, as long as the above
+ * guarantees are met.
  */
-public class PartitionDistributor {
+public interface PartitionDistributor {
 
-  public Collection<PartitionMetadata> generatePartitionDistribution(
-      final Collection<MemberId> clusterMembers,
-      final List<PartitionId> sortedPartitionIds,
-      final int replicationFactor) {
-    final List<MemberId> sorted = new ArrayList<>(clusterMembers);
-    Collections.sort(sorted);
-
-    final int length = sorted.size();
-    final int count = Math.min(replicationFactor, length);
-
-    final Set<PartitionMetadata> metadata = Sets.newHashSet();
-    for (int i = 0; i < sortedPartitionIds.size(); i++) {
-      final PartitionId partitionId = sortedPartitionIds.get(i);
-      final List<MemberId> membersForPartition = new ArrayList<>(count);
-      for (int j = 0; j < count; j++) {
-        membersForPartition.add(sorted.get((i + j) % length));
-      }
-      final var primary = sorted.get(i % length);
-      final var priorities =
-          getPriorities(
-              partitionId, membersForPartition, primary, sorted.size(), replicationFactor);
-      metadata.add(
-          new PartitionMetadata(
-              partitionId, membersForPartition, priorities, priorities.get(primary)));
-    }
-    return metadata;
-  }
-
-  private Map<MemberId, Integer> getPriorities(
-      final PartitionId partitionId,
-      final List<MemberId> membersForPartition,
-      final MemberId primary,
-      final int clusterSize,
-      final int replicationFactor) {
-    final Map<MemberId, Integer> priority = new HashMap<>();
-    final int lowestPriority = 1;
-
-    priority.put(primary, replicationFactor);
-    // To ensure that secondary priorities are distributed evenly, we alternate the nodes for which
-    // second priority is assigned. Example, clusterSize = 3 partitionCount = 12. Node 0 has highest
-    // priority (=3) for partition 1,4,7 and 10. For partition 1 and 7, node 1 gets priority 2. For
-    // partition 4 and 10, node 2 gets priority 2. This is done so that if node 0 dies, the
-    // leadership is evenly distributed on the rest of the followers.
-    if ((partitionId.id() - 1) / clusterSize % 2 == 0) {
-      int nextPriority = replicationFactor - 1;
-      for (final MemberId member : membersForPartition) {
-        if (!member.equals(primary)) {
-          priority.put(member, nextPriority);
-          nextPriority--;
-        }
-      }
-    } else {
-      int nextPriority = lowestPriority;
-      for (final MemberId member : membersForPartition) {
-        if (!member.equals(primary)) {
-          priority.put(member, nextPriority);
-          nextPriority++;
-        }
-      }
-    }
-    return priority;
-  }
+  /**
+   * Provides the partition distribution based on the given list of partition IDs, cluster members,
+   * and the replication factor. The set of partitions returned is guaranteed to be correctly
+   * replicated.
+   *
+   * @param clusterMembers the set of members that can own partitions
+   * @param sortedPartitionIds a sorted list of partition IDs
+   * @param replicationFactor the replication factor for each partition
+   * @return a set of distributed partitions, each specifying which members they belong to
+   */
+  Collection<PartitionMetadata> distributePartitions(
+      Collection<MemberId> clusterMembers,
+      List<PartitionId> sortedPartitionIds,
+      int replicationFactor);
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/PartitionDistributor.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/PartitionDistributor.java
@@ -18,8 +18,8 @@ package io.atomix.raft.partition;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
-import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Maps a list of partitions to a set of members, based on the given replication factor.
@@ -45,8 +45,6 @@ public interface PartitionDistributor {
    * @param replicationFactor the replication factor for each partition
    * @return a set of distributed partitions, each specifying which members they belong to
    */
-  Collection<PartitionMetadata> distributePartitions(
-      Collection<MemberId> clusterMembers,
-      List<PartitionId> sortedPartitionIds,
-      int replicationFactor);
+  Set<PartitionMetadata> distributePartitions(
+      Set<MemberId> clusterMembers, List<PartitionId> sortedPartitionIds, int replicationFactor);
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -27,6 +27,8 @@ public class RaftPartitionConfig {
   private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(5);
   private static final int DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT = 3;
   private static final Duration DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT = Duration.ofSeconds(0);
+  private static final RoundRobinPartitionDistributor DEFAULT_PARTITION_DISTRIBUTOR =
+      new RoundRobinPartitionDistributor();
 
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
@@ -36,6 +38,7 @@ public class RaftPartitionConfig {
   private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
   private int minStepDownFailureCount = DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT;
   private Duration maxQuorumResponseTimeout = DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT;
+  private PartitionDistributor partitionDistributor = DEFAULT_PARTITION_DISTRIBUTOR;
 
   /**
    * Returns the Raft leader election timeout.
@@ -145,5 +148,13 @@ public class RaftPartitionConfig {
    */
   public void setMaxQuorumResponseTimeout(final Duration maxQuorumResponseTimeout) {
     this.maxQuorumResponseTimeout = maxQuorumResponseTimeout;
+  }
+
+  public PartitionDistributor getPartitionDistributor() {
+    return partitionDistributor;
+  }
+
+  public void setPartitionDistributor(final PartitionDistributor partitionDistributor) {
+    this.partitionDistributor = partitionDistributor;
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -181,18 +181,10 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
     final var members =
         config.getMembers().stream().map(MemberId::from).collect(Collectors.toSet());
     metadata =
-        new PartitionDistributor()
-            .generatePartitionDistribution(members, sortedPartitionIds, replicationFactor);
-    // Example distribution with priority, clusterSize=4, partitionCount=5, replicationFactor=3
-    // +------------------+----+----+----+---+
-    // | Partition \ Node | 0  | 1  | 2  | 3 |
-    // +------------------+----+----+----+---+
-    // |                1 | 3  | 2  | 1  |   |
-    // |                2 |    | 3  | 2  | 1 |
-    // |                3 | 1  |    | 3  | 2 |
-    // |                4 | 2  | 1  |    | 3 |
-    // |                5 | 3  | 1  | 2  |   |
-    // +------------------+----+----+----+---+
+        config
+            .getPartitionConfig()
+            .getPartitionDistributor()
+            .distributePartitions(members, sortedPartitionIds, replicationFactor);
 
     communicationService = managementService.getMessagingService();
     communicationService.<Void, Void>subscribe(snapshotSubject, m -> handleSnapshot());
@@ -488,6 +480,18 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
      */
     public Builder withMaxQuorumResponseTimeout(final Duration maxQuorumResponseTimeout) {
       config.getPartitionConfig().setMaxQuorumResponseTimeout(maxQuorumResponseTimeout);
+      return this;
+    }
+
+    /**
+     * Sets the partition distributor to use. The partition distributor determines which members
+     * will own which partitions, and ensures they are correctly replicated.
+     *
+     * @param partitionDistributor the partition distributor to use
+     * @return this builder for chaining
+     */
+    public Builder withPartitionDistributor(final PartitionDistributor partitionDistributor) {
+      config.getPartitionConfig().setPartitionDistributor(partitionDistributor);
       return this;
     }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RoundRobinPartitionDistributor.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RoundRobinPartitionDistributor.java
@@ -20,7 +20,6 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -48,8 +47,8 @@ import java.util.Set;
 public final class RoundRobinPartitionDistributor implements PartitionDistributor {
 
   @Override
-  public Collection<PartitionMetadata> distributePartitions(
-      final Collection<MemberId> clusterMembers,
+  public Set<PartitionMetadata> distributePartitions(
+      final Set<MemberId> clusterMembers,
       final List<PartitionId> sortedPartitionIds,
       final int replicationFactor) {
     final List<MemberId> sorted = new ArrayList<>(clusterMembers);

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RoundRobinPartitionDistributor.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RoundRobinPartitionDistributor.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.partition;
+
+import com.google.common.collect.Sets;
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This implementation of {@link PartitionDistributor} distributes the partitions in a round robin
+ * fashion over the set of members in the cluster.
+ *
+ * <p>Example distribution with 4 members, 5 partitions, and a replication factor of 3
+ *
+ * <pre>
+ * +------------------+----+----+----+---+
+ * | Partition \ Node | 0  | 1  | 2  | 3 |
+ * +------------------+----+----+----+---+
+ * |                1 | 3  | 2  | 1  |   |
+ * |                2 |    | 3  | 2  | 1 |
+ * |                3 | 1  |    | 3  | 2 |
+ * |                4 | 2  | 1  |    | 3 |
+ * |                5 | 3  | 1  | 2  |   |
+ * +------------------+----+----+----+---+
+ * </pre>
+ */
+public final class RoundRobinPartitionDistributor implements PartitionDistributor {
+
+  @Override
+  public Collection<PartitionMetadata> distributePartitions(
+      final Collection<MemberId> clusterMembers,
+      final List<PartitionId> sortedPartitionIds,
+      final int replicationFactor) {
+    final List<MemberId> sorted = new ArrayList<>(clusterMembers);
+    Collections.sort(sorted);
+
+    final int length = sorted.size();
+    final int count = Math.min(replicationFactor, length);
+
+    final Set<PartitionMetadata> metadata = Sets.newHashSet();
+    for (int i = 0; i < sortedPartitionIds.size(); i++) {
+      final PartitionId partitionId = sortedPartitionIds.get(i);
+      final List<MemberId> membersForPartition = new ArrayList<>(count);
+      for (int j = 0; j < count; j++) {
+        membersForPartition.add(sorted.get((i + j) % length));
+      }
+      final var primary = sorted.get(i % length);
+      final var priorities =
+          getPriorities(
+              partitionId, membersForPartition, primary, sorted.size(), replicationFactor);
+      metadata.add(
+          new PartitionMetadata(
+              partitionId, membersForPartition, priorities, priorities.get(primary)));
+    }
+    return metadata;
+  }
+
+  private Map<MemberId, Integer> getPriorities(
+      final PartitionId partitionId,
+      final List<MemberId> membersForPartition,
+      final MemberId primary,
+      final int clusterSize,
+      final int replicationFactor) {
+    final Map<MemberId, Integer> priority = new HashMap<>();
+    final int lowestPriority = 1;
+
+    priority.put(primary, replicationFactor);
+    // To ensure that secondary priorities are distributed evenly, we alternate the nodes for which
+    // second priority is assigned. Example, clusterSize = 3 partitionCount = 12. Node 0 has highest
+    // priority (=3) for partition 1,4,7 and 10. For partition 1 and 7, node 1 gets priority 2. For
+    // partition 4 and 10, node 2 gets priority 2. This is done so that if node 0 dies, the
+    // leadership is evenly distributed on the rest of the followers.
+    if ((partitionId.id() - 1) / clusterSize % 2 == 0) {
+      int nextPriority = replicationFactor - 1;
+      for (final MemberId member : membersForPartition) {
+        if (!member.equals(primary)) {
+          priority.put(member, nextPriority);
+          nextPriority--;
+        }
+      }
+    } else {
+      int nextPriority = lowestPriority;
+      for (final MemberId member : membersForPartition) {
+        if (!member.equals(primary)) {
+          priority.put(member, nextPriority);
+          nextPriority++;
+        }
+      }
+    }
+    return priority;
+  }
+}

--- a/atomix/cluster/src/test/java/io/atomix/raft/partition/RoundRobinPartitionDistributorTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/partition/RoundRobinPartitionDistributorTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -108,7 +107,7 @@ final class RoundRobinPartitionDistributorTest {
             }));
   }
 
-  private Collection<MemberId> getMembers(final int nodeCount) {
+  private Set<MemberId> getMembers(final int nodeCount) {
     final Set<MemberId> members = new HashSet<>();
     for (int i = 0; i < nodeCount; i++) {
       members.add(MemberId.from(String.valueOf(i)));

--- a/atomix/cluster/src/test/java/io/atomix/raft/partition/RoundRobinPartitionDistributorTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/partition/RoundRobinPartitionDistributorTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class PartitionDistributorTest {
+final class RoundRobinPartitionDistributorTest {
 
   @ParameterizedTest(name = "[{index}] {0} {1} {2}")
   @MethodSource("clusterConfig")
@@ -40,8 +40,8 @@ class PartitionDistributorTest {
       final int[][] expected) {
     // when
     final var partitionMetadata =
-        new PartitionDistributor()
-            .generatePartitionDistribution(
+        new RoundRobinPartitionDistributor()
+            .distributePartitions(
                 getMembers(clusterSize), getSortedPartitionIds(partitionCount), replicationFactor);
 
     // then

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.partitioning;
 
 import io.atomix.raft.partition.RaftPartitionGroup;
 import io.atomix.raft.partition.RaftPartitionGroup.Builder;
+import io.atomix.raft.partition.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
 import io.camunda.zeebe.broker.system.configuration.DataCfg;
@@ -49,6 +50,7 @@ final class RaftPartitionGroupFactory {
     final DataCfg dataCfg = configuration.getData();
     final NetworkCfg networkCfg = configuration.getNetwork();
 
+    final var partitionDistributor = new RoundRobinPartitionDistributor();
     final Builder partitionGroupBuilder =
         RaftPartitionGroup.builder(PartitionManagerImpl.GROUP_NAME)
             .withNumPartitions(clusterCfg.getPartitionsCount())
@@ -62,7 +64,8 @@ final class RaftPartitionGroupFactory {
             .withFlushExplicitly(!experimentalCfg.isDisableExplicitRaftFlush())
             .withFreeDiskSpace(dataCfg.getFreeDiskSpaceReplicationWatermark())
             .withJournalIndexDensity(dataCfg.getLogIndexDensity())
-            .withPriorityElection(experimentalCfg.isEnablePriorityElection());
+            .withPriorityElection(experimentalCfg.isEnablePriorityElection())
+            .withPartitionDistributor(partitionDistributor);
 
     final int maxMessageSize = (int) networkCfg.getMaxMessageSizeInBytes();
 


### PR DESCRIPTION
## Description

This PR extracts a new interface from the `PartitionDistributor`, renaming the previous implementation to `RoundRobinPartitionDistributor`, and allows configuring the `RaftPartitionGroup` with an arbitrary implementation of this interface (which by default is the `RoundRobinPartitionDistributor`). This is in preparation for #6266, which will introduce a new configurable partitioning scheme.

## Related issues

related to #6266 in preparation for the new partitioning scheme

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
