### PR TITLE
feat(journal): do not reset readers when deleting segments

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -165,7 +165,6 @@ public final class SegmentedJournal implements Journal {
       compactSegments.clear();
 
       journalIndex.deleteUntil(index);
-      resetHead(getFirstSegment().index());
     }
   }
 
@@ -606,19 +605,6 @@ public final class SegmentedJournal implements Journal {
 
   public void closeReader(final SegmentedJournalReader segmentedJournalReader) {
     readers.remove(segmentedJournalReader);
-  }
-
-  /**
-   * Resets journal readers to the given head.
-   *
-   * @param index The index at which to reset readers.
-   */
-  void resetHead(final long index) {
-    for (final SegmentedJournalReader reader : readers) {
-      if (reader.getNextIndex() <= index) {
-        reader.unsafeSeek(index);
-      }
-    }
   }
 
   /**

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
@@ -65,6 +65,7 @@ class SegmentedJournalReaderTest {
     // when - compact up to the first index of segment 3
     final int indexToCompact = ENTRIES_PER_SEGMENT * 2 + 1;
     journal.deleteUntil(indexToCompact);
+    reader.seekToFirst();
 
     // then
     assertThat(reader.hasNext()).isTrue();

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -260,6 +260,7 @@ class SegmentedJournalTest {
 
     // then
     assertThat(journal.getFirstIndex()).isEqualTo(lastIndex - 1);
+    reader.seekToFirst();
     assertThat(reader.next().index()).isEqualTo(lastIndex - 1);
   }
 
@@ -279,6 +280,7 @@ class SegmentedJournalTest {
 
     // then
     assertThat(journal.getFirstIndex()).isEqualTo(lastIndex - 1);
+    reader.seekToFirst();
     assertThat(reader.next().index()).isEqualTo(lastIndex - 1);
   }
 


### PR DESCRIPTION
## Description

When reseting the readers transparently, there is always a possibility that these readers are accessed concurrently in another thread. This can lead to issues which are difficult to debug. We remove this automatic reset and expects the readers to seek to the new segments when necessary.

In this case, we are compacting the segments. The assumption is that there are no readers which are still reading from the segments to be deleted.

## Related issues

closes #7699

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
