### PR TITLE
Fix restore test

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -762,7 +762,11 @@ public final class ClusteringRule extends ExternalResource {
    * @return the id of the new snapshot
    */
   SnapshotId waitForNewSnapshotAtBroker(final Broker broker, final SnapshotId previousSnapshot) {
-    return Awaitility.await()
+    return Awaitility.await(
+            "Expected snapshot at partition one on broker: "
+                + broker.getConfig().getCluster().getNodeId()
+                + " with previous snapshot: "
+                + previousSnapshot)
         .pollInterval(Duration.ofMillis(100))
         .atMost(Duration.ofMinutes(1))
         .until(

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/RestoreTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/RestoreTest.java
@@ -87,6 +87,7 @@ public final class RestoreTest {
     final long thirdProcessDefinitionKey = clientRule.deployProcess(thirdProcess);
 
     writeManyEventsUntilAtomixLogIsCompactable();
+    clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
     clusteringRule.waitForSnapshotAtBroker(
         clusteringRule.getBroker(clusteringRule.getLeaderForPartition(1).getNodeId()));
 


### PR DESCRIPTION
## Description

Previously the snapshot time was not increased, which caused flaky tests. It happened depending on which was the previous leader and later the leader. It happened that an snapshot was taken already previously, then this test succeeded. If the latest leader was at the begin follower it happen that this node didn't took a snapshot before, this caused the test to fail.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
