### PR TITLE
feat(test-utils): Added random pathing through boundary events for user tasks

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessExecutor.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessExecutor.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.test.util.bpmn.random.steps.StepPublishMessage;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepPublishStartMessage;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepRaiseIncidentThenResolveAndPickConditionCase;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepStartProcessInstance;
+import io.camunda.zeebe.test.util.bpmn.random.steps.StepThrowError;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepTriggerTimerBoundaryEvent;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepTriggerTimerStartEvent;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -81,6 +82,9 @@ public class ProcessExecutor {
     } else if (step instanceof StepCompleteUserTask) {
       final StepCompleteUserTask stepCompleteUserTask = (StepCompleteUserTask) step;
       completeUserTask(stepCompleteUserTask);
+    } else if (step instanceof StepThrowError) {
+      final StepThrowError stepThrowError = (StepThrowError) step;
+      throwError(stepThrowError);
     } else {
       throw new IllegalStateException("Not yet implemented: " + step);
     }
@@ -268,6 +272,16 @@ public class ProcessExecutor {
     final Record<JobRecordValue> jobRecord = waitForJobToBeCreated(completeUserTask.getElementId());
 
     engineRule.job().withKey(jobRecord.getKey()).complete();
+  }
+
+  private void throwError(final StepThrowError stepThrowError) {
+    final Record<JobRecordValue> jobRecord = waitForJobToBeCreated(stepThrowError.getElementId());
+
+    engineRule
+        .job()
+        .withKey(jobRecord.getKey())
+        .withErrorCode(stepThrowError.getErrorCode())
+        .throwError();
   }
 
   private void resolveExpressionIncident(

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/JobWorkerTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/JobWorkerTaskBlockBuilder.java
@@ -149,7 +149,7 @@ public class JobWorkerTaskBlockBuilder implements BlockBuilder {
     if (hasBoundaryErrorEvent && random.nextBoolean()) {
       result = new StepActivateJobAndThrowError(jobType, errorCode, taskId);
     } else if (hasBoundaryTimerEvent && random.nextBoolean()) {
-      result = new StepTriggerTimerBoundaryEvent(jobType, boundaryTimerEventId);
+      result = new StepTriggerTimerBoundaryEvent(boundaryTimerEventId);
     } else {
       result = new StepActivateAndCompleteJob(jobType, taskId);
     }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
@@ -117,8 +117,7 @@ public class SubProcessBlockBuilder implements BlockBuilder {
       result.append(internalExecutionPath);
       if (hasBoundaryTimerEvent) {
         result.appendExecutionSuccessor(
-            new StepTriggerTimerBoundaryEvent(subProcessId, subProcessBoundaryTimerEventId),
-            activateSubProcess);
+            new StepTriggerTimerBoundaryEvent(subProcessBoundaryTimerEventId), activateSubProcess);
       } // extend here for other boundary events
     }
     return result;

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/steps/StepThrowError.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/steps/StepThrowError.java
@@ -8,24 +8,30 @@
 package io.camunda.zeebe.test.util.bpmn.random.steps;
 
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
-public final class StepTriggerTimerBoundaryEvent extends AbstractExecutionStep {
+public class StepThrowError extends AbstractExecutionStep {
 
-  private final String boundaryTimerEventId;
+  private final String elementId;
+  private final String errorCode;
 
-  public StepTriggerTimerBoundaryEvent(final String boundaryTimerEventId) {
-    this.boundaryTimerEventId = boundaryTimerEventId;
+  public StepThrowError(final String elementId, final String errorCode) {
+    this.elementId = elementId;
+    this.errorCode = errorCode;
+  }
+
+  public String getElementId() {
+    return elementId;
+  }
+
+  public String getErrorCode() {
+    return errorCode;
   }
 
   @Override
   protected Map<String, Object> updateVariables(
       final Map<String, Object> variables, final Duration activationDuration) {
-    final var result = new HashMap<>(variables);
-    result.put(boundaryTimerEventId, activationDuration.toString());
-    return result;
+    return variables;
   }
 
   @Override
@@ -35,12 +41,15 @@ public final class StepTriggerTimerBoundaryEvent extends AbstractExecutionStep {
 
   @Override
   public Duration getDeltaTime() {
-    return DEFAULT_DELTA;
+    return VIRTUALLY_NO_TIME;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), boundaryTimerEventId);
+    int result = super.hashCode();
+    result = 31 * result + elementId.hashCode();
+    result = 31 * result + errorCode.hashCode();
+    return result;
   }
 
   @Override
@@ -54,11 +63,8 @@ public final class StepTriggerTimerBoundaryEvent extends AbstractExecutionStep {
     if (!super.equals(o)) {
       return false;
     }
-    final StepTriggerTimerBoundaryEvent that = (StepTriggerTimerBoundaryEvent) o;
-    return boundaryTimerEventId.equals(that.boundaryTimerEventId);
-  }
 
-  public String getBoundaryTimerEventId() {
-    return boundaryTimerEventId;
+    final StepThrowError that = (StepThrowError) o;
+    return errorCode.equals(that.errorCode) && elementId.equals(that.elementId);
   }
 }


### PR DESCRIPTION
## Description

Added random pathing through the boundary events of user tasks

## Related issues

https://github.com/camunda-cloud/zeebe/pull/7780#discussion_r704173351

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
