### PR TITLE
Migrate leader management request handler step

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContext.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.bootstrap;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
+import io.camunda.zeebe.broker.system.management.deployment.PushDeploymentRequestHandler;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
@@ -35,4 +36,6 @@ public interface BrokerContext {
    * @return disk space usage monitor. May be {@code null} if disabled in configuration
    */
   DiskSpaceUsageMonitor getDiskSpaceUsageMonitor();
+
+  PushDeploymentRequestHandler getPushDeploymentRequestHandler();
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContextImpl.java
@@ -13,6 +13,8 @@ import static java.util.Objects.requireNonNull;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
+import io.camunda.zeebe.broker.system.management.LeaderManagementRequestHandler;
+import io.camunda.zeebe.broker.system.management.deployment.PushDeploymentRequestHandler;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
@@ -26,17 +28,20 @@ public final class BrokerContextImpl implements BrokerContext {
   private final EmbeddedGatewayService embeddedGatewayService;
   private final DiskSpaceUsageMonitor diskSpaceUsageMonitor;
   private final List<PartitionListener> partitionListeners;
+  private final LeaderManagementRequestHandler leaderManagementRequestHandler;
 
   public BrokerContextImpl(
       final DiskSpaceUsageMonitor diskSpaceUsageMonitor,
       final ClusterServicesImpl clusterServices,
       final CommandApiService commandApiService,
       final EmbeddedGatewayService embeddedGatewayService,
+      final LeaderManagementRequestHandler leaderManagementRequestHandler,
       final List<PartitionListener> partitionListeners) {
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
     this.clusterServices = requireNonNull(clusterServices);
     this.commandApiService = requireNonNull(commandApiService);
     this.embeddedGatewayService = embeddedGatewayService;
+    this.leaderManagementRequestHandler = requireNonNull(leaderManagementRequestHandler);
 
     this.partitionListeners = unmodifiableList(requireNonNull(partitionListeners));
   }
@@ -71,5 +76,10 @@ public final class BrokerContextImpl implements BrokerContext {
   @Override
   public DiskSpaceUsageMonitor getDiskSpaceUsageMonitor() {
     return diskSpaceUsageMonitor;
+  }
+
+  @Override
+  public PushDeploymentRequestHandler getPushDeploymentRequestHandler() {
+    return leaderManagementRequestHandler.getPushDeploymentRequestHandler();
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.engine.impl.SubscriptionApiCommandMessageHandlerService;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.management.LeaderManagementRequestHandler;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
@@ -85,4 +86,8 @@ public interface BrokerStartupContext {
   DiskSpaceUsageMonitor getDiskSpaceUsageMonitor();
 
   void setDiskSpaceUsageMonitor(DiskSpaceUsageMonitor diskSpaceUsageMonitor);
+
+  LeaderManagementRequestHandler getLeaderManagementRequestHandler();
+
+  void setLeaderManagementRequestHandler(final LeaderManagementRequestHandler handler);
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.engine.impl.SubscriptionApiCommandMessageHandlerService;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.management.LeaderManagementRequestHandler;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
@@ -48,6 +49,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private CommandApiServiceImpl commandApiService;
   private SubscriptionApiCommandMessageHandlerService subscriptionApiService;
   private EmbeddedGatewayService embeddedGatewayService;
+  private LeaderManagementRequestHandler leaderManagementRequestHandler;
 
   public BrokerStartupContextImpl(
       final BrokerInfo brokerInfo,
@@ -201,5 +203,16 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public void setDiskSpaceUsageMonitor(final DiskSpaceUsageMonitor diskSpaceUsageMonitor) {
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
+  }
+
+  @Override
+  public LeaderManagementRequestHandler getLeaderManagementRequestHandler() {
+    return leaderManagementRequestHandler;
+  }
+
+  @Override
+  public void setLeaderManagementRequestHandler(
+      final LeaderManagementRequestHandler leaderManagementRequestHandler) {
+    this.leaderManagementRequestHandler = leaderManagementRequestHandler;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -61,6 +61,8 @@ public final class BrokerStartupProcess {
       result.add(new EmbeddedGatewayServiceStep());
     }
 
+    result.add(new LeaderManagementRequestHandlerStep());
+
     return result;
   }
 
@@ -105,6 +107,7 @@ public final class BrokerStartupProcess {
         bsc.getClusterServices(),
         bsc.getCommandApiService(),
         bsc.getEmbeddedGatewayService(),
+        bsc.getLeaderManagementRequestHandler(),
         bsc.getPartitionListeners());
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/LeaderManagementRequestHandlerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/LeaderManagementRequestHandlerStep.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import io.camunda.zeebe.broker.system.management.LeaderManagementRequestHandler;
+import io.camunda.zeebe.util.sched.ConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+
+final class LeaderManagementRequestHandlerStep extends AbstractBrokerStartupStep {
+
+  @Override
+  public String getName() {
+    return "Leader Management Request Handler";
+  }
+
+  @Override
+  void startupInternal(
+      final BrokerStartupContext brokerStartupContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> startupFuture) {
+
+    final var brokerInfo = brokerStartupContext.getBrokerInfo();
+    final var clusterServices = brokerStartupContext.getClusterServices();
+
+    final var managementRequestHandler =
+        new LeaderManagementRequestHandler(
+            brokerInfo,
+            clusterServices.getCommunicationService(),
+            clusterServices.getEventService());
+
+    final var actorStartFuture =
+        brokerStartupContext.getActorSchedulingService().submitActor(managementRequestHandler);
+
+    concurrencyControl.runOnCompletion(
+        actorStartFuture,
+        (ok, error) -> {
+          if (error != null) {
+            startupFuture.completeExceptionally(error);
+            return;
+          }
+
+          forwardExceptions(
+              () -> {
+                brokerStartupContext.addPartitionListener(managementRequestHandler);
+                brokerStartupContext.addDiskSpaceUsageListener(managementRequestHandler);
+
+                brokerStartupContext.setLeaderManagementRequestHandler(managementRequestHandler);
+
+                startupFuture.complete(brokerStartupContext);
+              },
+              startupFuture);
+        });
+  }
+
+  @Override
+  void shutdownInternal(
+      final BrokerStartupContext brokerShutdownContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> shutdownFuture) {
+
+    final var handler = brokerShutdownContext.getLeaderManagementRequestHandler();
+
+    if (handler == null) {
+      shutdownFuture.complete(brokerShutdownContext);
+      return;
+    }
+
+    final var closeFuture = handler.closeAsync();
+
+    concurrencyControl.runOnCompletion(
+        closeFuture,
+        (ok, error) -> {
+          if (error != null) {
+            shutdownFuture.completeExceptionally(error);
+            return;
+          }
+
+          forwardExceptions(
+              () -> {
+                brokerShutdownContext.removeDiskSpaceUsageListener(handler);
+                brokerShutdownContext.removePartitionListener(handler);
+                brokerShutdownContext.setLeaderManagementRequestHandler(null);
+
+                shutdownFuture.complete(brokerShutdownContext);
+              },
+              shutdownFuture);
+        });
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/LeaderManagementRequestHandlerStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/LeaderManagementRequestHandlerStepTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
+import io.camunda.zeebe.broker.system.management.LeaderManagementRequestHandler;
+import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.camunda.zeebe.util.sched.ActorSchedulingService;
+import io.camunda.zeebe.util.sched.TestConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+public class LeaderManagementRequestHandlerStepTest {
+  private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
+
+  private BrokerStartupContext mockBrokerStartupContext;
+  private ActorSchedulingService mockActorSchedulingService;
+  private LeaderManagementRequestHandler mockLeaderManagementRequestHandler;
+
+  private ActorFuture<BrokerStartupContext> future;
+
+  private final LeaderManagementRequestHandlerStep sut = new LeaderManagementRequestHandlerStep();
+
+  @BeforeEach
+  void setUp() {
+    mockActorSchedulingService = mock(ActorSchedulingService.class);
+
+    when(mockActorSchedulingService.submitActor(any()))
+        .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
+
+    mockLeaderManagementRequestHandler = mock(LeaderManagementRequestHandler.class);
+    when(mockLeaderManagementRequestHandler.closeAsync())
+        .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
+
+    mockBrokerStartupContext = mock(BrokerStartupContext.class);
+
+    when(mockBrokerStartupContext.getConcurrencyControl()).thenReturn(CONCURRENCY_CONTROL);
+    when(mockBrokerStartupContext.getBrokerInfo()).thenReturn(mock(BrokerInfo.class));
+    when(mockBrokerStartupContext.getActorSchedulingService())
+        .thenReturn(mockActorSchedulingService);
+    when(mockBrokerStartupContext.getLeaderManagementRequestHandler())
+        .thenReturn(mockLeaderManagementRequestHandler);
+
+    when(mockBrokerStartupContext.getClusterServices())
+        .thenReturn(mock(ClusterServicesImpl.class, Mockito.RETURNS_DEEP_STUBS));
+
+    future = CONCURRENCY_CONTROL.createFuture();
+  }
+
+  @Test
+  void shouldCompleteFutureOnStartup() {
+    // when
+    sut.startupInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+    await().until(future::isDone);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isFalse();
+  }
+
+  @Test
+  void shouldScheduleLeaderManagementRequestHandlerActorOnStartup() {
+    // when
+    sut.startupInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+    await().until(future::isDone);
+
+    // then
+    final var argumentCaptor = ArgumentCaptor.forClass(LeaderManagementRequestHandler.class);
+    verify(mockActorSchedulingService).submitActor(argumentCaptor.capture());
+    verify(mockBrokerStartupContext).setLeaderManagementRequestHandler(argumentCaptor.getValue());
+  }
+
+  @Test
+  void shouldRegisterLeaderRequestManagementHandlerAsPartitionListenerOnStartup() {
+    // when
+    sut.startupInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+    await().until(future::isDone);
+
+    // then
+    final var argumentCaptor = ArgumentCaptor.forClass(LeaderManagementRequestHandler.class);
+    verify(mockBrokerStartupContext).setLeaderManagementRequestHandler(argumentCaptor.capture());
+    verify(mockBrokerStartupContext).addPartitionListener(argumentCaptor.getValue());
+  }
+
+  @Test
+  void shouldRegisterLeaderRequestManagementHandlerAsDiskSpaceListenerOnStartup() {
+    // when
+    sut.startupInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+    await().until(future::isDone);
+
+    // then
+    final var argumentCaptor = ArgumentCaptor.forClass(LeaderManagementRequestHandler.class);
+    verify(mockBrokerStartupContext).setLeaderManagementRequestHandler(argumentCaptor.capture());
+    verify(mockBrokerStartupContext).addDiskSpaceUsageListener(argumentCaptor.getValue());
+  }
+
+  @Test
+  void shouldCompleteFutureOnShutdown() {
+    // when
+    sut.shutdownInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+    await().until(future::isDone);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isFalse();
+  }
+
+  @Test
+  void shouldStopHealthCheckServiceOnShutdown() {
+    // when
+    sut.shutdownInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+    await().until(future::isDone);
+
+    // then
+    verify(mockLeaderManagementRequestHandler).closeAsync();
+    verify(mockBrokerStartupContext).setLeaderManagementRequestHandler(null);
+  }
+
+  @Test
+  void shouldRemoveLeaderRequestManagementHandlerAsPartitionListenerOnStartup() {
+    // when
+    sut.shutdownInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+    await().until(future::isDone);
+
+    // then
+    verify(mockBrokerStartupContext).removePartitionListener(mockLeaderManagementRequestHandler);
+  }
+
+  @Test
+  void shouldRemoveLeaderRequestManagementHandlerAsDiskSpaceListenerOnStartup() {
+    // when
+    sut.shutdownInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+    await().until(future::isDone);
+
+    // then
+    verify(mockBrokerStartupContext)
+        .removeDiskSpaceUsageListener(mockLeaderManagementRequestHandler);
+  }
+}


### PR DESCRIPTION
## Description

Migrate step that install the leader managerment request handler.

## Review Hints
* There will be a follow up PR to remove public from tests and use better assertions and stuff like this,

## Related issues

#7539 

<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
