### PR TITLE
Fix memory leak 

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -379,6 +379,16 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   /**
+   * Removes registered committedEntryListener
+   *
+   * @param raftCommittedEntryListener the listener to remove
+   */
+  public void removeCommittedEntryListener(
+      final RaftCommittedEntryListener raftCommittedEntryListener) {
+    committedEntryListeners.remove(raftCommittedEntryListener);
+  }
+
+  /**
    * Notifies all listeners of the latest entry.
    *
    * @param lastCommitIndex index of the most recently committed entry

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -260,6 +260,13 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
   }
 
   /**
+   * @see io.atomix.raft.impl.RaftContext#removeCommittedEntryListener(RaftCommittedEntryListener)
+   */
+  public void removeCommittedEntryListener(final RaftCommittedEntryListener commitListener) {
+    server.getContext().removeCommittedEntryListener(commitListener);
+  }
+
+  /**
    * @see
    *     io.atomix.raft.impl.RaftContext#addSnapshotReplicationListener(SnapshotReplicationListener)
    */

--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/PartitionCommandSenderImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/PartitionCommandSenderImpl.java
@@ -9,12 +9,9 @@ package io.camunda.zeebe.broker.engine.impl;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
-import io.camunda.zeebe.broker.partitioning.topology.TopologyPartitionListener;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyPartitionListenerImpl;
 import io.camunda.zeebe.engine.processing.message.command.PartitionCommandSender;
 import io.camunda.zeebe.util.buffer.BufferWriter;
-import io.camunda.zeebe.util.sched.ActorControl;
-import java.util.function.Consumer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Int2IntHashMap;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -27,11 +24,9 @@ public final class PartitionCommandSenderImpl implements PartitionCommandSender 
 
   public PartitionCommandSenderImpl(
       final ClusterCommunicationService communicationService,
-      final Consumer<TopologyPartitionListener> partitionListenerConsumer,
-      final ActorControl actor) {
+      final TopologyPartitionListenerImpl partitionListener) {
     this.communicationService = communicationService;
-    partitionListener = new TopologyPartitionListenerImpl(actor);
-    partitionListenerConsumer.accept(partitionListener);
+    this.partitionListener = partitionListener;
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -209,6 +209,8 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     isOpened.set(false);
     if (exporterMode == ExporterMode.ACTIVE) {
       containers.forEach(ExporterContainer::close);
+    } else {
+      exporterDistributionService.close();
     }
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterPositionsDistributionService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterPositionsDistributionService.java
@@ -52,7 +52,7 @@ public class ExporterPositionsDistributionService implements AutoCloseable {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     partitionMessagingService.unsubscribe(exporterPositionsTopic);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -150,7 +150,7 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
 
               partitions.addAll(
                   partitionFactory.constructPartitions(
-                      partitionGroup, partitionListeners, this::addTopologyPartitionListener));
+                      partitionGroup, partitionListeners, topologyManager));
 
               final var futures =
                   partitions.stream()

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionStep.java
@@ -39,6 +39,7 @@ public class SnapshotDirectorPartitionStep implements PartitionStep {
   public ActorFuture<Void> close(final PartitionStartupAndTransitionContextImpl context) {
     final var director = context.getSnapshotDirector();
     context.getComponentHealthMonitor().removeComponent(director.getName());
+    context.getRaftPartition().getServer().removeCommittedEntryListener(director);
     final ActorFuture<Void> future = director.closeAsync();
     context.setSnapshotDirector(null);
     return future;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -207,6 +207,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private void tearDown() {
     processingContext.getLogStreamReader().close();
     logStream.removeRecordAvailableListener(this);
+    replayStateMachine.close();
   }
 
   private void healthCheckTick() {


### PR DESCRIPTION
## Description

When we install services for a role, it installs several listeners. Most of them were not removed when these services are closed. References to StreamProcessor and LogStream are kept indirectly via these listeners. Thus they are not garbage collected. This lead to OOM in direct memory and eventually OOM in heap.

This PR fixes it by unregistering listeners when closing services.
After this fix, StreamProcessor is garbage collected. Following is from a heapdump after several role transitions in a broker
![image](https://user-images.githubusercontent.com/1997478/132211379-9e5b8498-31e3-4b60-b1df-f44605ade596.png)

## Related issues

closes #7744

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
