### PR TITLE
Log version string

### DIFF
--- a/atomix/utils/src/main/java/io/atomix/utils/Version.java
+++ b/atomix/utils/src/main/java/io/atomix/utils/Version.java
@@ -49,7 +49,7 @@ public final class Version implements Comparable<Version> {
    */
   public static Version from(final String version) {
     final String[] fields = version.split("[.-]", 4);
-    checkArgument(fields.length >= 3, "version number is invalid");
+    checkArgument(fields.length >= 3, String.format("version number is invalid :%s", version));
     return new Version(
         parseInt(fields[0]),
         parseInt(fields[1]),


### PR DESCRIPTION
## Description

Mini change to log the version string. I stumbled upon this while trying to run an integraton test locally.

<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
