### PR TITLE
Prefer replicating events instead of snapshots

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -1096,6 +1096,14 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     return partitionConfig.getMaxQuorumResponseTimeout();
   }
 
+  public int getPreferSnapshotReplicationThreshold() {
+    return partitionConfig.getPreferSnapshotReplicationThreshold();
+  }
+
+  public void setPreferSnapshotReplicationThreshold(int snapshotReplicationThreshold) {
+    partitionConfig.setPreferSnapshotReplicationThreshold(snapshotReplicationThreshold);
+  }
+
   public int getPartitionId() {
     return partitionId;
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -29,6 +29,7 @@ public class RaftPartitionConfig {
   private static final Duration DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT = Duration.ofSeconds(0);
   private static final RoundRobinPartitionDistributor DEFAULT_PARTITION_DISTRIBUTOR =
       new RoundRobinPartitionDistributor();
+  private static final int DEFAULT_SNAPSHOT_REPLICATION_THRESHOLD = 100;
 
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
@@ -39,6 +40,7 @@ public class RaftPartitionConfig {
   private int minStepDownFailureCount = DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT;
   private Duration maxQuorumResponseTimeout = DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT;
   private PartitionDistributor partitionDistributor = DEFAULT_PARTITION_DISTRIBUTOR;
+  private int preferSnapshotReplicationThreshold = DEFAULT_SNAPSHOT_REPLICATION_THRESHOLD;
 
   /**
    * Returns the Raft leader election timeout.
@@ -156,5 +158,13 @@ public class RaftPartitionConfig {
 
   public void setPartitionDistributor(final PartitionDistributor partitionDistributor) {
     this.partitionDistributor = partitionDistributor;
+  }
+
+  public int getPreferSnapshotReplicationThreshold() {
+    return preferSnapshotReplicationThreshold;
+  }
+
+  public void setPreferSnapshotReplicationThreshold(int preferSnapshotReplicationThreshold) {
+    this.preferSnapshotReplicationThreshold = preferSnapshotReplicationThreshold;
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftReplicationTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftReplicationTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class RaftReplicationTest {
+  @Rule @Parameter public RaftRule raftRule;
+
+  @Parameters(name = "{index}: {0}")
+  public static Object[][] raftConfigurations() {
+    return new Object[][] {
+      new Object[] {RaftRule.withBootstrappedNodes(3)},
+      new Object[] {RaftRule.withBootstrappedNodes(4)},
+      new Object[] {RaftRule.withBootstrappedNodes(5)}
+    };
+  }
+
+  @Test
+  public void shouldPreferReplicatingEvents() throws Exception {
+    // given
+    final var entryCount = 10;
+    final var snapshotIndex = 15;
+
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var follower = raftRule.getFollower().orElseThrow();
+
+    raftRule.appendEntries(entryCount);
+
+    // when
+    raftRule.partition(follower);
+    final var lastCommitIndex = raftRule.appendEntries(entryCount);
+    raftRule.doSnapshotOnMemberWithoutCompaction(leader, snapshotIndex, 1);
+    raftRule.reconnect(follower);
+
+    // then
+    assertThat(follower.getContext().getPersistedSnapshotStore().getCurrentSnapshotIndex())
+        .isNotEqualTo(snapshotIndex);
+    raftRule.awaitSameLogSizeOnAllNodes(lastCommitIndex);
+  }
+
+  @Test
+  public void shouldReplicateSnapshotIfEventsNotAvailable() throws Exception {
+    // given
+    final var entryCount = 10;
+    final var snapshotIndex = 15;
+
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var follower = raftRule.getFollower().orElseThrow();
+
+    raftRule.appendEntries(entryCount);
+
+    // when
+    raftRule.partition(follower);
+    final var lastCommitIndex = raftRule.appendEntries(entryCount);
+
+    // Snapshot multiple chunks to split snapshot replication across multiple messages
+    raftRule.doSnapshotOnMember(leader, snapshotIndex, 3);
+
+    raftRule.reconnect(follower);
+
+    // then - follower received snapshot
+    raftRule.awaitSameLogSizeOnAllNodes(lastCommitIndex);
+    assertThat(follower.getContext().getPersistedSnapshotStore().getCurrentSnapshotIndex())
+        .isEqualTo(snapshotIndex);
+  }
+
+  @Test
+  public void shouldReplicateSnapshotIfMemberLagAboveThreshold() throws Exception {
+    // given
+    final var entryCount = 10;
+    final var snapshotIndex = 15;
+
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var follower = raftRule.getFollower().orElseThrow();
+
+    raftRule.appendEntries(entryCount);
+
+    // when
+    raftRule.partition(follower);
+    final var lastCommitIndex = raftRule.appendEntries(entryCount);
+
+    // Set threshold to a smaller, sensible value
+    leader.getContext().setPreferSnapshotReplicationThreshold(1);
+    raftRule.doSnapshotOnMemberWithoutCompaction(leader, snapshotIndex, 1);
+
+    raftRule.reconnect(follower);
+
+    // then - follower received snapshot
+    raftRule.awaitSameLogSizeOnAllNodes(lastCommitIndex);
+    assertThat(follower.getContext().getPersistedSnapshotStore().getCurrentSnapshotIndex())
+        .isEqualTo(snapshotIndex);
+  }
+}

--- a/atomix/cluster/src/test/java/io/atomix/raft/SnapshotReplicationListenerTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/SnapshotReplicationListenerTest.java
@@ -37,8 +37,9 @@ public class SnapshotReplicationListenerTest {
     follower.getContext().addSnapshotReplicationListener(snapshotReplicationListener);
     raftRule.partition(follower);
 
-    final var commitIndex = raftRule.appendEntries(2); // awaits commit
     final var leader = raftRule.getLeader().orElseThrow();
+    leader.getContext().setPreferSnapshotReplicationThreshold(1);
+    final var commitIndex = raftRule.appendEntries(2); // awaits commit
     raftRule.doSnapshotOnMember(leader, commitIndex, 1);
     raftRule.appendEntry();
 


### PR DESCRIPTION
## Description

This adds a threshold on number of events a follower can lag behind a leader to decide wether we should replicate events or a snapshot. This should save resources because replicating a low number of events should be more efficient than replicating a snapshot.
We can't always replicate events even if the lag is below the threshold because some events might not be available anymore due to log compaction. 

## Related issues

closes #7784 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
