### PR TITLE
Extract interface for command API service

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -40,7 +40,7 @@ import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.transport.backpressure.PartitionAwareRequestLimiter;
-import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
+import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.transport.TransportFactory;
 import io.camunda.zeebe.util.FileUtil;
@@ -70,7 +70,7 @@ public final class Broker implements AutoCloseable {
   private ClusterServicesImpl clusterServices;
   private CompletableFuture<Broker> startFuture;
   private LeaderManagementRequestHandler managementRequestHandler;
-  private CommandApiService commandHandler;
+  private CommandApiServiceImpl commandHandler;
   private final ActorScheduler scheduler;
   private CloseProcess closeProcess;
   private EmbeddedGatewayService embeddedGatewayService;
@@ -263,7 +263,7 @@ public final class Broker implements AutoCloseable {
       limiter = PartitionAwareRequestLimiter.newLimiter(backpressureCfg);
     }
 
-    commandHandler = new CommandApiService(serverTransport, localBroker, limiter);
+    commandHandler = new CommandApiServiceImpl(serverTransport, localBroker, limiter);
     partitionListeners.add(commandHandler);
     scheduleActor(commandHandler);
     diskSpaceUsageListeners.add(commandHandler);

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiService.java
@@ -7,136 +7,13 @@
  */
 package io.camunda.zeebe.broker.transport.commandapi;
 
-import io.camunda.zeebe.broker.Loggers;
-import io.camunda.zeebe.broker.PartitionListener;
-import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
-import io.camunda.zeebe.broker.transport.backpressure.PartitionAwareRequestLimiter;
-import io.camunda.zeebe.broker.transport.backpressure.RequestLimiter;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
-import io.camunda.zeebe.logstreams.log.LogStream;
-import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
-import io.camunda.zeebe.protocol.record.RecordType;
-import io.camunda.zeebe.protocol.record.intent.Intent;
-import io.camunda.zeebe.transport.RequestType;
-import io.camunda.zeebe.transport.ServerTransport;
-import io.camunda.zeebe.util.sched.Actor;
-import io.camunda.zeebe.util.sched.future.ActorFuture;
-import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.util.function.Consumer;
-import org.agrona.collections.IntHashSet;
 
-public final class CommandApiService extends Actor
-    implements PartitionListener, DiskSpaceUsageListener {
+public interface CommandApiService {
 
-  private final PartitionAwareRequestLimiter limiter;
-  private final ServerTransport serverTransport;
-  private final CommandApiRequestHandler requestHandler;
-  private final IntHashSet leadPartitions = new IntHashSet();
-  private final String actorName;
+  CommandResponseWriter newCommandResponseWriter();
 
-  public CommandApiService(
-      final ServerTransport serverTransport,
-      final BrokerInfo localBroker,
-      final PartitionAwareRequestLimiter limiter) {
-    this.serverTransport = serverTransport;
-    this.limiter = limiter;
-    requestHandler = new CommandApiRequestHandler();
-    actorName = buildActorName(localBroker.getNodeId(), "CommandApiService");
-  }
-
-  @Override
-  public String getName() {
-    return actorName;
-  }
-
-  @Override
-  protected void onActorClosing() {
-    for (final Integer leadPartition : leadPartitions) {
-      removeForPartitionId(leadPartition);
-    }
-    leadPartitions.clear();
-  }
-
-  @Override
-  public ActorFuture<Void> onBecomingFollower(final int partitionId, final long term) {
-    return removeLeaderHandlersAsync(partitionId);
-  }
-
-  @Override
-  public ActorFuture<Void> onBecomingLeader(
-      final int partitionId, final long term, final LogStream logStream) {
-    final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
-    actor.call(
-        () -> {
-          leadPartitions.add(partitionId);
-          limiter.addPartition(partitionId);
-
-          logStream
-              .newLogStreamRecordWriter()
-              .onComplete(
-                  (recordWriter, error) -> {
-                    if (error == null) {
-
-                      final var requestLimiter = limiter.getLimiter(partitionId);
-                      requestHandler.addPartition(partitionId, recordWriter, requestLimiter);
-                      serverTransport.subscribe(partitionId, RequestType.COMMAND, requestHandler);
-                      future.complete(null);
-                    } else {
-                      Loggers.SYSTEM_LOGGER.error(
-                          "Error on retrieving write buffer from log stream {}",
-                          partitionId,
-                          error);
-                      future.completeExceptionally(error);
-                    }
-                  });
-        });
-    return future;
-  }
-
-  @Override
-  public ActorFuture<Void> onBecomingInactive(final int partitionId, final long term) {
-    return removeLeaderHandlersAsync(partitionId);
-  }
-
-  private ActorFuture<Void> removeLeaderHandlersAsync(final int partitionId) {
-    return actor.call(
-        () -> {
-          requestHandler.removePartition(partitionId);
-          cleanLeadingPartition(partitionId);
-        });
-  }
-
-  private void cleanLeadingPartition(final int partitionId) {
-    leadPartitions.remove(partitionId);
-    removeForPartitionId(partitionId);
-  }
-
-  private void removeForPartitionId(final int partitionId) {
-    limiter.removePartition(partitionId);
-    serverTransport.unsubscribe(partitionId);
-  }
-
-  public CommandResponseWriter newCommandResponseWriter() {
-    return new CommandResponseWriterImpl(serverTransport);
-  }
-
-  public Consumer<TypedRecord<?>> getOnProcessedListener(final int partitionId) {
-    final RequestLimiter<Intent> partitionLimiter = limiter.getLimiter(partitionId);
-    return typedRecord -> {
-      if (typedRecord.getRecordType() == RecordType.COMMAND && typedRecord.hasRequestMetadata()) {
-        partitionLimiter.onResponse(typedRecord.getRequestStreamId(), typedRecord.getRequestId());
-      }
-    };
-  }
-
-  @Override
-  public void onDiskSpaceNotAvailable() {
-    actor.run(requestHandler::onDiskSpaceNotAvailable);
-  }
-
-  @Override
-  public void onDiskSpaceAvailable() {
-    actor.run(requestHandler::onDiskSpaceAvailable);
-  }
+  Consumer<TypedRecord<?>> getOnProcessedListener(int partitionId);
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.commandapi;
+
+import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
+import io.camunda.zeebe.broker.transport.backpressure.PartitionAwareRequestLimiter;
+import io.camunda.zeebe.broker.transport.backpressure.RequestLimiter;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
+import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.transport.RequestType;
+import io.camunda.zeebe.transport.ServerTransport;
+import io.camunda.zeebe.util.sched.Actor;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
+import java.util.function.Consumer;
+import org.agrona.collections.IntHashSet;
+
+public final class CommandApiServiceImpl extends Actor
+    implements PartitionListener, DiskSpaceUsageListener, CommandApiService {
+
+  private final PartitionAwareRequestLimiter limiter;
+  private final ServerTransport serverTransport;
+  private final CommandApiRequestHandler requestHandler;
+  private final IntHashSet leadPartitions = new IntHashSet();
+  private final String actorName;
+
+  public CommandApiServiceImpl(
+      final ServerTransport serverTransport,
+      final BrokerInfo localBroker,
+      final PartitionAwareRequestLimiter limiter) {
+    this.serverTransport = serverTransport;
+    this.limiter = limiter;
+    requestHandler = new CommandApiRequestHandler();
+    actorName = buildActorName(localBroker.getNodeId(), "CommandApiService");
+  }
+
+  @Override
+  public String getName() {
+    return actorName;
+  }
+
+  @Override
+  protected void onActorClosing() {
+    for (final Integer leadPartition : leadPartitions) {
+      removeForPartitionId(leadPartition);
+    }
+    leadPartitions.clear();
+  }
+
+  @Override
+  public ActorFuture<Void> onBecomingFollower(final int partitionId, final long term) {
+    return removeLeaderHandlersAsync(partitionId);
+  }
+
+  @Override
+  public ActorFuture<Void> onBecomingLeader(
+      final int partitionId, final long term, final LogStream logStream) {
+    final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
+    actor.call(
+        () -> {
+          leadPartitions.add(partitionId);
+          limiter.addPartition(partitionId);
+
+          logStream
+              .newLogStreamRecordWriter()
+              .onComplete(
+                  (recordWriter, error) -> {
+                    if (error == null) {
+
+                      final var requestLimiter = limiter.getLimiter(partitionId);
+                      requestHandler.addPartition(partitionId, recordWriter, requestLimiter);
+                      serverTransport.subscribe(partitionId, RequestType.COMMAND, requestHandler);
+                      future.complete(null);
+                    } else {
+                      Loggers.SYSTEM_LOGGER.error(
+                          "Error on retrieving write buffer from log stream {}",
+                          partitionId,
+                          error);
+                      future.completeExceptionally(error);
+                    }
+                  });
+        });
+    return future;
+  }
+
+  @Override
+  public ActorFuture<Void> onBecomingInactive(final int partitionId, final long term) {
+    return removeLeaderHandlersAsync(partitionId);
+  }
+
+  private ActorFuture<Void> removeLeaderHandlersAsync(final int partitionId) {
+    return actor.call(
+        () -> {
+          requestHandler.removePartition(partitionId);
+          cleanLeadingPartition(partitionId);
+        });
+  }
+
+  private void cleanLeadingPartition(final int partitionId) {
+    leadPartitions.remove(partitionId);
+    removeForPartitionId(partitionId);
+  }
+
+  private void removeForPartitionId(final int partitionId) {
+    limiter.removePartition(partitionId);
+    serverTransport.unsubscribe(partitionId);
+  }
+
+  @Override
+  public CommandResponseWriter newCommandResponseWriter() {
+    return new CommandResponseWriterImpl(serverTransport);
+  }
+
+  @Override
+  public Consumer<TypedRecord<?>> getOnProcessedListener(final int partitionId) {
+    final RequestLimiter<Intent> partitionLimiter = limiter.getLimiter(partitionId);
+    return typedRecord -> {
+      if (typedRecord.getRecordType() == RecordType.COMMAND && typedRecord.hasRequestMetadata()) {
+        partitionLimiter.onResponse(typedRecord.getRequestStreamId(), typedRecord.getRequestId());
+      }
+    };
+  }
+
+  @Override
+  public void onDiskSpaceNotAvailable() {
+    actor.run(requestHandler::onDiskSpaceNotAvailable);
+  }
+
+  @Override
+  public void onDiskSpaceAvailable() {
+    actor.run(requestHandler::onDiskSpaceAvailable);
+  }
+}


### PR DESCRIPTION
## Description

This PR introduces an interface for the command API service. This hides implementation details from components that use the command API.

## Related issues

#7539 

<!-- Cut-off marker

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
