### PR TITLE
LogStream partition  transition step

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -31,6 +31,8 @@ public interface PartitionTransitionContext extends PartitionContext {
 
   LogStream getLogStream();
 
+  void setLogStream(LogStream logStream);
+
   AsyncSnapshotDirector getSnapshotDirector();
 
   StateController getStateController();
@@ -70,4 +72,6 @@ public interface PartitionTransitionContext extends PartitionContext {
   AtomixLogStorage getLogStorage();
 
   void setLogStorage(AtomixLogStorage logStorage);
+
+  int getMaxFragmentSize();
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
+import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.logstreams.log.LogStreamBuilder;
+import io.camunda.zeebe.logstreams.storage.atomix.AtomixLogStorage;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
+import java.util.function.Supplier;
+
+public class LogStreamPartitionTransitionStep implements PartitionTransitionStep {
+
+  private final Supplier<LogStreamBuilder> logStreamBuilderSupplier;
+
+  public LogStreamPartitionTransitionStep() {
+    this(LogStream::builder);
+  }
+
+  // Used for testing
+  public LogStreamPartitionTransitionStep(
+      final Supplier<LogStreamBuilder> logStreamBuilderSupplier) {
+    this.logStreamBuilderSupplier = logStreamBuilderSupplier;
+  }
+
+  @Override
+  public ActorFuture<Void> prepareTransition(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    final var logStream = context.getLogStream();
+    if (logStream != null
+        && (shouldInstallOnTransition(targetRole, context.getCurrentRole())
+            || targetRole == Role.INACTIVE)) {
+      context.getComponentHealthMonitor().removeComponent(logStream.getLogName());
+      final ActorFuture<Void> future = logStream.closeAsync();
+      future.onComplete(
+          (ok, error) -> {
+            if (error == null) {
+              context.setLogStream(null);
+            }
+          });
+
+      return future;
+    } else {
+      return CompletableActorFuture.completed(null);
+    }
+  }
+
+  @Override
+  public ActorFuture<Void> transitionTo(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    if ((context.getLogStream() == null && targetRole != Role.INACTIVE)
+        || shouldInstallOnTransition(targetRole, context.getCurrentRole())) {
+      final CompletableActorFuture<Void> openFuture = new CompletableActorFuture<>();
+
+      final var logStorage = context.getLogStorage();
+      buildLogstream(context, logStorage)
+          .onComplete(
+              ((logStream, err) -> {
+                if (err == null) {
+                  context.setLogStream(logStream);
+
+                  context
+                      .getComponentHealthMonitor()
+                      .registerComponent(logStream.getLogName(), logStream);
+                  openFuture.complete(null);
+                } else {
+                  openFuture.completeExceptionally(err);
+                }
+              }));
+
+      return openFuture;
+    } else {
+      return CompletableActorFuture.completed(null);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return "logstream";
+  }
+
+  private ActorFuture<LogStream> buildLogstream(
+      final PartitionTransitionContext context, final AtomixLogStorage atomixLogStorage) {
+    return logStreamBuilderSupplier
+        .get()
+        .withLogStorage(atomixLogStorage)
+        .withLogName("logstream-" + context.getRaftPartition().name())
+        .withNodeId(context.getNodeId())
+        .withPartitionId(context.getPartitionId())
+        .withMaxFragmentSize(context.getMaxFragmentSize())
+        .withActorSchedulingService(context.getActorSchedulingService())
+        .buildAsync();
+  }
+
+  private boolean shouldInstallOnTransition(final Role newRole, final Role currentRole) {
+    return newRole == Role.LEADER
+        || (newRole == Role.FOLLOWER && currentRole != Role.CANDIDATE)
+        || (newRole == Role.CANDIDATE && currentRole != Role.FOLLOWER);
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -108,10 +108,6 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
     this.exporterDirector = exporterDirector;
   }
 
-  public void setExporterRepository(final ExporterRepository exporterRepository) {
-    this.exporterRepository = exporterRepository;
-  }
-
   @Override
   public PartitionMessagingService getMessagingService() {
     return null;
@@ -125,6 +121,21 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public Collection<ExporterDescriptor> getExportedDescriptors() {
     return Set.of();
+  }
+
+  @Override
+  public AtomixLogStorage getLogStorage() {
+    return logStorage;
+  }
+
+  @Override
+  public void setLogStorage(final AtomixLogStorage logStorage) {
+    this.logStorage = logStorage;
+  }
+
+  @Override
+  public int getMaxFragmentSize() {
+    return 1;
   }
 
   @Override
@@ -188,14 +199,8 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
     this.raftPartition = raftPartition;
   }
 
-  @Override
-  public AtomixLogStorage getLogStorage() {
-    return logStorage;
-  }
-
-  @Override
-  public void setLogStorage(final AtomixLogStorage logStorage) {
-    this.logStorage = logStorage;
+  public void setExporterRepository(final ExporterRepository exporterRepository) {
+    this.exporterRepository = exporterRepository;
   }
 
   @Override
@@ -206,6 +211,10 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public LogStream getLogStream() {
     return logStream;
+  }
+
+  public void setLogStream(final LogStream logStream) {
+    this.logStream = logStream;
   }
 
   @Override
@@ -231,10 +240,6 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public PartitionContext getPartitionContext() {
     return null;
-  }
-
-  public void setLogStream(final LogStream logStream) {
-    this.logStream = logStream;
   }
 
   public void setStateController(final StateController stateController) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStepTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.raft.RaftServer.Role;
+import io.atomix.raft.partition.RaftPartition;
+import io.atomix.raft.partition.impl.RaftPartitionServer;
+import io.camunda.zeebe.broker.system.partitions.TestPartitionTransitionContext;
+import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.logstreams.log.LogStreamBuilder;
+import io.camunda.zeebe.logstreams.storage.atomix.AtomixLogStorage;
+import io.camunda.zeebe.util.health.HealthMonitor;
+import io.camunda.zeebe.util.sched.future.TestActorFuture;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class LogStreamPartitionTransitionStepTest {
+  final TestPartitionTransitionContext transitionContext = new TestPartitionTransitionContext();
+
+  private LogStreamPartitionTransitionStep step;
+  private final RaftPartition raftPartition = mock(RaftPartition.class);
+  private final RaftPartitionServer raftServer = mock(RaftPartitionServer.class);
+  private final LogStream logStream = mock(LogStream.class);
+  private final LogStreamBuilder logStreamBuilder = spy(LogStream.builder());
+  private final LogStream logStreamFromPrevRole = mock(LogStream.class);
+
+  @BeforeEach
+  void setup() {
+    transitionContext.setComponentHealthMonitor(mock(HealthMonitor.class));
+    transitionContext.setLogStorage(mock(AtomixLogStorage.class));
+
+    when(raftPartition.getServer()).thenReturn(raftServer);
+    transitionContext.setRaftPartition(raftPartition);
+
+    doReturn(TestActorFuture.completedFuture(logStream)).when(logStreamBuilder).buildAsync();
+    when(logStream.closeAsync()).thenReturn(TestActorFuture.completedFuture(null));
+    when(logStreamFromPrevRole.closeAsync()).thenReturn(TestActorFuture.completedFuture(null));
+
+    step = new LogStreamPartitionTransitionStep(() -> logStreamBuilder);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldCloseExistingLogStream")
+  void shouldCloseExistingLogStream(final Role currentRole, final Role targetRole) {
+    // given
+    initializeContext(currentRole);
+
+    // when
+    step.prepareTransition(transitionContext, 1, targetRole).join();
+
+    // then
+    assertThat(transitionContext.getLogStream()).isNull();
+    verify(logStreamFromPrevRole).closeAsync();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldInstallLogStream")
+  void shouldInstallLogStream(final Role currentRole, final Role targetRole) {
+    // given
+    initializeContext(currentRole);
+    final var existingLogStream = transitionContext.getLogStream();
+
+    // when
+    transitionTo(targetRole);
+
+    // then
+    assertThat(transitionContext.getLogStream()).isNotNull().isNotEqualTo(existingLogStream);
+    verify(logStreamBuilder).buildAsync();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldDoNothing")
+  void shoulNotReInstallLogStorage(final Role currentRole, final Role targetRole) {
+    // given
+    initializeContext(currentRole);
+    final var existingLogStream = transitionContext.getLogStream();
+
+    // when
+    transitionTo(targetRole);
+
+    // then
+    assertThat(transitionContext.getLogStream()).isEqualTo(existingLogStream);
+    verify(logStreamBuilder, never()).buildAsync();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = Role.class,
+      names = {"FOLLOWER", "LEADER", "CANDIDATE"})
+  void shouldCloseWhenTransitioningToInactive(final Role currentRole) {
+    // given
+    initializeContext(currentRole);
+
+    // when
+    transitionTo(Role.INACTIVE);
+
+    // then
+    assertThat(transitionContext.getStreamProcessor()).isNull();
+    verify(logStreamFromPrevRole).closeAsync();
+    verify(logStreamBuilder, never()).buildAsync();
+  }
+
+  private static Stream<Arguments> provideTransitionsThatShouldCloseExistingLogStream() {
+    return Stream.of(
+        Arguments.of(Role.FOLLOWER, Role.LEADER),
+        Arguments.of(Role.CANDIDATE, Role.LEADER),
+        Arguments.of(Role.LEADER, Role.FOLLOWER),
+        Arguments.of(Role.LEADER, Role.INACTIVE),
+        Arguments.of(Role.FOLLOWER, Role.INACTIVE),
+        Arguments.of(Role.CANDIDATE, Role.INACTIVE));
+  }
+
+  private static Stream<Arguments> provideTransitionsThatShouldInstallLogStream() {
+    return Stream.of(
+        Arguments.of(null, Role.FOLLOWER),
+        Arguments.of(null, Role.LEADER),
+        Arguments.of(null, Role.CANDIDATE),
+        Arguments.of(Role.FOLLOWER, Role.LEADER),
+        Arguments.of(Role.CANDIDATE, Role.LEADER),
+        Arguments.of(Role.LEADER, Role.FOLLOWER),
+        Arguments.of(Role.LEADER, Role.CANDIDATE),
+        Arguments.of(Role.INACTIVE, Role.FOLLOWER),
+        Arguments.of(Role.INACTIVE, Role.LEADER),
+        Arguments.of(Role.INACTIVE, Role.CANDIDATE));
+  }
+
+  private static Stream<Arguments> provideTransitionsThatShouldDoNothing() {
+    return Stream.of(
+        Arguments.of(Role.CANDIDATE, Role.FOLLOWER),
+        Arguments.of(Role.FOLLOWER, Role.CANDIDATE),
+        Arguments.of(null, Role.INACTIVE));
+  }
+
+  private void initializeContext(final Role currentRole) {
+    transitionContext.setCurrentRole(currentRole);
+    if (currentRole != null && currentRole != Role.INACTIVE) {
+      transitionContext.setLogStream(logStreamFromPrevRole);
+    }
+  }
+
+  private void transitionTo(final Role role) {
+    step.prepareTransition(transitionContext, 1, role).join();
+    step.transitionTo(transitionContext, 1, role).join();
+    transitionContext.setCurrentRole(role);
+  }
+}


### PR DESCRIPTION
## Description

Add LogStreamPartitionTransitionStep.
This step follows the same pattern as StreamProcessorTransitionStep. It install new LogStream when transition between Leader and Follower. But does nothing when transitioning between Follower and Candidate.
It is not currently possible to install LogStream once during startup because of its dependency to LogStorage which is role dependent.

This steps has a constructor that passes a supplier for LogStreamBuilder. This is only used for testing. It should be a supplier not a builder because the instance of the step is shared among all partitions.

## Related issues

closes #7515 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
