### PR TITLE
refactor: move reader reset

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -443,9 +443,14 @@ public final class ProcessingStateMachine {
     return !onErrorHandlingLoop;
   }
 
-  public void startProcessing(final long lastReprocessedPosition) {
+  public void startProcessing(final long lastProcessedPosition) {
+    // Replay ends at the end of the log and returns the lastSourceEventPosition
+    // which is equal to the last processed position
+    // we need to seek to the next record after that position where the processing should start
+    // Be aware on processing we ignore events, so we will process the next command
+    logStreamReader.seekToNextEvent(lastProcessedPosition);
     if (lastSuccessfulProcessedEventPosition == StreamProcessor.UNSET_POSITION) {
-      lastSuccessfulProcessedEventPosition = lastReprocessedPosition;
+      lastSuccessfulProcessedEventPosition = lastProcessedPosition;
     }
     actor.submit(this::readNextEvent);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateMachine.java
@@ -185,11 +185,6 @@ public final class ReplayStateMachine {
    * the last source event, which has caused the last applied event.
    */
   private void onRecordsReplayed() {
-    // Replay ends at the end of the log
-    // reset the position to the first event where the processing should start
-    // TODO(zell): this should probably done outside; makes no sense here
-    logStreamReader.seekToNextEvent(lastSourceEventPosition);
-
     // restore the key generate with the highest key from the log
     keyGeneratorControls.setKeyIfHigher(highestRecordKey);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -294,10 +294,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     // enable writing records to the stream
     processingContext.enableLogStreamWriter();
 
-    // Replay ends at the end of the log and returns the lastSourceEventPosition
-    // we need to seek to the next record after that position where the processing should start
-    // Be aware on processing we ignore events, so we will process the next command
-    logStreamReader.seekToNextEvent(lastSourceEventPosition);
     logStream.registerRecordAvailableListener(this);
 
     // start reading


### PR DESCRIPTION
## Description

In order to decouple the reprocessing state machine we reset the reader outside in the StreamProcessor, which prepares the reader before starting with the processing.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda-cloud/zeebe/issues/7477

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
