### PR TITLE
QueryService transition step

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -23,7 +23,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
-import io.camunda.zeebe.engine.state.query.StateQueryService;
+import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.storage.atomix.AtomixLogStorage;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
@@ -76,7 +76,7 @@ public class PartitionStartupAndTransitionContextImpl
   private ScheduledTimer metricsTimer;
   private ExporterDirector exporterDirector;
   private AtomixLogStorage logStorage;
-  private StateQueryService queryService;
+  private QueryService queryService;
 
   private long currentTerm;
   private Role currentRole;
@@ -255,12 +255,12 @@ public class PartitionStartupAndTransitionContextImpl
   }
 
   @Override
-  public StateQueryService getQueryService() {
+  public QueryService getQueryService() {
     return queryService;
   }
 
   @Override
-  public void setQueryService(final StateQueryService queryService) {
+  public void setQueryService(final QueryService queryService) {
     this.queryService = queryService;
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupContext.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
-import io.camunda.zeebe.engine.state.query.StateQueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
@@ -102,10 +101,6 @@ public interface PartitionStartupContext {
   ExporterDirector getExporterDirector();
 
   void setExporterDirector(ExporterDirector director);
-
-  StateQueryService getQueryService();
-
-  void setQueryService(final StateQueryService queryService);
 
   // can be called any time after bootstrap has completed
   PartitionStartupAndTransitionContextImpl createTransitionContext();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
+import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.storage.atomix.AtomixLogStorage;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
@@ -79,4 +80,8 @@ public interface PartitionTransitionContext extends PartitionContext {
   void setSnapshotDirector(AsyncSnapshotDirector snapshotDirector);
 
   BrokerCfg getBrokerCfg();
+
+  QueryService getQueryService();
+
+  void setQueryService(QueryService queryService);
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/QueryServicePartitionTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/QueryServicePartitionTransitionStep.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
+import io.camunda.zeebe.engine.state.QueryService;
+import io.camunda.zeebe.engine.state.query.StateQueryService;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
+import org.agrona.CloseHelper;
+
+public final class QueryServicePartitionTransitionStep implements PartitionTransitionStep {
+
+  @Override
+  public ActorFuture<Void> prepareTransition(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    final var currentRole = context.getCurrentRole();
+    final QueryService queryService = context.getQueryService();
+    if (queryService != null && (currentRole == Role.LEADER || targetRole == Role.INACTIVE)) {
+      try {
+        CloseHelper.close(queryService);
+        context.setQueryService(null);
+        return CompletableActorFuture.completed(null);
+      } catch (final Exception e) {
+        return CompletableActorFuture.completedExceptionally(e);
+      }
+    }
+
+    return CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  public ActorFuture<Void> transitionTo(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    final var currentRole = context.getCurrentRole();
+
+    if (targetRole != Role.INACTIVE
+        && (currentRole == Role.LEADER || context.getQueryService() == null)) {
+      try {
+        final var service = new StateQueryService(context.getZeebeDb());
+        context.setQueryService(service);
+        return CompletableActorFuture.completed(null);
+      } catch (final Exception e) {
+        return CompletableActorFuture.completedExceptionally(e);
+      }
+    }
+
+    return CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  public String getName() {
+    return "queryService";
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
+import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.storage.atomix.AtomixLogStorage;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
@@ -49,6 +50,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private AtomixLogStorage logStorage;
   private BrokerCfg brokerCfg;
   private AsyncSnapshotDirector snapshotDirector;
+  private QueryService queryService;
 
   @Override
   public int getPartitionId() {
@@ -233,6 +235,16 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public BrokerCfg getBrokerCfg() {
     return brokerCfg;
+  }
+
+  @Override
+  public QueryService getQueryService() {
+    return queryService;
+  }
+
+  @Override
+  public void setQueryService(final QueryService queryService) {
+    this.queryService = queryService;
   }
 
   public void setBrokerCfg(final BrokerCfg brokerCfg) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/QueryServicePartitionTransitionStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/QueryServicePartitionTransitionStepTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.system.partitions.TestPartitionTransitionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.state.QueryService;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class QueryServicePartitionTransitionStepTest {
+
+  TestPartitionTransitionContext transitionContext = new TestPartitionTransitionContext();
+
+  private final ZeebeDb zeebeDb = mock(ZeebeDb.class);
+  private final QueryService queryServiceFromPrevRole = mock(QueryService.class);
+
+  private QueryServicePartitionTransitionStep step;
+
+  @BeforeEach
+  void setup() {
+
+    transitionContext.setZeebeDb(zeebeDb);
+    step = new QueryServicePartitionTransitionStep();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldDoNothing")
+  void shouldNotInstallQueryService(final Role currentRole, final Role targetRole) {
+    // given
+    initializeContext(currentRole);
+    final var existingQueryService = transitionContext.getQueryService();
+
+    // when
+    transitionTo(targetRole);
+
+    // then
+    assertThat(transitionContext.getQueryService()).isEqualTo(existingQueryService);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldCloseExistingQueryService")
+  void shouldCloseExistingQueryService(final Role currentRole, final Role targetRole) {
+    // given
+    initializeContext(currentRole);
+
+    // when
+    step.prepareTransition(transitionContext, 1, targetRole);
+
+    // then
+    assertThat(transitionContext.getQueryService()).isNull();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTransitionsThatShouldInstallQueryService")
+  void shouldInstallQueryService(final Role currentRole, final Role targetRole) {
+    // given
+    initializeContext(currentRole);
+    final var existingQueryService = transitionContext.getQueryService();
+
+    // when
+    transitionTo(targetRole);
+
+    // then
+    assertThat(transitionContext.getQueryService()).isNotNull().isNotEqualTo(existingQueryService);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = Role.class,
+      names = {"FOLLOWER", "LEADER", "CANDIDATE"})
+  void shouldCloseWhenTransitioningToInactive(final Role currentRole) {
+    // given
+    initializeContext(currentRole);
+
+    // when
+    transitionTo(Role.INACTIVE);
+
+    // then
+    assertThat(transitionContext.getQueryService()).isNull();
+  }
+
+  private static Stream<Arguments> provideTransitionsThatShouldDoNothing() {
+    return Stream.of(
+        Arguments.of(Role.CANDIDATE, Role.FOLLOWER),
+        Arguments.of(Role.FOLLOWER, Role.CANDIDATE),
+        Arguments.of(Role.CANDIDATE, Role.LEADER),
+        Arguments.of(Role.FOLLOWER, Role.LEADER),
+        Arguments.of(null, Role.INACTIVE));
+  }
+
+  private static Stream<Arguments> provideTransitionsThatShouldInstallQueryService() {
+    return Stream.of(
+        Arguments.of(null, Role.FOLLOWER),
+        Arguments.of(null, Role.LEADER),
+        Arguments.of(null, Role.CANDIDATE),
+        Arguments.of(Role.LEADER, Role.FOLLOWER),
+        Arguments.of(Role.LEADER, Role.CANDIDATE),
+        Arguments.of(Role.INACTIVE, Role.FOLLOWER),
+        Arguments.of(Role.INACTIVE, Role.LEADER),
+        Arguments.of(Role.INACTIVE, Role.CANDIDATE));
+  }
+
+  private static Stream<Arguments> provideTransitionsThatShouldCloseExistingQueryService() {
+    return Stream.of(
+        Arguments.of(Role.LEADER, Role.FOLLOWER),
+        Arguments.of(Role.LEADER, Role.CANDIDATE),
+        Arguments.of(Role.LEADER, Role.INACTIVE),
+        Arguments.of(Role.FOLLOWER, Role.INACTIVE),
+        Arguments.of(Role.CANDIDATE, Role.INACTIVE));
+  }
+
+  private void initializeContext(final Role currentRole) {
+    transitionContext.setCurrentRole(currentRole);
+    if (currentRole != null && currentRole != Role.INACTIVE) {
+      transitionContext.setQueryService(queryServiceFromPrevRole);
+    }
+  }
+
+  private void transitionTo(final Role role) {
+    step.prepareTransition(transitionContext, 1, role).join();
+    step.transitionTo(transitionContext, 1, role).join();
+    transitionContext.setCurrentRole(role);
+  }
+}


### PR DESCRIPTION
## Description

Add QueryServicePartitionTransitionStep. QueryService is dependent on ZeebeDB. Hence it is re-installed everytime zeebedb is re-installed.

## Related issues

Related #7515 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
