### PR TITLE
Concurrency Control - Replace submit with run

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
@@ -33,7 +33,7 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
   public ActorFuture<Void> takeSnapshot() {
     final ActorFuture<Void> completed = concurrencyControl.createFuture();
 
-    concurrencyControl.submit(
+    concurrencyControl.run(
         () -> {
           try {
             adminControl.triggerSnapshot();
@@ -49,7 +49,7 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
   @Override
   public ActorFuture<Void> pauseExporting() {
     final ActorFuture<Void> completed = concurrencyControl.createFuture();
-    concurrencyControl.submit(
+    concurrencyControl.run(
         () -> {
           try {
             final var pauseStatePersisted = adminControl.pauseExporting();
@@ -70,7 +70,7 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
   @Override
   public ActorFuture<Void> resumeExporting() {
     final ActorFuture<Void> completed = concurrencyControl.createFuture();
-    concurrencyControl.submit(
+    concurrencyControl.run(
         () -> {
           try {
             adminControl.resumeExporting();
@@ -90,7 +90,7 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
   @Override
   public ActorFuture<Void> pauseProcessing() {
     final ActorFuture<Void> completed = concurrencyControl.createFuture();
-    concurrencyControl.submit(
+    concurrencyControl.run(
         () -> {
           try {
             adminControl.pauseProcessing();
@@ -111,7 +111,7 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
   @Override
   public ActorFuture<Void> resumeProcessing() {
     final ActorFuture<Void> completed = concurrencyControl.createFuture();
-    concurrencyControl.submit(
+    concurrencyControl.run(
         () -> {
           try {
             adminControl.resumeProcessing();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
@@ -72,7 +72,7 @@ public final class NewPartitionTransitionImpl implements PartitionTransition {
 
     final ActorFuture<Void> nextTransitionFuture = concurrencyControl.createFuture();
 
-    concurrencyControl.submit(
+    concurrencyControl.run(
         () -> {
           if (currentTransition != null) {
             LOG.info(

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -65,7 +65,7 @@ final class PartitionTransitionProcess {
       return;
     }
 
-    concurrencyControl.submit(
+    concurrencyControl.run(
         () -> {
           final var nextStep = pendingSteps.remove(0);
           startedSteps.push(nextStep);
@@ -115,7 +115,7 @@ final class PartitionTransitionProcess {
 
   private void proceedWithCleanup(
       final ActorFuture<Void> future, final long newTerm, final Role newRole) {
-    concurrencyControl.submit(
+    concurrencyControl.run(
         () -> {
           final var nextCleanupStep = startedSteps.pop();
 

--- a/util/src/main/java/io/camunda/zeebe/util/sched/Actor.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/Actor.java
@@ -101,7 +101,7 @@ public abstract class Actor implements CloseableSilently, AsyncClosable, Concurr
   }
 
   @Override
-  public void submit(final Runnable action) {
-    actor.submit(action);
+  public void run(final Runnable action) {
+    actor.run(action);
   }
 }

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorControl.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorControl.java
@@ -141,19 +141,6 @@ public class ActorControl implements ConcurrencyControl {
   }
 
   /**
-   * Runnables submitted by the actor itself are executed while the actor is in any of its lifecycle
-   * phases.
-   *
-   * <p>Runnables submitted externally are executed while the actor is in the following actor
-   * lifecycle phases: {@link ActorLifecyclePhase#STARTED}
-   *
-   * @param action
-   */
-  public void run(final Runnable action) {
-    scheduleRunnable(action, true);
-  }
-
-  /**
    * Run the provided runnable repeatedly until it calls {@link #done()}. To be used for jobs which
    * may experience backpressure.
    */
@@ -233,6 +220,20 @@ public class ActorControl implements ConcurrencyControl {
   }
 
   /**
+   * Runnables submitted by the actor itself are executed while the actor is in any of its lifecycle
+   * phases.
+   *
+   * <p>Runnables submitted externally are executed while the actor is in the following actor
+   * lifecycle phases: {@link ActorLifecyclePhase#STARTED}
+   *
+   * @param action
+   */
+  @Override
+  public void run(final Runnable action) {
+    scheduleRunnable(action, true);
+  }
+
+  /**
    * Like {@link #run(Runnable)} but submits the runnable to the end end of the actor's queue such
    * that other other actions may be executed before this. This method is useful in case an actor is
    * in a (potentially endless) loop and it should be able to interrupt it.
@@ -242,7 +243,6 @@ public class ActorControl implements ConcurrencyControl {
    *
    * @param action the action to run.
    */
-  @Override
   public void submit(final Runnable action) {
     final ActorThread currentActorRunner = ensureCalledFromActorThread("run(...)");
     final ActorTask currentTask = currentActorRunner.getCurrentTask();

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ConcurrencyControl.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ConcurrencyControl.java
@@ -31,7 +31,7 @@ public interface ConcurrencyControl {
    *
    * @param action action to be invoked
    */
-  void submit(final Runnable action);
+  void run(final Runnable action);
 
   /**
    * Create a new future object

--- a/util/src/main/java/io/camunda/zeebe/util/startup/StartupProcess.java
+++ b/util/src/main/java/io/camunda/zeebe/util/startup/StartupProcess.java
@@ -102,7 +102,7 @@ public final class StartupProcess<CONTEXT> {
       final ConcurrencyControl concurrencyControl, final CONTEXT context) {
 
     final var result = concurrencyControl.<CONTEXT>createFuture();
-    concurrencyControl.submit(() -> startupSynchronized(concurrencyControl, context, result));
+    concurrencyControl.run(() -> startupSynchronized(concurrencyControl, context, result));
 
     return result;
   }
@@ -116,7 +116,7 @@ public final class StartupProcess<CONTEXT> {
   public ActorFuture<CONTEXT> shutdown(
       final ConcurrencyControl concurrencyControl, final CONTEXT context) {
     final var result = concurrencyControl.<CONTEXT>createFuture();
-    concurrencyControl.submit(() -> shutdownSynchronized(concurrencyControl, context, result));
+    concurrencyControl.run(() -> shutdownSynchronized(concurrencyControl, context, result));
 
     return result;
   }

--- a/util/src/test/java/io/camunda/zeebe/util/sched/TestConcurrencyControl.java
+++ b/util/src/test/java/io/camunda/zeebe/util/sched/TestConcurrencyControl.java
@@ -40,7 +40,7 @@ public class TestConcurrencyControl implements ConcurrencyControl {
   }
 
   @Override
-  public void submit(final Runnable action) {
+  public void run(final Runnable action) {
     action.run();
   }
 


### PR DESCRIPTION
## Description

The `ConcurrencyControl` interface was intended as a reduced interface for the `ActorControl` logic.
The  logic offers `run()` and `submit()` methods which do pretty much the same thing,
they schedule a task. Out of those two, `run()` is more versatile. It can be called from actor threads
and non actor threads. Because of that, `run()` is preferable over `submit()`.

## Related issues

#7539

<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
