### PR TITLE
I can deploy a process with an intermediate message throw event

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/MessageEventDefinitionValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/MessageEventDefinitionValidator.java
@@ -15,8 +15,8 @@
  */
 package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
-import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.ThrowEvent;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
@@ -34,13 +34,13 @@ public class MessageEventDefinitionValidator
       final MessageEventDefinition element,
       final ValidationResultCollector validationResultCollector) {
 
-    if (!isMessageEndEvent(element) && element.getMessage() == null) {
+    if (!isMessageThrowEvent(element) && element.getMessage() == null) {
       validationResultCollector.addError(0, "Must reference a message");
     }
   }
 
-  private boolean isMessageEndEvent(final MessageEventDefinition element) {
+  private boolean isMessageThrowEvent(final MessageEventDefinition element) {
     final ModelElementInstance parentElement = element.getParentElement();
-    return parentElement instanceof EndEvent;
+    return parentElement instanceof ThrowEvent;
   }
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/MessageThrowEventValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/MessageThrowEventValidator.java
@@ -16,29 +16,28 @@
 package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
 import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
-import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.ThrowEvent;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 
-public class MessageEndEventValidator implements ModelElementValidator<EndEvent> {
+public class MessageThrowEventValidator implements ModelElementValidator<ThrowEvent> {
 
-  private final ExtensionElementsValidator<EndEvent, ZeebeTaskDefinition>
+  private final ExtensionElementsValidator<ThrowEvent, ZeebeTaskDefinition>
       extensionElementsValidator =
-          ExtensionElementsValidator.verifyThat(EndEvent.class)
+          ExtensionElementsValidator.verifyThat(ThrowEvent.class)
               .hasSingleExtensionElement(
                   ZeebeTaskDefinition.class, ZeebeConstants.ELEMENT_TASK_DEFINITION);
 
   @Override
-  public Class<EndEvent> getElementType() {
-    return EndEvent.class;
+  public Class<ThrowEvent> getElementType() {
+    return ThrowEvent.class;
   }
 
   @Override
   public void validate(
-      final EndEvent element, final ValidationResultCollector validationResultCollector) {
+      final ThrowEvent element, final ValidationResultCollector validationResultCollector) {
 
     if (isMessageThrowEvent(element)) {
       // a message throw event must have a task definition

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -57,7 +57,7 @@ public final class ZeebeDesignTimeValidators {
     validators.add(new FlowNodeValidator());
     validators.add(new IntermediateCatchEventValidator());
     validators.add(new MessageEventDefinitionValidator());
-    validators.add(new MessageEndEventValidator());
+    validators.add(new MessageThrowEventValidator());
     validators.add(new MessageValidator());
     validators.add(
         ExtensionElementsValidator.verifyThat(MultiInstanceLoopCharacteristics.class)

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeJobWorkerElementValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeJobWorkerElementValidationTest.java
@@ -20,6 +20,7 @@ import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.ex
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
+import io.camunda.zeebe.model.bpmn.builder.AbstractThrowEventBuilder;
 import io.camunda.zeebe.model.bpmn.builder.StartEventBuilder;
 import io.camunda.zeebe.model.bpmn.builder.ZeebeJobWorkerElementBuilder;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
@@ -114,7 +115,13 @@ public class ZeebeJobWorkerElementValidationTest {
         JobWorkerElementBuilder.of("sendTask", AbstractFlowNodeBuilder::sendTask),
         JobWorkerElementBuilder.of(
             "message end event",
-            process -> process.endEvent().messageEventDefinition().messageEventDefinitionDone()));
+            process ->
+                process.endEvent("message", AbstractThrowEventBuilder::messageEventDefinition)),
+        JobWorkerElementBuilder.of(
+            "intermediate message throw event",
+            process ->
+                process.intermediateThrowEvent(
+                    "message", AbstractThrowEventBuilder::messageEventDefinition)));
   }
 
   private static final class JobWorkerElementBuilder {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -92,7 +92,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             zeebeState, zeebeState.getKeyGenerator(), eventTriggerBehavior, writers);
     jobBehavior =
         new BpmnJobBehavior(
-            zeebeState.getKeyGenerator(), zeebeState.getJobState(), writers, jobMetrics);
+            zeebeState.getKeyGenerator(), zeebeState.getJobState(), writers, expressionBehavior, jobMetrics);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -92,7 +92,13 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             zeebeState, zeebeState.getKeyGenerator(), eventTriggerBehavior, writers);
     jobBehavior =
         new BpmnJobBehavior(
-            zeebeState.getKeyGenerator(), zeebeState.getJobState(), writers, expressionBehavior, jobMetrics);
+            zeebeState.getKeyGenerator(),
+            zeebeState.getJobState(),
+            writers,
+            expressionBehavior,
+            stateBehavior,
+            incidentBehavior,
+            jobMetrics);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -9,7 +9,10 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
+import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.JobWorkerProperties;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -19,6 +22,8 @@ import io.camunda.zeebe.engine.state.immutable.JobState.State;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.collection.Tuple;
 
 public final class BpmnJobBehavior {
 
@@ -28,21 +33,52 @@ public final class BpmnJobBehavior {
   private final StateWriter stateWriter;
   private final TypedCommandWriter commandWriter;
   private final JobState jobState;
+  private final ExpressionProcessor expressionBehavior;
   private final JobMetrics jobMetrics;
 
   public BpmnJobBehavior(
       final KeyGenerator keyGenerator,
       final JobState jobState,
       final Writers writers,
+      final ExpressionProcessor expressionBehavior,
       final JobMetrics jobMetrics) {
     this.keyGenerator = keyGenerator;
     this.jobState = jobState;
+    this.expressionBehavior = expressionBehavior;
     stateWriter = writers.state();
     commandWriter = writers.command();
     this.jobMetrics = jobMetrics;
   }
 
-  public void createNewJob(
+  public Either<Failure, ?> createNewJob(
+      final BpmnElementContext context, final ExecutableJobWorkerElement jobWorkerElement) {
+
+    return evaluateJobExpressions(context, jobWorkerElement.getJobWorkerProperties())
+        .map(
+            jobTypeAndRetries -> {
+              final var jobType = jobTypeAndRetries.getLeft();
+              final var retries = jobTypeAndRetries.getRight().intValue();
+
+              writeJobCreatedEvent(context, jobWorkerElement, jobType, retries);
+              jobMetrics.jobCreated(jobType);
+              return null;
+            });
+  }
+
+  private Either<Failure, Tuple<String, Long>> evaluateJobExpressions(
+      final BpmnElementContext context, final JobWorkerProperties jobWorkerProperties) {
+    final var scopeKey = context.getElementInstanceKey();
+
+    return expressionBehavior
+        .evaluateStringExpression(jobWorkerProperties.getType(), scopeKey)
+        .flatMap(
+            jobType ->
+                expressionBehavior
+                    .evaluateLongExpression(jobWorkerProperties.getRetries(), scopeKey)
+                    .map(retries -> new Tuple<>(jobType, retries)));
+  }
+
+  private void writeJobCreatedEvent(
       final BpmnElementContext context,
       final ExecutableJobWorkerElement jobWorkerElement,
       final String jobType,
@@ -61,7 +97,6 @@ public final class BpmnJobBehavior {
 
     final var jobKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.CREATED, jobRecord);
-    jobMetrics.jobCreated(jobType);
   }
 
   public void cancelJob(final long jobKey) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventPublicationBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
-import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnVariableMappingBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEndEvent;
@@ -30,8 +29,6 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
   private final BpmnEventPublicationBehavior eventPublicationBehavior;
   private final BpmnIncidentBehavior incidentBehavior;
   private final BpmnStateTransitionBehavior stateTransitionBehavior;
-
-  private final BpmnStateBehavior stateBehavior;
   private final BpmnVariableMappingBehavior variableMappingBehavior;
   private final BpmnJobBehavior jobBehavior;
 
@@ -39,8 +36,6 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
     eventPublicationBehavior = bpmnBehaviors.eventPublicationBehavior();
     incidentBehavior = bpmnBehaviors.incidentBehavior();
     stateTransitionBehavior = bpmnBehaviors.stateTransitionBehavior();
-
-    stateBehavior = bpmnBehaviors.stateBehavior();
     variableMappingBehavior = bpmnBehaviors.variableMappingBehavior();
     jobBehavior = bpmnBehaviors.jobBehavior();
   }
@@ -160,14 +155,7 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
     public void onTerminate(
         final ExecutableEndEvent element, final BpmnElementContext terminating) {
 
-      if (element.getJobWorkerProperties() != null) {
-        final var elementInstance = stateBehavior.getElementInstance(terminating);
-        final long jobKey = elementInstance.getJobKey();
-        if (jobKey > 0) {
-          jobBehavior.cancelJob(jobKey);
-          incidentBehavior.resolveJobIncident(jobKey);
-        }
-      }
+      jobBehavior.cancelJob(terminating);
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
@@ -13,9 +13,10 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnVariableMappingBehavior;
-import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableIntermediateThrowEvent;
 
-public class IntermediateThrowEventProcessor implements BpmnElementProcessor<ExecutableFlowNode> {
+public class IntermediateThrowEventProcessor
+    implements BpmnElementProcessor<ExecutableIntermediateThrowEvent> {
 
   private final BpmnVariableMappingBehavior variableMappingBehavior;
   private final BpmnStateTransitionBehavior stateTransitionBehavior;
@@ -28,18 +29,20 @@ public class IntermediateThrowEventProcessor implements BpmnElementProcessor<Exe
   }
 
   @Override
-  public Class<ExecutableFlowNode> getType() {
-    return ExecutableFlowNode.class;
+  public Class<ExecutableIntermediateThrowEvent> getType() {
+    return ExecutableIntermediateThrowEvent.class;
   }
 
   @Override
-  public void onActivate(final ExecutableFlowNode element, final BpmnElementContext context) {
+  public void onActivate(
+      final ExecutableIntermediateThrowEvent element, final BpmnElementContext context) {
     final var activated = stateTransitionBehavior.transitionToActivated(context);
     stateTransitionBehavior.completeElement(activated);
   }
 
   @Override
-  public void onComplete(final ExecutableFlowNode element, final BpmnElementContext context) {
+  public void onComplete(
+      final ExecutableIntermediateThrowEvent element, final BpmnElementContext context) {
     variableMappingBehavior
         .applyOutputMappings(context, element)
         .flatMap(ok -> stateTransitionBehavior.transitionToCompleted(element, context))
@@ -49,7 +52,8 @@ public class IntermediateThrowEventProcessor implements BpmnElementProcessor<Exe
   }
 
   @Override
-  public void onTerminate(final ExecutableFlowNode element, final BpmnElementContext context) {
+  public void onTerminate(
+      final ExecutableIntermediateThrowEvent element, final BpmnElementContext context) {
     final var terminated = stateTransitionBehavior.transitionToTerminated(context);
     incidentBehavior.resolveIncidents(terminated);
     stateTransitionBehavior.onElementTerminated(element, terminated);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskProcessor.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventSubscriptionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
-import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnVariableMappingBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerTask;
@@ -25,7 +24,6 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJob
 public final class JobWorkerTaskProcessor implements BpmnElementProcessor<ExecutableJobWorkerTask> {
 
   private final BpmnIncidentBehavior incidentBehavior;
-  private final BpmnStateBehavior stateBehavior;
   private final BpmnStateTransitionBehavior stateTransitionBehavior;
   private final BpmnVariableMappingBehavior variableMappingBehavior;
   private final BpmnEventSubscriptionBehavior eventSubscriptionBehavior;
@@ -36,7 +34,6 @@ public final class JobWorkerTaskProcessor implements BpmnElementProcessor<Execut
     incidentBehavior = behaviors.incidentBehavior();
     stateTransitionBehavior = behaviors.stateTransitionBehavior();
     variableMappingBehavior = behaviors.variableMappingBehavior();
-    stateBehavior = behaviors.stateBehavior();
     jobBehavior = behaviors.jobBehavior();
   }
 
@@ -73,13 +70,7 @@ public final class JobWorkerTaskProcessor implements BpmnElementProcessor<Execut
   @Override
   public void onTerminate(final ExecutableJobWorkerTask element, final BpmnElementContext context) {
 
-    final var elementInstance = stateBehavior.getElementInstance(context);
-    final long jobKey = elementInstance.getJobKey();
-    if (jobKey > 0) {
-      jobBehavior.cancelJob(jobKey);
-      incidentBehavior.resolveJobIncident(jobKey);
-    }
-
+    jobBehavior.cancelJob(context);
     eventSubscriptionBehavior.unsubscribeFromEvents(context);
     incidentBehavior.resolveIncidents(context);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableIntermediateThrowEvent.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableIntermediateThrowEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.element;
+
+public class ExecutableIntermediateThrowEvent extends ExecutableFlowNode
+    implements ExecutableJobWorkerElement {
+
+  private JobWorkerProperties jobWorkerProperties;
+
+  public ExecutableIntermediateThrowEvent(final String id) {
+    super(id);
+  }
+
+  @Override
+  public JobWorkerProperties getJobWorkerProperties() {
+    return jobWorkerProperties;
+  }
+
+  @Override
+  public void setJobWorkerProperties(final JobWorkerProperties jobWorkerProperties) {
+    this.jobWorkerProperties = jobWorkerProperties;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.transformer.Exclusive
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.FlowElementInstantiationTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.FlowNodeTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.IntermediateCatchEventTransformer;
+import io.camunda.zeebe.engine.processing.deployment.model.transformer.IntermediateThrowEventTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.JobWorkerElementTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.MessageTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.MultiInstanceActivityTransformer;
@@ -77,14 +78,15 @@ public final class BpmnTransformer {
     step2Visitor.registerHandler(new ContextProcessTransformer());
     step2Visitor.registerHandler(new EndEventTransformer());
     step2Visitor.registerHandler(new FlowNodeTransformer());
-    step2Visitor.registerHandler(new SequenceFlowTransformer());
+    step2Visitor.registerHandler(new IntermediateThrowEventTransformer());
     step2Visitor.registerHandler(new JobWorkerElementTransformer<>(ServiceTask.class));
     step2Visitor.registerHandler(new JobWorkerElementTransformer<>(BusinessRuleTask.class));
     step2Visitor.registerHandler(new JobWorkerElementTransformer<>(ScriptTask.class));
     step2Visitor.registerHandler(new JobWorkerElementTransformer<>(SendTask.class));
     step2Visitor.registerHandler(new ReceiveTaskTransformer());
-    step2Visitor.registerHandler(new UserTaskTransformer());
+    step2Visitor.registerHandler(new SequenceFlowTransformer());
     step2Visitor.registerHandler(new StartEventTransformer());
+    step2Visitor.registerHandler(new UserTaskTransformer());
 
     step3Visitor = new TransformationVisitor();
     step3Visitor.registerHandler(new ContextProcessTransformer());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowElementInstantiationTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowElementInstantiationTransformer.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEve
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableExclusiveGateway;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableIntermediateThrowEvent;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerTask;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableReceiveTask;
@@ -65,6 +66,8 @@ public final class FlowElementInstantiationTransformer
     ELEMENT_FACTORIES.put(EventBasedGateway.class, ExecutableEventBasedGateway::new);
     ELEMENT_FACTORIES.put(ExclusiveGateway.class, ExecutableExclusiveGateway::new);
     ELEMENT_FACTORIES.put(IntermediateCatchEvent.class, ExecutableCatchEventElement::new);
+    ELEMENT_FACTORIES.put(IntermediateThrowEvent.class, ExecutableIntermediateThrowEvent::new);
+    ELEMENT_FACTORIES.put(ManualTask.class, ExecutableActivity::new);
     ELEMENT_FACTORIES.put(ParallelGateway.class, ExecutableFlowNode::new);
     ELEMENT_FACTORIES.put(ReceiveTask.class, ExecutableReceiveTask::new);
     ELEMENT_FACTORIES.put(ScriptTask.class, ExecutableJobWorkerTask::new);
@@ -74,8 +77,6 @@ public final class FlowElementInstantiationTransformer
     ELEMENT_FACTORIES.put(StartEvent.class, ExecutableStartEvent::new);
     ELEMENT_FACTORIES.put(SubProcess.class, ExecutableFlowElementContainer::new);
     ELEMENT_FACTORIES.put(UserTask.class, ExecutableJobWorkerTask::new);
-    ELEMENT_FACTORIES.put(IntermediateThrowEvent.class, ExecutableFlowNode::new);
-    ELEMENT_FACTORIES.put(ManualTask.class, ExecutableActivity::new);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/IntermediateThrowEventTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/IntermediateThrowEventTransformer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.transformer;
+
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
+import io.camunda.zeebe.model.bpmn.instance.IntermediateThrowEvent;
+import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
+
+public final class IntermediateThrowEventTransformer
+    implements ModelElementTransformer<IntermediateThrowEvent> {
+
+  private final JobWorkerElementTransformer<IntermediateThrowEvent> jobWorkerElementTransformer =
+      new JobWorkerElementTransformer<>(IntermediateThrowEvent.class);
+
+  @Override
+  public Class<IntermediateThrowEvent> getType() {
+    return IntermediateThrowEvent.class;
+  }
+
+  @Override
+  public void transform(final IntermediateThrowEvent element, final TransformContext context) {
+
+    if (isMessageEvent(element) && hasTaskDefinition(element)) {
+      jobWorkerElementTransformer.transform(element, context);
+    }
+  }
+
+  private boolean isMessageEvent(final IntermediateThrowEvent element) {
+    return element.getEventDefinitions().stream()
+        .anyMatch(MessageEventDefinition.class::isInstance);
+  }
+
+  private boolean hasTaskDefinition(final IntermediateThrowEvent element) {
+    return element.getSingleExtensionElement(ZeebeTaskDefinition.class) != null;
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/JobWorkerElementBuilderProvider.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/JobWorkerElementBuilderProvider.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.util;
 
 import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
+import io.camunda.zeebe.model.bpmn.builder.AbstractThrowEventBuilder;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -40,7 +41,13 @@ public final class JobWorkerElementBuilderProvider implements ArgumentsProvider 
         JobWorkerElementBuilder.of(BpmnElementType.SEND_TASK, AbstractFlowNodeBuilder::sendTask),
         JobWorkerElementBuilder.of(
             BpmnElementType.END_EVENT,
-            process -> process.endEvent().messageEventDefinition().messageEventDefinitionDone()));
+            process ->
+                process.endEvent("message", AbstractThrowEventBuilder::messageEventDefinition)),
+        JobWorkerElementBuilder.of(
+            BpmnElementType.INTERMEDIATE_THROW_EVENT,
+            process ->
+                process.intermediateThrowEvent(
+                    "message", AbstractThrowEventBuilder::messageEventDefinition)));
   }
 
   public static Collection<Object[]> buildersAsParameters() {


### PR DESCRIPTION
## Description

* add support for intermediate message throw events
* intermediate message throw events behave like service/send tasks

**Notes**
I don't reuse the behavior from the message end event or extract behaviors like for the end event. At the moment, the intermediate throw event processor is simple enough and the message throw event behavior share major parts with the none event behavior. I prefer to reuse/extract parts when needed.  

## Related issues

closes #7763 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
