### PR TITLE
zip failsafe reports on failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -261,7 +261,7 @@ pipeline {
                                 }
 
                                 failure {
-                                    zip zipFile: 'test-reports-it.zip', archive: true, glob: "**/*/surefire-reports/**"
+                                    zip zipFile: 'test-reports-it.zip', archive: true, glob: "**/*/failsafe-reports/**"
                                     zip zipFile: 'test-errors-it.zip', archive: true, glob: "**/hs_err_*.log"
                                 }
                             }


### PR DESCRIPTION
## Description

Zip failsafe reports instead of surefire reports when an integration test failed

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
