### PR TITLE
Use read lock on opening reader

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -205,8 +205,10 @@ public final class SegmentedJournal implements Journal {
 
   @Override
   public JournalReader openReader() {
-    final SegmentedJournalReader reader = new SegmentedJournalReader(this);
+    final var stamped = acquireReadlock();
+    final var reader = new SegmentedJournalReader(this);
     readers.add(reader);
+    releaseReadlock(stamped);
     return reader;
   }
 


### PR DESCRIPTION
## Description

Test tries to reset journal concurrently with opening an reader and fails.
```
Exception in thread Thread-1 java.lang.IllegalStateException: Segment not open
	at com.google.common.base.Preconditions.checkState(Preconditions.java:510)
	at io.camunda.zeebe.journal.file.JournalSegment.checkOpen(JournalSegment.java:176)
	at io.camunda.zeebe.journal.file.JournalSegment.createReader(JournalSegment.java:147)
	at io.camunda.zeebe.journal.file.SegmentedJournalReader.initialize(SegmentedJournalReader.java:39)
	at io.camunda.zeebe.journal.file.SegmentedJournalReader.<init>(SegmentedJournalReader.java:33)
	at io.camunda.zeebe.journal.file.SegmentedJournal.openReader(SegmentedJournal.java:209)
	at io.camunda.zeebe.journal.file.SegmentedJournalTest.lambda(SegmentedJournalTest.java:503)
	at java.base/java.lang.Thread.run(Thread.java:829)

org.opentest4j.AssertionFailedError:
Expecting value to be true but was false
Expected :true
Actual   :false
```

After adding locks test is green.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7846 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
