### PR TITLE
refactor(broker): migrate cluster services step

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -147,8 +147,6 @@ public final class Broker implements AutoCloseable {
     final StartProcess startContext = new StartProcess("Broker-" + localBroker.getNodeId());
 
     startContext.addStep("Migrated Startup Steps", this::migratedStartupSteps);
-
-    startContext.addStep("cluster services", () -> clusterServices.start().join());
     if (brokerCfg.getGateway().isEnable()) {
       startContext.addStep(
           "embedded gateway",
@@ -320,6 +318,7 @@ public final class Broker implements AutoCloseable {
                     b -> {
                       closeProcess.closeReverse();
                       isClosed = true;
+                      testCompanionObject.atomix = null;
                       LOG.info("Broker shut down.");
                     })
                 .join();

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -94,17 +94,6 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   }
 
   @Override
-  public SubscriptionApiCommandMessageHandlerService getSubscriptionApiService() {
-    return subscriptionApiService;
-  }
-
-  @Override
-  public void setSubscriptionApiService(
-      final SubscriptionApiCommandMessageHandlerService subscriptionApiService) {
-    this.subscriptionApiService = subscriptionApiService;
-  }
-
-  @Override
   public void addPartitionListener(final PartitionListener listener) {
     partitionListeners.add(requireNonNull(listener));
   }
@@ -173,5 +162,16 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   public void setCommandApiMessagingService(
       final ManagedMessagingService commandApiMessagingService) {
     this.commandApiMessagingService = commandApiMessagingService;
+  }
+
+  @Override
+  public SubscriptionApiCommandMessageHandlerService getSubscriptionApiService() {
+    return subscriptionApiService;
+  }
+
+  @Override
+  public void setSubscriptionApiService(
+      final SubscriptionApiCommandMessageHandlerService subscriptionApiService) {
+    this.subscriptionApiService = subscriptionApiService;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -25,7 +25,8 @@ public final class BrokerStartupProcess {
           new MonitoringServerStep(),
           new ClusterServicesCreationStep(),
           new CommandApiServiceStep(),
-          new SubscriptionApiStep());
+          new SubscriptionApiStep(),
+          new ClusterServicesStep());
 
   private final StartupProcess<BrokerStartupContext> startupProcess;
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterServicesStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterServicesStep.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import io.camunda.zeebe.util.sched.ConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+
+public class ClusterServicesStep extends AbstractBrokerStartupStep {
+
+  @Override
+  public String getName() {
+    return "Cluster Services (Start)";
+  }
+
+  @Override
+  void startupInternal(
+      final BrokerStartupContext brokerStartupContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> startupFuture) {
+
+    final var clusterServices = brokerStartupContext.getClusterServices();
+
+    clusterServices
+        .start()
+        .whenComplete(
+            (ok, error) -> {
+              if (error != null) {
+                startupFuture.completeExceptionally(error);
+              } else {
+                startupFuture.complete(brokerStartupContext);
+              }
+            });
+  }
+
+  @Override
+  void shutdownInternal(
+      final BrokerStartupContext brokerShutdownContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> shutdownFuture) {
+
+    final var clusterServices = brokerShutdownContext.getClusterServices();
+
+    clusterServices
+        .stop()
+        .whenComplete(
+            (ok, error) -> {
+              if (error != null) {
+                shutdownFuture.completeExceptionally(error);
+              } else {
+                shutdownFuture.complete(brokerShutdownContext);
+              }
+            });
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ClusterServicesStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ClusterServicesStepTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
+import io.camunda.zeebe.util.sched.TestConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ClusterServicesStepTest {
+
+  private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
+
+  private BrokerStartupContext mockBrokerStartupContext;
+  private ClusterServicesImpl mockClusterServices;
+
+  private ActorFuture<BrokerStartupContext> future;
+
+  private final ClusterServicesStep sut = new ClusterServicesStep();
+
+  @BeforeEach
+  void setUp() {
+    mockBrokerStartupContext = mock(BrokerStartupContext.class);
+
+    mockClusterServices = mock(ClusterServicesImpl.class);
+    when(mockClusterServices.start()).thenReturn(CompletableFuture.completedFuture(null));
+    when(mockClusterServices.stop()).thenReturn(CompletableFuture.completedFuture(null));
+
+    when(mockBrokerStartupContext.getConcurrencyControl()).thenReturn(CONCURRENCY_CONTROL);
+    when(mockBrokerStartupContext.getClusterServices()).thenReturn(mockClusterServices);
+
+    future = CONCURRENCY_CONTROL.createFuture();
+  }
+
+  @Test
+  void shouldCompleteFutureOnStartup() {
+    // when
+    sut.startupInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isFalse();
+  }
+
+  @Test
+  void shouldStartClusterServicesOnStartup() {
+    // when
+    sut.startupInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+
+    // then
+    verify(mockClusterServices).start();
+  }
+
+  @Test
+  void shouldCompleteFutureOnShutdown() {
+    // when
+    sut.shutdownInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isFalse();
+  }
+
+  @Test
+  void shouldStopClusterServicesOnShutdown() {
+    // when
+    sut.shutdownInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+
+    // then
+    verify(mockClusterServices).stop();
+  }
+}


### PR DESCRIPTION
## Description

Migrates the cluster services step

## Review Hints
There will be a follow up PR for all step tests that removes the public keyword and adds a wait for the future to complete.  

## Related issues

#7539

<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
