### PR TITLE
Use request type to set topic name in transport

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiService.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.ServerTransport;
 import io.camunda.zeebe.util.sched.Actor;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
@@ -79,7 +80,7 @@ public final class CommandApiService extends Actor
 
                       final var requestLimiter = limiter.getLimiter(partitionId);
                       requestHandler.addPartition(partitionId, recordWriter, requestLimiter);
-                      serverTransport.subscribe(partitionId, requestHandler);
+                      serverTransport.subscribe(partitionId, RequestType.COMMAND, requestHandler);
                       future.complete(null);
                     } else {
                       Loggers.SYSTEM_LOGGER.error(

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerExecuteCommand.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerExecuteCommand.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.record.ExecuteCommandResponseDecoder;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.transport.RequestType;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 
@@ -44,11 +45,6 @@ public abstract class BrokerExecuteCommand<T> extends BrokerRequest<T> {
 
   public ValueType getValueType() {
     return request.getValueType();
-  }
-
-  @Override
-  public String getType() {
-    return type;
   }
 
   @Override
@@ -98,6 +94,16 @@ public abstract class BrokerExecuteCommand<T> extends BrokerRequest<T> {
       throw new UnsupportedBrokerResponseException(
           request.getValueType().name(), response.getValueType().name());
     }
+  }
+
+  @Override
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  public RequestType getRequestType() {
+    return RequestType.COMMAND;
   }
 
   @Override

--- a/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBrokerRule.java
+++ b/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBrokerRule.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.test.broker.protocol.MsgPackHelper;
 import io.camunda.zeebe.test.broker.protocol.brokerapi.data.Topology;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.ServerTransport;
 import io.camunda.zeebe.transport.TransportFactory;
 import io.camunda.zeebe.util.sched.ActorScheduler;
@@ -82,7 +83,7 @@ public final class StubBrokerRule extends ExternalResource {
     serverTransport = transportFactory.createServerTransport(0, cluster.getMessagingService());
 
     channelHandler = new StubRequestHandler(msgPackHelper);
-    serverTransport.subscribe(1, channelHandler);
+    serverTransport.subscribe(1, RequestType.COMMAND, channelHandler);
 
     currentTopology.set(topology);
   }

--- a/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/ExecuteCommandRequest.java
+++ b/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/ExecuteCommandRequest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.test.broker.protocol.MsgPackHelper;
 import io.camunda.zeebe.transport.ClientRequest;
 import io.camunda.zeebe.transport.ClientTransport;
+import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import java.time.Duration;
@@ -102,6 +103,11 @@ public final class ExecuteCommandRequest implements ClientRequest {
   @Override
   public int getPartitionId() {
     return partitionId;
+  }
+
+  @Override
+  public RequestType getRequestType() {
+    return RequestType.COMMAND;
   }
 
   @Override

--- a/transport/src/main/java/io/camunda/zeebe/transport/ClientRequest.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/ClientRequest.java
@@ -15,7 +15,5 @@ public interface ClientRequest extends BufferWriter {
   int getPartitionId();
 
   /** @return the type of this request */
-  default RequestType getRequestType() {
-    return RequestType.COMMAND;
-  }
+  RequestType getRequestType();
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/RequestType.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/RequestType.java
@@ -8,7 +8,8 @@
 package io.camunda.zeebe.transport;
 
 public enum RequestType {
-  COMMAND;
+  COMMAND,
+  UNKNOWN;
 
   public static RequestType from(final String name) {
     return RequestType.valueOf(name.toUpperCase());

--- a/transport/src/main/java/io/camunda/zeebe/transport/RequestType.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/RequestType.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.zeebe.transport;
 
-import io.camunda.zeebe.util.buffer.BufferWriter;
+public enum RequestType {
+  COMMAND;
 
-public interface ClientRequest extends BufferWriter {
+  public static RequestType from(final String name) {
+    return RequestType.valueOf(name.toUpperCase());
+  }
 
-  /** @return the partition id to which the request should be send to */
-  int getPartitionId();
-
-  /** @return the type of this request */
-  default RequestType getRequestType() {
-    return RequestType.COMMAND;
+  @Override
+  public String toString() {
+    return name().toLowerCase();
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/RequestType.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/RequestType.java
@@ -7,16 +7,30 @@
  */
 package io.camunda.zeebe.transport;
 
+/**
+ * Defines the supported types of request that can be sent through the transport. A subscribed
+ * request handler will only receive requests of the request types it subscribed to.
+ *
+ * <p>Normally describing the supported request types should not be a transport concern, but an
+ * application concern. However, having it as part of the transport makes unsubscribing from all
+ * possible request types easier. Sending and handling a new request type in the application will
+ * also require adding it here.
+ */
 public enum RequestType {
-  COMMAND,
-  UNKNOWN;
+  // Supported request types
+  COMMAND("command"),
 
-  public static RequestType from(final String name) {
-    return RequestType.valueOf(name.toUpperCase());
+  // All other request types are considered unknown
+  // This value exists mainly for testing purposes
+  UNKNOWN("unknown");
+
+  private final String id;
+
+  RequestType(final String id) {
+    this.id = id;
   }
 
-  @Override
-  public String toString() {
-    return name().toLowerCase();
+  public String getId() {
+    return id;
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/ServerTransport.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/ServerTransport.java
@@ -12,12 +12,25 @@ import io.camunda.zeebe.util.sched.future.ActorFuture;
 public interface ServerTransport extends ServerOutput, AutoCloseable {
 
   /**
-   * Subscribes to the given partition and call's the given handler on each new request.
+   * Subscribes to the given partition and call's the given handler on each new COMMAND request.
    *
    * @param partitionId the partition, for which should be subscribed
    * @param requestHandler the handler which should be called.
    */
-  ActorFuture<Void> subscribe(int partitionId, RequestHandler requestHandler);
+  default ActorFuture<Void> subscribe(final int partitionId, final RequestHandler requestHandler) {
+    return subscribe(partitionId, RequestType.COMMAND, requestHandler);
+  }
+
+  /**
+   * Subscribes to the given partition and call's the given handler on each new request of the given
+   * type.
+   *
+   * @param partitionId the partition, for which should be subscribed
+   * @param requestType the type of request that should be handled
+   * @param requestHandler the handler which should be called.
+   */
+  ActorFuture<Void> subscribe(
+      int partitionId, RequestType requestType, RequestHandler requestHandler);
 
   /**
    * Unsubscribe from the given partition, the registered handler will no longer be called on new

--- a/transport/src/main/java/io/camunda/zeebe/transport/ServerTransport.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/ServerTransport.java
@@ -12,16 +12,6 @@ import io.camunda.zeebe.util.sched.future.ActorFuture;
 public interface ServerTransport extends ServerOutput, AutoCloseable {
 
   /**
-   * Subscribes to the given partition and call's the given handler on each new COMMAND request.
-   *
-   * @param partitionId the partition, for which should be subscribed
-   * @param requestHandler the handler which should be called.
-   */
-  default ActorFuture<Void> subscribe(final int partitionId, final RequestHandler requestHandler) {
-    return subscribe(partitionId, RequestType.COMMAND, requestHandler);
-  }
-
-  /**
    * Subscribes to the given partition and call's the given handler on each new request of the given
    * type.
    *

--- a/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixClientTransportAdapter.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixClientTransportAdapter.java
@@ -68,6 +68,7 @@ public final class AtomixClientTransportAdapter extends Actor implements ClientT
     clientRequest.write(buffer, 0);
 
     final var partitionId = clientRequest.getPartitionId();
+    final var requestType = clientRequest.getRequestType();
 
     final var requestFuture = new CompletableActorFuture<DirectBuffer>();
     final var requestContext =
@@ -75,6 +76,7 @@ public final class AtomixClientTransportAdapter extends Actor implements ClientT
             requestFuture,
             nodeAddressSupplier,
             partitionId,
+            requestType,
             requestBytes,
             responseValidator,
             shouldRetry,

--- a/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
@@ -57,7 +57,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
     actor
         .call(
             () -> {
-              for (int partitionId : partitionsRequestMap.keySet()) {
+              for (final int partitionId : partitionsRequestMap.keySet()) {
                 removePartition(partitionId);
               }
               actor.close();

--- a/transport/src/main/java/io/camunda/zeebe/transport/impl/RequestContext.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/impl/RequestContext.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.transport.impl;
 import static io.camunda.zeebe.transport.impl.AtomixServerTransport.topicName;
 
 import io.atomix.utils.net.Address;
+import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.util.sched.ScheduledTimer;
 import io.camunda.zeebe.util.sched.clock.ActorClock;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
@@ -24,6 +25,7 @@ final class RequestContext {
   private final CompletableActorFuture<DirectBuffer> currentFuture;
   private final Supplier<String> nodeAddressSupplier;
   private final int partitionId;
+  private final RequestType requestType;
   private final byte[] requestBytes;
   private final boolean shouldRetry;
   private final long startTime;
@@ -36,6 +38,7 @@ final class RequestContext {
       final CompletableActorFuture<DirectBuffer> currentFuture,
       final Supplier<String> nodeAddressSupplier,
       final int partitionId,
+      final RequestType requestType,
       final byte[] requestBytes,
       final Predicate<DirectBuffer> responseValidator,
       final boolean shouldRetry,
@@ -43,6 +46,7 @@ final class RequestContext {
     this.currentFuture = currentFuture;
     this.nodeAddressSupplier = nodeAddressSupplier;
     this.partitionId = partitionId;
+    this.requestType = requestType;
     this.requestBytes = requestBytes;
     this.shouldRetry = shouldRetry;
     startTime = ActorClock.currentTimeMillis();
@@ -60,7 +64,7 @@ final class RequestContext {
   }
 
   String getTopicName() {
-    return topicName(partitionId);
+    return topicName(partitionId, requestType);
   }
 
   byte[] getRequestBytes() {

--- a/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
@@ -365,6 +365,11 @@ public class AtomixTransportTest {
     }
 
     @Override
+    public RequestType getRequestType() {
+      return RequestType.COMMAND;
+    }
+
+    @Override
     public int getLength() {
       return msg.length();
     }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

No longer assume that that all requests are commands. To handle different command types by different handlers, we can simply subscribe them to a different topic name. Since the request type was already part of the topic name, albeit hardcoded, we could easily swap out the `command-` prefix from the topic name with a new request type value. This also means that the changes are backwards compatible.

The request types themselves are captured in a RequestType enum.

The commits for this PR are structured due to the changes required in the different modules, so note that some early changes (like default interface methods) are removed again later. However, I do recommend reading the commit messages for additional implementation specifics.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7752

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
