### PR TITLE
Use BrokerContext in tests

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -7,20 +7,14 @@
  */
 package io.camunda.zeebe.broker;
 
-import io.atomix.cluster.AtomixCluster;
 import io.camunda.zeebe.broker.bootstrap.BrokerContext;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContextImpl;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupProcess;
-import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.exporter.repo.ExporterLoadException;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
-import io.camunda.zeebe.broker.partitioning.PartitionManager;
-import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
 import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.system.management.BrokerAdminService;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
-import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.util.LogUtil;
 import io.camunda.zeebe.util.VersionUtil;
@@ -184,34 +178,14 @@ public final class Broker implements AutoCloseable {
   }
 
   // only used for tests
-  public EmbeddedGatewayService getEmbeddedGatewayService() {
-    return brokerContext.getEmbeddedGatewayService();
+  public BrokerContext getBrokerContext() {
+    return brokerContext;
   }
 
-  public AtomixCluster getAtomixCluster() {
-    return brokerContext.getAtomixCluster();
-  }
-
-  public ClusterServices getClusterServices() {
-    return brokerContext.getClusterServices();
-  }
-
-  public DiskSpaceUsageMonitor getDiskSpaceUsageMonitor() {
-    return brokerContext.getDiskSpaceUsageMonitor();
-  }
-
-  public BrokerAdminService getBrokerAdminService() {
-    return brokerContext.getBrokerAdminService();
-  }
-
+  // only used for tests
   public SystemContext getSystemContext() {
     return systemContext;
   }
-
-  public PartitionManager getPartitionManager() {
-    return brokerContext.getPartitionManager();
-  }
-  // only used for tests
 
   /**
    * Temporary helper object. This object is needed during the transition of broker startup/shutdown

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContext.java
@@ -7,7 +7,8 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
-import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
+import io.atomix.cluster.AtomixCluster;
+import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
 import io.camunda.zeebe.broker.system.management.BrokerAdminService;
@@ -16,8 +17,9 @@ import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 /** Context for components/actors managed directly by the Broker */
 public interface BrokerContext {
 
-  // TODO change this to ClusterServices after migration
-  ClusterServicesImpl getClusterServices();
+  ClusterServices getClusterServices();
+
+  AtomixCluster getAtomixCluster();
 
   EmbeddedGatewayService getEmbeddedGatewayService();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerContextImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.bootstrap;
 
 import static java.util.Objects.requireNonNull;
 
+import io.atomix.cluster.AtomixCluster;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
@@ -39,6 +40,11 @@ final class BrokerContextImpl implements BrokerContext {
   @Override
   public ClusterServicesImpl getClusterServices() {
     return clusterServices;
+  }
+
+  @Override
+  public AtomixCluster getAtomixCluster() {
+    return clusterServices.getAtomixCluster();
   }
 
   @Override

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerSnapshotTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/BrokerSnapshotTest.java
@@ -45,11 +45,12 @@ public class BrokerSnapshotTest {
         (RaftPartition)
             brokerRule
                 .getBroker()
+                .getBrokerContext()
                 .getPartitionManager()
                 .getPartitionGroup()
                 .getPartition(PartitionId.from(PartitionManagerImpl.GROUP_NAME, PARTITION_ID));
     journalReader = raftPartition.getServer().openReader();
-    brokerAdminService = brokerRule.getBroker().getBrokerAdminService();
+    brokerAdminService = brokerRule.getBroker().getBrokerContext().getBrokerAdminService();
 
     final String contactPoint = NetUtil.toSocketAddressString(brokerRule.getGatewayAddress());
     final ZeebeClientBuilder zeebeClientBuilder =

--- a/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -173,11 +173,11 @@ public final class EmbeddedBrokerRule extends ExternalResource {
   }
 
   public ClusterServices getClusterServices() {
-    return broker.getClusterServices();
+    return broker.getBrokerContext().getClusterServices();
   }
 
   public AtomixCluster getAtomixCluster() {
-    return broker.getAtomixCluster();
+    return broker.getBrokerContext().getAtomixCluster();
   }
 
   public InetSocketAddress getGatewayAddress() {
@@ -245,7 +245,8 @@ public final class EmbeddedBrokerRule extends ExternalResource {
       Thread.currentThread().interrupt();
     }
 
-    final EmbeddedGatewayService embeddedGatewayService = broker.getEmbeddedGatewayService();
+    final EmbeddedGatewayService embeddedGatewayService =
+        broker.getBrokerContext().getEmbeddedGatewayService();
     if (embeddedGatewayService != null) {
       final BrokerClient brokerClient = embeddedGatewayService.get().getBrokerClient();
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceMonitoringFailOverTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceMonitoringFailOverTest.java
@@ -88,6 +88,7 @@ public class DiskSpaceMonitoringFailOverTest {
             () ->
                 clusteringRule
                     .getBroker(newLeaderId)
+                    .getBrokerContext()
                     .getBrokerAdminService()
                     .getPartitionStatus()
                     .get(1)
@@ -96,7 +97,7 @@ public class DiskSpaceMonitoringFailOverTest {
   }
 
   private void waitUntilDiskSpaceNotAvailable(final Broker broker) throws InterruptedException {
-    final var diskSpaceMonitor = broker.getDiskSpaceUsageMonitor();
+    final var diskSpaceMonitor = broker.getBrokerContext().getDiskSpaceUsageMonitor();
 
     final CountDownLatch diskSpaceNotAvailable = new CountDownLatch(1);
     diskSpaceMonitor.addDiskUsageListener(

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceRecoveryClusteredTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceRecoveryClusteredTest.java
@@ -165,7 +165,7 @@ public class DiskSpaceRecoveryClusteredTest {
   }
 
   private void waitUntilDiskSpaceNotAvailable(final Broker broker) throws InterruptedException {
-    final var diskSpaceMonitor = broker.getDiskSpaceUsageMonitor();
+    final var diskSpaceMonitor = broker.getBrokerContext().getDiskSpaceUsageMonitor();
 
     final CountDownLatch diskSpaceNotAvailable = new CountDownLatch(1);
     diskSpaceMonitor.addDiskUsageListener(
@@ -188,7 +188,7 @@ public class DiskSpaceRecoveryClusteredTest {
   }
 
   private void waitUntilDiskSpaceAvailable(final Broker broker) throws InterruptedException {
-    final var diskSpaceMonitor = broker.getDiskSpaceUsageMonitor();
+    final var diskSpaceMonitor = broker.getBrokerContext().getDiskSpaceUsageMonitor();
     final CountDownLatch diskSpaceAvailableAgain = new CountDownLatch(1);
     diskSpaceMonitor.addDiskUsageListener(
         new DiskSpaceUsageListener() {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceRecoveryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceRecoveryTest.java
@@ -192,7 +192,8 @@ public class DiskSpaceRecoveryTest {
   }
 
   private void waitUntilDiskSpaceNotAvailable() throws InterruptedException {
-    final var diskSpaceMonitor = embeddedBrokerRule.getBroker().getDiskSpaceUsageMonitor();
+    final var diskSpaceMonitor =
+        embeddedBrokerRule.getBroker().getBrokerContext().getDiskSpaceUsageMonitor();
 
     final CountDownLatch diskSpaceNotAvailable = new CountDownLatch(1);
     diskSpaceMonitor.addDiskUsageListener(
@@ -215,7 +216,8 @@ public class DiskSpaceRecoveryTest {
   }
 
   private void waitUntilDiskSpaceAvailable() throws InterruptedException {
-    final var diskSpaceMonitor = embeddedBrokerRule.getBroker().getDiskSpaceUsageMonitor();
+    final var diskSpaceMonitor =
+        embeddedBrokerRule.getBroker().getBrokerContext().getDiskSpaceUsageMonitor();
     final CountDownLatch diskSpaceAvailableAgain = new CountDownLatch(1);
     diskSpaceMonitor.addDiskUsageListener(
         new DiskSpaceUsageListener() {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/HealthMonitoringTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/HealthMonitoringTest.java
@@ -48,6 +48,7 @@ public class HealthMonitoringTest {
     final var raftPartition =
         (RaftPartition)
             leader
+                .getBrokerContext()
                 .getPartitionManager()
                 .getPartitionGroup()
                 .getPartition(

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceTest.java
@@ -41,7 +41,7 @@ public class BrokerAdminServiceTest {
   @Before
   public void before() {
     leader = clusteringRule.getBroker(clusteringRule.getLeaderForPartition(1).getNodeId());
-    leaderAdminService = leader.getBrokerAdminService();
+    leaderAdminService = leader.getBrokerContext().getBrokerAdminService();
   }
 
   @Test
@@ -144,7 +144,7 @@ public class BrokerAdminServiceTest {
 
     // then
     leader = clusteringRule.getBroker(clusteringRule.getLeaderForPartition(1).getNodeId());
-    leaderAdminService = leader.getBrokerAdminService();
+    leaderAdminService = leader.getBrokerContext().getBrokerAdminService();
     assertStreamProcessorPhase(leaderAdminService, Phase.PAUSED);
   }
 
@@ -161,7 +161,7 @@ public class BrokerAdminServiceTest {
 
     // then
     leader = clusteringRule.getBroker(clusteringRule.getLeaderForPartition(1).getNodeId());
-    leaderAdminService = leader.getBrokerAdminService();
+    leaderAdminService = leader.getBrokerContext().getBrokerAdminService();
     assertStreamProcessorPhase(leaderAdminService, Phase.PROCESSING);
   }
 
@@ -176,7 +176,7 @@ public class BrokerAdminServiceTest {
 
     // then
     leader = clusteringRule.getBroker(clusteringRule.getLeaderForPartition(1).getNodeId());
-    leaderAdminService = leader.getBrokerAdminService();
+    leaderAdminService = leader.getBrokerContext().getBrokerAdminService();
     assertExporterPhase(leaderAdminService, ExporterPhase.PAUSED);
   }
 
@@ -193,7 +193,7 @@ public class BrokerAdminServiceTest {
 
     // then
     leader = clusteringRule.getBroker(clusteringRule.getLeaderForPartition(1).getNodeId());
-    leaderAdminService = leader.getBrokerAdminService();
+    leaderAdminService = leader.getBrokerContext().getBrokerAdminService();
     assertExporterPhase(leaderAdminService, ExporterPhase.EXPORTING);
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceWithOutExporterTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceWithOutExporterTest.java
@@ -30,7 +30,7 @@ public class BrokerAdminServiceWithOutExporterTest {
     // given
     final var leader =
         clusteringRule.getBroker(clusteringRule.getLeaderForPartition(1).getNodeId());
-    final var leaderAdminService = leader.getBrokerAdminService();
+    final var leaderAdminService = leader.getBrokerContext().getBrokerAdminService();
     // when there are no exporters configured
     // then
     final var partitionStatus = leaderAdminService.getPartitionStatus().get(1);

--- a/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
+++ b/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
@@ -240,7 +240,8 @@ public class EmbeddedBrokerRule extends ExternalResource {
       Thread.currentThread().interrupt();
     }
 
-    final EmbeddedGatewayService embeddedGatewayService = broker.getEmbeddedGatewayService();
+    final EmbeddedGatewayService embeddedGatewayService =
+        broker.getBrokerContext().getEmbeddedGatewayService();
     if (embeddedGatewayService != null) {
       final BrokerClient brokerClient = embeddedGatewayService.get().getBrokerClient();
 


### PR DESCRIPTION
## Description

* Removes test companion object from `Broker`
* Refactors test code to use `BrokerContext` in tests consistently

## Related issues

closes #7540

<!-- Cut-off marker
## Definition of Ready
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
