### PR TITLE
Fix job metrics

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/JobMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/JobMetrics.java
@@ -47,8 +47,8 @@ public final class JobMetrics {
     PENDING_JOBS.labels(partitionIdLabel, type).dec();
   }
 
-  public void jobActivated(final String type) {
-    jobEvent("activated", type);
+  public void jobActivated(final String type, final int activatedJobs) {
+    JOB_EVENTS.labels("activated", partitionIdLabel, type).inc(activatedJobs);
   }
 
   public void jobTimedOut(final String type) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing;
 import static io.camunda.zeebe.protocol.record.intent.DeploymentIntent.CREATE;
 
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventPublicationBehavior;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
@@ -108,6 +109,8 @@ public final class EngineProcessors {
         typedRecordProcessors,
         writers);
 
+    final var jobMetrics = new JobMetrics(partitionId);
+
     final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor =
         addProcessProcessors(
             zeebeState,
@@ -117,7 +120,8 @@ public final class EngineProcessors {
             catchEventBehavior,
             eventTriggerBehavior,
             writers,
-            timerChecker);
+            timerChecker,
+            jobMetrics);
 
     JobEventProcessors.addJobProcessors(
         typedRecordProcessors,
@@ -125,7 +129,8 @@ public final class EngineProcessors {
         onJobsAvailableCallback,
         eventPublicationBehavior,
         maxFragmentSize,
-        writers);
+        writers,
+        jobMetrics);
 
     addIncidentProcessors(
         zeebeState,
@@ -145,7 +150,8 @@ public final class EngineProcessors {
       final CatchEventBehavior catchEventBehavior,
       final EventTriggerBehavior eventTriggerBehavior,
       final Writers writers,
-      final DueDateTimerChecker timerChecker) {
+      final DueDateTimerChecker timerChecker,
+      final JobMetrics jobMetrics) {
     return ProcessEventProcessors.addProcessProcessors(
         zeebeState,
         expressionProcessor,
@@ -154,7 +160,8 @@ public final class EngineProcessors {
         catchEventBehavior,
         timerChecker,
         eventTriggerBehavior,
-        writers);
+        writers,
+        jobMetrics);
   }
 
   private static void addDeploymentRelatedProcessorAndServices(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing;
 
+import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnStreamProcessor;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
@@ -52,7 +53,8 @@ public final class ProcessEventProcessors {
       final CatchEventBehavior catchEventBehavior,
       final DueDateTimerChecker timerChecker,
       final EventTriggerBehavior eventTriggerBehavior,
-      final Writers writers) {
+      final Writers writers,
+      final JobMetrics jobMetrics) {
     final MutableProcessMessageSubscriptionState subscriptionState =
         zeebeState.getProcessMessageSubscriptionState();
     final VariableBehavior variableBehavior =
@@ -68,7 +70,8 @@ public final class ProcessEventProcessors {
             variableBehavior,
             eventTriggerBehavior,
             zeebeState,
-            writers);
+            writers,
+            jobMetrics);
     addBpmnStepProcessor(typedRecordProcessors, bpmnStreamProcessor);
 
     addMessageStreamProcessors(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.bpmn;
 
 import io.camunda.zeebe.engine.Loggers;
+import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviorsImpl;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
@@ -62,7 +63,8 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
       final VariableBehavior variableBehavior,
       final EventTriggerBehavior eventTriggerBehavior,
       final MutableZeebeState zeebeState,
-      final Writers writers) {
+      final Writers writers,
+      final JobMetrics jobMetrics) {
     processState = zeebeState.getProcessState();
     elementInstanceState = zeebeState.getElementInstanceState();
 
@@ -77,7 +79,8 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
             variableBehavior,
             eventTriggerBehavior,
             this::getContainerProcessor,
-            writers);
+            writers,
+            jobMetrics);
     rejectionWriter = writers.rejection();
     incidentBehavior = bpmnBehaviors.incidentBehavior();
     processors = new BpmnElementProcessors(bpmnBehaviors);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
+import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContainerProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.ProcessInstanceStateTransitionGuard;
@@ -52,7 +53,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final EventTriggerBehavior eventTriggerBehavior,
       final Function<BpmnElementType, BpmnElementContainerProcessor<ExecutableFlowElement>>
           processorLookup,
-      final Writers writers) {
+      final Writers writers,
+      final JobMetrics jobMetrics) {
 
     stateWriter = writers.state();
     final var commandWriter = writers.command();
@@ -89,7 +91,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
         new BpmnBufferedMessageStartEventBehavior(
             zeebeState, zeebeState.getKeyGenerator(), eventTriggerBehavior, writers);
     jobBehavior =
-        new BpmnJobBehavior(zeebeState.getKeyGenerator(), zeebeState.getJobState(), writers);
+        new BpmnJobBehavior(
+            zeebeState.getKeyGenerator(), zeebeState.getJobState(), writers, jobMetrics);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
+import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -27,13 +28,18 @@ public final class BpmnJobBehavior {
   private final StateWriter stateWriter;
   private final TypedCommandWriter commandWriter;
   private final JobState jobState;
+  private final JobMetrics jobMetrics;
 
   public BpmnJobBehavior(
-      final KeyGenerator keyGenerator, final JobState jobState, final Writers writers) {
+      final KeyGenerator keyGenerator,
+      final JobState jobState,
+      final Writers writers,
+      final JobMetrics jobMetrics) {
     this.keyGenerator = keyGenerator;
     this.jobState = jobState;
     stateWriter = writers.state();
     commandWriter = writers.command();
+    this.jobMetrics = jobMetrics;
   }
 
   public void createNewJob(
@@ -55,6 +61,7 @@ public final class BpmnJobBehavior {
 
     final var jobKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.CREATED, jobRecord);
+    jobMetrics.jobCreated(jobType);
   }
 
   public void cancelJob(final long jobKey) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.job;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
+import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -53,12 +54,14 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   private final long maxJobBatchLength;
 
   private final ObjectHashSet<DirectBuffer> variableNames = new ObjectHashSet<>();
+  private final JobMetrics jobMetrics;
 
   public JobBatchActivateProcessor(
       final Writers writers,
       final ZeebeState state,
       final KeyGenerator keyGenerator,
-      final long maxRecordLength) {
+      final long maxRecordLength,
+      final JobMetrics jobMetrics) {
 
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
@@ -70,6 +73,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
 
     this.maxRecordLength = maxRecordLength;
     maxJobBatchLength = maxRecordLength - Long.BYTES;
+    this.jobMetrics = jobMetrics;
   }
 
   @Override
@@ -101,6 +105,9 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
 
     stateWriter.appendFollowUpEvent(jobBatchKey, JobBatchIntent.ACTIVATED, value);
     responseWriter.writeEventOnCommand(jobBatchKey, JobBatchIntent.ACTIVATED, value, record);
+
+    final var activatedJobs = record.getValue().getJobKeys().size();
+    jobMetrics.jobActivated(value.getType(), activatedJobs);
   }
 
   private void collectJobsToActivate(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -106,8 +106,8 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     stateWriter.appendFollowUpEvent(jobBatchKey, JobBatchIntent.ACTIVATED, value);
     responseWriter.writeEventOnCommand(jobBatchKey, JobBatchIntent.ACTIVATED, value, record);
 
-    final var activatedJobs = record.getValue().getJobKeys().size();
-    jobMetrics.jobActivated(value.getType(), activatedJobs);
+    final var activatedJobsCount = record.getValue().getJobKeys().size();
+    jobMetrics.jobActivated(value.getType(), activatedJobsCount);
   }
 
   private void collectJobsToActivate(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.state.immutable.JobState;
@@ -20,9 +21,11 @@ public final class JobCancelProcessor implements CommandProcessor<JobRecord> {
   public static final String NO_JOB_FOUND_MESSAGE =
       "Expected to cancel job with key '%d', but no such job was found";
   private final JobState jobState;
+  private final JobMetrics jobMetrics;
 
-  public JobCancelProcessor(final ZeebeState state) {
+  public JobCancelProcessor(final ZeebeState state, final JobMetrics jobMetrics) {
     jobState = state.getJobState();
+    this.jobMetrics = jobMetrics;
   }
 
   @Override
@@ -32,6 +35,7 @@ public final class JobCancelProcessor implements CommandProcessor<JobRecord> {
     final JobRecord job = jobState.getJob(jobKey);
     if (job != null) {
       commandControl.accept(JobIntent.CANCELED, job);
+      jobMetrics.jobCanceled(job.getType());
     } else {
       commandControl.reject(RejectionType.NOT_FOUND, String.format(NO_JOB_FOUND_MESSAGE, jobKey));
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -54,7 +54,7 @@ public final class JobEventProcessors {
             ValueType.JOB_BATCH,
             JobBatchIntent.ACTIVATE,
             new JobBatchActivateProcessor(
-                writers, zeebeState, zeebeState.getKeyGenerator(), maxRecordSize))
+                writers, zeebeState, zeebeState.getKeyGenerator(), maxRecordSize, jobMetrics))
         .withListener(new JobTimeoutTrigger(jobState))
         .withListener(
             new StreamProcessorLifecycleAware() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -45,7 +45,8 @@ public final class JobEventProcessors {
             JobIntent.THROW_ERROR,
             new JobThrowErrorProcessor(
                 zeebeState, eventPublicationBehavior, keyGenerator, jobMetrics))
-        .onCommand(ValueType.JOB, JobIntent.TIME_OUT, new JobTimeOutProcessor(zeebeState))
+        .onCommand(
+            ValueType.JOB, JobIntent.TIME_OUT, new JobTimeOutProcessor(zeebeState, jobMetrics))
         .onCommand(
             ValueType.JOB, JobIntent.UPDATE_RETRIES, new JobUpdateRetriesProcessor(zeebeState))
         .onCommand(ValueType.JOB, JobIntent.CANCEL, new JobCancelProcessor(zeebeState))

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventPublicationBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.ReadonlyProcessingContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorLifecycleAware;
@@ -30,9 +31,11 @@ public final class JobEventProcessors {
 
     final var jobState = zeebeState.getJobState();
     final var keyGenerator = zeebeState.getKeyGenerator();
+    final var jobMetrics = new JobMetrics(zeebeState.getPartitionId());
 
     typedRecordProcessors
-        .onCommand(ValueType.JOB, JobIntent.COMPLETE, new JobCompleteProcessor(zeebeState))
+        .onCommand(
+            ValueType.JOB, JobIntent.COMPLETE, new JobCompleteProcessor(zeebeState, jobMetrics))
         .onCommand(
             ValueType.JOB,
             JobIntent.FAIL,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -49,7 +49,7 @@ public final class JobEventProcessors {
             ValueType.JOB, JobIntent.TIME_OUT, new JobTimeOutProcessor(zeebeState, jobMetrics))
         .onCommand(
             ValueType.JOB, JobIntent.UPDATE_RETRIES, new JobUpdateRetriesProcessor(zeebeState))
-        .onCommand(ValueType.JOB, JobIntent.CANCEL, new JobCancelProcessor(zeebeState))
+        .onCommand(ValueType.JOB, JobIntent.CANCEL, new JobCancelProcessor(zeebeState, jobMetrics))
         .onCommand(
             ValueType.JOB_BATCH,
             JobBatchIntent.ACTIVATE,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -39,7 +39,7 @@ public final class JobEventProcessors {
         .onCommand(
             ValueType.JOB,
             JobIntent.FAIL,
-            new JobFailProcessor(zeebeState, zeebeState.getKeyGenerator()))
+            new JobFailProcessor(zeebeState, zeebeState.getKeyGenerator(), jobMetrics))
         .onCommand(
             ValueType.JOB,
             JobIntent.THROW_ERROR,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -27,11 +27,11 @@ public final class JobEventProcessors {
       final Consumer<String> onJobsAvailableCallback,
       final BpmnEventPublicationBehavior eventPublicationBehavior,
       final int maxRecordSize,
-      final Writers writers) {
+      final Writers writers,
+      final JobMetrics jobMetrics) {
 
     final var jobState = zeebeState.getJobState();
     final var keyGenerator = zeebeState.getKeyGenerator();
-    final var jobMetrics = new JobMetrics(zeebeState.getPartitionId());
 
     typedRecordProcessors
         .onCommand(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -43,7 +43,8 @@ public final class JobEventProcessors {
         .onCommand(
             ValueType.JOB,
             JobIntent.THROW_ERROR,
-            new JobThrowErrorProcessor(zeebeState, eventPublicationBehavior, keyGenerator))
+            new JobThrowErrorProcessor(
+                zeebeState, eventPublicationBehavior, keyGenerator, jobMetrics))
         .onCommand(ValueType.JOB, JobIntent.TIME_OUT, new JobTimeOutProcessor(zeebeState))
         .onCommand(
             ValueType.JOB, JobIntent.UPDATE_RETRIES, new JobUpdateRetriesProcessor(zeebeState))

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventPublicationBehavior;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
@@ -50,11 +51,13 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
   private final KeyGenerator keyGenerator;
   private final EventScopeInstanceState eventScopeInstanceState;
   private final BpmnEventPublicationBehavior eventPublicationBehavior;
+  private final JobMetrics jobMetrics;
 
   public JobThrowErrorProcessor(
       final ZeebeState state,
       final BpmnEventPublicationBehavior eventPublicationBehavior,
-      final KeyGenerator keyGenerator) {
+      final KeyGenerator keyGenerator,
+      final JobMetrics jobMetrics) {
     this.keyGenerator = keyGenerator;
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
@@ -66,6 +69,7 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
 
     stateAnalyzer = new CatchEventAnalyzer(state.getProcessState(), elementInstanceState);
     this.eventPublicationBehavior = eventPublicationBehavior;
+    this.jobMetrics = jobMetrics;
   }
 
   @Override
@@ -81,6 +85,7 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
       final long jobKey,
       final Intent intent,
       final JobRecord job) {
+    jobMetrics.jobErrorThrown(job.getType());
 
     final var serviceTaskInstanceKey = job.getElementId();
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.state.immutable.JobState;
@@ -20,9 +21,11 @@ public final class JobTimeOutProcessor implements CommandProcessor<JobRecord> {
   public static final String NOT_ACTIVATED_JOB_MESSAGE =
       "Expected to time out activated job with key '%d', but %s";
   private final JobState jobState;
+  private final JobMetrics jobMetrics;
 
-  public JobTimeOutProcessor(final ZeebeState state) {
+  public JobTimeOutProcessor(final ZeebeState state, final JobMetrics jobMetrics) {
     jobState = state.getJobState();
+    this.jobMetrics = jobMetrics;
   }
 
   @Override
@@ -33,6 +36,7 @@ public final class JobTimeOutProcessor implements CommandProcessor<JobRecord> {
 
     if (state == State.ACTIVATED) {
       commandControl.accept(JobIntent.TIMED_OUT, command.getValue());
+      jobMetrics.jobTimedOut(command.getValue().getType());
     } else {
       final String textState;
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -142,7 +142,6 @@ public final class DbJobState implements JobState, MutableJobState {
   @Override
   public void complete(final long key, final JobRecord record) {
     delete(key, record);
-    metrics.jobCompleted(record.getType());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -115,8 +115,6 @@ public final class DbJobState implements JobState, MutableJobState {
 
     deadlineKey.wrapLong(deadline);
     deadlinesColumnFamily.put(deadlineJobKey, DbNil.INSTANCE);
-
-    metrics.jobActivated(record.getType());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -154,8 +154,6 @@ public final class DbJobState implements JobState, MutableJobState {
   public void throwError(final long key, final JobRecord updatedValue) {
     updateJob(key, updatedValue, State.ERROR_THROWN);
     makeJobNotActivatable(updatedValue.getTypeBuffer());
-
-    metrics.jobErrorThrown(updatedValue.getType());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -90,7 +90,6 @@ public final class DbJobState implements JobState, MutableJobState {
   public void create(final long key, final JobRecord record) {
     final DirectBuffer type = record.getTypeBuffer();
     createJob(key, record, type);
-    metrics.jobCreated(record.getType());
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -129,8 +129,6 @@ public final class DbJobState implements JobState, MutableJobState {
 
     createJob(key, record, type);
     removeJobDeadline(deadline);
-
-    metrics.jobTimedOut(record.getType());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -137,7 +137,6 @@ public final class DbJobState implements JobState, MutableJobState {
   @Override
   public void cancel(final long key, final JobRecord record) {
     delete(key, record);
-    metrics.jobCanceled(record.getType());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -177,8 +177,6 @@ public final class DbJobState implements JobState, MutableJobState {
   public void fail(final long key, final JobRecord updatedValue) {
     final State newState = updatedValue.getRetries() > 0 ? State.ACTIVATABLE : State.FAILED;
     updateJob(key, updatedValue, newState);
-
-    metrics.jobFailed(updatedValue.getType());
   }
 
   @Override


### PR DESCRIPTION
## Description
EventAppliers are executed on replay and  cause counting metrics multiple times, which can lead to confusion. This PR moves the metric counting outside of the state changes into the processors.

 * fix: write job complete metric only in processor 
 * fix: write fail metrics in processor
* fix: write error metrics in processor
* fix: write time out metrics in processor
* fix: write activated metrics in processor
* fix: write cancel metrics in processor
* fix: write create metrics in processor 

The creation of the jobs are done in a BpmnBehavior which is unrelated to the job processors, this means we need to create the metrics class on a much higher level, and have to pass it through several layers which is not nice but the simplest solution for now. 

Alternative is to create a singleton, but I prefer not to do that, since we have then other issues. **OR** split it up in several metrics (currently it is one metric with several labels), such that we can have multiple metric classes. This would mean we could have one class for the created job metric, which can be used in the behavior. This would include more work and fixing the grafana panels, which I'm not sure whether this is currently necessary or worth the effort.



<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda-cloud/zeebe/issues/7772

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
