### PR TITLE
Temporary experimental broker query API

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -308,6 +308,10 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -245,8 +245,8 @@ public final class Broker implements AutoCloseable {
 
   private AutoCloseable commandApiTransportAndHandlerStep(
       final BrokerCfg brokerCfg, final BrokerInfo localBroker) {
-    final var messagingService =
-        createMessagingService(brokerCfg.getCluster(), brokerCfg.getNetwork().getExternalApi());
+    final var externalApiCfg = brokerCfg.getNetwork().getExternalApi();
+    final var messagingService = createMessagingService(brokerCfg.getCluster(), externalApiCfg);
     messagingService.start().join();
     LOG.debug(
         "Bound command API to {}, using advertised address {} ",
@@ -263,7 +263,8 @@ public final class Broker implements AutoCloseable {
       limiter = PartitionAwareRequestLimiter.newLimiter(backpressureCfg);
     }
 
-    externalApiService = new ExternalApiServiceImpl(serverTransport, localBroker, limiter);
+    externalApiService =
+        new ExternalApiServiceImpl(serverTransport, localBroker, limiter, externalApiCfg);
     partitionListeners.add(externalApiService);
     scheduleActor(externalApiService);
     diskSpaceUsageListeners.add(externalApiService);

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -264,7 +264,12 @@ public final class Broker implements AutoCloseable {
     }
 
     externalApiService =
-        new ExternalApiServiceImpl(serverTransport, localBroker, limiter, externalApiCfg);
+        new ExternalApiServiceImpl(
+            serverTransport,
+            localBroker,
+            limiter,
+            scheduler,
+            brokerCfg.getExperimental().getQueryApi());
     partitionListeners.add(externalApiService);
     scheduleActor(externalApiService);
     diskSpaceUsageListeners.add(externalApiService);

--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -40,7 +40,7 @@ import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.transport.backpressure.PartitionAwareRequestLimiter;
-import io.camunda.zeebe.broker.transport.commandapi.ExternalApiServiceImpl;
+import io.camunda.zeebe.broker.transport.externalapi.ExternalApiServiceImpl;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.transport.TransportFactory;
 import io.camunda.zeebe.util.FileUtil;

--- a/broker/src/main/java/io/camunda/zeebe/broker/PartitionListener.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/PartitionListener.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker;
 
+import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 
@@ -35,12 +36,15 @@ public interface PartitionListener {
    * @param partitionId the corresponding partition id
    * @param term the current term
    * @param logStream the corresponding log stream
+   * @param queryService the corresponding query service
    * @return future that should be completed by the listener
    */
   ActorFuture<Void> onBecomingLeader(
       int partitionId,
       long term,
-      @Deprecated LogStream logStream); // lookup of log stream will be changed in the future
+      // lookup of log stream and queryService will be changed in the future
+      @Deprecated LogStream logStream,
+      QueryService queryService);
 
   /**
    * Is called by the {@link io.camunda.zeebe.broker.system.partitions.ZeebePartition} on becoming

--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/SubscriptionApiCommandMessageHandlerService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/SubscriptionApiCommandMessageHandlerService.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandMessageHandler;
+import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
@@ -61,7 +62,10 @@ public final class SubscriptionApiCommandMessageHandlerService extends Actor
 
   @Override
   public ActorFuture<Void> onBecomingLeader(
-      final int partitionId, final long term, final LogStream logStream) {
+      final int partitionId,
+      final long term,
+      final LogStream logStream,
+      final QueryService queryService) {
     final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
     actor.submit(
         () ->

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -43,7 +43,7 @@ import io.camunda.zeebe.broker.system.partitions.impl.steps.SnapshotDirectorPart
 import io.camunda.zeebe.broker.system.partitions.impl.steps.StateControllerPartitionStartupStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.StreamProcessorPartitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.ZeebeDbPartitionStep;
-import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
+import io.camunda.zeebe.broker.transport.commandapi.ExternalApiService;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.ProcessingContext;
@@ -101,7 +101,7 @@ public final class PartitionFactory {
   private final BrokerCfg brokerCfg;
   private final BrokerInfo localBroker;
   private final PushDeploymentRequestHandler deploymentRequestHandler;
-  private final CommandApiService commandHApiService;
+  private final ExternalApiService externalApiService;
   private final FileBasedSnapshotStoreFactory snapshotStoreFactory;
   private final ClusterServices clusterServices;
   private final ExporterRepository exporterRepository;
@@ -112,7 +112,7 @@ public final class PartitionFactory {
       final BrokerCfg brokerCfg,
       final BrokerInfo localBroker,
       final PushDeploymentRequestHandler deploymentRequestHandler,
-      final CommandApiService commandHApiService,
+      final ExternalApiService externalApiService,
       final FileBasedSnapshotStoreFactory snapshotStoreFactory,
       final ClusterServices clusterServices,
       final ExporterRepository exporterRepository,
@@ -121,7 +121,7 @@ public final class PartitionFactory {
     this.brokerCfg = brokerCfg;
     this.localBroker = localBroker;
     this.deploymentRequestHandler = deploymentRequestHandler;
-    this.commandHApiService = commandHApiService;
+    this.externalApiService = externalApiService;
     this.snapshotStoreFactory = snapshotStoreFactory;
     this.clusterServices = clusterServices;
     this.exporterRepository = exporterRepository;
@@ -164,8 +164,8 @@ public final class PartitionFactory {
                   communicationService, membershipService, owningPartition.members()),
               actorSchedulingService,
               brokerCfg,
-              () -> commandHApiService.newCommandResponseWriter(),
-              () -> commandHApiService.getOnProcessedListener(partitionId),
+              () -> externalApiService.newCommandResponseWriter(),
+              () -> externalApiService.getOnProcessedListener(partitionId),
               snapshotStoreFactory.getConstructableSnapshotStore(partitionId),
               snapshotStoreFactory.getReceivableSnapshotStore(partitionId),
               typedRecordProcessorsFactory,

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.broker.system.partitions.impl.steps.ExporterDirectorPart
 import io.camunda.zeebe.broker.system.partitions.impl.steps.LogDeletionPartitionStartupStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.LogStoragePartitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.LogStreamPartitionStep;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.QueryServiceStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.RockDbMetricExporterPartitionStartupStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.SnapshotDirectorPartitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.StateControllerPartitionStartupStep;
@@ -79,6 +80,7 @@ public final class PartitionFactory {
           new LogStoragePartitionStep(),
           new LogStreamPartitionStep(),
           new ZeebeDbPartitionStep(),
+          new QueryServiceStep(),
           new StreamProcessorPartitionStep(),
           new SnapshotDirectorPartitionStep(),
           PartitionStepMigrationHelper.fromStartupStep(
@@ -91,6 +93,7 @@ public final class PartitionFactory {
           new LogStoragePartitionStep(),
           new LogStreamPartitionStep(),
           new ZeebeDbPartitionStep(),
+          new QueryServiceStep(),
           new StreamProcessorPartitionStep(),
           new SnapshotDirectorPartitionStep(),
           PartitionStepMigrationHelper.fromStartupStep(

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -43,7 +43,7 @@ import io.camunda.zeebe.broker.system.partitions.impl.steps.SnapshotDirectorPart
 import io.camunda.zeebe.broker.system.partitions.impl.steps.StateControllerPartitionStartupStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.StreamProcessorPartitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.ZeebeDbPartitionStep;
-import io.camunda.zeebe.broker.transport.commandapi.ExternalApiService;
+import io.camunda.zeebe.broker.transport.externalapi.ExternalApiService;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.ProcessingContext;

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -24,7 +24,7 @@ import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.partitions.PartitionHealthBroadcaster;
 import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
-import io.camunda.zeebe.broker.transport.commandapi.ExternalApiService;
+import io.camunda.zeebe.broker.transport.externalapi.ExternalApiService;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
 import io.camunda.zeebe.util.health.HealthStatus;

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -24,7 +24,7 @@ import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.partitions.PartitionHealthBroadcaster;
 import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
-import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
+import io.camunda.zeebe.broker.transport.commandapi.ExternalApiService;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
 import io.camunda.zeebe.util.health.HealthStatus;
@@ -59,7 +59,7 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
   private final PushDeploymentRequestHandler deploymentRequestHandler;
   private final List<PartitionListener> partitionListeners;
   private final ClusterServices clusterServices;
-  private final CommandApiService commandApiService;
+  private final ExternalApiService externalApiService;
   private final ExporterRepository exporterRepository;
 
   public PartitionManagerImpl(
@@ -71,7 +71,7 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
       final PushDeploymentRequestHandler deploymentRequestHandler,
       final Consumer<DiskSpaceUsageListener> diskSpaceUsageListenerRegistry,
       final List<PartitionListener> partitionListeners,
-      final CommandApiService commandApiService,
+      final ExternalApiService externalApiService,
       final ExporterRepository exporterRepository) {
 
     snapshotStoreFactory =
@@ -84,7 +84,7 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
     this.healthCheckService = healthCheckService;
     this.deploymentRequestHandler = deploymentRequestHandler;
     this.diskSpaceUsageListenerRegistry = diskSpaceUsageListenerRegistry;
-    this.commandApiService = commandApiService;
+    this.externalApiService = externalApiService;
     this.exporterRepository = exporterRepository;
 
     partitionGroup =
@@ -142,7 +142,7 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
                       brokerCfg,
                       localBroker,
                       deploymentRequestHandler,
-                      commandApiService,
+                      externalApiService,
                       snapshotStoreFactory,
                       clusterServices,
                       exporterRepository,

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -14,6 +14,7 @@ import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.Member;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.util.LogUtil;
@@ -53,7 +54,10 @@ public final class TopologyManagerImpl extends Actor
 
   @Override
   public ActorFuture<Void> onBecomingLeader(
-      final int partitionId, final long term, final LogStream logStream) {
+      final int partitionId,
+      final long term,
+      final LogStream logStream,
+      final QueryService queryService) {
     return setLeader(term, partitionId);
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -29,6 +29,7 @@ public class ExperimentalCfg implements ConfigurationEntry {
   private RocksdbCfg rocksdb = new RocksdbCfg();
   private RaftCfg raft = new RaftCfg();
   private PartitioningCfg partitioning = new PartitioningCfg();
+  private QueryApiCfg queryApi = new QueryApiCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -96,6 +97,14 @@ public class ExperimentalCfg implements ConfigurationEntry {
     this.partitioning = partitioning;
   }
 
+  public QueryApiCfg getQueryApi() {
+    return queryApi;
+  }
+
+  public void setQueryApi(final QueryApiCfg queryApi) {
+    this.queryApi = queryApi;
+  }
+
   @Override
   public String toString() {
     return "ExperimentalCfg{"
@@ -109,6 +118,8 @@ public class ExperimentalCfg implements ConfigurationEntry {
         + rocksdb
         + ", partitioning="
         + partitioning
+        + ", queryApi="
+        + queryApi
         + '}';
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.configuration;
 
-import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg.CommandApiCfg;
+import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg.ExternalApiCfg;
 import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg.InternalApiCfg;
 import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg.MonitoringApiCfg;
 import java.util.Optional;
@@ -26,7 +26,7 @@ public final class NetworkCfg implements ConfigurationEntry {
   private DataSize maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
   private String advertisedHost;
 
-  private final CommandApiCfg commandApi = new CommandApiCfg();
+  private final ExternalApiCfg commandApi = new ExternalApiCfg();
   private InternalApiCfg internalApi = new InternalApiCfg();
   private MonitoringApiCfg monitoringApi = new MonitoringApiCfg();
 
@@ -77,7 +77,13 @@ public final class NetworkCfg implements ConfigurationEntry {
     this.maxMessageSize = maxMessageSize;
   }
 
-  public CommandApiCfg getCommandApi() {
+  public ExternalApiCfg getExternalApi() {
+    return commandApi;
+  }
+
+  /** @deprecated replaced by {@link #getExternalApi()}. Exists only for backwards compatibility. */
+  @Deprecated(forRemoval = true)
+  public ExternalApiCfg getCommandApi() {
     return commandApi;
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/QueryApiCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/QueryApiCfg.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+public final class QueryApiCfg {
+  private boolean enabled = false;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  @Override
+  public String toString() {
+    return "QueryApiCfg{" + "enabled=" + enabled + '}';
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/SocketBindingCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/SocketBindingCfg.java
@@ -90,8 +90,53 @@ public class SocketBindingCfg {
   }
 
   public static class ExternalApiCfg extends SocketBindingCfg {
+
+    private QueryApiCfg queryApi = new QueryApiCfg();
+
     public ExternalApiCfg() {
       super(NetworkCfg.DEFAULT_COMMAND_API_PORT);
+    }
+
+    public QueryApiCfg getQueryApi() {
+      return queryApi;
+    }
+
+    public void setQueryApi(final QueryApiCfg queryApi) {
+      this.queryApi = queryApi;
+    }
+
+    @Override
+    public String toString() {
+      return "ExternalApiCfg{"
+          + "host='"
+          + getHost()
+          + '\''
+          + ", port="
+          + getPort()
+          + ", advertisedHost="
+          + getAdvertisedHost()
+          + ", advertisedPort="
+          + getAdvertisedPort()
+          + ", queryApi="
+          + queryApi
+          + '}';
+    }
+
+    public static class QueryApiCfg {
+      private boolean enabled = false;
+
+      public boolean isEnabled() {
+        return enabled;
+      }
+
+      public void setEnabled(final boolean enabled) {
+        this.enabled = enabled;
+      }
+
+      @Override
+      public String toString() {
+        return "QueryApiCfg{" + "enabled=" + enabled + '}';
+      }
     }
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/SocketBindingCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/SocketBindingCfg.java
@@ -91,18 +91,8 @@ public class SocketBindingCfg {
 
   public static class ExternalApiCfg extends SocketBindingCfg {
 
-    private QueryApiCfg queryApi = new QueryApiCfg();
-
     public ExternalApiCfg() {
       super(NetworkCfg.DEFAULT_COMMAND_API_PORT);
-    }
-
-    public QueryApiCfg getQueryApi() {
-      return queryApi;
-    }
-
-    public void setQueryApi(final QueryApiCfg queryApi) {
-      this.queryApi = queryApi;
     }
 
     @Override
@@ -117,26 +107,7 @@ public class SocketBindingCfg {
           + getAdvertisedHost()
           + ", advertisedPort="
           + getAdvertisedPort()
-          + ", queryApi="
-          + queryApi
           + '}';
-    }
-
-    public static class QueryApiCfg {
-      private boolean enabled = false;
-
-      public boolean isEnabled() {
-        return enabled;
-      }
-
-      public void setEnabled(final boolean enabled) {
-        this.enabled = enabled;
-      }
-
-      @Override
-      public String toString() {
-        return "QueryApiCfg{" + "enabled=" + enabled + '}';
-      }
     }
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/SocketBindingCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/SocketBindingCfg.java
@@ -89,8 +89,8 @@ public class SocketBindingCfg {
         + "}";
   }
 
-  public static class CommandApiCfg extends SocketBindingCfg {
-    public CommandApiCfg() {
+  public static class ExternalApiCfg extends SocketBindingCfg {
+    public ExternalApiCfg() {
       super(NetworkCfg.DEFAULT_COMMAND_API_PORT);
     }
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/management/LeaderManagementRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/management/LeaderManagementRequestHandler.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.system.management.deployment.PushDeploymentRequestHandler;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
+import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
@@ -67,7 +68,10 @@ public final class LeaderManagementRequestHandler extends Actor
 
   @Override
   public ActorFuture<Void> onBecomingLeader(
-      final int partitionId, final long term, final LogStream logStream) {
+      final int partitionId,
+      final long term,
+      final LogStream logStream,
+      final QueryService queryService) {
     final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
     actor.submit(
         () ->

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -12,6 +12,7 @@ import io.atomix.primitive.partition.PartitionGroup;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
+import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.util.health.CriticalComponentsHealthMonitor;
@@ -136,7 +137,10 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
 
   @Override
   public ActorFuture<Void> onBecomingLeader(
-      final int partitionId, final long term, final LogStream logStream) {
+      final int partitionId,
+      final long term,
+      final LogStream logStream,
+      final QueryService queryService) {
     checkState();
     return updateBrokerReadyStatus(partitionId);
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -73,6 +73,7 @@ public class PartitionStartupAndTransitionContextImpl
   private ScheduledTimer metricsTimer;
   private ExporterDirector exporterDirector;
   private AtomixLogStorage logStorage;
+  private StateQueryService queryService;
 
   private long currentTerm;
   private Role currentRole;
@@ -133,9 +134,8 @@ public class PartitionStartupAndTransitionContextImpl
 
   @Override
   public List<ActorFuture<Void>> notifyListenersOfBecomingLeader(final long newTerm) {
-    final var queryService = new StateQueryService(getZeebeDb());
     return partitionListeners.stream()
-        .map(l -> l.onBecomingLeader(getPartitionId(), newTerm, getLogStream(), queryService))
+        .map(l -> l.onBecomingLeader(getPartitionId(), newTerm, getLogStream(), getQueryService()))
         .collect(Collectors.toList());
   }
 
@@ -252,11 +252,6 @@ public class PartitionStartupAndTransitionContextImpl
   }
 
   @Override
-  public PartitionStartupAndTransitionContextImpl createTransitionContext() {
-    return this;
-  }
-
-  @Override
   public boolean shouldProcess() {
     return partitionProcessingState.shouldProcess();
   }
@@ -264,6 +259,11 @@ public class PartitionStartupAndTransitionContextImpl
   @Override
   public void setDiskSpaceAvailable(final boolean diskSpaceAvailable) {
     partitionProcessingState.setDiskSpaceAvailable(diskSpaceAvailable);
+  }
+
+  @Override
+  public StateQueryService getQueryService() {
+    return queryService;
   }
 
   public void setCurrentTerm(final long currentTerm) {
@@ -274,12 +274,22 @@ public class PartitionStartupAndTransitionContextImpl
     this.currentRole = currentRole;
   }
 
+  @Override
+  public void setQueryService(final StateQueryService queryService) {
+    this.queryService = queryService;
+  }
+
   public AtomixLogStorage getLogStorage() {
     return logStorage;
   }
 
   public void setLogStorage(final AtomixLogStorage logStorage) {
     this.logStorage = logStorage;
+  }
+
+  @Override
+  public PartitionStartupAndTransitionContextImpl createTransitionContext() {
+    return this;
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
+import io.camunda.zeebe.engine.state.query.StateQueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.storage.atomix.AtomixLogStorage;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
@@ -132,8 +133,9 @@ public class PartitionStartupAndTransitionContextImpl
 
   @Override
   public List<ActorFuture<Void>> notifyListenersOfBecomingLeader(final long newTerm) {
+    final var queryService = new StateQueryService(getZeebeDb());
     return partitionListeners.stream()
-        .map(l -> l.onBecomingLeader(getPartitionId(), newTerm, getLogStream()))
+        .map(l -> l.onBecomingLeader(getPartitionId(), newTerm, getLogStream(), queryService))
         .collect(Collectors.toList());
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupContext.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
+import io.camunda.zeebe.engine.state.query.StateQueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
@@ -103,6 +104,10 @@ public interface PartitionStartupContext {
   ExporterDirector getExporterDirector();
 
   void setExporterDirector(ExporterDirector director);
+
+  void setQueryService(final StateQueryService queryService);
+
+  StateQueryService getQueryService();
 
   // can be called any time after bootstrap has completed
   PartitionStartupAndTransitionContextImpl createTransitionContext();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/QueryServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/QueryServiceStep.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import io.camunda.zeebe.broker.system.partitions.PartitionStartupAndTransitionContextImpl;
+import io.camunda.zeebe.broker.system.partitions.PartitionStep;
+import io.camunda.zeebe.engine.state.query.StateQueryService;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
+import org.agrona.CloseHelper;
+
+public final class QueryServiceStep implements PartitionStep {
+
+  @Override
+  public ActorFuture<Void> open(final PartitionStartupAndTransitionContextImpl context) {
+    try {
+      final var service = new StateQueryService(context.getZeebeDb());
+      context.setQueryService(service);
+      return CompletableActorFuture.completed(null);
+    } catch (final Exception e) {
+      return CompletableActorFuture.completedExceptionally(e);
+    }
+  }
+
+  @Override
+  public ActorFuture<Void> close(final PartitionStartupAndTransitionContextImpl context) {
+    try {
+      CloseHelper.close(context.getQueryService());
+      context.setQueryService(null);
+      return CompletableActorFuture.completed(null);
+    } catch (final Exception e) {
+      return CompletableActorFuture.completedExceptionally(e);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return "queryService";
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/ExternalApiService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/ExternalApiService.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import java.util.function.Consumer;
 
-public interface CommandApiService {
+public interface ExternalApiService {
 
   CommandResponseWriter newCommandResponseWriter();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/CommandApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/CommandApiRequestHandler.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.commandapi;
+package io.camunda.zeebe.broker.transport.externalapi;
 
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.transport.backpressure.BackpressureMetrics;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/CommandResponseWriterImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/CommandResponseWriterImpl.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.commandapi;
+package io.camunda.zeebe.broker.transport.externalapi;
 
 import static io.camunda.zeebe.protocol.record.ExecuteCommandResponseEncoder.keyNullValue;
 import static io.camunda.zeebe.protocol.record.ExecuteCommandResponseEncoder.partitionIdNullValue;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/ErrorResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/ErrorResponseWriter.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.commandapi;
+package io.camunda.zeebe.broker.transport.externalapi;
 
 import static io.camunda.zeebe.util.StringUtil.getBytes;
 import static java.lang.String.format;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/ExternalApiService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/ExternalApiService.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.commandapi;
+package io.camunda.zeebe.broker.transport.externalapi;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/ExternalApiServiceImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/ExternalApiServiceImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.transport.externalapi;
 
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg.ExternalApiCfg;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.transport.backpressure.PartitionAwareRequestLimiter;
 import io.camunda.zeebe.broker.transport.backpressure.RequestLimiter;
@@ -40,11 +41,12 @@ public final class ExternalApiServiceImpl extends Actor
   public ExternalApiServiceImpl(
       final ServerTransport serverTransport,
       final BrokerInfo localBroker,
-      final PartitionAwareRequestLimiter limiter) {
+      final PartitionAwareRequestLimiter limiter,
+      final ExternalApiCfg externalApi) {
     this.serverTransport = serverTransport;
     this.limiter = limiter;
     commandHandler = new CommandApiRequestHandler();
-    queryHandler = new QueryApiRequestHandler();
+    queryHandler = new QueryApiRequestHandler(externalApi.getQueryApi());
     actorName = buildActorName(localBroker.getNodeId(), "ExternalApiService");
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/ExternalApiServiceImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/ExternalApiServiceImpl.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.commandapi;
+package io.camunda.zeebe.broker.transport.externalapi;
 
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.PartitionListener;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/ExternalApiServiceImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/ExternalApiServiceImpl.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.transport.backpressure.PartitionAwareRequestLimit
 import io.camunda.zeebe.broker.transport.backpressure.RequestLimiter;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
+import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -65,7 +66,10 @@ public final class ExternalApiServiceImpl extends Actor
 
   @Override
   public ActorFuture<Void> onBecomingLeader(
-      final int partitionId, final long term, final LogStream logStream) {
+      final int partitionId,
+      final long term,
+      final LogStream logStream,
+      final QueryService queryService) {
     final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
     actor.call(
         () -> {

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/QueryApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/QueryApiRequestHandler.java
@@ -7,16 +7,22 @@
  */
 package io.camunda.zeebe.broker.transport.externalapi;
 
-import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg.ExternalApiCfg.QueryApiCfg;
+import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.broker.system.configuration.QueryApiCfg;
 import io.camunda.zeebe.engine.state.QueryService;
+import io.camunda.zeebe.engine.state.QueryService.ClosedServiceException;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.ExecuteQueryRequestDecoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.transport.RequestHandler;
 import io.camunda.zeebe.transport.ServerOutput;
+import io.camunda.zeebe.util.sched.Actor;
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.Int2ObjectHashMap;
 
@@ -25,18 +31,42 @@ import org.agrona.collections.Int2ObjectHashMap;
  * bpmnProcessId of a process based on the request details. Make sure to set {@link
  * QueryApiCfg#setEnabled(boolean)} to true to enable this functionality.
  */
-public final class QueryApiRequestHandler implements RequestHandler {
+@SuppressWarnings("removal")
+@Deprecated(forRemoval = true, since = "1.2.0")
+public final class QueryApiRequestHandler extends Actor implements RequestHandler {
+  private static final Set<ValueType> ACCEPTED_VALUE_TYPES =
+      EnumSet.of(ValueType.PROCESS, ValueType.PROCESS_INSTANCE, ValueType.JOB);
 
   private final Map<Integer, QueryService> queryServicePerPartition = new Int2ObjectHashMap<>();
-  private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
-  private final ExecuteQueryRequestDecoder requestDecoder = new ExecuteQueryRequestDecoder();
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+  private final ExecuteQueryRequestDecoder messageDecoder = new ExecuteQueryRequestDecoder();
 
   private final ErrorResponseWriter errorResponseWriter = new ErrorResponseWriter();
   private final QueryResponseWriter queryResponseWriter = new QueryResponseWriter();
   private final QueryApiCfg config;
+  private final String actorName;
 
-  public QueryApiRequestHandler(final QueryApiCfg config) {
+  public QueryApiRequestHandler(final QueryApiCfg config, final int nodeId) {
     this.config = config;
+    actorName = buildActorName(nodeId, "QueryApi");
+  }
+
+  @Override
+  public String getName() {
+    return actorName;
+  }
+
+  @Override
+  protected void onActorClosing() {
+    queryServicePerPartition.clear();
+  }
+
+  public void addPartition(final int partitionId, final QueryService queryService) {
+    actor.run(() -> queryServicePerPartition.put(partitionId, queryService));
+  }
+
+  public void removePartition(final int partitionId) {
+    actor.run(() -> queryServicePerPartition.remove(partitionId));
   }
 
   @Override
@@ -47,26 +77,41 @@ public final class QueryApiRequestHandler implements RequestHandler {
       final DirectBuffer buffer,
       final int offset,
       final int length) {
+    actor.run(
+        () -> {
+          try {
+            handleRequest(serverOutput, partitionId, requestId, buffer, offset);
+          } catch (final Exception e) {
+            Loggers.TRANSPORT_LOGGER.error(
+                "Failed to handle query on partition {}", partitionId, e);
+            errorResponseWriter
+                .internalError(
+                    "Failed to handle query due to internal error; see the broker logs for"
+                        + " more")
+                .tryWriteResponse(serverOutput, partitionId, requestId);
+          }
+        });
+  }
 
+  private void handleRequest(
+      final ServerOutput serverOutput,
+      final int partitionId,
+      final long requestId,
+      final DirectBuffer buffer,
+      final int offset) {
     if (!config.isEnabled()) {
       errorResponseWriter
           .errorCode(ErrorCode.UNSUPPORTED_MESSAGE)
-          .errorMessage("Expected to handle ExecuteQueryRequest, but QueryApi is disabled")
+          .errorMessage(
+              "Failed to handle query as the query API is disabled; did you configure"
+                  + " zeebe.broker.experimental.queryapi.enabled?")
           .tryWriteResponse(serverOutput, partitionId, requestId);
       return;
     }
 
-    messageHeaderDecoder.wrap(buffer, offset);
-
-    // todo: check all things that can be wrong with the message
-
-    requestDecoder.wrap(
-        buffer,
-        offset + messageHeaderDecoder.encodedLength(),
-        messageHeaderDecoder.blockLength(),
-        messageHeaderDecoder.version());
-
-    final var key = requestDecoder.key();
+    if (!decodeMessage(serverOutput, partitionId, requestId, buffer, offset)) {
+      return;
+    }
 
     final var queryService = queryServicePerPartition.get(partitionId);
     if (queryService == null) {
@@ -76,26 +121,45 @@ public final class QueryApiRequestHandler implements RequestHandler {
       return;
     }
 
+    try {
+      handleQuery(serverOutput, partitionId, requestId, queryService);
+    } catch (final ClosedServiceException e) {
+      Loggers.TRANSPORT_LOGGER.debug(
+          "Failed to handle query on partition {} as the query service was closed concurrently",
+          partitionId,
+          e);
+      errorResponseWriter
+          .partitionLeaderMismatch(partitionId)
+          .tryWriteResponse(serverOutput, partitionId, requestId);
+    }
+  }
+
+  /** {@link #messageDecoder} here is guaranteed to hold a valid, decoded query. */
+  private void handleQuery(
+      final ServerOutput serverOutput,
+      final int partitionId,
+      final long requestId,
+      final QueryService queryService) {
+    final var key = messageDecoder.key();
+
     final Optional<DirectBuffer> bpmnProcessId;
-    switch (requestDecoder.valueType()) {
+    switch (messageDecoder.valueType()) {
       case PROCESS:
         bpmnProcessId = queryService.getBpmnProcessIdForProcess(key);
         break;
-      default:
-        // todo: add other value types
-        // todo: deal with this failure
-        bpmnProcessId = Optional.empty();
+      case PROCESS_INSTANCE:
+        bpmnProcessId = queryService.getBpmnProcessIdForProcessInstance(key);
         break;
+      case JOB:
+        bpmnProcessId = queryService.getBpmnProcessIdForJob(key);
+        break;
+      default:
+        failOnInvalidValueType(serverOutput, partitionId, requestId);
+        return;
     }
 
     if (bpmnProcessId.isEmpty()) {
-      final String type = getValueTypeName(requestDecoder.valueType());
-      errorResponseWriter
-          .errorCode(ErrorCode.PROCESS_NOT_FOUND)
-          .errorMessage(
-              String.format(
-                  "Expected to handle ExecuteQueryRequest, but no %s found with key %d", type, key))
-          .tryWriteResponse(serverOutput, partitionId, requestId);
+      failOnResourceNotFound(serverOutput, partitionId, requestId, key);
       return;
     }
 
@@ -104,24 +168,71 @@ public final class QueryApiRequestHandler implements RequestHandler {
         .tryWriteResponse(serverOutput, partitionId, requestId);
   }
 
-  private static String getValueTypeName(final ValueType valueType) {
-    switch (valueType) {
-      case PROCESS:
-        return "process";
-      case PROCESS_INSTANCE:
-        return "process instance";
-      case JOB:
-        return "job";
-      default:
-        return "element";
+  private boolean decodeMessage(
+      final ServerOutput serverOutput,
+      final int partitionId,
+      final long requestId,
+      final DirectBuffer buffer,
+      final int offset) {
+    if (decodeMessageHeader(serverOutput, partitionId, requestId, buffer, offset)) {
+      return false;
     }
+
+    messageDecoder.wrap(
+        buffer,
+        offset + headerDecoder.encodedLength(),
+        headerDecoder.blockLength(),
+        headerDecoder.version());
+
+    return true;
   }
 
-  public void addPartition(final int partitionId, final QueryService queryService) {
-    queryServicePerPartition.put(partitionId, queryService);
+  private boolean decodeMessageHeader(
+      final ServerOutput serverOutput,
+      final int partitionId,
+      final long requestId,
+      final DirectBuffer buffer,
+      final int offset) {
+    headerDecoder.wrap(buffer, offset);
+    final int templateId = headerDecoder.templateId();
+    final int clientVersion = headerDecoder.version();
+
+    if (clientVersion > Protocol.PROTOCOL_VERSION) {
+      errorResponseWriter
+          .invalidClientVersion(Protocol.PROTOCOL_VERSION, clientVersion)
+          .tryWriteResponse(serverOutput, partitionId, requestId);
+      return true;
+    }
+
+    if (templateId != ExecuteQueryRequestDecoder.TEMPLATE_ID) {
+      errorResponseWriter
+          .invalidMessageTemplate(templateId, ExecuteQueryRequestDecoder.TEMPLATE_ID)
+          .tryWriteResponse(serverOutput, partitionId, requestId);
+      return true;
+    }
+    return false;
   }
 
-  public void removePartition(final int partitionId) {
-    queryServicePerPartition.remove(partitionId);
+  private void failOnResourceNotFound(
+      final ServerOutput serverOutput,
+      final int partitionId,
+      final long requestId,
+      final long key) {
+    errorResponseWriter
+        .errorCode(ErrorCode.PROCESS_NOT_FOUND)
+        .errorMessage(
+            "Expected to find the process ID for resource of type %s with key %d, but"
+                + " no such resource was found",
+            messageDecoder.valueType(), key)
+        .tryWriteResponse(serverOutput, partitionId, requestId);
+  }
+
+  private void failOnInvalidValueType(
+      final ServerOutput serverOutput, final int partitionId, final long requestId) {
+    errorResponseWriter
+        .internalError(
+            "Expected to handle query with value type of %s, but was %s",
+            ACCEPTED_VALUE_TYPES, messageDecoder.valueType())
+        .tryWriteResponse(serverOutput, partitionId, requestId);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/QueryApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/QueryApiRequestHandler.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.externalapi;
+
+import io.camunda.zeebe.engine.state.QueryService;
+import io.camunda.zeebe.protocol.record.ErrorCode;
+import io.camunda.zeebe.protocol.record.ExecuteQueryRequestDecoder;
+import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.transport.RequestHandler;
+import io.camunda.zeebe.transport.ServerOutput;
+import java.util.Map;
+import java.util.Optional;
+import org.agrona.DirectBuffer;
+import org.agrona.collections.Int2ObjectHashMap;
+
+/**
+ * Request handler for ExecuteQueryRequest SBE messages. When successful, it looks up the
+ * bpmnProcessId of a process based on the request details. Make sure to set {@link
+ * QueryApiCfg#setEnabled(boolean)} to true to enable this functionality.
+ */
+public final class QueryApiRequestHandler implements RequestHandler {
+
+  private final Map<Integer, QueryService> queryServicePerPartition = new Int2ObjectHashMap<>();
+  private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
+  private final ExecuteQueryRequestDecoder requestDecoder = new ExecuteQueryRequestDecoder();
+
+  private final ErrorResponseWriter errorResponseWriter = new ErrorResponseWriter();
+  private final QueryResponseWriter queryResponseWriter = new QueryResponseWriter();
+
+  @Override
+  public void onRequest(
+      final ServerOutput serverOutput,
+      final int partitionId,
+      final long requestId,
+      final DirectBuffer buffer,
+      final int offset,
+      final int length) {
+
+    messageHeaderDecoder.wrap(buffer, offset);
+
+    // todo: check all things that can be wrong with the message
+
+    requestDecoder.wrap(
+        buffer,
+        offset + messageHeaderDecoder.encodedLength(),
+        messageHeaderDecoder.blockLength(),
+        messageHeaderDecoder.version());
+
+    final var key = requestDecoder.key();
+
+    final var queryService = queryServicePerPartition.get(partitionId);
+    if (queryService == null) {
+      errorResponseWriter
+          .errorCode(ErrorCode.INTERNAL_ERROR)
+          .errorMessage(
+              "Expected to handle ExecuteQueryRequest, but unable to access query service")
+          .tryWriteResponse(serverOutput, partitionId, requestId);
+      return;
+    }
+
+    final Optional<DirectBuffer> bpmnProcessId;
+    if (requestDecoder.valueType() == ValueType.PROCESS) {
+      bpmnProcessId = queryService.getBpmnProcessIdForProcess(key);
+    } else {
+      // todo: add other value types
+      // todo: deal with this failure
+      return;
+    }
+
+    if (bpmnProcessId.isEmpty()) {
+      errorResponseWriter
+          .errorCode(ErrorCode.PROCESS_NOT_FOUND)
+          .errorMessage(
+              "Expected to handle ExecuteQueryRequest, but no process found with key " + key)
+          .tryWriteResponse(serverOutput, partitionId, requestId);
+      return;
+    }
+
+    queryResponseWriter
+        .bpmnProcessId(bpmnProcessId.get())
+        .tryWriteResponse(serverOutput, partitionId, requestId);
+  }
+
+  public void addPartition(final int partitionId, final QueryService queryService) {
+    queryServicePerPartition.put(partitionId, queryService);
+  }
+
+  public void removePartition(final int partitionId) {
+    queryServicePerPartition.remove(partitionId);
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/QueryApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/QueryApiRequestHandler.java
@@ -71,9 +71,7 @@ public final class QueryApiRequestHandler implements RequestHandler {
     final var queryService = queryServicePerPartition.get(partitionId);
     if (queryService == null) {
       errorResponseWriter
-          .errorCode(ErrorCode.INTERNAL_ERROR)
-          .errorMessage(
-              "Expected to handle ExecuteQueryRequest, but unable to access query service")
+          .partitionLeaderMismatch(partitionId)
           .tryWriteResponse(serverOutput, partitionId, requestId);
       return;
     }

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/QueryResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/QueryResponseWriter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.externalapi;
+
+import io.camunda.zeebe.protocol.record.ExecuteQueryResponseEncoder;
+import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
+import io.camunda.zeebe.transport.ServerOutput;
+import io.camunda.zeebe.transport.impl.ServerResponseImpl;
+import io.camunda.zeebe.util.EnsureUtil;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public final class QueryResponseWriter implements BufferWriter {
+
+  private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final ExecuteQueryResponseEncoder responseEncoder = new ExecuteQueryResponseEncoder();
+  private final ServerResponseImpl response = new ServerResponseImpl();
+
+  private DirectBuffer bpmnProcessId;
+
+  public void tryWriteResponse(
+      final ServerOutput output, final int streamId, final long requestId) {
+    EnsureUtil.ensureNotNull("bpmnProcessId", bpmnProcessId);
+
+    try {
+      response.reset().writer(this).setPartitionId(streamId).setRequestId(requestId);
+      output.sendResponse(response);
+
+    } finally {
+      reset();
+    }
+  }
+
+  @Override
+  public int getLength() {
+    return MessageHeaderEncoder.ENCODED_LENGTH
+        + ExecuteQueryResponseEncoder.BLOCK_LENGTH
+        + ExecuteQueryResponseEncoder.bpmnProcessIdHeaderLength()
+        + bpmnProcessId.capacity();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, int offset) {
+    // protocol header
+    headerEncoder.wrap(buffer, offset);
+
+    headerEncoder
+        .blockLength(responseEncoder.sbeBlockLength())
+        .templateId(responseEncoder.sbeTemplateId())
+        .schemaId(responseEncoder.sbeSchemaId())
+        .version(responseEncoder.sbeSchemaVersion());
+
+    offset += headerEncoder.encodedLength();
+
+    responseEncoder.wrap(buffer, offset);
+
+    responseEncoder.putBpmnProcessId(bpmnProcessId, 0, bpmnProcessId.capacity());
+  }
+
+  public void reset() {
+    bpmnProcessId = null;
+  }
+
+  public QueryResponseWriter bpmnProcessId(final DirectBuffer bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
+    return this;
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/QueryResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/externalapi/QueryResponseWriter.java
@@ -11,25 +11,23 @@ import io.camunda.zeebe.protocol.record.ExecuteQueryResponseEncoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
 import io.camunda.zeebe.transport.ServerOutput;
 import io.camunda.zeebe.transport.impl.ServerResponseImpl;
-import io.camunda.zeebe.util.EnsureUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public final class QueryResponseWriter implements BufferWriter {
 
   private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
   private final ExecuteQueryResponseEncoder responseEncoder = new ExecuteQueryResponseEncoder();
   private final ServerResponseImpl response = new ServerResponseImpl();
-
-  private DirectBuffer bpmnProcessId;
+  private final DirectBuffer bpmnProcessId = new UnsafeBuffer();
 
   public void tryWriteResponse(
-      final ServerOutput output, final int streamId, final long requestId) {
-    EnsureUtil.ensureNotNull("bpmnProcessId", bpmnProcessId);
+      final ServerOutput output, final int partitionId, final long requestId) {
 
     try {
-      response.reset().writer(this).setPartitionId(streamId).setRequestId(requestId);
+      response.reset().writer(this).setPartitionId(partitionId).setRequestId(requestId);
       output.sendResponse(response);
 
     } finally {
@@ -64,11 +62,11 @@ public final class QueryResponseWriter implements BufferWriter {
   }
 
   public void reset() {
-    bpmnProcessId = null;
+    bpmnProcessId.wrap(0, 0);
   }
 
   public QueryResponseWriter bpmnProcessId(final DirectBuffer bpmnProcessId) {
-    this.bpmnProcessId = bpmnProcessId;
+    this.bpmnProcessId.wrap(bpmnProcessId);
     return this;
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
@@ -74,7 +75,10 @@ public final class SimpleBrokerStartTest {
 
           @Override
           public ActorFuture<Void> onBecomingLeader(
-              final int partitionId, final long term, final LogStream logStream) {
+              final int partitionId,
+              final long term,
+              final LogStream logStream,
+              final QueryService queryService) {
             leaderLatch.countDown();
             return CompletableActorFuture.completed(null);
           }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -712,8 +712,8 @@ public final class BrokerCfgTest {
       final String configFileName, final int command, final int internal, final int monitoring) {
     final BrokerCfg brokerCfg = TestConfigReader.readConfig(configFileName, environment);
     final NetworkCfg network = brokerCfg.getNetwork();
-    assertThat(network.getCommandApi().getAddress().getPort()).isEqualTo(command);
-    assertThat(network.getCommandApi().getAdvertisedAddress().getPort()).isEqualTo(command);
+    assertThat(network.getExternalApi().getAddress().getPort()).isEqualTo(command);
+    assertThat(network.getExternalApi().getAdvertisedAddress().getPort()).isEqualTo(command);
     assertThat(network.getInternalApi().getPort()).isEqualTo(internal);
     assertThat(network.getMonitoringApi().getPort()).isEqualTo(monitoring);
   }
@@ -738,7 +738,7 @@ public final class BrokerCfgTest {
     final NetworkCfg networkCfg = brokerCfg.getNetwork();
     assertThat(networkCfg.getHost()).isEqualTo(host);
     assertThat(brokerCfg.getGateway().getNetwork().getHost()).isEqualTo(gateway);
-    assertThat(networkCfg.getCommandApi().getAddress().getHostString()).isEqualTo(command);
+    assertThat(networkCfg.getExternalApi().getAddress().getHostString()).isEqualTo(command);
     assertThat(networkCfg.getInternalApi().getHost()).isEqualTo(internal);
     assertThat(networkCfg.getMonitoringApi().getHost()).isEqualTo(monitoring);
   }
@@ -746,15 +746,15 @@ public final class BrokerCfgTest {
   private void assertAdvertisedHost(final String configFileName, final String host) {
     final BrokerCfg brokerCfg = TestConfigReader.readConfig(configFileName, environment);
     final NetworkCfg networkCfg = brokerCfg.getNetwork();
-    assertThat(networkCfg.getCommandApi().getAdvertisedAddress().getHostName()).isEqualTo(host);
+    assertThat(networkCfg.getExternalApi().getAdvertisedAddress().getHostName()).isEqualTo(host);
   }
 
   private void assertAdvertisedAddress(
       final String configFileName, final String host, final int port) {
     final BrokerCfg brokerCfg = TestConfigReader.readConfig(configFileName, environment);
     final NetworkCfg networkCfg = brokerCfg.getNetwork();
-    assertThat(networkCfg.getCommandApi().getAdvertisedAddress().getHostName()).isEqualTo(host);
-    assertThat(networkCfg.getCommandApi().getAdvertisedAddress().getPort()).isEqualTo(port);
+    assertThat(networkCfg.getExternalApi().getAdvertisedAddress().getHostName()).isEqualTo(host);
+    assertThat(networkCfg.getExternalApi().getAdvertisedAddress().getPort()).isEqualTo(port);
   }
 
   private void assertDefaultContactPoints(final String... contactPoints) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
@@ -49,7 +49,7 @@ public class BrokerHealthCheckServiceTest {
         .isInstanceOf(IllegalStateException.class);
     assertThatThrownBy(() -> healthCheckService.onBecomingFollower(0, 0))
         .isInstanceOf(IllegalStateException.class);
-    assertThatThrownBy(() -> healthCheckService.onBecomingLeader(0, 0, null))
+    assertThatThrownBy(() -> healthCheckService.onBecomingLeader(0, 0, null, null))
         .isInstanceOf(IllegalStateException.class);
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerConfigurator.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerConfigurator.java
@@ -74,7 +74,7 @@ public final class EmbeddedBrokerConfigurator {
   }
 
   public static Consumer<BrokerCfg> setCommandApiPort(final int port) {
-    return cfg -> cfg.getNetwork().getCommandApi().setPort(port);
+    return cfg -> cfg.getNetwork().getExternalApi().setPort(port);
   }
 
   public static Consumer<BrokerCfg> setInternalApiPort(final int port) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
 import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
@@ -310,7 +311,10 @@ public final class EmbeddedBrokerRule extends ExternalResource {
 
     @Override
     public ActorFuture<Void> onBecomingLeader(
-        final int partitionId, final long term, final LogStream logStream) {
+        final int partitionId,
+        final long term,
+        final LogStream logStream,
+        final QueryService queryService) {
       latch.countDown();
       return CompletableActorFuture.completed(null);
     }

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/externalapi/CommandResponseWriterImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/externalapi/CommandResponseWriterImplTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.commandapi;
+package io.camunda.zeebe.broker.transport.externalapi;
 
 import static io.camunda.zeebe.util.StringUtil.getBytes;
 import static io.camunda.zeebe.util.VarDataUtil.readBytes;

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/externalapi/ErrorResponseWriterTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/externalapi/ErrorResponseWriterTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.commandapi;
+package io.camunda.zeebe.broker.transport.externalapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/externalapi/QueryApiIT.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/externalapi/QueryApiIT.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.externalapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.atomix.cluster.messaging.MessagingConfig;
+import io.atomix.cluster.messaging.impl.NettyMessagingService;
+import io.atomix.utils.net.Address;
+import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.ErrorCode;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.test.broker.protocol.commandapi.CommandApiRule;
+import io.camunda.zeebe.test.broker.protocol.commandapi.ErrorResponseException;
+import io.camunda.zeebe.test.broker.protocol.queryapi.ExecuteQueryRequest;
+import io.camunda.zeebe.test.broker.protocol.queryapi.ExecuteQueryResponse;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.transport.ClientTransport;
+import io.camunda.zeebe.transport.impl.AtomixClientTransportAdapter;
+import io.camunda.zeebe.util.sched.testing.ActorSchedulerRule;
+import io.netty.util.NetUtil;
+import java.time.Duration;
+import org.agrona.DirectBuffer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public final class QueryApiIT {
+
+  public final ActorSchedulerRule actor = new ActorSchedulerRule();
+  public final EmbeddedBrokerRule broker =
+      new EmbeddedBrokerRule(
+          cfg -> cfg.getNetwork().getExternalApi().getQueryApi().setEnabled(true));
+  public final CommandApiRule command = new CommandApiRule(broker::getAtomixCluster);
+
+  @Rule
+  public final RuleChain ruleChain = RuleChain.outerRule(broker).around(command).around(actor);
+
+  private ClientTransport clientTransport;
+  private String serverAddress;
+
+  @Before
+  public void setup() {
+    serverAddress =
+        NetUtil.toSocketAddressString(
+            broker.getBrokerCfg().getNetwork().getExternalApi().getAddress());
+    final var messagingService =
+        new NettyMessagingService(
+            broker.getBrokerCfg().getCluster().getClusterName(),
+            Address.from(SocketUtil.getNextAddress().getPort()),
+            new MessagingConfig());
+
+    clientTransport = new AtomixClientTransportAdapter(messagingService);
+    actor.submitActor((AtomixClientTransportAdapter) clientTransport).join();
+    messagingService.start().join();
+  }
+
+  @Test
+  public void shouldRespondWithErrorWhenDisabled() {
+    // given
+    broker.getBrokerCfg().getNetwork().getExternalApi().getQueryApi().setEnabled(false);
+
+    // when
+    final DirectBuffer response =
+        clientTransport
+            .sendRequest(
+                () -> serverAddress,
+                new ExecuteQueryRequest().partitionId(1).key(123L).valueType(ValueType.PROCESS),
+                Duration.ofSeconds(10))
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    final var result = new ExecuteQueryResponse();
+    final var length = response.capacity();
+    assertThatThrownBy(() -> result.wrap(response, 0, length))
+        .isInstanceOf(ErrorResponseException.class)
+        .extracting(ErrorResponseException.class::cast)
+        .extracting(ErrorResponseException::getErrorCode, ErrorResponseException::getErrorMessage)
+        .containsExactly(
+            ErrorCode.UNSUPPORTED_MESSAGE,
+            "Expected to handle ExecuteQueryRequest, but QueryApi is disabled");
+  }
+
+  @Test
+  public void shouldRespondWithBpmnProcessIdWhenFound() {
+    // given
+    final long key =
+        command
+            .partitionClient(1)
+            .deployProcess(
+                Bpmn.createExecutableProcess("OneProcessToRuleThemAll")
+                    .startEvent()
+                    .endEvent()
+                    .done())
+            .getProcessDefinitionKey();
+
+    // when
+    final DirectBuffer response =
+        clientTransport
+            .sendRequest(
+                () -> serverAddress,
+                // todo: consider whether partitionId is really necessary
+                new ExecuteQueryRequest().partitionId(1).key(key).valueType(ValueType.PROCESS),
+                Duration.ofSeconds(10))
+            .join();
+
+    final var result = new ExecuteQueryResponse();
+    result.wrap(response, 0, response.capacity());
+    assertThat(result)
+        .extracting(ExecuteQueryResponse::getBpmnProcessId)
+        .isEqualTo("OneProcessToRuleThemAll");
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/externalapi/QueryApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/externalapi/QueryApiRequestHandlerTest.java
@@ -98,6 +98,56 @@ final class QueryApiRequestHandlerTest {
             "Expected to handle ExecuteQueryRequest, but no process found with key 1");
   }
 
+  @DisplayName("should respond with PROCESS_NOT_FOUND when no process instance with key exists")
+  @Test
+  void processInstanceNotFound() {
+    // given
+    final QueryApiRequestHandler sut = createQueryApiRequestHandler(true);
+    sut.addPartition(1, new QueryServiceReturning(null));
+
+    // when
+    final Either<ErrorResponse, ExecuteQueryResponse> response =
+        new AsyncExecuteQueryRequestSender(sut)
+            .sendRequest(
+                new ExecuteQueryRequest()
+                    .partitionId(1)
+                    .key(1)
+                    .valueType(ValueType.PROCESS_INSTANCE))
+            .join();
+
+    // then
+    EitherAssert.assertThat(response)
+        .isLeft()
+        .extracting(Either::getLeft)
+        .extracting(ErrorResponse::getErrorCode, ErrorResponse::getErrorData)
+        .containsExactly(
+            ErrorCode.PROCESS_NOT_FOUND,
+            "Expected to handle ExecuteQueryRequest, but no process instance found with key 1");
+  }
+
+  @DisplayName("should respond with PROCESS_NOT_FOUND when no job with key exists")
+  @Test
+  void jobNotFound() {
+    // given
+    final QueryApiRequestHandler sut = createQueryApiRequestHandler(true);
+    sut.addPartition(1, new QueryServiceReturning(null));
+
+    // when
+    final Either<ErrorResponse, ExecuteQueryResponse> response =
+        new AsyncExecuteQueryRequestSender(sut)
+            .sendRequest(new ExecuteQueryRequest().partitionId(1).key(1).valueType(ValueType.JOB))
+            .join();
+
+    // then
+    EitherAssert.assertThat(response)
+        .isLeft()
+        .extracting(Either::getLeft)
+        .extracting(ErrorResponse::getErrorCode, ErrorResponse::getErrorData)
+        .containsExactly(
+            ErrorCode.PROCESS_NOT_FOUND,
+            "Expected to handle ExecuteQueryRequest, but no job found with key 1");
+  }
+
   @DisplayName("should respond with bpmnProcessId when process found")
   @Test
   void processFound() {

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/externalapi/QueryApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/externalapi/QueryApiRequestHandlerTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.externalapi;
+
+import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg.ExternalApiCfg.QueryApiCfg;
+import io.camunda.zeebe.engine.state.QueryService;
+import io.camunda.zeebe.protocol.record.ErrorCode;
+import io.camunda.zeebe.protocol.record.ErrorResponseDecoder;
+import io.camunda.zeebe.protocol.record.ExecuteQueryResponseDecoder;
+import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.test.broker.protocol.MsgPackHelper;
+import io.camunda.zeebe.test.broker.protocol.commandapi.ErrorResponse;
+import io.camunda.zeebe.test.broker.protocol.queryapi.ExecuteQueryRequest;
+import io.camunda.zeebe.test.broker.protocol.queryapi.ExecuteQueryResponse;
+import io.camunda.zeebe.transport.ServerOutput;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.EitherAssert;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+final class QueryApiRequestHandlerTest {
+
+  @DisplayName("should respond with UNSUPPORTED_MESSAGE when QueryApi is disabled")
+  @Test
+  void disabledQueryApi() {
+    // given
+    final QueryApiRequestHandler sut = createQueryApiRequestHandler(false);
+
+    // when
+    final Either<ErrorResponse, ExecuteQueryResponse> response =
+        new AsyncExecuteQueryRequestSender(sut).sendRequest(new ExecuteQueryRequest()).join();
+
+    // then
+    EitherAssert.assertThat(response)
+        .isLeft()
+        .extracting(Either::getLeft)
+        .extracting(ErrorResponse::getErrorCode, ErrorResponse::getErrorData)
+        .containsExactly(
+            ErrorCode.UNSUPPORTED_MESSAGE,
+            "Expected to handle ExecuteQueryRequest, but QueryApi is disabled");
+  }
+
+  @DisplayName("should respond with INTERNAL_ERROR when partition is unknown")
+  @Test
+  void unknownPartition() {
+    // given
+    final QueryApiRequestHandler sut = createQueryApiRequestHandler(true);
+    sut.addPartition(1, new QueryServiceReturning(null));
+
+    // when
+    final Either<ErrorResponse, ExecuteQueryResponse> response =
+        new AsyncExecuteQueryRequestSender(sut)
+            .sendRequest(new ExecuteQueryRequest().partitionId(9999))
+            .join();
+
+    // then
+    EitherAssert.assertThat(response)
+        .isLeft()
+        .extracting(Either::getLeft)
+        .extracting(ErrorResponse::getErrorCode, ErrorResponse::getErrorData)
+        .containsExactly(
+            ErrorCode.INTERNAL_ERROR,
+            "Expected to handle ExecuteQueryRequest, but unable to access query service");
+  }
+
+  @DisplayName("should respond with PROCESS_NOT_FOUND when no process with key exists")
+  @Test
+  void processNotFound() {
+    // given
+    final QueryApiRequestHandler sut = createQueryApiRequestHandler(true);
+    sut.addPartition(1, new QueryServiceReturning(null));
+
+    // when
+    final Either<ErrorResponse, ExecuteQueryResponse> response =
+        new AsyncExecuteQueryRequestSender(sut)
+            .sendRequest(
+                new ExecuteQueryRequest().partitionId(1).key(1).valueType(ValueType.PROCESS))
+            .join();
+
+    // then
+    EitherAssert.assertThat(response)
+        .isLeft()
+        .extracting(Either::getLeft)
+        .extracting(ErrorResponse::getErrorCode, ErrorResponse::getErrorData)
+        .containsExactly(
+            ErrorCode.PROCESS_NOT_FOUND,
+            "Expected to handle ExecuteQueryRequest, but no process found with key 1");
+  }
+
+  @DisplayName("should respond with bpmnProcessId when process found")
+  @Test
+  void processFound() {
+    // given
+    final QueryApiRequestHandler sut = createQueryApiRequestHandler(true);
+    sut.addPartition(1, new QueryServiceReturning("OneProcessToFindThem"));
+
+    // when
+    final Either<ErrorResponse, ExecuteQueryResponse> response =
+        new AsyncExecuteQueryRequestSender(sut)
+            .sendRequest(
+                new ExecuteQueryRequest().partitionId(1).key(1).valueType(ValueType.PROCESS))
+            .join();
+
+    // then
+    EitherAssert.assertThat(response)
+        .isRight()
+        .extracting(Either::get)
+        .extracting(ExecuteQueryResponse::getBpmnProcessId)
+        .isEqualTo("OneProcessToFindThem");
+  }
+
+  private static QueryApiRequestHandler createQueryApiRequestHandler(final boolean enabled) {
+    final var config = new QueryApiCfg();
+    config.setEnabled(enabled);
+    return new QueryApiRequestHandler(config);
+  }
+
+  private static final class AsyncExecuteQueryRequestSender {
+
+    private final QueryApiRequestHandler sut;
+    private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
+    private final ExecuteQueryResponseDecoder queryResponseDecoder =
+        new ExecuteQueryResponseDecoder();
+
+    private int requestCount = 0;
+
+    public AsyncExecuteQueryRequestSender(final QueryApiRequestHandler requestHandler) {
+      sut = requestHandler;
+    }
+
+    private CompletableFuture<Either<ErrorResponse, ExecuteQueryResponse>> sendRequest(
+        final ExecuteQueryRequest queryRequest) {
+      final var future = new CompletableFuture<Either<ErrorResponse, ExecuteQueryResponse>>();
+      final ServerOutput serverOutput =
+          serverResponse -> {
+            // we need to write the serverResponse into a buffer in order to read it as SBE
+            final var bytes = new byte[serverResponse.getLength()];
+            final var buffer = new UnsafeBuffer(bytes);
+            serverResponse.write(buffer, 0);
+
+            messageHeaderDecoder.wrap(buffer, 0);
+            // we can use the template id to determine the type of response that was send
+            switch (messageHeaderDecoder.templateId()) {
+              case ErrorResponseDecoder.TEMPLATE_ID:
+                future.complete(Either.left(decodeErrorResponse(buffer)));
+                break;
+              case ExecuteQueryResponseDecoder.TEMPLATE_ID:
+                future.complete(Either.right(decodeQueryResponse(buffer)));
+                break;
+              default:
+                throw new IllegalStateException(
+                    String.format(
+                        "Expected to decode a specific response type, but %d is an unknown template id",
+                        messageHeaderDecoder.templateId()));
+            }
+          };
+      final var partitionId = queryRequest.getPartitionId();
+      final var request = BufferUtil.createCopy(queryRequest);
+      sut.onRequest(serverOutput, partitionId, requestCount++, request, 0, request.capacity());
+      return future;
+    }
+
+    private static ErrorResponse decodeErrorResponse(final UnsafeBuffer buffer) {
+      final var result = new ErrorResponse(new MsgPackHelper());
+      result.wrap(buffer, 0, buffer.capacity());
+      return result;
+    }
+
+    private static ExecuteQueryResponse decodeQueryResponse(final UnsafeBuffer buffer) {
+      final var result = new ExecuteQueryResponse();
+      result.wrap(buffer, 0, buffer.capacity());
+      return result;
+    }
+  }
+
+  private static final class QueryServiceReturning implements QueryService {
+
+    private final DirectBuffer bpmnProcessId;
+
+    public QueryServiceReturning(final String bpmnProcessId) {
+      this.bpmnProcessId = bpmnProcessId == null ? null : BufferUtil.wrapString(bpmnProcessId);
+    }
+
+    @Override
+    public Optional<DirectBuffer> getBpmnProcessIdForProcess(final long processKey) {
+      return Optional.ofNullable(bpmnProcessId);
+    }
+
+    @Override
+    public Optional<DirectBuffer> getBpmnProcessIdForProcessInstance(
+        final long processInstanceKey) {
+      return Optional.ofNullable(bpmnProcessId);
+    }
+
+    @Override
+    public Optional<DirectBuffer> getBpmnProcessIdForJob(final long jobKey) {
+      return Optional.ofNullable(bpmnProcessId);
+    }
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/externalapi/QueryApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/externalapi/QueryApiRequestHandlerTest.java
@@ -70,8 +70,8 @@ final class QueryApiRequestHandlerTest {
         .extracting(Either::getLeft)
         .extracting(ErrorResponse::getErrorCode, ErrorResponse::getErrorData)
         .containsExactly(
-            ErrorCode.INTERNAL_ERROR,
-            "Expected to handle ExecuteQueryRequest, but unable to access query service");
+            ErrorCode.PARTITION_LEADER_MISMATCH,
+            "Expected to handle client message on the leader of partition '9999', but this node is not the leader for it");
   }
 
   @DisplayName("should respond with PROCESS_NOT_FOUND when no process with key exists")

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/QueryService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/QueryService.java
@@ -19,13 +19,14 @@ import org.agrona.DirectBuffer;
  * than it's intended purpose.
  */
 @Deprecated(forRemoval = true, since = "1.2")
-public interface QueryService {
+public interface QueryService extends AutoCloseable {
 
   /**
    * Queries the state for the bpmn process id of a specific process.
    *
    * @param processKey The key of the process
    * @return Optionally the bpmn process id if found, otherwise an empty optional
+   * @throws ClosedServiceException if the service is already closed
    */
   Optional<DirectBuffer> getBpmnProcessIdForProcess(long processKey);
 
@@ -34,6 +35,7 @@ public interface QueryService {
    *
    * @param processInstanceKey The key of the process instance
    * @return Optionally the bpmn process id if found, otherwise an empty optional
+   * @throws ClosedServiceException if the service is already closed
    */
   Optional<DirectBuffer> getBpmnProcessIdForProcessInstance(long processInstanceKey);
 
@@ -42,6 +44,9 @@ public interface QueryService {
    *
    * @param jobKey The key of the job
    * @return Optionally the bpmn process id if found, otherwise an empty optional
+   * @throws ClosedServiceException if the service is already closed
    */
   Optional<DirectBuffer> getBpmnProcessIdForJob(long jobKey);
+
+  final class ClosedServiceException extends RuntimeException {}
 }

--- a/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/PartitionTestClient.java
+++ b/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/PartitionTestClient.java
@@ -100,7 +100,7 @@ public final class PartitionTestClient {
 
     TestUtil.waitUntil(
         () ->
-            RecordingExporter.deploymentRecords(DeploymentIntent.DISTRIBUTED)
+            RecordingExporter.deploymentRecords(DeploymentIntent.FULLY_DISTRIBUTED)
                 .withRecordKey(key)
                 .exists());
 

--- a/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/queryapi/ExecuteQueryRequest.java
+++ b/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/queryapi/ExecuteQueryRequest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.broker.protocol.queryapi;
+
+import static io.camunda.zeebe.protocol.record.ExecuteCommandRequestEncoder.keyNullValue;
+import static io.camunda.zeebe.protocol.record.ExecuteCommandRequestEncoder.partitionIdNullValue;
+
+import io.camunda.zeebe.protocol.record.ExecuteQueryRequestEncoder;
+import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.transport.ClientRequest;
+import io.camunda.zeebe.transport.RequestType;
+import org.agrona.MutableDirectBuffer;
+
+public final class ExecuteQueryRequest implements ClientRequest {
+  private final MessageHeaderEncoder messageHeaderEncoder = new MessageHeaderEncoder();
+  private final ExecuteQueryRequestEncoder requestEncoder = new ExecuteQueryRequestEncoder();
+
+  private int partitionId = partitionIdNullValue();
+  private long key = keyNullValue();
+  private ValueType valueType = ValueType.NULL_VAL;
+
+  // todo: consider adding a real builder pattern
+
+  public ExecuteQueryRequest partitionId(final int partitionId) {
+    this.partitionId = partitionId;
+    return this;
+  }
+
+  public ExecuteQueryRequest key(final long key) {
+    this.key = key;
+    return this;
+  }
+
+  public ExecuteQueryRequest valueType(final ValueType valueType) {
+    this.valueType = valueType;
+    return this;
+  }
+
+  @Override
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  @Override
+  public RequestType getRequestType() {
+    return RequestType.QUERY;
+  }
+
+  @Override
+  public int getLength() {
+    return MessageHeaderEncoder.ENCODED_LENGTH + ExecuteQueryRequestEncoder.BLOCK_LENGTH;
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    messageHeaderEncoder
+        .wrap(buffer, offset)
+        .schemaId(requestEncoder.sbeSchemaId())
+        .templateId(requestEncoder.sbeTemplateId())
+        .blockLength(requestEncoder.sbeBlockLength())
+        .version(requestEncoder.sbeSchemaVersion());
+
+    requestEncoder
+        .wrap(buffer, offset + messageHeaderEncoder.encodedLength())
+        .partitionId(partitionId)
+        .key(key)
+        .valueType(valueType);
+  }
+}

--- a/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/queryapi/ExecuteQueryResponse.java
+++ b/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/queryapi/ExecuteQueryResponse.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.broker.protocol.queryapi;
+
+import io.camunda.zeebe.protocol.record.ErrorResponseDecoder;
+import io.camunda.zeebe.protocol.record.ExecuteQueryResponseDecoder;
+import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.test.broker.protocol.MsgPackHelper;
+import io.camunda.zeebe.test.broker.protocol.commandapi.ErrorResponse;
+import io.camunda.zeebe.test.broker.protocol.commandapi.ErrorResponseException;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import org.agrona.DirectBuffer;
+
+public final class ExecuteQueryResponse implements BufferReader {
+  private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
+  private final ExecuteQueryResponseDecoder responseDecoder = new ExecuteQueryResponseDecoder();
+  private final ErrorResponse errorResponse = new ErrorResponse(new MsgPackHelper());
+
+  public long getKey() {
+    return responseDecoder.key();
+  }
+
+  public int getPartitionId() {
+    return responseDecoder.partitionId();
+  }
+
+  public ValueType getValueType() {
+    return responseDecoder.valueType();
+  }
+
+  public String getBpmnProcessId() {
+    return responseDecoder.bpmnProcessId();
+  }
+
+  @Override
+  public void wrap(final DirectBuffer responseBuffer, final int offset, final int length) {
+    messageHeaderDecoder.wrap(responseBuffer, offset);
+
+    if (messageHeaderDecoder.templateId() != responseDecoder.sbeTemplateId()) {
+      if (messageHeaderDecoder.templateId() == ErrorResponseDecoder.TEMPLATE_ID) {
+        errorResponse.wrap(responseBuffer, offset + messageHeaderDecoder.encodedLength(), length);
+        throw new ErrorResponseException(errorResponse);
+      } else {
+        throw new RuntimeException(
+            "Unexpected response from broker. Template id " + messageHeaderDecoder.templateId());
+      }
+    }
+
+    responseDecoder.wrap(
+        responseBuffer,
+        offset + messageHeaderDecoder.encodedLength(),
+        messageHeaderDecoder.blockLength(),
+        messageHeaderDecoder.version());
+  }
+}

--- a/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/queryapi/ExecuteQueryResponse.java
+++ b/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/queryapi/ExecuteQueryResponse.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.test.broker.protocol.queryapi;
 import io.camunda.zeebe.protocol.record.ErrorResponseDecoder;
 import io.camunda.zeebe.protocol.record.ExecuteQueryResponseDecoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
-import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.test.broker.protocol.MsgPackHelper;
 import io.camunda.zeebe.test.broker.protocol.commandapi.ErrorResponse;
 import io.camunda.zeebe.test.broker.protocol.commandapi.ErrorResponseException;
@@ -21,18 +20,6 @@ public final class ExecuteQueryResponse implements BufferReader {
   private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
   private final ExecuteQueryResponseDecoder responseDecoder = new ExecuteQueryResponseDecoder();
   private final ErrorResponse errorResponse = new ErrorResponse(new MsgPackHelper());
-
-  public long getKey() {
-    return responseDecoder.key();
-  }
-
-  public int getPartitionId() {
-    return responseDecoder.partitionId();
-  }
-
-  public ValueType getValueType() {
-    return responseDecoder.valueType();
-  }
 
   public String getBpmnProcessId() {
     return responseDecoder.bpmnProcessId();

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -103,6 +103,19 @@
     <data name="rejectionReason" id="8" type="varDataEncoding"/>
   </sbe:message>
 
+  <sbe:message name="ExecuteQueryRequest" id="30">
+    <field name="partitionId" id="1" type="uint16"/>
+    <field name="key" id="2" type="uint64"/>
+    <field name="valueType" id="3" type="ValueType"/>
+  </sbe:message>
+
+  <sbe:message name="ExecuteQueryResponse" id="31">
+    <field name="partitionId" id="1" type="uint16"/>
+    <field name="key" id="2" type="uint64"/>
+    <field name="valueType" id="3" type="ValueType"/>
+    <data name="bpmnProcessId" id="4" type="varDataEncoding"/>
+  </sbe:message>
+
   <!-- L2 Common Messages 200 - 399 -->
 
   <sbe:message name="RecordMetadata" id="200" description="Descriptor for Record Metadata">

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -110,10 +110,7 @@
   </sbe:message>
 
   <sbe:message name="ExecuteQueryResponse" id="31">
-    <field name="partitionId" id="1" type="uint16"/>
-    <field name="key" id="2" type="uint64"/>
-    <field name="valueType" id="3" type="ValueType"/>
-    <data name="bpmnProcessId" id="4" type="varDataEncoding"/>
+    <data name="bpmnProcessId" id="1" type="varDataEncoding"/>
   </sbe:message>
 
   <!-- L2 Common Messages 200 - 399 -->

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -42,6 +42,7 @@ import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.client.api.response.BrokerInfo;
 import io.camunda.zeebe.client.api.response.PartitionInfo;
 import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.gateway.Gateway;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
@@ -875,7 +876,10 @@ public final class ClusteringRule extends ExternalResource {
 
     @Override
     public ActorFuture<Void> onBecomingLeader(
-        final int partitionId, final long term, final LogStream logStream) {
+        final int partitionId,
+        final long term,
+        final LogStream logStream,
+        final QueryService queryService) {
       logstreams.put(partitionId, logStream);
       latch.countDown();
       partitionLeader.put(partitionId, new Leader(nodeId, term, logStream));

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -420,7 +420,7 @@ public final class ClusteringRule extends ExternalResource {
     final Set<InetSocketAddress> addresses =
         brokers.values().stream()
             .map(Broker::getConfig)
-            .map(b -> b.getNetwork().getCommandApi().getAddress())
+            .map(b -> b.getNetwork().getExternalApi().getAddress())
             .collect(Collectors.toSet());
 
     waitForTopology(
@@ -503,7 +503,7 @@ public final class ClusteringRule extends ExternalResource {
   public void startBroker(final int nodeId) {
     final Broker broker = getBroker(nodeId).start().join();
     final InetSocketAddress commandApi =
-        broker.getConfig().getNetwork().getCommandApi().getAddress();
+        broker.getConfig().getNetwork().getExternalApi().getAddress();
     waitUntilBrokerIsAddedToTopology(commandApi);
     waitForPartitionReplicationFactor();
   }
@@ -561,13 +561,14 @@ public final class ClusteringRule extends ExternalResource {
 
   public InetSocketAddress[] getOtherBrokers(final InetSocketAddress address) {
     return getBrokers().stream()
-        .map(b -> b.getConfig().getNetwork().getCommandApi().getAddress())
+        .map(b -> b.getConfig().getNetwork().getExternalApi().getAddress())
         .filter(a -> !address.equals(a))
         .toArray(InetSocketAddress[]::new);
   }
 
   public InetSocketAddress[] getOtherBrokers(final int nodeId) {
-    final InetSocketAddress filter = getBrokerCfg(nodeId).getNetwork().getCommandApi().getAddress();
+    final InetSocketAddress filter =
+        getBrokerCfg(nodeId).getNetwork().getExternalApi().getAddress();
     return getOtherBrokers(filter);
   }
 
@@ -626,7 +627,7 @@ public final class ClusteringRule extends ExternalResource {
     final Broker broker = brokers.get(nodeId);
     if (broker != null) {
       final InetSocketAddress socketAddress =
-          broker.getConfig().getNetwork().getCommandApi().getAddress();
+          broker.getConfig().getNetwork().getExternalApi().getAddress();
       final List<Integer> brokersLeadingPartitions = getBrokersLeadingPartitions(socketAddress);
       stopBroker(nodeId);
       waitForNewLeaderOfPartitions(brokersLeadingPartitions, socketAddress);
@@ -637,7 +638,7 @@ public final class ClusteringRule extends ExternalResource {
     final Broker broker = brokers.remove(nodeId);
     if (broker != null) {
       final InetSocketAddress socketAddress =
-          broker.getConfig().getNetwork().getCommandApi().getAddress();
+          broker.getConfig().getNetwork().getExternalApi().getAddress();
       broker.close();
       waitUntilBrokerIsRemovedFromTopology(socketAddress);
       try {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/BrokerRestartTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/BrokerRestartTest.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.response.PublishMessageResponse;
+import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.it.util.GrpcClientRule;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
@@ -84,7 +85,10 @@ public class BrokerRestartTest {
 
     @Override
     public ActorFuture<Void> onBecomingLeader(
-        final int partitionId, final long term, final LogStream logStream) {
+        final int partitionId,
+        final long term,
+        final LogStream logStream,
+        final QueryService queryService) {
       this.logStream = logStream;
       return CompletableActorFuture.completed(null);
     }

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -69,6 +69,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-workflow-engine</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
+++ b/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.broker.system.configuration.NetworkCfg;
+import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
@@ -296,7 +297,10 @@ public class EmbeddedBrokerRule extends ExternalResource {
 
     @Override
     public ActorFuture<Void> onBecomingLeader(
-        final int partitionId, final long term, final LogStream logStream) {
+        final int partitionId,
+        final long term,
+        final LogStream logStream,
+        final QueryService queryService) {
       latch.countDown();
       return CompletableActorFuture.completed(null);
     }

--- a/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
+++ b/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
@@ -136,7 +136,7 @@ public class EmbeddedBrokerRule extends ExternalResource {
   public static void assignSocketAddresses(final BrokerCfg brokerCfg) {
     final NetworkCfg network = brokerCfg.getNetwork();
     brokerCfg.getGateway().getNetwork().setPort(SocketUtil.getNextAddress().getPort());
-    network.getCommandApi().setPort(SocketUtil.getNextAddress().getPort());
+    network.getExternalApi().setPort(SocketUtil.getNextAddress().getPort());
     network.getInternalApi().setPort(SocketUtil.getNextAddress().getPort());
     network.getMonitoringApi().setPort(SocketUtil.getNextAddress().getPort());
   }

--- a/transport/src/main/java/io/camunda/zeebe/transport/RequestType.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/RequestType.java
@@ -19,6 +19,7 @@ package io.camunda.zeebe.transport;
 public enum RequestType {
   // Supported request types
   COMMAND("command"),
+  QUERY("query"),
 
   // All other request types are considered unknown
   // This value exists mainly for testing purposes


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This adds a new query API to the broker. It is disabled by default. To enable it, set `zeebe.broker.network.commandapi.queryapi.enabled` to true. 

Usage requires you to write your own code to encode ExecuteQueryRequest and decode ErrorResponse and ExecuteQueryResponse messages. See `io.camunda.zeebe.broker.transport.externalapi.QueryApiIT` for an example of this. In particular, have a look at `io.camunda.zeebe.test.broker.protocol.queryapi.ExecuteQueryRequest` and `io.camunda.zeebe.test.broker.protocol.queryapi.ExecuteQueryResponse`.

At the moment of writing this pull request is not yet complete, additional tests and safe guards need to be added to the QueryApiRequestHandler (see the todo's in that class). In addition, request limiting is completely unimplemented. Lastly, changes to the configuration templates are still required to incorporate the new config option.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7753
closes #7754

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
