### PR TITLE
Allow secure inter-node communication over TLS

### DIFF
--- a/atomix/cluster/pom.xml
+++ b/atomix/cluster/pom.xml
@@ -267,10 +267,8 @@
             <!-- dependency used but plugin seems to report a false positive here -->
             <dependency>uk.co.real-logic:sbe-tool</dependency>
             <dependency>net.jqwik:jqwik</dependency>
+            <dependency>io.netty:netty-tcnative-boringssl-static</dependency>
           </usedDependencies>
-          <ignoredDependencies>
-            <ignoredDependency>io.netty:netty-tcnative-boringssl-static</ignoredDependency>
-          </ignoredDependencies>
         </configuration>
       </plugin>
 

--- a/atomix/cluster/pom.xml
+++ b/atomix/cluster/pom.xml
@@ -73,6 +73,15 @@
       <classifier>linux-x86_64</classifier>
     </dependency>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-math3</artifactId>
     </dependency>
@@ -259,6 +268,9 @@
             <dependency>uk.co.real-logic:sbe-tool</dependency>
             <dependency>net.jqwik:jqwik</dependency>
           </usedDependencies>
+          <ignoredDependencies>
+            <ignoredDependency>io.netty:netty-tcnative-boringssl-static</ignoredDependency>
+          </ignoredDependencies>
         </configuration>
       </plugin>
 

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
@@ -17,6 +17,7 @@
 package io.atomix.cluster.messaging;
 
 import io.atomix.utils.config.Config;
+import java.io.File;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +29,9 @@ public class MessagingConfig implements Config {
   private Integer port;
   private Duration shutdownQuietPeriod = Duration.ofMillis(20);
   private Duration shutdownTimeout = Duration.ofSeconds(1);
+  private boolean tlsEnabled = false;
+  private File certificateChain;
+  private File privateKey;
 
   /**
    * Returns the local interfaces to which to bind the node.
@@ -42,7 +46,7 @@ public class MessagingConfig implements Config {
    * Sets the local interfaces to which to bind the node.
    *
    * @param interfaces the local interfaces to which to bind the node
-   * @return the local cluster configuration
+   * @return this config for chaining
    */
   public MessagingConfig setInterfaces(final List<String> interfaces) {
     this.interfaces = interfaces;
@@ -62,7 +66,7 @@ public class MessagingConfig implements Config {
    * Sets the local port to which to bind the node.
    *
    * @param port the local port to which to bind the node
-   * @return the local cluster configuration
+   * @return this config for chaining
    */
   public MessagingConfig setPort(final Integer port) {
     this.port = port;
@@ -88,7 +92,7 @@ public class MessagingConfig implements Config {
    * otherwise every tests takes an additional 2 second just to shutdown the executor.
    *
    * @param shutdownQuietPeriod the quiet period on shutdown
-   * @return this config
+   * @return this config for chaining
    */
   public MessagingConfig setShutdownQuietPeriod(final Duration shutdownQuietPeriod) {
     this.shutdownQuietPeriod = shutdownQuietPeriod;
@@ -104,9 +108,68 @@ public class MessagingConfig implements Config {
    * Sets the shutdown timeout.
    *
    * @param shutdownTimeout the time to wait for an orderly shutdown of the messaging service
-   * @return this config
+   * @return this config for chaining
    */
-  public void setShutdownTimeout(final Duration shutdownTimeout) {
+  public MessagingConfig setShutdownTimeout(final Duration shutdownTimeout) {
     this.shutdownTimeout = shutdownTimeout;
+    return this;
+  }
+
+  /** @return true if TLS is enabled for inter-cluster communication */
+  public boolean isTlsEnabled() {
+    return tlsEnabled;
+  }
+
+  /**
+   * Sets whether or not to enable TLS for inter-cluster communication.
+   *
+   * @param tlsEnabled true to enable TLS between all nodes, false otherwise
+   * @return this config for chaining
+   */
+  public MessagingConfig setTlsEnabled(final boolean tlsEnabled) {
+    this.tlsEnabled = tlsEnabled;
+    return this;
+  }
+
+  /**
+   * The certificate chain to use for inter-cluster communication. This certificate is used for both
+   * the server and the client.
+   *
+   * @return a file which contains the certificate chain
+   */
+  public File getCertificateChain() {
+    return certificateChain;
+  }
+
+  /**
+   * Sets the certificate chain to use for inter-cluster communication. If using a self-signed
+   * certificate, or one which is not widely trusted, this must be the complete chain.
+   *
+   * <p>Mandatory if TLS is enabled.
+   *
+   * @param certificateChain a file containing the certificate chain
+   * @return this config for chaining
+   */
+  public MessagingConfig setCertificateChain(final File certificateChain) {
+    this.certificateChain = certificateChain;
+    return this;
+  }
+
+  /** @return the private key of the certificate chain */
+  public File getPrivateKey() {
+    return privateKey;
+  }
+
+  /**
+   * Sets the private key of the certificate chain.
+   *
+   * <p>Mandatory if TLS is enabled.
+   *
+   * @param privateKey the private key of the associated certificate chain
+   * @return this config for chaining
+   */
+  public MessagingConfig setPrivateKey(final File privateKey) {
+    this.privateKey = privateKey;
+    return this;
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingException.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingException.java
@@ -25,6 +25,10 @@ public class MessagingException extends IOException {
     super(message);
   }
 
+  public MessagingException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
   /** Exception indicating no remote registered remote handler. */
   public static class NoRemoteHandler extends MessagingException {
     public NoRemoteHandler() {

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -49,6 +49,9 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
 import java.net.ConnectException;
@@ -89,20 +92,23 @@ public final class NettyMessagingService implements ManagedMessagingService {
   private final ProtocolVersion protocolVersion;
   private final AtomicBoolean started = new AtomicBoolean(false);
   private final HandlerRegistry handlers = new HandlerRegistry();
-  private volatile LocalClientConnection localConnection;
   private final Map<Channel, RemoteClientConnection> connections = Maps.newConcurrentMap();
   private final AtomicLong messageIdGenerator = new AtomicLong(0);
   private final ChannelPool channelPool;
+  private final List<CompletableFuture> openFutures;
+  private final MessagingConfig config;
+
   private EventLoopGroup serverGroup;
   private EventLoopGroup clientGroup;
   private Class<? extends ServerChannel> serverChannelClass;
   private Class<? extends Channel> clientChannelClass;
   private Channel serverChannel;
-  private final List<CompletableFuture> openFutures;
-  private final MessagingConfig config;
 
   // a single thread executor which silently rejects tasks being submitted when it's shutdown
   private ScheduledExecutorService timeoutExecutor;
+  private volatile LocalClientConnection localConnection;
+  private SslContext serverSslContext;
+  private SslContext clientSslContext;
 
   public NettyMessagingService(
       final String cluster, final Address advertisedAddress, final MessagingConfig config) {
@@ -282,14 +288,27 @@ public final class NettyMessagingService implements ManagedMessagingService {
   }
 
   @Override
+  public boolean isRunning() {
+    return started.get();
+  }
+
+  @Override
   public CompletableFuture<MessagingService> start() {
     if (started.get()) {
       log.warn("Already running at local address: {}", advertisedAddress);
       return CompletableFuture.completedFuture(this);
     }
 
+    final CompletableFuture<Void> serviceLoader;
+    if (config.isTlsEnabled()) {
+      serviceLoader = loadServerSslContext().thenCompose(ok -> loadClientSslContext());
+    } else {
+      serviceLoader = CompletableFuture.completedFuture(null);
+    }
+
     initTransport();
-    return bootstrapServer()
+    return serviceLoader
+        .thenCompose(ok -> bootstrapServer())
         .thenRun(
             () -> {
               timeoutExecutor =
@@ -300,11 +319,6 @@ public final class NettyMessagingService implements ManagedMessagingService {
               log.info("Started");
             })
         .thenApply(v -> this);
-  }
-
-  @Override
-  public boolean isRunning() {
-    return started.get();
   }
 
   @Override
@@ -363,6 +377,37 @@ public final class NettyMessagingService implements ManagedMessagingService {
           });
     }
     return CompletableFuture.completedFuture(null);
+  }
+
+  private CompletableFuture<Void> loadClientSslContext() {
+    try {
+      clientSslContext =
+          SslContextBuilder.forClient()
+              .trustManager(config.getCertificateChain())
+              .sslProvider(SslProvider.OPENSSL_REFCNT)
+              .protocols("TLSv1.3")
+              .build();
+      return CompletableFuture.completedFuture(null);
+    } catch (final Exception e) {
+      return CompletableFuture.failedFuture(
+          new MessagingException(
+              "Failed to start messaging service; invalid client TLS configuration", e));
+    }
+  }
+
+  private CompletableFuture<Void> loadServerSslContext() {
+    try {
+      serverSslContext =
+          SslContextBuilder.forServer(config.getCertificateChain(), config.getPrivateKey())
+              .sslProvider(SslProvider.OPENSSL_REFCNT)
+              .protocols("TLSv1.3")
+              .build();
+      return CompletableFuture.completedFuture(null);
+    } catch (final Exception e) {
+      return CompletableFuture.failedFuture(
+          new MessagingException(
+              "Failed to start messaging service; invalid server TLS configuration", e));
+    }
   }
 
   private void initTransport() {
@@ -710,8 +755,20 @@ public final class NettyMessagingService implements ManagedMessagingService {
     }
 
     @Override
-    protected void initChannel(final SocketChannel channel) throws Exception {
+    protected void initChannel(final SocketChannel channel) {
+      if (config.isTlsEnabled()) {
+        final var sslHandler = clientSslContext.newHandler(channel.alloc());
+        channel.pipeline().addLast("tls", sslHandler);
+      }
+
       channel.pipeline().addLast("handshake", new ClientHandshakeHandlerAdapter(future));
+    }
+
+    @Override
+    public void exceptionCaught(final ChannelHandlerContext ctx, final Throwable cause)
+        throws Exception {
+      future.completeExceptionally(cause);
+      super.exceptionCaught(ctx, cause);
     }
   }
 
@@ -719,7 +776,12 @@ public final class NettyMessagingService implements ManagedMessagingService {
   private class BasicServerChannelInitializer extends ChannelInitializer<SocketChannel> {
 
     @Override
-    protected void initChannel(final SocketChannel channel) throws Exception {
+    protected void initChannel(final SocketChannel channel) {
+      if (config.isTlsEnabled()) {
+        final var sslHandler = serverSslContext.newHandler(channel.alloc());
+        channel.pipeline().addLast("tls", sslHandler);
+      }
+
       channel.pipeline().addLast("handshake", new ServerHandshakeHandlerAdapter());
     }
   }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -84,6 +84,7 @@ import org.slf4j.LoggerFactory;
 /** Netty based MessagingService. */
 public final class NettyMessagingService implements ManagedMessagingService {
   private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
+  private static final String TLS_PROTOCOL = "TLSv1.3";
 
   private final Logger log = LoggerFactory.getLogger(getClass());
   private final Address advertisedAddress;
@@ -385,7 +386,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
           SslContextBuilder.forClient()
               .trustManager(config.getCertificateChain())
               .sslProvider(SslProvider.OPENSSL_REFCNT)
-              .protocols("TLSv1.3")
+              .protocols(TLS_PROTOCOL)
               .build();
       return CompletableFuture.completedFuture(null);
     } catch (final Exception e) {
@@ -400,7 +401,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
       serverSslContext =
           SslContextBuilder.forServer(config.getCertificateChain(), config.getPrivateKey())
               .sslProvider(SslProvider.OPENSSL_REFCNT)
-              .protocols("TLSv1.3")
+              .protocols(TLS_PROTOCOL)
               .build();
       return CompletableFuture.completedFuture(null);
     } catch (final Exception e) {

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTlsTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTlsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.atomix.cluster.messaging.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTlsTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTlsTest.java
@@ -1,0 +1,106 @@
+package io.atomix.cluster.messaging.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.messaging.MessagingConfig;
+import io.atomix.utils.net.Address;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import java.net.ConnectException;
+import java.security.cert.CertificateException;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+final class NettyMessagingServiceTlsTest {
+  @Test
+  void shouldCommunicateOverTls() throws CertificateException {
+    // given
+    final var certificate = new SelfSignedCertificate();
+    final var client = createSecureMessagingService(certificate);
+    final var server = createSecureMessagingService(certificate);
+    final var payload = "foo".getBytes();
+
+    // when
+    client.start().join();
+    server.start().join();
+    server.registerHandler(
+        "topic",
+        (sender, request) ->
+            CompletableFuture.completedFuture((new String(request) + "bar").getBytes()));
+    final var response = client.sendAndReceive(server.address(), "topic", payload).join();
+
+    // then
+    assertThat(response).isEqualTo("foobar".getBytes());
+  }
+
+  @Test
+  void shouldFailWhenClientIsNotUsingTls() throws CertificateException {
+    // given
+    final var certificate = new SelfSignedCertificate();
+    final var client = createInsecureMessagingService();
+    final var server = createSecureMessagingService(certificate);
+    final var payload = "foo".getBytes();
+
+    // when
+    client.start().join();
+    server.start().join();
+    server.registerHandler(
+        "topic",
+        (sender, request) ->
+            CompletableFuture.completedFuture((new String(request) + "bar").getBytes()));
+    final var response =
+        client.sendAndReceive(server.address(), "topic", payload, true, Duration.ofSeconds(10));
+
+    // then
+    assertThat(response)
+        .failsWithin(Duration.ofSeconds(10))
+        .withThrowableOfType(ExecutionException.class)
+        .havingRootCause()
+        .isInstanceOf(ConnectException.class);
+  }
+
+  @Test
+  void shouldFailWhenServerIsNotUsingTls() throws CertificateException {
+    // given
+    final var certificate = new SelfSignedCertificate();
+    final var server = createInsecureMessagingService();
+    final var client = createSecureMessagingService(certificate);
+    final var payload = "foo".getBytes();
+
+    // when
+    client.start().join();
+    server.start().join();
+    server.registerHandler(
+        "topic",
+        (sender, request) ->
+            CompletableFuture.completedFuture((new String(request) + "bar").getBytes()));
+    final var response =
+        client.sendAndReceive(server.address(), "topic", payload, true, Duration.ofSeconds(1));
+
+    // then
+    assertThat(response)
+        .failsWithin(Duration.ofSeconds(2))
+        .withThrowableOfType(ExecutionException.class)
+        .havingRootCause()
+        .isInstanceOf(ConnectException.class);
+  }
+
+  private NettyMessagingService createInsecureMessagingService() {
+    final var config =
+        new MessagingConfig().setPort(SocketUtil.getNextAddress().getPort()).setTlsEnabled(false);
+    return new NettyMessagingService("cluster", Address.from(config.getPort()), config);
+  }
+
+  private NettyMessagingService createSecureMessagingService(
+      final SelfSignedCertificate certificate) {
+    final var config =
+        new MessagingConfig()
+            .setPort(SocketUtil.getNextAddress().getPort())
+            .setTlsEnabled(true)
+            .setCertificateChain(certificate.certificate())
+            .setPrivateKey(certificate.privateKey());
+    return new NettyMessagingService("cluster", Address.from(config.getPort()), config);
+  }
+}

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTlsTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTlsTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
 
 final class NettyMessagingServiceTlsTest {
+
   @Test
   void shouldCommunicateOverTls() throws CertificateException {
     // given


### PR DESCRIPTION
## Description

Introduces security configuration similar to the gateway's for inter-node communication. Users can now configure a certificate chain and private key which is loaded by the NettyMessagingService in order to encrypt communication between all cluster nodes. TLS version is fixed at 1.3, and uses BoringSSL via the tcnative artifact provided by Netty.

This solution assumes all nodes share the same certificates, as we load the certificate chain as part of the trust manager for client connections, and there's no real way to specify a different trust manager. Assuming they share the same intermediate chain, it could be possible to have different final certificates, but this is not tested.

This PR does not include the broker configuration wiring, so it's currently not usable, but it's the first step to allow this. The next issue will cover wiring the broker configuration to configure secure inter-cluster communication.

## Related issues

related to #5272 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
