### PR TITLE
Simplify interface for taking snapshots

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/StateController.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/StateController.java
@@ -10,18 +10,17 @@ package io.camunda.zeebe.broker.system.partitions;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
-import java.util.Optional;
 
 public interface StateController extends AutoCloseable {
   /**
    * Takes a snapshot based on the given position. The position is a last processed lower bound
-   * event position. When the returned future completes successfully and the optional is not empty,
-   * the transient snapshot will be valid.
+   * event position. When the returned future completes successfully the transient snapshot will be
+   * valid.
    *
    * @param lowerBoundSnapshotPosition the lower bound snapshot position
    * @return a future
    */
-  ActorFuture<Optional<TransientSnapshot>> takeTransientSnapshot(long lowerBoundSnapshotPosition);
+  ActorFuture<TransientSnapshot> takeTransientSnapshot(long lowerBoundSnapshotPosition);
 
   /**
    * Recovers the state from the snapshot and opens the database

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -243,8 +243,8 @@ public final class AsyncSnapshotDirector extends Actor
               LOG.debug("Did not take a snapshot. {}", snapshotTakenError.getMessage());
             } else {
               LOG.error("Failed to take a snapshot for {}", processorName, snapshotTakenError);
-              resetStateOnFailure();
             }
+            resetStateOnFailure();
             return;
           }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -13,6 +13,8 @@ import io.camunda.zeebe.broker.system.partitions.StateController;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorMode;
 import io.camunda.zeebe.logstreams.impl.Loggers;
+import io.camunda.zeebe.snapshots.SnapshotException;
+import io.camunda.zeebe.snapshots.SnapshotException.SnapshotNotFoundException;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
@@ -235,18 +237,18 @@ public final class AsyncSnapshotDirector extends Actor
     final var transientSnapshotFuture =
         stateController.takeTransientSnapshot(lowerBoundSnapshotPosition);
     transientSnapshotFuture.onComplete(
-        (optionalTransientSnapshot, snapshotTakenError) -> {
+        (transientSnapshot, snapshotTakenError) -> {
           if (snapshotTakenError != null) {
-            LOG.error("Could not take a snapshot for {}", processorName, snapshotTakenError);
-            resetStateOnFailure();
+            if (snapshotTakenError instanceof SnapshotException.SnapshotAlreadyExistsException) {
+              LOG.debug("Did not take a snapshot. Snapshot already exists.", snapshotTakenError);
+            } else {
+              LOG.error("Failed to take a snapshot for {}", processorName, snapshotTakenError);
+              resetStateOnFailure();
+            }
             return;
           }
 
-          if (optionalTransientSnapshot.isEmpty()) {
-            takingSnapshot = false;
-            return;
-          }
-          onTransientSnapshotTaken(optionalTransientSnapshot.get());
+          onTransientSnapshotTaken(transientSnapshot);
         });
   }
 
@@ -313,7 +315,14 @@ public final class AsyncSnapshotDirector extends Actor
       snapshotPersistFuture.onComplete(
           (snapshot, persistError) -> {
             if (persistError != null) {
-              LOG.error(ERROR_MSG_MOVE_SNAPSHOT, persistError);
+              if (persistError instanceof SnapshotNotFoundException) {
+                LOG.warn(
+                    "Failed to persist transient snapshot {}. Nothing to worry if a newer snapshot exists.",
+                    pendingSnapshot,
+                    persistError);
+              } else {
+                LOG.error(ERROR_MSG_MOVE_SNAPSHOT, persistError);
+              }
             }
             lastWrittenEventPosition = null;
             takingSnapshot = false;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -240,7 +240,7 @@ public final class AsyncSnapshotDirector extends Actor
         (transientSnapshot, snapshotTakenError) -> {
           if (snapshotTakenError != null) {
             if (snapshotTakenError instanceof SnapshotException.SnapshotAlreadyExistsException) {
-              LOG.debug("Did not take a snapshot. Snapshot already exists.", snapshotTakenError);
+              LOG.debug("Did not take a snapshot. {}", snapshotTakenError.getMessage());
             } else {
               LOG.error("Failed to take a snapshot for {}", processorName, snapshotTakenError);
               resetStateOnFailure();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -155,7 +155,7 @@ public class StateControllerImpl implements StateController {
     }
 
     final var snapshotIndexedEntry = optionalIndexed.get();
-    final Optional<TransientSnapshot> transientSnapshot =
+    final var transientSnapshot =
         constructableSnapshotStore.newTransientSnapshot(
             snapshotIndexedEntry.index(),
             snapshotIndexedEntry.term(),
@@ -163,8 +163,11 @@ public class StateControllerImpl implements StateController {
             exportedPosition);
 
     // Now takeSnapshot result can be either true, false or error.
-    transientSnapshot.ifPresentOrElse(
-        snapshot -> takeSnapshot(snapshot, future), () -> future.complete(Optional.empty()));
+    if (transientSnapshot.isLeft()) {
+      future.complete(Optional.empty());
+    } else {
+      takeSnapshot(transientSnapshot.get(), future);
+    }
   }
 
   @SuppressWarnings("rawtypes")

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/ConstructableSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/ConstructableSnapshotStore.java
@@ -19,8 +19,7 @@ public interface ConstructableSnapshotStore extends PersistedSnapshotStore {
    * @param term the term to which the snapshots corresponds to
    * @param processedPosition the processed position in the snapshot
    * @param exportedPosition the exported position in the snapshot
-   * @return an Either that contains and exception or transientSnapshot if it was taken
-   *     successfully.
+   * @return either an exception or transientSnapshot, if it was taken successfully.
    */
   Either<SnapshotException, TransientSnapshot> newTransientSnapshot(
       long index, long term, long processedPosition, long exportedPosition);

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/ConstructableSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/ConstructableSnapshotStore.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.snapshots;
 
-import java.util.Optional;
+import io.camunda.zeebe.util.Either;
 
 /** A persisted snapshot store than can create a new snapshot and persists it. */
 public interface ConstructableSnapshotStore extends PersistedSnapshotStore {
@@ -19,9 +19,9 @@ public interface ConstructableSnapshotStore extends PersistedSnapshotStore {
    * @param term the term to which the snapshots corresponds to
    * @param processedPosition the processed position in the snapshot
    * @param exportedPosition the exported position in the snapshot
-   * @return an optional with a transient snapshot if new transient snapshot was taken successfully,
-   *     otherwise return an empty optional
+   * @return an Either that contains and exception or transientSnapshot if it was taken
+   *     successfully.
    */
-  Optional<TransientSnapshot> newTransientSnapshot(
+  Either<SnapshotException, TransientSnapshot> newTransientSnapshot(
       long index, long term, long processedPosition, long exportedPosition);
 }

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotException.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotException.java
@@ -18,4 +18,16 @@ public class SnapshotException extends RuntimeException {
       super(message);
     }
   }
+
+  public static class StateClosedException extends SnapshotException {
+    public StateClosedException(final String message) {
+      super(message);
+    }
+  }
+
+  public static class SnapshotNotFoundException extends SnapshotException {
+    public SnapshotNotFoundException(final String message) {
+      super(message);
+    }
+  }
 }

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotException.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.snapshots;
+
+public class SnapshotException extends RuntimeException {
+
+  public SnapshotException(final String message) {
+    super(message);
+  }
+
+  public static class SnapshotAlreadyExistsException extends SnapshotException {
+    public SnapshotAlreadyExistsException(final String message) {
+      super(message);
+    }
+  }
+}

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/TransientSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/TransientSnapshot.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.snapshots;
 
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import java.nio.file.Path;
-import java.util.function.Predicate;
+import java.util.function.Consumer;
 
 /** A transient snapshot which can be persisted after taking a snapshot. */
 public interface TransientSnapshot extends PersistableSnapshot {
@@ -23,5 +23,5 @@ public interface TransientSnapshot extends PersistableSnapshot {
    *     success
    * @return true on success, false otherwise
    */
-  ActorFuture<Boolean> take(Predicate<Path> takeSnapshot);
+  ActorFuture<Void> take(Consumer<Path> takeSnapshot);
 }

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
@@ -119,14 +119,14 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
       return;
     }
 
-    if (!takenFuture.isDone()) {
+    if (!takenFuture.isDone() || takenFuture.isCompletedExceptionally()) {
       future.completeExceptionally(new IllegalStateException("Snapshot is not taken"));
       return;
     }
 
     if (!isValid) {
       future.completeExceptionally(
-          new SnapshotNotFoundException("Snapshot is not valid. It may have been deleted."));
+          new SnapshotNotFoundException("Snapshot may have been already deleted."));
       return;
     }
 

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.snapshots.impl;
 
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.snapshots.SnapshotException.SnapshotNotFoundException;
 import io.camunda.zeebe.snapshots.SnapshotId;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
 import io.camunda.zeebe.util.FileUtil;
@@ -125,7 +126,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
 
     if (!isValid) {
       future.completeExceptionally(
-          new IllegalStateException("Snapshot is not valid. It may have been deleted."));
+          new SnapshotNotFoundException("Snapshot is not valid. It may have been deleted."));
       return;
     }
 

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.function.Predicate;
+import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +31,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
   private final ActorControl actor;
   private final FileBasedSnapshotStore snapshotStore;
   private final FileBasedSnapshotMetadata metadata;
-  private final ActorFuture<Boolean> takenFuture = new CompletableActorFuture<>();
+  private final ActorFuture<Void> takenFuture = new CompletableActorFuture<>();
   private boolean isValid = false;
   private PersistedSnapshot snapshot;
   private long checksum;
@@ -48,28 +48,34 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
   }
 
   @Override
-  public ActorFuture<Boolean> take(final Predicate<Path> takeSnapshot) {
+  public ActorFuture<Void> take(final Consumer<Path> takeSnapshot) {
     actor.run(() -> takeInternal(takeSnapshot));
     return takenFuture;
   }
 
-  private void takeInternal(final Predicate<Path> takeSnapshot) {
+  private void takeInternal(final Consumer<Path> takeSnapshot) {
     final var snapshotMetrics = snapshotStore.getSnapshotMetrics();
 
     try (final var ignored = snapshotMetrics.startTimer()) {
       try {
-        isValid = takeSnapshot.test(getPath());
-        if (!isValid) {
-          abortInternal();
-        } else if (!directory.toFile().exists() || directory.toFile().listFiles().length == 0) {
+        takeSnapshot.accept(getPath());
+        if (!directory.toFile().exists() || directory.toFile().listFiles().length == 0) {
           // If no snapshot files are created, snapshot is not valid
-          isValid = false;
+          abortInternal();
+          takenFuture.completeExceptionally(
+              new IllegalStateException(
+                  String.format(
+                      "Expected to find transient snapshot in directory %s, but the directory is empty or does not exists",
+                      directory)));
+
         } else {
           checksum = SnapshotChecksum.calculate(directory);
+
+          snapshot = null;
+          isValid = true;
+          takenFuture.complete(null);
         }
 
-        snapshot = null;
-        takenFuture.complete(isValid);
       } catch (final Exception exception) {
         LOGGER.warn("Unexpected exception on taking snapshot ({})", metadata, exception);
         abortInternal();

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotTest.java
@@ -42,7 +42,7 @@ public final class PersistedSnapshotTest {
   @Test
   public void shouldDeleteSnapshot() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).get();
     transientSnapshot.take(this::writeSnapshot);
     final var persistedSnapshot = transientSnapshot.persist().join();
 

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
@@ -480,8 +480,7 @@ public class ReceivedSnapshotTest {
   }
 
   private PersistedSnapshot takePersistedSnapshot() {
-    final var transientSnapshot =
-        senderSnapshotStore.newTransientSnapshot(1L, 0L, 1, 0).orElseThrow();
+    final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(1L, 0L, 1, 0).get();
     transientSnapshot.take(this::writeSnapshot).join();
     return transientSnapshot.persist().join();
   }

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
@@ -485,7 +485,7 @@ public class ReceivedSnapshotTest {
     return transientSnapshot.persist().join();
   }
 
-  private boolean writeSnapshot(final Path path) {
+  private void writeSnapshot(final Path path) {
     try {
       FileUtil.ensureDirectoryExists(path);
 
@@ -497,6 +497,5 @@ public class ReceivedSnapshotTest {
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }
-    return true;
   }
 }

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/SnapshotChunkReaderTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/SnapshotChunkReaderTest.java
@@ -49,8 +49,7 @@ public class SnapshotChunkReaderTest {
     factory.createReceivableSnapshotStore(snapshotDirectory, partitionId);
     final var persistedSnapshotStore = factory.getConstructableSnapshotStore(partitionId);
 
-    final var transientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(1, 2, 3, 2).orElseThrow();
+    final var transientSnapshot = persistedSnapshotStore.newTransientSnapshot(1, 2, 3, 2).get();
     transientSnapshot.take(this::takeSnapshot);
     persistedSnapshot = transientSnapshot.persist().join();
   }

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
@@ -11,6 +11,7 @@ import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.zeebe.snapshots.SnapshotException.SnapshotAlreadyExistsException;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
@@ -54,7 +55,7 @@ public class TransientSnapshotTest {
   @Test
   public void shouldHaveCorrectSnapshotId() {
     // when
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).get();
     final var snapshotId = transientSnapshot.snapshotId();
 
     // then
@@ -71,7 +72,7 @@ public class TransientSnapshotTest {
   @Test
   public void shouldAbortSuccessfullyEvenIfNothingWasWritten() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
 
     // when
     final ActorFuture<Void> didAbort = transientSnapshot.abort();
@@ -85,7 +86,7 @@ public class TransientSnapshotTest {
   @Test
   public void shouldNotCommitUntilPersisted() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).get();
 
     // when
     transientSnapshot.take(this::writeSnapshot).join();
@@ -99,7 +100,7 @@ public class TransientSnapshotTest {
   @Test
   public void shouldTakeTransientSnapshot() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).get();
 
     // when
     final var didWriteSnapshot = transientSnapshot.take(this::writeSnapshot).join();
@@ -111,7 +112,7 @@ public class TransientSnapshotTest {
   @Test
   public void shouldReturnFalseOnFailureTake() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).get();
 
     // when
     final var didTakeSnapshot = transientSnapshot.take(p -> false).join();
@@ -125,7 +126,7 @@ public class TransientSnapshotTest {
   @Test
   public void shouldCompleteExceptionallyOnExceptionInTake() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).get();
 
     // when
     final var didTakeSnapshot =
@@ -144,7 +145,7 @@ public class TransientSnapshotTest {
   @Test
   public void shouldBeAbleToAbortNotStartedSnapshot() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).get();
 
     // when
     final ActorFuture<Void> didAbort = transientSnapshot.abort();
@@ -158,7 +159,7 @@ public class TransientSnapshotTest {
   @Test
   public void shouldPersistSnapshotWithCorrectId() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
     transientSnapshot.take(this::writeSnapshot).join();
 
     // when
@@ -173,7 +174,7 @@ public class TransientSnapshotTest {
   @Test
   public void shouldPersistSnapshot() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
     transientSnapshot.take(this::writeSnapshot);
 
     // when
@@ -190,12 +191,12 @@ public class TransientSnapshotTest {
   @Test
   public void shouldReplacePreviousSnapshotOnPersist() {
     // given
-    final var oldSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var oldSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
     oldSnapshot.take(this::writeSnapshot);
     oldSnapshot.persist().join();
 
     // when
-    final var newSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).orElseThrow();
+    final var newSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).get();
     newSnapshot.take(this::writeSnapshot);
     final var persistedSnapshot = newSnapshot.persist().join();
 
@@ -208,13 +209,12 @@ public class TransientSnapshotTest {
   @Test
   public void shouldNotPersistSnapshotIfIdIsLessThanTheLatestSnapshot() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(2L, 2L, 3L, 4L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(2L, 2L, 3L, 4L).get();
     transientSnapshot.take(this::writeSnapshot);
     final var previousSnapshot = transientSnapshot.persist().join();
 
     // when
-    final var newTransientSnapshot =
-        snapshotStore.newTransientSnapshot(1L, 2L, 4L, 5L).orElseThrow();
+    final var newTransientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 4L, 5L).get();
     newTransientSnapshot.take(this::writeSnapshot);
     final var didPersist = newTransientSnapshot.persist();
 
@@ -230,11 +230,11 @@ public class TransientSnapshotTest {
   @Test
   public void shouldRemoveTransientSnapshotOnPersist() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
     transientSnapshot.take(this::writeSnapshot);
 
     // when
-    final var newSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).orElseThrow();
+    final var newSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).get();
     newSnapshot.take(this::writeSnapshot);
     newSnapshot.persist().join();
 
@@ -244,12 +244,11 @@ public class TransientSnapshotTest {
 
   @Test
   public void shouldNotRemoveTransientSnapshotWithGreaterIdOnPersist() {
-    final var newerTransientSnapshot =
-        snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).orElseThrow();
+    final var newerTransientSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).get();
     newerTransientSnapshot.take(this::writeSnapshot);
 
     // when
-    final var newSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var newSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
     newSnapshot.take(this::writeSnapshot);
     newSnapshot.persist().join();
     final var persistedSnapshot = newerTransientSnapshot.persist().join();
@@ -263,7 +262,7 @@ public class TransientSnapshotTest {
   @Test
   public void shouldNotPersistOnTakeFailure() {
     // given
-    final var snapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var snapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
 
     // when
     snapshot.take(path -> false).join();
@@ -277,7 +276,7 @@ public class TransientSnapshotTest {
   @Test
   public void shouldNotPersistOnTakeException() {
     // given
-    final var snapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var snapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
 
     // when
     final var didTakeSnapshot =
@@ -298,7 +297,7 @@ public class TransientSnapshotTest {
     // given
     final AtomicReference<PersistedSnapshot> snapshotRef = new AtomicReference<>();
     final PersistedSnapshotListener listener = snapshotRef::set;
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
     snapshotStore.addSnapshotListener(listener);
     transientSnapshot.take(this::writeSnapshot).join();
 
@@ -314,7 +313,7 @@ public class TransientSnapshotTest {
     // given
     final AtomicReference<PersistedSnapshot> snapshotRef = new AtomicReference<>();
     final PersistedSnapshotListener listener = snapshotRef::set;
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
     snapshotStore.addSnapshotListener(listener);
     snapshotStore.removeSnapshotListener(listener);
     transientSnapshot.take(this::writeSnapshot).join();
@@ -331,7 +330,7 @@ public class TransientSnapshotTest {
   @Test
   public void shouldNotTakeSnapshotIfIdAlreadyExists() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L).get();
     transientSnapshot.take(this::writeSnapshot).join();
 
     // when
@@ -339,14 +338,14 @@ public class TransientSnapshotTest {
     final var secondTransientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L);
 
     // then
-    assertThat(secondTransientSnapshot)
+    assertThat(secondTransientSnapshot.getLeft())
         .as("should have no value since there already exists a transient snapshot with the same ID")
-        .isEmpty();
+        .isInstanceOf(SnapshotAlreadyExistsException.class);
   }
 
   @Test
   public void shouldNotPersistDeletedTransientSnapshot() {
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L).get();
     transientSnapshot.take(this::writeSnapshot).join();
 
     // when

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.snapshots.SnapshotException.SnapshotAlreadyExistsException;
+import io.camunda.zeebe.snapshots.SnapshotException.SnapshotNotFoundException;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
@@ -330,7 +331,7 @@ public class TransientSnapshotTest {
     // then
     assertThatThrownBy(persisted::join)
         .as("did not persist a deleted transient snapshot")
-        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasCauseInstanceOf(SnapshotNotFoundException.class)
         .hasMessageContaining("Snapshot is not valid");
   }
 

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
@@ -331,8 +331,7 @@ public class TransientSnapshotTest {
     // then
     assertThatThrownBy(persisted::join)
         .as("did not persist a deleted transient snapshot")
-        .hasCauseInstanceOf(SnapshotNotFoundException.class)
-        .hasMessageContaining("Snapshot is not valid");
+        .hasCauseInstanceOf(SnapshotNotFoundException.class);
   }
 
   private void writeSnapshot(final Path path) {

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -336,8 +336,7 @@ public class FileBasedReceivedSnapshotTest {
   }
 
   private PersistedSnapshot takePersistedSnapshot(final long index) {
-    final var transientSnapshot =
-        senderSnapshotStore.newTransientSnapshot(index, 0L, 1, 0).orElseThrow();
+    final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(index, 0L, 1, 0).get();
     transientSnapshot.take(this::writeSnapshot).join();
     return transientSnapshot.persist().join();
   }

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -203,7 +203,7 @@ public class FileBasedSnapshotStoreTest {
 
   private TransientSnapshot takeTransientSnapshot(
       final long index, final FileBasedSnapshotStore store) {
-    final var transientSnapshot = store.newTransientSnapshot(index, 1, 1, 0).orElseThrow();
+    final var transientSnapshot = store.newTransientSnapshot(index, 1, 1, 0).get();
     transientSnapshot.take(this::createSnapshotDir);
     return transientSnapshot;
   }

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
@@ -234,29 +234,6 @@ public class FileBasedTransientSnapshotTest {
   }
 
   @Test
-  public void shouldRemoveTransientDirectoryOnTakeFailure() {
-    // given
-    final var snapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
-
-    // when
-    snapshot
-        .take(
-            path -> {
-              try {
-                FileUtil.ensureDirectoryExists(path);
-              } catch (final IOException e) {
-                throw new UncheckedIOException(e);
-              }
-              return false;
-            })
-        .join();
-
-    // then
-    assertThat(pendingDir).as("there is no leftover transient directory").isEmptyDirectory();
-    assertThat(snapshotsDir).as("there is no committed snapshot").isEmptyDirectory();
-  }
-
-  @Test
   public void shouldRemoveTransientDirectoryOnTakeException() {
     // given
     final var snapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
@@ -277,7 +254,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldNotPersistNonExistentTransientSnapshot() {
     final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L).get();
-    transientSnapshot.take(p -> true).join();
+    transientSnapshot.take(p -> {});
 
     // when
     final var persisted = transientSnapshot.persist();
@@ -292,7 +269,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldNotPersistEmptyTransientSnapshot() {
     final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L).get();
-    transientSnapshot.take(p -> p.toFile().mkdir()).join();
+    transientSnapshot.take(p -> p.toFile().mkdir());
 
     // when
     final var persisted = transientSnapshot.persist();

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
@@ -65,7 +65,7 @@ public class FileBasedTransientSnapshotTest {
 
   @Test
   public void shouldEncodeSnapshotIdInPath() {
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).get();
 
     // when
     final var pathId = FileBasedSnapshotMetadata.ofPath(transientSnapshot.getPath()).orElseThrow();
@@ -77,7 +77,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldNotCommitUntilPersisted() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).get();
 
     // when
     transientSnapshot.take(this::writeSnapshot).join();
@@ -91,7 +91,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldTakeTransientSnapshot() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).get();
 
     // when
     transientSnapshot.take(this::writeSnapshot).join();
@@ -106,7 +106,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldDeleteTransientDirectoryOnAbort() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
     transientSnapshot.take(this::writeSnapshot).join();
 
     // when
@@ -122,7 +122,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldNotDeletePersistedSnapshotOnPurge() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
     transientSnapshot.take(this::writeSnapshot).join();
     final var persistedSnapshot = transientSnapshot.persist().join();
 
@@ -142,7 +142,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldDeleteOlderTransientDirectoryOnPersist() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
     transientSnapshot.take(this::writeSnapshot).join();
 
     // when
@@ -157,7 +157,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldPersistSnapshot() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
     transientSnapshot.take(this::writeSnapshot);
 
     // when
@@ -181,12 +181,12 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldReplacePreviousSnapshotOnPersist() {
     // given
-    final var oldSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var oldSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
     oldSnapshot.take(this::writeSnapshot);
     oldSnapshot.persist().join();
 
     // when
-    final var newSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).orElseThrow();
+    final var newSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).get();
     newSnapshot.take(this::writeSnapshot);
     final var persistedSnapshot = (FileBasedSnapshot) newSnapshot.persist().join();
 
@@ -201,11 +201,11 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldRemoveTransientSnapshotOnPersist() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
     transientSnapshot.take(this::writeSnapshot);
 
     // when
-    final var newSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).orElseThrow();
+    final var newSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).get();
     newSnapshot.take(this::writeSnapshot);
     newSnapshot.persist().join();
 
@@ -218,12 +218,11 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldNotRemoveTransientSnapshotWithGreaterIdOnPersist() {
     // given
-    final var newerTransientSnapshot =
-        snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).orElseThrow();
+    final var newerTransientSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).get();
     newerTransientSnapshot.take(this::writeSnapshot);
 
     // when
-    final var newSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var newSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
     newSnapshot.take(this::writeSnapshot);
     newSnapshot.persist().join();
 
@@ -237,7 +236,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldRemoveTransientDirectoryOnTakeFailure() {
     // given
-    final var snapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var snapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
 
     // when
     snapshot
@@ -260,7 +259,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldRemoveTransientDirectoryOnTakeException() {
     // given
-    final var snapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    final var snapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).get();
 
     // when
     final var didTakeSnapshot =
@@ -277,7 +276,7 @@ public class FileBasedTransientSnapshotTest {
 
   @Test
   public void shouldNotPersistNonExistentTransientSnapshot() {
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L).get();
     transientSnapshot.take(p -> true).join();
 
     // when
@@ -292,7 +291,7 @@ public class FileBasedTransientSnapshotTest {
 
   @Test
   public void shouldNotPersistEmptyTransientSnapshot() {
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L).get();
     transientSnapshot.take(p -> p.toFile().mkdir()).join();
 
     // when
@@ -308,7 +307,7 @@ public class FileBasedTransientSnapshotTest {
   @Test
   public void shouldPersistIdempotently() {
     // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3, 4).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3, 4).get();
     transientSnapshot.take(this::writeSnapshot).join();
     final var firstSnapshot = (FileBasedSnapshot) transientSnapshot.persist().join();
 

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
@@ -11,7 +11,6 @@ import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.zeebe.snapshots.SnapshotException.SnapshotNotFoundException;
 import io.camunda.zeebe.test.util.asserts.DirectoryAssert;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.sched.testing.ActorSchedulerRule;
@@ -263,8 +262,7 @@ public class FileBasedTransientSnapshotTest {
     // then
     assertThatThrownBy(persisted::join)
         .as("did not persist a non existent transient snapshot")
-        .hasCauseInstanceOf(SnapshotNotFoundException.class)
-        .hasMessageContaining("Snapshot is not valid");
+        .hasCauseInstanceOf(IllegalStateException.class);
   }
 
   @Test
@@ -278,8 +276,7 @@ public class FileBasedTransientSnapshotTest {
     // then
     assertThatThrownBy(persisted::join)
         .as("did not persist an empty transient snapshot directory")
-        .hasCauseInstanceOf(SnapshotNotFoundException.class)
-        .hasMessageContaining("Snapshot is not valid");
+        .hasCauseInstanceOf(IllegalStateException.class);
   }
 
   @Test

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
@@ -11,6 +11,7 @@ import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.zeebe.snapshots.SnapshotException.SnapshotNotFoundException;
 import io.camunda.zeebe.test.util.asserts.DirectoryAssert;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.sched.testing.ActorSchedulerRule;
@@ -262,7 +263,7 @@ public class FileBasedTransientSnapshotTest {
     // then
     assertThatThrownBy(persisted::join)
         .as("did not persist a non existent transient snapshot")
-        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasCauseInstanceOf(SnapshotNotFoundException.class)
         .hasMessageContaining("Snapshot is not valid");
   }
 
@@ -277,7 +278,7 @@ public class FileBasedTransientSnapshotTest {
     // then
     assertThatThrownBy(persisted::join)
         .as("did not persist an empty transient snapshot directory")
-        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasCauseInstanceOf(SnapshotNotFoundException.class)
         .hasMessageContaining("Snapshot is not valid");
   }
 


### PR DESCRIPTION
## Description

To simplify the code for taking snapshots:
* Removed Optional and used Either instead. Using Either is useful to return the errors. Optional hides the reason why the snapshot was not taken
* Similarly, removed the predicate that returns a boolean to indicate a snapshot was taken and instead throw an exception. This makes the error handling consistent.
* Introduced new exceptions to identify failures when taking or persisting a snapshot. 
* Update all tests to reflect the api change.

## Related issues

closes #7906 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
