### PR TITLE
Delete corrupted snapshots if valid snapshot is available

### DIFF
--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -139,10 +139,11 @@ public final class FileBasedSnapshotStore extends Actor
     try (final var paths =
         Files.newDirectoryStream(
             snapshotDirectory, p -> !p.equals(latestDirectory) && !p.equals(latestChecksumFile))) {
-      LOGGER.debug("Deleting snapshots other than {}", latestPersistedSnapshot);
+      LOGGER.debug("Deleting snapshots other than {}", latestPersistedSnapshot.getId());
       paths.forEach(
           p -> {
             try {
+              LOGGER.debug("Deleting {}", p);
               FileUtil.deleteFolderIfExists(p);
             } catch (final IOException e) {
               LOGGER.warn("Unable to delete {}", p, e);

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -145,6 +145,8 @@ public class FileBasedSnapshotStoreTest {
 
     // then
     assertThat(snapshotStore.getLatestSnapshot()).hasValue(newerSnapshot);
+    assertThat(newerSnapshot.getDirectory()).exists();
+    assertThat(newerSnapshot.getChecksumFile()).exists();
     assertThat(corruptOlderSnapshot.getDirectory()).doesNotExist();
     assertThat(corruptOlderSnapshot.getChecksumFile()).doesNotExist();
   }
@@ -166,6 +168,8 @@ public class FileBasedSnapshotStoreTest {
 
     // then
     assertThat(snapshotStore.getLatestSnapshot()).get().isEqualTo(newerSnapshot);
+    assertThat(newerSnapshot.getDirectory()).exists();
+    assertThat(newerSnapshot.getChecksumFile()).exists();
     assertThat(corruptOlderSnapshot.getDirectory()).doesNotExist();
     assertThat(corruptOlderSnapshot.getChecksumFile()).doesNotExist();
   }
@@ -184,6 +188,8 @@ public class FileBasedSnapshotStoreTest {
 
     // then -- valid snapshot is unaffected and corrupt snapshot is deleted
     assertThat(otherStore.getLatestSnapshot()).get().isEqualTo(newerSnapshot);
+    assertThat(newerSnapshot.getDirectory()).exists();
+    assertThat(newerSnapshot.getChecksumFile()).exists();
     assertThat(olderSnapshot.getDirectory()).doesNotExist();
     assertThat(olderSnapshot.getChecksumFile()).doesNotExist();
   }

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -129,6 +129,66 @@ public class FileBasedSnapshotStoreTest {
   }
 
   @Test
+  public void shouldDeleteOlderSnapshotsWithCorruptChecksums() throws IOException {
+    // given
+    final var otherStore = createStore(snapshotsDir, pendingSnapshotsDir);
+    final var corruptOlderSnapshot =
+        (FileBasedSnapshot) takeTransientSnapshot(1, otherStore).persist().join();
+    SnapshotChecksum.persist(corruptOlderSnapshot.getChecksumFile(), 0xCAFEL);
+
+    final var newerSnapshot =
+        (FileBasedSnapshot) takeTransientSnapshot(2, snapshotStore).persist().join();
+
+    // when
+    snapshotStore.close();
+    snapshotStore = createStore(snapshotsDir, pendingSnapshotsDir);
+
+    // then
+    assertThat(snapshotStore.getLatestSnapshot()).hasValue(newerSnapshot);
+    assertThat(corruptOlderSnapshot.getDirectory()).doesNotExist();
+    assertThat(corruptOlderSnapshot.getChecksumFile()).doesNotExist();
+  }
+
+  @Test
+  public void shouldDeleteOlderSnapshotsWithMissingChecksums() throws IOException {
+    // given
+    final var otherStore = createStore(snapshotsDir, pendingSnapshotsDir);
+    final var corruptOlderSnapshot =
+        (FileBasedSnapshot) takeTransientSnapshot(1, otherStore).persist().join();
+    Files.delete(corruptOlderSnapshot.getChecksumFile());
+
+    final var newerSnapshot =
+        (FileBasedSnapshot) takeTransientSnapshot(2, snapshotStore).persist().join();
+
+    // when
+    snapshotStore.close();
+    snapshotStore = createStore(snapshotsDir, pendingSnapshotsDir);
+
+    // then
+    assertThat(snapshotStore.getLatestSnapshot()).get().isEqualTo(newerSnapshot);
+    assertThat(corruptOlderSnapshot.getDirectory()).doesNotExist();
+    assertThat(corruptOlderSnapshot.getChecksumFile()).doesNotExist();
+  }
+
+  @Test
+  public void shouldDeleteCorruptSnapshotsWhenAddingNewSnapshot() throws IOException {
+    // given
+    final var olderSnapshot =
+        (FileBasedSnapshot) takeTransientSnapshot(1, snapshotStore).persist().join();
+    final var otherStore = createStore(snapshotsDir, pendingSnapshotsDir);
+
+    // when - corrupting old snapshot and adding new valid snapshot
+    SnapshotChecksum.persist(olderSnapshot.getChecksumFile(), 0xCAFEL);
+    final var newerSnapshot =
+        (FileBasedSnapshot) takeTransientSnapshot(2, otherStore).persist().join();
+
+    // then -- valid snapshot is unaffected and corrupt snapshot is deleted
+    assertThat(otherStore.getLatestSnapshot()).get().isEqualTo(newerSnapshot);
+    assertThat(olderSnapshot.getDirectory()).doesNotExist();
+    assertThat(olderSnapshot.getChecksumFile()).doesNotExist();
+  }
+
+  @Test
   public void shouldPurgePendingSnapshots() {
     // given
     takeTransientSnapshot();


### PR DESCRIPTION
## Description

Previously we only deleted corrupt snapshots in the case of a missing checksum file. Now, if there is a valid snapshot, we delete everything else in the snapshot directory.
This ensures that we don't accumulate corrupted snapshots. It also replaces the logic that deleted older, valid snapshots.


## Related issues

closes #7531

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
