### PR TITLE
7539 start actor scheduler before broker

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -46,7 +46,6 @@ import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.exception.UncheckedExecutionException;
 import io.camunda.zeebe.util.sched.Actor;
 import io.camunda.zeebe.util.sched.ActorScheduler;
-import io.camunda.zeebe.util.sched.clock.ActorClock;
 import io.netty.util.NetUtil;
 import java.io.File;
 import java.io.IOException;
@@ -84,14 +83,6 @@ public final class Broker implements AutoCloseable {
     brokerContext = systemContext;
     partitionListeners = new ArrayList<>();
     this.springBrokerBridge = springBrokerBridge;
-  }
-
-  public Broker(
-      final BrokerCfg cfg,
-      final String basePath,
-      final ActorClock clock,
-      final SpringBrokerBridge springBrokerBridge) {
-    this(new SystemContext(cfg, basePath, clock), springBrokerBridge);
   }
 
   public void addPartitionListener(final PartitionListener listener) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -86,10 +86,12 @@ public final class SimpleBrokerStartTest {
         });
 
     // when
+    systemContext.getScheduler().start();
     broker.start().join();
 
     // then
     leaderLatch.await();
     broker.close();
+    systemContext.getScheduler().stop().get();
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker;
 import static io.camunda.zeebe.broker.test.EmbeddedBrokerRule.assignSocketAddresses;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
@@ -41,14 +42,14 @@ public final class SimpleBrokerStartTest {
     brokerCfg.getData().setSnapshotPeriod(Duration.ofMillis(1));
 
     // when
+
     final var catchedThrownBy =
         assertThatThrownBy(
-            () ->
-                new Broker(
-                    brokerCfg,
-                    newTemporaryFolder.getAbsolutePath(),
-                    null,
-                    TEST_SPRING_BROKER_BRIDGE));
+            () -> {
+              final var systemContext =
+                  new SystemContext(brokerCfg, newTemporaryFolder.getAbsolutePath(), null);
+              new Broker(systemContext, TEST_SPRING_BROKER_BRIDGE);
+            });
 
     // then
     catchedThrownBy.isInstanceOf(IllegalArgumentException.class);
@@ -59,10 +60,10 @@ public final class SimpleBrokerStartTest {
     // given
     final var brokerCfg = new BrokerCfg();
     assignSocketAddresses(brokerCfg);
+    final var systemContext =
+        new SystemContext(brokerCfg, newTemporaryFolder.getAbsolutePath(), null);
 
-    final var broker =
-        new Broker(
-            brokerCfg, newTemporaryFolder.getAbsolutePath(), null, TEST_SPRING_BROKER_BRIDGE);
+    final var broker = new Broker(systemContext, TEST_SPRING_BROKER_BRIDGE);
     final var leaderLatch = new CountDownLatch(1);
     broker.addPartitionListener(
         new PartitionListener() {

--- a/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.TestLoggers;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
+import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
@@ -213,13 +214,9 @@ public final class EmbeddedBrokerRule extends ExternalResource {
         throw new RuntimeException("Unable to open configuration", e);
       }
     }
-
-    broker =
-        new Broker(
-            brokerCfg,
-            newTemporaryFolder.getAbsolutePath(),
-            controlledActorClock,
-            springBrokerBridge);
+    final var systemContext =
+        new SystemContext(brokerCfg, newTemporaryFolder.getAbsolutePath(), controlledActorClock);
+    broker = new Broker(systemContext, springBrokerBridge);
 
     final CountDownLatch latch = new CountDownLatch(brokerCfg.getCluster().getPartitionsCount());
     broker.addPartitionListener(new LeaderPartitionListener(latch));

--- a/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker;
 
+import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.shared.EnvironmentHelper;
 import io.camunda.zeebe.util.FileUtil;
@@ -82,8 +83,8 @@ public class StandaloneBroker
     if (basePath == null) {
       basePath = Paths.get(".").toAbsolutePath().normalize().toString();
     }
-
-    return new Broker(configuration, basePath, null, springBrokerBridge);
+    final var systemContext = new SystemContext(configuration, basePath, null);
+    return new Broker(systemContext, springBrokerBridge);
   }
 
   private Broker createBrokerInTempDirectory() {
@@ -91,7 +92,8 @@ public class StandaloneBroker
 
     try {
       tempFolder = Files.createTempDirectory("zeebe").toAbsolutePath().normalize().toString();
-      return new Broker(configuration, tempFolder, null, springBrokerBridge);
+      final var systemContext = new SystemContext(configuration, tempFolder, null);
+      return new Broker(systemContext, springBrokerBridge);
     } catch (final IOException e) {
       throw new UncheckedIOException("Could not start broker", e);
     }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -84,6 +84,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.agrona.LangUtil;
 import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.rules.ExternalResource;
@@ -123,6 +124,7 @@ public final class ClusteringRule extends ExternalResource {
   private CountDownLatch partitionLatch;
   private final Map<Integer, Leader> partitionLeader;
   private final Map<Integer, SpringBrokerBridge> springBrokerBridge;
+  private final Map<Integer, SystemContext> systemContexts;
 
   public ClusteringRule() {
     this(3);
@@ -168,9 +170,11 @@ public final class ClusteringRule extends ExternalResource {
     controlledClock = new ControlledActorClock();
     brokers = new HashMap<>();
     brokerCfgs = new HashMap<>();
+    systemContexts = new HashMap<>();
     partitionLeader = new ConcurrentHashMap<>();
     logstreams = new ConcurrentHashMap<>();
     springBrokerBridge = new HashMap<>();
+
     partitionIds =
         IntStream.range(START_PARTITION_ID, START_PARTITION_ID + partitionCount)
             .boxed()
@@ -276,11 +280,17 @@ public final class ClusteringRule extends ExternalResource {
     final BrokerCfg brokerCfg = getBrokerCfg(nodeId);
     final var systemContext =
         new SystemContext(brokerCfg, brokerBase.getAbsolutePath(), controlledClock);
+    systemContexts.put(nodeId, systemContext);
 
     final Broker broker = new Broker(systemContext, getSpringBrokerBridge(nodeId));
 
     broker.addPartitionListener(new LeaderListener(partitionLatch, nodeId));
-    new Thread(broker::start).start();
+    new Thread(
+            () -> {
+              systemContext.getScheduler().start();
+              broker.start();
+            })
+        .start();
     return broker;
   }
 
@@ -630,6 +640,14 @@ public final class ClusteringRule extends ExternalResource {
           broker.getConfig().getNetwork().getCommandApi().getAddress();
       broker.close();
       waitUntilBrokerIsRemovedFromTopology(socketAddress);
+      try {
+        final var systemContext = systemContexts.remove(nodeId);
+        if (systemContext != null) {
+          systemContext.getScheduler().stop().get();
+        }
+      } catch (final InterruptedException | ExecutionException e) {
+        LangUtil.rethrowUnchecked(e);
+      }
     }
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
+import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.NetworkCfg;
 import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg;
@@ -273,12 +274,10 @@ public final class ClusteringRule extends ExternalResource {
   private Broker createBroker(final int nodeId) {
     final File brokerBase = getBrokerBase(nodeId);
     final BrokerCfg brokerCfg = getBrokerCfg(nodeId);
-    final Broker broker =
-        new Broker(
-            brokerCfg,
-            brokerBase.getAbsolutePath(),
-            controlledClock,
-            getSpringBrokerBridge(nodeId));
+    final var systemContext =
+        new SystemContext(brokerCfg, brokerBase.getAbsolutePath(), controlledClock);
+
+    final Broker broker = new Broker(systemContext, getSpringBrokerBridge(nodeId));
 
     broker.addPartitionListener(new LeaderListener(partitionLatch, nodeId));
     new Thread(broker::start).start();

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -102,6 +102,11 @@
       <artifactId>netty-common</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
+++ b/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
@@ -37,9 +37,11 @@ import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import org.agrona.LangUtil;
 import org.assertj.core.util.Files;
 import org.junit.rules.ExternalResource;
 import org.junit.runner.Description;
@@ -67,6 +69,7 @@ public class EmbeddedBrokerRule extends ExternalResource {
   private final Duration timeout;
   private final File newTemporaryFolder;
   private String dataDirectory;
+  private SystemContext systemContext;
 
   @SafeVarargs
   public EmbeddedBrokerRule(final Consumer<BrokerCfg>... configurators) {
@@ -198,12 +201,18 @@ public class EmbeddedBrokerRule extends ExternalResource {
     if (broker != null) {
       broker.close();
       broker = null;
+      try {
+        systemContext.getScheduler().stop().get();
+      } catch (final InterruptedException | ExecutionException e) {
+        LangUtil.rethrowUnchecked(e);
+      }
+      systemContext = null;
       System.gc();
     }
   }
 
   public void startBroker() {
-    final var systemContext =
+    systemContext =
         new SystemContext(brokerCfg, newTemporaryFolder.getAbsolutePath(), controlledActorClock);
 
     broker = new Broker(systemContext, springBrokerBridge);
@@ -211,6 +220,7 @@ public class EmbeddedBrokerRule extends ExternalResource {
     final CountDownLatch latch = new CountDownLatch(brokerCfg.getCluster().getPartitionsCount());
     broker.addPartitionListener(new LeaderPartitionListener(latch));
 
+    systemContext.getScheduler().start();
     broker.start().join();
 
     try {

--- a/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
+++ b/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
+import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.broker.system.configuration.NetworkCfg;
@@ -202,12 +203,10 @@ public class EmbeddedBrokerRule extends ExternalResource {
   }
 
   public void startBroker() {
-    broker =
-        new Broker(
-            brokerCfg,
-            newTemporaryFolder.getAbsolutePath(),
-            controlledActorClock,
-            springBrokerBridge);
+    final var systemContext =
+        new SystemContext(brokerCfg, newTemporaryFolder.getAbsolutePath(), controlledActorClock);
+
+    broker = new Broker(systemContext, springBrokerBridge);
 
     final CountDownLatch latch = new CountDownLatch(brokerCfg.getCluster().getPartitionsCount());
     broker.addPartitionListener(new LeaderPartitionListener(latch));


### PR DESCRIPTION
## Description

Changes bootstrap sequence such that the actor scheduler is started before the broker,

## Related issues

#7539


<!-- Cut-off marker
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
