### PR TITLE
fix: set client request timeout

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -460,6 +460,7 @@
         #
         # args:
         #   url: http://localhost:9200
+        #   requestTimeoutMs: 1000
         #
         #   bulk:
         #     delay: 5

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -278,6 +278,10 @@ public class ElasticsearchClient {
     final HttpHost[] httpHosts = urlsToHttpHosts(configuration.url);
     final RestClientBuilder builder =
         RestClient.builder(httpHosts)
+            .setRequestConfigCallback(
+                b ->
+                    b.setConnectTimeout(configuration.requestTimeoutMs)
+                        .setSocketTimeout(configuration.requestTimeoutMs))
             .setHttpClientConfigCallback(this::setHttpClientConfigCallback);
 
     return builder.build();

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -18,6 +18,9 @@ public class ElasticsearchExporterConfiguration {
   /** Comma-separated Elasticsearch http urls */
   public String url = DEFAULT_URL;
 
+  /** The request timeout for the elastic search client. The timeout unit is milliseconds. */
+  public int requestTimeoutMs = 1000;
+
   public final IndexConfiguration index = new IndexConfiguration();
   public final BulkConfiguration bulk = new BulkConfiguration();
   private final AuthenticationConfiguration authentication = new AuthenticationConfiguration();

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -19,7 +19,7 @@ public class ElasticsearchExporterConfiguration {
   public String url = DEFAULT_URL;
 
   /** The request timeout for the elastic search client. The timeout unit is milliseconds. */
-  public int requestTimeoutMs = 1000;
+  public int requestTimeoutMs = 30_000;
 
   public final IndexConfiguration index = new IndexConfiguration();
   public final BulkConfiguration bulk = new BulkConfiguration();

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterJobRecordIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterJobRecordIT.java
@@ -108,6 +108,7 @@ public class ElasticsearchExporterJobRecordIT
 
     final var processInstanceKey = exporterBrokerRule.createProcessInstance("process", Map.of());
 
+    await("index templates need to be created").untilAsserted(this::assertIndexSettings);
     final var jobCreated =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterJobRecordIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterJobRecordIT.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import io.camunda.zeebe.client.api.worker.JobWorker;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -58,6 +59,7 @@ public class ElasticsearchExporterJobRecordIT
     final var processInstanceKey = exporterBrokerRule.createProcessInstance("process", Map.of());
 
     // then
+    await("index templates need to be created").untilAsserted(this::assertIndexSettings);
     final var jobCreated =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
@@ -82,6 +84,7 @@ public class ElasticsearchExporterJobRecordIT
     final var processInstanceKey = exporterBrokerRule.createProcessInstance("process", Map.of());
 
     // then
+    await("index templates need to be created").untilAsserted(this::assertIndexSettings);
     final var jobCreated =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/util/ElasticsearchContainer.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/util/ElasticsearchContainer.java
@@ -131,6 +131,7 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
     final var waitStrategy =
         new HttpWaitStrategy()
             .forPort(DEFAULT_HTTP_PORT)
+            .forPath("/_cluster/health?wait_for_status=green&timeout=1s")
             .forStatusCodeMatching(status -> status == HTTP_OK || status == HTTP_UNAUTHORIZED);
     waitStrategy.withStartupTimeout(Duration.ofMinutes(2));
     if (isSslEnabled) {


### PR DESCRIPTION


## Description

Elastic search seem to not response on some requests, which caused IT test to fail. The elastic rest client was configured without any request timeout which caused a deadlock. This fix adds a new request timeout config (default 1 second), which allows to fail the request after one second and retry.
<!-- Please explain the changes you made here. -->

Thanks for your help @npepinpe 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda-cloud/zeebe/issues/7724
<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
