### PR TITLE
Load arbitrary interceptors in the gateway

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterDescriptor.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterDescriptor.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.broker.exporter.repo;
 
 import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
 import io.camunda.zeebe.exporter.api.Exporter;
-import java.lang.reflect.InvocationTargetException;
+import io.camunda.zeebe.util.ReflectUtil;
 import java.util.Map;
 
 public class ExporterDescriptor {
@@ -26,11 +26,8 @@ public class ExporterDescriptor {
 
   public Exporter newInstance() throws ExporterInstantiationException {
     try {
-      return exporterClass.getDeclaredConstructor().newInstance();
-    } catch (final InstantiationException
-        | IllegalAccessException
-        | NoSuchMethodException
-        | InvocationTargetException e) {
+      return ReflectUtil.newInstance(exporterClass);
+    } catch (final Exception e) {
       throw new ExporterInstantiationException(getId(), e);
     }
   }

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/repo/ExporterRepositoryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/repo/ExporterRepositoryTest.java
@@ -185,7 +185,7 @@ final class ExporterRepositoryTest {
     public void export(final Record<?> record) {}
   }
 
-  static class InvalidExporter implements Exporter {
+  public static class InvalidExporter implements Exporter {
     @Override
     public void configure(final Context context) {
       throw new IllegalStateException("what");
@@ -195,7 +195,7 @@ final class ExporterRepositoryTest {
     public void export(final Record<?> record) {}
   }
 
-  static class MinimalExporter implements Exporter {
+  public static class MinimalExporter implements Exporter {
     @Override
     public void export(final Record<?> record) {}
   }

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Gateway</name>
@@ -87,6 +89,11 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-context</artifactId>
     </dependency>
 
     <dependency>
@@ -225,6 +232,18 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -18,17 +18,24 @@ import io.camunda.zeebe.gateway.impl.configuration.SecurityCfg;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.RoundRobinActivateJobsHandler;
+import io.camunda.zeebe.gateway.interceptors.impl.DecoratedInterceptor;
+import io.camunda.zeebe.gateway.interceptors.impl.InterceptorRepository;
 import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
+import io.grpc.ServerServiceDefinition;
 import io.grpc.netty.NettyServerBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import me.dinowernli.grpc.prometheus.Configuration;
 import me.dinowernli.grpc.prometheus.MonitoringServerInterceptor;
 import org.slf4j.Logger;
@@ -109,22 +116,12 @@ public final class Gateway {
     final GatewayGrpcService gatewayGrpcService = new GatewayGrpcService(endpointManager);
     final ServerBuilder<?> serverBuilder = serverBuilderFactory.apply(gatewayCfg);
 
-    if (gatewayCfg.getMonitoring().isEnabled()) {
-      final MonitoringServerInterceptor monitoringInterceptor =
-          MonitoringServerInterceptor.create(Configuration.allMetrics());
-      serverBuilder.addService(
-          ServerInterceptors.intercept(gatewayGrpcService, monitoringInterceptor));
-    } else {
-      serverBuilder.addService(gatewayGrpcService);
-    }
-
     final SecurityCfg securityCfg = gatewayCfg.getSecurity();
     if (securityCfg.isEnabled()) {
       setSecurityConfig(serverBuilder, securityCfg);
     }
 
-    server = serverBuilder.build();
-
+    server = serverBuilder.addService(applyInterceptors(gatewayGrpcService)).build();
     server.start();
     status = Status.RUNNING;
   }
@@ -182,9 +179,22 @@ public final class Gateway {
     return LongPollingActivateJobsHandler.newBuilder().setBrokerClient(brokerClient).build();
   }
 
-  public void listenAndServe() throws InterruptedException, IOException {
-    start();
-    server.awaitTermination();
+  private ServerServiceDefinition applyInterceptors(final GatewayGrpcService service) {
+    final var repository = new InterceptorRepository().load(gatewayCfg.getInterceptors());
+    final List<ServerInterceptor> interceptors =
+        repository.instantiate().map(DecoratedInterceptor::decorate).collect(Collectors.toList());
+
+    // reverse the user interceptors, such that they will be called in the order in which they are
+    // configured, such that the first configured interceptor is the outermost interceptor in the
+    // chain
+    Collections.reverse(interceptors);
+
+    if (gatewayCfg.getMonitoring().isEnabled()) {
+      final var interceptor = MonitoringServerInterceptor.create(Configuration.allMetrics());
+      interceptors.add(interceptor);
+    }
+
+    return ServerInterceptors.intercept(service, interceptors);
   }
 
   public void stop() {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfg.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfg.java
@@ -11,6 +11,8 @@ import static io.camunda.zeebe.util.ObjectWriterFactory.getDefaultJsonObjectWrit
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.camunda.zeebe.util.exception.UncheckedExecutionException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -25,6 +27,7 @@ public class GatewayCfg {
   private MonitoringCfg monitoring = new MonitoringCfg();
   private SecurityCfg security = new SecurityCfg();
   private LongPollingCfg longPolling = new LongPollingCfg();
+  private List<InterceptorCfg> interceptors = new ArrayList<>();
   private boolean initialized = false;
 
   public void init() {
@@ -95,9 +98,17 @@ public class GatewayCfg {
     return this;
   }
 
+  public List<InterceptorCfg> getInterceptors() {
+    return interceptors;
+  }
+
+  public void setInterceptors(final List<InterceptorCfg> interceptors) {
+    this.interceptors = interceptors;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(network, cluster, threads, monitoring, security, longPolling);
+    return Objects.hash(network, cluster, threads, monitoring, security, longPolling, interceptors);
   }
 
   @Override
@@ -114,7 +125,8 @@ public class GatewayCfg {
         && Objects.equals(threads, that.threads)
         && Objects.equals(monitoring, that.monitoring)
         && Objects.equals(security, that.security)
-        && Objects.equals(longPolling, that.longPolling);
+        && Objects.equals(longPolling, that.longPolling)
+        && Objects.equals(interceptors, that.interceptors);
   }
 
   @Override
@@ -132,13 +144,15 @@ public class GatewayCfg {
         + security
         + ", longPollingCfg="
         + longPolling
+        + ", interceptors="
+        + interceptors
         + '}';
   }
 
   public String toJson() {
     try {
       return getDefaultJsonObjectWriter().writeValueAsString(this);
-    } catch (JsonProcessingException e) {
+    } catch (final JsonProcessingException e) {
       throw new UncheckedExecutionException("Writing to JSON failed", e);
     }
   }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/InterceptorCfg.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/InterceptorCfg.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.impl.configuration;
+
+import java.util.Objects;
+
+/**
+ * Configuration to load a single extra interceptor. The {@link #className} property is required,
+ * and must be a fully qualified name referring to an implementation of {@link
+ * io.grpc.ServerInterceptor}.
+ *
+ * <p>Optionally, a {@link #jarPath} can be supplied, and the class will be looked up there. Note
+ * that the JAR is loaded within an isolated class loader to avoid dependency conflicts, so you must
+ * make sure that all dependencies are available in the JAR, or via the gateway itself.
+ */
+public final class InterceptorCfg {
+  private String id;
+  private String jarPath;
+  private String className;
+
+  /** @return true if the class must be loaded from an external JAR, false otherwise */
+  public boolean isExternal() {
+    return !isEmpty(jarPath);
+  }
+
+  /**
+   * Returns a human readable identifier, mostly for debugging purposes to differentiate instances
+   * of the same interceptor, for example. If not specified, defaults to the {@link #className}.
+   *
+   * @return a human readable identifier, mostly for debugging purposes
+   */
+  public String getId() {
+    return id == null ? className : id;
+  }
+
+  /** @param id the interceptor's new debug identifier */
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  /**
+   * Returns the path to the JAR file containing the interceptor implementation. Note that this may
+   * be null, as this field is optional. If it is null, then the implementation is looked up within
+   * the base class path.
+   *
+   * <p>NOTE: the path may be relative or absolute. The caller must be handle both cases.
+   *
+   * @return a path to the JAR, or null
+   */
+  public String getJarPath() {
+    return jarPath;
+  }
+
+  /**
+   * Sets the path to the interceptor JAR. Can be null if the interceptor implementation class can
+   * be found on the class path.
+   *
+   * @param jarPath the new JAR path, or null
+   */
+  public void setJarPath(final String jarPath) {
+    this.jarPath = jarPath;
+  }
+
+  /** @return the fully qualified class name of the interceptor implementation */
+  public String getClassName() {
+    return className;
+  }
+
+  /**
+   * Sets a new class name. Note that this must be a fully qualified class name to avoid any
+   * collisions.
+   *
+   * @param className the new class name
+   */
+  public void setClassName(final String className) {
+    this.className = className;
+  }
+
+  private boolean isEmpty(final String value) {
+    return value == null || value.isEmpty();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(jarPath, className);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final InterceptorCfg that = (InterceptorCfg) o;
+    return Objects.equals(jarPath, that.jarPath) && Objects.equals(className, that.className);
+  }
+
+  @Override
+  public String toString() {
+    return "InterceptorCfg{"
+        + ", jarPath='"
+        + jarPath
+        + '\''
+        + ", className='"
+        + className
+        + '\''
+        + '}';
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/InterceptorUtil.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/InterceptorUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.interceptors;
+
+import io.grpc.Context;
+import io.grpc.Context.Key;
+import java.util.concurrent.Executor;
+
+/** A set of utilities which interceptor authors can use in their interceptors. */
+public final class InterceptorUtil {
+  private static final Key<Executor> EXECUTOR_KEY = Context.key("zeebe-interceptor-executor");
+
+  private InterceptorUtil() {}
+
+  /**
+   * @return the context key associated with the executor returned by {@link #getContextExecutor()}
+   * @see #getContextExecutor()
+   */
+  public static Key<Executor> getExecutorKey() {
+    return EXECUTOR_KEY;
+  }
+
+  /**
+   * Returns an {@link Executor} which can be used in your interceptor when dealing with
+   * asynchronous code. This executor will execute callbacks in the thread that is completing * the
+   * future, but will ensure that the thread context class loader is correctly set before * calling
+   * your callback.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * final CompletionStage<String> future = queryApi.getBpmnProcessIdForProcess(processKey);
+   * future
+   *     .whenCompleteAsync(
+   *        (processId, error) -> this::onProcessId,
+   *        InterceptorUtil.getContextExecutor());
+   * }</pre>
+   *
+   * @return an executor which can be used when dealing with asynchronous code
+   */
+  public static Executor getContextExecutor() {
+    return getExecutorKey().get();
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/DecoratedInterceptor.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/DecoratedInterceptor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
+import io.camunda.zeebe.util.jar.ThreadContextUtil;
+import io.grpc.Context;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import org.agrona.LangUtil;
+
+/**
+ * Decorates third-party interceptors in order to ensure that the thread context class loader is
+ * correctly set (required for interceptors loaded from external, isolated JARs), and provide
+ * additional context.
+ *
+ * <p>It will inject the following context values to all interceptors further down the chain:
+ *
+ * <ul>
+ *   <li>{@link InterceptorUtil#getContextExecutor()} ()} => a serializing executor which wraps
+ *       every call with {@link ThreadContextUtil#runWithClassLoader(Runnable, ClassLoader)}
+ * </ul>
+ */
+public final class DecoratedInterceptor implements ServerInterceptor {
+  private final ServerInterceptor delegate;
+  private final ClassLoader classLoader;
+
+  DecoratedInterceptor(final ServerInterceptor delegate, final ClassLoader classLoader) {
+    this.delegate = delegate;
+    this.classLoader = classLoader;
+  }
+
+  public static DecoratedInterceptor decorate(final ServerInterceptor interceptor) {
+    return new DecoratedInterceptor(interceptor, interceptor.getClass().getClassLoader());
+  }
+
+  @Override
+  public <ReqT, RespT> Listener<ReqT> interceptCall(
+      final ServerCall<ReqT, RespT> call,
+      final Metadata headers,
+      final ServerCallHandler<ReqT, RespT> next) {
+    final var executor = new TclAwareExecutor(classLoader);
+    final var context = Context.current().withValue(InterceptorUtil.getExecutorKey(), executor);
+
+    try {
+      return ThreadContextUtil.callWithClassLoader(
+          () -> context.call(() -> delegate.interceptCall(call, headers, next)), classLoader);
+    } catch (final Exception e) {
+      LangUtil.rethrowUnchecked(e);
+      throw new UnsupportedOperationException(
+          "Unexpectedly reached unreachable code; an exception should have been thrown beforehand");
+    }
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/InterceptorLoadException.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/InterceptorLoadException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+/** Exception thrown when an interceptor cannot be loaded. */
+public class InterceptorLoadException extends RuntimeException {
+  private static final long serialVersionUID = -9192947670450762759L;
+  private static final String MESSAGE_FORMAT = "Cannot load interceptor [%s]: %s";
+
+  public InterceptorLoadException(final String id, final String reason, final Throwable cause) {
+    super(String.format(MESSAGE_FORMAT, id, reason), cause);
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/InterceptorRepository.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/InterceptorRepository.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import io.camunda.zeebe.gateway.Loggers;
+import io.camunda.zeebe.gateway.impl.configuration.InterceptorCfg;
+import io.camunda.zeebe.util.ReflectUtil;
+import io.camunda.zeebe.util.jar.ExternalJarLoadException;
+import io.camunda.zeebe.util.jar.ExternalJarRepository;
+import io.grpc.ServerInterceptor;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.agrona.LangUtil;
+import org.slf4j.Logger;
+
+/** Loads and holds references to the configured interceptors. */
+public final class InterceptorRepository {
+  private static final Logger LOGGER = Loggers.GATEWAY_LOGGER;
+
+  private final ExternalJarRepository jarRepository;
+  private final Map<String, Class<? extends ServerInterceptor>> interceptors;
+  private final Path basePath;
+
+  public InterceptorRepository() {
+    this(
+        new HashMap<>(),
+        new ExternalJarRepository(),
+        Paths.get(Optional.ofNullable(System.getProperty("basedir")).orElse(".")));
+  }
+
+  InterceptorRepository(
+      final Map<String, Class<? extends ServerInterceptor>> interceptors,
+      final ExternalJarRepository jarRepository,
+      final Path basePath) {
+    this.interceptors = interceptors;
+    this.jarRepository = jarRepository;
+    this.basePath = basePath;
+  }
+
+  public Map<String, Class<? extends ServerInterceptor>> getInterceptors() {
+    return Collections.unmodifiableMap(interceptors);
+  }
+
+  public Stream<ServerInterceptor> instantiate() {
+    return interceptors.entrySet().stream()
+        .map(entry -> instantiate(entry.getKey(), entry.getValue()));
+  }
+
+  public InterceptorRepository load(final Iterable<? extends InterceptorCfg> configs) {
+    for (final var config : configs) {
+      try {
+        load(config);
+      } catch (final Exception e) {
+        LOGGER.debug("Failed to load interceptor {} with config {}", config.getId(), config);
+        LangUtil.rethrowUnchecked(e);
+      }
+    }
+
+    return this;
+  }
+
+  Class<? extends ServerInterceptor> load(final InterceptorCfg config)
+      throws ExternalJarLoadException {
+    final ClassLoader classLoader;
+    final Class<? extends ServerInterceptor> interceptorClass;
+    final String id = config.getId();
+
+    if (interceptors.containsKey(id)) {
+      return interceptors.get(id);
+    }
+
+    if (!config.isExternal()) {
+      classLoader = getClass().getClassLoader();
+    } else {
+      final var jarPath = basePath.resolve(config.getJarPath());
+      classLoader = jarRepository.load(jarPath);
+    }
+
+    try {
+      final Class<?> specifiedClass = classLoader.loadClass(config.getClassName());
+      interceptorClass = specifiedClass.asSubclass(ServerInterceptor.class);
+    } catch (final ClassNotFoundException e) {
+      throw new InterceptorLoadException(id, "cannot load specified class", e);
+    } catch (final ClassCastException e) {
+      throw new InterceptorLoadException(
+          id, "specified class does not implement ServerInterceptor", e);
+    }
+
+    put(id, interceptorClass);
+    return interceptorClass;
+  }
+
+  private void put(final String id, final Class<? extends ServerInterceptor> interceptorClass) {
+    interceptors.put(id, interceptorClass);
+  }
+
+  private ServerInterceptor instantiate(
+      final String id, final Class<? extends ServerInterceptor> interceptorClass) {
+    try {
+      return ReflectUtil.newInstance(interceptorClass);
+    } catch (final Exception e) {
+      throw new InterceptorLoadException(id, "cannot instantiate via the default constructor", e);
+    }
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/TclAwareExecutor.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/TclAwareExecutor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import io.camunda.zeebe.util.jar.ThreadContextUtil;
+import java.util.concurrent.Executor;
+
+/**
+ * A utility executor which ensures all submitted tasks are executed with the right thread context
+ * class loader set. This is useful for interceptors loaded by external JARs. These interceptors run
+ * with an isolated class loader, and they (or their dependencies) may use the thread context class
+ * loader to load classes only available in their JAR.
+ *
+ * <p>So any interceptor which needs to deal with asynchronous code can use this executor to handle
+ * callbacks in a way that their callback will have access to the required classes.
+ */
+final class TclAwareExecutor implements Executor {
+  private final ClassLoader classLoader;
+
+  TclAwareExecutor(final ClassLoader classLoader) {
+    this.classLoader = classLoader;
+  }
+
+  @SuppressWarnings("NullableProblems")
+  @Override
+  public void execute(final Runnable command) {
+    ThreadContextUtil.runWithClassLoader(command, classLoader);
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.interceptors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.AtomixCluster;
+import io.atomix.utils.net.Address;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.zeebe.gateway.Gateway;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.camunda.zeebe.gateway.impl.configuration.InterceptorCfg;
+import io.camunda.zeebe.gateway.interceptors.util.TestInterceptor;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.util.sched.ActorScheduler;
+import io.grpc.StatusRuntimeException;
+import io.netty.util.NetUtil;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.agrona.CloseHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class InterceptorIT {
+
+  private final GatewayCfg config = new GatewayCfg();
+  private final ActorScheduler scheduler =
+      ActorScheduler.newActorScheduler()
+          .setCpuBoundActorThreadCount(1)
+          .setIoBoundActorThreadCount(1)
+          .build();
+
+  private AtomixCluster cluster;
+  private Gateway gateway;
+
+  @BeforeEach
+  void beforeEach() {
+    final var clusterAddress = SocketUtil.getNextAddress();
+    final var gatewayAddress = SocketUtil.getNextAddress();
+    config
+        .getCluster()
+        .setHost(clusterAddress.getHostName())
+        .setPort(clusterAddress.getPort())
+        .setRequestTimeout(Duration.ofSeconds(3));
+    config.getNetwork().setHost(gatewayAddress.getHostName()).setPort(gatewayAddress.getPort());
+    config.init();
+
+    cluster =
+        AtomixCluster.builder()
+            .withAddress(Address.from(clusterAddress.getHostName(), clusterAddress.getPort()))
+            .build();
+    gateway = new Gateway(config, this::getBrokerClient, scheduler);
+
+    cluster.start().join();
+    scheduler.start();
+
+    // gateway is purposefully not started to allow configuration changes
+  }
+
+  @AfterEach
+  void afterEach() {
+    CloseHelper.quietCloseAll(gateway::stop, () -> cluster.stop().join(), scheduler);
+  }
+
+  @Test
+  void shouldAbortDeploymentCalls() throws IOException {
+    // given
+    final var interceptorCfg = new InterceptorCfg();
+    interceptorCfg.setId("test");
+    interceptorCfg.setClassName(TestInterceptor.class.getName());
+    config.getInterceptors().add(interceptorCfg);
+
+    // when
+    gateway.start();
+    try (final var client = createZeebeClient()) {
+      final Future<DeploymentEvent> result =
+          client
+              .newDeployCommand()
+              .addResourceFromClasspath("processes/one-task-process.bpmn")
+              .send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(5))
+          .withThrowableOfType(ExecutionException.class)
+          .havingRootCause()
+          .isInstanceOf(StatusRuntimeException.class)
+          .withMessage("PERMISSION_DENIED: Aborting because of test");
+    }
+  }
+
+  private BrokerClientImpl getBrokerClient(final GatewayCfg gatewayConfig) {
+    return new BrokerClientImpl(
+        gatewayConfig,
+        cluster.getMessagingService(),
+        cluster.getMembershipService(),
+        cluster.getEventService(),
+        scheduler,
+        false);
+  }
+
+  private ZeebeClient createZeebeClient() {
+    return ZeebeClient.newClientBuilder()
+        .gatewayAddress(
+            NetUtil.toSocketAddressString(gateway.getGatewayCfg().getNetwork().toSocketAddress()))
+        .usePlaintext()
+        .build();
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/DecoratedInterceptorTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/DecoratedInterceptorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.internal.NoopServerCall;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+final class DecoratedInterceptorTest {
+
+  @Test
+  void shouldSetThreadContextClassLoader() {
+    // given
+    final var interceptor = new TestInterceptor();
+    final var classLoader = new ClassLoader("testLoader", getClass().getClassLoader()) {};
+    final var decorated = new DecoratedInterceptor(interceptor, classLoader);
+
+    // when
+    decorated.interceptCall(new NoopServerCall<>() {}, new Metadata(), (call, headers) -> null);
+
+    // then
+    assertThat(interceptor.threadContextClassLoader).isSameAs(classLoader);
+  }
+
+  @Test
+  void shouldSetContextExecutor() {
+    // given
+    final var interceptor = new TestInterceptor();
+    final var classLoader = new ClassLoader("testLoader", getClass().getClassLoader()) {};
+    final var decorated = new DecoratedInterceptor(interceptor, classLoader);
+    final AtomicReference<ClassLoader> tcl = new AtomicReference<>();
+
+    // when
+    decorated.interceptCall(new NoopServerCall<>() {}, new Metadata(), (call, headers) -> null);
+    interceptor.contextExecutor.execute(
+        () -> tcl.set(Thread.currentThread().getContextClassLoader()));
+
+    // then
+    assertThat(tcl.get()).isSameAs(classLoader);
+  }
+
+  private static final class TestInterceptor implements ServerInterceptor {
+    private ClassLoader threadContextClassLoader;
+    private Executor contextExecutor;
+
+    @Override
+    public <ReqT, RespT> Listener<ReqT> interceptCall(
+        final ServerCall<ReqT, RespT> call,
+        final Metadata headers,
+        final ServerCallHandler<ReqT, RespT> next) {
+      threadContextClassLoader = Thread.currentThread().getContextClassLoader();
+      contextExecutor = InterceptorUtil.getContextExecutor();
+      return next.startCall(call, headers);
+    }
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/InterceptorRepositoryTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/InterceptorRepositoryTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.gateway.impl.configuration.InterceptorCfg;
+import io.camunda.zeebe.gateway.interceptors.util.ExternalInterceptor;
+import io.camunda.zeebe.util.jar.ExternalJarLoadException;
+import io.camunda.zeebe.util.jar.ExternalJarRepository;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import net.bytebuddy.ByteBuddy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+class InterceptorRepositoryTest {
+  private final InterceptorRepository repository = new InterceptorRepository();
+
+  @Test
+  void shouldFailToLoadNonInterceptorClassFromClassPath() {
+    // given
+    final var id = "myInterceptor";
+    final var config = new InterceptorCfg();
+    config.setClassName(String.class.getName());
+    config.setId(id);
+
+    // then
+    assertThatThrownBy(() -> repository.load(config))
+        .isInstanceOf(InterceptorLoadException.class)
+        .hasCauseInstanceOf(ClassCastException.class);
+  }
+
+  @Test
+  void shouldFailToLoadNonExistingClassFromClassPath() {
+    // given
+    final var id = "myInterceptor";
+    final var config = new InterceptorCfg();
+    config.setClassName("a");
+    config.setId(id);
+
+    // then
+    assertThatThrownBy(() -> repository.load(config))
+        .isInstanceOf(InterceptorLoadException.class)
+        .hasCauseInstanceOf(ClassNotFoundException.class);
+  }
+
+  @Test
+  void shouldLoadInterceptorFromClassPath()
+      throws InterceptorLoadException, ExternalJarLoadException {
+    // given
+    final var id = "myInterceptor";
+    final var config = new InterceptorCfg();
+    config.setClassName(MinimalInterceptor.class.getName());
+    config.setJarPath(null);
+    config.setId(id);
+
+    // when
+    final var loadedClass = repository.load(config);
+
+    // then
+    assertThat(config.isExternal()).isFalse();
+    assertThat(loadedClass).isEqualTo(MinimalInterceptor.class);
+    assertThat(loadedClass.getClassLoader()).isEqualTo(getClass().getClassLoader());
+    assertThat(repository.getInterceptors()).containsEntry(id, loadedClass);
+  }
+
+  @Test
+  void shouldLoadInterceptorFromJar(final @TempDir File tempDir) throws Exception {
+    // given
+    final var id = "myInterceptor";
+    final var interceptorClass = ExternalInterceptor.createUnloadedInterceptorClass();
+    final var jarFile = interceptorClass.toJar(new File(tempDir, "interceptor.jar"));
+    final var config = new InterceptorCfg();
+
+    // when
+    config.setClassName(ExternalInterceptor.CLASS_NAME);
+    config.setJarPath(jarFile.getAbsolutePath());
+    config.setId(id);
+
+    // when
+    final var loadedClass = repository.load(config);
+
+    // then
+    assertThat(config.isExternal()).isTrue();
+    assertThat(ServerInterceptor.class.isAssignableFrom(loadedClass))
+        .as("the loaded class implements ServerInterceptor")
+        .isTrue();
+    assertThat(loadedClass.getClassLoader()).isNotEqualTo(getClass().getClassLoader());
+    assertThat(repository.getInterceptors()).containsEntry(id, loadedClass);
+  }
+
+  @Test
+  void shouldFailToLoadNonInterceptorClassFromJar(final @TempDir File tempDir) throws IOException {
+    // given
+    final var id = "myInterceptor";
+    final var externalClass =
+        new ByteBuddy().subclass(Object.class).name("com.acme.MyObject").make();
+    final var jarFile = externalClass.toJar(new File(tempDir, "library.jar"));
+    final var config = new InterceptorCfg();
+
+    // when
+    config.setId(id);
+    config.setClassName("com.acme.MyObject");
+    config.setJarPath(jarFile.getAbsolutePath());
+
+    // then
+    assertThatThrownBy(() -> repository.load(config))
+        .isInstanceOf(InterceptorLoadException.class)
+        .hasCauseInstanceOf(ClassCastException.class);
+  }
+
+  @Test
+  void shouldFailToLoadNonExistingClassFromJar(final @TempDir File tempDir) throws IOException {
+    // given
+    final var id = "myInterceptor";
+    final var interceptorClass = ExternalInterceptor.createUnloadedInterceptorClass();
+    final var jarFile = interceptorClass.toJar(new File(tempDir, "interceptor.jar"));
+    final var config = new InterceptorCfg();
+
+    // when
+    config.setId(id);
+    config.setClassName("xyz.i.dont.Exist");
+    config.setJarPath(jarFile.getAbsolutePath());
+
+    // then
+    assertThatThrownBy(() -> repository.load(config))
+        .isInstanceOf(InterceptorLoadException.class)
+        .hasCauseInstanceOf(ClassNotFoundException.class);
+  }
+
+  @Test
+  void shouldLoadExternalInterceptorRelativeToBasedir(final @TempDir File tempDir)
+      throws IOException {
+    // given
+    final var baseRepository =
+        new InterceptorRepository(new HashMap<>(), new ExternalJarRepository(), tempDir.toPath());
+    final var id = "myInterceptor";
+    final var interceptorClass = ExternalInterceptor.createUnloadedInterceptorClass();
+    final var jarFile = interceptorClass.toJar(new File(tempDir, "interceptor.jar"));
+    final var config = new InterceptorCfg();
+
+    // when
+    config.setId(id);
+    config.setClassName(ExternalInterceptor.CLASS_NAME);
+    config.setJarPath(jarFile.getName());
+
+    // when
+    final Class<? extends ServerInterceptor> loadedClass;
+    loadedClass = baseRepository.load(config);
+
+    // then
+    assertThat(ServerInterceptor.class.isAssignableFrom(loadedClass))
+        .as("the loaded class implements ServerInterceptor")
+        .isTrue();
+  }
+
+  @Test
+  void shouldInstantiateInterceptors(final @TempDir File tempDir) throws IOException {
+    // given
+    final var internalConfig = new InterceptorCfg();
+    internalConfig.setClassName(MinimalInterceptor.class.getName());
+    internalConfig.setJarPath(null);
+    internalConfig.setId("internal");
+    final var externalClass = ExternalInterceptor.createUnloadedInterceptorClass();
+    final var jarFile = externalClass.toJar(new File(tempDir, "interceptor.jar"));
+    final var externalConfig = new InterceptorCfg();
+    externalConfig.setClassName(ExternalInterceptor.CLASS_NAME);
+    externalConfig.setJarPath(jarFile.getAbsolutePath());
+    externalConfig.setId("external");
+
+    // when
+    final var interceptors = repository.load(List.of(internalConfig, externalConfig)).instantiate();
+
+    // then
+    final var loadedClass = repository.getInterceptors().get("external");
+    assertThat(interceptors)
+        .hasSize(2)
+        .map(interceptor -> (Class) interceptor.getClass())
+        .containsExactlyInAnyOrder(MinimalInterceptor.class, loadedClass);
+  }
+
+  public static final class MinimalInterceptor implements ServerInterceptor {
+    @Override
+    public <ReqT, RespT> Listener<ReqT> interceptCall(
+        final ServerCall<ReqT, RespT> call,
+        final Metadata headers,
+        final ServerCallHandler<ReqT, RespT> next) {
+      return next.startCall(call, headers);
+    }
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/util/CloseAwareListener.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/util/CloseAwareListener.java
@@ -1,0 +1,51 @@
+package io.camunda.zeebe.gateway.interceptors.util;
+
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener;
+import io.grpc.ServerCall.Listener;
+
+/**
+ * Utility interceptor which stops forwarding any callbacks to its delegate when closed in order to
+ * prevent errors.
+ */
+class CloseAwareListener<ReqT> extends SimpleForwardingServerCallListener<ReqT> {
+  protected volatile boolean isClosed;
+
+  public CloseAwareListener(final Listener<ReqT> delegate) {
+    super(delegate);
+  }
+
+  @Override
+  public void onMessage(final ReqT message) {
+    if (!isClosed) {
+      super.onMessage(message);
+    }
+  }
+
+  @Override
+  public void onHalfClose() {
+    if (!isClosed) {
+      super.onHalfClose();
+    }
+  }
+
+  @Override
+  public void onCancel() {
+    if (!isClosed) {
+      super.onCancel();
+    }
+  }
+
+  @Override
+  public void onComplete() {
+    if (!isClosed) {
+      super.onComplete();
+    }
+  }
+
+  @Override
+  public void onReady() {
+    if (!isClosed) {
+      super.onReady();
+    }
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/util/CloseAwareListener.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/util/CloseAwareListener.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
 package io.camunda.zeebe.gateway.interceptors.util;
 
 import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener;

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/util/ExternalInterceptor.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/util/ExternalInterceptor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.interceptors.util;
+
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import java.io.File;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.DynamicType.Unloaded;
+import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.jar.asm.Opcodes;
+import net.bytebuddy.matcher.ElementMatchers;
+
+public final class ExternalInterceptor {
+  public static final String CLASS_NAME = "com.acme.ExternalInterceptor";
+
+  /**
+   * Creates a new, unloaded class - that is, unavailable via any existing class loaders - which
+   * implements {@link ServerInterceptor}. The implementation of {@link
+   * ServerInterceptor#interceptCall(ServerCall, Metadata, ServerCallHandler)}} here simply
+   * delegates to {@link ExternalInterceptorImpl}. The class also defines a {@link String} constant
+   * called {@code FOO} which returns the value {@code "bar"}.
+   *
+   * <p>The class is created with {@link #CLASS_NAME} as its canonical class name.
+   *
+   * <p>You can easily create a JAR from this class by using {@link Unloaded#toJar(File)}.
+   *
+   * @return the unloaded class
+   */
+  public static Unloaded<ServerInterceptor> createUnloadedInterceptorClass() {
+    return new ByteBuddy()
+        .subclass(ServerInterceptor.class)
+        .name(CLASS_NAME)
+        .method(ElementMatchers.named("interceptCall"))
+        .intercept(MethodDelegation.to(ExternalInterceptorImpl.class))
+        .defineField("FOO", String.class, Opcodes.ACC_STATIC | Opcodes.ACC_PUBLIC)
+        .value("bar")
+        .make();
+  }
+
+  /**
+   * Must be public so that the ByteBuddy generated class can find it to ensure we have some default
+   * implementation.
+   */
+  public static final class ExternalInterceptorImpl {
+    public static <ReqT, RespT> Listener<ReqT> interceptCall(
+        final ServerCall<ReqT, RespT> call,
+        final Metadata headers,
+        final ServerCallHandler<ReqT, RespT> next) {
+      headers.put(Key.of("FOO", Metadata.ASCII_STRING_MARSHALLER), "BAR");
+      return next.startCall(call, headers);
+    }
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/util/TestInterceptor.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/util/TestInterceptor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.interceptors.util;
+
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessRequest;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+
+/**
+ * A dummy interceptor which aborts deployments with a specific error message. The class must be
+ * public since we will load it via JAR into the gateway.
+ */
+public final class TestInterceptor implements ServerInterceptor {
+  static final String ERROR_MESSAGE = "Aborting because of test";
+
+  @Override
+  public <ReqT, RespT> Listener<ReqT> interceptCall(
+      final ServerCall<ReqT, RespT> call,
+      final Metadata headers,
+      final ServerCallHandler<ReqT, RespT> next) {
+    final var listener = next.startCall(call, headers);
+    return new CloseAwareListener<>(listener) {
+      @Override
+      public void onMessage(final ReqT message) {
+        if (message instanceof DeployProcessRequest) {
+          call.close(Status.PERMISSION_DENIED.augmentDescription(ERROR_MESSAGE), new Metadata());
+          isClosed = true;
+          return;
+        }
+
+        super.onMessage(message);
+      }
+    };
+  }
+}

--- a/util/src/main/java/io/camunda/zeebe/util/ReflectUtil.java
+++ b/util/src/main/java/io/camunda/zeebe/util/ReflectUtil.java
@@ -7,13 +7,23 @@
  */
 package io.camunda.zeebe.util;
 
+import java.lang.reflect.InvocationTargetException;
+
 public final class ReflectUtil {
+
+  private ReflectUtil() {}
 
   public static <T> T newInstance(final Class<T> clazz) {
     try {
-      return clazz.newInstance();
-    } catch (final Exception e) {
-      throw new RuntimeException("Could not instantiate class " + clazz.getName(), e);
+      return clazz.getDeclaredConstructor().newInstance();
+    } catch (final InstantiationException
+        | IllegalAccessException
+        | NoSuchMethodException
+        | InvocationTargetException e) {
+      throw new IllegalStateException(
+          String.format(
+              "Failed to instantiate class %s with the default constructor", clazz.getName()),
+          e);
     }
   }
 }

--- a/util/src/main/java/io/camunda/zeebe/util/jar/ThreadContextUtil.java
+++ b/util/src/main/java/io/camunda/zeebe/util/jar/ThreadContextUtil.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.util.jar;
 
 import io.camunda.zeebe.util.CheckedRunnable;
+import java.util.concurrent.Callable;
 import org.agrona.LangUtil;
 
 /**
@@ -55,6 +56,27 @@ public final class ThreadContextUtil {
     try {
       currentThread.setContextClassLoader(classLoader);
       runnable.run();
+    } finally {
+      currentThread.setContextClassLoader(contextClassLoader);
+    }
+  }
+
+  /**
+   * Executes the given {@code callable}, swapping the thread context class loader for the given
+   * class loader, and swapping it back with the previous class loader afterwards.
+   *
+   * @param callable the operation to execute
+   * @param classLoader the class loader to temporarily assign to the current thread's context class
+   *     loader
+   */
+  public static <V> V callWithClassLoader(final Callable<V> callable, final ClassLoader classLoader)
+      throws Exception {
+    final var currentThread = Thread.currentThread();
+    final var contextClassLoader = currentThread.getContextClassLoader();
+
+    try {
+      currentThread.setContextClassLoader(classLoader);
+      return callable.call();
     } finally {
       currentThread.setContextClassLoader(contextClassLoader);
     }


### PR DESCRIPTION
## Description

This PR allows loading arbitrary interceptors in the gateway, which will wrap every call and allow for users to specify custom logic before and after each call.

Interceptors are specified in the configuration of the gateway under `zeebe.gateway.interceptors`, or `zeebe.broker.gateway.interceptors`. They're mapped as a list, and will be called in the order in which they are defined in the configuration. So item 0 will be called first, then item 1, etc., with the actual service at the end. NOTE: the monitoring interceptor, if enabled, remains the top level one and will wrap all further interceptors.

Interceptors can be loaded from the class path, or via an external JAR by specifying their `jarPath` configuration property. If so, they will have an isolated class loader, which will ensure that, should they bundle dependencies that would collide with Zeebe's, there will be no collision and each side (the interceptor and the gateway) will use the right dependency.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7755

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
