### PR TITLE
Throw exceptions when task is submitted while actor scheduler is not running

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -63,6 +63,7 @@ public final class SimpleBrokerStartTest {
     assignSocketAddresses(brokerCfg);
     final var systemContext =
         new SystemContext(brokerCfg, newTemporaryFolder.getAbsolutePath(), null);
+    systemContext.getScheduler().start();
 
     final var broker = new Broker(systemContext, TEST_SPRING_BROKER_BRIDGE);
     final var leaderLatch = new CountDownLatch(1);
@@ -90,7 +91,6 @@ public final class SimpleBrokerStartTest {
         });
 
     // when
-    systemContext.getScheduler().start();
     broker.start().join();
 
     // then

--- a/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -226,6 +226,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
     }
     systemContext =
         new SystemContext(brokerCfg, newTemporaryFolder.getAbsolutePath(), controlledActorClock);
+    systemContext.getScheduler().start();
     broker = new Broker(systemContext, springBrokerBridge);
 
     final CountDownLatch latch = new CountDownLatch(brokerCfg.getCluster().getPartitionsCount());
@@ -234,7 +235,6 @@ public final class EmbeddedBrokerRule extends ExternalResource {
       broker.addPartitionListener(listener);
     }
 
-    systemContext.getScheduler().start();
     broker.start().join();
 
     try {

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
@@ -125,11 +125,14 @@ public final class SecurityTest {
 
   private Gateway buildGateway(final GatewayCfg gatewayCfg) {
     final var atomix = AtomixCluster.builder().build();
+    final var actorScheduler = ActorScheduler.newActorScheduler().build();
+    actorScheduler.start();
+
     return new Gateway(
         gatewayCfg,
         atomix.getMessagingService(),
         atomix.getMembershipService(),
         atomix.getEventService(),
-        ActorScheduler.newActorScheduler().build());
+        actorScheduler);
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -283,12 +283,13 @@ public final class ClusteringRule extends ExternalResource {
         new SystemContext(brokerCfg, brokerBase.getAbsolutePath(), controlledClock);
     systemContexts.put(nodeId, systemContext);
 
+    systemContext.getScheduler().start();
+
     final Broker broker = new Broker(systemContext, getSpringBrokerBridge(nodeId));
 
     broker.addPartitionListener(new LeaderListener(partitionLatch, nodeId));
     new Thread(
             () -> {
-              systemContext.getScheduler().start();
               broker.start();
             })
         .start();

--- a/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
+++ b/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
@@ -215,13 +215,13 @@ public class EmbeddedBrokerRule extends ExternalResource {
   public void startBroker() {
     systemContext =
         new SystemContext(brokerCfg, newTemporaryFolder.getAbsolutePath(), controlledActorClock);
+    systemContext.getScheduler().start();
 
     broker = new Broker(systemContext, springBrokerBridge);
 
     final CountDownLatch latch = new CountDownLatch(brokerCfg.getCluster().getPartitionsCount());
     broker.addPartitionListener(new LeaderPartitionListener(latch));
 
-    systemContext.getScheduler().start();
     broker.start().join();
 
     try {

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorScheduler.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorScheduler.java
@@ -30,6 +30,7 @@ public final class ActorScheduler implements AutoCloseable, ActorSchedulingServi
    */
   @Override
   public ActorFuture<Void> submitActor(final Actor actor) {
+    checkRunningState();
     return actorTaskExecutor.submitCpuBound(actor.actor.task);
   }
 
@@ -50,7 +51,10 @@ public final class ActorScheduler implements AutoCloseable, ActorSchedulingServi
    * @param actor the actor to submit
    * @param schedulingHints additional scheduling hint
    */
+  @Override
   public ActorFuture<Void> submitActor(final Actor actor, final int schedulingHints) {
+    checkRunningState();
+
     final ActorTask task = actor.actor.task;
 
     final ActorFuture<Void> startingFuture;
@@ -61,6 +65,12 @@ public final class ActorScheduler implements AutoCloseable, ActorSchedulingServi
       startingFuture = actorTaskExecutor.submitIoBoundTask(task);
     }
     return startingFuture;
+  }
+
+  private void checkRunningState() {
+    if (state.get() != SchedulerState.RUNNING) {
+      throw new IllegalStateException("Actor scheduler is not running");
+    }
   }
 
   public void start() {

--- a/util/src/test/java/io/camunda/zeebe/util/sched/ActorSchedulerTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/sched/ActorSchedulerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util.sched;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import org.junit.jupiter.api.Test;
+
+final class ActorSchedulerTest {
+
+  @Test
+  void shouldThrowIllegalStateExceptionWhenTaskIsSubmittedBeforeActorSchedulerIsNotRunning() {
+    // given
+    final var testActor = new TestActor();
+    final var sut = ActorScheduler.newActorScheduler().build();
+
+    // when + then
+    assertThatThrownBy(() -> sut.submitActor(testActor)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> sut.submitActor(testActor, 0))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void shouldThrowIllegalStateExceptionWhenTaskIsSubmittedAfterActorSchedulerIsStopped() {
+    // given
+    final var testActor = new TestActor();
+    final var sut = ActorScheduler.newActorScheduler().build();
+
+    sut.start();
+    final var stopFuture = sut.stop();
+
+    await().until(stopFuture::isDone);
+
+    // when + then
+    assertThatThrownBy(() -> sut.submitActor(testActor)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> sut.submitActor(testActor, 0))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  private static final class TestActor extends Actor {}
+}


### PR DESCRIPTION
## Description

Changes the actor scheduler to check for running state when an actor is submitted

## Related issues

closes #7771 

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
