### PR TITLE
Revert external API to original name of command API

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -44,7 +44,7 @@ import io.camunda.zeebe.broker.system.partitions.impl.steps.SnapshotDirectorPart
 import io.camunda.zeebe.broker.system.partitions.impl.steps.StateControllerPartitionStartupStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.StreamProcessorPartitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.ZeebeDbPartitionStep;
-import io.camunda.zeebe.broker.transport.externalapi.ExternalApiService;
+import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.ProcessingContext;
@@ -102,7 +102,7 @@ public final class PartitionFactory {
   private final BrokerCfg brokerCfg;
   private final BrokerInfo localBroker;
   private final PushDeploymentRequestHandler deploymentRequestHandler;
-  private final ExternalApiService externalApiService;
+  private final CommandApiService commandApiService;
   private final FileBasedSnapshotStoreFactory snapshotStoreFactory;
   private final ClusterServices clusterServices;
   private final ExporterRepository exporterRepository;
@@ -113,7 +113,7 @@ public final class PartitionFactory {
       final BrokerCfg brokerCfg,
       final BrokerInfo localBroker,
       final PushDeploymentRequestHandler deploymentRequestHandler,
-      final ExternalApiService externalApiService,
+      final CommandApiService commandApiService,
       final FileBasedSnapshotStoreFactory snapshotStoreFactory,
       final ClusterServices clusterServices,
       final ExporterRepository exporterRepository,
@@ -122,7 +122,7 @@ public final class PartitionFactory {
     this.brokerCfg = brokerCfg;
     this.localBroker = localBroker;
     this.deploymentRequestHandler = deploymentRequestHandler;
-    this.externalApiService = externalApiService;
+    this.commandApiService = commandApiService;
     this.snapshotStoreFactory = snapshotStoreFactory;
     this.clusterServices = clusterServices;
     this.exporterRepository = exporterRepository;
@@ -165,8 +165,8 @@ public final class PartitionFactory {
                   communicationService, membershipService, owningPartition.members()),
               actorSchedulingService,
               brokerCfg,
-              () -> externalApiService.newCommandResponseWriter(),
-              () -> externalApiService.getOnProcessedListener(partitionId),
+              () -> commandApiService.newCommandResponseWriter(),
+              () -> commandApiService.getOnProcessedListener(partitionId),
               snapshotStoreFactory.getConstructableSnapshotStore(partitionId),
               snapshotStoreFactory.getReceivableSnapshotStore(partitionId),
               typedRecordProcessorsFactory,

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -24,7 +24,7 @@ import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.partitions.PartitionHealthBroadcaster;
 import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
-import io.camunda.zeebe.broker.transport.externalapi.ExternalApiService;
+import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
 import io.camunda.zeebe.util.health.HealthStatus;
@@ -59,7 +59,7 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
   private final PushDeploymentRequestHandler deploymentRequestHandler;
   private final List<PartitionListener> partitionListeners;
   private final ClusterServices clusterServices;
-  private final ExternalApiService externalApiService;
+  private final CommandApiService commandApiService;
   private final ExporterRepository exporterRepository;
 
   public PartitionManagerImpl(
@@ -71,7 +71,7 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
       final PushDeploymentRequestHandler deploymentRequestHandler,
       final Consumer<DiskSpaceUsageListener> diskSpaceUsageListenerRegistry,
       final List<PartitionListener> partitionListeners,
-      final ExternalApiService externalApiService,
+      final CommandApiService commandApiService,
       final ExporterRepository exporterRepository) {
 
     snapshotStoreFactory =
@@ -84,7 +84,7 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
     this.healthCheckService = healthCheckService;
     this.deploymentRequestHandler = deploymentRequestHandler;
     this.diskSpaceUsageListenerRegistry = diskSpaceUsageListenerRegistry;
-    this.externalApiService = externalApiService;
+    this.commandApiService = commandApiService;
     this.exporterRepository = exporterRepository;
 
     partitionGroup =
@@ -142,7 +142,7 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
                       brokerCfg,
                       localBroker,
                       deploymentRequestHandler,
-                      externalApiService,
+                      commandApiService,
                       snapshotStoreFactory,
                       clusterServices,
                       exporterRepository,

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.configuration;
 
-import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg.ExternalApiCfg;
+import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg.CommandApiCfg;
 import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg.InternalApiCfg;
 import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg.MonitoringApiCfg;
 import java.util.Optional;
@@ -26,7 +26,7 @@ public final class NetworkCfg implements ConfigurationEntry {
   private DataSize maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
   private String advertisedHost;
 
-  private final ExternalApiCfg commandApi = new ExternalApiCfg();
+  private final CommandApiCfg commandApi = new CommandApiCfg();
   private InternalApiCfg internalApi = new InternalApiCfg();
   private MonitoringApiCfg monitoringApi = new MonitoringApiCfg();
 
@@ -77,13 +77,7 @@ public final class NetworkCfg implements ConfigurationEntry {
     this.maxMessageSize = maxMessageSize;
   }
 
-  public ExternalApiCfg getExternalApi() {
-    return commandApi;
-  }
-
-  /** @deprecated replaced by {@link #getExternalApi()}. Exists only for backwards compatibility. */
-  @Deprecated(forRemoval = true)
-  public ExternalApiCfg getCommandApi() {
+  public CommandApiCfg getCommandApi() {
     return commandApi;
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/SocketBindingCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/SocketBindingCfg.java
@@ -89,15 +89,15 @@ public class SocketBindingCfg {
         + "}";
   }
 
-  public static class ExternalApiCfg extends SocketBindingCfg {
+  public static class CommandApiCfg extends SocketBindingCfg {
 
-    public ExternalApiCfg() {
+    public CommandApiCfg() {
       super(NetworkCfg.DEFAULT_COMMAND_API_PORT);
     }
 
     @Override
     public String toString() {
-      return "ExternalApiCfg{"
+      return "CommandApiCfg{"
           + "host='"
           + getHost()
           + '\''

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.externalapi;
+package io.camunda.zeebe.broker.transport.commandapi;
 
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.transport.backpressure.BackpressureMetrics;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiService.java
@@ -5,13 +5,13 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.externalapi;
+package io.camunda.zeebe.broker.transport.commandapi;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import java.util.function.Consumer;
 
-public interface ExternalApiService {
+public interface CommandApiService {
 
   CommandResponseWriter newCommandResponseWriter();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.externalapi;
+package io.camunda.zeebe.broker.transport.commandapi;
 
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.PartitionListener;
@@ -29,8 +29,8 @@ import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.util.function.Consumer;
 import org.agrona.collections.IntHashSet;
 
-public final class ExternalApiServiceImpl extends Actor
-    implements PartitionListener, DiskSpaceUsageListener, ExternalApiService {
+public final class CommandApiServiceImpl extends Actor
+    implements PartitionListener, DiskSpaceUsageListener, CommandApiService {
 
   private final PartitionAwareRequestLimiter limiter;
   private final ServerTransport serverTransport;
@@ -40,7 +40,7 @@ public final class ExternalApiServiceImpl extends Actor
   private final String actorName;
   private final ActorSchedulingService scheduler;
 
-  public ExternalApiServiceImpl(
+  public CommandApiServiceImpl(
       final ServerTransport serverTransport,
       final BrokerInfo localBroker,
       final PartitionAwareRequestLimiter limiter,
@@ -51,7 +51,7 @@ public final class ExternalApiServiceImpl extends Actor
     this.scheduler = scheduler;
     commandHandler = new CommandApiRequestHandler();
     queryHandler = new QueryApiRequestHandler(queryApiCfg, localBroker.getNodeId());
-    actorName = buildActorName(localBroker.getNodeId(), "ExternalApiService");
+    actorName = buildActorName(localBroker.getNodeId(), "CommandApiService");
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandResponseWriterImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandResponseWriterImpl.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.externalapi;
+package io.camunda.zeebe.broker.transport.commandapi;
 
 import static io.camunda.zeebe.protocol.record.ExecuteCommandResponseEncoder.keyNullValue;
 import static io.camunda.zeebe.protocol.record.ExecuteCommandResponseEncoder.partitionIdNullValue;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/ErrorResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/ErrorResponseWriter.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.externalapi;
+package io.camunda.zeebe.broker.transport.commandapi;
 
 import static io.camunda.zeebe.util.StringUtil.getBytes;
 import static java.lang.String.format;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/QueryApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/QueryApiRequestHandler.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.externalapi;
+package io.camunda.zeebe.broker.transport.commandapi;
 
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.system.configuration.QueryApiCfg;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/QueryResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/QueryResponseWriter.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.externalapi;
+package io.camunda.zeebe.broker.transport.commandapi;
 
 import io.camunda.zeebe.protocol.record.ExecuteQueryResponseEncoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -712,8 +712,8 @@ public final class BrokerCfgTest {
       final String configFileName, final int command, final int internal, final int monitoring) {
     final BrokerCfg brokerCfg = TestConfigReader.readConfig(configFileName, environment);
     final NetworkCfg network = brokerCfg.getNetwork();
-    assertThat(network.getExternalApi().getAddress().getPort()).isEqualTo(command);
-    assertThat(network.getExternalApi().getAdvertisedAddress().getPort()).isEqualTo(command);
+    assertThat(network.getCommandApi().getAddress().getPort()).isEqualTo(command);
+    assertThat(network.getCommandApi().getAdvertisedAddress().getPort()).isEqualTo(command);
     assertThat(network.getInternalApi().getPort()).isEqualTo(internal);
     assertThat(network.getMonitoringApi().getPort()).isEqualTo(monitoring);
   }
@@ -738,7 +738,7 @@ public final class BrokerCfgTest {
     final NetworkCfg networkCfg = brokerCfg.getNetwork();
     assertThat(networkCfg.getHost()).isEqualTo(host);
     assertThat(brokerCfg.getGateway().getNetwork().getHost()).isEqualTo(gateway);
-    assertThat(networkCfg.getExternalApi().getAddress().getHostString()).isEqualTo(command);
+    assertThat(networkCfg.getCommandApi().getAddress().getHostString()).isEqualTo(command);
     assertThat(networkCfg.getInternalApi().getHost()).isEqualTo(internal);
     assertThat(networkCfg.getMonitoringApi().getHost()).isEqualTo(monitoring);
   }
@@ -746,15 +746,15 @@ public final class BrokerCfgTest {
   private void assertAdvertisedHost(final String configFileName, final String host) {
     final BrokerCfg brokerCfg = TestConfigReader.readConfig(configFileName, environment);
     final NetworkCfg networkCfg = brokerCfg.getNetwork();
-    assertThat(networkCfg.getExternalApi().getAdvertisedAddress().getHostName()).isEqualTo(host);
+    assertThat(networkCfg.getCommandApi().getAdvertisedAddress().getHostName()).isEqualTo(host);
   }
 
   private void assertAdvertisedAddress(
       final String configFileName, final String host, final int port) {
     final BrokerCfg brokerCfg = TestConfigReader.readConfig(configFileName, environment);
     final NetworkCfg networkCfg = brokerCfg.getNetwork();
-    assertThat(networkCfg.getExternalApi().getAdvertisedAddress().getHostName()).isEqualTo(host);
-    assertThat(networkCfg.getExternalApi().getAdvertisedAddress().getPort()).isEqualTo(port);
+    assertThat(networkCfg.getCommandApi().getAdvertisedAddress().getHostName()).isEqualTo(host);
+    assertThat(networkCfg.getCommandApi().getAdvertisedAddress().getPort()).isEqualTo(port);
   }
 
   private void assertDefaultContactPoints(final String... contactPoints) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerConfigurator.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerConfigurator.java
@@ -74,7 +74,7 @@ public final class EmbeddedBrokerConfigurator {
   }
 
   public static Consumer<BrokerCfg> setCommandApiPort(final int port) {
-    return cfg -> cfg.getNetwork().getExternalApi().setPort(port);
+    return cfg -> cfg.getNetwork().getCommandApi().setPort(port);
   }
 
   public static Consumer<BrokerCfg> setInternalApiPort(final int port) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandResponseWriterImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandResponseWriterImplTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.externalapi;
+package io.camunda.zeebe.broker.transport.commandapi;
 
 import static io.camunda.zeebe.util.StringUtil.getBytes;
 import static io.camunda.zeebe.util.VarDataUtil.readBytes;

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/ErrorResponseWriterTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/ErrorResponseWriterTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.externalapi;
+package io.camunda.zeebe.broker.transport.commandapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/QueryApiIT.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/QueryApiIT.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.externalapi;
+package io.camunda.zeebe.broker.transport.commandapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -56,7 +56,7 @@ public final class QueryApiIT {
   public void setup() {
     serverAddress =
         NetUtil.toSocketAddressString(
-            broker.getBrokerCfg().getNetwork().getExternalApi().getAddress());
+            broker.getBrokerCfg().getNetwork().getCommandApi().getAddress());
     final var messagingService =
         new NettyMessagingService(
             broker.getBrokerCfg().getCluster().getClusterName(),

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/QueryApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/QueryApiRequestHandlerTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.externalapi;
+package io.camunda.zeebe.broker.transport.commandapi;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -424,7 +424,7 @@ public final class ClusteringRule extends ExternalResource {
     final Set<InetSocketAddress> addresses =
         brokers.values().stream()
             .map(Broker::getConfig)
-            .map(b -> b.getNetwork().getExternalApi().getAddress())
+            .map(b -> b.getNetwork().getCommandApi().getAddress())
             .collect(Collectors.toSet());
 
     waitForTopology(
@@ -507,7 +507,7 @@ public final class ClusteringRule extends ExternalResource {
   public void startBroker(final int nodeId) {
     final Broker broker = getBroker(nodeId).start().join();
     final InetSocketAddress commandApi =
-        broker.getConfig().getNetwork().getExternalApi().getAddress();
+        broker.getConfig().getNetwork().getCommandApi().getAddress();
     waitUntilBrokerIsAddedToTopology(commandApi);
     waitForPartitionReplicationFactor();
   }
@@ -565,14 +565,13 @@ public final class ClusteringRule extends ExternalResource {
 
   public InetSocketAddress[] getOtherBrokers(final InetSocketAddress address) {
     return getBrokers().stream()
-        .map(b -> b.getConfig().getNetwork().getExternalApi().getAddress())
+        .map(b -> b.getConfig().getNetwork().getCommandApi().getAddress())
         .filter(a -> !address.equals(a))
         .toArray(InetSocketAddress[]::new);
   }
 
   public InetSocketAddress[] getOtherBrokers(final int nodeId) {
-    final InetSocketAddress filter =
-        getBrokerCfg(nodeId).getNetwork().getExternalApi().getAddress();
+    final InetSocketAddress filter = getBrokerCfg(nodeId).getNetwork().getCommandApi().getAddress();
     return getOtherBrokers(filter);
   }
 
@@ -631,7 +630,7 @@ public final class ClusteringRule extends ExternalResource {
     final Broker broker = brokers.get(nodeId);
     if (broker != null) {
       final InetSocketAddress socketAddress =
-          broker.getConfig().getNetwork().getExternalApi().getAddress();
+          broker.getConfig().getNetwork().getCommandApi().getAddress();
       final List<Integer> brokersLeadingPartitions = getBrokersLeadingPartitions(socketAddress);
       stopBroker(nodeId);
       waitForNewLeaderOfPartitions(brokersLeadingPartitions, socketAddress);
@@ -642,7 +641,7 @@ public final class ClusteringRule extends ExternalResource {
     final Broker broker = brokers.remove(nodeId);
     if (broker != null) {
       final InetSocketAddress socketAddress =
-          broker.getConfig().getNetwork().getExternalApi().getAddress();
+          broker.getConfig().getNetwork().getCommandApi().getAddress();
       broker.close();
       waitUntilBrokerIsRemovedFromTopology(socketAddress);
       try {

--- a/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
+++ b/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
@@ -137,7 +137,7 @@ public class EmbeddedBrokerRule extends ExternalResource {
   public static void assignSocketAddresses(final BrokerCfg brokerCfg) {
     final NetworkCfg network = brokerCfg.getNetwork();
     brokerCfg.getGateway().getNetwork().setPort(SocketUtil.getNextAddress().getPort());
-    network.getExternalApi().setPort(SocketUtil.getNextAddress().getPort());
+    network.getCommandApi().setPort(SocketUtil.getNextAddress().getPort());
     network.getInternalApi().setPort(SocketUtil.getNextAddress().getPort());
     network.getMonitoringApi().setPort(SocketUtil.getNextAddress().getPort());
   }


### PR DESCRIPTION
## Description

This PR reverts the internal renaming of the external API back to command API. While we should still consider renaming it, especially with the possibility of relaying queries and/or in the future decisions to read replicas, we should consider the name carefully since it breaks backwards compatibility once we change the configuration.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
