### PR TITLE
Use current term in inactive transition

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransition.java
@@ -34,8 +34,9 @@ public interface PartitionTransition {
    * Closes the current partition's components asynchronously.
    *
    * @return an ActorFuture completed when the transition is complete
+   * @param term
    */
-  ActorFuture<Void> toInactive();
+  ActorFuture<Void> toInactive(final long term);
 
   /**
    * Sets the ConcurrencyControl through which tasks are executed.

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -292,7 +292,7 @@ public final class ZeebePartition extends Actor
 
   private ActorFuture<Void> transitionToInactive() {
     zeebePartitionHealth.setServicesInstalled(false);
-    final var inactiveTransitionFuture = transition.toInactive();
+    final var inactiveTransitionFuture = transition.toInactive(context.getCurrentTerm());
     currentTransitionFuture = inactiveTransitionFuture;
     return inactiveTransitionFuture;
   }
@@ -457,7 +457,7 @@ public final class ZeebePartition extends Actor
     // restart from a new state. So we transition to Inactive to close existing services. The
     // services will be reinstalled when snapshot replication is completed.
     // We do not want to mark it as unhealthy, hence we don't reuse transitionToInactive()
-    actor.run(() -> currentTransitionFuture = transition.toInactive());
+    actor.run(() -> currentTransitionFuture = transition.toInactive(context.getCurrentTerm()));
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -215,9 +215,7 @@ public final class ZeebePartition extends Actor
     ActorFuture<Void> nextTransitionFuture = null;
     switch (newRole) {
       case LEADER:
-        if (raftRole != Role.LEADER) {
-          nextTransitionFuture = leaderTransition(newTerm);
-        }
+        nextTransitionFuture = leaderTransition(newTerm);
         break;
       case INACTIVE:
         nextTransitionFuture = transitionToInactive();
@@ -227,9 +225,7 @@ public final class ZeebePartition extends Actor
       case CANDIDATE:
       case FOLLOWER:
       default:
-        if (raftRole == null || raftRole == Role.LEADER) {
-          nextTransitionFuture = followerTransition(newTerm);
-        }
+        nextTransitionFuture = followerTransition(newTerm);
         break;
     }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 import org.slf4j.Logger;
 
 public final class PartitionTransitionImpl implements PartitionTransition {
-  private static final int INACTIVE_TERM = -1;
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
 
   private final List<PartitionTransitionStep> steps;
@@ -48,8 +47,8 @@ public final class PartitionTransitionImpl implements PartitionTransition {
   }
 
   @Override
-  public ActorFuture<Void> toInactive() {
-    return transitionTo(INACTIVE_TERM, Role.INACTIVE);
+  public ActorFuture<Void> toInactive(final long term) {
+    return transitionTo(term, Role.INACTIVE);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -71,7 +71,9 @@ final class PartitionTransitionProcess {
           startedSteps.push(nextStep);
 
           LOG.info(
-              format("Transition to %s on term %d - executing %s", role, term, nextStep.getName()));
+              format(
+                  "Transition to %s on term %d - transitioning %s",
+                  role, term, nextStep.getName()));
 
           nextStep
               .transitionTo(context, term, role)
@@ -98,14 +100,11 @@ final class PartitionTransitionProcess {
   }
 
   ActorFuture<Void> cleanup(final long newTerm, final Role newRole) {
-    LOG.info(
-        format(
-            "Cleanup of transition to %s on term %d starting (in preparation for new transition to %s)",
-            role, term, newRole));
+    LOG.info(format("Prepare transition from %s on term %d to %s", role, term, newRole));
     final ActorFuture<Void> cleanupFuture = concurrencyControl.createFuture();
 
     if (startedSteps.isEmpty()) {
-      LOG.info("No steps to clean up");
+      LOG.info("No steps to prepare transition");
       cleanupFuture.complete(null);
     } else {
       proceedWithCleanup(cleanupFuture, newTerm, newRole);
@@ -121,8 +120,8 @@ final class PartitionTransitionProcess {
 
           LOG.info(
               format(
-                  "Cleanup of transition to %s on term %d - executing %s",
-                  role, term, nextCleanupStep.getName()));
+                  "Prepare transition from %s on term %d to %s - preparing %s",
+                  role, term, newRole, nextCleanupStep.getName()));
 
           nextCleanupStep
               .prepareTransition(context, newTerm, newRole)
@@ -143,7 +142,7 @@ final class PartitionTransitionProcess {
     }
 
     if (startedSteps.isEmpty()) {
-      LOG.info(format("Cleanup of transition to %s on term %d completed", role, term));
+      LOG.info(format("Preparing transition from %s on term %d completed", role, term));
       future.complete(null);
 
       return;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.broker.system.partitions.impl;
 
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 import io.atomix.raft.RaftServer.Role;
@@ -47,7 +46,7 @@ final class PartitionTransitionProcess {
   }
 
   void start(final ActorFuture<Void> future) {
-    LOG.info(format("Transition to %s on term %d starting", role, term));
+    LOG.info("Transition to {} on term {} starting", role, term);
 
     if (pendingSteps.isEmpty()) {
       LOG.info("No steps defined for transition");
@@ -60,7 +59,7 @@ final class PartitionTransitionProcess {
 
   private void proceedWithTransition(final ActorFuture<Void> future) {
     if (cancelRequested) {
-      LOG.info(format("Cancelling transition to %s on term %d", role, term));
+      LOG.info("Cancelling transition to {} on term {}", role, term);
       future.complete(null);
       return;
     }
@@ -71,9 +70,7 @@ final class PartitionTransitionProcess {
           startedSteps.push(nextStep);
 
           LOG.info(
-              format(
-                  "Transition to %s on term %d - transitioning %s",
-                  role, term, nextStep.getName()));
+              "Transition to {} on term {} - transitioning {}", role, term, nextStep.getName());
 
           nextStep
               .transitionTo(context, term, role)
@@ -90,7 +87,7 @@ final class PartitionTransitionProcess {
     }
 
     if (pendingSteps.isEmpty()) {
-      LOG.info(format("Transition to %s on term %d completed", role, term));
+      LOG.info("Transition to {} on term {} completed", role, term);
       future.complete(null);
 
       return;
@@ -100,7 +97,7 @@ final class PartitionTransitionProcess {
   }
 
   ActorFuture<Void> cleanup(final long newTerm, final Role newRole) {
-    LOG.info(format("Prepare transition from %s on term %d to %s", role, term, newRole));
+    LOG.info("Prepare transition from {} on term {} to {}", role, term, newRole);
     final ActorFuture<Void> cleanupFuture = concurrencyControl.createFuture();
 
     if (startedSteps.isEmpty()) {
@@ -119,9 +116,11 @@ final class PartitionTransitionProcess {
           final var nextCleanupStep = startedSteps.pop();
 
           LOG.info(
-              format(
-                  "Prepare transition from %s on term %d to %s - preparing %s",
-                  role, term, newRole, nextCleanupStep.getName()));
+              "Prepare transition from {} on term {} to {} - preparing {}",
+              role,
+              term,
+              newRole,
+              nextCleanupStep.getName());
 
           nextCleanupStep
               .prepareTransition(context, newTerm, newRole)
@@ -142,7 +141,7 @@ final class PartitionTransitionProcess {
     }
 
     if (startedSteps.isEmpty()) {
-      LOG.info(format("Preparing transition from %s on term %d completed", role, term));
+      LOG.info("Preparing transition from {} on term {} completed", role, term);
       future.complete(null);
 
       return;
@@ -152,7 +151,7 @@ final class PartitionTransitionProcess {
   }
 
   void cancel() {
-    LOG.info(format("Received cancel signal for transition to %s on term %d", role, term));
+    LOG.info("Received cancel signal for transition to {} on term {}", role, term);
     cancelRequested = true;
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -160,7 +160,7 @@ public class ZeebePartitionTest {
 
     when(transition.toFollower(anyLong()))
         .thenReturn(CompletableActorFuture.completedExceptionally(new Exception("expected")));
-    when(transition.toInactive())
+    when(transition.toInactive(anyLong()))
         .then(
             invocation -> {
               latch.countDown();
@@ -184,7 +184,7 @@ public class ZeebePartitionTest {
     final InOrder order = inOrder(transition, raft);
     order.verify(transition).toFollower(0L);
     order.verify(raft).goInactive();
-    order.verify(transition).toInactive();
+    order.verify(transition).toInactive(anyLong());
   }
 
   @Test
@@ -194,7 +194,7 @@ public class ZeebePartitionTest {
     when(transition.toLeader(anyLong()))
         .thenReturn(
             CompletableActorFuture.completedExceptionally(new UnrecoverableException("expected")));
-    when(transition.toInactive())
+    when(transition.toInactive(anyLong()))
         .then(
             invocation -> {
               latch.countDown();
@@ -210,7 +210,7 @@ public class ZeebePartitionTest {
     // then
     final InOrder order = inOrder(transition, raft);
     order.verify(transition).toLeader(0L);
-    order.verify(transition).toInactive();
+    order.verify(transition).toInactive(anyLong());
     order.verify(raft).goInactive();
   }
 
@@ -227,7 +227,7 @@ public class ZeebePartitionTest {
     }
 
     @Override
-    public ActorFuture<Void> toInactive() {
+    public ActorFuture<Void> toInactive(final long currentTerm) {
       return CompletableActorFuture.completed(null);
     }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.partitions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -21,11 +22,11 @@ import io.atomix.primitive.partition.PartitionId;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.atomix.raft.partition.impl.RaftPartitionServer;
+import io.camunda.zeebe.broker.system.partitions.impl.PartitionTransitionImpl;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.health.CriticalComponentsHealthMonitor;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthStatus;
-import io.camunda.zeebe.util.sched.ConcurrencyControl;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import io.camunda.zeebe.util.sched.testing.ControlledActorSchedulerRule;
@@ -51,7 +52,7 @@ public class ZeebePartitionTest {
   @Before
   public void setup() {
     ctx = mock(PartitionStartupAndTransitionContextImpl.class);
-    transition = spy(new NoopTransition());
+    transition = spy(new PartitionTransitionImpl(List.of(new NoopTransitionStep())));
 
     raft = mock(RaftPartition.class);
     when(raft.id()).thenReturn(new PartitionId("", 0));
@@ -79,6 +80,50 @@ public class ZeebePartitionTest {
 
     // then
     verify(transition).toLeader(1);
+  }
+
+  @Test
+  public void shouldInstallFollowerPartition() {
+    // given
+    schedulerRule.submitActor(partition);
+
+    // when
+    partition.onNewRole(Role.FOLLOWER, 1);
+    schedulerRule.workUntilDone();
+
+    // then
+    verify(transition).toFollower(1);
+  }
+
+  @Test
+  public void shouldUpdateCurrentTermAndRoleAfterTransition() {
+    // given
+    schedulerRule.submitActor(partition);
+    schedulerRule.workUntilDone();
+
+    // when
+    partition.onNewRole(Role.FOLLOWER, 2);
+    schedulerRule.workUntilDone();
+
+    // then
+    verify(ctx, atLeast(1)).setCurrentRole(Role.FOLLOWER);
+    verify(ctx, atLeast(1)).setCurrentTerm(2);
+  }
+
+  @Test
+  public void shouldUseCurrentTermForInactiveTransition() {
+    // given
+    schedulerRule.submitActor(partition);
+    when(ctx.getCurrentTerm()).thenReturn(3L);
+
+    // when
+    // term given for inactive role is ignored, hence we pass -1 here to verify that it uses
+    // the term from the context. In reality the term passes here will be a valid term.
+    partition.onNewRole(Role.INACTIVE, -1);
+    schedulerRule.workUntilDone();
+
+    // then
+    verify(transition, atLeast(1)).toInactive(3);
   }
 
   @Test
@@ -214,34 +259,6 @@ public class ZeebePartitionTest {
     order.verify(raft).goInactive();
   }
 
-  private static class NoopTransition implements PartitionTransition {
-
-    @Override
-    public ActorFuture<Void> toFollower(final long currentTerm) {
-      return CompletableActorFuture.completed(null);
-    }
-
-    @Override
-    public ActorFuture<Void> toLeader(final long currentTerm) {
-      return CompletableActorFuture.completed(null);
-    }
-
-    @Override
-    public ActorFuture<Void> toInactive(final long currentTerm) {
-      return CompletableActorFuture.completed(null);
-    }
-
-    @Override
-    public void setConcurrencyControl(final ConcurrencyControl concurrencyControl) {
-      // Do nothing
-    }
-
-    @Override
-    public void updateTransitionContext(final PartitionTransitionContext transitionContext) {
-      // Do nothing
-    }
-  }
-
   private static class NoopStartupStep implements PartitionStartupStep {
 
     @Override
@@ -259,6 +276,26 @@ public class ZeebePartitionTest {
     public ActorFuture<PartitionStartupContext> shutdown(
         final PartitionStartupContext partitionStartupContext) {
       return CompletableActorFuture.completed(partitionStartupContext);
+    }
+  }
+
+  private static class NoopTransitionStep implements PartitionTransitionStep {
+
+    @Override
+    public ActorFuture<Void> prepareTransition(
+        final PartitionTransitionContext context, final long term, final Role targetRole) {
+      return CompletableActorFuture.completed(null);
+    }
+
+    @Override
+    public ActorFuture<Void> transitionTo(
+        final PartitionTransitionContext context, final long term, final Role targetRole) {
+      return CompletableActorFuture.completed(null);
+    }
+
+    @Override
+    public String getName() {
+      return "noop-transition-step";
     }
   }
 }


### PR DESCRIPTION
## Description

The changes are more than what was intended.

1. Use current term in inactive transition. The current term is read from the context.
2. While adding new test, found out that the conditionally triggering the transitions may be error prone. I think we can rely on the PartitionTransitionSteps to optimize the transitions.
3. Updated some of the log messages. 

## Related issues

Not sure if the issue can be closed. So marking it as related

related #7896 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
