### PR TITLE
fix(broker): do not set old exported position

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -169,7 +169,9 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       recoverFromSnapshot();
       exporterDistributionService =
           new ExporterPositionsDistributionService(
-              state::setPosition, partitionMessagingService, exporterPositionsTopic);
+              this::consumeExporterPositionFromLeader,
+              partitionMessagingService,
+              exporterPositionsTopic);
 
       // Initialize containers irrespective of if it is Active or Passive mode
       initContainers();
@@ -236,6 +238,13 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       for (final var listener : listeners) {
         listener.onFailure();
       }
+    }
+  }
+
+  private void consumeExporterPositionFromLeader(
+      final String exporterId, final long receivedPosition) {
+    if (state.getPosition(exporterId) < receivedPosition) {
+      state.setPosition(exporterId, receivedPosition);
     }
   }
 


### PR DESCRIPTION
## Description

When a follower receives exported position from the leader, it is not always the latest exported position. If a new leader is started and it recovers from an older snapshot, the exported position that it sends to the follower might be older than what the follower has already received from the old leader. This can cause to inconsistent state in snapshot, as a previous snapshot might have already compacted the events at the exported position from the new leader. Hence when receiving an exporter position, follower should update its state only if it is larger that what it has already observed.

## Related issues

closes #7858 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
