### PR TITLE
Allow submitting to an actor from outside of an actor thread

### DIFF
--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorControl.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorControl.java
@@ -244,12 +244,12 @@ public class ActorControl implements ConcurrencyControl {
    * @param action the action to run.
    */
   public void submit(final Runnable action) {
-    final ActorThread currentActorRunner = ensureCalledFromActorThread("run(...)");
-    final ActorTask currentTask = currentActorRunner.getCurrentTask();
-
+    final ActorThread currentThread = ActorThread.current();
+    final ActorTask currentTask = currentThread == null ? null : currentThread.getCurrentTask();
     final ActorJob job;
-    if (currentTask == task) {
-      job = currentActorRunner.newJob();
+
+    if (currentThread != null && currentTask == task) {
+      job = currentThread.newJob();
     } else {
       job = new ActorJob();
     }
@@ -259,7 +259,7 @@ public class ActorControl implements ConcurrencyControl {
     job.onJobAddedToTask(task);
     task.submit(job);
 
-    if (currentTask == task) {
+    if (currentTask != null && currentTask == task) {
       yieldThread();
     }
   }

--- a/util/src/test/java/io/camunda/zeebe/util/sched/functional/RunnableActionsTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/sched/functional/RunnableActionsTest.java
@@ -66,6 +66,21 @@ public final class RunnableActionsTest {
   }
 
   @Test
+  public void shouldInvokeSubmitFromNonActorThread() {
+    // given
+    final AtomicBoolean toggle = new AtomicBoolean(false);
+    final Submitter submitter = new Submitter();
+    scheduler.submitActor(submitter);
+
+    // when
+    submitter.submit(() -> toggle.set(true));
+    scheduler.workUntilDone();
+
+    // then
+    assertThat(toggle).isTrue();
+  }
+
+  @Test
   public void shouldInvokeRunFromAnotherActor() {
     // given
     final Runner runner = new Runner();


### PR DESCRIPTION
## Description

This PR refactors the ActorControl#submit method to allow submitting tasks from outside of an actor thread. This was previously only possible via run or call, but these had confusing semantics: when run was called from within an actor thread, it would prepend its job (or rather, append it to the high priority queue). When called from the outside, it was append its job (i.e. append it to the normal queue). With the introduction of interfaces to better handle interfacing between actors/non actors, this
becomes very confusing.

This commit fixes submit such that it now be used outside and inside an actor thread. From within an actor thread, it behaves exactly as before. From without, it now behaves like run behaves. This way, we have a method which allows appending tasks to the normal queue in a consistent way both from within and without an actor thread.

The one downside here is that submitting many jobs means constantly creating new ActorJob objects, and not reusing the ones from the reusable task pool. This causes more allocations - but as we're already using run or call for such cases, which are doing this, I don't think this is a major worry (at least not introduced in this commit).

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #7799 - see https://github.com/camunda-cloud/zeebe/pull/7799#pullrequestreview-751368725 for more

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
