### PR TITLE
[Backport stable/1.1] Remove listeners to prevent memory leak

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -71,6 +71,7 @@ import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.ProcessingContext;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
@@ -478,7 +479,7 @@ public final class Broker implements AutoCloseable {
               communicationService, eventService, partitionListener, actor);
 
       final PartitionCommandSenderImpl partitionCommandSender =
-          new PartitionCommandSenderImpl(communicationService, topologyManager, actor);
+          new PartitionCommandSenderImpl(communicationService, partitionListener);
       final SubscriptionCommandSender subscriptionCommandSender =
           new SubscriptionCommandSender(stream.getPartitionId(), partitionCommandSender);
 
@@ -488,13 +489,22 @@ public final class Broker implements AutoCloseable {
       final LongPollingJobNotification jobsAvailableNotification =
           new LongPollingJobNotification(clusterServices.getEventService());
 
-      return EngineProcessors.createEngineProcessors(
-          processingContext,
-          clusterCfg.getPartitionsCount(),
-          subscriptionCommandSender,
-          deploymentDistributor,
-          deploymentRequestHandler,
-          jobsAvailableNotification::onJobsAvailable);
+      final var processor =
+          EngineProcessors.createEngineProcessors(
+              processingContext,
+              clusterCfg.getPartitionsCount(),
+              subscriptionCommandSender,
+              deploymentDistributor,
+              deploymentRequestHandler,
+              jobsAvailableNotification::onJobsAvailable);
+
+      return processor.withListener(
+          new StreamProcessorLifecycleAware() {
+            @Override
+            public void onClose() {
+              topologyManager.removeTopologyPartitionListener(partitionListener);
+            }
+          });
     };
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/PartitionCommandSenderImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/PartitionCommandSenderImpl.java
@@ -9,11 +9,9 @@ package io.camunda.zeebe.broker.engine.impl;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
-import io.camunda.zeebe.broker.clustering.topology.TopologyManager;
 import io.camunda.zeebe.broker.clustering.topology.TopologyPartitionListenerImpl;
 import io.camunda.zeebe.engine.processing.message.command.PartitionCommandSender;
 import io.camunda.zeebe.util.buffer.BufferWriter;
-import io.camunda.zeebe.util.sched.ActorControl;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Int2IntHashMap;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -26,11 +24,9 @@ public final class PartitionCommandSenderImpl implements PartitionCommandSender 
 
   public PartitionCommandSenderImpl(
       final ClusterCommunicationService communicationService,
-      final TopologyManager topologyManager,
-      final ActorControl actor) {
+      final TopologyPartitionListenerImpl partitionListener) {
     this.communicationService = communicationService;
-    partitionListener = new TopologyPartitionListenerImpl(actor);
-    topologyManager.addTopologyPartitionListener(partitionListener);
+    this.partitionListener = partitionListener;
   }
 
   @Override


### PR DESCRIPTION
## Description

This is a backport of #7762 , but only [one commit ](https://github.com/camunda-cloud/zeebe/pull/7762/commits/4459ea19d146a8cb32d108fa93c0b09b1b661f7d)from this PR was relevant for the backport.
