### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/os-smoke-test.yml
+++ b/.github/workflows/os-smoke-test.yml
@@ -14,14 +14,15 @@ jobs:
     strategy:
       matrix:
         os: [ macos-latest, windows-latest, ubuntu-latest ]
+        java: [ 11.0.3, 11 ]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: ${{ matrix.java }}
+          distribution: 'zulu'
       - name: Cache Maven packages
         uses: actions/cache@v2.1.6
         with:


### PR DESCRIPTION
## Description
This is in regards to the project's GitHub Actions workflow `os-smoke-test.yml`. 

The AdoptOpenJDK as a build distribution has been discontinued since July 2021 (https://adoptopenjdk.net). This request is to switch the distribution from 'adopt' to Azul `zulu`. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK even archived fixed versions. 

Also added to the GH Action workflow are fixed (major) release version(s) such as `JDK 11.0.3`. This is often a good practice whenever a build/test triggers (push/pull events) to help determine if the latest (`JDK 11`) had failed the from the **latest build** vs something in **your code** caused (or introduced). 

**For example**, when building with `JDK 11.0.3` (fixed version) the build/tests passes (Green) and JDK 11 fails (Red) will mean that the latest `JDK 11` was the cause and not your code. 

**Note:** Other distributions such as Temurin do not support archived fixed releases prior to Sept. 2021 and many of the non-LTS (long term support) releases if you are planning to try out newer features of the Java language.


## Definition of Ready

The CI/CD GitHub Actions workflow `os-smoke-test.yml` runs and passes (green).


## Definition of Done

The workflow that tests on different operating systems did not change, however I added fixed JDK version(s) such as `11.0.3` for backwards compatibility. 

Testing:
N/A - This is a GitHub Actions workflow update from `adopt` to `zulu` as a JDK distribution used in the os smoke test. 

Documentation: 
N/A 