### PR TITLE
Enqueue transitions again

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.broker.system.partitions.impl;
 
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 import io.atomix.raft.RaftServer.Role;
@@ -29,10 +28,10 @@ public final class NewPartitionTransitionImpl implements PartitionTransition {
   private PartitionTransitionContext context;
   private ConcurrencyControl concurrencyControl;
   private PartitionTransitionProcess lastTransition;
-  // these two should be set/cleared in tandem
+
+  // transient state - to keep track of the current transitions
   private PartitionTransitionProcess currentTransition;
   private ActorFuture<Void> currentTransitionFuture;
-  // these two should be set in tandem
 
   public NewPartitionTransitionImpl(
       final List<PartitionTransitionStep> steps, final PartitionTransitionContext context) {
@@ -66,74 +65,91 @@ public final class NewPartitionTransitionImpl implements PartitionTransition {
   }
 
   public ActorFuture<Void> transitionTo(final long term, final Role role) {
-    LOG.info(format("Transition to %s on term %d requested.", role, term));
+    LOG.info("Transition to {} on term {} requested.", role, term);
 
     // notify steps immediately that a transition is coming; steps are encouraged to cancel any
     // ongoing activity at this point in time
     steps.forEach(step -> step.onNewRaftRole(context, role));
 
     final ActorFuture<Void> nextTransitionFuture = concurrencyControl.createFuture();
-
     concurrencyControl.run(
         () -> {
-          if (currentTransition != null) {
-            LOG.info(
-                format(
-                    "Transition to %s on term %d requested while another transition is still running",
-                    role, term));
-            currentTransition.cancel(); // this will drop any subsequent transition steps
+          final var nextTransition =
+              new PartitionTransitionProcess(steps, concurrencyControl, context, term, role);
+          nextTransitionFuture.onComplete(
+              (v, error) -> {
+                // term and role should only bet set after the transition is completed, since on
+                // clean up
+                // we expect old term and role to make decision based on that
+                if (error == null) {
+                  context.setCurrentTerm(term);
+                  context.setCurrentRole(role);
+                }
+                lastTransition = nextTransition;
+              });
 
-            // schedule new transition as soon as the current step of the current transition
-            // has completed
-            concurrencyControl.runOnCompletion(
-                currentTransitionFuture,
-                (ok, error) -> cleanupLastTransition(nextTransitionFuture, term, role));
-
-          } else {
-            cleanupLastTransition(nextTransitionFuture, term, role);
-          }
+          enqueueNextTransition(term, role, nextTransitionFuture, nextTransition);
         });
+
     return nextTransitionFuture;
   }
 
-  private void cleanupLastTransition(
-      final ActorFuture<Void> nextTransitionFuture, final long term, final Role role) {
+  /**
+   * Enqueues the new next transition after the current ongoing transition. It will cancel the
+   * ongoing transition to speed up the process of execution.
+   */
+  private void enqueueNextTransition(
+      final long term,
+      final Role role,
+      final ActorFuture<Void> nextTransitionFuture,
+      final PartitionTransitionProcess nextTransition) {
+    final ActorFuture<Void> ongoingTransitionFuture;
+    if (currentTransition == null) {
+      // we run our first transition nothing to cancel nor to enqueue
+      ongoingTransitionFuture = concurrencyControl.createCompletedFuture();
+    } else {
+      // we can be sure that the currentTransitionFuture is also set, since it is always set
+      // with the currentTransition
+      ongoingTransitionFuture = currentTransitionFuture;
+
+      final var ongoingTransition = currentTransition;
+      ongoingTransition.cancel();
+    }
+
+    // For safety reasons we have to immediately replace the current transition future with
+    // the next transition future, such that we make sure that we enqueue all transitions
+    // after another. We cancel current transitions to make the process faster.
+    currentTransitionFuture = nextTransitionFuture;
+    currentTransition = nextTransition;
+
+    ongoingTransitionFuture.onComplete(
+        (nothing, error) ->
+            performNextTransition(term, role, nextTransitionFuture, nextTransition));
+  }
+
+  /**
+   * Performs the next transition after the ongoing transition is completed. It will start to clean
+   * resources of the previous transition before performing the next transition.
+   */
+  private void performNextTransition(
+      final long term,
+      final Role role,
+      final ActorFuture<Void> nextTransitionFuture,
+      final PartitionTransitionProcess nextTransition) {
     if (lastTransition == null) {
-      startNewTransition(nextTransitionFuture, term, role);
+      nextTransition.start(nextTransitionFuture);
     } else {
       final var cleanupFuture = lastTransition.cleanup(term, role);
-      concurrencyControl.runOnCompletion(
-          cleanupFuture,
+      cleanupFuture.onComplete(
           (ok, error) -> {
             if (error != null) {
-              LOG.error(
-                  String.format("Error during transition clean up: %s", error.getMessage()), error);
-              LOG.info(
-                  String.format("Aborting transition to %s on term %d due to error.", role, term));
+              LOG.error("Error during transition clean up: {}", error.getMessage(), error);
+              LOG.info("Aborting transition to {} on term {} due to error.", role, term);
               nextTransitionFuture.completeExceptionally(error);
             } else {
-              startNewTransition(nextTransitionFuture, term, role);
+              nextTransition.start(nextTransitionFuture);
             }
           });
     }
-  }
-
-  private void startNewTransition(
-      final ActorFuture<Void> nextTransitionFuture, final long term, final Role role) {
-    currentTransition =
-        new PartitionTransitionProcess(steps, concurrencyControl, context, term, role);
-    currentTransitionFuture = nextTransitionFuture;
-    concurrencyControl.runOnCompletion(
-        currentTransitionFuture,
-        (ok, error) -> {
-          if (error == null) {
-            context.setCurrentTerm(term);
-            context.setCurrentRole(role);
-          }
-          lastTransition = currentTransition;
-          currentTransition = null;
-          currentTransitionFuture = null;
-        });
-    currentTransition.start(currentTransitionFuture);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
@@ -40,14 +40,6 @@ public final class NewPartitionTransitionImpl implements PartitionTransition {
     this.context = requireNonNull(context);
   }
 
-  public void setConcurrencyControl(final ConcurrencyControl concurrencyControl) {
-    this.concurrencyControl = requireNonNull(concurrencyControl);
-  }
-
-  public void updateTransitionContext(final PartitionTransitionContext transitionContext) {
-    context = transitionContext;
-  }
-
   @Override
   public ActorFuture<Void> toFollower(final long term) {
     return transitionTo(term, Role.FOLLOWER);
@@ -61,6 +53,16 @@ public final class NewPartitionTransitionImpl implements PartitionTransition {
   @Override
   public ActorFuture<Void> toInactive() {
     return transitionTo(INACTIVE_TERM, Role.INACTIVE);
+  }
+
+  @Override
+  public void setConcurrencyControl(final ConcurrencyControl concurrencyControl) {
+    this.concurrencyControl = requireNonNull(concurrencyControl);
+  }
+
+  @Override
+  public void updateTransitionContext(final PartitionTransitionContext transitionContext) {
+    context = transitionContext;
   }
 
   public ActorFuture<Void> transitionTo(final long term, final Role role) {

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ConcurrencyControl.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ConcurrencyControl.java
@@ -42,4 +42,14 @@ public interface ConcurrencyControl {
   default <V> ActorFuture<V> createFuture() {
     return new CompletableActorFuture<>();
   }
+
+  /**
+   * Create a new completed future object
+   *
+   * @param <V> value type of future
+   * @return new completed future object
+   */
+  default <V> ActorFuture<V> createCompletedFuture() {
+    return CompletableActorFuture.completed(null);
+  }
 }

--- a/util/src/test/java/io/camunda/zeebe/util/sched/TestConcurrencyControl.java
+++ b/util/src/test/java/io/camunda/zeebe/util/sched/TestConcurrencyControl.java
@@ -49,6 +49,11 @@ public class TestConcurrencyControl implements ConcurrencyControl {
     return new TestActorFuture<>();
   }
 
+  @Override
+  public <V> ActorFuture<V> createCompletedFuture() {
+    return completedFuture(null);
+  }
+
   public <U> ActorFuture<U> completedFuture(final U value) {
     final ActorFuture<U> result = createFuture();
     result.complete(value);


### PR DESCRIPTION
## Description

First commit adds failing tests in regards to our issue. As discussed I changed the transition logic again to enqueuing on the transition futures, which means we will executed all transitions in order. 

I don't know who want to review it @npepinpe @pihme @deepthidevaki let me know what you think
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7873 
closes https://github.com/camunda-cloud/zeebe/issues/7880

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
