### PR TITLE
Last processed position should not be less than the snapshot position 

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorPartitionStep.java
@@ -77,7 +77,7 @@ public class StreamProcessorPartitionStep implements PartitionStep {
         .eventApplierFactory(EventAppliers::new)
         .nodeId(state.getNodeId())
         .commandResponseWriter(state.getCommandResponseWriter())
-        .onProcessedListener(state.getOnProcessedListener())
+        .listener(processedCommand -> state.getOnProcessedListener().accept(processedCommand))
         .streamProcessorFactory(
             processingContext -> {
               final ActorControl actor = processingContext.getActor();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingContext.java
@@ -22,12 +22,12 @@ import io.camunda.zeebe.engine.state.mutable.MutableLastProcessedPositionState;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
-import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.util.sched.ActorControl;
 import java.util.function.BooleanSupplier;
-import java.util.function.Consumer;
 
 public final class ProcessingContext implements ReadonlyProcessingContext {
+
+  private static final StreamProcessorListener NOOP_LISTENER = processedCommand -> {};
 
   private final TypedStreamWriterProxy streamWriterProxy = new TypedStreamWriterProxy();
   private final NoopTypedStreamWriter noopTypedStreamWriter = new NoopTypedStreamWriter();
@@ -46,8 +46,8 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
   private EventApplier eventApplier;
 
   private BooleanSupplier abortCondition;
-  private Consumer<TypedRecord<?>> onProcessedListener = record -> {};
-  private Consumer<LoggedEvent> onSkippedListener = record -> {};
+  private StreamProcessorListener streamProcessorListener = NOOP_LISTENER;
+
   private int maxFragmentSize;
   private StreamProcessorMode streamProcessorMode = StreamProcessorMode.PROCESSING;
 
@@ -112,13 +112,8 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
     return commandResponseWriter;
   }
 
-  public ProcessingContext onProcessedListener(final Consumer<TypedRecord<?>> onProcessedListener) {
-    this.onProcessedListener = onProcessedListener;
-    return this;
-  }
-
-  public ProcessingContext onSkippedListener(final Consumer<LoggedEvent> onSkippedListener) {
-    this.onSkippedListener = onSkippedListener;
+  public ProcessingContext listener(final StreamProcessorListener streamProcessorListener) {
+    this.streamProcessorListener = streamProcessorListener;
     return this;
   }
 
@@ -208,12 +203,8 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
     return eventApplier;
   }
 
-  public Consumer<TypedRecord<?>> getOnProcessedListener() {
-    return onProcessedListener;
-  }
-
-  public Consumer<LoggedEvent> getOnSkippedListener() {
-    return onSkippedListener;
+  public StreamProcessorListener getStreamProcessorListener() {
+    return streamProcessorListener;
   }
 
   public void enableLogStreamWriter() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -34,7 +34,6 @@ import io.camunda.zeebe.util.sched.clock.ActorClock;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import java.time.Duration;
 import java.util.function.BooleanSupplier;
-import java.util.function.Consumer;
 import org.slf4j.Logger;
 
 /**
@@ -127,8 +126,7 @@ public final class ProcessingStateMachine {
   private final RecordProcessorMap recordProcessorMap;
   private final TypedEventImpl typedEvent;
   private final StreamProcessorMetrics metrics;
-  private final Consumer<TypedRecord<?>> onProcessedListener;
-  private final Consumer<LoggedEvent> onSkippedListener;
+  private final StreamProcessorListener streamProcessorListener;
 
   // current iteration
   private SideEffectProducer sideEffectProducer;
@@ -167,8 +165,7 @@ public final class ProcessingStateMachine {
     responseWriter = context.getWriters().response();
 
     metrics = new StreamProcessorMetrics(partitionId);
-    onProcessedListener = context.getOnProcessedListener();
-    onSkippedListener = context.getOnSkippedListener();
+    streamProcessorListener = context.getStreamProcessorListener();
   }
 
   private void skipRecord() {
@@ -417,7 +414,7 @@ public final class ProcessingStateMachine {
 
   private void notifyProcessedListener(final TypedRecord processedRecord) {
     try {
-      onProcessedListener.accept(processedRecord);
+      streamProcessorListener.onProcessed(processedRecord);
     } catch (final Exception e) {
       LOG.error(NOTIFY_PROCESSED_LISTENER_ERROR_MESSAGE, processedRecord, e);
     }
@@ -425,7 +422,7 @@ public final class ProcessingStateMachine {
 
   private void notifySkippedListener(final LoggedEvent skippedRecord) {
     try {
-      onSkippedListener.accept(skippedRecord);
+      streamProcessorListener.onSkipped(skippedRecord);
     } catch (final Exception e) {
       LOG.error(NOTIFY_SKIPPED_LISTENER_ERROR_MESSAGE, skippedRecord, metadata, e);
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateMachine.java
@@ -78,6 +78,7 @@ public final class ReplayStateMachine {
   private ZeebeDbTransaction zeebeDbTransaction;
   private final StreamProcessorMode streamProcessorMode;
   private final LogStream logStream;
+  private final StreamProcessorListener streamProcessorListener;
 
   private State currentState = State.AWAIT_RECORD;
   private final BooleanSupplier shouldPause;
@@ -93,6 +94,7 @@ public final class ReplayStateMachine {
     eventApplier = context.getEventApplier();
     keyGeneratorControls = context.getKeyGeneratorControls();
     lastProcessedPositionState = context.getLastProcessedPositionState();
+    streamProcessorListener = context.getStreamProcessorListener();
 
     typedEvent = new TypedEventImpl(context.getLogStream().getPartitionId());
     replayStrategy = new RecoverableRetryStrategy(actor);
@@ -165,6 +167,8 @@ public final class ReplayStateMachine {
                     lastSourceEventPosition =
                         Math.max(lastSourceEventPosition, batchSourceEventPosition);
                     actor.submit(this::replayNextEvent);
+
+                    notifyReplayListener();
                   }
                 });
 
@@ -288,6 +292,17 @@ public final class ReplayStateMachine {
     eventApplier.applyState(
         currentEvent.getKey(), currentEvent.getIntent(), currentEvent.getValue());
     lastReplayedEventPosition = currentEvent.getPosition();
+  }
+
+  private void notifyReplayListener() {
+    try {
+      streamProcessorListener.onReplayed(lastReplayedEventPosition, lastReadRecordPosition);
+    } catch (final Exception e) {
+      LOG.error(
+          "Expected to invoke replay listener successfully, but an exception was thrown. [last-read-record-position: {}, last-replayed-event-position: {}]",
+          lastReadRecordPosition,
+          lastReplayedEventPosition);
+    }
   }
 
   public long getLastSourceEventPosition() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 public final class StreamProcessorBuilder {
@@ -61,8 +60,8 @@ public final class StreamProcessorBuilder {
     return this;
   }
 
-  public StreamProcessorBuilder onProcessedListener(final Consumer<TypedRecord<?>> onProcessed) {
-    processingContext.onProcessedListener(onProcessed);
+  public StreamProcessorBuilder listener(final StreamProcessorListener listener) {
+    processingContext.listener(listener);
     return this;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorListener.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorListener.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+import io.camunda.zeebe.logstreams.log.LoggedEvent;
+
+/**
+ * A listener for the {@link StreamProcessor}. Allows retrieving insides of the processing and
+ * replay of records. It can be especially useful for testing purposes. Note that the listener is
+ * invoked inside the context of the stream processor and should not block its execution.
+ */
+public interface StreamProcessorListener {
+
+  /**
+   * Is called when a command is processed.
+   *
+   * @param processedCommand the command that is processed
+   */
+  void onProcessed(TypedRecord<?> processedCommand);
+
+  /**
+   * Is called when a record is skipped and not processed.
+   *
+   * @param skippedRecord the record that is skipped
+   */
+  default void onSkipped(final LoggedEvent skippedRecord) {}
+
+  /**
+   * Is called when one or more events are replayed. Even if the state changes are not applied.
+   *
+   * @param lastReplayedEventPosition the position of the event that is replayed last
+   * @param lastReadRecordPosition the position of the record that is read last
+   */
+  default void onReplayed(
+      final long lastReplayedEventPosition, final long lastReadRecordPosition) {}
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorReplayModeTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorReplayModeTest.java
@@ -317,10 +317,8 @@ public final class StreamProcessorReplayModeTest {
             RECORD,
             writer -> writer.sourceRecordPosition(commandPositionBeforeSnapshot));
 
-    Awaitility.await()
-        .untilAsserted(
-            () ->
-                assertThat(getLastProcessedPosition(replayContinuously)).isEqualTo(eventPosition));
+    verify(replayContinuously.getMockStreamProcessorListener(), TIMEOUT)
+        .onReplayed(-1L, eventPosition);
 
     // then
     final var lastProcessedPositionState =

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -12,7 +12,6 @@ import static io.camunda.zeebe.engine.util.Records.processInstance;
 import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.ReadonlyProcessingContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
-import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.state.immutable.LastProcessedPositionState;
@@ -22,7 +21,6 @@ import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
-import java.util.function.Consumer;
 
 public class StreamProcessingComposite {
 
@@ -47,33 +45,16 @@ public class StreamProcessingComposite {
   }
 
   public StreamProcessor startTypedStreamProcessor(final StreamProcessorTestFactory factory) {
-    return startTypedStreamProcessor(factory, r -> {});
-  }
-
-  public StreamProcessor startTypedStreamProcessor(
-      final StreamProcessorTestFactory factory,
-      final Consumer<TypedRecord<?>> onProcessedListener) {
     return startTypedStreamProcessor(
-        (processingContext) ->
-            createTypedRecordProcessors(factory, onProcessedListener, processingContext));
-  }
-
-  public StreamProcessor startTypedStreamProcessorNotAwaitOpening(
-      final StreamProcessorTestFactory factory,
-      final Consumer<TypedRecord<?>> onProcessedListener) {
-    return startTypedStreamProcessorNotAwaitOpening(
-        (processingContext) ->
-            createTypedRecordProcessors(factory, onProcessedListener, processingContext));
+        (processingContext) -> createTypedRecordProcessors(factory, processingContext));
   }
 
   private TypedRecordProcessors createTypedRecordProcessors(
       final StreamProcessorTestFactory factory,
-      final Consumer<TypedRecord<?>> onProcessedListener,
       final io.camunda.zeebe.engine.processing.streamprocessor.ProcessingContext
           processingContext) {
     zeebeState = processingContext.getZeebeState();
     lastProcessedPositionState = processingContext.getLastProcessedPositionState();
-    processingContext.onProcessedListener(onProcessedListener);
     return factory.build(
         TypedRecordProcessors.processors(
             zeebeState.getKeyGenerator(), processingContext.getWriters()),
@@ -98,7 +79,8 @@ public class StreamProcessingComposite {
 
   public StreamProcessor startTypedStreamProcessorNotAwaitOpening(
       final StreamProcessorTestFactory factory) {
-    return startTypedStreamProcessorNotAwaitOpening(factory, r -> {});
+    return startTypedStreamProcessorNotAwaitOpening(
+        (processingContext) -> createTypedRecordProcessors(factory, processingContext));
   }
 
   public StreamProcessor startTypedStreamProcessorNotAwaitOpening(

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -11,8 +11,8 @@ import static io.camunda.zeebe.engine.util.StreamProcessingComposite.getLogName;
 
 import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorListener;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorMode;
-import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
@@ -33,7 +33,6 @@ import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
 import io.camunda.zeebe.util.sched.testing.ActorSchedulerRule;
 import java.io.File;
 import java.io.IOException;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
@@ -138,22 +137,12 @@ public final class StreamProcessorRule implements TestRule {
   }
 
   public StreamProcessor startTypedStreamProcessor(final StreamProcessorTestFactory factory) {
-    return streamProcessingComposite.startTypedStreamProcessor(factory, r -> {});
-  }
-
-  public StreamProcessor startTypedStreamProcessor(
-      final StreamProcessorTestFactory factory,
-      final Consumer<TypedRecord<?>> onProcessedListener) {
-    return streamProcessingComposite.startTypedStreamProcessor(factory, onProcessedListener);
-  }
-
-  public StreamProcessor startTypedStreamProcessor(final TypedRecordProcessorFactory factory) {
-    return startTypedStreamProcessor(startPartitionId, factory);
+    return streamProcessingComposite.startTypedStreamProcessor(factory);
   }
 
   public StreamProcessor startTypedStreamProcessorNotAwaitOpening(
       final StreamProcessorTestFactory factory) {
-    return streamProcessingComposite.startTypedStreamProcessorNotAwaitOpening(factory, r -> {});
+    return streamProcessingComposite.startTypedStreamProcessorNotAwaitOpening(factory);
   }
 
   public StreamProcessor startTypedStreamProcessorNotAwaitOpening(
@@ -191,8 +180,8 @@ public final class StreamProcessorRule implements TestRule {
     return streams.getMockedResponseWriter();
   }
 
-  public Consumer<TypedRecord<?>> getProcessedListener() {
-    return streams.getMockedOnProcessedListener();
+  public StreamProcessorListener getMockStreamProcessorListener() {
+    return streams.getMockStreamProcessorListener();
   }
 
   public ControlledActorClock getClock() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -282,8 +282,8 @@ public final class TestStreams {
       } catch (final InterruptedException e) {
         Thread.interrupted();
       }
-      openFuture.join(15, TimeUnit.SECONDS);
     }
+    openFuture.join(15, TimeUnit.SECONDS);
 
     final LogContext context = logContextMap.get(logName);
     final ProcessorContext processorContext =

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -20,9 +20,9 @@ import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.ReadonlyProcessingContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorListener;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorMode;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedEventRegistry;
-import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import io.camunda.zeebe.engine.state.EventApplier;
@@ -77,7 +77,7 @@ public final class TestStreams {
   private final ActorScheduler actorScheduler;
 
   private final CommandResponseWriter mockCommandResponseWriter;
-  private final Consumer<TypedRecord<?>> mockOnProcessedListener;
+  private final StreamProcessorListener mockStreamProcessorListener;
   private final Map<String, LogContext> logContextMap = new HashMap<>();
   private final Map<String, ProcessorContext> streamContextMap = new HashMap<>();
   private boolean snapshotWasTaken = false;
@@ -104,7 +104,7 @@ public final class TestStreams {
     when(mockCommandResponseWriter.valueWriter(any())).thenReturn(mockCommandResponseWriter);
 
     when(mockCommandResponseWriter.tryWriteResponse(anyInt(), anyLong())).thenReturn(true);
-    mockOnProcessedListener = mock(Consumer.class);
+    mockStreamProcessorListener = mock(StreamProcessorListener.class);
   }
 
   public void withEventApplierFactory(
@@ -120,8 +120,8 @@ public final class TestStreams {
     return mockCommandResponseWriter;
   }
 
-  public Consumer<TypedRecord<?>> getMockedOnProcessedListener() {
-    return mockOnProcessedListener;
+  public StreamProcessorListener getMockStreamProcessorListener() {
+    return mockStreamProcessorListener;
   }
 
   public SynchronousLogStream createLogStream(final String name) {
@@ -269,7 +269,7 @@ public final class TestStreams {
             .zeebeDb(zeebeDb)
             .actorSchedulingService(actorScheduler)
             .commandResponseWriter(mockCommandResponseWriter)
-            .onProcessedListener(mockOnProcessedListener)
+            .listener(mockStreamProcessorListener)
             .streamProcessorFactory(wrappedFactory)
             .eventApplierFactory(eventApplierFactory)
             .streamProcessorMode(streamProcessorMode)


### PR DESCRIPTION
## Description

* the last processed position must be greater than the snapshot position
  * a follower may receive events that are already applied on the snapshot
  * the follower should ignore these events and should not update the last processed position
* introduce a new listener for replay to write a proper test case
  * bundle the existing listeners for processing into a new interface
  * get notified when events are replayed
  * the new interface should improve the maintainability  
* reducing the execution time of the test
  * previously, the test waited until the processing starts (i.e. until recovered is called)
  * but in replay mode, the stream processor doesn't switch to processing

## Related issues

closes #7686 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
