### PR TITLE
Prepare transition steps

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -48,11 +48,9 @@ import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.ProcessingContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorLifecycleAware;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
-import io.camunda.zeebe.util.sched.ActorControl;
 import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import java.util.ArrayList;
 import java.util.List;
@@ -197,9 +195,9 @@ public final class PartitionFactory {
       final ClusterCommunicationService communicationService,
       final ClusterEventService eventService,
       final PushDeploymentRequestHandler deploymentRequestHandler) {
-    return (ActorControl actor,
-        MutableZeebeState zeebeState,
-        ProcessingContext processingContext) -> {
+    return (ProcessingContext processingContext) -> {
+      final var actor = processingContext.getActor();
+
       final LogStream stream = processingContext.getLogStream();
 
       final TopologyPartitionListenerImpl partitionListener =

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.broker.system.partitions.impl.StateControllerImpl;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.storage.atomix.AtomixLogStorage;
@@ -323,11 +324,6 @@ public class PartitionStartupAndTransitionContextImpl
   @Override
   public Consumer<TypedRecord<?>> getOnProcessedListener() {
     return onProcessedListenerSupplier.get();
-  }
-
-  @Override
-  public TypedRecordProcessorsFactory getTypedRecordProcessorsFactory() {
-    return typedRecordProcessorsFactory;
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -272,6 +272,11 @@ public class PartitionStartupAndTransitionContextImpl
     this.currentRole = currentRole;
   }
 
+  @Override
+  public TypedRecordProcessorFactory getStreamProcessorFactory() {
+    return typedRecordProcessorsFactory::createTypedStreamProcessor;
+  }
+
   public AtomixLogStorage getLogStorage() {
     return logStorage;
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupContext.java
@@ -52,8 +52,6 @@ public interface PartitionStartupContext {
 
   Consumer<TypedRecord<?>> getOnProcessedListener();
 
-  TypedRecordProcessorsFactory getTypedRecordProcessorsFactory();
-
   ExporterRepository getExporterRepository();
 
   List<PartitionListener> getPartitionListeners();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -29,4 +29,22 @@ public interface PartitionTransitionContext extends PartitionContext {
   List<PartitionListener> getPartitionListeners();
 
   PartitionContext getPartitionContext();
+
+  void setStreamProcessor(StreamProcessor streamProcessor);
+
+  void setCurrentTerm(long term);
+
+  void setCurrentRole(Role role);
+
+  ActorSchedulingService getActorSchedulingService();
+
+  ZeebeDb getZeebeDb();
+
+  CommandResponseWriter getCommandResponseWriter();
+
+  Consumer<TypedRecord<?>> getOnProcessedListener();
+
+  TypedRecordProcessorFactory getStreamProcessorFactory();
+
+  void setZeebeDb(ZeebeDb zeebeDb);
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -7,12 +7,20 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
+import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.StateControllerImpl;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import java.util.List;
+import java.util.function.Consumer;
 
 public interface PartitionTransitionContext extends PartitionContext {
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.broker.system.partitions;
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
-import io.camunda.zeebe.broker.system.partitions.impl.StateControllerImpl;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
@@ -30,7 +29,7 @@ public interface PartitionTransitionContext extends PartitionContext {
 
   AsyncSnapshotDirector getSnapshotDirector();
 
-  StateControllerImpl getStateController();
+  StateController getStateController();
 
   ConstructableSnapshotStore getConstructableSnapshotStore();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionStep.java
@@ -49,9 +49,10 @@ public interface PartitionTransitionStep {
    * the raft partition transitions faster than the Zeebe partition. In this case steps are
    * encouraged to cancel what they are doing
    *
+   * @param context
    * @param newRole target role to transition to
    */
-  default void onNewRaftRole(final Role newRole) {}
+  default void onNewRaftRole(final PartitionTransitionContext context, final Role newRole) {}
 
   /**
    * This method is a hook to prepare steps for a pending transition. This method is deprecated

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/TypedRecordProcessorsFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/TypedRecordProcessorsFactory.java
@@ -9,12 +9,9 @@ package io.camunda.zeebe.broker.system.partitions;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.ProcessingContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.util.sched.ActorControl;
 
 @FunctionalInterface
 public interface TypedRecordProcessorsFactory {
 
-  TypedRecordProcessors createTypedStreamProcessor(
-      ActorControl actor, MutableZeebeState zeebeState, ProcessingContext processingContext);
+  TypedRecordProcessors createTypedStreamProcessor(ProcessingContext processingContext);
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
@@ -68,7 +68,7 @@ public final class NewPartitionTransitionImpl implements PartitionTransition {
 
     // notify steps immediately that a transition is coming; steps are encouraged to cancel any
     // ongoing activity at this point in time
-    steps.forEach(step -> step.onNewRaftRole(role));
+    steps.forEach(step -> step.onNewRaftRole(context, role));
 
     final ActorFuture<Void> nextTransitionFuture = concurrencyControl.createFuture();
 
@@ -124,6 +124,10 @@ public final class NewPartitionTransitionImpl implements PartitionTransition {
     concurrencyControl.runOnCompletion(
         currentTransitionFuture,
         (ok, error) -> {
+          if (error == null) {
+            context.setCurrentTerm(term);
+            context.setCurrentRole(role);
+          }
           lastTransition = currentTransition;
           currentTransition = null;
           currentTransitionFuture = null;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorPartitionStep.java
@@ -13,8 +13,6 @@ import io.camunda.zeebe.broker.system.partitions.PartitionStep;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorMode;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.util.sched.ActorControl;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 
@@ -78,14 +76,7 @@ public class StreamProcessorPartitionStep implements PartitionStep {
         .nodeId(state.getNodeId())
         .commandResponseWriter(state.getCommandResponseWriter())
         .listener(processedCommand -> state.getOnProcessedListener().accept(processedCommand))
-        .streamProcessorFactory(
-            processingContext -> {
-              final ActorControl actor = processingContext.getActor();
-              final MutableZeebeState zeebeState = processingContext.getZeebeState();
-              return state
-                  .getTypedRecordProcessorsFactory()
-                  .createTypedStreamProcessor(actor, zeebeState, processingContext);
-            })
+        .streamProcessorFactory(state.getStreamProcessorFactory())
         .streamProcessorMode(streamProcessorMode)
         .build();
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorMode;
+import io.camunda.zeebe.engine.state.appliers.EventAppliers;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
+
+public class StreamProcessorTransitionStep implements PartitionTransitionStep {
+
+  @Override
+  public void onNewRaftRole(final PartitionTransitionContext context, final Role newRole) {
+    final var currentRole = context.getCurrentRole();
+    final var streamprocessor = context.getStreamProcessor();
+    if (streamprocessor == null) {
+      return;
+    }
+    if (shouldCloseOnTransition(newRole, currentRole)) {
+      // Right now this step has no value. But in future, we hope to remove `prepareTransition`
+      // step. Then we will be closing the steps asynchronously. At that time we need to stop/pause
+      // the services until the transition is complete.
+      streamprocessor.pauseProcessing();
+    }
+  }
+
+  private boolean shouldCloseOnTransition(final Role newRole, final Role currentRole) {
+    return newRole == Role.LEADER
+        || (newRole == Role.FOLLOWER && currentRole != Role.CANDIDATE)
+        || newRole == Role.INACTIVE;
+  }
+
+  @Override
+  public ActorFuture<Void> prepareTransition(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    final var currentRole = context.getCurrentRole();
+    final var streamprocessor = context.getStreamProcessor();
+    if (streamprocessor == null) {
+      return CompletableActorFuture.completed(null);
+    }
+    if (shouldCloseOnTransition(targetRole, currentRole)) {
+      context.getComponentHealthMonitor().removeComponent(streamprocessor.getName());
+      final ActorFuture<Void> future = streamprocessor.closeAsync();
+      future.onComplete(
+          (success, error) -> {
+            if (error == null) {
+              context.setStreamProcessor(null);
+            }
+          });
+      return future;
+    } else {
+      return CompletableActorFuture.completed(null);
+    }
+  }
+
+  @Override
+  public ActorFuture<Void> transitionTo(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    final var currentRole = context.getCurrentRole();
+
+    if (targetRole == Role.LEADER
+        || (targetRole == Role.FOLLOWER && currentRole != Role.CANDIDATE)
+        || (context.getStreamProcessor() == null && targetRole != Role.INACTIVE)) {
+
+      final StreamProcessor streamProcessor = createStreamProcessor(context, targetRole);
+      final ActorFuture<Void> openFuture = streamProcessor.openAsync(!context.shouldProcess());
+      final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
+
+      openFuture.onComplete(
+          (nothing, err) -> {
+            if (err == null) {
+              context.setStreamProcessor(streamProcessor);
+
+              // Have to pause/resume it here in case the state changed after streamProcessor was
+              // created
+              if (!context.shouldProcess()) {
+                streamProcessor.pauseProcessing();
+              } else {
+                streamProcessor.resumeProcessing();
+              }
+
+              context
+                  .getComponentHealthMonitor()
+                  .registerComponent(streamProcessor.getName(), streamProcessor);
+              future.complete(null);
+            } else {
+              future.completeExceptionally(err);
+            }
+          });
+
+      return future;
+    }
+
+    return CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  public String getName() {
+    return "StreamProcessor";
+  }
+
+  private StreamProcessor createStreamProcessor(
+      final PartitionTransitionContext context, final Role targetRole) {
+    final StreamProcessorMode streamProcessorMode =
+        targetRole == Role.LEADER ? StreamProcessorMode.PROCESSING : StreamProcessorMode.REPLAY;
+    return StreamProcessor.builder()
+        .logStream(context.getLogStream())
+        .actorSchedulingService(context.getActorSchedulingService())
+        .zeebeDb(context.getZeebeDb())
+        .eventApplierFactory(EventAppliers::new)
+        .nodeId(context.getNodeId())
+        .commandResponseWriter(context.getCommandResponseWriter())
+        .listener(processedCommand -> context.getOnProcessedListener().accept(processedCommand))
+        .streamProcessorFactory(context.getStreamProcessorFactory())
+        .streamProcessorMode(streamProcessorMode)
+        .build();
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -11,12 +11,24 @@ import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorBuilder;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorMode;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 
 public class StreamProcessorTransitionStep implements PartitionTransitionStep {
+
+  private final StreamProcessorBuilder streamProcessorBuilder;
+
+  public StreamProcessorTransitionStep() {
+    streamProcessorBuilder = StreamProcessor.builder();
+  }
+
+  // Used for testing
+  public StreamProcessorTransitionStep(final StreamProcessorBuilder streamProcessorBuilder) {
+    this.streamProcessorBuilder = streamProcessorBuilder;
+  }
 
   @Override
   public void onNewRaftRole(final PartitionTransitionContext context, final Role newRole) {
@@ -112,7 +124,7 @@ public class StreamProcessorTransitionStep implements PartitionTransitionStep {
       final PartitionTransitionContext context, final Role targetRole) {
     final StreamProcessorMode streamProcessorMode =
         targetRole == Role.LEADER ? StreamProcessorMode.PROCESSING : StreamProcessorMode.REPLAY;
-    return StreamProcessor.builder()
+    return streamProcessorBuilder
         .logStream(context.getLogStream())
         .actorSchedulingService(context.getActorSchedulingService())
         .zeebeDb(context.getZeebeDb())

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ZeebeDbPartitionTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ZeebeDbPartitionTransitionStep.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
+
+public class ZeebeDbPartitionTransitionStep implements PartitionTransitionStep {
+
+  @Override
+  public ActorFuture<Void> prepareTransition(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+
+    final var currentRole = context.getCurrentRole();
+    if (currentRole == Role.LEADER || targetRole == Role.INACTIVE) {
+      try {
+        context.getStateController().closeDb();
+        context.setZeebeDb(null);
+      } catch (final Exception e) {
+        return CompletableActorFuture.completedExceptionally(e);
+      }
+    }
+
+    return CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  public ActorFuture<Void> transitionTo(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    final var currentRole = context.getCurrentRole();
+
+    if (targetRole == Role.INACTIVE) {
+      return CompletableActorFuture.completed(null);
+    }
+    if (currentRole == Role.LEADER
+        || currentRole == Role.INACTIVE
+        || context.getZeebeDb() == null) {
+
+      final ZeebeDb zeebeDb;
+      try {
+        context.getStateController().recover();
+        zeebeDb = context.getStateController().openDb();
+      } catch (final Exception e) {
+        Loggers.SYSTEM_LOGGER.error("Failed to recover from snapshot", e);
+
+        return CompletableActorFuture.completedExceptionally(
+            new IllegalStateException(
+                String.format(
+                    "Unexpected error occurred while recovering snapshot controller during leader partition install for partition %d",
+                    context.getPartitionId()),
+                e));
+      }
+
+      context.setZeebeDb(zeebeDb);
+    }
+    return CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  public String getName() {
+    return "ZeebeDb";
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ZeebeDbPartitionTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ZeebeDbPartitionTransitionStep.java
@@ -22,7 +22,8 @@ public class ZeebeDbPartitionTransitionStep implements PartitionTransitionStep {
       final PartitionTransitionContext context, final long term, final Role targetRole) {
 
     final var currentRole = context.getCurrentRole();
-    if (currentRole == Role.LEADER || targetRole == Role.INACTIVE) {
+    if (context.getZeebeDb() != null
+        && (currentRole == Role.LEADER || targetRole == Role.INACTIVE)) {
       try {
         context.getStateController().closeDb();
         context.setZeebeDb(null);

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -5,15 +5,12 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.system.partitions.impl.steps;
+package io.camunda.zeebe.broker.system.partitions;
 
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
-import io.camunda.zeebe.broker.system.partitions.PartitionContext;
-import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
-import io.camunda.zeebe.broker.system.partitions.StateController;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -21,8 +21,8 @@ import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import io.camunda.zeebe.util.sched.ActorSchedulingService;
-import io.camunda.zeebe.util.sched.TestConcurrencyControl;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.sched.future.TestActorFuture;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -38,7 +38,6 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private StreamProcessor streamProcessor;
   private ActorSchedulingService actorSchedulingService;
   private ZeebeDb zeebeDB;
-  private TestConcurrencyControl concurrencyControl;
   private StateController stateController;
 
   @Override
@@ -53,12 +52,12 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
 
   @Override
   public List<ActorFuture<Void>> notifyListenersOfBecomingLeader(final long newTerm) {
-    return null;
+    return List.of(TestActorFuture.completedFuture(null));
   }
 
   @Override
   public List<ActorFuture<Void>> notifyListenersOfBecomingFollower(final long newTerm) {
-    return null;
+    return List.of(TestActorFuture.completedFuture(null));
   }
 
   @Override
@@ -91,7 +90,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
 
   @Override
   public boolean shouldProcess() {
-    return false;
+    return true;
   }
 
   @Override

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImplTest.java
@@ -74,8 +74,8 @@ class NewPartitionTransitionImplTest {
 
     // then
     final var invocationRecorder = inOrder(mockStep1, mockStep2);
-    invocationRecorder.verify(mockStep1).onNewRaftRole(DEFAULT_ROLE);
-    invocationRecorder.verify(mockStep2).onNewRaftRole(DEFAULT_ROLE);
+    invocationRecorder.verify(mockStep1).onNewRaftRole(mockContext, DEFAULT_ROLE);
+    invocationRecorder.verify(mockStep2).onNewRaftRole(mockContext, DEFAULT_ROLE);
     invocationRecorder.verify(mockStep1).transitionTo(mockContext, DEFAULT_TERM, DEFAULT_ROLE);
     invocationRecorder.verify(mockStep2).transitionTo(mockContext, DEFAULT_TERM, DEFAULT_ROLE);
   }
@@ -140,13 +140,13 @@ class NewPartitionTransitionImplTest {
 
     final var invocationRecorder = inOrder(spyStep1, mockStep2);
     // first transition sequence
-    invocationRecorder.verify(spyStep1).onNewRaftRole(DEFAULT_ROLE);
-    invocationRecorder.verify(mockStep2).onNewRaftRole(DEFAULT_ROLE);
+    invocationRecorder.verify(spyStep1).onNewRaftRole(mockContext, DEFAULT_ROLE);
+    invocationRecorder.verify(mockStep2).onNewRaftRole(mockContext, DEFAULT_ROLE);
     invocationRecorder.verify(spyStep1).transitionTo(mockContext, DEFAULT_TERM, DEFAULT_ROLE);
 
     // second transition sequence
-    invocationRecorder.verify(spyStep1).onNewRaftRole(secondRole);
-    invocationRecorder.verify(mockStep2).onNewRaftRole(secondRole);
+    invocationRecorder.verify(spyStep1).onNewRaftRole(mockContext, secondRole);
+    invocationRecorder.verify(mockStep2).onNewRaftRole(mockContext, secondRole);
     invocationRecorder.verify(spyStep1).prepareTransition(mockContext, secondTerm, secondRole);
     invocationRecorder.verify(spyStep1).transitionTo(mockContext, secondTerm, secondRole);
     invocationRecorder.verify(mockStep2).transitionTo(mockContext, secondTerm, secondRole);

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStepTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.system.partitions.TestPartitionTransitionContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorBuilder;
 import io.camunda.zeebe.logstreams.log.LogStream;

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStepTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorBuilder;
+import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.util.health.HealthMonitor;
+import io.camunda.zeebe.util.sched.future.TestActorFuture;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+class StreamProcessorTransitionStepTest {
+
+  TestPartitionTransitionContext transitionContext = new TestPartitionTransitionContext();
+  final StreamProcessorBuilder streamProcessorBuilder = spy(StreamProcessorBuilder.class);
+  final StreamProcessor streamProcessor = mock(StreamProcessor.class);
+
+  private StreamProcessorTransitionStep step;
+
+  @BeforeEach
+  void setup() {
+    transitionContext.setLogStream(mock(LogStream.class));
+    transitionContext.setComponentHealthMonitor(mock(HealthMonitor.class));
+
+    doReturn(streamProcessor).when(streamProcessorBuilder).build();
+
+    when(streamProcessor.openAsync(anyBoolean())).thenReturn(TestActorFuture.completedFuture(null));
+    when(streamProcessor.closeAsync()).thenReturn(TestActorFuture.completedFuture(null));
+
+    step = new StreamProcessorTransitionStep(streamProcessorBuilder);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldReInstallStreamProcessor")
+  void shouldCloseExistingStreamProcessor(final Role currentRole, final Role targetRole) {
+    // given
+    if (currentRole != null) {
+      transitionTo(currentRole);
+    }
+
+    // when
+    step.prepareTransition(transitionContext, 1, targetRole).join();
+
+    // then
+    assertThat(transitionContext.getStreamProcessor()).isNull();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldReInstallStreamProcessor")
+  void shouldReInstallStreamProcessor(final Role currentRole, final Role targetRole) {
+    // given
+    if (currentRole != null) {
+      transitionTo(currentRole);
+    }
+    Mockito.clearInvocations(streamProcessor);
+
+    // when
+    transitionTo(targetRole);
+
+    // then
+    assertThat(transitionContext.getStreamProcessor()).isNotNull();
+    verify(streamProcessor).openAsync(anyBoolean());
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldDoNothing")
+  void shouldNotCloseExistingStreamProcessor(final Role currentRole, final Role targetRole) {
+    // given
+    transitionTo(currentRole);
+
+    // when
+    step.prepareTransition(transitionContext, 1, targetRole).join();
+
+    // then
+    assertThat(transitionContext.getStreamProcessor()).isNotNull();
+    verify(streamProcessor, never()).closeAsync();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldDoNothing")
+  void shouldNotReInstallStreamProcessor(final Role currentRole, final Role targetRole) {
+    // given
+    transitionTo(currentRole);
+
+    // when
+    transitionTo(targetRole);
+
+    // then
+    assertThat(transitionContext.getStreamProcessor()).isNotNull();
+    verify(streamProcessor).openAsync(anyBoolean());
+    verify(streamProcessor, never()).closeAsync();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = Role.class,
+      names = {"FOLLOWER", "LEADER", "CANDIDATE"})
+  void shouldCloseStreamProcessorWhenTransitioningToInactive(final Role currentRole) {
+    // given
+    transitionTo(currentRole);
+
+    // when
+    transitionTo(Role.INACTIVE);
+
+    // then
+    assertThat(transitionContext.getStreamProcessor()).isNull();
+    verify(streamProcessor).closeAsync();
+  }
+
+  private static Stream<Arguments> provideTransitionsThatShouldReInstallStreamProcessor() {
+    return Stream.of(
+        Arguments.of(null, Role.FOLLOWER),
+        Arguments.of(null, Role.LEADER),
+        Arguments.of(Role.FOLLOWER, Role.LEADER),
+        Arguments.of(Role.CANDIDATE, Role.LEADER),
+        Arguments.of(Role.LEADER, Role.FOLLOWER),
+        Arguments.of(Role.INACTIVE, Role.FOLLOWER),
+        Arguments.of(Role.INACTIVE, Role.LEADER));
+  }
+
+  private static Stream<Arguments> provideTransitionsThatShouldDoNothing() {
+    return Stream.of(
+        Arguments.of(Role.CANDIDATE, Role.FOLLOWER), Arguments.of(Role.FOLLOWER, Role.CANDIDATE));
+  }
+
+  private void transitionTo(final Role role) {
+    step.prepareTransition(transitionContext, 1, role).join();
+    step.transitionTo(transitionContext, 1, role).join();
+    transitionContext.setCurrentRole(role);
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/TestPartitionTransitionContext.java
@@ -13,8 +13,8 @@ import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.system.partitions.PartitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
+import io.camunda.zeebe.broker.system.partitions.StateController;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
-import io.camunda.zeebe.broker.system.partitions.impl.StateControllerImpl;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
@@ -42,6 +42,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private ActorSchedulingService actorSchedulingService;
   private ZeebeDb zeebeDB;
   private TestConcurrencyControl concurrencyControl;
+  private StateController stateController;
 
   @Override
   public int getPartitionId() {
@@ -172,8 +173,8 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   }
 
   @Override
-  public StateControllerImpl getStateController() {
-    return null;
+  public StateController getStateController() {
+    return stateController;
   }
 
   @Override
@@ -193,5 +194,9 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
 
   public void setLogStream(final LogStream logStream) {
     this.logStream = logStream;
+  }
+
+  public void setStateController(final StateController stateController) {
+    this.stateController = stateController;
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/TestPartitionTransitionContext.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import io.atomix.raft.RaftServer.Role;
+import io.atomix.raft.partition.RaftPartition;
+import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
+import io.camunda.zeebe.broker.system.partitions.PartitionContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
+import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
+import io.camunda.zeebe.broker.system.partitions.impl.StateControllerImpl;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
+import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
+import io.camunda.zeebe.util.health.HealthMonitor;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
+import io.camunda.zeebe.util.sched.TestConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class TestPartitionTransitionContext implements PartitionTransitionContext {
+
+  private RaftPartition raftPartition;
+  private Role currentRole;
+  private long currentTerm;
+  private HealthMonitor healthMonitor;
+  private TypedRecordProcessorFactory streamProcessorFactory;
+  private ExporterDirector exporterDirector;
+  private LogStream logStream;
+  private StreamProcessor streamProcessor;
+  private ActorSchedulingService actorSchedulingService;
+  private ZeebeDb zeebeDB;
+  private TestConcurrencyControl concurrencyControl;
+
+  @Override
+  public int getPartitionId() {
+    return 1;
+  }
+
+  @Override
+  public RaftPartition getRaftPartition() {
+    return raftPartition;
+  }
+
+  @Override
+  public List<ActorFuture<Void>> notifyListenersOfBecomingLeader(final long newTerm) {
+    return null;
+  }
+
+  @Override
+  public List<ActorFuture<Void>> notifyListenersOfBecomingFollower(final long newTerm) {
+    return null;
+  }
+
+  @Override
+  public void notifyListenersOfBecomingInactive() {}
+
+  @Override
+  public Role getCurrentRole() {
+    return currentRole;
+  }
+
+  @Override
+  public long getCurrentTerm() {
+    return currentTerm;
+  }
+
+  @Override
+  public HealthMonitor getComponentHealthMonitor() {
+    return healthMonitor;
+  }
+
+  @Override
+  public StreamProcessor getStreamProcessor() {
+    return streamProcessor;
+  }
+
+  @Override
+  public ExporterDirector getExporterDirector() {
+    return exporterDirector;
+  }
+
+  @Override
+  public boolean shouldProcess() {
+    return false;
+  }
+
+  @Override
+  public void setDiskSpaceAvailable(final boolean b) {}
+
+  @Override
+  public void setStreamProcessor(final StreamProcessor streamProcessor) {
+    this.streamProcessor = streamProcessor;
+  }
+
+  public void setComponentHealthMonitor(final HealthMonitor healthMonitor) {
+    this.healthMonitor = healthMonitor;
+  }
+
+  @Override
+  public void setCurrentTerm(final long term) {
+    currentTerm = term;
+  }
+
+  @Override
+  public void setCurrentRole(final Role role) {
+    currentRole = role;
+  }
+
+  @Override
+  public ActorSchedulingService getActorSchedulingService() {
+    return actorSchedulingService;
+  }
+
+  public void setActorSchedulingService(final ActorSchedulingService actorSchedulingService) {
+    this.actorSchedulingService = actorSchedulingService;
+  }
+
+  @Override
+  public ZeebeDb getZeebeDb() {
+    return zeebeDB;
+  }
+
+  @Override
+  public CommandResponseWriter getCommandResponseWriter() {
+    return null;
+  }
+
+  @Override
+  public Consumer<TypedRecord<?>> getOnProcessedListener() {
+    return null;
+  }
+
+  @Override
+  public TypedRecordProcessorFactory getStreamProcessorFactory() {
+    return streamProcessorFactory;
+  }
+
+  public void setStreamProcessorFactory(final TypedRecordProcessorFactory streamProcessorFactory) {
+    this.streamProcessorFactory = streamProcessorFactory;
+  }
+
+  @Override
+  public void setZeebeDb(final ZeebeDb zeebeDb) {
+    zeebeDB = zeebeDb;
+  }
+
+  @Override
+  public int getNodeId() {
+    return 0;
+  }
+
+  @Override
+  public LogStream getLogStream() {
+    return logStream;
+  }
+
+  @Override
+  public AsyncSnapshotDirector getSnapshotDirector() {
+    return null;
+  }
+
+  @Override
+  public StateControllerImpl getStateController() {
+    return null;
+  }
+
+  @Override
+  public ConstructableSnapshotStore getConstructableSnapshotStore() {
+    return null;
+  }
+
+  @Override
+  public List<PartitionListener> getPartitionListeners() {
+    return null;
+  }
+
+  @Override
+  public PartitionContext getPartitionContext() {
+    return null;
+  }
+
+  public void setLogStream(final LogStream logStream) {
+    this.logStream = logStream;
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ZeebeDbPartitionTransitionStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ZeebeDbPartitionTransitionStepTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.system.partitions.StateController;
+import io.camunda.zeebe.broker.system.partitions.TestPartitionTransitionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ZeebeDbPartitionTransitionStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ZeebeDbPartitionTransitionStepTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.system.partitions.StateController;
+import io.camunda.zeebe.db.ZeebeDb;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+class ZeebeDbPartitionTransitionStepTest {
+
+  TestPartitionTransitionContext transitionContext = new TestPartitionTransitionContext();
+
+  private final StateController stateController = mock(StateController.class);
+  private final ZeebeDb zeebeDb = mock(ZeebeDb.class);
+
+  private ZeebeDbPartitionTransitionStep step;
+
+  @BeforeEach
+  void setup() {
+
+    when(stateController.openDb()).thenReturn(zeebeDb);
+    transitionContext.setStateController(stateController);
+
+    step = new ZeebeDbPartitionTransitionStep();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldDoNothing")
+  void shouldNotCloseZeebeDb(final Role currentRole, final Role targetRole) throws Exception {
+    // given
+    transitionTo(currentRole);
+    Mockito.clearInvocations(stateController);
+
+    // when
+    step.prepareTransition(transitionContext, 1, targetRole);
+
+    // then
+    assertThat(transitionContext.getZeebeDb()).isNotNull();
+    verify(stateController, never()).closeDb();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldDoNothing")
+  void shouldNotReInstallZeebeDb(final Role currentRole, final Role targetRole) throws Exception {
+    // given
+    transitionTo(currentRole);
+    Mockito.clearInvocations(stateController);
+
+    // when
+    transitionTo(targetRole);
+
+    // then
+    assertThat(transitionContext.getZeebeDb()).isNotNull();
+    verify(stateController, never()).closeDb();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldCloseZeebeDb")
+  void shouldCloseExistingZeebeDb(final Role currentRole, final Role targetRole) throws Exception {
+    // given
+    transitionTo(currentRole);
+    Mockito.clearInvocations(stateController);
+
+    // when
+    step.prepareTransition(transitionContext, 1, targetRole);
+
+    // then
+    assertThat(transitionContext.getZeebeDb()).isNull();
+    verify(stateController).closeDb();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldReInstallZeebeDb")
+  void shouldInstallZeebeDb(final Role currentRole, final Role targetRole) throws Exception {
+    // given
+    if (currentRole != null) {
+      transitionTo(currentRole);
+    }
+    Mockito.clearInvocations(stateController);
+
+    // when
+    transitionTo(targetRole);
+
+    // then
+    assertThat(transitionContext.getZeebeDb()).isNotNull();
+    verify(stateController).openDb();
+  }
+
+  private static Stream<Arguments> provideTransitionsThatShouldDoNothing() {
+    return Stream.of(
+        Arguments.of(Role.CANDIDATE, Role.FOLLOWER),
+        Arguments.of(Role.FOLLOWER, Role.CANDIDATE),
+        Arguments.of(Role.CANDIDATE, Role.LEADER));
+  }
+
+  private static Stream<Arguments> provideTransitionsThatShouldReInstallZeebeDb() {
+    return Stream.of(
+        Arguments.of(null, Role.FOLLOWER),
+        Arguments.of(null, Role.LEADER),
+        Arguments.of(Role.LEADER, Role.FOLLOWER),
+        Arguments.of(Role.INACTIVE, Role.FOLLOWER),
+        Arguments.of(Role.INACTIVE, Role.LEADER));
+  }
+
+  private static Stream<Arguments> provideTransitionsThatShouldCloseZeebeDb() {
+    return Stream.of(
+        Arguments.of(Role.LEADER, Role.FOLLOWER),
+        Arguments.of(Role.LEADER, Role.INACTIVE),
+        Arguments.of(Role.FOLLOWER, Role.INACTIVE),
+        Arguments.of(Role.CANDIDATE, Role.INACTIVE));
+  }
+
+  private void transitionTo(final Role role) {
+    step.prepareTransition(transitionContext, 1, role).join();
+    step.transitionTo(transitionContext, 1, role).join();
+    transitionContext.setCurrentRole(role);
+  }
+}


### PR DESCRIPTION
## Description

In this PR, we implement two Steps using the new interface `PartitionTransitionStep`. In addition some more necessary field are added to the `PartitionTransitionContext`. They are needed for some transition steps.

Note that the new transition steps are not yet used. The new transition logic will be used when all steps are moved.

## Related issues

Related #7515 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
