### PR TITLE
Fix NPE during shutdown

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterServicesCreationStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterServicesCreationStep.java
@@ -51,7 +51,7 @@ final class ClusterServicesCreationStep extends AbstractBrokerStartupStep {
             concurrencyControl.run(
                 () -> {
                   brokerShutdownContext.setClusterServices(null);
-                  shutdownFuture.complete(null);
+                  shutdownFuture.complete(brokerShutdownContext);
                 });
           }
         });

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ClusterServicesCreationStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ClusterServicesCreationStepTest.java
@@ -60,6 +60,7 @@ public class ClusterServicesCreationStepTest {
     // then
     assertThat(future.isDone()).isTrue();
     assertThat(future.isCompletedExceptionally()).isFalse();
+    assertThat(future.join()).isNotNull();
   }
 
   @Test
@@ -81,6 +82,7 @@ public class ClusterServicesCreationStepTest {
     // then
     assertThat(future.isDone()).isTrue();
     assertThat(future.isCompletedExceptionally()).isFalse();
+    assertThat(future.join()).isNotNull();
   }
 
   @Test


### PR DESCRIPTION
## Description

Fixes a NPE during shutdown. (see e.g. here for an instance of the NPE: https://ci.zeebe.camunda.cloud/job/camunda-cloud/job/zeebe/job/7873-fix-intermittent-role-transitions/8/testReport/junit/io.camunda.zeebe.broker.exporter/ExporterManagerPartitionTest(java-testrun)/Verify___Test__Java____shouldRunExporterForEveryPartition/)

<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
