### PR TITLE
Introduce state query service

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/QueryService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/QueryService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state;
+
+import java.util.Optional;
+import org.agrona.DirectBuffer;
+
+/**
+ * This service provides a few highly specific queries.
+ *
+ * <p>It exists to be used by the broker's temporary query api, which only exists as a temporary
+ * solution to provide client authorization. Once client authorization is a first-class citizen,
+ * this interface should be removed. We strongly discourage using this interface for anything else
+ * than it's intended purpose.
+ */
+@Deprecated(forRemoval = true, since = "1.2")
+public interface QueryService {
+
+  /**
+   * Queries the state for the bpmn process id of a specific process.
+   *
+   * @param processKey The key of the process
+   * @return Optionally the bpmn process id if found, otherwise an empty optional
+   */
+  Optional<DirectBuffer> getBpmnProcessIdForProcess(long processKey);
+
+  /**
+   * Queries the state for the bpmn process id of the process of a specific process instance.
+   *
+   * @param processInstanceKey The key of the process instance
+   * @return Optionally the bpmn process id if found, otherwise an empty optional
+   */
+  Optional<DirectBuffer> getBpmnProcessIdForProcessInstance(long processInstanceKey);
+
+  /**
+   * Queries the state for the bpmn process id of the process that a specific job belongs to.
+   *
+   * @param jobKey The key of the job
+   * @return Optionally the bpmn process id if found, otherwise an empty optional
+   */
+  Optional<DirectBuffer> getBpmnProcessIdForJob(long jobKey);
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 
-public class StateQueryService implements QueryService {
+public final class StateQueryService implements QueryService {
   private final ProcessState processes;
   private final ElementInstanceState instances;
   private final JobState jobs;

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.query;
+
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.state.QueryService;
+import io.camunda.zeebe.engine.state.ZbColumnFamilies;
+import io.camunda.zeebe.engine.state.ZeebeDbState;
+import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.JobState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import java.util.Optional;
+import org.agrona.DirectBuffer;
+
+public class StateQueryService implements QueryService {
+  private final ProcessState processes;
+  private final ElementInstanceState instances;
+  private final JobState jobs;
+
+  public StateQueryService(final ZeebeDb<ZbColumnFamilies> zeebeDb) {
+    final ZeebeState state = new ZeebeDbState(zeebeDb, zeebeDb.createContext());
+    processes = state.getProcessState();
+    instances = state.getElementInstanceState();
+    jobs = state.getJobState();
+  }
+
+  @Override
+  public Optional<DirectBuffer> getBpmnProcessIdForProcess(final long key) {
+    return Optional.ofNullable(processes.getProcessByKey(key))
+        .map(DeployedProcess::getBpmnProcessId);
+  }
+
+  @Override
+  public Optional<DirectBuffer> getBpmnProcessIdForProcessInstance(final long key) {
+    return Optional.ofNullable(instances.getInstance(key))
+        .map(ElementInstance::getValue)
+        .map(ProcessInstanceRecord::getBpmnProcessIdBuffer);
+  }
+
+  @Override
+  public Optional<DirectBuffer> getBpmnProcessIdForJob(final long key) {
+    return Optional.ofNullable(jobs.getJob(key)).map(JobRecord::getBpmnProcessIdBuffer);
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/query/StateQueryServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/query/StateQueryServiceTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.state.ZbColumnFamilies;
+import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.util.Records;
+import io.camunda.zeebe.engine.util.ZeebeStateExtension;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ZeebeStateExtension.class)
+final class StateQueryServiceTest {
+
+  private StateQueryService sut;
+  private ZeebeDb<ZbColumnFamilies> db;
+  private MutableZeebeState state;
+  private TransactionContext transactionContext;
+
+  @BeforeEach
+  void setup() {
+    sut = new StateQueryService(db);
+  }
+
+  @Nested
+  @DisplayName("getBpmnProcessIdForProcess(processKey)")
+  final class GetBpmnProcessIdForProcess {
+
+    @Test
+    @DisplayName("should return an empty optional when process is not found")
+    void shouldReturnEmptyWhenNotFound() {
+      // when
+      final var key = Protocol.encodePartitionId(1, 1L);
+      final var result = sut.getBpmnProcessIdForProcess(key);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should return a bpmn process id when process is found")
+    void shouldReturnMatchWhenPresent() {
+      // given
+      final var processId = "processId";
+      final var key = Protocol.encodePartitionId(1, 1L);
+      final var record = Records.process(key, processId);
+      state.getProcessState().putProcess(record.getKey(), record);
+
+      // when
+      final var result = sut.getBpmnProcessIdForProcess(record.getKey());
+
+      // then
+      assertThat(result).contains(BufferUtil.wrapString(processId));
+    }
+  }
+
+  @Nested
+  @DisplayName("getBpmnProcessIdForProcessInstance(processInstanceKey)")
+  final class GetBpmnProcessIdForProcessInstance {
+
+    @Test
+    @DisplayName("should return an empty optional when process instance is not found")
+    void shouldReturnEmptyWhenNotFound() {
+      // when
+      final var key = Protocol.encodePartitionId(1, 1L);
+      final var result = sut.getBpmnProcessIdForProcessInstance(key);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should return a bpmn process id when process instance is found")
+    void shouldReturnMatchWhenPresent() {
+      // given
+      final var processId = "processId";
+      final var key = Protocol.encodePartitionId(1, 1L);
+      final var record = Records.processInstance(key, processId);
+      state
+          .getElementInstanceState()
+          .newInstance(key, record, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+
+      // when
+      final var result = sut.getBpmnProcessIdForProcessInstance(key);
+
+      // then
+      assertThat(result).contains(BufferUtil.wrapString(processId));
+    }
+  }
+
+  @Nested
+  @DisplayName("getBpmnProcessIdForJob(jobKey)")
+  class GetBpmnProcessIdForJob {
+
+    @Test
+    @DisplayName("should return an empty optional when job is not found")
+    void shouldReturnEmptyWhenNotFound() {
+      // when
+      final var key = Protocol.encodePartitionId(1, 1L);
+      final var result = sut.getBpmnProcessIdForJob(key);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should return a bpmn process id when job is found")
+    void shouldReturnMatchWhenPresent() {
+      // given
+      final var processId = "processId";
+      final var key = Protocol.encodePartitionId(1, 1L);
+      final var record = Records.job(key, processId);
+      state.getJobState().create(key, record);
+
+      // when
+      final var result = sut.getBpmnProcessIdForJob(key);
+
+      // then
+      assertThat(result).contains(BufferUtil.wrapString(processId));
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Introduces a new query service interface and implementation to the engine's state module, that can be used to find the bpmn process id of a process, process instance or job.

The interface is deprecated to avoid additional usages.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7751 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
