### PR TITLE
Add configurable fixed partitioning scheme

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -35,8 +35,6 @@ import io.atomix.primitive.partition.PartitionManagementService;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.utils.concurrent.Futures;
-import io.atomix.utils.logging.ContextualLoggerFactory;
-import io.atomix.utils.logging.LoggerContext;
 import io.atomix.utils.memory.MemorySize;
 import io.atomix.utils.serializer.Namespace;
 import io.atomix.utils.serializer.Namespaces;
@@ -70,16 +68,10 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
   private ClusterCommunicationService communicationService;
 
   public RaftPartitionGroup(final RaftPartitionGroupConfig config) {
-    final Logger log =
-        ContextualLoggerFactory.getLogger(
-            RaftPartitionGroup.class,
-            LoggerContext.builder(RaftPartitionGroup.class).addValue(config.getName()).build());
-    name = config.getName();
     this.config = config;
-    replicationFactor = config.getReplicationFactor();
 
-    final int threadPoolSize =
-        Math.max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 16), 4);
+    name = config.getName();
+    replicationFactor = config.getReplicationFactor();
     snapshotSubject = "raft-partition-group-" + name + "-snapshot";
 
     buildPartitions(config)

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -175,6 +175,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedDistributionMember.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedDistributionMember.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.partitioning.distribution;
+
+import io.atomix.cluster.MemberId;
+import java.util.Objects;
+
+final class FixedDistributionMember {
+  private final MemberId id;
+  private final int priority;
+
+  FixedDistributionMember(final MemberId id, final int priority) {
+    this.id = id;
+    this.priority = priority;
+  }
+
+  MemberId getId() {
+    return id;
+  }
+
+  int getPriority() {
+    return priority;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof FixedDistributionMember)) {
+      return false;
+    }
+
+    final FixedDistributionMember member = (FixedDistributionMember) o;
+    return id.equals(member.id);
+  }
+
+  @Override
+  public String toString() {
+    return "FixedDistributionMember{" + "id=" + id + ", priority=" + priority + '}';
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributor.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributor.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.partitioning.distribution;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.atomix.raft.partition.PartitionDistributor;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A {@link PartitionDistributor} implementation which takes in a provided, fixed mapping which
+ * already describes which member maps to which partitions, and returns the appropriate set of
+ * distributed partitions on demand.
+ *
+ * <p>See {@link FixedPartitionDistributorBuilder} to build a new instance. The class is
+ * intentionally not publicly instantiable to reduce the risk of configuration errors.
+ */
+public final class FixedPartitionDistributor implements PartitionDistributor {
+  private final Map<PartitionId, Set<FixedDistributionMember>> distribution;
+
+  FixedPartitionDistributor(final Map<PartitionId, Set<FixedDistributionMember>> distribution) {
+    this.distribution = distribution;
+  }
+
+  /**
+   * Generates a partition distribution based on the initial configuration, using the input here
+   * mostly for validation.
+   *
+   * @param clusterMembers the set of members that can own partitions
+   * @param sortedPartitionIds a sorted list of partition IDs
+   * @param replicationFactor the replication factor for each partition
+   * @return a set of distributed partitions, containing the set of members to which they belong to
+   * @throws IllegalStateException if any of the configured members are not found in the set of
+   *     {@code clusterMembers}; this implies that these members do not exist in the cluster
+   * @throws IllegalStateException if at least one of the partitions in {@code sortedPartitionIds}
+   *     is not distributed over any members
+   * @throws IllegalStateException if at least one of the partitions in {@code sortedPartitionIds}
+   *     does not have exactly {@code replicationFactor} members
+   */
+  @Override
+  public Set<PartitionMetadata> distributePartitions(
+      final Set<MemberId> clusterMembers,
+      final List<PartitionId> sortedPartitionIds,
+      final int replicationFactor) {
+    final var partitions = new HashSet<PartitionMetadata>();
+    for (final var partitionId : sortedPartitionIds) {
+      final var metadata = createPartitionMetadata(clusterMembers, replicationFactor, partitionId);
+      partitions.add(metadata);
+    }
+
+    return partitions;
+  }
+
+  private PartitionMetadata createPartitionMetadata(
+      final Set<MemberId> clusterMembers,
+      final int replicationFactor,
+      final PartitionId partitionId) {
+    final var members = new ArrayList<MemberId>();
+    final var priorities = new HashMap<MemberId, Integer>();
+    final var configuredMembers = distribution.get(partitionId);
+    int targetPriority = 0;
+
+    if (configuredMembers == null) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected to distribute partition %d, but no members configured for it",
+              partitionId.id()));
+    }
+
+    for (final var member : configuredMembers) {
+      members.add(member.getId());
+      priorities.put(member.getId(), member.getPriority());
+      targetPriority = Math.max(targetPriority, member.getPriority());
+    }
+
+    ensureMembersArePartOfCluster(clusterMembers, partitionId, members);
+    ensurePartitionIsFullyReplicated(replicationFactor, partitionId, members);
+
+    return new PartitionMetadata(partitionId, members, priorities, targetPriority);
+  }
+
+  private void ensureMembersArePartOfCluster(
+      final Set<MemberId> clusterMembers,
+      final PartitionId partitionId,
+      final ArrayList<MemberId> members) {
+    if (!clusterMembers.containsAll(members)) {
+      final var unknownMembers = new HashSet<>(members);
+      unknownMembers.removeAll(clusterMembers);
+
+      throw new IllegalStateException(
+          String.format(
+              "Expected partition %d to be replicated across a cluster made of members %s, but the "
+                  + "following configured members %s are not part of the cluster",
+              partitionId.id(), clusterMembers, unknownMembers));
+    }
+  }
+
+  private void ensurePartitionIsFullyReplicated(
+      final int replicationFactor,
+      final PartitionId partitionId,
+      final ArrayList<MemberId> members) {
+    if (members.size() != replicationFactor) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected each partition to be replicated across exactly %d members, but partition %d"
+                  + " is replicated across members %s",
+              replicationFactor, partitionId.id(), members));
+    }
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorBuilder.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorBuilder.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.partitioning.distribution;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Simplified builder interface to construct a {@link FixedPartitionDistributor} to reduce the risk
+ * of misconfiguration when building a fixed partition distribution.
+ */
+public final class FixedPartitionDistributorBuilder {
+  private final Map<PartitionId, Set<FixedDistributionMember>> partitions = new HashMap<>();
+
+  private final String partitionGroupName;
+
+  /**
+   * Creates a new builder with the specific partition group name. The group name will be used to
+   * generated {@link PartitionId} from raw integers. This effectively scopes the distributor to a
+   * given partition group - you should not use the distributor with a different partition group.
+   *
+   * @param partitionGroupName the name of the partition group for which the distributor is built
+   */
+  public FixedPartitionDistributorBuilder(final String partitionGroupName) {
+    this.partitionGroupName = partitionGroupName;
+  }
+
+  /**
+   * Assigns a member, with a given priority, to the given partition. Members assigned to a
+   * partition will take part in the Raft for that partition.
+   *
+   * <p>NOTE: this method is a convenience method which will convert the raw IDs into strongly typed
+   * identifiers. See {@link #assignMember(PartitionId, MemberId, int)} for more.
+   *
+   * @param partitionId the ID of the partition to which the member should be assigned
+   * @param nodeId the ID of the member to assign, e.g. 0, 1, 2
+   * @param priority the priority of the member
+   * @return this builder for chaining
+   */
+  public FixedPartitionDistributorBuilder assignMember(
+      final int partitionId, final int nodeId, final int priority) {
+    return assignMember(
+        PartitionId.from(partitionGroupName, partitionId),
+        MemberId.from(String.valueOf(nodeId)),
+        priority);
+  }
+
+  /**
+   * Assigns a member, with a given priority, to the given partition. Members assigned to a
+   * partition will take part in the Raft for that partition.
+   *
+   * <p>There is no validation applied to the IDs, as there is no intrinsically "wrong" ID. However
+   * passing the wrong ID may cause failures later on when attempting to use the distributor.
+   *
+   * @param partitionId the ID of the partition to which the member should be assigned
+   * @param memberId the ID of the member to assign
+   * @param priority the priority of the member
+   * @return this builder for chaining
+   */
+  public FixedPartitionDistributorBuilder assignMember(
+      final PartitionId partitionId, final MemberId memberId, final int priority) {
+    final var members = partitions.computeIfAbsent(partitionId, ignored -> new HashSet<>());
+    members.add(new FixedDistributionMember(memberId, priority));
+
+    return this;
+  }
+
+  /** @return a distributor configured for a map of partitions to members */
+  public FixedPartitionDistributor build() {
+    return new FixedPartitionDistributor(partitions);
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -13,12 +13,18 @@ import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
 import io.camunda.zeebe.broker.system.configuration.DataCfg;
+import io.camunda.zeebe.broker.system.configuration.ExperimentalCfg;
 import io.camunda.zeebe.broker.system.configuration.ThreadsCfg;
+import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
+import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import io.camunda.zeebe.util.sched.ActorScheduler;
 import io.camunda.zeebe.util.sched.clock.ActorClock;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import org.slf4j.Logger;
 
 public final class SystemContext {
@@ -143,6 +149,80 @@ public final class SystemContext {
               "electionTimeout %s must be greater than heartbeatInterval %s",
               electionTimeout, heartbeatInterval));
     }
+
+    final var partitioningConfig = experimental.getPartitioning();
+    if (partitioningConfig.getScheme() == Scheme.FIXED) {
+      validateFixedPartitioningScheme(cluster, experimental);
+    }
+  }
+
+  private void validateFixedPartitioningScheme(
+      final ClusterCfg cluster, final ExperimentalCfg experimental) {
+    final var partitioning = experimental.getPartitioning();
+    final var partitions = partitioning.getFixed();
+    final var replicationFactor = cluster.getReplicationFactor();
+    final var partitionsCount = cluster.getPartitionsCount();
+
+    final var partitionMembers = new HashMap<Integer, Set<Integer>>();
+    for (final var partition : partitions) {
+      final var members =
+          validateFixedPartitionMembers(
+              cluster, partition, experimental.isEnablePriorityElection());
+      partitionMembers.put(partition.getPartitionId(), members);
+    }
+
+    for (int partitionId = 1; partitionId <= partitionsCount; partitionId++) {
+      final var members = partitionMembers.getOrDefault(partitionId, Collections.emptySet());
+      if (members.size() < replicationFactor) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Expected fixed partition scheme to define configurations for all partitions such "
+                    + "that they have %d replicas, but partition %d has %d configured replicas: %s",
+                replicationFactor, partitionId, members.size(), members));
+      }
+    }
+  }
+
+  private Set<Integer> validateFixedPartitionMembers(
+      final ClusterCfg cluster,
+      final FixedPartitionCfg partitionConfig,
+      final boolean isPriorityElectionEnabled) {
+    final var members = new HashSet<Integer>();
+    final var clusterSize = cluster.getClusterSize();
+    final var partitionsCount = cluster.getPartitionsCount();
+    final var partitionId = partitionConfig.getPartitionId();
+
+    if (partitionId < 1 || partitionId > partitionsCount) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected fixed partition scheme to define entries with a valid partitionId between 1"
+                  + " and %d, but %d was given",
+              partitionsCount, partitionId));
+    }
+
+    final var observedPriorities = new HashSet<Integer>();
+    for (final var node : partitionConfig.getNodes()) {
+      final var nodeId = node.getNodeId();
+      if (nodeId < 0 || nodeId >= clusterSize) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Expected fixed partition scheme for partition %d to define nodes with a nodeId "
+                    + "between 0 and %d, but it was %d",
+                partitionId, clusterSize - 1, nodeId));
+      }
+
+      if (isPriorityElectionEnabled && !observedPriorities.add(node.getPriority())) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Expected each node for a partition %d to have a different priority, but at least "
+                    + "two of them have the same priorities: %s",
+                partitionId, partitionConfig.getNodes()));
+      }
+
+      members.add(nodeId);
+    }
+
+    return members;
   }
 
   private ActorScheduler initScheduler(final ActorClock clock, final String brokerId) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -28,6 +28,7 @@ public class ExperimentalCfg implements ConfigurationEntry {
   private boolean enablePriorityElection = DEFAULT_ENABLE_PRIORITY_ELECTION;
   private RocksdbCfg rocksdb = new RocksdbCfg();
   private RaftCfg raft = new RaftCfg();
+  private PartitioningCfg partitioning = new PartitioningCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -79,6 +80,22 @@ public class ExperimentalCfg implements ConfigurationEntry {
     this.enablePriorityElection = enablePriorityElection;
   }
 
+  public RaftCfg getRaft() {
+    return raft;
+  }
+
+  public void setRaft(final RaftCfg raft) {
+    this.raft = raft;
+  }
+
+  public PartitioningCfg getPartitioning() {
+    return partitioning;
+  }
+
+  public void setPartitioning(final PartitioningCfg partitioning) {
+    this.partitioning = partitioning;
+  }
+
   @Override
   public String toString() {
     return "ExperimentalCfg{"
@@ -90,14 +107,8 @@ public class ExperimentalCfg implements ConfigurationEntry {
         + disableExplicitRaftFlush
         + ", rocksdb="
         + rocksdb
+        + ", partitioning="
+        + partitioning
         + '}';
-  }
-
-  public RaftCfg getRaft() {
-    return raft;
-  }
-
-  public void setRaft(final RaftCfg raft) {
-    this.raft = raft;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/PartitioningCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/PartitioningCfg.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
+import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The partitioning configuration allow configuring experimental settings related to partitioning.
+ *
+ * <p>At the moment, it lets users configure the scheme - that is, how partitions are distributed
+ * across the brokers. The default scheme is currently {@link Scheme#ROUND_ROBIN}.
+ *
+ * <p>When using {@link Scheme#FIXED}, a map of brokers to a list of partitions should be specified
+ * under {@link #fixed}. This map takes keys as the broker node IDs, with values as a list of
+ * partition IDs. The mapping must be exhaustive, meaning all brokers should appear, and all
+ * partitions should be specified with the appropriate replication factor.
+ */
+public final class PartitioningCfg {
+
+  /**
+   * The default partitioning {@link Scheme} is the {@link Scheme#ROUND_ROBIN} scheme. This is
+   * required for backwards compatibility, but it's also a good default for now as there is no
+   * better alternative in most cases.
+   */
+  private static final Scheme DEFAULT_SCHEME = Scheme.ROUND_ROBIN;
+
+  private Scheme scheme = DEFAULT_SCHEME;
+  private List<FixedPartitionCfg> fixed = new ArrayList<>();
+
+  public Scheme getScheme() {
+    return scheme;
+  }
+
+  public void setScheme(final Scheme scheme) {
+    this.scheme = scheme;
+  }
+
+  public List<FixedPartitionCfg> getFixed() {
+    return fixed;
+  }
+
+  public void setFixed(final List<FixedPartitionCfg> fixed) {
+    this.fixed = fixed;
+  }
+
+  @Override
+  public String toString() {
+    return "PartitioningCfg{" + "scheme=" + scheme + ", fixed=" + fixed + '}';
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/FixedPartitionCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/FixedPartitionCfg.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration.partitioning;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Bean configuration for the {@link Scheme#FIXED} partitioning scheme. Allows users to define a
+ * mapping between a partition with a given {@link #partitionId} and a set of {@link #nodes}, as
+ * defined in {@link NodeCfg}.
+ */
+public final class FixedPartitionCfg {
+
+  /**
+   * The default partition ID is 1, taken from the single node, single partition deployment commonly
+   * used for development.
+   */
+  private static final int DEFAULT_PARTITION_ID = 1;
+
+  private int partitionId = DEFAULT_PARTITION_ID;
+  private List<NodeCfg> nodes = new ArrayList<>();
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  public void setPartitionId(final int partitionId) {
+    this.partitionId = partitionId;
+  }
+
+  public List<NodeCfg> getNodes() {
+    return nodes;
+  }
+
+  public void setNodes(final List<NodeCfg> nodes) {
+    this.nodes = nodes;
+  }
+
+  @Override
+  public String toString() {
+    return "FixedPartitionCfg{" + "partitionId=" + partitionId + ", nodes=" + nodes + '}';
+  }
+
+  /**
+   * Bean configuration class which lets users configure a {@link #priority} for a given node with
+   * ID {@link #nodeId}. Note that the priority is only useful if you use the priority election;
+   * otherwise it should be left as the default priority.
+   */
+  public static final class NodeCfg {
+
+    /**
+     * The default node ID is 0, taken from the single node deployment, commonly used for
+     * development.
+     */
+    private static final int DEFAULT_NODE_ID = 0;
+
+    /**
+     * The default priority is 1. When priority election is not enabled, this has no impact on the
+     * system, and can be left as is. If priority election is enabled, all nodes can have priority
+     * 1, but then the election is essentially the same as a normal election without any priorities.
+     */
+    private static final int DEFAULT_PRIORITY = 1;
+
+    private int nodeId = DEFAULT_NODE_ID;
+    private int priority = DEFAULT_PRIORITY;
+
+    public int getNodeId() {
+      return nodeId;
+    }
+
+    public void setNodeId(final int nodeId) {
+      this.nodeId = nodeId;
+    }
+
+    public int getPriority() {
+      return priority;
+    }
+
+    public void setPriority(final int priority) {
+      this.priority = priority;
+    }
+
+    @Override
+    public String toString() {
+      return "NodeCfg{" + "nodeId=" + nodeId + ", priority=" + priority + '}';
+    }
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/Scheme.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/Scheme.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration.partitioning;
+
+public enum Scheme {
+  FIXED,
+  ROUND_ROBIN;
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.partitioning.distribution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class FixedPartitionDistributorTest {
+  private static final String PARTITION_GROUP_NAME = "group";
+
+  @Test
+  void shouldFailOnMissingPartition() {
+    // given
+    final var distributor =
+        new FixedPartitionDistributorBuilder(PARTITION_GROUP_NAME).assignMember(2, 0, 1).build();
+    final var clusterMembers = Set.of(node(0));
+    final var sortedPartitionIds = List.of(partition(1), partition(2));
+
+    // when - then
+    assertThatCode(() -> distributor.distributePartitions(clusterMembers, sortedPartitionIds, 1))
+        .as("should fail because partition 1 exists, but was not configured")
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Expected to distribute partition 1, but no members configured for it");
+  }
+
+  @Test
+  void shouldFailOnUnknownMember() {
+    // given
+    final var distributor =
+        new FixedPartitionDistributorBuilder(PARTITION_GROUP_NAME).assignMember(1, 0, 1).build();
+    final var clusterMembers = Set.of(node(1));
+    final var sortedPartitionIds = List.of(partition(1), partition(2));
+
+    // when - then
+    assertThatCode(() -> distributor.distributePartitions(clusterMembers, sortedPartitionIds, 1))
+        .as("should fail because node 0 is not part of the cluster members, only node 1 is")
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "Expected partition 1 to be replicated across a cluster made of members [1], but the "
+                + "following configured members [0] are not part of the cluster");
+  }
+
+  @Test
+  void shouldFailOnMissingReplica() {
+    // given
+    final var distributor =
+        new FixedPartitionDistributorBuilder(PARTITION_GROUP_NAME).assignMember(1, 0, 1).build();
+    final var clusterMembers = Set.of(node(0));
+    final var sortedPartitionIds = List.of(partition(1), partition(2));
+
+    // when - then
+    assertThatCode(() -> distributor.distributePartitions(clusterMembers, sortedPartitionIds, 2))
+        .as("should fail because only one replica, 0, is specified, and 1 is missing")
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "Expected each partition to be replicated across exactly 2 members, but partition 1 is "
+                + "replicated across members [0]");
+  }
+
+  @Test
+  void shouldDistributeEvenly() {
+    // given
+    final var expectedDistribution =
+        Set.of(
+            new PartitionMetadata(
+                partition(1), List.of(node(0), node(1)), Map.of(node(0), 1, node(1), 2), 2),
+            new PartitionMetadata(
+                partition(2), List.of(node(0), node(1)), Map.of(node(0), 2, node(1), 1), 2));
+    final var distributor =
+        new FixedPartitionDistributorBuilder(PARTITION_GROUP_NAME)
+            .assignMember(1, 0, 1)
+            .assignMember(1, 1, 2)
+            .assignMember(2, 0, 2)
+            .assignMember(2, 1, 1)
+            .build();
+    final var clusterMembers = Set.of(node(0), node(1));
+    final var sortedPartitionIds = List.of(partition(1), partition(2));
+
+    // when
+    final var distribution =
+        distributor.distributePartitions(clusterMembers, sortedPartitionIds, 2);
+
+    // then
+    assertThat(distribution)
+        .as("should distribute the partitions as expected")
+        .containsExactlyInAnyOrderElementsOf(expectedDistribution);
+  }
+
+  @Test
+  void shouldDistributeUnevenly() {
+    // given
+    final var expectedDistribution =
+        Set.of(
+            new PartitionMetadata(partition(1), List.of(node(0)), Map.of(node(0), 2), 2),
+            new PartitionMetadata(partition(2), List.of(node(0)), Map.of(node(0), 2), 2));
+    final var distributor =
+        new FixedPartitionDistributorBuilder(PARTITION_GROUP_NAME)
+            .assignMember(1, 0, 2)
+            .assignMember(2, 0, 2)
+            .build();
+    final var clusterMembers = Set.of(node(0), node(1));
+    final var sortedPartitionIds = List.of(partition(1), partition(2));
+
+    // when
+    final var distribution =
+        distributor.distributePartitions(clusterMembers, sortedPartitionIds, 1);
+
+    // then
+    assertThat(distribution)
+        .as("should distribute the partitions as expected")
+        .containsExactlyInAnyOrderElementsOf(expectedDistribution);
+  }
+
+  private PartitionId partition(final int id) {
+    return PartitionId.from(PARTITION_GROUP_NAME, id);
+  }
+
+  private MemberId node(final int id) {
+    return MemberId.from(String.valueOf(id));
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -11,9 +11,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
+import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg.NodeCfg;
+import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
 import java.time.Duration;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.util.unit.DataSize;
 import org.springframework.util.unit.DataUnit;
 
@@ -180,6 +186,130 @@ final class SystemContextTest {
     assertThatCode(() -> initSystemContext(brokerCfg))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("electionTimeout PT1S must be greater than heartbeatInterval PT2S");
+  }
+
+  @Test
+  void shouldThrowExceptionIfFixedPartitioningSchemeDoesNotSpecifyAnyPartitions() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    final var config = brokerCfg.getExperimental().getPartitioning();
+    config.setScheme(Scheme.FIXED);
+    config.setFixed(List.of());
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Expected fixed partition scheme to define configurations for all partitions such that "
+                + "they have 1 replicas, but partition 1 has 0 configured replicas: []");
+  }
+
+  @Test
+  void shouldThrowExceptionIfFixedPartitioningSchemeIsNotExhaustive() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    final var config = brokerCfg.getExperimental().getPartitioning();
+    final var fixedPartition = new FixedPartitionCfg();
+    config.setScheme(Scheme.FIXED);
+    config.setFixed(List.of(fixedPartition));
+    fixedPartition.getNodes().add(new NodeCfg());
+    brokerCfg.getCluster().setPartitionsCount(2);
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Expected fixed partition scheme to define configurations for all partitions such that "
+                + "they have 1 replicas, but partition 2 has 0 configured replicas: []");
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-1, 2})
+  void shouldThrowExceptionIfFixedPartitioningSchemeUsesInvalidPartitionId(final int invalidId) {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    final var config = brokerCfg.getExperimental().getPartitioning();
+    final var fixedPartition = new FixedPartitionCfg();
+    config.setScheme(Scheme.FIXED);
+    config.setFixed(List.of(fixedPartition));
+    fixedPartition.setPartitionId(invalidId);
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Expected fixed partition scheme to define entries with a valid partitionId "
+                + "between 1 and 1, but %d was given",
+            invalidId);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-1, 2})
+  void shouldThrowExceptionIfFixedPartitioningSchemeUsesInvalidNodeId(final int invalidId) {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    final var config = brokerCfg.getExperimental().getPartitioning();
+    final var fixedPartition = new FixedPartitionCfg();
+    final var node = new NodeCfg();
+    config.setScheme(Scheme.FIXED);
+    config.setFixed(List.of(fixedPartition));
+    fixedPartition.getNodes().add(node);
+    node.setNodeId(invalidId);
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Expected fixed partition scheme for partition 1 to define nodes with a "
+                + "nodeId between 0 and 0, but it was %d",
+            invalidId);
+  }
+
+  @Test
+  void shouldThrowExceptionIfFixedPartitioningSchemeHasSamePriorities() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    final var config = brokerCfg.getExperimental().getPartitioning();
+    final var fixedPartition = new FixedPartitionCfg();
+    final var nodes = List.of(new NodeCfg(), new NodeCfg());
+    brokerCfg.getExperimental().setEnablePriorityElection(true);
+    brokerCfg.getCluster().setClusterSize(2);
+    config.setScheme(Scheme.FIXED);
+    config.setFixed(List.of(fixedPartition));
+    fixedPartition.setNodes(nodes);
+    nodes.get(0).setNodeId(0);
+    nodes.get(0).setPriority(1);
+    nodes.get(1).setNodeId(1);
+    nodes.get(1).setPriority(1);
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Expected each node for a partition 1 to have a different priority, but at least two of"
+                + " them have the same priorities: [NodeCfg{nodeId=0, priority=1},"
+                + " NodeCfg{nodeId=1, priority=1}]");
+  }
+
+  @Test
+  void shouldNotThrowExceptionIfFixedPartitioningSchemeHasWrongPrioritiesWhenPriorityDisabled() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    final var config = brokerCfg.getExperimental().getPartitioning();
+    final var fixedPartition = new FixedPartitionCfg();
+    final var nodes = List.of(new NodeCfg(), new NodeCfg());
+    brokerCfg.getExperimental().setEnablePriorityElection(false);
+    brokerCfg.getCluster().setClusterSize(2);
+    config.setScheme(Scheme.FIXED);
+    config.setFixed(List.of(fixedPartition));
+    fixedPartition.setNodes(nodes);
+    nodes.get(0).setNodeId(0);
+    nodes.get(0).setPriority(1);
+    nodes.get(1).setNodeId(1);
+    nodes.get(1).setPriority(1);
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg)).doesNotThrowAnyException();
   }
 
   private SystemContext initSystemContext(final BrokerCfg brokerCfg) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/PartitioningCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/PartitioningCfgTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class PartitioningCfgTest {
+  private final Map<String, String> environment = new HashMap<>();
+
+  /**
+   * This test is a smoke test, primarily to ensure backwards compatibility when changing defaults.
+   */
+  @Test
+  void shouldUseRoundRobinAsDefaultScheme() {
+    // when
+    final var brokerConfig = TestConfigReader.readConfig("empty", environment);
+    final var config = brokerConfig.getExperimental().getPartitioning();
+
+    // then
+    assertThat(config.getScheme()).isEqualTo(Scheme.ROUND_ROBIN);
+  }
+}

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -518,6 +518,65 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENABLEPRIORITYELECTION
       # enablePriorityElection = false;
 
+      # This setting allows you to configure how partitions are distributed amongst the node of the
+      # clusters. It currently supports to partitioning schemes: ROUND_ROBIN, and FIXED.
+      #
+      # ROUND_ROBIN is the default partitioning scheme. To enable it, set `scheme` to `ROUND_ROBIN`;
+      # not extra configuration is required. To understand how it will distribute the partitions,
+      # refer to the documentation:
+      #   https://docs.camunda.io/docs/product-manuals/zeebe/technical-concepts/partitions#partition-distribution
+      #
+      # The FIXED partitioning scheme allows users with non-traditional deployments to manual
+      # distribute the partitions across their set of brokers. This can be useful, for example, if
+      # you want to deploy a cluster across multiple data centers with some replication guarantees.
+      # See below for details on how to configure it.
+      #
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING
+      # partitioning:
+        # The partitioning scheme to use. Can be one of: ROUND_ROBIN, FIXED. Defaults to
+        # ROUND_ROBIN.
+        # scheme: ROUND_ROBIN
+        #
+        # The FIXED partitioning scheme configuration. This must be an exhaustive mapping of all
+        # partitions to a set of brokers. If any partitions are not configured, the broker will not
+        # start.
+        #
+        # For each partition, you must specify its partition ID (ranging from 1 to
+        # partitionCount), and the set of nodes which will manage it. This must be a subset
+        # of nodes whose IDs are valid within your cluster. This means with node IDs ranging from 0
+        # to the (clusterSize - 1), without any repeated IDs. This subset must have the same amount
+        # of nodes as the replication factor, otherwise the broker will not start.
+        #
+        # If you are using priority election, then you can also specify the priorities for each
+        # nodes. Note that for a given partition, the priorities of each member must be different,
+        # otherwise the broker will fail to start.
+        #
+        # fixed:
+        #   - partitionId: 1
+        #     nodes:
+        #       - nodeId: 0
+        #         priority: 1
+        #       - nodeId: 1
+        #         priority: 2
+        #       - nodeId: 2
+        #         priority: 3
+        #   - partitionId: 2
+        #     nodes:
+        #       - nodeId: 0
+        #         priority: 3
+        #       - nodeId: 1
+        #         priority: 2
+        #       - nodeId: 2
+        #         priority: 1
+        #   - partitionId: 3
+        #     nodes:
+        #       - nodeId: 0
+        #         priority: 2
+        #       - nodeId: 1
+        #         priority: 3
+        #       - nodeId: 2
+        #         priority: 2
+
       # Allows to configure specific raft properties
       # raft:
         # Sets the timeout for all requests send by raft leaders and followers.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -479,6 +479,65 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENABLEPRIORITYELECTION
       # enablePriorityElection = false;
 
+      # This setting allows you to configure how partitions are distributed amongst the node of the
+      # clusters. It currently supports to partitioning schemes: ROUND_ROBIN, and FIXED.
+      #
+      # ROUND_ROBIN is the default partitioning scheme. To enable it, set `scheme` to `ROUND_ROBIN`;
+      # not extra configuration is required. To understand how it will distribute the partitions,
+      # refer to the documentation:
+      #   https://docs.camunda.io/docs/product-manuals/zeebe/technical-concepts/partitions#partition-distribution
+      #
+      # The FIXED partitioning scheme allows users with non-traditional deployments to manual
+      # distribute the partitions across their set of brokers. This can be useful, for example, if
+      # you want to deploy a cluster across multiple data centers with some replication guarantees.
+      # See below for details on how to configure it.
+      #
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING
+      # partitioning:
+        # The partitioning scheme to use. Can be one of: ROUND_ROBIN, FIXED. Defaults to
+        # ROUND_ROBIN.
+        # scheme: ROUND_ROBIN
+        #
+        # The FIXED partitioning scheme configuration. This must be an exhaustive mapping of all
+        # partitions to a set of brokers. If any partitions are not configured, the broker will not
+        # start.
+        #
+        # For each partition, you must specify its partition ID (ranging from 1 to
+        # partitionCount), and the set of nodes which will manage it. This must be a subset
+        # of nodes whose IDs are valid within your cluster. This means with node IDs ranging from 0
+        # to the (clusterSize - 1), without any repeated IDs. This subset must have the same amount
+        # of nodes as the replication factor, otherwise the broker will not start.
+        #
+        # If you are using priority election, then you can also specify the priorities for each
+        # nodes. Note that for a given partition, the priorities of each member must be different,
+        # otherwise the broker will fail to start.
+        #
+        # fixed:
+        #   - partitionId: 1
+        #     nodes:
+        #       - nodeId: 0
+        #         priority: 1
+        #       - nodeId: 1
+        #         priority: 2
+        #       - nodeId: 2
+        #         priority: 3
+        #   - partitionId: 2
+        #     nodes:
+        #       - nodeId: 0
+        #         priority: 3
+        #       - nodeId: 1
+        #         priority: 2
+        #       - nodeId: 2
+        #         priority: 1
+        #   - partitionId: 3
+        #     nodes:
+        #       - nodeId: 0
+        #         priority: 2
+        #       - nodeId: 1
+        #         priority: 3
+        #       - nodeId: 2
+        #         priority: 2
+
       # Allows to configure specific raft properties
       # raft:
         # Sets the timeout for all requests send by raft leaders and followers.

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FixedPartitionDistributionIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FixedPartitionDistributionIT.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering;
+
+import io.camunda.zeebe.test.util.actuator.PartitionsActuatorClient;
+import io.camunda.zeebe.test.util.actuator.PartitionsActuatorClient.PartitionStatus;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
+import io.camunda.zeebe.test.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.util.Either;
+import io.zeebe.containers.ZeebeBrokerNode;
+import io.zeebe.containers.cluster.ZeebeCluster;
+import java.util.List;
+import org.agrona.CloseHelper;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
+
+final class FixedPartitionDistributionIT {
+  private static final Logger LOGGER = LoggerFactory.getLogger(FixedPartitionDistributionIT.class);
+
+  private Network network;
+  private ZeebeCluster cluster;
+
+  @SuppressWarnings("unused")
+  @RegisterExtension
+  final ContainerLogsDumper logsWatcher =
+      new ContainerLogsDumper(() -> cluster.getBrokers(), LOGGER);
+
+  @BeforeEach
+  void beforeEach() {
+    network = Network.newNetwork();
+  }
+
+  @AfterEach
+  void afterEach() {
+    CloseHelper.quietCloseAll(cluster, network);
+  }
+
+  @Test
+  void shouldDistributePartitions() {
+    // given
+    cluster =
+        ZeebeCluster.builder()
+            .withBrokersCount(3)
+            .withEmbeddedGateway(true)
+            .withPartitionsCount(3)
+            .withReplicationFactor(2)
+            .build();
+    cluster.getBrokers().forEach((nodeId, broker) -> configureBroker(broker));
+    cluster.start();
+
+    // when - then
+    final var brokerZeroPartitions = List.of("2", "3");
+    final var brokerOnePartitions = List.of("1", "3");
+    final var brokerTwoPartitions = List.of("1", "2");
+
+    assertPartitionsDistributedPerBroker(brokerZeroPartitions, 0);
+    assertPartitionsDistributedPerBroker(brokerOnePartitions, 1);
+    assertPartitionsDistributedPerBroker(brokerTwoPartitions, 2);
+  }
+
+  private void assertPartitionsDistributedPerBroker(
+      final List<String> expectedPartitionIds, final Integer nodeId) {
+    final var broker = cluster.getBrokers().get(nodeId);
+    final var client = new PartitionsActuatorClient(broker.getExternalMonitoringAddress());
+    final var partitionsResult = client.queryPartitions();
+
+    EitherAssert.assertThat(partitionsResult)
+        .as("partitions status request should have succeeded")
+        .isRight()
+        .extracting(Either::get)
+        .asInstanceOf(InstanceOfAssertFactories.map(String.class, PartitionStatus.class))
+        .as("broker %d should report entries for the expected partitions", nodeId)
+        .containsOnlyKeys(expectedPartitionIds);
+  }
+
+  private void configureBroker(final ZeebeBrokerNode<?> broker) {
+    broker.setDockerImageName(
+        ZeebeTestContainerDefaults.defaultTestImage().asCanonicalNameString());
+    broker
+        .withEnv("ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING_SCHEME", "FIXED")
+        .withEnv("ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING_FIXED_0_PARTITIONID", "1")
+        .withEnv("ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING_FIXED_0_NODES_0_NODEID", "1")
+        .withEnv("ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING_FIXED_0_NODES_1_NODEID", "2")
+        .withEnv("ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING_FIXED_1_PARTITIONID", "2")
+        .withEnv("ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING_FIXED_1_NODES_0_NODEID", "0")
+        .withEnv("ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING_FIXED_1_NODES_1_NODEID", "2")
+        .withEnv("ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING_FIXED_2_PARTITIONID", "3")
+        .withEnv("ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING_FIXED_2_NODES_0_NODEID", "0")
+        .withEnv("ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING_FIXED_2_NODES_1_NODEID", "1");
+  }
+}


### PR DESCRIPTION
## Description

This PR introduces a new configurable partitioning scheme which lets users manually distribute partitions across a static set of nodes. Additionally, if priority election is used, it lets users assign priorities to these nodes as well.

A valid configuration consists of:

- All partitions with IDs between 1 and `partitionsCount` are configured explicitly
- All partitions configure exactly `replicationFactor` nodes
- All nodes configured for a partition have a valid node ID, i.e. between 0 and `clusterSize - 1`.
- If priority election is enabled, then all priorities configured for a partition are different

If any of these conditions are not met, then the broker will fail to start. Note that if priority election is enabled, the target priority for a partition will be whatever was the highest configured priority.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6266 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
