### PR TITLE
fix(engine): streamprocessor can recover on replay mode when no event available

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -264,7 +264,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
         zeebeState.getLastProcessedPositionState().getLastSuccessfulProcessedRecordPosition();
 
     final boolean failedToRecoverReader = !logStreamReader.seekToNextEvent(snapshotPosition);
-    if (failedToRecoverReader) {
+    if (failedToRecoverReader
+        && processingContext.getProcessorMode() == StreamProcessorMode.PROCESSING) {
       throw new IllegalStateException(
           String.format(ERROR_MESSAGE_RECOVER_FROM_SNAPSHOT_FAILED, snapshotPosition, getName()));
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ZeebeDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ZeebeDbState.java
@@ -238,6 +238,7 @@ public class ZeebeDbState implements MutableZeebeState {
     return keyGenerator;
   }
 
+  @Override
   public MutableLastProcessedPositionState getLastProcessedPositionState() {
     return lastProcessedPositionState;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableZeebeState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableZeebeState.java
@@ -58,4 +58,6 @@ public interface MutableZeebeState extends ZeebeState {
   MutablePendingProcessMessageSubscriptionState getPendingProcessMessageSubscriptionState();
 
   KeyGenerator getKeyGenerator();
+
+  MutableLastProcessedPositionState getLastProcessedPositionState();
 }


### PR DESCRIPTION
## Description

When starting on replay mode, the events that are already applied in the snapshot may not be available in the logstreams. This can happen because after the snapshot is received, the replication of events after the snapshot index is delayed. In this case, we don't want to fail the recovery. ReplayStateMachine can wait and apply the events when they are available.

## Related issues

closes #7662 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
