### PR TITLE
fix(broker): do not fail exporter if position not found when recovering

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -243,10 +243,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
   private void recoverFromSnapshot() {
     state = new ExportersState(zeebeDb, zeebeDb.createContext());
-
     final long snapshotPosition = state.getLowestPosition();
-    logStreamReader.seekToNextEvent(snapshotPosition);
-
     LOG.debug(
         "Recovered exporter '{}' from snapshot at lastExportedPosition {}",
         getName(),
@@ -290,6 +287,8 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     }
 
     if (state.hasExporters()) {
+      final long snapshotPosition = state.getLowestPosition();
+      logStreamReader.seekToNextEvent(snapshotPosition);
       if (!isPaused) {
         exporterPhase = ExporterPhase.EXPORTING;
         actor.submit(this::readNextEvent);

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -52,8 +52,6 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
   private static final String ERROR_MESSAGE_EXPORTING_ABORTED =
       "Expected to export record '{}' successfully, but exception was thrown.";
-  private static final String ERROR_MESSAGE_RECOVER_FROM_SNAPSHOT_FAILED =
-      "Expected to find event with the snapshot position %s in log stream, but nothing was found. Failed to recover '%s'.";
   private static final String EXPORTER_STATE_TOPIC_FORMAT = "exporterState-%d";
 
   private static final Logger LOG = Loggers.EXPORTER_LOGGER;
@@ -247,11 +245,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     state = new ExportersState(zeebeDb, zeebeDb.createContext());
 
     final long snapshotPosition = state.getLowestPosition();
-    final boolean failedToRecoverReader = !logStreamReader.seekToNextEvent(snapshotPosition);
-    if (failedToRecoverReader) {
-      throw new IllegalStateException(
-          String.format(ERROR_MESSAGE_RECOVER_FROM_SNAPSHOT_FAILED, snapshotPosition, getName()));
-    }
+    logStreamReader.seekToNextEvent(snapshotPosition);
 
     LOG.debug(
         "Recovered exporter '{}' from snapshot at lastExportedPosition {}",

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -52,6 +52,8 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
   private static final String ERROR_MESSAGE_EXPORTING_ABORTED =
       "Expected to export record '{}' successfully, but exception was thrown.";
+  private static final String ERROR_MESSAGE_RECOVER_FROM_SNAPSHOT_FAILED =
+      "Expected to find event with the snapshot position %s in log stream, but nothing was found. Failed to recover '%s'.";
   private static final String EXPORTER_STATE_TOPIC_FORMAT = "exporterState-%d";
 
   private static final Logger LOG = Loggers.EXPORTER_LOGGER;
@@ -292,7 +294,11 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
     if (state.hasExporters()) {
       final long snapshotPosition = state.getLowestPosition();
-      logStreamReader.seekToNextEvent(snapshotPosition);
+      final boolean failedToRecoverReader = !logStreamReader.seekToNextEvent(snapshotPosition);
+      if (failedToRecoverReader) {
+        throw new IllegalStateException(
+            String.format(ERROR_MESSAGE_RECOVER_FROM_SNAPSHOT_FAILED, snapshotPosition, getName()));
+      }
       if (!isPaused) {
         exporterPhase = ExporterPhase.EXPORTING;
         actor.submit(this::readNextEvent);

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -139,23 +139,25 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
   @Override
   protected void onActorStarting() {
-    final ActorFuture<LogStreamReader> newReaderFuture = logStream.newLogStreamReader();
-    actor.runOnCompletionBlockingCurrentPhase(
-        newReaderFuture,
-        (reader, errorOnReceivingReader) -> {
-          if (errorOnReceivingReader == null) {
-            logStreamReader = reader;
-          } else {
-            // TODO https://github.com/zeebe-io/zeebe/issues/3499
-            // ideally we could fail the actor start future such that we are able to propagate the
-            // error
-            LOG.error(
-                "Unexpected error on retrieving reader from log {}",
-                logStream.getLogName(),
-                errorOnReceivingReader);
-            actor.close();
-          }
-        });
+    if (exporterMode == ExporterMode.ACTIVE) {
+      final ActorFuture<LogStreamReader> newReaderFuture = logStream.newLogStreamReader();
+      actor.runOnCompletionBlockingCurrentPhase(
+          newReaderFuture,
+          (reader, errorOnReceivingReader) -> {
+            if (errorOnReceivingReader == null) {
+              logStreamReader = reader;
+            } else {
+              // TODO https://github.com/zeebe-io/zeebe/issues/3499
+              // ideally we could fail the actor start future such that we are able to propagate the
+              // error
+              LOG.error(
+                  "Unexpected error on retrieving reader from log {}",
+                  logStream.getLogName(),
+                  errorOnReceivingReader);
+              actor.close();
+            }
+          });
+    }
   }
 
   @Override
@@ -188,7 +190,9 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
   @Override
   protected void onActorClosing() {
-    logStreamReader.close();
+    if (logStreamReader != null) {
+      logStreamReader.close();
+    }
     logStream.removeRecordAvailableListener(this);
   }
 


### PR DESCRIPTION
## Description

On followers it is possible that the log does not contain the event at last exported position when recovering from a snapshot. This can happen because if the node is lagging behind in replication, it receives a snapshot and throws away its log. After receiving the snapshot exporter will be reset which tries to recover the state from the new snapshot. But the replication of the events might be delayed.
It is arguable if we want to keep this check for the leader. But we can safely assume that this node never become the leader if it does not have an up-to-date log.

## Related issues

closes #7697 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
