### PR TITLE
ExporterDirector transition step

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.system.partitions;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.logstreams.LogDeletionService;
@@ -32,6 +33,7 @@ import io.camunda.zeebe.util.sched.ActorControl;
 import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import io.camunda.zeebe.util.sched.ScheduledTimer;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
@@ -364,5 +366,10 @@ public class PartitionStartupAndTransitionContextImpl
 
   public boolean shouldExport() {
     return !partitionProcessingState.isExportingPaused();
+  }
+
+  @Override
+  public Collection<ExporterDescriptor> getExportedDescriptors() {
+    return getExporterRepository().getExporters().values();
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.broker.system.partitions;
 
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
+import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
@@ -18,6 +20,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandRespons
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
 import io.camunda.zeebe.util.sched.ActorSchedulingService;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -54,4 +57,12 @@ public interface PartitionTransitionContext extends PartitionContext {
   TypedRecordProcessorFactory getStreamProcessorFactory();
 
   void setZeebeDb(ZeebeDb zeebeDb);
+
+  void setExporterDirector(ExporterDirector exporterDirector);
+
+  PartitionMessagingService getMessagingService();
+
+  boolean shouldExport();
+
+  Collection<ExporterDescriptor> getExportedDescriptors();
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
+import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
+import io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext;
+import io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext.ExporterMode;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
+import io.camunda.zeebe.util.sched.Actor;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
+import java.util.Collection;
+
+public class ExporterDirectorPartitionTransitionStep implements PartitionTransitionStep {
+
+  private static final int EXPORTER_PROCESSOR_ID = 1003;
+
+  @Override
+  public void onNewRaftRole(final PartitionTransitionContext context, final Role newRole) {
+    final var director = context.getExporterDirector();
+    if (director != null && shouldCloseOnTransition(newRole, context.getCurrentRole())) {
+      director.pauseExporting();
+    }
+  }
+
+  @Override
+  public ActorFuture<Void> prepareTransition(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    final var director = context.getExporterDirector();
+    if (director != null && shouldCloseOnTransition(targetRole, context.getCurrentRole())) {
+      context.getComponentHealthMonitor().removeComponent(director.getName());
+      final ActorFuture<Void> future = director.closeAsync();
+      future.onComplete(
+          (success, error) -> {
+            if (error == null) {
+              context.setExporterDirector(null);
+            }
+          });
+
+      return future;
+    } else {
+      return CompletableActorFuture.completed(null);
+    }
+  }
+
+  @Override
+  public ActorFuture<Void> transitionTo(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+
+    if (shouldInstallOnTransition(targetRole, context.getCurrentRole())
+        || (context.getExporterDirector() == null && targetRole != Role.INACTIVE)) {
+      return openExporter(context, targetRole);
+    } else {
+      return CompletableActorFuture.completed(null);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return "ExporterDirector";
+  }
+
+  private boolean shouldInstallOnTransition(final Role newRole, final Role currentRole) {
+    return newRole == Role.LEADER
+        || (newRole == Role.FOLLOWER && currentRole != Role.CANDIDATE)
+        || (newRole == Role.CANDIDATE && currentRole != Role.FOLLOWER);
+  }
+
+  private boolean shouldCloseOnTransition(final Role newRole, final Role currentRole) {
+    return shouldInstallOnTransition(newRole, currentRole) || newRole == Role.INACTIVE;
+  }
+
+  private ActorFuture<Void> openExporter(
+      final PartitionTransitionContext context, final Role targetRole) {
+    final Collection<ExporterDescriptor> exporterDescriptors = context.getExportedDescriptors();
+
+    final ExporterMode exporterMode =
+        targetRole == Role.LEADER ? ExporterMode.ACTIVE : ExporterMode.PASSIVE;
+    final ExporterDirectorContext exporterCtx =
+        new ExporterDirectorContext()
+            .id(EXPORTER_PROCESSOR_ID)
+            .name(Actor.buildActorName(context.getNodeId(), "Exporter", context.getPartitionId()))
+            .logStream(context.getLogStream())
+            .zeebeDb(context.getZeebeDb())
+            .partitionMessagingService(context.getMessagingService())
+            .descriptors(exporterDescriptors)
+            .exporterMode(exporterMode);
+
+    final ExporterDirector director = new ExporterDirector(exporterCtx, !context.shouldExport());
+
+    context.getComponentHealthMonitor().registerComponent(director.getName(), director);
+
+    final var startFuture = director.startAsync(context.getActorSchedulingService());
+    startFuture.onComplete(
+        (nothing, error) -> {
+          if (error == null) {
+            context.setExporterDirector(director);
+            // Pause/Resume here in case the state was changed after the director was created
+            if (!context.shouldExport()) {
+              director.pauseExporting();
+            } else {
+              director.resumeExporting();
+            }
+          }
+        });
+    return startFuture;
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.broker.system.partitions;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
+import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -23,7 +25,9 @@ import io.camunda.zeebe.util.health.HealthMonitor;
 import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.TestActorFuture;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 
 public class TestPartitionTransitionContext implements PartitionTransitionContext {
@@ -39,6 +43,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private ActorSchedulingService actorSchedulingService;
   private ZeebeDb zeebeDB;
   private StateController stateController;
+  private ExporterRepository exporterRepository;
 
   @Override
   public int getPartitionId() {
@@ -95,6 +100,30 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
 
   @Override
   public void setDiskSpaceAvailable(final boolean b) {}
+
+  @Override
+  public void setExporterDirector(final ExporterDirector exporterDirector) {
+    this.exporterDirector = exporterDirector;
+  }
+
+  public void setExporterRepository(final ExporterRepository exporterRepository) {
+    this.exporterRepository = exporterRepository;
+  }
+
+  @Override
+  public PartitionMessagingService getMessagingService() {
+    return null;
+  }
+
+  @Override
+  public boolean shouldExport() {
+    return true;
+  }
+
+  @Override
+  public Collection<ExporterDescriptor> getExportedDescriptors() {
+    return Set.of();
+  }
 
   @Override
   public void setStreamProcessor(final StreamProcessor streamProcessor) {
@@ -188,11 +217,11 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
     return null;
   }
 
-  public void setLogStream(final LogStream logStream) {
-    this.logStream = logStream;
-  }
-
   public void setStateController(final StateController stateController) {
     this.stateController = stateController;
+  }
+
+  public void setLogStream(final LogStream logStream) {
+    this.logStream = logStream;
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
+import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
+import io.camunda.zeebe.broker.system.partitions.TestPartitionTransitionContext;
+import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.util.health.HealthMonitor;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
+import io.camunda.zeebe.util.sched.future.TestActorFuture;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ExporterDirectorPartitionTransitionStepTest {
+
+  final TestPartitionTransitionContext transitionContext = new TestPartitionTransitionContext();
+
+  final ActorSchedulingService actorSchedulingService = mock(ActorSchedulingService.class);
+  final ExporterRepository exporterRepository = mock(ExporterRepository.class);
+  final ExporterDirector exporterDirectorFromPrevRole = mock(ExporterDirector.class);
+  private ExporterDirectorPartitionTransitionStep step;
+
+  @BeforeEach
+  void setup() {
+    transitionContext.setLogStream(mock(LogStream.class));
+    transitionContext.setComponentHealthMonitor(mock(HealthMonitor.class));
+
+    when(exporterRepository.getExporters()).thenReturn(Map.of());
+    transitionContext.setExporterRepository(exporterRepository);
+
+    when(actorSchedulingService.submitActor(any(), anyInt()))
+        .thenReturn(TestActorFuture.completedFuture(null));
+    transitionContext.setActorSchedulingService(actorSchedulingService);
+
+    when(exporterDirectorFromPrevRole.closeAsync())
+        .thenReturn(TestActorFuture.completedFuture(null));
+
+    step = new ExporterDirectorPartitionTransitionStep();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldCloseExistingExporter")
+  void shouldCloseExistingStreamProcessor(final Role currentRole, final Role targetRole) {
+    // given
+    initializeContext(currentRole);
+
+    // when
+    step.prepareTransition(transitionContext, 1, targetRole).join();
+
+    // then
+    assertThat(transitionContext.getExporterDirector()).isNull();
+    verify(exporterDirectorFromPrevRole).closeAsync();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldInstallExporter")
+  void shouldInstallExporterDirector(final Role currentRole, final Role targetRole) {
+    // given
+    initializeContext(currentRole);
+
+    // when
+    transitionTo(targetRole);
+
+    // then
+    assertThat(transitionContext.getExporterDirector())
+        .isNotNull()
+        .isNotEqualTo(exporterDirectorFromPrevRole);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldDoNothing")
+  void shouldNotInstallExporterDirector(final Role currentRole, final Role targetRole) {
+    // given
+    initializeContext(currentRole);
+    final var existingExporterDirector = transitionContext.getExporterDirector();
+
+    // when
+    transitionTo(targetRole);
+
+    // then
+    assertThat(transitionContext.getExporterDirector()).isEqualTo(existingExporterDirector);
+    verify(exporterDirectorFromPrevRole, never()).closeAsync();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = Role.class,
+      names = {"FOLLOWER", "LEADER", "CANDIDATE"})
+  void shouldCloseWhenTransitionToInactive(final Role currentRole) {
+    // given
+    initializeContext(currentRole);
+
+    // when
+    transitionTo(Role.INACTIVE);
+
+    // then
+    assertThat(transitionContext.getExporterDirector()).isNull();
+    verify(exporterDirectorFromPrevRole).closeAsync();
+  }
+
+  private static Stream<Arguments> provideTransitionsThatShouldCloseExistingExporter() {
+    return Stream.of(
+        Arguments.of(Role.FOLLOWER, Role.LEADER),
+        Arguments.of(Role.CANDIDATE, Role.LEADER),
+        Arguments.of(Role.LEADER, Role.FOLLOWER),
+        Arguments.of(Role.LEADER, Role.CANDIDATE),
+        Arguments.of(Role.LEADER, Role.INACTIVE),
+        Arguments.of(Role.FOLLOWER, Role.INACTIVE),
+        Arguments.of(Role.CANDIDATE, Role.INACTIVE));
+  }
+
+  private static Stream<Arguments> provideTransitionsThatShouldInstallExporter() {
+    return Stream.of(
+        Arguments.of(null, Role.FOLLOWER),
+        Arguments.of(null, Role.LEADER),
+        Arguments.of(null, Role.CANDIDATE),
+        Arguments.of(Role.FOLLOWER, Role.LEADER),
+        Arguments.of(Role.CANDIDATE, Role.LEADER),
+        Arguments.of(Role.LEADER, Role.FOLLOWER),
+        Arguments.of(Role.LEADER, Role.CANDIDATE),
+        Arguments.of(Role.INACTIVE, Role.FOLLOWER),
+        Arguments.of(Role.INACTIVE, Role.LEADER),
+        Arguments.of(Role.INACTIVE, Role.CANDIDATE));
+  }
+
+  private static Stream<Arguments> provideTransitionsThatShouldDoNothing() {
+    return Stream.of(
+        Arguments.of(Role.CANDIDATE, Role.FOLLOWER),
+        Arguments.of(Role.FOLLOWER, Role.CANDIDATE),
+        Arguments.of(null, Role.INACTIVE));
+  }
+
+  private void initializeContext(final Role currentRole) {
+    transitionContext.setCurrentRole(currentRole);
+    if (currentRole != null && currentRole != Role.INACTIVE) {
+      transitionContext.setExporterDirector(exporterDirectorFromPrevRole);
+    }
+  }
+
+  private void transitionTo(final Role role) {
+    step.prepareTransition(transitionContext, 1, role).join();
+    step.transitionTo(transitionContext, 1, role).join();
+    transitionContext.setCurrentRole(role);
+  }
+}


### PR DESCRIPTION
## Description

Implement ExporterDirectorPartitionTransitionStep. The step re-installs exporter director when transition between Leader <-> Follower. It does nothing when transitioning between Follower <-> Candidate.

## Related issues

Related #7515 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
