### PR TITLE
PartitionId in the logging context

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -421,6 +421,7 @@ public interface RaftServer {
     protected EntryValidator entryValidator = new NoopEntryValidator();
     protected RaftElectionConfig electionConfig = RaftElectionConfig.ofDefaultElection();
     protected RaftPartitionConfig partitionConfig = new RaftPartitionConfig();
+    protected int partitionId;
 
     protected Builder(final MemberId localMemberId) {
       this.localMemberId = checkNotNull(localMemberId, "localMemberId cannot be null");
@@ -498,6 +499,11 @@ public interface RaftServer {
 
     public Builder withPartitionConfig(final RaftPartitionConfig partitionConfig) {
       this.partitionConfig = partitionConfig;
+      return this;
+    }
+
+    public Builder withPartitionId(final int partitionId) {
+      this.partitionId = partitionId;
       return this;
     }
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -140,6 +140,26 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
     return bootstrapFutureRef.get().whenComplete((result, error) -> bootstrapFutureRef.set(null));
   }
 
+  @Override
+  public RaftMember getLeader() {
+    return raft.getLeader();
+  }
+
+  @Override
+  public RaftMember getLocalMember() {
+    return localMember;
+  }
+
+  @Override
+  public Collection<RaftMember> getMembers() {
+    return new ArrayList<>(members);
+  }
+
+  @Override
+  public long getTerm() {
+    return raft.getTerm();
+  }
+
   private void ensureConfigurationIsConsistent(final Collection<MemberId> cluster) {
     final var configuration = configurationRef.get();
     final var hasPersistedConfiguration = configuration != null;
@@ -191,26 +211,6 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
     // Create a new configuration and store it on disk to ensure the cluster can fall back to the
     // configuration.
     configure(new Configuration(0, 0, localMember.getLastUpdated().toEpochMilli(), activeMembers));
-  }
-
-  @Override
-  public RaftMember getLeader() {
-    return raft.getLeader();
-  }
-
-  @Override
-  public RaftMember getLocalMember() {
-    return localMember;
-  }
-
-  @Override
-  public Collection<RaftMember> getMembers() {
-    return new ArrayList<>(members);
-  }
-
-  @Override
-  public long getTerm() {
-    return raft.getTerm();
   }
 
   /**

--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -40,6 +40,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import org.slf4j.MDC;
 
 /** Manages the persistent state of the Raft cluster from the perspective of a single server. */
 public final class RaftClusterContext implements RaftCluster, AutoCloseable {
@@ -124,6 +125,7 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
     raft.getThreadContext()
         .execute(
             () -> {
+              MDC.put("partitionId", Integer.toString(raft.getPartitionId()));
               // Transition the server to the appropriate state for the local member type.
               raft.transition(localMember.getType());
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -40,7 +40,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import org.slf4j.MDC;
 
 /** Manages the persistent state of the Raft cluster from the perspective of a single server. */
 public final class RaftClusterContext implements RaftCluster, AutoCloseable {
@@ -125,7 +124,6 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
     raft.getThreadContext()
         .execute(
             () -> {
-              MDC.put("partitionId", Integer.toString(raft.getPartitionId()));
               // Transition the server to the appropriate state for the local member type.
               raft.transition(localMember.getType());
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -258,6 +258,7 @@ public class DefaultRaftServer implements RaftServer {
       final RaftContext raft =
           new RaftContext(
               name,
+              partitionId,
               localMemberId,
               membershipService,
               protocol,

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -80,6 +80,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
+import org.slf4j.MDC;
 
 /**
  * Manages the volatile state and state transitions of a Raft server.
@@ -173,6 +174,8 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     threadContext =
         threadContextFactory.createContext(
             namedThreads(baseThreadName, log), this::onUncaughtException);
+    // in order to set the partition id once in the raft thread
+    threadContext.execute(() -> MDC.put("partitionId", Integer.toString(partitionId)));
 
     // Open the metadata store.
     meta = storage.openMetaStore();

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -130,9 +130,11 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
   private long lastHeartbeat;
   private final RaftPartitionConfig partitionConfig;
+  private final int partitionId;
 
   public RaftContext(
       final String name,
+      final int partitionId,
       final MemberId localMemberId,
       final ClusterMembershipService membershipService,
       final RaftServerProtocol protocol,
@@ -146,6 +148,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     this.protocol = checkNotNull(protocol, "protocol cannot be null");
     this.storage = checkNotNull(storage, "storage cannot be null");
     random = randomFactory.get();
+    this.partitionId = partitionId;
 
     raftRoleMetrics = new RaftRoleMetrics(name);
 
@@ -1088,6 +1091,10 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
   public Duration getMaxQuorumResponseTimeout() {
     return partitionConfig.getMaxQuorumResponseTimeout();
+  }
+
+  public int getPartitionId() {
+    return partitionId;
   }
 
   /** Raft server state. */

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -181,6 +181,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
 
     return RaftServer.builder(localMemberId)
         .withName(partition.name())
+        .withPartitionId(partitionId)
         .withMembershipService(membershipService)
         .withProtocol(createServerProtocol())
         .withPartitionConfig(partitionConfig)

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -153,6 +153,7 @@ public final class ControllableRaftContexts {
     final var raft =
         new RaftContext(
             memberId.id() + "-partition-1",
+            1,
             memberId,
             mock(ClusterMembershipService.class),
             new ControllableRaftServerProtocol(memberId, serverProtocols, messageQueue),

--- a/broker/src/main/java/io/camunda/zeebe/broker/logstreams/LogDeletionService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/logstreams/LogDeletionService.java
@@ -13,11 +13,13 @@ import io.camunda.zeebe.snapshots.PersistedSnapshotListener;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.util.sched.Actor;
 import java.util.Collection;
+import java.util.Map;
 
 public final class LogDeletionService extends Actor implements PersistedSnapshotListener {
   private final LogCompactor logCompactor;
   private final String actorName;
   private final Collection<PersistedSnapshotStore> persistedSnapshotStores;
+  private final int partitionId;
 
   public LogDeletionService(
       final int nodeId,
@@ -27,6 +29,14 @@ public final class LogDeletionService extends Actor implements PersistedSnapshot
     this.persistedSnapshotStores = persistedSnapshotStores;
     this.logCompactor = logCompactor;
     actorName = buildActorName(nodeId, "DeletionService", partitionId);
+    this.partitionId = partitionId;
+  }
+
+  @Override
+  protected Map<String, String> createContext() {
+    final var context = super.createContext();
+    context.put(ACTOR_PROP_PARTITION_ID, Integer.toString(partitionId));
+    return context;
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -94,103 +94,6 @@ public final class ZeebePartition extends Actor
     return new ZeebePartitionAdminAccess(actor, adminControl);
   }
 
-  /**
-   * Called by atomix on role change.
-   *
-   * @param newRole the new role of the raft partition
-   */
-  @Override
-  @Deprecated // will be removed from public API of ZeebePartition
-  public void onNewRole(final Role newRole, final long newTerm) {
-    actor.run(() -> onRoleChange(newRole, newTerm));
-  }
-
-  private void onRoleChange(final Role newRole, final long newTerm) {
-    ActorFuture<Void> nextTransitionFuture = null;
-    switch (newRole) {
-      case LEADER:
-        if (raftRole != Role.LEADER) {
-          nextTransitionFuture = leaderTransition(newTerm);
-        }
-        break;
-      case INACTIVE:
-        nextTransitionFuture = transitionToInactive();
-        break;
-      case PASSIVE:
-      case PROMOTABLE:
-      case CANDIDATE:
-      case FOLLOWER:
-      default:
-        if (raftRole == null || raftRole == Role.LEADER) {
-          nextTransitionFuture = followerTransition(newTerm);
-        }
-        break;
-    }
-
-    if (nextTransitionFuture != null) {
-      currentTransitionFuture = nextTransitionFuture;
-    }
-    LOG.debug("Partition role transitioning from {} to {} in term {}", raftRole, newRole, newTerm);
-    raftRole = newRole;
-  }
-
-  private ActorFuture<Void> leaderTransition(final long newTerm) {
-    final var installStartTime = ActorClock.currentTimeMillis();
-    final var leaderTransitionFuture = transition.toLeader(newTerm);
-    leaderTransitionFuture.onComplete(
-        (success, error) -> {
-          if (error == null) {
-            final var leaderTransitionLatency = ActorClock.currentTimeMillis() - installStartTime;
-            roleMetrics.setLeaderTransitionLatency(leaderTransitionLatency);
-            final List<ActorFuture<Void>> listenerFutures =
-                context.notifyListenersOfBecomingLeader(newTerm);
-            actor.runOnCompletion(
-                listenerFutures,
-                t -> {
-                  if (t != null) {
-                    onInstallFailure(t);
-                  }
-                });
-            onRecoveredInternal();
-          } else {
-            LOG.error("Failed to install leader partition {}", context.getPartitionId(), error);
-            onInstallFailure(error);
-          }
-        });
-    return leaderTransitionFuture;
-  }
-
-  private ActorFuture<Void> followerTransition(final long newTerm) {
-    final var followerTransitionFuture = transition.toFollower(newTerm);
-    followerTransitionFuture.onComplete(
-        (success, error) -> {
-          if (error == null) {
-            final List<ActorFuture<Void>> listenerFutures =
-                context.notifyListenersOfBecomingFollower(newTerm);
-            actor.runOnCompletion(
-                listenerFutures,
-                t -> {
-                  // Compare with the current term in case a new role transition happened
-                  if (t != null) {
-                    onInstallFailure(t);
-                  }
-                });
-            onRecoveredInternal();
-          } else {
-            LOG.error("Failed to install follower partition {}", context.getPartitionId(), error);
-            onInstallFailure(error);
-          }
-        });
-    return followerTransitionFuture;
-  }
-
-  private ActorFuture<Void> transitionToInactive() {
-    zeebePartitionHealth.setServicesInstalled(false);
-    final var inactiveTransitionFuture = transition.toInactive();
-    currentTransitionFuture = inactiveTransitionFuture;
-    return inactiveTransitionFuture;
-  }
-
   @Override
   public String getName() {
     return actorName;
@@ -300,6 +203,103 @@ public final class ZeebePartition extends Actor
     // Most probably exception happened in the middle of installing leader or follower services
     // because this actor is not doing anything else
     onInstallFailure(failure);
+  }
+
+  /**
+   * Called by atomix on role change.
+   *
+   * @param newRole the new role of the raft partition
+   */
+  @Override
+  @Deprecated // will be removed from public API of ZeebePartition
+  public void onNewRole(final Role newRole, final long newTerm) {
+    actor.run(() -> onRoleChange(newRole, newTerm));
+  }
+
+  private void onRoleChange(final Role newRole, final long newTerm) {
+    ActorFuture<Void> nextTransitionFuture = null;
+    switch (newRole) {
+      case LEADER:
+        if (raftRole != Role.LEADER) {
+          nextTransitionFuture = leaderTransition(newTerm);
+        }
+        break;
+      case INACTIVE:
+        nextTransitionFuture = transitionToInactive();
+        break;
+      case PASSIVE:
+      case PROMOTABLE:
+      case CANDIDATE:
+      case FOLLOWER:
+      default:
+        if (raftRole == null || raftRole == Role.LEADER) {
+          nextTransitionFuture = followerTransition(newTerm);
+        }
+        break;
+    }
+
+    if (nextTransitionFuture != null) {
+      currentTransitionFuture = nextTransitionFuture;
+    }
+    LOG.debug("Partition role transitioning from {} to {} in term {}", raftRole, newRole, newTerm);
+    raftRole = newRole;
+  }
+
+  private ActorFuture<Void> leaderTransition(final long newTerm) {
+    final var installStartTime = ActorClock.currentTimeMillis();
+    final var leaderTransitionFuture = transition.toLeader(newTerm);
+    leaderTransitionFuture.onComplete(
+        (success, error) -> {
+          if (error == null) {
+            final var leaderTransitionLatency = ActorClock.currentTimeMillis() - installStartTime;
+            roleMetrics.setLeaderTransitionLatency(leaderTransitionLatency);
+            final List<ActorFuture<Void>> listenerFutures =
+                context.notifyListenersOfBecomingLeader(newTerm);
+            actor.runOnCompletion(
+                listenerFutures,
+                t -> {
+                  if (t != null) {
+                    onInstallFailure(t);
+                  }
+                });
+            onRecoveredInternal();
+          } else {
+            LOG.error("Failed to install leader partition {}", context.getPartitionId(), error);
+            onInstallFailure(error);
+          }
+        });
+    return leaderTransitionFuture;
+  }
+
+  private ActorFuture<Void> followerTransition(final long newTerm) {
+    final var followerTransitionFuture = transition.toFollower(newTerm);
+    followerTransitionFuture.onComplete(
+        (success, error) -> {
+          if (error == null) {
+            final List<ActorFuture<Void>> listenerFutures =
+                context.notifyListenersOfBecomingFollower(newTerm);
+            actor.runOnCompletion(
+                listenerFutures,
+                t -> {
+                  // Compare with the current term in case a new role transition happened
+                  if (t != null) {
+                    onInstallFailure(t);
+                  }
+                });
+            onRecoveredInternal();
+          } else {
+            LOG.error("Failed to install follower partition {}", context.getPartitionId(), error);
+            onInstallFailure(error);
+          }
+        });
+    return followerTransitionFuture;
+  }
+
+  private ActorFuture<Void> transitionToInactive() {
+    zeebePartitionHealth.setServicesInstalled(false);
+    final var inactiveTransitionFuture = transition.toInactive();
+    currentTransitionFuture = inactiveTransitionFuture;
+    return inactiveTransitionFuture;
   }
 
   private void registerListenersAndTriggerRoleChange() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.util.startup.StartupProcess;
 import io.camunda.zeebe.util.startup.StartupStep;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
 
@@ -92,6 +93,13 @@ public final class ZeebePartition extends Actor
 
   public PartitionAdminAccess createAdminAccess() {
     return new ZeebePartitionAdminAccess(actor, adminControl);
+  }
+
+  @Override
+  protected Map<String, String> createContext() {
+    final var actorContext = super.createContext();
+    actorContext.put(ACTOR_PROP_PARTITION_ID, Integer.toString(context.getPartitionId()));
+    return actorContext;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -95,6 +96,13 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   public static StreamProcessorBuilder builder() {
     return new StreamProcessorBuilder();
+  }
+
+  @Override
+  protected Map<String, String> createContext() {
+    final var context = super.createContext();
+    context.put(ACTOR_PROP_PARTITION_ID, Integer.toString(partitionId));
+    return context;
   }
 
   @Override

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
@@ -55,6 +55,7 @@ public class LogStorageAppender extends Actor implements HealthMonitorable {
   private final AppenderMetrics appenderMetrics;
   private final Set<FailureListener> failureListeners = new HashSet<>();
   private final ActorFuture<Void> closeFuture;
+  private final int partitionId;
 
   public LogStorageAppender(
       final String name,
@@ -65,6 +66,7 @@ public class LogStorageAppender extends Actor implements HealthMonitorable {
     appenderMetrics = new AppenderMetrics(Integer.toString(partitionId));
     env = new Environment();
     this.name = name;
+    this.partitionId = partitionId;
     this.logStorage = logStorage;
     this.writeBufferSubscription = writeBufferSubscription;
     maxAppendBlockSize = maxBlockSize;
@@ -127,6 +129,13 @@ public class LogStorageAppender extends Actor implements HealthMonitorable {
           appendEntryLimiter.getLimit());
       // we will be called later again
     }
+  }
+
+  @Override
+  protected Map<String, String> createContext() {
+    final var context = super.createContext();
+    context.put(ACTOR_PROP_PARTITION_ID, Integer.toString(partitionId));
+    return context;
   }
 
   @Override

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -78,59 +78,6 @@ public final class LogStreamImpl extends Actor
   }
 
   @Override
-  public int getPartitionId() {
-    return partitionId;
-  }
-
-  @Override
-  public String getLogName() {
-    return logName;
-  }
-
-  @Override
-  public ActorFuture<LogStreamReader> newLogStreamReader() {
-    return actor.call(this::createLogStreamReader);
-  }
-
-  @Override
-  public ActorFuture<LogStreamRecordWriter> newLogStreamRecordWriter() {
-    // this should be replaced after refactoring the actor control
-    if (actor.isClosed()) {
-      return CompletableActorFuture.completedExceptionally(new RuntimeException("Actor is closed"));
-    }
-
-    final var writerFuture = new CompletableActorFuture<LogStreamRecordWriter>();
-    actor.run(() -> createWriter(writerFuture, LogStreamWriterImpl::new));
-    return writerFuture;
-  }
-
-  @Override
-  public ActorFuture<LogStreamBatchWriter> newLogStreamBatchWriter() {
-    // this should be replaced after refactoring the actor control
-    if (actor.isClosed()) {
-      return CompletableActorFuture.completedExceptionally(new RuntimeException("Actor is closed"));
-    }
-
-    final var writerFuture = new CompletableActorFuture<LogStreamBatchWriter>();
-    actor.run(() -> createWriter(writerFuture, LogStreamBatchWriterImpl::new));
-    return writerFuture;
-  }
-
-  @Override
-  public void registerRecordAvailableListener(final LogRecordAwaiter recordAwaiter) {
-    actor.call(() -> recordAwaiters.add(recordAwaiter));
-  }
-
-  @Override
-  public void removeRecordAvailableListener(final LogRecordAwaiter recordAwaiter) {
-    actor.call(() -> recordAwaiters.remove(recordAwaiter));
-  }
-
-  private void notifyRecordAwaiters() {
-    recordAwaiters.forEach(LogRecordAwaiter::onRecordAvailable);
-  }
-
-  @Override
   public String getName() {
     return actorName;
   }
@@ -185,6 +132,59 @@ public final class LogStreamImpl extends Actor
     }
 
     super.handleFailure(failure);
+  }
+
+  @Override
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  @Override
+  public String getLogName() {
+    return logName;
+  }
+
+  @Override
+  public ActorFuture<LogStreamReader> newLogStreamReader() {
+    return actor.call(this::createLogStreamReader);
+  }
+
+  @Override
+  public ActorFuture<LogStreamRecordWriter> newLogStreamRecordWriter() {
+    // this should be replaced after refactoring the actor control
+    if (actor.isClosed()) {
+      return CompletableActorFuture.completedExceptionally(new RuntimeException("Actor is closed"));
+    }
+
+    final var writerFuture = new CompletableActorFuture<LogStreamRecordWriter>();
+    actor.run(() -> createWriter(writerFuture, LogStreamWriterImpl::new));
+    return writerFuture;
+  }
+
+  @Override
+  public ActorFuture<LogStreamBatchWriter> newLogStreamBatchWriter() {
+    // this should be replaced after refactoring the actor control
+    if (actor.isClosed()) {
+      return CompletableActorFuture.completedExceptionally(new RuntimeException("Actor is closed"));
+    }
+
+    final var writerFuture = new CompletableActorFuture<LogStreamBatchWriter>();
+    actor.run(() -> createWriter(writerFuture, LogStreamBatchWriterImpl::new));
+    return writerFuture;
+  }
+
+  @Override
+  public void registerRecordAvailableListener(final LogRecordAwaiter recordAwaiter) {
+    actor.call(() -> recordAwaiters.add(recordAwaiter));
+  }
+
+  @Override
+  public void removeRecordAvailableListener(final LogRecordAwaiter recordAwaiter) {
+    actor.call(() -> recordAwaiters.remove(recordAwaiter));
+  }
+
+  private void notifyRecordAwaiters() {
+    recordAwaiters.forEach(LogRecordAwaiter::onRecordAvailable);
   }
 
   @Override

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import org.slf4j.Logger;
@@ -75,6 +76,13 @@ public final class LogStreamImpl extends Actor
     closeFuture = new CompletableActorFuture<>();
 
     readers = new ArrayList<>();
+  }
+
+  @Override
+  protected Map<String, String> createContext() {
+    final var context = super.createContext();
+    context.put(ACTOR_PROP_PARTITION_ID, Integer.toString(partitionId));
+    return context;
   }
 
   @Override

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -63,6 +64,7 @@ public final class FileBasedSnapshotStore extends Actor
   private final AtomicLong receivingSnapshotStartCount;
   private final Set<PersistableSnapshot> pendingSnapshots = new HashSet<>();
   private final String actorName;
+  private final int partitionId;
 
   public FileBasedSnapshotStore(
       final int nodeId,
@@ -77,6 +79,14 @@ public final class FileBasedSnapshotStore extends Actor
 
     listeners = new CopyOnWriteArraySet<>();
     actorName = buildActorName(nodeId, "SnapshotStore", partitionId);
+    this.partitionId = partitionId;
+  }
+
+  @Override
+  protected Map<String, String> createContext() {
+    final var context = super.createContext();
+    context.put(ACTOR_PROP_PARTITION_ID, Integer.toString(partitionId));
+    return context;
   }
 
   @Override

--- a/util/src/main/java/io/camunda/zeebe/util/sched/Actor.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/Actor.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.util.sched;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.Loggers;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
@@ -25,6 +25,15 @@ public abstract class Actor implements CloseableSilently, AsyncClosable, Concurr
   protected final ActorControl actor = new ActorControl(this);
   private Map<String, String> context;
 
+  /**
+   * Should be overwritten by sub classes to add more context where the actor is run.
+   *
+   * @return the context of the actor
+   */
+  protected Map<String, String> createContext() {
+    return Map.of(ACTOR_PROP_NAME, getName());
+  }
+
   public String getName() {
     return getClass().getName();
   }
@@ -35,10 +44,8 @@ public abstract class Actor implements CloseableSilently, AsyncClosable, Concurr
    */
   public Map<String, String> getContext() {
     if (context == null) {
-      context = new HashMap<>();
-      context.put(ACTOR_PROP_NAME, getName());
+      context = Collections.unmodifiableMap(createContext());
     }
-
     return context;
   }
 

--- a/util/src/main/java/io/camunda/zeebe/util/sched/Actor.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/Actor.java
@@ -23,6 +23,7 @@ public abstract class Actor implements CloseableSilently, AsyncClosable, Concurr
 
   private static final int MAX_CLOSE_TIMEOUT = 300;
   protected final ActorControl actor = new ActorControl(this);
+  private Map<String, String> context;
 
   public String getName() {
     return getClass().getName();
@@ -33,8 +34,11 @@ public abstract class Actor implements CloseableSilently, AsyncClosable, Concurr
    *     map with the actor name. Ideally sub classes add more context, like the partition id etc.
    */
   public Map<String, String> getContext() {
-    final var context = new HashMap<String, String>();
-    context.put(ACTOR_PROP_NAME, getName());
+    if (context == null) {
+      context = new HashMap<>();
+      context.put(ACTOR_PROP_NAME, getName());
+    }
+
     return context;
   }
 

--- a/util/src/main/java/io/camunda/zeebe/util/sched/Actor.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/Actor.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.Loggers;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
@@ -31,7 +32,10 @@ public abstract class Actor implements CloseableSilently, AsyncClosable, Concurr
    * @return the context of the actor
    */
   protected Map<String, String> createContext() {
-    return Map.of(ACTOR_PROP_NAME, getName());
+    // return an modifiable map in order to simplify sub class implementation
+    final var baseContext = new HashMap<String, String>();
+    baseContext.put(ACTOR_PROP_NAME, getName());
+    return baseContext;
   }
 
   public String getName() {

--- a/util/src/main/java/io/camunda/zeebe/util/sched/Actor.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/Actor.java
@@ -18,8 +18,8 @@ import java.util.function.Consumer;
 
 public abstract class Actor implements CloseableSilently, AsyncClosable, ConcurrencyControl {
 
-  public static String ACTOR_PROP_NAME = "actor-name";
-  public static String ACTOR_PROP_PARTITION_ID = "partitionId";
+  public static final String ACTOR_PROP_NAME = "actor-name";
+  public static final String ACTOR_PROP_PARTITION_ID = "partitionId";
 
   private static final int MAX_CLOSE_TIMEOUT = 300;
   protected final ActorControl actor = new ActorControl(this);

--- a/util/src/main/java/io/camunda/zeebe/util/sched/Actor.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/Actor.java
@@ -10,17 +10,32 @@ package io.camunda.zeebe.util.sched;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.Loggers;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public abstract class Actor implements CloseableSilently, AsyncClosable, ConcurrencyControl {
 
+  public static String ACTOR_PROP_NAME = "actor-name";
+  public static String ACTOR_PROP_PARTITION_ID = "partitionId";
+
   private static final int MAX_CLOSE_TIMEOUT = 300;
   protected final ActorControl actor = new ActorControl(this);
 
   public String getName() {
     return getClass().getName();
+  }
+
+  /**
+   * @return a map which defines the context where the actor is run. Per default it just returns a
+   *     map with the actor name. Ideally sub classes add more context, like the partition id etc.
+   */
+  public Map<String, String> getContext() {
+    final var context = new HashMap<String, String>();
+    context.put(ACTOR_PROP_NAME, getName());
+    return context;
   }
 
   public boolean isActorClosed() {

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorThread.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorThread.java
@@ -85,7 +85,8 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
   }
 
   private void executeCurrentTask() {
-    MDC.put("actor-name", currentTask.getName());
+    final var properties = currentTask.getActor().getContext();
+    MDC.setContextMap(properties);
     idleStrategy.onTaskExecuted();
 
     boolean resubmit = false;


### PR DESCRIPTION
## Description

 * Add the partition id explicitly to the raft context 
 * Set the partition id to the MDC on the first raft thread execution
 * Add a context map to the actor which is used for the MDC on exection

@npepinpe please take a look at this and let me know whether this approach makes sense to you. If this is the case I will change sub classes of the Actor class to add there partition id to the context.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda-cloud/zeebe/issues/7859

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
