### PR TITLE
Remove step timeout configuration option

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -54,7 +54,6 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 
 public final class Broker implements AutoCloseable {
@@ -211,8 +210,7 @@ public final class Broker implements AutoCloseable {
   private AutoCloseable actorSchedulerStep() {
     scheduler = brokerContext.getScheduler();
     scheduler.start();
-    return () ->
-        scheduler.stop().get(brokerContext.getStepTimeout().toMillis(), TimeUnit.MILLISECONDS);
+    return () -> scheduler.stop().get();
   }
 
   private AutoCloseable atomixCreateStep(final BrokerCfg brokerCfg) {
@@ -221,7 +219,7 @@ public final class Broker implements AutoCloseable {
     clusterServices = new ClusterServicesImpl(atomix);
 
     return () -> {
-      clusterServices.stop().get(brokerContext.getStepTimeout().toMillis(), TimeUnit.MILLISECONDS);
+      clusterServices.stop().get();
       testCompanionObject.atomix = null;
     };
   }
@@ -284,10 +282,7 @@ public final class Broker implements AutoCloseable {
   }
 
   private void scheduleActor(final Actor actor) {
-    brokerContext
-        .getScheduler()
-        .submitActor(actor)
-        .join(brokerContext.getStepTimeout().toSeconds(), TimeUnit.SECONDS);
+    brokerContext.getScheduler().submitActor(actor).join();
   }
 
   private AutoCloseable monitoringServerStep(final BrokerInfo localBroker) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionC
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import io.camunda.zeebe.util.sched.ActorScheduler;
 import io.camunda.zeebe.util.sched.clock.ActorClock;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -43,10 +42,9 @@ public final class SystemContext {
       "Disabling explicit flushing is an experimental feature and can lead to inconsistencies "
           + "and/or data loss! Please refer to the documentation whether or not you should use this!";
 
-  protected final BrokerCfg brokerCfg;
+  private final BrokerCfg brokerCfg;
   private Map<String, String> diagnosticContext;
   private ActorScheduler scheduler;
-  private Duration stepTimeout;
 
   public SystemContext(final BrokerCfg brokerCfg, final String basePath, final ActorClock clock) {
     this.brokerCfg = brokerCfg;
@@ -60,14 +58,11 @@ public final class SystemContext {
     brokerCfg.init(basePath);
     validateConfiguration();
 
-    stepTimeout = brokerCfg.getStepTimeout();
-
     final var cluster = brokerCfg.getCluster();
     final String brokerId = String.format("Broker-%d", cluster.getNodeId());
 
     diagnosticContext = Collections.singletonMap(BROKER_ID_LOG_PROPERTY, brokerId);
     scheduler = initScheduler(clock, brokerId);
-    setStepTimeout(stepTimeout);
   }
 
   private void validateConfiguration() {
@@ -249,13 +244,5 @@ public final class SystemContext {
 
   public Map<String, String> getDiagnosticContext() {
     return diagnosticContext;
-  }
-
-  public Duration getStepTimeout() {
-    return stepTimeout;
-  }
-
-  private void setStepTimeout(final Duration stepTimeout) {
-    this.stepTimeout = stepTimeout;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/BrokerCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/BrokerCfg.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.broker.exporter.metrics.MetricsExporter;
 import io.camunda.zeebe.broker.system.configuration.backpressure.BackpressureCfg;
 import io.camunda.zeebe.util.Environment;
 import io.camunda.zeebe.util.exception.UncheckedExecutionException;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -36,7 +35,6 @@ public final class BrokerCfg {
   private BackpressureCfg backpressure = new BackpressureCfg();
   private ExperimentalCfg experimental = new ExperimentalCfg();
 
-  private Duration stepTimeout = Duration.ofMinutes(5);
   private boolean executionMetricsExporterEnabled;
 
   public void init(final String brokerBase) {
@@ -124,14 +122,6 @@ public final class BrokerCfg {
     return this;
   }
 
-  public Duration getStepTimeout() {
-    return stepTimeout;
-  }
-
-  public void setStepTimeout(final Duration stepTimeout) {
-    this.stepTimeout = stepTimeout;
-  }
-
   public boolean isExecutionMetricsExporterEnabled() {
     return executionMetricsExporterEnabled;
   }
@@ -167,8 +157,6 @@ public final class BrokerCfg {
         + backpressure
         + ", experimental="
         + experimental
-        + ", stepTimeout="
-        + stepTimeout
         + ", executionMetricsExporterEnabled="
         + executionMetricsExporterEnabled
         + '}';

--- a/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.io.File;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeoutException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,24 +32,6 @@ public final class SimpleBrokerStartTest {
   @Before
   public void setup() throws Exception {
     newTemporaryFolder = temporaryFolder.newFolder();
-  }
-
-  @Test
-  public void shouldFailToStartBrokerWithSmallTimeout() {
-    // given
-    final var brokerCfg = new BrokerCfg();
-    assignSocketAddresses(brokerCfg);
-    brokerCfg.setStepTimeout(Duration.ofMillis(1));
-
-    final var broker =
-        new Broker(
-            brokerCfg, newTemporaryFolder.getAbsolutePath(), null, TEST_SPRING_BROKER_BRIDGE);
-
-    // when
-    final var catchedThrownBy = assertThatThrownBy(() -> broker.start().join());
-
-    // then
-    catchedThrownBy.hasRootCauseInstanceOf(TimeoutException.class);
   }
 
   @Test

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -90,22 +90,6 @@ public final class BrokerCfgTest {
   }
 
   @Test
-  public void shouldUseDefaultStepTimeout() {
-    assertDefaultStepTimeout(Duration.ofMinutes(5));
-  }
-
-  @Test
-  public void shouldUseStepTimeout() {
-    assertStepTimeout("step-timeout-cfg", Duration.ofMinutes(2));
-  }
-
-  @Test
-  public void shouldUseStepTimeoutFromEnv() {
-    environment.put("zeebe.broker.stepTimeout", Duration.ofMinutes(1).toString());
-    assertDefaultStepTimeout(Duration.ofMinutes(1));
-  }
-
-  @Test
   public void shouldUseSpecifiedNodeId() {
     assertNodeId("specific-node-id", 123);
   }
@@ -717,16 +701,6 @@ public final class BrokerCfgTest {
   private void assertClusterName(final String configFileName, final String clusterName) {
     final BrokerCfg cfg = TestConfigReader.readConfig(configFileName, environment);
     assertThat(cfg.getCluster().getClusterName()).isEqualTo(clusterName);
-  }
-
-  private void assertDefaultStepTimeout(final Duration stepTimeout) {
-    assertStepTimeout("default", stepTimeout);
-    assertStepTimeout("empty", stepTimeout);
-  }
-
-  private void assertStepTimeout(final String configFileName, final Duration stepTimeout) {
-    final BrokerCfg cfg = TestConfigReader.readConfig(configFileName, environment);
-    assertThat(cfg.getStepTimeout()).isEqualTo(stepTimeout);
   }
 
   private void assertDefaultPorts(final int command, final int internal, final int monitoring) {

--- a/broker/src/test/resources/system/step-timeout-cfg.yaml
+++ b/broker/src/test/resources/system/step-timeout-cfg.yaml
@@ -1,3 +1,0 @@
-zeebe:
-  broker:
-    stepTimeout: 2m

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -32,14 +32,6 @@
 
 # zeebe:
   # broker:
-    # Sets the timeout for each start and closing step.
-    #
-    # Broker bootstrap and closing is divided in several individual steps.
-    # Each step should take at max the defined stepTimeout, otherwise the bootstrap is aborted.
-    #
-    # This setting can also be overridden using the environment variable ZEEBE_BROKER_STEPTIMEOUT.
-    # stepTimeout: 5m
-
     # gateway:
       # Enable the embedded gateway to start on broker startup.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_ENABLE.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -32,14 +32,6 @@
 
 # zeebe:
   # broker:
-    # Sets the timeout for each start and closing step.
-    #
-    # Broker bootstrap and closing is divided in several individual steps.
-    # Each step should take at max the defined stepTimeout, otherwise the bootstrap is aborted.
-    #
-    # This setting can also be overridden using the environment variable ZEEBE_BROKER_STEPTIMEOUT.
-    # stepTimeout: 5m
-
     # gateway:
       # Enable the embedded gateway to start on broker startup.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_ENABLE.


### PR DESCRIPTION
## Description

The step timeout was used sparingly and not consistently. If it would be applied consistently, then setting a timeout for all steps is challenging.
The value needs to be long enough for the longest step. But thereby it also gives too much time for short steps.

With the move to K8S environments it will be easier to set a global timeout for the system to get ready.

## Related issues

Preparation step for: #7539

<!-- Cut-off marker
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [X] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
