### PR TITLE
Avoid multiple correlations of a message to a non-interrupting event 

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageSubscriptionCorrelatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageSubscriptionCorrelatedApplier.java
@@ -32,7 +32,7 @@ public final class MessageSubscriptionCorrelatedApplier
     if (value.isInterrupting()) {
       messageSubscriptionState.remove(subscription);
     } else {
-      messageSubscriptionState.resetCorrelatingState(subscription);
+      messageSubscriptionState.updateToCorrelatedState(subscription);
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessMessageSubscriptionCorrelatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessMessageSubscriptionCorrelatedApplier.java
@@ -39,8 +39,13 @@ public final class ProcessMessageSubscriptionCorrelatedApplier
   @Override
   public void applyState(final long key, final ProcessMessageSubscriptionRecord value) {
     final var eventScopeKey = value.getElementInstanceKey();
+
     if (value.isInterrupting()) {
       subscriptionState.remove(eventScopeKey, value.getMessageNameBuffer());
+    } else {
+      // if the message subscription is created and a matching message is buffered then it writes a
+      // process message subscription CORRELATE instead of a CREATE command
+      subscriptionState.updateToOpenedState(value);
     }
 
     if (shouldCreateTemporaryVariables(value)) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
@@ -155,7 +155,7 @@ public final class DbMessageSubscriptionState
   }
 
   @Override
-  public void resetCorrelatingState(final MessageSubscription subscription) {
+  public void updateToCorrelatedState(final MessageSubscription subscription) {
     updateCorrelatingFlag(subscription, false);
     transientState.remove(subscription.getRecord());
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
@@ -157,6 +157,7 @@ public final class DbMessageSubscriptionState
   @Override
   public void resetCorrelatingState(final MessageSubscription subscription) {
     updateCorrelatingFlag(subscription, false);
+    transientState.remove(subscription.getRecord());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMessageSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMessageSubscriptionState.java
@@ -18,7 +18,7 @@ public interface MutableMessageSubscriptionState extends MessageSubscriptionStat
 
   void updateToCorrelatingState(MessageSubscriptionRecord record);
 
-  void resetCorrelatingState(MessageSubscription subscription);
+  void updateToCorrelatedState(MessageSubscription subscription);
 
   boolean remove(long elementInstanceKey, DirectBuffer messageName);
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationTest.java
@@ -832,6 +832,59 @@ public final class MessageCorrelationTest {
   }
 
   @Test
+  public void shouldCorrelateOnlyOnceToNonInterruptingBoundaryEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", b -> b.zeebeJobType("test"))
+            .boundaryEvent("message")
+            .cancelActivity(false)
+            .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
+            .endEvent("correlated")
+            .moveToActivity("task")
+            .boundaryEvent("timer")
+            .timerWithDuration("PT5M")
+            .endEvent()
+            .done();
+
+    engine.deployment().withXmlResource(process).deploy();
+
+    final var processInstanceKey =
+        engine.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("key", "key-1").create();
+
+    // when
+    engine.message().withName("message").withCorrelationKey("key-1").publish();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.BOUNDARY_EVENT)
+        .await();
+
+    // complete the process instance by triggering the interrupting timer boundary event
+    engine.increaseTime(Duration.ofMinutes(5));
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted()
+                .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withElementType(BpmnElementType.BOUNDARY_EVENT))
+        .describedAs("Expected that the message boundary event is activated only once")
+        .hasSize(2)
+        .extracting(r -> r.getValue().getElementId())
+        .containsExactly("message", "timer");
+
+    assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .onlyCommandRejections())
+        .describedAs("Expected no subscription command rejections")
+        .isEmpty();
+  }
+
+  @Test
   public void shouldCorrelateMessageAgainAfterRejection() {
     // given
     engine.message().withName("a").withCorrelationKey("123").publish();


### PR DESCRIPTION
## Description

* messages were correlated multiple times because pending subscriptions were not removed
* the engine assumed that the subscription commands were not written/distributed successful and sent them again
* fix the message correlation by removing the pending subscriptions

## Related issues

closes #7619 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
