### PR TITLE
fix(engine): Added null-check to ProcessMessageStartEventMessageNameValidator

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessMessageStartEventMessageNameValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessMessageStartEventMessageNameValidator.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.el.EvaluationResult;
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ResultType;
+import io.camunda.zeebe.model.bpmn.instance.Message;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.Process;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
@@ -50,7 +51,12 @@ final class ProcessMessageStartEventMessageNameValidator
   private void validateMessageName(
       final MessageEventDefinition messageEventDefinition,
       final ValidationResultCollector resultCollector) {
-    final String nameExpression = messageEventDefinition.getMessage().getName();
+
+    final Message message = messageEventDefinition.getMessage();
+    if (message == null) {
+      return;
+    }
+    final String nameExpression = message.getName();
     final Expression parseResult = expressionLanguage.parseExpression(nameExpression);
 
     final EvaluationResult evaluationResult =

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentTest.java
@@ -642,29 +642,6 @@ public final class CreateDeploymentTest {
                 + "'INVALID_CYCLE_EXPRESSION')\n");
   }
 
-  @Test
-  public void shouldRejectDeploymentWhenNoMessageReferenced() {
-    // given
-    final BpmnModelInstance definition =
-        Bpmn.createExecutableProcess("processId")
-            .startEvent("startEvent")
-            .messageEventDefinition()
-            .id("messageEvent")
-            .done();
-
-    // when
-    final Record<DeploymentRecordValue> deployment =
-        ENGINE.deployment().withXmlResource("process.bpmn", definition).expectRejection().deploy();
-
-    // then
-    Assertions.assertThat(deployment)
-        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
-        .hasRejectionReason(
-            "Expected to deploy new resources, but encountered the following errors:\n"
-                + "'process.bpmn': - Element: messageEvent\n"
-                + "    - ERROR: Must reference a message\n");
-  }
-
   private ProcessMetadataValue findProcess(
       final List<ProcessMetadataValue> processes, final String processId) {
     return processes.stream()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentTest.java
@@ -642,6 +642,29 @@ public final class CreateDeploymentTest {
                 + "'INVALID_CYCLE_EXPRESSION')\n");
   }
 
+  @Test
+  public void shouldRejectDeploymentWhenNoMessageReferenced() {
+    // given
+    final BpmnModelInstance definition =
+        Bpmn.createExecutableProcess("processId")
+            .startEvent("startEvent")
+            .messageEventDefinition()
+            .id("messageEvent")
+            .done();
+
+    // when
+    final Record<DeploymentRecordValue> deployment =
+        ENGINE.deployment().withXmlResource("process.bpmn", definition).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(deployment)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Expected to deploy new resources, but encountered the following errors:\n"
+                + "'process.bpmn': - Element: messageEvent\n"
+                + "    - ERROR: Must reference a message\n");
+  }
+
   private ProcessMetadataValue findProcess(
       final List<ProcessMetadataValue> processes, final String processId) {
     return processes.stream()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/MessageEventValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/MessageEventValidationTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public final class MessageEventValidationTest {
+
+  @Test
+  @DisplayName("message start event with no message reference")
+  public void shouldRejectDeploymentWhenNoMessageReferenced() {
+
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("processId")
+            .startEvent("startEvent")
+            .messageEventDefinition()
+            .id("messageEvent")
+            .done();
+
+    ProcessValidationUtil.validateProcess(
+        instance,
+        ExpectedValidationResult.expect(MessageEventDefinition.class, "Must reference a message"));
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessValidationUtil.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessValidationUtil.java
@@ -17,8 +17,10 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.traversal.ModelWalker;
 import io.camunda.zeebe.model.bpmn.validation.ValidationVisitor;
+import io.camunda.zeebe.model.bpmn.validation.zeebe.ZeebeDesignTimeValidators;
 import java.util.Collection;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.camunda.bpm.model.xml.validation.ValidationResults;
 
 public class ProcessValidationUtil {
@@ -53,7 +55,11 @@ public class ProcessValidationUtil {
     final var expressionProcessor = new ExpressionProcessor(expressionLanguage, emptyLookup);
     final ValidationVisitor visitor =
         new ValidationVisitor(
-            ZeebeRuntimeValidators.getValidators(expressionLanguage, expressionProcessor));
+            Stream.of(
+                    ZeebeRuntimeValidators.getValidators(expressionLanguage, expressionProcessor),
+                    ZeebeDesignTimeValidators.VALIDATORS)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList()));
     walker.walk(visitor);
 
     return visitor.getValidationResult();


### PR DESCRIPTION
## Description

Fix for NPE during validation of new deployment.

## Related issues

closes #5510 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
