### PR TITLE
Do not export on followers

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -121,7 +121,9 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
         () -> {
           isPaused = false;
           exporterPhase = ExporterPhase.EXPORTING;
-          actor.submit(this::readNextEvent);
+          if (exporterMode == ExporterMode.ACTIVE) {
+            actor.submit(this::readNextEvent);
+          }
         });
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorPauseTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorPauseTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.exporter.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
+import io.camunda.zeebe.broker.exporter.util.ControlledTestExporter;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class ExporterDirectorPauseTest {
+
+  private static final long TIMEOUT = 2_000;
+
+  @Rule public final ExporterRule passiveExporter = ExporterRule.passiveExporter();
+  @Rule public final ExporterRule activeExporter = ExporterRule.activeExporter();
+
+  private ControlledTestExporter exporter;
+  private ExporterDescriptor descriptor;
+
+  @Before
+  public void init() {
+    exporter = spy(new ControlledTestExporter());
+    descriptor = spy(new ExporterDescriptor("exporter-1", exporter.getClass(), Map.of()));
+    doAnswer(c -> exporter).when(descriptor).newInstance();
+  }
+
+  @Test
+  public void shouldPauseActiveExporter() {
+    // given
+    activeExporter.startExporterDirector(List.of(descriptor));
+    activeExporter.getDirector().pauseExporting().join();
+
+    // when
+    activeExporter.writeEvent(DeploymentIntent.CREATED, new DeploymentRecord());
+    assertThat(activeExporter.getDirector().getPhase().join()).isEqualTo(ExporterPhase.PAUSED);
+
+    // then
+    verify(exporter, after(TIMEOUT).times(0)).export(any());
+  }
+
+  @Test
+  public void shouldResumeActiveExporter() {
+    // given
+    activeExporter.startExporterDirector(List.of(descriptor));
+    activeExporter.getDirector().pauseExporting().join();
+    activeExporter.writeEvent(DeploymentIntent.CREATED, new DeploymentRecord());
+    assertThat(activeExporter.getDirector().getPhase().join()).isEqualTo(ExporterPhase.PAUSED);
+
+    // when
+    activeExporter.getDirector().resumeExporting().join();
+    assertThat(activeExporter.getDirector().getPhase().join()).isEqualTo(ExporterPhase.EXPORTING);
+
+    // then
+    verify(exporter, timeout(TIMEOUT).times(1)).export(any());
+  }
+
+  @Test
+  public void shouldNotExportPassiveExporterAfterResume() {
+    // given
+    passiveExporter.startExporterDirector(List.of(descriptor));
+    passiveExporter.getDirector().pauseExporting().join();
+    passiveExporter.writeEvent(DeploymentIntent.CREATED, new DeploymentRecord());
+    assertThat(passiveExporter.getDirector().getPhase().join()).isEqualTo(ExporterPhase.PAUSED);
+
+    // when
+    passiveExporter.getDirector().resumeExporting().join();
+    assertThat(passiveExporter.getDirector().getPhase().join()).isEqualTo(ExporterPhase.EXPORTING);
+    passiveExporter.writeEvent(DeploymentIntent.CREATED, new DeploymentRecord());
+
+    // then
+    verify(exporter, after(TIMEOUT).times(0)).export(any());
+  }
+}


### PR DESCRIPTION
## Description

Followers were accidently exporting because `resumeExporting` is always called after installing the exporter. This PR fixes it by checking the exporter mode when resuming.

## Related issues

closes #7695 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
