### PR TITLE
Move RocksDBMetricsExporterStep to startup step

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -81,7 +81,7 @@ public final class PartitionFactory {
           new ZeebeDbPartitionStep(),
           new StreamProcessorPartitionStep(),
           new SnapshotDirectorPartitionStep(),
-          new RocksDbMetricExporterPartitionStep(),
+          PartitionStepMigrationHelper.fromStartupStep(new RocksDbMetricExporterPartitionStep()),
           new ExporterDirectorPartitionStep());
   private static final List<PartitionStep> FOLLOWER_STEPS =
       List.of(
@@ -92,7 +92,7 @@ public final class PartitionFactory {
           new ZeebeDbPartitionStep(),
           new StreamProcessorPartitionStep(),
           new SnapshotDirectorPartitionStep(),
-          new RocksDbMetricExporterPartitionStep(),
+          PartitionStepMigrationHelper.fromStartupStep(new RocksDbMetricExporterPartitionStep()),
           new ExporterDirectorPartitionStep());
 
   private final ActorSchedulingService actorSchedulingService;

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -35,12 +35,12 @@ import io.camunda.zeebe.broker.system.partitions.impl.NewPartitionTransitionImpl
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionProcessingState;
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionTransitionImpl;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.ExporterDirectorPartitionStep;
-import io.camunda.zeebe.broker.system.partitions.impl.steps.LogDeletionPartitionStep;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.LogDeletionPartitionStartupStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.LogStoragePartitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.LogStreamPartitionStep;
-import io.camunda.zeebe.broker.system.partitions.impl.steps.RocksDbMetricExporterPartitionStep;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.RockDbMetricExporterPartitionStartupStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.SnapshotDirectorPartitionStep;
-import io.camunda.zeebe.broker.system.partitions.impl.steps.StateControllerPartitionStep;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.StateControllerPartitionStartupStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.StreamProcessorPartitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.ZeebeDbPartitionStep;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
@@ -74,25 +74,27 @@ public final class PartitionFactory {
 
   private static final List<PartitionStep> LEADER_STEPS =
       List.of(
-          PartitionStepMigrationHelper.fromStartupStep(new StateControllerPartitionStep()),
-          PartitionStepMigrationHelper.fromStartupStep(new LogDeletionPartitionStep()),
+          PartitionStepMigrationHelper.fromStartupStep(new StateControllerPartitionStartupStep()),
+          PartitionStepMigrationHelper.fromStartupStep(new LogDeletionPartitionStartupStep()),
           new LogStoragePartitionStep(),
           new LogStreamPartitionStep(),
           new ZeebeDbPartitionStep(),
           new StreamProcessorPartitionStep(),
           new SnapshotDirectorPartitionStep(),
-          PartitionStepMigrationHelper.fromStartupStep(new RocksDbMetricExporterPartitionStep()),
+          PartitionStepMigrationHelper.fromStartupStep(
+              new RockDbMetricExporterPartitionStartupStep()),
           new ExporterDirectorPartitionStep());
   private static final List<PartitionStep> FOLLOWER_STEPS =
       List.of(
-          PartitionStepMigrationHelper.fromStartupStep(new StateControllerPartitionStep()),
-          PartitionStepMigrationHelper.fromStartupStep(new LogDeletionPartitionStep()),
+          PartitionStepMigrationHelper.fromStartupStep(new StateControllerPartitionStartupStep()),
+          PartitionStepMigrationHelper.fromStartupStep(new LogDeletionPartitionStartupStep()),
           new LogStoragePartitionStep(),
           new LogStreamPartitionStep(),
           new ZeebeDbPartitionStep(),
           new StreamProcessorPartitionStep(),
           new SnapshotDirectorPartitionStep(),
-          PartitionStepMigrationHelper.fromStartupStep(new RocksDbMetricExporterPartitionStep()),
+          PartitionStepMigrationHelper.fromStartupStep(
+              new RockDbMetricExporterPartitionStartupStep()),
           new ExporterDirectorPartitionStep());
 
   private final ActorSchedulingService actorSchedulingService;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupContext.java
@@ -84,7 +84,7 @@ public interface PartitionStartupContext {
 
   void setLogStream(final LogStream logStream);
 
-  ZeebeDb<?> getZeebeDb();
+  ZeebeDb getZeebeDb();
 
   void setZeebeDb(final ZeebeDb<?> db);
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -17,9 +17,9 @@ import io.camunda.zeebe.broker.partitioning.PartitionFactory;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.monitoring.HealthMetrics;
 import io.camunda.zeebe.broker.system.partitions.impl.NewPartitionTransitionImpl;
-import io.camunda.zeebe.broker.system.partitions.impl.steps.LogDeletionPartitionStep;
-import io.camunda.zeebe.broker.system.partitions.impl.steps.RocksDbMetricExporterPartitionStep;
-import io.camunda.zeebe.broker.system.partitions.impl.steps.StateControllerPartitionStep;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.LogDeletionPartitionStartupStep;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.RockDbMetricExporterPartitionStartupStep;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.StateControllerPartitionStartupStep;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
@@ -50,9 +50,9 @@ public final class ZeebePartition extends Actor
       new StartupProcess<>(
           LOG,
           List.of(
-              new StateControllerPartitionStep(),
-              new LogDeletionPartitionStep(),
-              new RocksDbMetricExporterPartitionStep()));
+              new StateControllerPartitionStartupStep(),
+              new LogDeletionPartitionStartupStep(),
+              new RockDbMetricExporterPartitionStartupStep()));
 
   private Role raftRole;
   private final String actorName;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.monitoring.HealthMetrics;
 import io.camunda.zeebe.broker.system.partitions.impl.NewPartitionTransitionImpl;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.LogDeletionPartitionStep;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.RocksDbMetricExporterPartitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.StateControllerPartitionStep;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
@@ -47,7 +48,11 @@ public final class ZeebePartition extends Actor
 
   private static final StartupProcess<PartitionStartupContext> STARTUP_PROCESS =
       new StartupProcess<>(
-          LOG, List.of(new StateControllerPartitionStep(), new LogDeletionPartitionStep()));
+          LOG,
+          List.of(
+              new StateControllerPartitionStep(),
+              new LogDeletionPartitionStep(),
+              new RocksDbMetricExporterPartitionStep()));
 
   private Role raftRole;
   private final String actorName;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogDeletionPartitionStartupStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogDeletionPartitionStartupStep.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.util.List;
 
-public class LogDeletionPartitionStep implements PartitionStartupStep {
+public class LogDeletionPartitionStartupStep implements PartitionStartupStep {
 
   @Override
   public String getName() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/RockDbMetricExporterPartitionStartupStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/RockDbMetricExporterPartitionStartupStep.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.time.Duration;
 
-public class RocksDbMetricExporterPartitionStep implements PartitionStartupStep {
+public class RockDbMetricExporterPartitionStartupStep implements PartitionStartupStep {
 
   @Override
   public String getName() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/RocksDbMetricExporterPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/RocksDbMetricExporterPartitionStep.java
@@ -21,7 +21,7 @@ public class RocksDbMetricExporterPartitionStep implements PartitionStep {
   public ActorFuture<Void> open(final PartitionStartupAndTransitionContextImpl context) {
     final var metricExporter =
         DEFAULT_DB_METRIC_EXPORTER_FACTORY.apply(
-            Integer.toString(context.getPartitionId()), context.getZeebeDb());
+            Integer.toString(context.getPartitionId()), context::getZeebeDb);
     final var metricsTimer =
         context
             .getActorControl()

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStartupStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStartupStep.java
@@ -17,7 +17,7 @@ import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 
-public class StateControllerPartitionStep implements PartitionStartupStep {
+public class StateControllerPartitionStartupStep implements PartitionStartupStep {
 
   @Override
   public String getName() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/DefaultZeebeDbFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/DefaultZeebeDbFactory.java
@@ -14,10 +14,12 @@ import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDBMetricExporter;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import java.util.Properties;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 
 public final class DefaultZeebeDbFactory {
 
-  public static final BiFunction<String, ZeebeDb<ZbColumnFamilies>, ZeebeRocksDBMetricExporter>
+  public static final BiFunction<
+          String, Supplier<ZeebeDb<ZbColumnFamilies>>, ZeebeRocksDBMetricExporter>
       DEFAULT_DB_METRIC_EXPORTER_FACTORY = ZeebeRocksDBMetricExporter::new;
 
   /**

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDBMetricExporter.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDBMetricExporter.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.db.impl.rocksdb;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.prometheus.client.Gauge;
 import java.util.Objects;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,12 +71,12 @@ public final class ZeebeRocksDBMetricExporter<ColumnFamilyType extends Enum<Colu
   };
 
   private final String partition;
-  private final ZeebeDb<ColumnFamilyType> database;
+  private final Supplier<ZeebeDb<ColumnFamilyType>> databaseSupplier;
 
   public ZeebeRocksDBMetricExporter(
-      final String partition, final ZeebeDb<ColumnFamilyType> database) {
+      final String partition, final Supplier<ZeebeDb<ColumnFamilyType>> databaseSupplier) {
     this.partition = Objects.requireNonNull(partition);
-    this.database = Objects.requireNonNull(database);
+    this.databaseSupplier = databaseSupplier;
   }
 
   public void exportMetrics() {
@@ -92,10 +93,13 @@ public final class ZeebeRocksDBMetricExporter<ColumnFamilyType extends Enum<Colu
   private void exportMetrics(final RocksDBMetric[] metrics) {
     for (final RocksDBMetric metric : metrics) {
       try {
-        database
-            .getProperty(metric.getPropertyName())
-            .map(Double::parseDouble)
-            .ifPresent(value -> metric.exportValue(partition, value));
+        final var database = databaseSupplier.get();
+        if (database != null) {
+          database
+              .getProperty(metric.getPropertyName())
+              .map(Double::parseDouble)
+              .ifPresent(value -> metric.exportValue(partition, value));
+        }
       } catch (final Exception exception) {
         LOG.debug("Error occurred on exporting metric {}", metric.getPropertyName(), exception);
       }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDBMetricExporter.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDBMetricExporter.java
@@ -91,15 +91,16 @@ public final class ZeebeRocksDBMetricExporter<ColumnFamilyType extends Enum<Colu
   }
 
   private void exportMetrics(final RocksDBMetric[] metrics) {
+    final var database = databaseSupplier.get();
+    if (database == null) {
+      return;
+    }
     for (final RocksDBMetric metric : metrics) {
       try {
-        final var database = databaseSupplier.get();
-        if (database != null) {
-          database
-              .getProperty(metric.getPropertyName())
-              .map(Double::parseDouble)
-              .ifPresent(value -> metric.exportValue(partition, value));
-        }
+        database
+            .getProperty(metric.getPropertyName())
+            .map(Double::parseDouble)
+            .ifPresent(value -> metric.exportValue(partition, value));
       } catch (final Exception exception) {
         LOG.debug("Error occurred on exporting metric {}", metric.getPropertyName(), exception);
       }


### PR DESCRIPTION
## Description

Even though ZeebeDB is re-installed during role transitions, we can move RocksDBMetricsExporterStep to startup step. The metrics exporter now uses a supplier to get zeebedb. This supplier ensures that it access the latest zeebedb instance. 

## Related issues

Related #7514 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
