### PR TITLE
Migrate disk monitor step

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContext.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
 import java.util.Collection;
 
@@ -24,7 +25,14 @@ public interface BrokerContext {
 
   CommandApiService getCommandApiService();
 
-  Collection<? extends DiskSpaceUsageListener> getDiskSpaceUsageListeners();
-
   EmbeddedGatewayService getEmbeddedGatewayService();
+
+  void addDiskSpaceUsageListener(DiskSpaceUsageListener diskSpaceUsageListener);
+
+  /**
+   * Returns disk space usage monitor. May be {@code null} if disabled in configuration
+   *
+   * @return disk space usage monitor. May be {@code null} if disabled in configuration
+   */
+  DiskSpaceUsageMonitor getDiskSpaceUsageMonitor();
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContextImpl.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
 import java.util.Collection;
 import java.util.List;
@@ -23,20 +24,21 @@ public final class BrokerContextImpl implements BrokerContext {
   private final ClusterServicesImpl clusterServices;
   private final CommandApiService commandApiService;
   private final EmbeddedGatewayService embeddedGatewayService;
+  private final DiskSpaceUsageMonitor diskSpaceUsageMonitor;
   private final List<PartitionListener> partitionListeners;
-  private final List<DiskSpaceUsageListener> diskSpaceUsageListeners;
 
   public BrokerContextImpl(
+      final DiskSpaceUsageMonitor diskSpaceUsageMonitor,
       final ClusterServicesImpl clusterServices,
       final CommandApiService commandApiService,
       final EmbeddedGatewayService embeddedGatewayService,
-      final List<PartitionListener> partitionListeners,
-      final List<DiskSpaceUsageListener> diskSpaceUsageListeners) {
+      final List<PartitionListener> partitionListeners) {
+    this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
     this.clusterServices = requireNonNull(clusterServices);
     this.commandApiService = requireNonNull(commandApiService);
     this.embeddedGatewayService = embeddedGatewayService;
+
     this.partitionListeners = unmodifiableList(requireNonNull(partitionListeners));
-    this.diskSpaceUsageListeners = diskSpaceUsageListeners;
   }
 
   @Override
@@ -55,12 +57,19 @@ public final class BrokerContextImpl implements BrokerContext {
   }
 
   @Override
-  public List<DiskSpaceUsageListener> getDiskSpaceUsageListeners() {
-    return diskSpaceUsageListeners;
+  public EmbeddedGatewayService getEmbeddedGatewayService() {
+    return embeddedGatewayService;
   }
 
   @Override
-  public EmbeddedGatewayService getEmbeddedGatewayService() {
-    return embeddedGatewayService;
+  public void addDiskSpaceUsageListener(final DiskSpaceUsageListener diskSpaceUsageListener) {
+    if (diskSpaceUsageMonitor != null) {
+      diskSpaceUsageMonitor.addDiskUsageListener(diskSpaceUsageListener);
+    }
+  }
+
+  @Override
+  public DiskSpaceUsageMonitor getDiskSpaceUsageMonitor() {
+    return diskSpaceUsageMonitor;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
@@ -60,8 +61,6 @@ public interface BrokerStartupContext {
 
   void removeDiskSpaceUsageListener(DiskSpaceUsageListener listener);
 
-  List<DiskSpaceUsageListener> getDiskSpaceUsageListeners();
-
   CommandApiServiceImpl getCommandApiService();
 
   void setCommandApiService(CommandApiServiceImpl commandApiService);
@@ -82,4 +81,8 @@ public interface BrokerStartupContext {
   EmbeddedGatewayService getEmbeddedGatewayService();
 
   void setEmbeddedGatewayService(EmbeddedGatewayService embeddedGatewayService);
+
+  DiskSpaceUsageMonitor getDiskSpaceUsageMonitor();
+
+  void setDiskSpaceUsageMonitor(DiskSpaceUsageMonitor diskSpaceUsageMonitor);
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -45,6 +45,12 @@ public final class BrokerStartupProcess {
 
   private List<StartupStep<BrokerStartupContext>> buildStartupSteps(final BrokerCfg config) {
     final var result = new ArrayList<StartupStep<BrokerStartupContext>>();
+
+    if (config.getData().isDiskUsageMonitoringEnabled()) {
+      // must be executed before any disk space usage listeners are registered
+      result.add(new DiskSpaceUsageMonitorStep());
+    }
+
     result.add(new MonitoringServerStep());
     result.add(new ClusterServicesCreationStep());
     result.add(new CommandApiServiceStep());
@@ -95,10 +101,10 @@ public final class BrokerStartupProcess {
 
   private BrokerContext createBrokerContext(final BrokerStartupContext bsc) {
     return new BrokerContextImpl(
+        bsc.getDiskSpaceUsageMonitor(),
         bsc.getClusterServices(),
         bsc.getCommandApiService(),
         bsc.getEmbeddedGatewayService(),
-        bsc.getPartitionListeners(),
-        bsc.getDiskSpaceUsageListeners());
+        bsc.getPartitionListeners());
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/DiskSpaceUsageMonitorStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/DiskSpaceUsageMonitorStep.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
+import io.camunda.zeebe.util.FileUtil;
+import io.camunda.zeebe.util.sched.ConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+public class DiskSpaceUsageMonitorStep extends AbstractBrokerStartupStep {
+
+  @Override
+  void startupInternal(
+      final BrokerStartupContext brokerStartupContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> startupFuture) {
+
+    final var data = brokerStartupContext.getBrokerConfiguration().getData();
+    try {
+      FileUtil.ensureDirectoryExists(Paths.get(data.getDirectory()));
+    } catch (final IOException e) {
+      startupFuture.completeExceptionally(e);
+      return;
+    }
+
+    final var diskSpaceUsageMonitor = new DiskSpaceUsageMonitor(data);
+
+    final var actorStartFuture =
+        brokerStartupContext.getActorSchedulingService().submitActor(diskSpaceUsageMonitor);
+
+    brokerStartupContext
+        .getConcurrencyControl()
+        .runOnCompletion(
+            actorStartFuture,
+            (ok, error) -> {
+              if (error != null) {
+                startupFuture.completeExceptionally(error);
+                return;
+              }
+
+              brokerStartupContext.setDiskSpaceUsageMonitor(diskSpaceUsageMonitor);
+              startupFuture.complete(brokerStartupContext);
+            });
+  }
+
+  @Override
+  void shutdownInternal(
+      final BrokerStartupContext brokerShutdownContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> shutdownFuture) {
+
+    final var diskSpaceUsageMonitor = brokerShutdownContext.getDiskSpaceUsageMonitor();
+
+    if (diskSpaceUsageMonitor != null) {
+      final var closeFuture = diskSpaceUsageMonitor.closeAsync();
+      concurrencyControl.runOnCompletion(
+          closeFuture,
+          (ok, error) -> {
+            if (error != null) {
+              shutdownFuture.completeExceptionally(error);
+              return;
+            }
+
+            forwardExceptions(
+                () ->
+                    concurrencyControl.run(
+                        () ->
+                            forwardExceptions(
+                                () -> {
+                                  brokerShutdownContext.setDiskSpaceUsageMonitor(null);
+                                  shutdownFuture.complete(brokerShutdownContext);
+                                },
+                                shutdownFuture)),
+                shutdownFuture);
+          });
+    } else {
+      shutdownFuture.complete(brokerShutdownContext);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return "Disk Space Usage Monitor";
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/DiskSpaceUsageMonitorStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/DiskSpaceUsageMonitorStepTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
+import io.camunda.zeebe.util.sched.TestConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+public class DiskSpaceUsageMonitorStepTest {
+  private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
+  private static final BrokerCfg TEST_BROKER_CONFIG = new BrokerCfg();
+
+  private BrokerStartupContext mockBrokerStartupContext;
+  private ActorSchedulingService mockActorSchedulingService;
+  private DiskSpaceUsageMonitor mockDiskSpaceUsageMonitor;
+
+  private ActorFuture<BrokerStartupContext> future;
+
+  private final DiskSpaceUsageMonitorStep sut = new DiskSpaceUsageMonitorStep();
+
+  @BeforeEach
+  void setUp() {
+    mockBrokerStartupContext = mock(BrokerStartupContext.class);
+    mockActorSchedulingService = mock(ActorSchedulingService.class);
+    mockDiskSpaceUsageMonitor = mock(DiskSpaceUsageMonitor.class);
+
+    when(mockBrokerStartupContext.getBrokerConfiguration()).thenReturn(TEST_BROKER_CONFIG);
+    when(mockBrokerStartupContext.getConcurrencyControl()).thenReturn(CONCURRENCY_CONTROL);
+    when(mockBrokerStartupContext.getActorSchedulingService())
+        .thenReturn(mockActorSchedulingService);
+    when(mockBrokerStartupContext.getDiskSpaceUsageMonitor()).thenReturn(mockDiskSpaceUsageMonitor);
+    when(mockDiskSpaceUsageMonitor.closeAsync())
+        .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
+
+    when(mockActorSchedulingService.submitActor(any()))
+        .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
+
+    future = CONCURRENCY_CONTROL.createFuture();
+  }
+
+  @Test
+  void shouldCompleteFutureOnStartup() {
+    // when
+    sut.startupInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isFalse();
+  }
+
+  @Test
+  void shouldScheduleDiskSpaceUsageMonitorOnStartup() {
+    // when
+    sut.startupInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+
+    // then
+    final var argumentCaptor = ArgumentCaptor.forClass(DiskSpaceUsageMonitor.class);
+    verify(mockBrokerStartupContext).setDiskSpaceUsageMonitor(argumentCaptor.capture());
+    verify(mockActorSchedulingService).submitActor(argumentCaptor.getValue());
+  }
+
+  @Test
+  void shouldCompleteFutureOnShutdown() {
+    // when
+    sut.shutdownInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isFalse();
+  }
+
+  @Test
+  void shouldStopHealthCheckServiceOnShutdown() {
+    // when
+    sut.shutdownInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+
+    // then
+    verify(mockDiskSpaceUsageMonitor).closeAsync();
+    verify(mockBrokerStartupContext).setDiskSpaceUsageMonitor(null);
+  }
+}


### PR DESCRIPTION
## Description
Migrates disk space monitor step. Also changes order such that disk space usage monitor is executed first.

## Review Hints
* there will be follow up PR for all step unit tests to remove public identifiers, change assertions to wait for futures and stuff like that

## Related issues

closes #7539

<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
