### PR TITLE
Reduce shutdown timeouts

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
@@ -26,8 +26,8 @@ public class MessagingConfig implements Config {
   private final int connectionPoolSize = 8;
   private List<String> interfaces = new ArrayList<>();
   private Integer port;
-  private Duration shutdownQuietPeriod = Duration.ofSeconds(2); // taken from Netty's default value
-  private Duration shutdownTimeout = Duration.ofSeconds(15); // taken from Netty's default value
+  private Duration shutdownQuietPeriod = Duration.ofMillis(20);
+  private Duration shutdownTimeout = Duration.ofSeconds(1);
 
   /**
    * Returns the local interfaces to which to bind the node.


### PR DESCRIPTION
## Description

Previously we have set the timeouts to 2 and 15 seconds, which are netty defaults. This caused to delay the closing of a broker by ~4 seconds, since the quite period in the netty service is waiting 2 seconds until it is really turning off. If there is a request coming in it will wait another 2 seconds. This can happen until the max timeout of 15 seconds is reached. In general we don't want to postpone the shutdown of the broker for so long, especially not in our integration tests. Reducing the timeouts to a minimum caused reducing the an example test case by ~ 7-8 seconds. We want to try out the low values first in benchmarks and production if we see no issues with that we will remove them completely and use the normal shutdown.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
