### PR TITLE
Refactor step to start Broker health monitor

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -46,7 +46,6 @@ import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.exception.UncheckedExecutionException;
 import io.camunda.zeebe.util.sched.Actor;
 import io.camunda.zeebe.util.sched.ActorScheduler;
-import io.camunda.zeebe.util.sched.clock.ActorClock;
 import io.netty.util.NetUtil;
 import java.io.File;
 import java.io.IOException;
@@ -84,14 +83,6 @@ public final class Broker implements AutoCloseable {
     brokerContext = systemContext;
     partitionListeners = new ArrayList<>();
     this.springBrokerBridge = springBrokerBridge;
-  }
-
-  public Broker(
-      final BrokerCfg cfg,
-      final String basePath,
-      final ActorClock clock,
-      final SpringBrokerBridge springBrokerBridge) {
-    this(new SystemContext(cfg, basePath, clock), springBrokerBridge);
   }
 
   public void addPartitionListener(final PartitionListener listener) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/AbstractBrokerStartupStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/AbstractBrokerStartupStep.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import static io.camunda.zeebe.util.sched.future.CompletableActorFuture.completedExceptionally;
+
+import io.camunda.zeebe.util.sched.ConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.startup.StartupStep;
+import java.util.function.BiConsumer;
+
+abstract class AbstractBrokerStartupStep implements StartupStep<BrokerStartupContext> {
+
+  @Override
+  public final ActorFuture<BrokerStartupContext> startup(
+      final BrokerStartupContext brokerStartupContext) {
+    return createFutureAndRun(
+        brokerStartupContext,
+        (concurrencyControl, future) ->
+            startupInternal(brokerStartupContext, concurrencyControl, future));
+  }
+
+  @Override
+  public final ActorFuture<BrokerStartupContext> shutdown(
+      final BrokerStartupContext brokerShutdownContext) {
+    return createFutureAndRun(
+        brokerShutdownContext,
+        (concurrencyControl, future) ->
+            shutdownInternal(brokerShutdownContext, concurrencyControl, future));
+  }
+
+  abstract void startupInternal(
+      final BrokerStartupContext brokerStartupContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> startupFuture);
+
+  abstract void shutdownInternal(
+      final BrokerStartupContext brokerShutdownContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> shutdownFuture);
+
+  /**
+   * Helper function that tries to create a future and call a runnable. If an exception is thrown
+   * while creating the future, then this exception is forwarded to a dummy future
+   */
+  final ActorFuture<BrokerStartupContext> createFutureAndRun(
+      final BrokerStartupContext brokerStartupContext,
+      final BiConsumer<ConcurrencyControl, ActorFuture<BrokerStartupContext>> runnable) {
+    try {
+      final var concurrencyControl = brokerStartupContext.getConcurrencyControl();
+      final ActorFuture<BrokerStartupContext> future = concurrencyControl.createFuture();
+
+      forwardExceptions(() -> runnable.accept(concurrencyControl, future), future);
+      return future;
+    } catch (final Throwable t) {
+      return completedExceptionally(t);
+    }
+  }
+  /**
+   * helper function that forwards exceptions thrown by a synchronous block of code to a future
+   * object
+   */
+  final <V> void forwardExceptions(final Runnable r, final ActorFuture<V> future) {
+    try {
+      r.run();
+    } catch (final Throwable t) {
+      future.completeExceptionally(t);
+    }
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/AbstractBrokerStartupStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/AbstractBrokerStartupStep.java
@@ -57,8 +57,8 @@ abstract class AbstractBrokerStartupStep implements StartupStep<BrokerStartupCon
 
       forwardExceptions(() -> runnable.accept(concurrencyControl, future), future);
       return future;
-    } catch (final Throwable t) {
-      return completedExceptionally(t);
+    } catch (final Exception e) {
+      return completedExceptionally(e);
     }
   }
   /**
@@ -68,8 +68,8 @@ abstract class AbstractBrokerStartupStep implements StartupStep<BrokerStartupCon
   final <V> void forwardExceptions(final Runnable r, final ActorFuture<V> future) {
     try {
       r.run();
-    } catch (final Throwable t) {
-      future.completeExceptionally(t);
+    } catch (final Exception e) {
+      future.completeExceptionally(e);
     }
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContext.java
@@ -7,4 +7,13 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
-public interface BrokerContext {}
+import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import java.util.Collection;
+
+public interface BrokerContext {
+
+  BrokerHealthCheckService getHealthCheckService();
+
+  Collection<? extends PartitionListener> getPartitionListeners();
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContext.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import java.util.Collection;
 
+/** Context for components/actors managed directly by the Broker */
 public interface BrokerContext {
 
   BrokerHealthCheckService getHealthCheckService();

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContext.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+public interface BrokerContext {}

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContextImpl.java
@@ -7,4 +7,33 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
-public final class BrokerContextImpl implements BrokerContext {}
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
+
+import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import java.util.Collection;
+import java.util.List;
+
+public final class BrokerContextImpl implements BrokerContext {
+
+  private final BrokerHealthCheckService healthCheckService;
+  private final List<PartitionListener> partitionListeners;
+
+  public BrokerContextImpl(
+      final BrokerHealthCheckService healthCheckService,
+      final List<PartitionListener> partitionListeners) {
+    this.healthCheckService = requireNonNull(healthCheckService);
+    this.partitionListeners = unmodifiableList(requireNonNull(partitionListeners));
+  }
+
+  @Override
+  public BrokerHealthCheckService getHealthCheckService() {
+    return healthCheckService;
+  }
+
+  @Override
+  public Collection<? extends PartitionListener> getPartitionListeners() {
+    return partitionListeners;
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContextImpl.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+public final class BrokerContextImpl implements BrokerContext {}

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+public interface BrokerStartupContext {}

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -16,6 +16,11 @@ import io.camunda.zeebe.util.sched.ConcurrencyControl;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import java.util.List;
 
+/**
+ * Context that is utilized during broker startup and shutdown process. It contains dependencies
+ * that are needed during the startup/shutdown. It is a modifiable context and will be updated
+ * during startup or shutdown.
+ */
 public interface BrokerStartupContext {
 
   BrokerInfo getBrokerInfo();

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -28,8 +28,6 @@ public interface BrokerStartupContext {
 
   BrokerHealthCheckService getHealthCheckService();
 
-  void setHealthCheckService(BrokerHealthCheckService healthCheckService);
-
   void addPartitionListener(PartitionListener partitionListener);
 
   void removePartitionListener(PartitionListener partitionListener);

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -7,4 +7,32 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
-public interface BrokerStartupContext {}
+import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.SpringBrokerBridge;
+import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.camunda.zeebe.util.sched.Actor;
+import io.camunda.zeebe.util.sched.ConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import java.util.List;
+
+public interface BrokerStartupContext {
+
+  BrokerInfo getBrokerInfo();
+
+  SpringBrokerBridge getSpringBrokerBridge();
+
+  ConcurrencyControl getConcurrencyControl();
+
+  ActorFuture<Void> scheduleActor(Actor actor);
+
+  BrokerHealthCheckService getHealthCheckService();
+
+  void setHealthCheckService(BrokerHealthCheckService healthCheckService);
+
+  void addPartitionListener(PartitionListener partitionListener);
+
+  void removePartitionListener(PartitionListener partitionListener);
+
+  List<PartitionListener> getPartitionListeners();
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+public class BrokerStartupContextImpl implements BrokerStartupContext {}

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
+import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.broker.PartitionListener;
@@ -28,17 +29,20 @@ public class BrokerStartupContextImpl implements BrokerStartupContext {
   private final ActorSchedulingService actorSchedulingService;
   private final List<PartitionListener> partitionListeners = new ArrayList<>();
 
-  private BrokerHealthCheckService healthCheckService;
+  private final BrokerHealthCheckService healthCheckService;
 
   public BrokerStartupContextImpl(
       final BrokerInfo brokerInfo,
       final SpringBrokerBridge springBrokerBridge,
       final ConcurrencyControl concurrencyControl,
-      final ActorSchedulingService actorSchedulingService) {
-    this.brokerInfo = brokerInfo;
-    this.springBrokerBridge = springBrokerBridge;
-    this.concurrencyControl = concurrencyControl;
-    this.actorSchedulingService = actorSchedulingService;
+      final ActorSchedulingService actorSchedulingService,
+      final BrokerHealthCheckService healthCheckService) {
+
+    this.brokerInfo = requireNonNull(brokerInfo);
+    this.springBrokerBridge = requireNonNull(springBrokerBridge);
+    this.concurrencyControl = requireNonNull(concurrencyControl);
+    this.actorSchedulingService = requireNonNull(actorSchedulingService);
+    this.healthCheckService = requireNonNull(healthCheckService);
   }
 
   @Override
@@ -67,11 +71,6 @@ public class BrokerStartupContextImpl implements BrokerStartupContext {
   }
 
   @Override
-  public void setHealthCheckService(final BrokerHealthCheckService healthCheckService) {
-    this.healthCheckService = healthCheckService;
-  }
-
-  @Override
   public void addPartitionListener(final PartitionListener listener) {
     partitionListeners.add(requireNonNull(listener));
   }
@@ -83,6 +82,6 @@ public class BrokerStartupContextImpl implements BrokerStartupContext {
 
   @Override
   public List<PartitionListener> getPartitionListeners() {
-    return partitionListeners;
+    return unmodifiableList(partitionListeners);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.util.sched.future.ActorFuture;
 import java.util.ArrayList;
 import java.util.List;
 
-public class BrokerStartupContextImpl implements BrokerStartupContext {
+public final class BrokerStartupContextImpl implements BrokerStartupContext {
 
   private final BrokerInfo brokerInfo;
   private final SpringBrokerBridge springBrokerBridge;

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -20,27 +20,27 @@ import io.camunda.zeebe.util.sched.ConcurrencyControl;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public final class BrokerStartupContextImpl implements BrokerStartupContext {
 
   private final BrokerInfo brokerInfo;
   private final SpringBrokerBridge springBrokerBridge;
-  private final ConcurrencyControl concurrencyControl;
   private final ActorSchedulingService actorSchedulingService;
   private final List<PartitionListener> partitionListeners = new ArrayList<>();
+
+  private ConcurrencyControl concurrencyControl;
 
   private final BrokerHealthCheckService healthCheckService;
 
   public BrokerStartupContextImpl(
       final BrokerInfo brokerInfo,
       final SpringBrokerBridge springBrokerBridge,
-      final ConcurrencyControl concurrencyControl,
       final ActorSchedulingService actorSchedulingService,
       final BrokerHealthCheckService healthCheckService) {
 
     this.brokerInfo = requireNonNull(brokerInfo);
     this.springBrokerBridge = requireNonNull(springBrokerBridge);
-    this.concurrencyControl = requireNonNull(concurrencyControl);
     this.actorSchedulingService = requireNonNull(actorSchedulingService);
     this.healthCheckService = requireNonNull(healthCheckService);
   }
@@ -58,6 +58,10 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public ConcurrencyControl getConcurrencyControl() {
     return concurrencyControl;
+  }
+
+  public void setConcurrencyControl(final ConcurrencyControl concurrencyControl) {
+    this.concurrencyControl = Objects.requireNonNull(concurrencyControl);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -7,4 +7,82 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
-public class BrokerStartupContextImpl implements BrokerStartupContext {}
+import static java.util.Objects.requireNonNull;
+
+import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.SpringBrokerBridge;
+import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.camunda.zeebe.util.sched.Actor;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
+import io.camunda.zeebe.util.sched.ConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BrokerStartupContextImpl implements BrokerStartupContext {
+
+  private final BrokerInfo brokerInfo;
+  private final SpringBrokerBridge springBrokerBridge;
+  private final ConcurrencyControl concurrencyControl;
+  private final ActorSchedulingService actorSchedulingService;
+  private final List<PartitionListener> partitionListeners = new ArrayList<>();
+
+  private BrokerHealthCheckService healthCheckService;
+
+  public BrokerStartupContextImpl(
+      final BrokerInfo brokerInfo,
+      final SpringBrokerBridge springBrokerBridge,
+      final ConcurrencyControl concurrencyControl,
+      final ActorSchedulingService actorSchedulingService) {
+    this.brokerInfo = brokerInfo;
+    this.springBrokerBridge = springBrokerBridge;
+    this.concurrencyControl = concurrencyControl;
+    this.actorSchedulingService = actorSchedulingService;
+  }
+
+  @Override
+  public BrokerInfo getBrokerInfo() {
+    return brokerInfo;
+  }
+
+  @Override
+  public SpringBrokerBridge getSpringBrokerBridge() {
+    return springBrokerBridge;
+  }
+
+  @Override
+  public ConcurrencyControl getConcurrencyControl() {
+    return concurrencyControl;
+  }
+
+  @Override
+  public ActorFuture<Void> scheduleActor(final Actor actor) {
+    return actorSchedulingService.submitActor(actor);
+  }
+
+  @Override
+  public BrokerHealthCheckService getHealthCheckService() {
+    return healthCheckService;
+  }
+
+  @Override
+  public void setHealthCheckService(final BrokerHealthCheckService healthCheckService) {
+    this.healthCheckService = healthCheckService;
+  }
+
+  @Override
+  public void addPartitionListener(final PartitionListener listener) {
+    partitionListeners.add(requireNonNull(listener));
+  }
+
+  @Override
+  public void removePartitionListener(final PartitionListener listener) {
+    partitionListeners.remove(requireNonNull(listener));
+  }
+
+  @Override
+  public List<PartitionListener> getPartitionListeners() {
+    return partitionListeners;
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
+
+import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.util.sched.ConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.startup.StartupProcess;
+import org.slf4j.Logger;
+
+public final class BrokerStartupProcess {
+
+  public static final Logger LOG = Loggers.SYSTEM_LOGGER;
+
+  private final ConcurrencyControl concurrencyControl;
+
+  private final StartupProcess<BrokerStartupContext> startupProcess =
+      new StartupProcess<>(LOG, emptyList());
+
+  public BrokerStartupProcess(final ConcurrencyControl concurrencyControl) {
+    this.concurrencyControl = requireNonNull(concurrencyControl);
+  }
+
+  public ActorFuture<BrokerContext> start() {
+    final ActorFuture<BrokerContext> result = concurrencyControl.createFuture();
+
+    final var startupContext = new BrokerStartupContextImpl();
+
+    final var startupFuture = startupProcess.startup(concurrencyControl, startupContext);
+
+    concurrencyControl.runOnCompletion(
+        startupFuture,
+        (bsc, error) -> {
+          if (error != null) {
+            result.completeExceptionally(error);
+          } else {
+            result.complete(createBrokerContext(bsc));
+          }
+        });
+    return result;
+  }
+
+  public ActorFuture<Void> stop() {
+    final ActorFuture<Void> result = concurrencyControl.createFuture();
+
+    final var shutdownContext = new BrokerStartupContextImpl();
+
+    final var startupFuture = startupProcess.shutdown(concurrencyControl, shutdownContext);
+
+    concurrencyControl.runOnCompletion(
+        startupFuture,
+        (bsc, error) -> {
+          if (error != null) {
+            result.completeExceptionally(error);
+          } else {
+            result.complete(null);
+          }
+        });
+    return result;
+  }
+
+  private BrokerContext createBrokerContext(final BrokerStartupContext bsc) {
+    return new BrokerContextImpl();
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -7,12 +7,7 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
-import static java.util.Objects.requireNonNull;
-
 import io.camunda.zeebe.broker.Loggers;
-import io.camunda.zeebe.broker.SpringBrokerBridge;
-import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
-import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import io.camunda.zeebe.util.sched.ConcurrencyControl;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.startup.StartupProcess;
@@ -23,32 +18,18 @@ public final class BrokerStartupProcess {
 
   public static final Logger LOG = Loggers.SYSTEM_LOGGER;
 
-  private final BrokerInfo brokerInfo;
-  private final SpringBrokerBridge springBrokerBridge;
-  private final ConcurrencyControl concurrencyControl;
-  private final ActorSchedulingService actorSchedulingService;
-
   private final StartupProcess<BrokerStartupContext> startupProcess =
       new StartupProcess<>(LOG, List.of(new MonitoringServerStep()));
   private BrokerStartupContext context;
+  private final ConcurrencyControl concurrencyControl;
 
-  public BrokerStartupProcess(
-      final BrokerInfo brokerInfo,
-      final SpringBrokerBridge springBrokerBridge,
-      final ConcurrencyControl concurrencyControl,
-      final ActorSchedulingService actorSchedulingService) {
-    this.brokerInfo = brokerInfo;
-    this.springBrokerBridge = springBrokerBridge;
-    this.concurrencyControl = requireNonNull(concurrencyControl);
-    this.actorSchedulingService = actorSchedulingService;
+  public BrokerStartupProcess(final BrokerStartupContext brokerStartupContext) {
+    concurrencyControl = brokerStartupContext.getConcurrencyControl();
+    context = brokerStartupContext;
   }
 
   public ActorFuture<BrokerContext> start() {
     final ActorFuture<BrokerContext> result = concurrencyControl.createFuture();
-
-    context =
-        new BrokerStartupContextImpl(
-            brokerInfo, springBrokerBridge, concurrencyControl, actorSchedulingService);
 
     final var startupFuture = startupProcess.startup(concurrencyControl, context);
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStepMetricDecorator.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStepMetricDecorator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import static java.util.Objects.requireNonNull;
+
+import io.camunda.zeebe.broker.system.monitoring.BrokerStepMetrics;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
+import io.camunda.zeebe.util.startup.StartupStep;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+/**
+ * Decorator that measures the execution time of a step and updated metrics accordingly. Note that
+ * this decorator cannot measure directly the time between the start and the end of the step.
+ * Instead, it measures the time between the start of the step and whenever the followup task to
+ * update the metrics gets executed.
+ */
+final class BrokerStepMetricDecorator implements StartupStep<BrokerStartupContext> {
+
+  private final BrokerStepMetrics brokerStepMetrics;
+  private final StartupStep<BrokerStartupContext> delegate;
+
+  BrokerStepMetricDecorator(
+      final BrokerStepMetrics brokerStepMetrics, final StartupStep<BrokerStartupContext> delegate) {
+    this.brokerStepMetrics = requireNonNull(brokerStepMetrics);
+    this.delegate = requireNonNull(delegate);
+  }
+
+  @Override
+  public String getName() {
+    return delegate.getName();
+  }
+
+  @Override
+  public ActorFuture<BrokerStartupContext> startup(
+      final BrokerStartupContext brokerStartupContext) {
+    return callDelegateAndUpdateMetrics(
+        brokerStartupContext, delegate::startup, brokerStepMetrics::observeDurationForStarStep);
+  }
+
+  @Override
+  public ActorFuture<BrokerStartupContext> shutdown(
+      final BrokerStartupContext brokerStartupContext) {
+    return callDelegateAndUpdateMetrics(
+        brokerStartupContext, delegate::shutdown, brokerStepMetrics::observeDurationForCloseStep);
+  }
+
+  private ActorFuture<BrokerStartupContext> callDelegateAndUpdateMetrics(
+      final BrokerStartupContext brokerStartupContext,
+      final Function<BrokerStartupContext, ActorFuture<BrokerStartupContext>> functionToCall,
+      final BiConsumer<String, Long> metricUpdater) {
+    try {
+      final long startTime = System.currentTimeMillis();
+
+      final var concurrencyControl = brokerStartupContext.getConcurrencyControl();
+      final var future = functionToCall.apply(brokerStartupContext);
+      concurrencyControl.runOnCompletion(
+          future,
+          (nil, error) -> {
+            final long durationStepStarting = System.currentTimeMillis() - startTime;
+            metricUpdater.accept(delegate.getName(), durationStepStarting);
+          });
+
+      return future;
+    } catch (final Throwable t) {
+      return CompletableActorFuture.completedExceptionally(t);
+    }
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStepMetricDecorator.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStepMetricDecorator.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
+import static io.camunda.zeebe.util.sched.future.CompletableActorFuture.completedExceptionally;
 import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.broker.system.monitoring.BrokerStepMetrics;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
-import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import io.camunda.zeebe.util.startup.StartupStep;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -56,6 +56,7 @@ final class BrokerStepMetricDecorator implements StartupStep<BrokerStartupContex
       final BrokerStartupContext brokerStartupContext,
       final Function<BrokerStartupContext, ActorFuture<BrokerStartupContext>> functionToCall,
       final BiConsumer<String, Long> metricUpdater) {
+
     try {
       final long startTime = System.currentTimeMillis();
 
@@ -70,7 +71,7 @@ final class BrokerStepMetricDecorator implements StartupStep<BrokerStartupContex
 
       return future;
     } catch (final Throwable t) {
-      return CompletableActorFuture.completedExceptionally(t);
+      return completedExceptionally(t);
     }
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/MonitoringServerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/MonitoringServerStep.java
@@ -23,8 +23,6 @@ final class MonitoringServerStep extends AbstractBrokerStartupStep {
       final BrokerStartupContext brokerStartupContext,
       final ConcurrencyControl concurrencyControl,
       final ActorFuture<BrokerStartupContext> startupFuture) {
-    final var brokerInfo = brokerStartupContext.getBrokerInfo();
-
     final var healthCheckService = brokerStartupContext.getHealthCheckService();
     concurrencyControl.runOnCompletion(
         brokerStartupContext.scheduleActor(healthCheckService),

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/MonitoringServerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/MonitoringServerStep.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import static io.camunda.zeebe.util.sched.future.CompletableActorFuture.completedExceptionally;
+
+import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.util.sched.ConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.startup.StartupStep;
+import java.util.function.BiConsumer;
+
+final class MonitoringServerStep implements StartupStep<BrokerStartupContext> {
+
+  @Override
+  public String getName() {
+    return "monitoring services";
+  }
+
+  @Override
+  public ActorFuture<BrokerStartupContext> startup(
+      final BrokerStartupContext brokerStartupContext) {
+    return createFutureAndRun(
+        brokerStartupContext,
+        (concurrencyControl, future) ->
+            startupInternal(brokerStartupContext, concurrencyControl, future));
+  }
+
+  @Override
+  public ActorFuture<BrokerStartupContext> shutdown(
+      final BrokerStartupContext brokerShutdownContext) {
+    return createFutureAndRun(
+        brokerShutdownContext,
+        (concurrencyControl, future) ->
+            shutdownInternal(brokerShutdownContext, concurrencyControl, future));
+  }
+
+  private void startupInternal(
+      final BrokerStartupContext brokerStartupContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> startupFuture) {
+    final var brokerInfo = brokerStartupContext.getBrokerInfo();
+
+    final var healthCheckService = new BrokerHealthCheckService(brokerInfo);
+
+    concurrencyControl.runOnCompletion(
+        brokerStartupContext.scheduleActor(healthCheckService),
+        (nil, error) ->
+            forwardExceptions(
+                () ->
+                    completeStartup(brokerStartupContext, startupFuture, healthCheckService, error),
+                startupFuture));
+  }
+
+  private void completeStartup(
+      final BrokerStartupContext brokerStartupContext,
+      final ActorFuture<BrokerStartupContext> startupFuture,
+      final BrokerHealthCheckService healthCheckService,
+      final Throwable error) {
+    if (error != null) {
+      startupFuture.completeExceptionally(error);
+    } else {
+      final var springBrokerBridge = brokerStartupContext.getSpringBrokerBridge();
+      springBrokerBridge.registerBrokerHealthCheckServiceSupplier(() -> healthCheckService);
+      brokerStartupContext.addPartitionListener(healthCheckService);
+      brokerStartupContext.setHealthCheckService(healthCheckService);
+      startupFuture.complete(brokerStartupContext);
+    }
+  }
+
+  private void shutdownInternal(
+      final BrokerStartupContext brokerShutdownContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> shutdownFuture) {
+    final var healthCheckService = brokerShutdownContext.getHealthCheckService();
+
+    brokerShutdownContext.removePartitionListener(healthCheckService);
+    concurrencyControl.runOnCompletion(
+        healthCheckService.closeAsync(),
+        (nil, error) ->
+            forwardExceptions(
+                () -> completeShutDown(brokerShutdownContext, shutdownFuture, error),
+                shutdownFuture));
+  }
+
+  private void completeShutDown(
+      final BrokerStartupContext brokerShutdownContext,
+      final ActorFuture<BrokerStartupContext> shutdownFuture,
+      final Throwable error) {
+    if (error != null) {
+      shutdownFuture.completeExceptionally(error);
+    } else {
+      try {
+        brokerShutdownContext.setHealthCheckService(null);
+      } finally {
+        shutdownFuture.complete(brokerShutdownContext);
+      }
+    }
+  }
+
+  /**
+   * Helper function that tries to create a future and call a runnable. If an exception is thrown
+   * while creating the future, then this exception is forwarded to a dummy future
+   */
+  private ActorFuture<BrokerStartupContext> createFutureAndRun(
+      final BrokerStartupContext brokerStartupContext,
+      final BiConsumer<ConcurrencyControl, ActorFuture<BrokerStartupContext>> runnable) {
+    try {
+      final var concurrencyControl = brokerStartupContext.getConcurrencyControl();
+      final ActorFuture<BrokerStartupContext> future = concurrencyControl.createFuture();
+
+      forwardExceptions(() -> runnable.accept(concurrencyControl, future), future);
+      return future;
+    } catch (final Throwable t) {
+      return completedExceptionally(t);
+    }
+  }
+  /**
+   * helper function that forwards exceptions thrown by a synchronous block of code to a future
+   * object
+   */
+  private <V> void forwardExceptions(final Runnable r, final ActorFuture<V> future) {
+    try {
+      r.run();
+    } catch (final Throwable t) {
+      future.completeExceptionally(t);
+    }
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/MonitoringServerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/MonitoringServerStep.java
@@ -26,7 +26,7 @@ final class MonitoringServerStep extends AbstractBrokerStartupStep {
     final var healthCheckService = brokerStartupContext.getHealthCheckService();
     concurrencyControl.runOnCompletion(
         brokerStartupContext.scheduleActor(healthCheckService),
-        (nil, error) ->
+        (ok, error) ->
             forwardExceptions(
                 () ->
                     completeStartup(brokerStartupContext, startupFuture, healthCheckService, error),
@@ -45,7 +45,7 @@ final class MonitoringServerStep extends AbstractBrokerStartupStep {
     brokerShutdownContext.removePartitionListener(healthCheckService);
     concurrencyControl.runOnCompletion(
         healthCheckService.closeAsync(),
-        (nil, error) ->
+        (ok, error) ->
             forwardExceptions(
                 () -> {
                   if (error != null) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/MonitoringServerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/MonitoringServerStep.java
@@ -7,15 +7,11 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
-import static io.camunda.zeebe.util.sched.future.CompletableActorFuture.completedExceptionally;
-
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.util.sched.ConcurrencyControl;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
-import io.camunda.zeebe.util.startup.StartupStep;
-import java.util.function.BiConsumer;
 
-final class MonitoringServerStep implements StartupStep<BrokerStartupContext> {
+final class MonitoringServerStep extends AbstractBrokerStartupStep {
 
   @Override
   public String getName() {
@@ -23,24 +19,7 @@ final class MonitoringServerStep implements StartupStep<BrokerStartupContext> {
   }
 
   @Override
-  public ActorFuture<BrokerStartupContext> startup(
-      final BrokerStartupContext brokerStartupContext) {
-    return createFutureAndRun(
-        brokerStartupContext,
-        (concurrencyControl, future) ->
-            startupInternal(brokerStartupContext, concurrencyControl, future));
-  }
-
-  @Override
-  public ActorFuture<BrokerStartupContext> shutdown(
-      final BrokerStartupContext brokerShutdownContext) {
-    return createFutureAndRun(
-        brokerShutdownContext,
-        (concurrencyControl, future) ->
-            shutdownInternal(brokerShutdownContext, concurrencyControl, future));
-  }
-
-  private void startupInternal(
+  void startupInternal(
       final BrokerStartupContext brokerStartupContext,
       final ConcurrencyControl concurrencyControl,
       final ActorFuture<BrokerStartupContext> startupFuture) {
@@ -56,22 +35,8 @@ final class MonitoringServerStep implements StartupStep<BrokerStartupContext> {
                 startupFuture));
   }
 
-  private void completeStartup(
-      final BrokerStartupContext brokerStartupContext,
-      final ActorFuture<BrokerStartupContext> startupFuture,
-      final BrokerHealthCheckService healthCheckService,
-      final Throwable error) {
-    if (error != null) {
-      startupFuture.completeExceptionally(error);
-    } else {
-      final var springBrokerBridge = brokerStartupContext.getSpringBrokerBridge();
-      springBrokerBridge.registerBrokerHealthCheckServiceSupplier(() -> healthCheckService);
-      brokerStartupContext.addPartitionListener(healthCheckService);
-      startupFuture.complete(brokerStartupContext);
-    }
-  }
-
-  private void shutdownInternal(
+  @Override
+  void shutdownInternal(
       final BrokerStartupContext brokerShutdownContext,
       final ConcurrencyControl concurrencyControl,
       final ActorFuture<BrokerStartupContext> shutdownFuture) {
@@ -94,32 +59,18 @@ final class MonitoringServerStep implements StartupStep<BrokerStartupContext> {
                 shutdownFuture));
   }
 
-  /**
-   * Helper function that tries to create a future and call a runnable. If an exception is thrown
-   * while creating the future, then this exception is forwarded to a dummy future
-   */
-  private ActorFuture<BrokerStartupContext> createFutureAndRun(
+  private void completeStartup(
       final BrokerStartupContext brokerStartupContext,
-      final BiConsumer<ConcurrencyControl, ActorFuture<BrokerStartupContext>> runnable) {
-    try {
-      final var concurrencyControl = brokerStartupContext.getConcurrencyControl();
-      final ActorFuture<BrokerStartupContext> future = concurrencyControl.createFuture();
-
-      forwardExceptions(() -> runnable.accept(concurrencyControl, future), future);
-      return future;
-    } catch (final Throwable t) {
-      return completedExceptionally(t);
-    }
-  }
-  /**
-   * helper function that forwards exceptions thrown by a synchronous block of code to a future
-   * object
-   */
-  private <V> void forwardExceptions(final Runnable r, final ActorFuture<V> future) {
-    try {
-      r.run();
-    } catch (final Throwable t) {
-      future.completeExceptionally(t);
+      final ActorFuture<BrokerStartupContext> startupFuture,
+      final BrokerHealthCheckService healthCheckService,
+      final Throwable error) {
+    if (error != null) {
+      startupFuture.completeExceptionally(error);
+    } else {
+      final var springBrokerBridge = brokerStartupContext.getSpringBrokerBridge();
+      springBrokerBridge.registerBrokerHealthCheckServiceSupplier(() -> healthCheckService);
+      brokerStartupContext.addPartitionListener(healthCheckService);
+      startupFuture.complete(brokerStartupContext);
     }
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -175,12 +175,12 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
       closeFuture =
           CompletableFuture.runAsync(this::stopPartitions)
               .whenComplete(
-                  (nil, error) -> {
+                  (ok, error) -> {
                     logErrorIfApplicable(error);
                     partitionService.stop().join();
                   })
               .whenComplete(
-                  (nil, error) -> {
+                  (ok, error) -> {
                     logErrorIfApplicable(error);
                     partitionGroup = null;
                     partitionService = null;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerStepMetrics.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerStepMetrics.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.monitoring;
 
 import io.prometheus.client.Gauge;
+import io.prometheus.client.Gauge.Timer;
 
 public class BrokerStepMetrics {
 
@@ -35,8 +36,16 @@ public class BrokerStepMetrics {
    * @param stepName the name of the step
    * @param startupDuration the step start duration in ms
    */
-  public void observeDurationForStarStep(String stepName, long startupDuration) {
+  public void observeDurationForStarStep(final String stepName, final long startupDuration) {
     STARTUP_METRIC.labels(stepName).set(startupDuration);
+  }
+
+  public Timer createStartupTimer(final String stepName) {
+    return STARTUP_METRIC.labels(stepName).startTimer();
+  }
+
+  public Timer createCloseTimer(final String stepName) {
+    return CLOSE_METRICS.labels(stepName).startTimer();
   }
 
   /**
@@ -45,7 +54,7 @@ public class BrokerStepMetrics {
    * @param stepName the name of the step
    * @param closeDuration the step close duration in ms
    */
-  public void observeDurationForCloseStep(String stepName, long closeDuration) {
+  public void observeDurationForCloseStep(final String stepName, final long closeDuration) {
     CLOSE_METRICS.labels(stepName).set(closeDuration);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
@@ -38,8 +38,8 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
           try {
             adminControl.triggerSnapshot();
             completed.complete(null);
-          } catch (final Throwable t) {
-            completed.completeExceptionally(t);
+          } catch (final Exception e) {
+            completed.completeExceptionally(e);
           }
         });
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
@@ -85,7 +85,7 @@ public final class NewPartitionTransitionImpl implements PartitionTransition {
             // has completed
             concurrencyControl.runOnCompletion(
                 currentTransitionFuture,
-                (nil, error) -> cleanupLastTransition(nextTransitionFuture, term, role));
+                (ok, error) -> cleanupLastTransition(nextTransitionFuture, term, role));
 
           } else {
             cleanupLastTransition(nextTransitionFuture, term, role);
@@ -102,7 +102,7 @@ public final class NewPartitionTransitionImpl implements PartitionTransition {
       final var cleanupFuture = lastTransition.cleanup(term, role);
       concurrencyControl.runOnCompletion(
           cleanupFuture,
-          (nil, error) -> {
+          (ok, error) -> {
             if (error != null) {
               LOG.error(
                   String.format("Error during transition clean up: %s", error.getMessage()), error);
@@ -123,7 +123,7 @@ public final class NewPartitionTransitionImpl implements PartitionTransition {
     currentTransitionFuture = nextTransitionFuture;
     concurrencyControl.runOnCompletion(
         currentTransitionFuture,
-        (nil, error) -> {
+        (ok, error) -> {
           lastTransition = currentTransition;
           currentTransition = null;
           currentTransitionFuture = null;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -75,7 +75,7 @@ final class PartitionTransitionProcess {
 
           nextStep
               .transitionTo(context, term, role)
-              .onComplete((nil, error) -> onStepCompletion(future, error));
+              .onComplete((ok, error) -> onStepCompletion(future, error));
         });
   }
 
@@ -126,7 +126,7 @@ final class PartitionTransitionProcess {
 
           nextCleanupStep
               .prepareTransition(context, newTerm, newRole)
-              .onComplete((nil, error) -> onCleanupStepCompletion(future, error, newTerm, newRole));
+              .onComplete((ok, error) -> onCleanupStepCompletion(future, error, newTerm, newRole));
         });
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -86,10 +86,12 @@ public final class SimpleBrokerStartTest {
         });
 
     // when
+    systemContext.getScheduler().start();
     broker.start().join();
 
     // then
     leaderLatch.await();
     broker.close();
+    systemContext.getScheduler().stop().get();
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker;
 import static io.camunda.zeebe.broker.test.EmbeddedBrokerRule.assignSocketAddresses;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
@@ -41,14 +42,14 @@ public final class SimpleBrokerStartTest {
     brokerCfg.getData().setSnapshotPeriod(Duration.ofMillis(1));
 
     // when
+
     final var catchedThrownBy =
         assertThatThrownBy(
-            () ->
-                new Broker(
-                    brokerCfg,
-                    newTemporaryFolder.getAbsolutePath(),
-                    null,
-                    TEST_SPRING_BROKER_BRIDGE));
+            () -> {
+              final var systemContext =
+                  new SystemContext(brokerCfg, newTemporaryFolder.getAbsolutePath(), null);
+              new Broker(systemContext, TEST_SPRING_BROKER_BRIDGE);
+            });
 
     // then
     catchedThrownBy.isInstanceOf(IllegalArgumentException.class);
@@ -59,10 +60,10 @@ public final class SimpleBrokerStartTest {
     // given
     final var brokerCfg = new BrokerCfg();
     assignSocketAddresses(brokerCfg);
+    final var systemContext =
+        new SystemContext(brokerCfg, newTemporaryFolder.getAbsolutePath(), null);
 
-    final var broker =
-        new Broker(
-            brokerCfg, newTemporaryFolder.getAbsolutePath(), null, TEST_SPRING_BROKER_BRIDGE);
+    final var broker = new Broker(systemContext, TEST_SPRING_BROKER_BRIDGE);
     final var leaderLatch = new CountDownLatch(1);
     broker.addPartitionListener(
         new PartitionListener() {

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/BrokerStepMetricDecoratorTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/BrokerStepMetricDecoratorTest.java
@@ -16,7 +16,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.broker.system.monitoring.BrokerStepMetrics;
-import io.camunda.zeebe.util.sched.ConcurrencyControl;
 import io.camunda.zeebe.util.sched.TestConcurrencyControl;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.startup.StartupStep;
@@ -25,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 class BrokerStepMetricDecoratorTest {
 
-  private static final ConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
+  private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
   private static final String DELEGATE_STEP_NAME = "delegate step";
 
   private BrokerStartupContext mockBrokerStartupContext;

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/BrokerStepMetricDecoratorTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/BrokerStepMetricDecoratorTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.broker.system.monitoring.BrokerStepMetrics;
+import io.camunda.zeebe.util.sched.ConcurrencyControl;
+import io.camunda.zeebe.util.sched.TestConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.startup.StartupStep;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BrokerStepMetricDecoratorTest {
+
+  private static final ConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
+  private static final String DELEGATE_STEP_NAME = "delegate step";
+
+  private BrokerStartupContext mockBrokerStartupContext;
+  private BrokerStepMetrics mockBrokerStepMetrics;
+  private StartupStep<BrokerStartupContext> mockStep;
+  private BrokerStepMetricDecorator sut;
+  private ActorFuture<BrokerStartupContext> startupFuture;
+  private ActorFuture<BrokerStartupContext> shutdownFuture;
+
+  @BeforeEach
+  void setUp() {
+    mockBrokerStepMetrics = mock(BrokerStepMetrics.class);
+
+    mockBrokerStartupContext = mock(BrokerStartupContext.class);
+    when(mockBrokerStartupContext.getConcurrencyControl()).thenReturn(CONCURRENCY_CONTROL);
+
+    startupFuture = CONCURRENCY_CONTROL.createFuture();
+    shutdownFuture = CONCURRENCY_CONTROL.createFuture();
+
+    mockStep = mock(StartupStep.class);
+    when(mockStep.startup(mockBrokerStartupContext)).thenReturn(startupFuture);
+    when(mockStep.shutdown(mockBrokerStartupContext)).thenReturn(shutdownFuture);
+    when(mockStep.getName()).thenReturn(DELEGATE_STEP_NAME);
+
+    sut = new BrokerStepMetricDecorator(mockBrokerStepMetrics, mockStep);
+  }
+
+  @Test
+  void shouldCallStartupOnDelegate() {
+    // when
+    sut.startup(mockBrokerStartupContext);
+
+    // then
+    verify(mockStep).startup(mockBrokerStartupContext);
+    verifyNoMoreInteractions(mockStep);
+  }
+
+  @Test
+  void shouldCallShutdownOnDelegate() {
+    // when
+    sut.shutdown(mockBrokerStartupContext);
+
+    // then
+    verify(mockStep).shutdown(mockBrokerStartupContext);
+    verifyNoMoreInteractions(mockStep);
+  }
+
+  @Test
+  void shouldUpdateStartStepDuration() {
+    // when
+    sut.startup(mockBrokerStartupContext);
+    startupFuture.complete(mockBrokerStartupContext);
+
+    // then
+    verify(mockBrokerStepMetrics).observeDurationForStarStep(eq(DELEGATE_STEP_NAME), anyLong());
+    verifyNoMoreInteractions(mockBrokerStepMetrics);
+  }
+
+  @Test
+  void shouldUpdateShutdownStepDuration() {
+    // when
+    sut.shutdown(mockBrokerStartupContext);
+    shutdownFuture.complete(mockBrokerStartupContext);
+
+    // then
+    verify(mockBrokerStepMetrics).observeDurationForCloseStep(eq(DELEGATE_STEP_NAME), anyLong());
+    verifyNoMoreInteractions(mockBrokerStepMetrics);
+  }
+
+  @Test
+  void shouldReturnNameOfDelegate() {
+    // when
+    final var actual = sut.getName();
+
+    // then
+    assertThat(actual).isEqualTo(DELEGATE_STEP_NAME);
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MonitoringServerStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MonitoringServerStepTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.broker.SpringBrokerBridge;
+import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.util.sched.TestConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+public class MonitoringServerStepTest {
+  private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
+
+  private SpringBrokerBridge mockSpringBrokerBridge;
+  private BrokerStartupContext mockBrokerStartupContext;
+  private BrokerHealthCheckService mockHealthCheckService;
+
+  private ActorFuture<BrokerStartupContext> future;
+
+  private final MonitoringServerStep sut = new MonitoringServerStep();
+
+  @BeforeEach
+  void setUp() {
+    mockSpringBrokerBridge = mock(SpringBrokerBridge.class);
+    mockBrokerStartupContext = mock(BrokerStartupContext.class);
+
+    mockHealthCheckService = mock(BrokerHealthCheckService.class);
+    when(mockHealthCheckService.closeAsync()).thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
+
+    when(mockBrokerStartupContext.getConcurrencyControl()).thenReturn(CONCURRENCY_CONTROL);
+    when(mockBrokerStartupContext.getSpringBrokerBridge()).thenReturn(mockSpringBrokerBridge);
+    when(mockBrokerStartupContext.getHealthCheckService()).thenReturn(mockHealthCheckService);
+
+    when(mockBrokerStartupContext.scheduleActor(Mockito.any()))
+        .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
+
+    future = CONCURRENCY_CONTROL.createFuture();
+  }
+
+  @Test
+  void shouldCompleteFutureOnStartup() {
+    // when
+    sut.startupInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isFalse();
+  }
+
+  @Test
+  void shouldScheduleHealthMonitorActorOnStartup() {
+    // when
+    sut.startupInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+
+    // then
+    verify(mockBrokerStartupContext).scheduleActor(mockHealthCheckService);
+  }
+
+  @Test
+  void shouldRegisterHealthMonitorAsPartitionListenerOnStartup() {
+    // when
+    sut.startupInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+
+    // then
+    verify(mockBrokerStartupContext).addPartitionListener(mockHealthCheckService);
+  }
+
+  @Test
+  void shouldRegisterHealthMonitorInSpringBrokerBridgeOnStartup() {
+    // when
+    sut.startupInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+
+    // then
+    final var argumentCaptor = ArgumentCaptor.forClass(Supplier.class);
+    verify(mockSpringBrokerBridge)
+        .registerBrokerHealthCheckServiceSupplier(argumentCaptor.capture());
+
+    assertThat(argumentCaptor.getValue().get()).isSameAs(mockHealthCheckService);
+  }
+
+  @Test
+  void shouldCompleteFutureOnShutdown() {
+    // when
+    sut.shutdownInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isFalse();
+  }
+
+  @Test
+  void shouldStopHealthCheckServiceOnShutdown() {
+    // when
+    sut.shutdownInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+
+    // then
+    verify(mockHealthCheckService).closeAsync();
+  }
+
+  @Test
+  void shouldUnregisterHealthCheckServiceAsPartitionListenerOnShutdown() {
+    // when
+    sut.shutdownInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+
+    // then
+    verify(mockBrokerStartupContext).removePartitionListener(mockHealthCheckService);
+  }
+
+  @Test
+  void shouldUnregisterHealthMonitorInSpringBrokerBridgeOnStartup() {
+    // when
+    sut.shutdownInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+
+    // then
+    final var argumentCaptor = ArgumentCaptor.forClass(Supplier.class);
+    verify(mockSpringBrokerBridge)
+        .registerBrokerHealthCheckServiceSupplier(argumentCaptor.capture());
+
+    assertThat(argumentCaptor.getValue().get()).isNull();
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.TestLoggers;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
+import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
@@ -213,13 +214,9 @@ public final class EmbeddedBrokerRule extends ExternalResource {
         throw new RuntimeException("Unable to open configuration", e);
       }
     }
-
-    broker =
-        new Broker(
-            brokerCfg,
-            newTemporaryFolder.getAbsolutePath(),
-            controlledActorClock,
-            springBrokerBridge);
+    final var systemContext =
+        new SystemContext(brokerCfg, newTemporaryFolder.getAbsolutePath(), controlledActorClock);
+    broker = new Broker(systemContext, springBrokerBridge);
 
     final CountDownLatch latch = new CountDownLatch(brokerCfg.getCluster().getPartitionsCount());
     broker.addPartitionListener(new LeaderPartitionListener(latch));

--- a/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -255,7 +255,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
           });
     }
 
-    dataDirectory = broker.getBrokerContext().getBrokerConfiguration().getData().getDirectory();
+    dataDirectory = broker.getSystemContext().getBrokerConfiguration().getData().getDirectory();
   }
 
   public void configureBroker(final BrokerCfg brokerCfg) {

--- a/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker;
 
+import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.shared.EnvironmentHelper;
 import io.camunda.zeebe.util.FileUtil;
@@ -82,8 +83,8 @@ public class StandaloneBroker
     if (basePath == null) {
       basePath = Paths.get(".").toAbsolutePath().normalize().toString();
     }
-
-    return new Broker(configuration, basePath, null, springBrokerBridge);
+    final var systemContext = new SystemContext(configuration, basePath, null);
+    return new Broker(systemContext, springBrokerBridge);
   }
 
   private Broker createBrokerInTempDirectory() {
@@ -91,7 +92,8 @@ public class StandaloneBroker
 
     try {
       tempFolder = Files.createTempDirectory("zeebe").toAbsolutePath().normalize().toString();
-      return new Broker(configuration, tempFolder, null, springBrokerBridge);
+      final var systemContext = new SystemContext(configuration, tempFolder, null);
+      return new Broker(systemContext, springBrokerBridge);
     } catch (final IOException e) {
       throw new UncheckedIOException("Could not start broker", e);
     }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -84,6 +84,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.agrona.LangUtil;
 import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.rules.ExternalResource;
@@ -123,6 +124,7 @@ public final class ClusteringRule extends ExternalResource {
   private CountDownLatch partitionLatch;
   private final Map<Integer, Leader> partitionLeader;
   private final Map<Integer, SpringBrokerBridge> springBrokerBridge;
+  private final Map<Integer, SystemContext> systemContexts;
 
   public ClusteringRule() {
     this(3);
@@ -168,9 +170,11 @@ public final class ClusteringRule extends ExternalResource {
     controlledClock = new ControlledActorClock();
     brokers = new HashMap<>();
     brokerCfgs = new HashMap<>();
+    systemContexts = new HashMap<>();
     partitionLeader = new ConcurrentHashMap<>();
     logstreams = new ConcurrentHashMap<>();
     springBrokerBridge = new HashMap<>();
+
     partitionIds =
         IntStream.range(START_PARTITION_ID, START_PARTITION_ID + partitionCount)
             .boxed()
@@ -276,11 +280,17 @@ public final class ClusteringRule extends ExternalResource {
     final BrokerCfg brokerCfg = getBrokerCfg(nodeId);
     final var systemContext =
         new SystemContext(brokerCfg, brokerBase.getAbsolutePath(), controlledClock);
+    systemContexts.put(nodeId, systemContext);
 
     final Broker broker = new Broker(systemContext, getSpringBrokerBridge(nodeId));
 
     broker.addPartitionListener(new LeaderListener(partitionLatch, nodeId));
-    new Thread(broker::start).start();
+    new Thread(
+            () -> {
+              systemContext.getScheduler().start();
+              broker.start();
+            })
+        .start();
     return broker;
   }
 
@@ -630,6 +640,14 @@ public final class ClusteringRule extends ExternalResource {
           broker.getConfig().getNetwork().getCommandApi().getAddress();
       broker.close();
       waitUntilBrokerIsRemovedFromTopology(socketAddress);
+      try {
+        final var systemContext = systemContexts.remove(nodeId);
+        if (systemContext != null) {
+          systemContext.getScheduler().stop().get();
+        }
+      } catch (final InterruptedException | ExecutionException e) {
+        LangUtil.rethrowUnchecked(e);
+      }
     }
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
+import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.NetworkCfg;
 import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg;
@@ -273,12 +274,10 @@ public final class ClusteringRule extends ExternalResource {
   private Broker createBroker(final int nodeId) {
     final File brokerBase = getBrokerBase(nodeId);
     final BrokerCfg brokerCfg = getBrokerCfg(nodeId);
-    final Broker broker =
-        new Broker(
-            brokerCfg,
-            brokerBase.getAbsolutePath(),
-            controlledClock,
-            getSpringBrokerBridge(nodeId));
+    final var systemContext =
+        new SystemContext(brokerCfg, brokerBase.getAbsolutePath(), controlledClock);
+
+    final Broker broker = new Broker(systemContext, getSpringBrokerBridge(nodeId));
 
     broker.addPartitionListener(new LeaderListener(partitionLatch, nodeId));
     new Thread(broker::start).start();

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -102,6 +102,11 @@
       <artifactId>netty-common</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
+++ b/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
@@ -37,9 +37,11 @@ import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import org.agrona.LangUtil;
 import org.assertj.core.util.Files;
 import org.junit.rules.ExternalResource;
 import org.junit.runner.Description;
@@ -67,6 +69,7 @@ public class EmbeddedBrokerRule extends ExternalResource {
   private final Duration timeout;
   private final File newTemporaryFolder;
   private String dataDirectory;
+  private SystemContext systemContext;
 
   @SafeVarargs
   public EmbeddedBrokerRule(final Consumer<BrokerCfg>... configurators) {
@@ -198,12 +201,18 @@ public class EmbeddedBrokerRule extends ExternalResource {
     if (broker != null) {
       broker.close();
       broker = null;
+      try {
+        systemContext.getScheduler().stop().get();
+      } catch (final InterruptedException | ExecutionException e) {
+        LangUtil.rethrowUnchecked(e);
+      }
+      systemContext = null;
       System.gc();
     }
   }
 
   public void startBroker() {
-    final var systemContext =
+    systemContext =
         new SystemContext(brokerCfg, newTemporaryFolder.getAbsolutePath(), controlledActorClock);
 
     broker = new Broker(systemContext, springBrokerBridge);
@@ -211,6 +220,7 @@ public class EmbeddedBrokerRule extends ExternalResource {
     final CountDownLatch latch = new CountDownLatch(brokerCfg.getCluster().getPartitionsCount());
     broker.addPartitionListener(new LeaderPartitionListener(latch));
 
+    systemContext.getScheduler().start();
     broker.start().join();
 
     try {

--- a/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
+++ b/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
+import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.broker.system.configuration.NetworkCfg;
@@ -202,12 +203,10 @@ public class EmbeddedBrokerRule extends ExternalResource {
   }
 
   public void startBroker() {
-    broker =
-        new Broker(
-            brokerCfg,
-            newTemporaryFolder.getAbsolutePath(),
-            controlledActorClock,
-            springBrokerBridge);
+    final var systemContext =
+        new SystemContext(brokerCfg, newTemporaryFolder.getAbsolutePath(), controlledActorClock);
+
+    broker = new Broker(systemContext, springBrokerBridge);
 
     final CountDownLatch latch = new CountDownLatch(brokerCfg.getCluster().getPartitionsCount());
     broker.addPartitionListener(new LeaderPartitionListener(latch));

--- a/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
+++ b/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
@@ -247,7 +247,7 @@ public class EmbeddedBrokerRule extends ExternalResource {
           });
     }
 
-    dataDirectory = broker.getBrokerContext().getBrokerConfiguration().getData().getDirectory();
+    dataDirectory = broker.getSystemContext().getBrokerConfiguration().getData().getDirectory();
   }
 
   public void configureBroker(final BrokerCfg brokerCfg) {

--- a/util/src/main/java/io/camunda/zeebe/util/startup/StartupProcess.java
+++ b/util/src/main/java/io/camunda/zeebe/util/startup/StartupProcess.java
@@ -86,7 +86,7 @@ public final class StartupProcess<CONTEXT> {
    *     null}
    * @param steps the steps to execute; must not be {@code null}
    */
-  public StartupProcess(final Logger logger, final List<StartupStep<CONTEXT>> steps) {
+  public StartupProcess(final Logger logger, final List<? extends StartupStep<CONTEXT>> steps) {
     this.steps = new ArrayDeque<>(Objects.requireNonNull(steps));
     this.logger = Objects.requireNonNull(logger);
   }


### PR DESCRIPTION
## Description

Migration of the first step in the bootstrap sequence of the Broker. This step shall serve as a template for the migration of subsequent steps.

### Comments
- The broker health monitor is created in the constructor of the Broker; the startup step is only responsible for starting the actor and wiring it to other actors. If we can keep this pattern, we have a better change at having an immutable startup context.
- The metric update is realized via a decorator. The decorator does not exactly measure the duration. Instead, the end time is taken when a follow-up task is scheduled. This is not ideal, but the best I could come up with.
- One thing that might seem a little bit paranoid is catching throwables in the abstract base class `AbstractBrokerStartupStep`. This is not without reason, though. I did check what would happen if an exception occurs at an odd place. And basically what happens is that the exception is logged by the thread as unhandled exception. But the startup process just hangs. Happy to discuss alternatives here. What I would like to achieve is that any exception during startup is forwarded to the future representing the startup process.

## Related issues

#7539 

<!-- Cut-off marker
## Definition of Ready

* [ ] I've reviewed my own code
* [X] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
