### PR TITLE
Remove artificial job activation batch size limit

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -69,9 +69,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     this.keyGenerator = keyGenerator;
 
     this.maxRecordLength = maxRecordLength;
-    // we can only add the half of the max record length to the job batch
-    // because the jobs itself are also written to the same batch
-    maxJobBatchLength = (maxRecordLength - Long.BYTES) / 2;
+    maxJobBatchLength = maxRecordLength - Long.BYTES;
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR removes the artificial limitation of the job batch record length to be half of the maximum message size. This was previously there because we used to write the activated job into the job batch once, and again as a separate record. This was removed in #5991, but we didn't remove the limit.

This PR makes it so that we can now activate single jobs whose payload is almost the max message size, minus some framing/header space, and also activate slightly more jobs in a single batch.

It's still a little counter intuitive since we need a little extra space, so you can't quite fit exactly the `maxMessageSize` as a variable, but that's anyway not possible to do in most other commands as well.

## Related issues

closes #6207 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
