### PR TITLE
Wait until exporter is recovered before running test

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorDistributionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorDistributionTest.java
@@ -57,6 +57,12 @@ public final class ExporterDirectorDistributionTest {
     createExporter(EXPORTER_ID_2, Collections.singletonMap("y", 2));
   }
 
+  @After
+  public void tearDown() throws Exception {
+    activeExporters.closeExporterDirector();
+    passiveExporters.closeExporterDirector();
+  }
+
   private void createExporter(final String exporterId, final Map<String, Object> arguments) {
     final ControlledTestExporter exporter = spy(new ControlledTestExporter());
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorDistributionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorDistributionTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.awaitility.Awaitility;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -113,12 +114,18 @@ public final class ExporterDirectorDistributionTest {
   }
 
   @Test
-  public void shouldNotResetExporterPositionWhenOldPositionReceived() throws Exception {
+  public void shouldNotResetExporterPositionWhenOldPositionReceived() {
     // given
     exporters.forEach(e -> e.shouldAutoUpdatePosition(true));
     startExporters(exporterDescriptors);
-    final long position = 10L;
 
+    Awaitility.await("Exporter has recovered and started exporting.")
+        .untilAsserted(
+            () ->
+                assertThat(activeExporters.getDirector().getPhase().join())
+                    .isEqualTo(ExporterPhase.EXPORTING));
+
+    final long position = 10L;
     activeExporters.getExportersState().setPosition(EXPORTER_ID_1, position);
     activeExporters.getExportersState().setPosition(EXPORTER_ID_2, position);
 


### PR DESCRIPTION
## Description

The test was flaky because we may update the position before the exporter has recovered from the snapshot. As a result the exporter reads the new position instead of the position in the snapshot and fail to recover.

## Related issues

closes #7924 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
