### PR TITLE
feat(engine) Error codes in incident error message

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
-import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
-
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
@@ -21,8 +19,8 @@ import io.camunda.zeebe.engine.state.analyzers.CatchEventAnalyzer.CatchEventTupl
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
-import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.util.Either;
+import java.util.Optional;
 import org.agrona.DirectBuffer;
 
 public final class BpmnEventPublicationBehavior {
@@ -79,17 +77,6 @@ public final class BpmnEventPublicationBehavior {
   public Either<Failure, CatchEventTuple> findErrorCatchEvent(
       final DirectBuffer errorCode, final BpmnElementContext context) {
     final var flowScopeInstance = elementInstanceState.getInstance(context.getFlowScopeKey());
-    final var catchEvent = catchEventAnalyzer.findCatchEvent(errorCode, flowScopeInstance);
-
-    if (catchEvent.isRight()) {
-      return Either.right(catchEvent.get());
-    }
-
-    final var errorMessage =
-        String.format(
-            "Expected to throw an error event with the code '%s', but it was not caught.",
-            bufferAsString(errorCode));
-    final var failure = new Failure(errorMessage, ErrorType.UNHANDLED_ERROR_EVENT);
-    return Either.left(failure);
+    return catchEventAnalyzer.findCatchEvent(errorCode, flowScopeInstance, Optional.empty());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
@@ -79,11 +79,10 @@ public final class BpmnEventPublicationBehavior {
   public Either<Failure, CatchEventTuple> findErrorCatchEvent(
       final DirectBuffer errorCode, final BpmnElementContext context) {
     final var flowScopeInstance = elementInstanceState.getInstance(context.getFlowScopeKey());
-    final CatchEventTuple catchEvent =
-        catchEventAnalyzer.findCatchEvent(errorCode, flowScopeInstance);
+    final var catchEvent = catchEventAnalyzer.findCatchEvent(errorCode, flowScopeInstance);
 
-    if (catchEvent != null) {
-      return Either.right(catchEvent);
+    if (catchEvent.isRight()) {
+      return Either.right(catchEvent.get());
     }
 
     final var errorMessage =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
 public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
@@ -139,7 +140,11 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
             String.format(
                 "An error was thrown with the code '%s' but not caught.", job.getErrorCode()));
     if (jobErrorMessage.capacity() > 0) {
-      incidentErrorMessage = jobErrorMessage;
+      incidentErrorMessage =
+          wrapString(
+              String.format(
+                  "An error was thrown with the code '%s' with message '%s', but not caught.",
+                  job.getErrorCode(), BufferUtil.bufferAsString(jobErrorMessage)));
     }
 
     incidentEvent.reset();

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/analyzers/CatchEventAnalyzer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/analyzers/CatchEventAnalyzer.java
@@ -36,10 +36,6 @@ public final class CatchEventAnalyzer {
     this.elementInstanceState = elementInstanceState;
   }
 
-  public boolean hasCatchEvent(final DirectBuffer errorCode, final ElementInstance instance) {
-    return findCatchEvent(errorCode, instance).isRight();
-  }
-
   public Either<List<DirectBuffer>, CatchEventTuple> findCatchEvent(
       final DirectBuffer errorCode, ElementInstance instance) {
     // assuming that error events are used rarely

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ErrorEventIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ErrorEventIncidentTest.java
@@ -87,7 +87,7 @@ public final class ErrorEventIncidentTest {
         .describedAs("unhandled error event incident created")
         .hasErrorType(ErrorType.UNHANDLED_ERROR_EVENT)
         .hasErrorMessage(
-            "An error was thrown with the code 'other-error' with message 'error thrown', but not caught.")
+            "An error was thrown with the code 'other-error' with message 'error thrown', but not caught. Available error events are [error]")
         .hasBpmnProcessId(jobEvent.getValue().getBpmnProcessId())
         .hasProcessDefinitionKey(jobEvent.getValue().getProcessDefinitionKey())
         .hasProcessInstanceKey(jobEvent.getValue().getProcessInstanceKey())
@@ -121,7 +121,8 @@ public final class ErrorEventIncidentTest {
 
     Assertions.assertThat(incidentEvent.getValue())
         .hasErrorType(ErrorType.UNHANDLED_ERROR_EVENT)
-        .hasErrorMessage("An error was thrown with the code 'other-error' but not caught.");
+        .hasErrorMessage(
+            "An error was thrown with the code 'other-error' but not caught. Available error events are [error]");
   }
 
   @Test
@@ -157,7 +158,9 @@ public final class ErrorEventIncidentTest {
                 .getValue())
         .hasErrorType(ErrorType.UNHANDLED_ERROR_EVENT)
         .hasErrorMessage(
-            String.format("An error was thrown with the code '%s' but not caught.", ERROR_CODE))
+            String.format(
+                "An error was thrown with the code '%s' but not caught. Available error events are []",
+                ERROR_CODE))
         .hasElementId("NO_CATCH_EVENT_FOUND");
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ErrorEventIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ErrorEventIncidentTest.java
@@ -86,7 +86,8 @@ public final class ErrorEventIncidentTest {
                 .getValue())
         .describedAs("unhandled error event incident created")
         .hasErrorType(ErrorType.UNHANDLED_ERROR_EVENT)
-        .hasErrorMessage("error thrown")
+        .hasErrorMessage(
+            "An error was thrown with the code 'other-error' with message 'error thrown', but not caught.")
         .hasBpmnProcessId(jobEvent.getValue().getBpmnProcessId())
         .hasProcessDefinitionKey(jobEvent.getValue().getProcessDefinitionKey())
         .hasProcessInstanceKey(jobEvent.getValue().getProcessInstanceKey())

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorTest.java
@@ -8,20 +8,15 @@
 package io.camunda.zeebe.engine.processing.job;
 
 import static io.camunda.zeebe.protocol.record.intent.JobIntent.ERROR_THROWN;
-import static io.camunda.zeebe.test.util.record.RecordingExporter.jobRecords;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
-import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
-import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
-import io.camunda.zeebe.test.util.record.RecordingExporter;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -104,54 +99,5 @@ public final class JobThrowErrorTest {
     // then
     Assertions.assertThat(result).hasRejectionType(RejectionType.INVALID_STATE);
     assertThat(result.getRejectionReason()).contains("it is in state 'ERROR_THROWN'");
-  }
-
-  @Test
-  public void shouldThrowErrorIfNoCatchEventFound() {
-    // given
-    final String processId = "process_with_error_boundary";
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            processId,
-            Bpmn.createExecutableProcess(processId)
-                .startEvent("start")
-                .serviceTask("task", b -> b.zeebeJobType(jobType).done())
-                .boundaryEvent("error1", b -> b.error("error_message_1"))
-                .endEvent()
-                .moveToActivity("task")
-                .boundaryEvent("error2", b -> b.error("error_message_2"))
-                .endEvent("end")
-                .done())
-        .deploy();
-
-    final long instanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
-
-    final var job =
-        jobRecords(JobIntent.CREATED)
-            .withType(jobType)
-            .filter(r -> r.getValue().getProcessInstanceKey() == instanceKey)
-            .getFirst();
-
-    // when
-    final Record<JobRecordValue> result =
-        ENGINE
-            .job()
-            .withKey(job.getKey())
-            .withErrorCode("error")
-            .withErrorMessage("error message")
-            .throwError();
-
-    // then
-    Assertions.assertThat(result).hasRecordType(RecordType.EVENT).hasIntent(ERROR_THROWN);
-    Assertions.assertThat(result.getValue()).hasErrorCode("error").hasErrorMessage("error message");
-    Assertions.assertThat(
-            RecordingExporter.incidentRecords()
-                .withJobKey(job.getKey())
-                .withIntent(IncidentIntent.CREATED)
-                .getFirst()
-                .getValue())
-        .hasErrorMessage(
-            "An error was thrown with the code 'error' with message 'error message', but not caught. Available error events are [error_message_2, error_message_1]");
   }
 }


### PR DESCRIPTION
## Description

Added the used error code and the available error codes to incident error messages.

## Related issues

closes #7566

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
