### PR TITLE
feat(gateway): expose a GRPC health endpoint

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -98,6 +98,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-services</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>
@@ -129,6 +134,11 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
     </dependency>
 
     <dependency>

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.messaging.ClusterEventService;
 import io.atomix.cluster.messaging.MessagingService;
+import io.camunda.zeebe.gateway.health.Status;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
@@ -217,12 +218,5 @@ public final class Gateway {
       brokerClient.close();
       brokerClient = null;
     }
-  }
-
-  public enum Status {
-    INITIAL,
-    STARTING,
-    RUNNING,
-    SHUTDOWN
   }
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/health/GatewayHealthManager.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/health/GatewayHealthManager.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.health;
+
+import io.grpc.BindableService;
+
+public interface GatewayHealthManager {
+
+  /**
+   * This method returns the latest health status for the gateway, and is thread safe.
+   *
+   * @return the current health status
+   */
+  Status getStatus();
+
+  /**
+   * This method sets the health status in a thread safe way.
+   *
+   * @param status the new health status of the gateway
+   */
+  void setStatus(final Status status);
+
+  /**
+   * This method return the GRPC {@link BindableService} to use it in the {@link
+   * io.grpc.ServerBuilder }
+   *
+   * @return the bindable GRPC service
+   */
+  BindableService getHealthService();
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/health/Status.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/health/Status.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.health;
+
+public enum Status {
+  INITIAL,
+  STARTING,
+  RUNNING,
+  SHUTDOWN
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/health/impl/GatewayHealthManagerImpl.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/health/impl/GatewayHealthManagerImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.health.impl;
+
+import io.camunda.zeebe.gateway.health.GatewayHealthManager;
+import io.camunda.zeebe.gateway.health.Status;
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
+import io.grpc.BindableService;
+import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
+import io.grpc.protobuf.services.HealthStatusManager;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.concurrent.ThreadSafe;
+
+@ThreadSafe
+public final class GatewayHealthManagerImpl implements GatewayHealthManager {
+  private static final Set<String> MONITORED_SERVICES =
+      Set.of(GatewayGrpc.SERVICE_NAME, HealthStatusManager.SERVICE_NAME_ALL_SERVICES);
+
+  private final HealthStatusManager statusManager;
+  private final AtomicReference<Status> status = new AtomicReference<>();
+
+  public GatewayHealthManagerImpl() {
+    this(new HealthStatusManager());
+  }
+
+  public GatewayHealthManagerImpl(final HealthStatusManager statusManager) {
+    this.statusManager = statusManager;
+    setStatus(Status.INITIAL);
+  }
+
+  @Override
+  public Status getStatus() {
+    return status.get();
+  }
+
+  @Override
+  public void setStatus(final Status status) {
+    final var oldStatus = this.status.getAndAccumulate(status, this::computeStatus);
+
+    if (oldStatus != Status.SHUTDOWN && oldStatus != status) {
+      updateGrpcHealthStatus(status);
+    }
+  }
+
+  private Status computeStatus(final Status currentStatus, final Status newStatus) {
+    if (currentStatus == Status.SHUTDOWN) {
+      return Status.SHUTDOWN;
+    }
+
+    return newStatus;
+  }
+
+  public BindableService getHealthService() {
+    return statusManager.getHealthService();
+  }
+
+  private void updateGrpcHealthStatus(final Status status) {
+    switch (status) {
+      case RUNNING:
+        setGrpcHealthStatus(ServingStatus.SERVING);
+        break;
+      case SHUTDOWN:
+        statusManager.enterTerminalState();
+        break;
+      case INITIAL:
+      case STARTING:
+      default:
+        setGrpcHealthStatus(ServingStatus.NOT_SERVING);
+        break;
+    }
+  }
+
+  private void setGrpcHealthStatus(final ServingStatus servingStatus) {
+    MONITORED_SERVICES.forEach(service -> statusManager.setStatus(service, servingStatus));
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridge.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridge.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.gateway.impl;
 
-import io.camunda.zeebe.gateway.Gateway.Status;
+import io.camunda.zeebe.gateway.health.Status;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
 import java.util.Optional;
 import java.util.function.Supplier;

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/StartedHealthIndicator.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/StartedHealthIndicator.java
@@ -9,8 +9,8 @@ package io.camunda.zeebe.gateway.impl.probes.health;
 
 import static java.util.Objects.requireNonNull;
 
-import io.camunda.zeebe.gateway.Gateway.Status;
 import io.camunda.zeebe.gateway.Loggers;
+import io.camunda.zeebe.gateway.health.Status;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.slf4j.Logger;

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/health/GatewayHealthManagerImplTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/health/GatewayHealthManagerImplTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.camunda.zeebe.gateway.health.impl.GatewayHealthManagerImpl;
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
+import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
+import io.grpc.protobuf.services.HealthStatusManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class GatewayHealthManagerImplTest {
+  private GatewayHealthManagerImpl gatewayHealthManagerImpl;
+  private HealthStatusManager statusManager;
+
+  @BeforeEach
+  void setUp() {
+    statusManager = mock(HealthStatusManager.class);
+    gatewayHealthManagerImpl = new GatewayHealthManagerImpl(statusManager);
+  }
+
+  @Test
+  void shouldHaveNonServingStatusOnCreation() {
+    // then
+    assertThat(gatewayHealthManagerImpl.getStatus()).isEqualTo(Status.INITIAL);
+
+    verify(statusManager).setStatus(GatewayGrpc.SERVICE_NAME, ServingStatus.NOT_SERVING);
+    verify(statusManager)
+        .setStatus(HealthStatusManager.SERVICE_NAME_ALL_SERVICES, ServingStatus.NOT_SERVING);
+    verifyNoMoreInteractions(statusManager);
+  }
+
+  @Test
+  void shouldSetServingStatusOnRunningStatus() {
+    // when
+    gatewayHealthManagerImpl.setStatus(Status.RUNNING);
+    // then
+    verify(statusManager).setStatus(GatewayGrpc.SERVICE_NAME, ServingStatus.SERVING);
+    verify(statusManager)
+        .setStatus(HealthStatusManager.SERVICE_NAME_ALL_SERVICES, ServingStatus.SERVING);
+  }
+
+  @Test
+  void shouldSetNonServingStatusOnStartingStatus() {
+    // when
+    gatewayHealthManagerImpl.setStatus(Status.STARTING);
+    // then
+    verify(statusManager, times(2)).setStatus(GatewayGrpc.SERVICE_NAME, ServingStatus.NOT_SERVING);
+    verify(statusManager, times(2))
+        .setStatus(HealthStatusManager.SERVICE_NAME_ALL_SERVICES, ServingStatus.NOT_SERVING);
+    verifyNoMoreInteractions(statusManager);
+  }
+
+  @Test
+  void shouldNotSetOtherStatusIfInTheShutdownStatus() {
+    // given
+    gatewayHealthManagerImpl.setStatus(Status.SHUTDOWN);
+    // when
+    gatewayHealthManagerImpl.setStatus(Status.RUNNING);
+    // then
+    verify(statusManager, never()).setStatus(GatewayGrpc.SERVICE_NAME, ServingStatus.SERVING);
+    verify(statusManager, never())
+        .setStatus(HealthStatusManager.SERVICE_NAME_ALL_SERVICES, ServingStatus.SERVING);
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridgeTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridgeTest.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.gateway.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.gateway.Gateway.Status;
+import io.camunda.zeebe.gateway.health.Status;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
 import java.util.Optional;
 import java.util.function.Supplier;

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/StartedHealthIndicatorAutoConfigurationTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/StartedHealthIndicatorAutoConfigurationTest.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.gateway.impl.probes.health;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.gateway.Gateway.Status;
+import io.camunda.zeebe.gateway.health.Status;
 import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
 import java.util.function.Supplier;
 import org.junit.Before;

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/StartedHealthIndicatorTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/StartedHealthIndicatorTest.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.gateway.impl.probes.health;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.zeebe.gateway.Gateway.Status;
+import io.camunda.zeebe.gateway.health.Status;
 import java.util.Optional;
 import org.junit.Test;
 import org.springframework.boot.actuate.health.Health;

--- a/gateway/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/gateway/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -107,6 +107,7 @@
     <version.revapi>0.26.0</version.revapi>
     <version.commons-io>2.11.0</version.commons-io>
     <version.immutables>2.8.9-ea-1</version.immutables>
+    <version.jsr305>3.0.2</version.jsr305>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.0.0</plugin.version.antrun>
@@ -745,6 +746,12 @@
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>${version.commons-io}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>${version.jsr305}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -156,6 +156,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
@@ -291,6 +297,16 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-context</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-services</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayGrpcHealthIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayGrpcHealthIT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
+import io.camunda.zeebe.test.util.testcontainers.ZeebeTestContainerDefaults;
+import io.grpc.ManagedChannel;
+import io.grpc.health.v1.HealthCheckRequest;
+import io.grpc.health.v1.HealthCheckResponse;
+import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
+import io.grpc.health.v1.HealthGrpc;
+import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.protobuf.services.HealthStatusManager;
+import io.zeebe.containers.ZeebeGatewayContainer;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class GatewayGrpcHealthIT {
+
+  @Container
+  private final ZeebeGatewayContainer zeebeGatewayContainer =
+      new ZeebeGatewayContainer(ZeebeTestContainerDefaults.defaultTestImage())
+          .withoutTopologyCheck();
+
+  @ParameterizedTest
+  @ValueSource(strings = {GatewayGrpc.SERVICE_NAME, HealthStatusManager.SERVICE_NAME_ALL_SERVICES})
+  void shouldReturnServingStatusWhenGatewayIsStarted(final String serviceName) {
+    // given
+    final ManagedChannel channel =
+        NettyChannelBuilder.forTarget(zeebeGatewayContainer.getExternalGatewayAddress())
+            .usePlaintext()
+            .build();
+    final HealthCheckResponse response;
+
+    // when
+    try {
+      final var client = HealthGrpc.newBlockingStub(channel);
+      response = client.check(HealthCheckRequest.newBuilder().setService(serviceName).build());
+    } finally {
+      channel.shutdownNow();
+    }
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(ServingStatus.SERVING);
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayHealthIndicatorsIntegrationTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayHealthIndicatorsIntegrationTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.data.Offset.offset;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.gateway.Gateway.Status;
+import io.camunda.zeebe.gateway.health.Status;
 import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
 import io.camunda.zeebe.gateway.impl.probes.health.ClusterAwarenessHealthIndicator;


### PR DESCRIPTION
## Description

I've created a GRPC health endpoint, that based on a gateway status.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7635 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
