### PR TITLE
LogStorage partition transition step

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.logstreams.storage.atomix.AtomixLogStorage;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
 import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import java.util.Collection;
@@ -65,4 +66,8 @@ public interface PartitionTransitionContext extends PartitionContext {
   boolean shouldExport();
 
   Collection<ExporterDescriptor> getExportedDescriptors();
+
+  AtomixLogStorage getLogStorage();
+
+  void setLogStorage(AtomixLogStorage logStorage);
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStep.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import static io.camunda.zeebe.util.Either.left;
+import static io.camunda.zeebe.util.Either.right;
+
+import io.atomix.raft.RaftServer.Role;
+import io.atomix.raft.partition.impl.RaftPartitionServer;
+import io.atomix.raft.zeebe.ZeebeLogAppender;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
+import io.camunda.zeebe.logstreams.storage.atomix.AtomixLogStorage;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
+import java.nio.ByteBuffer;
+
+public class LogStoragePartitionTransitionStep implements PartitionTransitionStep {
+  private static final String WRONG_TERM_ERROR_MSG =
+      "Expected that current term '%d' is same as raft term '%d', but was not. Failing installation of 'LogStoragePartitionStep' on partition %d.";
+
+  @Override
+  public ActorFuture<Void> prepareTransition(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+
+    final var logStorage = context.getLogStorage();
+    if (logStorage != null
+        && (shouldInstallOnTransition(targetRole, context.getCurrentRole())
+            || targetRole == Role.INACTIVE)) {
+      context.getRaftPartition().getServer().removeCommitListener(logStorage);
+      context.setLogStorage(null);
+    }
+    return CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  public ActorFuture<Void> transitionTo(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    if (shouldInstallOnTransition(targetRole, context.getCurrentRole())
+        || (context.getLogStorage() == null && targetRole != Role.INACTIVE)) {
+      final CompletableActorFuture<Void> openFuture = new CompletableActorFuture<>();
+
+      final var logStorageOrException = buildAtomixLogStorage(context, term, targetRole);
+
+      if (logStorageOrException.isRight()) {
+        final var logStorage = logStorageOrException.get();
+        context.setLogStorage(logStorage);
+        context.getRaftPartition().getServer().addCommitListener(logStorage);
+        openFuture.complete(null);
+      } else {
+        openFuture.completeExceptionally(logStorageOrException.getLeft());
+      }
+
+      return openFuture;
+    } else {
+      return CompletableActorFuture.completed(null);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return "logstorage";
+  }
+
+  private boolean shouldInstallOnTransition(final Role newRole, final Role currentRole) {
+    return newRole == Role.LEADER
+        || (newRole == Role.FOLLOWER && currentRole != Role.CANDIDATE)
+        || (newRole == Role.CANDIDATE && currentRole != Role.FOLLOWER);
+  }
+
+  private Either<Exception, AtomixLogStorage> buildAtomixLogStorage(
+      final PartitionTransitionContext context, final long targetTerm, final Role targetRole) {
+    final var server = context.getRaftPartition().getServer();
+
+    if (targetRole == Role.LEADER) {
+      return createWritableLogStorage(context, server, targetTerm);
+    } else {
+      return createReadOnlyStorage(server);
+    }
+  }
+
+  private Either<Exception, AtomixLogStorage> createReadOnlyStorage(
+      final RaftPartitionServer server) {
+
+    return right(
+        new AtomixLogStorage(
+            server::openReader,
+            // Prevent followers from writing new events
+            new LogAppenderForReadOnlyStorage()));
+  }
+
+  private Either<Exception, AtomixLogStorage> createWritableLogStorage(
+      final PartitionTransitionContext context,
+      final RaftPartitionServer server,
+      final long targetTerm) {
+    final var appenderOptional = server.getAppender();
+    return appenderOptional
+        .map(
+            logAppender -> checkAndCreateAtomixLogStorage(context, server, logAppender, targetTerm))
+        .orElseGet(
+            () ->
+                left(
+                    new IllegalStateException(
+                        "Not leader of partition " + context.getPartitionId())));
+  }
+
+  private Either<Exception, AtomixLogStorage> checkAndCreateAtomixLogStorage(
+      final PartitionTransitionContext context,
+      final RaftPartitionServer server,
+      final ZeebeLogAppender logAppender,
+      final long targetTerm) {
+    final var raftTerm = server.getTerm();
+
+    if (raftTerm != targetTerm) {
+      return left(
+          new IllegalStateException(
+              String.format(WRONG_TERM_ERROR_MSG, targetTerm, raftTerm, context.getPartitionId())));
+    } else {
+      final var logStorage = AtomixLogStorage.ofPartition(server::openReader, logAppender);
+      return right(logStorage);
+    }
+  }
+
+  private static class LogAppenderForReadOnlyStorage implements ZeebeLogAppender {
+    @Override
+    public void appendEntry(
+        final long lowestPosition,
+        final long highestPosition,
+        final ByteBuffer data,
+        final AppendListener appendListener) {
+      throw new UnsupportedOperationException(
+          String.format(
+              "Expect to append entry (positions %d - %d), but was in Follower role. Followers must not append entries to the log storage",
+              lowestPosition, highestPosition));
+    }
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -184,6 +184,10 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
     zeebeDB = zeebeDb;
   }
 
+  public void setRaftPartition(final RaftPartition raftPartition) {
+    this.raftPartition = raftPartition;
+  }
+
   @Override
   public AtomixLogStorage getLogStorage() {
     return logStorage;

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.logstreams.storage.atomix.AtomixLogStorage;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import io.camunda.zeebe.util.sched.ActorSchedulingService;
@@ -44,6 +45,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private ZeebeDb zeebeDB;
   private StateController stateController;
   private ExporterRepository exporterRepository;
+  private AtomixLogStorage logStorage;
 
   @Override
   public int getPartitionId() {
@@ -183,6 +185,16 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   }
 
   @Override
+  public AtomixLogStorage getLogStorage() {
+    return logStorage;
+  }
+
+  @Override
+  public void setLogStorage(final AtomixLogStorage logStorage) {
+    this.logStorage = logStorage;
+  }
+
+  @Override
   public int getNodeId() {
     return 0;
   }
@@ -217,11 +229,11 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
     return null;
   }
 
-  public void setStateController(final StateController stateController) {
-    this.stateController = stateController;
-  }
-
   public void setLogStream(final LogStream logStream) {
     this.logStream = logStream;
+  }
+
+  public void setStateController(final StateController stateController) {
+    this.stateController = stateController;
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStoragePartitionTransitionStepTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.raft.RaftServer.Role;
+import io.atomix.raft.partition.RaftPartition;
+import io.atomix.raft.partition.impl.RaftPartitionServer;
+import io.atomix.raft.zeebe.ZeebeLogAppender;
+import io.camunda.zeebe.broker.system.partitions.TestPartitionTransitionContext;
+import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.logstreams.storage.atomix.AtomixLogStorage;
+import io.camunda.zeebe.util.health.HealthMonitor;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class LogStoragePartitionTransitionStepTest {
+
+  TestPartitionTransitionContext transitionContext = new TestPartitionTransitionContext();
+
+  private LogStoragePartitionTransitionStep step;
+  private final RaftPartition raftPartition = mock(RaftPartition.class);
+  private final RaftPartitionServer raftServer = mock(RaftPartitionServer.class);
+  private final AtomixLogStorage logStorageFromPrevRole = mock(AtomixLogStorage.class);
+
+  @BeforeEach
+  void setup() {
+    transitionContext.setLogStream(mock(LogStream.class));
+    transitionContext.setComponentHealthMonitor(mock(HealthMonitor.class));
+
+    when(raftPartition.getServer()).thenReturn(raftServer);
+    when(raftServer.getTerm()).thenReturn(1L);
+    when(raftServer.getAppender()).thenReturn(Optional.of(mock(ZeebeLogAppender.class)));
+    transitionContext.setRaftPartition(raftPartition);
+
+    step = new LogStoragePartitionTransitionStep();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldCloseExistingLogStorage")
+  void shouldCloseExistingLogStorage(final Role currentRole, final Role targetRole) {
+    // given
+    initializeContext(currentRole);
+
+    // when
+    step.prepareTransition(transitionContext, 1, targetRole).join();
+
+    // then
+    assertThat(transitionContext.getLogStorage()).isNull();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldInstallLogStorage")
+  void shouldInstallLogStorage(final Role currentRole, final Role targetRole) {
+    // given
+    initializeContext(currentRole);
+    final var existingLogStorage = transitionContext.getLogStorage();
+
+    // when
+    transitionTo(targetRole);
+
+    // then
+    assertThat(transitionContext.getLogStorage()).isNotNull().isNotEqualTo(existingLogStorage);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldDoNothing")
+  void shouldNotReInstallLogStorage(final Role currentRole, final Role targetRole) {
+    // given
+    initializeContext(currentRole);
+    final var existingLogStorage = transitionContext.getLogStorage();
+
+    // when
+    transitionTo(targetRole);
+
+    // then
+    assertThat(transitionContext.getLogStorage()).isEqualTo(existingLogStorage);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = Role.class,
+      names = {"FOLLOWER", "LEADER", "CANDIDATE"})
+  void shouldCloseWhenTransitioningToInactive(final Role currentRole) {
+    // given
+    initializeContext(currentRole);
+
+    // when
+    transitionTo(Role.INACTIVE);
+
+    // then
+    assertThat(transitionContext.getLogStorage()).isNull();
+  }
+
+  private static Stream<Arguments> provideTransitionsThatShouldCloseExistingLogStorage() {
+    return Stream.of(
+        Arguments.of(Role.FOLLOWER, Role.LEADER),
+        Arguments.of(Role.CANDIDATE, Role.LEADER),
+        Arguments.of(Role.LEADER, Role.FOLLOWER),
+        Arguments.of(Role.LEADER, Role.INACTIVE),
+        Arguments.of(Role.FOLLOWER, Role.INACTIVE),
+        Arguments.of(Role.CANDIDATE, Role.INACTIVE));
+  }
+
+  private static Stream<Arguments> provideTransitionsThatShouldInstallLogStorage() {
+    return Stream.of(
+        Arguments.of(null, Role.FOLLOWER),
+        Arguments.of(null, Role.LEADER),
+        Arguments.of(null, Role.CANDIDATE),
+        Arguments.of(Role.FOLLOWER, Role.LEADER),
+        Arguments.of(Role.CANDIDATE, Role.LEADER),
+        Arguments.of(Role.LEADER, Role.FOLLOWER),
+        Arguments.of(Role.LEADER, Role.CANDIDATE),
+        Arguments.of(Role.INACTIVE, Role.FOLLOWER),
+        Arguments.of(Role.INACTIVE, Role.LEADER),
+        Arguments.of(Role.INACTIVE, Role.CANDIDATE));
+  }
+
+  private static Stream<Arguments> provideTransitionsThatShouldDoNothing() {
+    return Stream.of(
+        Arguments.of(Role.CANDIDATE, Role.FOLLOWER),
+        Arguments.of(Role.FOLLOWER, Role.CANDIDATE),
+        Arguments.of(null, Role.INACTIVE));
+  }
+
+  private void initializeContext(final Role currentRole) {
+    transitionContext.setCurrentRole(currentRole);
+    if (currentRole != null && currentRole != Role.INACTIVE) {
+      transitionContext.setLogStorage(logStorageFromPrevRole);
+    }
+  }
+
+  private void transitionTo(final Role role) {
+    step.prepareTransition(transitionContext, 1, role).join();
+    step.transitionTo(transitionContext, 1, role).join();
+    transitionContext.setCurrentRole(role);
+  }
+}


### PR DESCRIPTION
## Description

Add `LogStoragePartitionTransitionStep`. Depending on the current and target roles, this step closes/installs AtomixLogStorage during role transitions. 

## Related issues

Related #7515 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
