### PR TITLE
Add snapshot replication test

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredSnapshotTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredSnapshotTest.java
@@ -93,6 +93,22 @@ public class ClusteredSnapshotTest {
   }
 
   @Test
+  public void shouldSendSnapshotOnReconnect() {
+    // given
+    final var followerId = clusteringRule.stopAnyFollower();
+    ControllableExporter.updatePosition(true);
+    publishMessages();
+    snapshotTrigger.accept(clusteringRule);
+
+    // when
+    clusteringRule.startBroker(followerId);
+
+    // then
+    clusteringRule.waitForSnapshotAtBroker(clusteringRule.getBroker(followerId));
+    assertThat(clusteringRule.getSnapshot(followerId)).isPresent();
+  }
+
+  @Test
   public void shouldIncludeExportedPositionInSnapshot() {
     // given
     ControllableExporter.updatePosition(true);

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -718,6 +718,10 @@ public final class ClusteringRule extends ExternalResource {
     return Paths.get(dataDir).resolve(RAFT_PARTITION_PATH);
   }
 
+  public SnapshotId waitForSnapshotAtBroker(final int nodeId) {
+    return waitForNewSnapshotAtBroker(getBroker(nodeId), null);
+  }
+
   public SnapshotId waitForSnapshotAtBroker(final Broker broker) {
     return waitForNewSnapshotAtBroker(broker, null);
   }
@@ -802,6 +806,15 @@ public final class ClusteringRule extends ExternalResource {
 
   public Leader getCurrentLeaderForPartition(final int partition) {
     return partitionLeader.get(partition);
+  }
+
+  public int stopAnyFollower() {
+    final var leaderForPartition = getLeaderForPartition(START_PARTITION_ID);
+
+    final var otherBrokerObjects = getOtherBrokerObjects(leaderForPartition.getNodeId());
+    final var nodeId = otherBrokerObjects.get(0).getConfig().getCluster().getNodeId();
+    stopBroker(nodeId);
+    return nodeId;
   }
 
   private class LeaderListener implements PartitionListener {


### PR DESCRIPTION
## Description

When a follower joins late then the snapshot has to be replicated, this is now tested via an IT test
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda-cloud/zeebe/issues/7696

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
