### PR TITLE
Migrate command api step

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/AbstractBrokerStartupStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/AbstractBrokerStartupStep.java
@@ -61,6 +61,7 @@ abstract class AbstractBrokerStartupStep implements StartupStep<BrokerStartupCon
       return completedExceptionally(e);
     }
   }
+
   /**
    * helper function that forwards exceptions thrown by a synchronous block of code to a future
    * object
@@ -71,5 +72,20 @@ abstract class AbstractBrokerStartupStep implements StartupStep<BrokerStartupCon
     } catch (final Exception e) {
       future.completeExceptionally(e);
     }
+  }
+
+  /**
+   * helper function that consumes the result of a previous future. If the previous future completed
+   * exceptionally, this exception is forwarded to the future passed in as argument. Otherwise, it
+   * executed the runnable.
+   */
+  final <V> BiConsumer<Void, Throwable> proceed(final Runnable r, final ActorFuture<V> future) {
+    return (ok, error) -> {
+      if (error != null) {
+        future.completeExceptionally(error);
+      } else {
+        forwardExceptions(r, future);
+      }
+    };
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContext.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.broker.bootstrap;
 
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
+import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
 import java.util.Collection;
 
 /** Context for components/actors managed directly by the Broker */
@@ -18,4 +20,8 @@ public interface BrokerContext {
 
   // TODO change this to ClusterServices after migration
   ClusterServicesImpl getClusterServices();
+
+  CommandApiService getCommandApiService();
+
+  Collection<? extends DiskSpaceUsageListener> getDiskSpaceUsageListeners();
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContextImpl.java
@@ -12,18 +12,27 @@ import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
+import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
 import java.util.Collection;
 import java.util.List;
 
 public final class BrokerContextImpl implements BrokerContext {
 
   private final ClusterServicesImpl clusterServices;
+  private final CommandApiService commandApiService;
   private final List<PartitionListener> partitionListeners;
+  private final List<DiskSpaceUsageListener> diskSpaceUsageListeners;
 
   public BrokerContextImpl(
-      final ClusterServicesImpl clusterServices, final List<PartitionListener> partitionListeners) {
+      final ClusterServicesImpl clusterServices,
+      final CommandApiService commandApiService,
+      final List<PartitionListener> partitionListeners,
+      final List<DiskSpaceUsageListener> diskSpaceUsageListeners) {
     this.clusterServices = requireNonNull(clusterServices);
+    this.commandApiService = requireNonNull(commandApiService);
     this.partitionListeners = unmodifiableList(requireNonNull(partitionListeners));
+    this.diskSpaceUsageListeners = diskSpaceUsageListeners;
   }
 
   @Override
@@ -34,5 +43,15 @@ public final class BrokerContextImpl implements BrokerContext {
   @Override
   public ClusterServicesImpl getClusterServices() {
     return clusterServices;
+  }
+
+  @Override
+  public CommandApiService getCommandApiService() {
+    return commandApiService;
+  }
+
+  @Override
+  public List<DiskSpaceUsageListener> getDiskSpaceUsageListeners() {
+    return diskSpaceUsageListeners;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -7,15 +7,18 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
+import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
+import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
-import io.camunda.zeebe.util.sched.Actor;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import io.camunda.zeebe.util.sched.ConcurrencyControl;
-import io.camunda.zeebe.util.sched.future.ActorFuture;
 import java.util.List;
 
 /**
@@ -31,9 +34,9 @@ public interface BrokerStartupContext {
 
   SpringBrokerBridge getSpringBrokerBridge();
 
-  ConcurrencyControl getConcurrencyControl();
+  ActorSchedulingService getActorSchedulingService();
 
-  ActorFuture<Void> scheduleActor(Actor actor);
+  ConcurrencyControl getConcurrencyControl();
 
   BrokerHealthCheckService getHealthCheckService();
 
@@ -46,4 +49,22 @@ public interface BrokerStartupContext {
   ClusterServicesImpl getClusterServices();
 
   void setClusterServices(ClusterServicesImpl o);
+
+  void addDiskSpaceUsageListener(DiskSpaceUsageListener listener);
+
+  void removeDiskSpaceUsageListener(DiskSpaceUsageListener listener);
+
+  List<DiskSpaceUsageListener> getDiskSpaceUsageListeners();
+
+  CommandApiServiceImpl getCommandApiService();
+
+  void setCommandApiService(CommandApiServiceImpl commandApiService);
+
+  AtomixServerTransport getCommandApiServerTransport();
+
+  void setCommandApiServerTransport(AtomixServerTransport commandApiServerTransport);
+
+  ManagedMessagingService getCommandApiMessagingService();
+
+  void setCommandApiMessagingService(ManagedMessagingService commandApiMessagingService);
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -21,7 +21,10 @@ public final class BrokerStartupProcess {
 
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
   private static final List<StartupStep<BrokerStartupContext>> STARTUP_STEPS =
-      List.of(new MonitoringServerStep(), new ClusterServicesCreationStep());
+      List.of(
+          new MonitoringServerStep(),
+          new ClusterServicesCreationStep(),
+          new CommandApiServiceStep());
 
   private final StartupProcess<BrokerStartupContext> startupProcess;
 
@@ -77,6 +80,10 @@ public final class BrokerStartupProcess {
   }
 
   private BrokerContext createBrokerContext(final BrokerStartupContext bsc) {
-    return new BrokerContextImpl(bsc.getClusterServices(), bsc.getPartitionListeners());
+    return new BrokerContextImpl(
+        bsc.getClusterServices(),
+        bsc.getCommandApiService(),
+        bsc.getPartitionListeners(),
+        bsc.getDiskSpaceUsageListeners());
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStep.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import io.atomix.cluster.messaging.MessagingConfig;
+import io.atomix.cluster.messaging.impl.NettyMessagingService;
+import io.atomix.utils.net.Address;
+import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.broker.transport.backpressure.PartitionAwareRequestLimiter;
+import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
+import io.camunda.zeebe.transport.ServerTransport;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.camunda.zeebe.util.sched.ConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import java.util.List;
+import org.slf4j.Logger;
+
+final class CommandApiServiceStep extends AbstractBrokerStartupStep {
+
+  private static final Logger LOG = Loggers.SYSTEM_LOGGER;
+
+  @Override
+  public String getName() {
+    return "Command API";
+  }
+
+  @Override
+  void startupInternal(
+      final BrokerStartupContext brokerStartupContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> startupFuture) {
+
+    final var brokerCfg = brokerStartupContext.getBrokerConfiguration();
+
+    final var socketCfg = brokerCfg.getNetwork().getCommandApi();
+    final var messagingConfig = new MessagingConfig();
+    messagingConfig.setInterfaces(List.of(socketCfg.getHost()));
+    messagingConfig.setPort(socketCfg.getPort());
+    final var messagingService =
+        new NettyMessagingService(
+            brokerCfg.getCluster().getClusterName(),
+            Address.from(socketCfg.getAdvertisedHost(), socketCfg.getAdvertisedPort()),
+            messagingConfig);
+
+    messagingService
+        .start()
+        .whenComplete(
+            (createdMessagingService, error) -> {
+              /* the next block doesn't use "createdMessagingService" because it is only a
+               * MessagingService, but we need a ManagedMessagingService. At the time of this
+               * writing createdMessagingService == messagingService, so we use this instead.
+               */
+              forwardExceptions(
+                  () ->
+                      concurrencyControl.run(
+                          () ->
+                              forwardExceptions(
+                                  () ->
+                                      completeStartup(
+                                          brokerStartupContext,
+                                          startupFuture,
+                                          messagingService,
+                                          error),
+                                  startupFuture)),
+                  startupFuture);
+            });
+  }
+
+  @Override
+  void shutdownInternal(
+      final BrokerStartupContext brokerShutdownContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> shutdownFuture) {
+
+    final var commandApiServiceActor = brokerShutdownContext.getCommandApiService();
+    if (commandApiServiceActor == null) {
+      closeServerTransport(brokerShutdownContext, concurrencyControl, shutdownFuture);
+      return;
+    }
+    brokerShutdownContext.removePartitionListener(commandApiServiceActor);
+    brokerShutdownContext.removeDiskSpaceUsageListener(commandApiServiceActor);
+
+    concurrencyControl.runOnCompletion(
+        commandApiServiceActor.closeAsync(),
+        proceed(
+            () -> {
+              brokerShutdownContext.setCommandApiService(null);
+              closeServerTransport(brokerShutdownContext, concurrencyControl, shutdownFuture);
+            },
+            shutdownFuture));
+  }
+
+  private void completeStartup(
+      final BrokerStartupContext brokerStartupContext,
+      final ActorFuture<BrokerStartupContext> startupFuture,
+      final NettyMessagingService messagingService,
+      final Throwable error) {
+    if (error != null) {
+      startupFuture.completeExceptionally(error);
+    } else {
+      brokerStartupContext.setCommandApiMessagingService(messagingService);
+      LOG.debug(
+          "Bound command API to {}, using advertised address {} ",
+          messagingService.bindingAddresses(),
+          messagingService.address());
+
+      startServerTransport(brokerStartupContext, startupFuture);
+    }
+  }
+
+  private void startServerTransport(
+      final BrokerStartupContext brokerStartupContext,
+      final ActorFuture<BrokerStartupContext> startupFuture) {
+
+    final var concurrencyControl = brokerStartupContext.getConcurrencyControl();
+    final var brokerInfo = brokerStartupContext.getBrokerInfo();
+    final var schedulingService = brokerStartupContext.getActorSchedulingService();
+    final var messagingService = brokerStartupContext.getCommandApiMessagingService();
+
+    final var atomixServerTransport =
+        new AtomixServerTransport(brokerInfo.getNodeId(), messagingService);
+
+    concurrencyControl.runOnCompletion(
+        schedulingService.submitActor(atomixServerTransport),
+        proceed(
+            () -> {
+              brokerStartupContext.setCommandApiServerTransport(atomixServerTransport);
+              startCommandApiService(brokerStartupContext, atomixServerTransport, startupFuture);
+            },
+            startupFuture));
+  }
+
+  private void startCommandApiService(
+      final BrokerStartupContext brokerStartupContext,
+      final ServerTransport serverTransport,
+      final ActorFuture<BrokerStartupContext> startupFuture) {
+
+    final var concurrencyControl = brokerStartupContext.getConcurrencyControl();
+    final var brokerInfo = brokerStartupContext.getBrokerInfo();
+    final var brokerCfg = brokerStartupContext.getBrokerConfiguration();
+    final var schedulingService = brokerStartupContext.getActorSchedulingService();
+
+    final var backpressureCfg = brokerCfg.getBackpressure();
+    var limiter = PartitionAwareRequestLimiter.newNoopLimiter();
+    if (backpressureCfg.isEnabled()) {
+      limiter = PartitionAwareRequestLimiter.newLimiter(backpressureCfg);
+    }
+
+    final var commandApiService =
+        new CommandApiServiceImpl(
+            serverTransport,
+            brokerInfo,
+            limiter,
+            schedulingService,
+            brokerCfg.getExperimental().getQueryApi());
+
+    concurrencyControl.runOnCompletion(
+        schedulingService.submitActor(commandApiService),
+        proceed(
+            () -> {
+              brokerStartupContext.setCommandApiService(commandApiService);
+              brokerStartupContext.addPartitionListener(commandApiService);
+              brokerStartupContext.addDiskSpaceUsageListener(commandApiService);
+              startupFuture.complete(brokerStartupContext);
+            },
+            startupFuture));
+  }
+
+  private void closeServerTransport(
+      final BrokerStartupContext brokerShutdownContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> shutdownFuture) {
+    final var serverTransport = brokerShutdownContext.getCommandApiServerTransport();
+
+    if (serverTransport == null) {
+      stopMessagingService(brokerShutdownContext, concurrencyControl, shutdownFuture);
+      return;
+    }
+
+    concurrencyControl.runOnCompletion(
+        serverTransport.closeAsync(),
+        proceed(
+            () -> {
+              brokerShutdownContext.setCommandApiServerTransport(null);
+              stopMessagingService(brokerShutdownContext, concurrencyControl, shutdownFuture);
+            },
+            shutdownFuture));
+  }
+
+  private void stopMessagingService(
+      final BrokerStartupContext brokerShutdownContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> shutdownFuture) {
+
+    final var messagingService = brokerShutdownContext.getCommandApiMessagingService();
+
+    if (messagingService == null) {
+      shutdownFuture.complete(brokerShutdownContext);
+      return;
+    }
+
+    messagingService
+        .stop()
+        .whenComplete(
+            (of, error) -> {
+              if (error != null) {
+                shutdownFuture.completeExceptionally(error);
+              } else {
+                concurrencyControl.run(
+                    () -> {
+                      brokerShutdownContext.setCommandApiMessagingService(null);
+                      shutdownFuture.complete(brokerShutdownContext);
+                    });
+              }
+            });
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.messaging.ManagedMessagingService;
+import io.camunda.zeebe.broker.SpringBrokerBridge;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
+import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
+import io.camunda.zeebe.util.sched.TestConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class CommandApiServiceStepTest {
+  private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
+  private static final BrokerCfg TEST_BROKER_CONFIG = new BrokerCfg();
+  private static final BrokerInfo TEST_BROKER_INFO = new BrokerInfo(0, "localhost");
+
+  static {
+    final var commandApiCfg = TEST_BROKER_CONFIG.getNetwork().getCommandApi();
+    commandApiCfg.setHost("localhost");
+    commandApiCfg.setAdvertisedHost("localhost");
+  }
+
+  private final ActorSchedulingService mockActorSchedulingService =
+      mock(ActorSchedulingService.class);
+
+  private BrokerStartupContextImpl testBrokerStartupContext;
+
+  private final CommandApiServiceStep sut = new CommandApiServiceStep();
+
+  @BeforeEach
+  void setUp() {
+    when(mockActorSchedulingService.submitActor(any()))
+        .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
+
+    testBrokerStartupContext =
+        new BrokerStartupContextImpl(
+            TEST_BROKER_INFO,
+            TEST_BROKER_CONFIG,
+            Mockito.mock(SpringBrokerBridge.class),
+            mockActorSchedulingService,
+            Mockito.mock(BrokerHealthCheckService.class));
+    testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
+  }
+
+  @Test
+  void shouldHaveDescriptiveName() {
+    // when
+    final var actual = sut.getName();
+
+    // then
+    assertThat(actual).isSameAs("Command API");
+  }
+
+  @Nested
+  class StartupBehavior {
+
+    private ActorFuture<BrokerStartupContext> startupFuture;
+
+    @BeforeEach
+    void setUp() {
+      startupFuture = CONCURRENCY_CONTROL.createFuture();
+
+      final var port = SocketUtil.getNextAddress().getPort();
+      final var commandApiCfg = TEST_BROKER_CONFIG.getNetwork().getCommandApi();
+      commandApiCfg.setPort(port);
+      commandApiCfg.setAdvertisedPort(port);
+    }
+
+    @AfterEach
+    void tearDown() {
+      /* we need to stop the messaging service. This is the one component that is actually started
+       * and it binds to a port. The other components are constructed, but never started (they are
+       * passed to the actor scheduler mock, but this does not start the actor)
+       */
+      final var messagingGService = testBrokerStartupContext.getCommandApiMessagingService();
+      if (messagingGService != null) {
+        messagingGService.stop().join();
+      }
+    }
+
+    @Test
+    void shouldCompleteFuture() {
+      // when
+      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+      await().until(startupFuture::isDone);
+
+      // then
+      assertThat(startupFuture.isCompletedExceptionally()).isFalse();
+
+      assertThat(startupFuture.join()).isEqualTo(testBrokerStartupContext);
+    }
+
+    @Test
+    void shouldStartAndInstallMessagingService() {
+      // when
+      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+      await().until(startupFuture::isDone);
+
+      // then
+      final var messagingService = testBrokerStartupContext.getCommandApiMessagingService();
+      assertThat(messagingService).isNotNull();
+      assertThat(messagingService.isRunning()).isTrue();
+    }
+
+    @Test
+    void shouldStartAndInstallServerTransport() {
+      // when
+      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+      await().until(startupFuture::isDone);
+
+      // then
+      final var serverTransport = testBrokerStartupContext.getCommandApiServerTransport();
+
+      assertThat(serverTransport).isNotNull();
+      verify(mockActorSchedulingService).submitActor(serverTransport);
+    }
+
+    @Test
+    void shouldStartAndInstallCommandApiService() {
+      // when
+      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+      await().until(startupFuture::isDone);
+
+      // then
+      final var commandApiService = testBrokerStartupContext.getCommandApiService();
+
+      assertThat(commandApiService).isNotNull();
+      verify(mockActorSchedulingService).submitActor(commandApiService);
+    }
+
+    @Test
+    void shouldAddCommandApiServiceAsPartitionListener() {
+      // when
+      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+      await().until(startupFuture::isDone);
+
+      // then
+      final var commandApiService = testBrokerStartupContext.getCommandApiService();
+
+      assertThat(commandApiService).isNotNull();
+      assertThat(testBrokerStartupContext.getPartitionListeners()).contains(commandApiService);
+    }
+
+    @Test
+    void shouldAddCommandApiServiceAsDiskSpaceUsageListener() {
+      // when
+      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+      await().until(startupFuture::isDone);
+
+      // then
+      final var commandApiService = testBrokerStartupContext.getCommandApiService();
+
+      assertThat(commandApiService).isNotNull();
+      assertThat(testBrokerStartupContext.getDiskSpaceUsageListeners()).contains(commandApiService);
+    }
+  }
+
+  @Nested
+  class ShutdownBehavior {
+
+    private CommandApiServiceImpl mockCommandApiService;
+    private AtomixServerTransport mockAtomixServerTransport;
+    private ManagedMessagingService mockManagedMessagingService;
+
+    private ActorFuture<BrokerStartupContext> shutdownFuture;
+
+    @BeforeEach
+    void setUp() {
+      mockCommandApiService = mock(CommandApiServiceImpl.class);
+      when(mockCommandApiService.closeAsync())
+          .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
+
+      mockAtomixServerTransport = mock(AtomixServerTransport.class);
+      when(mockAtomixServerTransport.closeAsync())
+          .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
+
+      mockManagedMessagingService = mock(ManagedMessagingService.class);
+      when(mockManagedMessagingService.stop()).thenReturn(CompletableFuture.completedFuture(null));
+
+      testBrokerStartupContext.setCommandApiMessagingService(mockManagedMessagingService);
+      testBrokerStartupContext.setCommandApiServerTransport(mockAtomixServerTransport);
+      testBrokerStartupContext.setCommandApiService(mockCommandApiService);
+      testBrokerStartupContext.addPartitionListener(mockCommandApiService);
+      testBrokerStartupContext.addDiskSpaceUsageListener(mockCommandApiService);
+
+      shutdownFuture = CONCURRENCY_CONTROL.createFuture();
+    }
+
+    @Test
+    void shouldRemoveCommandApiFromDiskSpaceUsageListenerList() {
+      // when
+      sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);
+      await().until(shutdownFuture::isDone);
+
+      // then
+      assertThat(testBrokerStartupContext.getDiskSpaceUsageListeners())
+          .doesNotContain(mockCommandApiService);
+    }
+
+    @Test
+    void shouldRemoveCommandApiFromPartitionListenerList() {
+      // when
+      sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);
+      await().until(shutdownFuture::isDone);
+
+      // then
+      assertThat(testBrokerStartupContext.getPartitionListeners())
+          .doesNotContain(mockCommandApiService);
+    }
+
+    @Test
+    void shouldStopAndUninstallCommandApiService() {
+      // when
+      sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);
+      await().until(shutdownFuture::isDone);
+
+      // then
+      verify(mockCommandApiService).closeAsync();
+      final var commandApiService = testBrokerStartupContext.getCommandApiService();
+      assertThat(commandApiService).isNull();
+    }
+
+    @Test
+    void shouldStopAndUninstallServerTransport() {
+      // when
+      sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);
+      await().until(shutdownFuture::isDone);
+
+      // then
+      verify(mockAtomixServerTransport).closeAsync();
+      final var serverTransport = testBrokerStartupContext.getCommandApiServerTransport();
+      assertThat(serverTransport).isNull();
+    }
+
+    @Test
+    void shouldStopAndUninstallMessagingService() {
+      // when
+      sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);
+      await().until(shutdownFuture::isDone);
+
+      // then
+      verify(mockManagedMessagingService).stop();
+      final var messagingService = testBrokerStartupContext.getCommandApiMessagingService();
+      assertThat(messagingService).isNull();
+    }
+
+    @Test
+    void shouldCompleteFuture() {
+      // when
+      sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);
+      await().until(shutdownFuture::isDone);
+
+      // then
+      assertThat(shutdownFuture.isCompletedExceptionally()).isFalse();
+      assertThat(shutdownFuture.join()).isEqualTo(testBrokerStartupContext);
+    }
+  }
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
@@ -10,29 +10,26 @@ package io.camunda.zeebe.transport;
 import io.atomix.cluster.messaging.MessagingService;
 import io.camunda.zeebe.transport.impl.AtomixClientTransportAdapter;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
-import io.camunda.zeebe.util.sched.ActorScheduler;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
 
 public final class TransportFactory {
 
-  // we need to schedule the transports, but Actor is not an interface
-  // which means we need to schedule in the factory otherwise we can return the transport interface
-  // types
-  private final ActorScheduler actorScheduler;
+  private final ActorSchedulingService actorSchedulingService;
 
-  public TransportFactory(final ActorScheduler actorScheduler) {
-    this.actorScheduler = actorScheduler;
+  public TransportFactory(final ActorSchedulingService actorSchedulingService) {
+    this.actorSchedulingService = actorSchedulingService;
   }
 
   public ServerTransport createServerTransport(
       final int nodeId, final MessagingService messagingService) {
     final var atomixServerTransport = new AtomixServerTransport(nodeId, messagingService);
-    actorScheduler.submitActor(atomixServerTransport);
+    actorSchedulingService.submitActor(atomixServerTransport);
     return atomixServerTransport;
   }
 
   public ClientTransport createClientTransport(final MessagingService messagingService) {
     final var atomixClientTransportAdapter = new AtomixClientTransportAdapter(messagingService);
-    actorScheduler.submitActor(atomixClientTransportAdapter);
+    actorSchedulingService.submitActor(atomixClientTransportAdapter);
     return atomixClientTransportAdapter;
   }
 }

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ConcurrencyControl.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ConcurrencyControl.java
@@ -27,7 +27,7 @@ public interface ConcurrencyControl {
   <T> void runOnCompletion(final ActorFuture<T> future, final BiConsumer<T, Throwable> callback);
 
   /**
-   * Schedules an action to be invoked
+   * Schedules an action to be invoked (must be called from an actor thread)
    *
    * @param action action to be invoked
    */


### PR DESCRIPTION
## Description

This PR migrates the step to create the command API. Please see the commit comment for discussion on alternative implementation and why they were not chosen.

### Review hints
- I have tried this time to work with smaller PRs. Mostly because the last commit has grown quite large on its own, and the previous commits were easy to understand and review on their own. So this PR depends on #7797 , #7798 and #7799 
- in order to move forward with this PR, I have here the same commits as in the other PRs. They are marked as "Duplicate of commit in other PR" and do not need to be reviewed here.
- The new tests only test the happy path and only test what is easy to observe. I would leave it at that for now. Overall, I feel that the startup step still has too many responsibilities and testing this is cumbersome. The current tests are nice to read and understand, but debugging them is still a pain with the mix of blocking and non-blocking code.
- One detail that I was on the fence about is what to do in the case of errors during shutdown. Right now both startup and shutdown have stages. If any stage fails, the startup or shutdown is completed exceptionally. I think this makes sense for the startup case. In the shutdown case, one might want to aim a little higher and try to clean up as much as possible, even in the presence of errors. I felt so code would get too confusing for very little benefit and so I went for the simpler mechanism. This mechanism should also be easier to debug, because you can see in the startup context which objects were cleaned up and which were not
- Now that I write this, I realize I didn't put any log messages in. So please let me know if you want more logging.

## Related issues

#7539

<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
