### PR TITLE
Add feature flag for new bootstrap/transition behavior

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -232,6 +232,13 @@
       <groupId>uk.co.real-logic</groupId>
       <artifactId>sbe-tool</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
   </dependencies>
 
   <build>

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -115,13 +115,6 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-util</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-      <type>test-jar</type>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>zeebe-transport</artifactId>
     </dependency>
     <dependency>

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -61,6 +61,11 @@ import java.util.stream.Collectors;
 // TODO make package private again
 public final class PartitionFactory {
 
+  /**
+   * Feature flag to switch between old and new partition bootstrap and transition code. The old
+   * code is based on LEADER_STEPS and FOLLOWER steps. The new code is based on TRANSITION_STEPS and
+   * ZeebePartition.STARTUP_PROCESS
+   */
   public static final boolean FEATURE_TOGGLE_USE_NEW_CODE = false;
   private static final List<PartitionStartupStep> STARTUP_STEPS =
       List.of(new StateControllerPartitionStep(), new LogDeletionPartitionStep());

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -67,8 +67,6 @@ public final class PartitionFactory {
    * ZeebePartition.STARTUP_PROCESS
    */
   public static final boolean FEATURE_TOGGLE_USE_NEW_CODE = false;
-  private static final List<PartitionStartupStep> STARTUP_STEPS =
-      List.of(new StateControllerPartitionStep(), new LogDeletionPartitionStep());
 
   // will probably be executed in parallel
   private static final List<PartitionTransitionStep> TRANSITION_STEPS = List.of();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionStep.java
@@ -13,13 +13,27 @@ import io.camunda.zeebe.util.sched.future.ActorFuture;
 /**
  * A PartitionTransitionStep is an action to be taken while transitioning the partition to a new
  * role
+ *
+ * <p>The sequence of method calls is as follows:
+ *
+ * <ol>
+ *   <li>onNewRaftRole(..) - called always as soon as a raft role change is announced.
+ *   <li>prepareTransition(..) - called on all steps that executed during the last transition; steps
+ *       will be called in reverse order
+ *   <li>transitionTo(...) - called on all steps to perform the actual transition
+ * </ol>
+ *
+ * <p>Note that a transition may be interrupted at any time. To that end, {@code onNewRaftRole(..)}
+ * can be called at any time and can/should be used as a trigger to cancel the current step. The
+ * other methods are called in order. An ongoing transition will only be aborted in between steps,
+ * not while a step is running. Also, any subsequent steps will execute only after the currently
+ * active step has completed
  */
 public interface PartitionTransitionStep {
 
   /**
-   * This method is called prior to starting a new transition. It is called immediately after the
-   * new Raft role is known. It is expected that this method completes instantly. It is called on
-   * all steps, and only afterwards the first step is called with the transition.
+   * This method is called immediately after the new Raft role is known. It is expected that this
+   * method completes instantly. It is called on all steps.
    *
    * <p>Steps are expected to pause any active requests and assume a neutral stance after this
    * method is called. After all steps have been notified, the first steps' {@code
@@ -39,6 +53,19 @@ public interface PartitionTransitionStep {
    */
   default void onNewRaftRole(final Role newRole) {}
 
+  /**
+   * This method is a hook to prepare steps for a pending transition. This method is deprecated
+   * because eventually we want ro remove it. Once removed, all steps need to take the necessary
+   * preparatory steps as part of {@code newRaftRole(...)}.
+   *
+   * <p>For a time being, however, this method will be supported. Steps will be called in reverse
+   * order and are expected to take any steps to assume a neutral stance
+   */
+  @Deprecated
+  ActorFuture<Void> prepareTransition(
+      final PartitionTransitionContext context, final long term, final Role targetRole);
+
+  /** This method is called to start the actual transition */
   ActorFuture<Void> transitionTo(
       final PartitionTransitionContext context, final long term, final Role targetRole);
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionStep.java
@@ -16,8 +16,33 @@ import io.camunda.zeebe.util.sched.future.ActorFuture;
  */
 public interface PartitionTransitionStep {
 
+  /**
+   * This method is called prior to starting a new transition. It is expected that this method
+   * completes instantly. It is called on all steps, and only afterwards the first step is called
+   * with the transition.
+   *
+   * <p>Steps are expected to pause any active requests and assume a neutral stance after this
+   * method is called. After all steps have been notified, the first steps' {@code
+   * transitionTo(...)} will be called, and then subsequently all other steps. This means that
+   * during the time between the call to thie method and the call to {@code transitionTo(...)} some
+   * preceding steps may have already transitioned, but others are still waiting for transition.
+   *
+   * <p>To summarize, after this method is called, the partition is in an undefined state. And as
+   * soon as {@code transitionTo(...)} is called the partition has completed all transition steps up
+   * to this point
+   *
+   * <p>Note, that this may also be called while a transition is currently running, for example if
+   * the raft partition transitions faster than the Zeebe partition. In this case steps are
+   * encouraged to cancel what they are doing
+   *
+   * @param targetRole target role to transition to
+   */
+  default void prepareForTransition(final Role targetRole) {
+    // todo remove default implementation
+  }
+
   ActorFuture<Void> transitionTo(
-      final PartitionTransitionContext context, final long term, final Role role);
+      final PartitionTransitionContext context, final long term, final Role targetRole);
 
   /** @return A log-friendly identification of the PartitionTransitionStep. */
   String getName();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionStep.java
@@ -17,9 +17,9 @@ import io.camunda.zeebe.util.sched.future.ActorFuture;
 public interface PartitionTransitionStep {
 
   /**
-   * This method is called prior to starting a new transition. It is expected that this method
-   * completes instantly. It is called on all steps, and only afterwards the first step is called
-   * with the transition.
+   * This method is called prior to starting a new transition. It is called immediately after the
+   * new Raft role is known. It is expected that this method completes instantly. It is called on
+   * all steps, and only afterwards the first step is called with the transition.
    *
    * <p>Steps are expected to pause any active requests and assume a neutral stance after this
    * method is called. After all steps have been notified, the first steps' {@code
@@ -35,11 +35,9 @@ public interface PartitionTransitionStep {
    * the raft partition transitions faster than the Zeebe partition. In this case steps are
    * encouraged to cancel what they are doing
    *
-   * @param targetRole target role to transition to
+   * @param newRole target role to transition to
    */
-  default void prepareForTransition(final Role targetRole) {
-    // todo remove default implementation
-  }
+  default void onNewRaftRole(final Role newRole) {}
 
   ActorFuture<Void> transitionTo(
       final PartitionTransitionContext context, final long term, final Role targetRole);

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -17,6 +17,8 @@ import io.camunda.zeebe.broker.partitioning.PartitionFactory;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.monitoring.HealthMetrics;
 import io.camunda.zeebe.broker.system.partitions.impl.NewPartitionTransitionImpl;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.LogDeletionPartitionStep;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.StateControllerPartitionStep;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
@@ -44,7 +46,8 @@ public final class ZeebePartition extends Actor
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
 
   private static final StartupProcess<PartitionStartupContext> STARTUP_PROCESS =
-      new StartupProcess<PartitionStartupContext>(LOG, List.of());
+      new StartupProcess<>(
+          LOG, List.of(new StateControllerPartitionStep(), new LogDeletionPartitionStep()));
 
   private Role raftRole;
   private final String actorName;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.util.sched.ConcurrencyControl;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Stack;
 import org.slf4j.Logger;
 
 public final class NewPartitionTransitionImpl implements PartitionTransition {
@@ -29,9 +28,9 @@ public final class NewPartitionTransitionImpl implements PartitionTransition {
   private final List<PartitionTransitionStep> steps;
   private PartitionTransitionContext context;
   private ConcurrencyControl concurrencyControl;
-  private Transition lastTransition;
+  private PartitionTransitionProcess lastTransition;
   // these two should be set/cleared in tandem
-  private Transition currentTransition;
+  private PartitionTransitionProcess currentTransition;
   private ActorFuture<Void> currentTransitionFuture;
   // these two should be set in tandem
 
@@ -119,7 +118,8 @@ public final class NewPartitionTransitionImpl implements PartitionTransition {
 
   private void startNewTransition(
       final ActorFuture<Void> nextTransitionFuture, final long term, final Role role) {
-    currentTransition = new Transition(steps, concurrencyControl, context, term, role);
+    currentTransition =
+        new PartitionTransitionProcess(steps, concurrencyControl, context, term, role);
     currentTransitionFuture = nextTransitionFuture;
     concurrencyControl.runOnCompletion(
         currentTransitionFuture,
@@ -129,142 +129,5 @@ public final class NewPartitionTransitionImpl implements PartitionTransition {
           currentTransitionFuture = null;
         });
     currentTransition.start(currentTransitionFuture);
-  }
-
-  private static final class Transition {
-
-    private final List<PartitionTransitionStep> pendingSteps;
-    private final Stack<PartitionTransitionStep> startedSteps = new Stack<>();
-    private final ConcurrencyControl concurrencyControl;
-    private final PartitionTransitionContext context;
-    private final long term;
-    private final Role role;
-    private boolean cancelRequested = false;
-
-    private Transition(
-        final List<PartitionTransitionStep> pendingSteps,
-        final ConcurrencyControl concurrencyControl,
-        final PartitionTransitionContext context,
-        final long term,
-        final Role role) {
-      this.pendingSteps = new ArrayList<>(pendingSteps);
-      this.concurrencyControl = concurrencyControl;
-      this.context = context;
-      this.term = term;
-      this.role = role;
-    }
-
-    private void start(final ActorFuture<Void> future) {
-      LOG.info(format("Transition to %s on term %d starting", role, term));
-
-      if (pendingSteps.isEmpty()) {
-        LOG.info("No steps defined for transition");
-        future.complete(null);
-        return;
-      }
-
-      proceedWithTransition(future);
-    }
-
-    private void proceedWithTransition(final ActorFuture<Void> future) {
-      if (cancelRequested) {
-        LOG.info(format("Cancelling transition to %s on term %d", role, term));
-        future.complete(null);
-        return;
-      }
-
-      concurrencyControl.submit(
-          () -> {
-            final var nextStep = pendingSteps.remove(0);
-            startedSteps.push(nextStep);
-
-            LOG.info(
-                format(
-                    "Transition to %s on term %d - executing %s", role, term, nextStep.getName()));
-
-            nextStep
-                .transitionTo(context, term, role)
-                .onComplete((nil, error) -> onStepCompletion(future, error));
-          });
-    }
-
-    private void onStepCompletion(final ActorFuture<Void> future, final Throwable error) {
-      if (error != null) {
-        LOG.error(error.getMessage(), error);
-        future.completeExceptionally(error);
-
-        return;
-      }
-
-      if (pendingSteps.isEmpty()) {
-        LOG.info(format("Transition to %s on term %d completed", role, term));
-        future.complete(null);
-
-        return;
-      }
-
-      proceedWithTransition(future);
-    }
-
-    public ActorFuture<Void> cleanup(final long newTerm, final Role newRole) {
-      LOG.info(
-          format(
-              "Cleanup of transition to %s on term %d starting (in preparation for new transition to %s)",
-              role, term, newRole));
-      final ActorFuture<Void> cleanupFuture = concurrencyControl.createFuture();
-
-      if (startedSteps.isEmpty()) {
-        LOG.info("No steps to clean up");
-        cleanupFuture.complete(null);
-      } else {
-        proceedWithCleanup(cleanupFuture, newTerm, newRole);
-      }
-      return cleanupFuture;
-    }
-
-    private void proceedWithCleanup(
-        final ActorFuture<Void> future, final long newTerm, final Role newRole) {
-      concurrencyControl.submit(
-          () -> {
-            final var nextCleanupStep = startedSteps.pop();
-
-            LOG.info(
-                format(
-                    "Cleanup of transition to %s on term %d - executing %s",
-                    role, term, nextCleanupStep.getName()));
-
-            nextCleanupStep
-                .prepareTransition(context, newTerm, newRole)
-                .onComplete(
-                    (nil, error) -> onCleanupStepCompletion(future, error, newTerm, newRole));
-          });
-    }
-
-    private void onCleanupStepCompletion(
-        final ActorFuture<Void> future,
-        final Throwable error,
-        final long newTerm,
-        final Role newRole) {
-      if (error != null) {
-        LOG.error(error.getMessage(), error);
-        future.completeExceptionally(error);
-
-        return;
-      }
-
-      if (startedSteps.isEmpty()) {
-        LOG.info(format("Cleanup of transition to %s on term %d completed", role, term));
-        future.complete(null);
-
-        return;
-      }
-
-      proceedWithCleanup(future, newTerm, newRole);
-    }
-
-    private void cancel() {
-      LOG.info(format("Received cancel signal for transition to %s on term %d", role, term));
-      cancelRequested = true;
-    }
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.util.sched.ConcurrencyControl;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
+import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 
@@ -34,7 +35,7 @@ public final class NewPartitionTransitionImpl implements PartitionTransition {
 
   public NewPartitionTransitionImpl(
       final List<PartitionTransitionStep> steps, final PartitionTransitionContext context) {
-    this.steps = requireNonNull(steps);
+    this.steps = new ArrayList<>(requireNonNull(steps));
     this.context = requireNonNull(context);
   }
 
@@ -118,7 +119,7 @@ public final class NewPartitionTransitionImpl implements PartitionTransition {
         final PartitionTransitionContext context,
         final long term,
         final Role role) {
-      this.pendingSteps = pendingSteps;
+      this.pendingSteps = new ArrayList<>(pendingSteps);
       this.concurrencyControl = concurrencyControl;
       this.context = context;
       this.term = term;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
@@ -65,7 +65,7 @@ public final class NewPartitionTransitionImpl implements PartitionTransition {
   public ActorFuture<Void> transitionTo(final long term, final Role role) {
     // notify steps immediately that a transition is coming; steps are encouraged to cancel any
     // ongoing activity at this point in time
-    steps.forEach(step -> step.prepareForTransition(role));
+    steps.forEach(step -> step.onNewRaftRole(role));
 
     final ActorFuture<Void> nextTransitionFuture = concurrencyControl.createFuture();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransition;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
+import io.camunda.zeebe.util.sched.ConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import java.util.List;
+import org.slf4j.Logger;
+
+public final class NewPartitionTransitionImpl implements PartitionTransition {
+  private static final int INACTIVE_TERM = -1;
+  private static final Logger LOG = Loggers.SYSTEM_LOGGER;
+
+  private final List<PartitionTransitionStep> steps;
+  private PartitionTransitionContext context;
+  private ConcurrencyControl concurrencyControl;
+  // these two should be set/cleared in tandem
+  private Transition currentTransition;
+  private ActorFuture<Void> currentTransitionFuture;
+  // these two should be set in tandem
+
+  public NewPartitionTransitionImpl(
+      final List<PartitionTransitionStep> steps, final PartitionTransitionContext context) {
+    this.steps = requireNonNull(steps);
+    this.context = requireNonNull(context);
+  }
+
+  public void setConcurrencyControl(final ConcurrencyControl concurrencyControl) {
+    this.concurrencyControl = requireNonNull(concurrencyControl);
+  }
+
+  public void updateTransitionContext(final PartitionTransitionContext transitionContext) {
+    context = transitionContext;
+  }
+
+  @Override
+  public ActorFuture<Void> toFollower(final long term) {
+    return transitionTo(term, Role.FOLLOWER);
+  }
+
+  @Override
+  public ActorFuture<Void> toLeader(final long term) {
+    return transitionTo(term, Role.LEADER);
+  }
+
+  @Override
+  public ActorFuture<Void> toInactive() {
+    return transitionTo(INACTIVE_TERM, Role.INACTIVE);
+  }
+
+  public ActorFuture<Void> transitionTo(final long term, final Role role) {
+    // notify steps immediately that a transition is coming; steps are encouraged to cancel any
+    // ongoing activity at this point in time
+    steps.forEach(step -> step.prepareForTransition(role));
+
+    final ActorFuture<Void> nextTransitionFuture = concurrencyControl.createFuture();
+
+    concurrencyControl.submit(
+        () -> {
+          if (currentTransition != null) {
+            LOG.info(
+                format(
+                    "Transition to %s on term %d requested while another transition is still running",
+                    role, term));
+            currentTransition.cancel(); // this will drop any subsequent transition steps
+
+            // schedule new transition as soon as the current step of the current transition
+            // has completed
+            concurrencyControl.runOnCompletion(
+                currentTransitionFuture,
+                (nil, error) -> startNewTransition(nextTransitionFuture, term, role));
+
+          } else {
+            startNewTransition(nextTransitionFuture, term, role);
+          }
+        });
+    return nextTransitionFuture;
+  }
+
+  private void startNewTransition(
+      final ActorFuture<Void> nextTransitionFuture, final long term, final Role role) {
+    currentTransition = new Transition(steps, concurrencyControl, context, term, role);
+    currentTransitionFuture = nextTransitionFuture;
+    concurrencyControl.runOnCompletion(
+        currentTransitionFuture,
+        (nil, error) -> {
+          currentTransition = null;
+          currentTransitionFuture = null;
+        });
+    currentTransition.start(currentTransitionFuture);
+  }
+
+  private static final class Transition {
+
+    private final List<PartitionTransitionStep> pendingSteps;
+    private final ConcurrencyControl concurrencyControl;
+    private final PartitionTransitionContext context;
+    private final long term;
+    private final Role role;
+    private boolean cancelRequested = false;
+
+    private Transition(
+        final List<PartitionTransitionStep> pendingSteps,
+        final ConcurrencyControl concurrencyControl,
+        final PartitionTransitionContext context,
+        final long term,
+        final Role role) {
+      this.pendingSteps = pendingSteps;
+      this.concurrencyControl = concurrencyControl;
+      this.context = context;
+      this.term = term;
+      this.role = role;
+    }
+
+    private void start(final ActorFuture<Void> future) {
+      LOG.info(format("Transition to %s on term %d starting", role, term));
+
+      if (pendingSteps.isEmpty()) {
+        LOG.info("No steps defined for transition");
+        future.complete(null);
+        return;
+      }
+
+      proceed(future);
+    }
+
+    private void proceed(final ActorFuture<Void> future) {
+      if (cancelRequested) {
+        LOG.info(format("Cancelling transition to %s on term %d", role, term));
+        future.complete(null);
+        return;
+      }
+
+      concurrencyControl.submit(
+          () -> {
+            final var nextStep = pendingSteps.remove(0);
+
+            LOG.info(
+                format(
+                    "Transition to %s on term %d - executing %s", role, term, nextStep.getName()));
+
+            nextStep
+                .transitionTo(context, term, role)
+                .onComplete((nil, error) -> onStepCompletion(future, error));
+          });
+    }
+
+    private void onStepCompletion(final ActorFuture<Void> future, final Throwable error) {
+      if (error != null) {
+        LOG.error(error.getMessage(), error);
+        future.completeExceptionally(error);
+
+        return;
+      }
+
+      if (pendingSteps.isEmpty()) {
+        LOG.info(format("Transition to %s on term %d completed", role, term));
+        future.complete(null);
+
+        return;
+      }
+
+      proceed(future);
+    }
+
+    private void cancel() {
+      LOG.info(format("Received cancel signal for transition to %s on term %d", role, term));
+      cancelRequested = true;
+    }
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
+import io.camunda.zeebe.util.sched.ConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Stack;
+import org.slf4j.Logger;
+
+final class PartitionTransitionProcess {
+
+  private static final Logger LOG = Loggers.SYSTEM_LOGGER;
+
+  private final List<PartitionTransitionStep> pendingSteps;
+  private final Stack<PartitionTransitionStep> startedSteps = new Stack<>();
+  private final ConcurrencyControl concurrencyControl;
+  private final PartitionTransitionContext context;
+  private final long term;
+  private final Role role;
+  private boolean cancelRequested = false;
+
+  PartitionTransitionProcess(
+      final List<PartitionTransitionStep> pendingSteps,
+      final ConcurrencyControl concurrencyControl,
+      final PartitionTransitionContext context,
+      final long term,
+      final Role role) {
+    this.pendingSteps = new ArrayList<>(requireNonNull(pendingSteps));
+    this.concurrencyControl = requireNonNull(concurrencyControl);
+    this.context = requireNonNull(context);
+    this.term = term;
+    this.role = requireNonNull(role);
+  }
+
+  void start(final ActorFuture<Void> future) {
+    LOG.info(format("Transition to %s on term %d starting", role, term));
+
+    if (pendingSteps.isEmpty()) {
+      LOG.info("No steps defined for transition");
+      future.complete(null);
+      return;
+    }
+
+    proceedWithTransition(future);
+  }
+
+  private void proceedWithTransition(final ActorFuture<Void> future) {
+    if (cancelRequested) {
+      LOG.info(format("Cancelling transition to %s on term %d", role, term));
+      future.complete(null);
+      return;
+    }
+
+    concurrencyControl.submit(
+        () -> {
+          final var nextStep = pendingSteps.remove(0);
+          startedSteps.push(nextStep);
+
+          LOG.info(
+              format("Transition to %s on term %d - executing %s", role, term, nextStep.getName()));
+
+          nextStep
+              .transitionTo(context, term, role)
+              .onComplete((nil, error) -> onStepCompletion(future, error));
+        });
+  }
+
+  private void onStepCompletion(final ActorFuture<Void> future, final Throwable error) {
+    if (error != null) {
+      LOG.error(error.getMessage(), error);
+      future.completeExceptionally(error);
+
+      return;
+    }
+
+    if (pendingSteps.isEmpty()) {
+      LOG.info(format("Transition to %s on term %d completed", role, term));
+      future.complete(null);
+
+      return;
+    }
+
+    proceedWithTransition(future);
+  }
+
+  ActorFuture<Void> cleanup(final long newTerm, final Role newRole) {
+    LOG.info(
+        format(
+            "Cleanup of transition to %s on term %d starting (in preparation for new transition to %s)",
+            role, term, newRole));
+    final ActorFuture<Void> cleanupFuture = concurrencyControl.createFuture();
+
+    if (startedSteps.isEmpty()) {
+      LOG.info("No steps to clean up");
+      cleanupFuture.complete(null);
+    } else {
+      proceedWithCleanup(cleanupFuture, newTerm, newRole);
+    }
+    return cleanupFuture;
+  }
+
+  private void proceedWithCleanup(
+      final ActorFuture<Void> future, final long newTerm, final Role newRole) {
+    concurrencyControl.submit(
+        () -> {
+          final var nextCleanupStep = startedSteps.pop();
+
+          LOG.info(
+              format(
+                  "Cleanup of transition to %s on term %d - executing %s",
+                  role, term, nextCleanupStep.getName()));
+
+          nextCleanupStep
+              .prepareTransition(context, newTerm, newRole)
+              .onComplete((nil, error) -> onCleanupStepCompletion(future, error, newTerm, newRole));
+        });
+  }
+
+  private void onCleanupStepCompletion(
+      final ActorFuture<Void> future,
+      final Throwable error,
+      final long newTerm,
+      final Role newRole) {
+    if (error != null) {
+      LOG.error(error.getMessage(), error);
+      future.completeExceptionally(error);
+
+      return;
+    }
+
+    if (startedSteps.isEmpty()) {
+      LOG.info(format("Cleanup of transition to %s on term %d completed", role, term));
+      future.complete(null);
+
+      return;
+    }
+
+    proceedWithCleanup(future, newTerm, newRole);
+  }
+
+  void cancel() {
+    LOG.info(format("Received cancel signal for transition to %s on term %d", role, term));
+    cancelRequested = true;
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImplTest.java
@@ -74,8 +74,8 @@ class NewPartitionTransitionImplTest {
 
     // then
     final var invocationRecorder = inOrder(mockStep1, mockStep2);
-    invocationRecorder.verify(mockStep1).prepareForTransition(DEFAULT_ROLE);
-    invocationRecorder.verify(mockStep2).prepareForTransition(DEFAULT_ROLE);
+    invocationRecorder.verify(mockStep1).onNewRaftRole(DEFAULT_ROLE);
+    invocationRecorder.verify(mockStep2).onNewRaftRole(DEFAULT_ROLE);
     invocationRecorder.verify(mockStep1).transitionTo(mockContext, DEFAULT_TERM, DEFAULT_ROLE);
     invocationRecorder.verify(mockStep2).transitionTo(mockContext, DEFAULT_TERM, DEFAULT_ROLE);
   }
@@ -139,13 +139,13 @@ class NewPartitionTransitionImplTest {
 
     final var invocationRecorder = inOrder(spyStep1, mockStep2);
     // first transition sequence
-    invocationRecorder.verify(spyStep1).prepareForTransition(DEFAULT_ROLE);
-    invocationRecorder.verify(mockStep2).prepareForTransition(DEFAULT_ROLE);
+    invocationRecorder.verify(spyStep1).onNewRaftRole(DEFAULT_ROLE);
+    invocationRecorder.verify(mockStep2).onNewRaftRole(DEFAULT_ROLE);
     invocationRecorder.verify(spyStep1).transitionTo(mockContext, DEFAULT_TERM, DEFAULT_ROLE);
 
     // second transition sequence
-    invocationRecorder.verify(spyStep1).prepareForTransition(secondRole);
-    invocationRecorder.verify(mockStep2).prepareForTransition(secondRole);
+    invocationRecorder.verify(spyStep1).onNewRaftRole(secondRole);
+    invocationRecorder.verify(mockStep2).onNewRaftRole(secondRole);
     invocationRecorder.verify(spyStep1).transitionTo(mockContext, secondTerm, secondRole);
     invocationRecorder.verify(mockStep2).transitionTo(mockContext, secondTerm, secondRole);
   }

--- a/util/src/test/java/io/camunda/zeebe/util/sched/TestConcurrencyControl.java
+++ b/util/src/test/java/io/camunda/zeebe/util/sched/TestConcurrencyControl.java
@@ -48,4 +48,16 @@ public class TestConcurrencyControl implements ConcurrencyControl {
   public <V> ActorFuture<V> createFuture() {
     return new TestActorFuture<>();
   }
+
+  public <U> ActorFuture<U> completedFuture(final U value) {
+    final ActorFuture<U> result = createFuture();
+    result.complete(value);
+    return result;
+  }
+
+  public <U> ActorFuture<U> failedFuture(final Throwable error) {
+    final ActorFuture<U> result = createFuture();
+    result.completeExceptionally(error);
+    return result;
+  }
 }


### PR DESCRIPTION
## Description

- Adds a feature flag to switch between existing and new logic to bootstrap and transition partition
- Adds alternative implementation for partition transition
- Adds additional steps for partition bootstrap and shutdown
- extends `PartitionTransitionStep` interface as discussed

Review hints:
The one thing that maybe is unfamiliar is `ConcurrencyControl`. This was added recently for cases in which you need an `ActorControl` to schedule stuff but you don't want to pass that actor control object around. It also comes in handy when you want to test actor-style code without spinning up an actor scheduler. 

## Related issues

closes #7733

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
