### PR TITLE
Identify steps that can be moved to startup 

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -61,7 +61,7 @@ final class PartitionFactory {
   // preparation for future steps
   // will be executed in the order they are defined in this list
   private static final List<PartitionStartupStep> STARTUP_STEPS =
-      List.of(new StateControllerPartitionStep());
+      List.of(new StateControllerPartitionStep(), new LogDeletionPartitionStep());
 
   // will probably be executed in parallel
   private static final List<PartitionTransitionStep> TRANSITION_STEPS = List.of();
@@ -70,7 +70,7 @@ final class PartitionFactory {
   private static final List<PartitionStep> LEADER_STEPS =
       List.of(
           PartitionStepMigrationHelper.fromStartupStep(new StateControllerPartitionStep()),
-          new LogDeletionPartitionStep(),
+          PartitionStepMigrationHelper.fromStartupStep(new LogDeletionPartitionStep()),
           new LogStoragePartitionStep(),
           new LogStreamPartitionStep(),
           new ZeebeDbPartitionStep(),
@@ -81,7 +81,7 @@ final class PartitionFactory {
   private static final List<PartitionStep> FOLLOWER_STEPS =
       List.of(
           PartitionStepMigrationHelper.fromStartupStep(new StateControllerPartitionStep()),
-          new LogDeletionPartitionStep(),
+          PartitionStepMigrationHelper.fromStartupStep(new LogDeletionPartitionStep()),
           new LogStoragePartitionStep(),
           new LogStreamPartitionStep(),
           new ZeebeDbPartitionStep(),

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.partitions.PartitionStartupAndTransitionContextImpl;
 import io.camunda.zeebe.broker.system.partitions.PartitionStartupStep;
 import io.camunda.zeebe.broker.system.partitions.PartitionStep;
+import io.camunda.zeebe.broker.system.partitions.PartitionStepMigrationHelper;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.broker.system.partitions.TypedRecordProcessorsFactory;
 import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
@@ -59,7 +60,8 @@ import java.util.stream.Collectors;
 final class PartitionFactory {
   // preparation for future steps
   // will be executed in the order they are defined in this list
-  private static final List<PartitionStartupStep> STARTUP_STEPS = List.of();
+  private static final List<PartitionStartupStep> STARTUP_STEPS =
+      List.of(new StateControllerPartitionStep());
 
   // will probably be executed in parallel
   private static final List<PartitionTransitionStep> TRANSITION_STEPS = List.of();
@@ -67,7 +69,7 @@ final class PartitionFactory {
 
   private static final List<PartitionStep> LEADER_STEPS =
       List.of(
-          new StateControllerPartitionStep(),
+          PartitionStepMigrationHelper.fromStartupStep(new StateControllerPartitionStep()),
           new LogDeletionPartitionStep(),
           new LogStoragePartitionStep(),
           new LogStreamPartitionStep(),
@@ -78,7 +80,7 @@ final class PartitionFactory {
           new ExporterDirectorPartitionStep());
   private static final List<PartitionStep> FOLLOWER_STEPS =
       List.of(
-          new StateControllerPartitionStep(),
+          PartitionStepMigrationHelper.fromStartupStep(new StateControllerPartitionStep()),
           new LogDeletionPartitionStep(),
           new LogStoragePartitionStep(),
           new LogStreamPartitionStep(),

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -109,15 +109,6 @@ public class PartitionStartupAndTransitionContextImpl
   }
 
   @Override
-  public StateControllerImpl getSnapshotController() {
-    return stateController;
-  }
-
-  public void setSnapshotController(final StateControllerImpl controller) {
-    stateController = controller;
-  }
-
-  @Override
   public PartitionContext getPartitionContext() {
     return this;
   }
@@ -173,11 +164,13 @@ public class PartitionStartupAndTransitionContextImpl
 
   @Override
   public StateControllerImpl getStateController() {
-    return null;
+    return stateController;
   }
 
   @Override
-  public void setStateController(final StateControllerImpl stateController) {}
+  public void setStateController(final StateControllerImpl stateController) {
+    this.stateController = stateController;
+  }
 
   @Override
   public LogDeletionService getLogDeletionService() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -22,7 +22,7 @@ public interface PartitionTransitionContext extends PartitionContext {
 
   AsyncSnapshotDirector getSnapshotDirector();
 
-  StateControllerImpl getSnapshotController();
+  StateControllerImpl getStateController();
 
   ConstructableSnapshotStore getConstructableSnapshotStore();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/StateController.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/StateController.java
@@ -31,6 +31,8 @@ public interface StateController extends AutoCloseable {
    */
   ZeebeDb openDb();
 
+  void closeDb() throws Exception;
+
   /**
    * Returns the current number of valid snapshots.
    *

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -128,12 +128,7 @@ public class StateControllerImpl implements StateController {
   }
 
   @Override
-  public int getValidSnapshotsCount() {
-    return constructableSnapshotStore.getLatestSnapshot().isPresent() ? 1 : 0;
-  }
-
-  @Override
-  public void close() throws Exception {
+  public void closeDb() throws Exception {
     if (db != null) {
       final var dbToClose = db;
       db = null;
@@ -143,6 +138,16 @@ public class StateControllerImpl implements StateController {
     }
 
     FileUtil.deleteFolderIfExists(runtimeDirectory);
+  }
+
+  @Override
+  public int getValidSnapshotsCount() {
+    return constructableSnapshotStore.getLatestSnapshot().isPresent() ? 1 : 0;
+  }
+
+  @Override
+  public void close() throws Exception {
+    closeDb();
   }
 
   boolean isDbOpened() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.logstreams.impl.Loggers;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
-import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
@@ -41,18 +40,14 @@ public class StateControllerImpl implements StateController {
   private ZeebeDb db;
 
   private final ConstructableSnapshotStore constructableSnapshotStore;
-  private final ReceivableSnapshotStore receivableSnapshotStore;
 
   public StateControllerImpl(
-      final int partitionId,
       @SuppressWarnings("rawtypes") final ZeebeDbFactory zeebeDbFactory,
       final ConstructableSnapshotStore constructableSnapshotStore,
-      final ReceivableSnapshotStore receivableSnapshotStore,
       final Path runtimeDirectory,
       final AtomixRecordEntrySupplier entrySupplier,
       @SuppressWarnings("rawtypes") final ToLongFunction<ZeebeDb> exporterPositionSupplier) {
     this.constructableSnapshotStore = constructableSnapshotStore;
-    this.receivableSnapshotStore = receivableSnapshotStore;
     this.runtimeDirectory = runtimeDirectory;
     this.zeebeDbFactory = zeebeDbFactory;
     this.exporterPositionSupplier = exporterPositionSupplier;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogDeletionPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogDeletionPartitionStep.java
@@ -10,37 +10,64 @@ package io.camunda.zeebe.broker.system.partitions.impl.steps;
 import io.camunda.zeebe.broker.logstreams.AtomixLogCompactor;
 import io.camunda.zeebe.broker.logstreams.LogCompactor;
 import io.camunda.zeebe.broker.logstreams.LogDeletionService;
-import io.camunda.zeebe.broker.system.partitions.PartitionStartupAndTransitionContextImpl;
-import io.camunda.zeebe.broker.system.partitions.PartitionStep;
+import io.camunda.zeebe.broker.system.partitions.PartitionStartupContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionStartupStep;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.util.List;
 
-public class LogDeletionPartitionStep implements PartitionStep {
-
-  @Override
-  public ActorFuture<Void> open(final PartitionStartupAndTransitionContextImpl context) {
-    final LogCompactor logCompactor =
-        new AtomixLogCompactor(context.getRaftPartition().getServer());
-    final LogDeletionService deletionService =
-        new LogDeletionService(
-            context.getNodeId(),
-            context.getPartitionId(),
-            logCompactor,
-            List.of(context.getConstructableSnapshotStore(), context.getReceivableSnapshotStore()));
-
-    context.setLogDeletionService(deletionService);
-    return context.getActorSchedulingService().submitActor(deletionService);
-  }
-
-  @Override
-  public ActorFuture<Void> close(final PartitionStartupAndTransitionContextImpl context) {
-    final ActorFuture<Void> future = context.getLogDeletionService().closeAsync();
-    context.setLogDeletionService(null);
-    return future;
-  }
+public class LogDeletionPartitionStep implements PartitionStartupStep {
 
   @Override
   public String getName() {
     return "LogDeletionService";
+  }
+
+  @Override
+  public ActorFuture<PartitionStartupContext> startup(
+      final PartitionStartupContext partitionStartupContext) {
+    final LogCompactor logCompactor =
+        new AtomixLogCompactor(partitionStartupContext.getRaftPartition().getServer());
+    final LogDeletionService deletionService =
+        new LogDeletionService(
+            partitionStartupContext.getNodeId(),
+            partitionStartupContext.getPartitionId(),
+            logCompactor,
+            List.of(
+                partitionStartupContext.getConstructableSnapshotStore(),
+                partitionStartupContext.getReceivableSnapshotStore()));
+
+    partitionStartupContext.setLogDeletionService(deletionService);
+    final ActorFuture<PartitionStartupContext> startupFuture = new CompletableActorFuture<>();
+    partitionStartupContext
+        .getActorSchedulingService()
+        .submitActor(deletionService)
+        .onComplete(
+            (success, failure) -> {
+              if (failure != null) {
+                startupFuture.completeExceptionally(failure);
+              } else {
+                startupFuture.complete(partitionStartupContext);
+              }
+            });
+    return startupFuture;
+  }
+
+  @Override
+  public ActorFuture<PartitionStartupContext> shutdown(
+      final PartitionStartupContext partitionStartupContext) {
+    final ActorFuture<Void> closeFuture =
+        partitionStartupContext.getLogDeletionService().closeAsync();
+    partitionStartupContext.setLogDeletionService(null);
+    final ActorFuture<PartitionStartupContext> shutdownFuture = new CompletableActorFuture<>();
+    closeFuture.onComplete(
+        (success, failure) -> {
+          if (failure != null) {
+            shutdownFuture.completeExceptionally(failure);
+          } else {
+            shutdownFuture.complete(partitionStartupContext);
+          }
+        });
+    return shutdownFuture;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionStep.java
@@ -58,7 +58,7 @@ public class SnapshotDirectorPartitionStep implements PartitionStep {
             context.getNodeId(),
             context.getPartitionId(),
             context.getStreamProcessor(),
-            context.getSnapshotController(),
+            context.getStateController(),
             snapshotPeriod);
 
     server.addCommittedEntryListener(director);
@@ -73,7 +73,7 @@ public class SnapshotDirectorPartitionStep implements PartitionStep {
             context.getNodeId(),
             context.getPartitionId(),
             context.getStreamProcessor(),
-            context.getSnapshotController(),
+            context.getStateController(),
             snapshotPeriod);
 
     return director;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
@@ -9,54 +9,57 @@ package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.logstreams.state.StatePositionSupplier;
-import io.camunda.zeebe.broker.system.partitions.PartitionStartupAndTransitionContextImpl;
-import io.camunda.zeebe.broker.system.partitions.PartitionStep;
+import io.camunda.zeebe.broker.system.partitions.PartitionStartupContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionStartupStep;
 import io.camunda.zeebe.broker.system.partitions.impl.AtomixRecordEntrySupplierImpl;
 import io.camunda.zeebe.broker.system.partitions.impl.StateControllerImpl;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 
-public class StateControllerPartitionStep implements PartitionStep {
-
-  @Override
-  public ActorFuture<Void> open(final PartitionStartupAndTransitionContextImpl context) {
-    final var runtimeDirectory =
-        context.getRaftPartition().dataDirectory().toPath().resolve("runtime");
-    final var databaseCfg = context.getBrokerCfg().getExperimental().getRocksdb();
-
-    final var stateController =
-        new StateControllerImpl(
-            context.getPartitionId(),
-            DefaultZeebeDbFactory.defaultFactory(databaseCfg.createRocksDbConfiguration()),
-            context.getConstructableSnapshotStore(),
-            context.getReceivableSnapshotStore(),
-            runtimeDirectory,
-            new AtomixRecordEntrySupplierImpl(context.getRaftPartition().getServer()),
-            StatePositionSupplier::getHighestExportedPosition);
-
-    context.setSnapshotController(stateController);
-    return CompletableActorFuture.completed(null);
-  }
-
-  @Override
-  public ActorFuture<Void> close(final PartitionStartupAndTransitionContextImpl context) {
-    try {
-      context.getSnapshotController().close();
-    } catch (final Exception e) {
-      Loggers.SYSTEM_LOGGER.error(
-          "Unexpected error occurred while closing the state snapshot controller for partition {}.",
-          context.getPartitionId(),
-          e);
-    } finally {
-      context.setSnapshotController(null);
-    }
-
-    return CompletableActorFuture.completed(null);
-  }
+public class StateControllerPartitionStep implements PartitionStartupStep {
 
   @Override
   public String getName() {
     return "StateController";
+  }
+
+  @Override
+  public ActorFuture<PartitionStartupContext> startup(
+      final PartitionStartupContext partitionStartupContext) {
+    final var runtimeDirectory =
+        partitionStartupContext.getRaftPartition().dataDirectory().toPath().resolve("runtime");
+    final var databaseCfg = partitionStartupContext.getBrokerCfg().getExperimental().getRocksdb();
+
+    final var stateController =
+        new StateControllerImpl(
+            partitionStartupContext.getPartitionId(),
+            DefaultZeebeDbFactory.defaultFactory(databaseCfg.createRocksDbConfiguration()),
+            partitionStartupContext.getConstructableSnapshotStore(),
+            partitionStartupContext.getReceivableSnapshotStore(),
+            runtimeDirectory,
+            new AtomixRecordEntrySupplierImpl(
+                partitionStartupContext.getRaftPartition().getServer()),
+            StatePositionSupplier::getHighestExportedPosition);
+
+    partitionStartupContext.setStateController(stateController);
+    return CompletableActorFuture.completed(partitionStartupContext);
+  }
+
+  @Override
+  public ActorFuture<PartitionStartupContext> shutdown(
+      final PartitionStartupContext partitionStartupContext) {
+    try {
+      partitionStartupContext.getStateController().close();
+    } catch (final Exception e) {
+      Loggers.SYSTEM_LOGGER.error(
+          "Unexpected error occurred while closing the state snapshot controller for partition {}.",
+          partitionStartupContext.getPartitionId(),
+          e);
+    } finally {
+      partitionStartupContext.setStateController(null);
+    }
+
+    return CompletableActorFuture.completed(partitionStartupContext);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
@@ -33,10 +33,8 @@ public class StateControllerPartitionStep implements PartitionStartupStep {
 
     final var stateController =
         new StateControllerImpl(
-            partitionStartupContext.getPartitionId(),
             DefaultZeebeDbFactory.defaultFactory(databaseCfg.createRocksDbConfiguration()),
             partitionStartupContext.getConstructableSnapshotStore(),
-            partitionStartupContext.getReceivableSnapshotStore(),
             runtimeDirectory,
             new AtomixRecordEntrySupplierImpl(
                 partitionStartupContext.getRaftPartition().getServer()),

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ZeebeDbPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ZeebeDbPartitionStep.java
@@ -21,8 +21,8 @@ public class ZeebeDbPartitionStep implements PartitionStep {
 
     final ZeebeDb zeebeDb;
     try {
-      context.getSnapshotController().recover();
-      zeebeDb = context.getSnapshotController().openDb();
+      context.getStateController().recover();
+      zeebeDb = context.getStateController().openDb();
     } catch (final Exception e) {
       Loggers.SYSTEM_LOGGER.error("Failed to recover from snapshot", e);
 
@@ -42,7 +42,7 @@ public class ZeebeDbPartitionStep implements PartitionStep {
   public ActorFuture<Void> close(final PartitionStartupAndTransitionContextImpl context) {
     context.setZeebeDb(null);
     try {
-      context.getSnapshotController().closeDb();
+      context.getStateController().closeDb();
     } catch (final Exception e) {
       return CompletableActorFuture.completedExceptionally(e);
     }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ZeebeDbPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ZeebeDbPartitionStep.java
@@ -40,8 +40,13 @@ public class ZeebeDbPartitionStep implements PartitionStep {
 
   @Override
   public ActorFuture<Void> close(final PartitionStartupAndTransitionContextImpl context) {
-    // ZeebeDb is closed in the StateController's close()
     context.setZeebeDb(null);
+    try {
+      context.getSnapshotController().closeDb();
+    } catch (final Exception e) {
+      return CompletableActorFuture.completedExceptionally(e);
+    }
+
     return CompletableActorFuture.completed(null);
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshotingTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshotingTest.java
@@ -62,10 +62,8 @@ public final class AsyncSnapshotingTest {
 
     snapshotController =
         new StateControllerImpl(
-            1,
             ZeebeRocksDbFactory.newFactory(),
             persistedSnapshotStore,
-            factory.getReceivableSnapshotStore(partitionId),
             rootDirectory.resolve("runtime"),
             l ->
                 Optional.of(

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -58,10 +58,8 @@ public final class StateControllerImplTest {
     runtimeDirectory = rootDirectory.resolve("runtime");
     snapshotController =
         new StateControllerImpl(
-            1,
             ZeebeRocksDbFactory.newFactory(),
             store,
-            factory.getReceivableSnapshotStore(1),
             runtimeDirectory,
             l ->
                 Optional.of(


### PR DESCRIPTION
## Description

This PR is in preparation to #7514 

The following steps are moved to PartitionStartupStep
* StateCotrollerPartitionStep
* LogDeletionParitionStep

Now only their types have changes. These services are still re-installed during each transitions. This will be changed in future when we split all steps into startup vs transition steps. 

ZeebeDbPartitionStep can also be moved to PartitionStartupStep, this will be done in a different PR.

## Related issues

Related #7514

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
