### PR TITLE
#7903 add SfvChecksum file logic to read and write SfvFiles

### DIFF
--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
@@ -70,7 +70,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
                       directory)));
 
         } else {
-          checksum = SnapshotChecksum.calculate(directory);
+          checksum = SnapshotChecksum.calculate(directory).getCombinedValue();
 
           snapshot = null;
           isValid = true;

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksum.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksum.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.snapshots.impl;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Map.Entry;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.CRC32C;
+import java.util.zip.Checksum;
+import org.agrona.IoUtil;
+
+/**
+ * Supports building individual CRCs compatible with SFV file format and also supports backward
+ * compatibility with 'combinedChecksum' field.
+ * https://en.wikipedia.org/wiki/Simple_file_verification
+ */
+final class SfvChecksum {
+
+  private static final String FILE_CRC_SEPARATOR = "   ";
+  private static final String FILE_CRC_SEPARATOR_REGEX = " {3}";
+  private static final Pattern FILE_CRC_PATTERN =
+      Pattern.compile("(.*)" + FILE_CRC_SEPARATOR_REGEX + "([0-9a-fA-F]{1,16})");
+  private static final String COMBINED_VALUE_PREFIX = "; combinedValue = ";
+  private static final Pattern COMBINED_VALUE_PATTERN =
+      Pattern.compile(".*combinedValue\\s+=\\s+([0-9a-fA-F]{1,16})");
+  private static final String SNAPSHOT_DIRECTORY_PREFIX = "; snapshot directory = ";
+
+  private Checksum combinedChecksum;
+  private final SortedMap<String, Long> checksums = new TreeMap<>();
+  private String snapshotDirectoryComment;
+
+  /**
+   * creates an immutable and pre-defined checksum
+   *
+   * @param combinedChecksum pre-defined checksum
+   */
+  public SfvChecksum(long combinedChecksum) {
+    this.combinedChecksum = new PreDefinedImmutableChecksum(combinedChecksum);
+  }
+
+  public SfvChecksum() {
+    this.combinedChecksum = new CRC32C();
+  }
+
+  public long getCombinedValue() {
+    return combinedChecksum.getValue();
+  }
+
+  public void setSnapshotDirectoryComment(String headerComment) {
+    this.snapshotDirectoryComment = headerComment;
+  }
+
+  public void updateFromFile(final Path filePath) throws IOException {
+    final String fileName = filePath.getFileName().toString();
+    final byte[] chunkId = fileName.getBytes(UTF_8);
+    combinedChecksum.update(chunkId);
+
+    final Checksum checksum = new CRC32C();
+    final ByteBuffer readBuffer = ByteBuffer.allocate(IoUtil.BLOCK_SIZE);
+    try (final FileChannel channel = FileChannel.open(filePath, StandardOpenOption.READ)) {
+      readBuffer.clear();
+      while (channel.read(readBuffer) > 0) {
+        readBuffer.flip();
+        combinedChecksum.update(readBuffer);
+        readBuffer.flip();
+        checksum.update(readBuffer);
+        readBuffer.clear();
+      }
+    }
+    checksums.put(fileName, checksum.getValue());
+  }
+
+  public void updateFromSfvFile(String... lines) {
+    for (String line : lines) {
+      line = line.trim();
+      if (line.startsWith(";")) {
+        final Matcher matcher = COMBINED_VALUE_PATTERN.matcher(line);
+        if (matcher.find()) {
+          final String hexString = matcher.group(1);
+          final long crc = Long.parseLong(hexString, 16);
+          combinedChecksum = new PreDefinedImmutableChecksum(crc);
+        }
+      } else {
+        final Matcher matcher = FILE_CRC_PATTERN.matcher(line);
+        if (matcher.find()) {
+          final Long crc = Long.parseLong(matcher.group(2), 16);
+          final String fileName = matcher.group(1).trim();
+          checksums.put(fileName, crc);
+        }
+      }
+    }
+  }
+
+  byte[] serializeSfvFileData() throws IOException {
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(baos, UTF_8));
+    writer.write("; This is an SFC checksum file for all files in the given directory.");
+    writer.newLine();
+    writer.write("; You might use cksfv or another tool to validate these files manually.");
+    writer.newLine();
+    writer.write("; This is an automatically created file - please do NOT modify.");
+    writer.newLine();
+    if (snapshotDirectoryComment != null) {
+      writer.write(SNAPSHOT_DIRECTORY_PREFIX);
+      writer.write(snapshotDirectoryComment);
+      writer.newLine();
+    }
+    writer.write(COMBINED_VALUE_PREFIX);
+    writer.write(Long.toHexString(combinedChecksum.getValue()));
+    writer.newLine();
+    writer.write("; number of files used for combined value = " + checksums.size());
+    writer.newLine();
+    for (Entry<String, Long> entry : checksums.entrySet()) {
+      writer.write(entry.getKey());
+      writer.write(FILE_CRC_SEPARATOR);
+      writer.write(Long.toHexString(entry.getValue()));
+      writer.newLine();
+    }
+    writer.flush();
+    return baos.toByteArray();
+  }
+
+  private static class PreDefinedImmutableChecksum implements Checksum {
+
+    private final long crc;
+
+    public PreDefinedImmutableChecksum(long crc) {
+      this.crc = crc;
+    }
+
+    @Override
+    public void update(int b) {
+      throw getUnsupportedOperationException();
+    }
+
+    @Override
+    public void update(byte[] b, int off, int len) {
+      throw getUnsupportedOperationException();
+    }
+
+    @Override
+    public long getValue() {
+      return crc;
+    }
+
+    @Override
+    public void reset() {
+      throw getUnsupportedOperationException();
+    }
+
+    private static UnsupportedOperationException getUnsupportedOperationException() {
+      return new UnsupportedOperationException("This is an immutable checksum.");
+    }
+  }
+}

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksum.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksum.java
@@ -9,16 +9,10 @@ package io.camunda.zeebe.snapshots.impl;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.zip.Checksum;
-import org.agrona.IoUtil;
 
 final class SnapshotChecksum {
 
@@ -26,43 +20,50 @@ final class SnapshotChecksum {
     throw new IllegalStateException("Utility class");
   }
 
-  public static long read(final Path checksumPath) throws IOException {
+  public static SfvChecksum read(final Path checksumPath) throws IOException {
     try (final RandomAccessFile checksumFile = new RandomAccessFile(checksumPath.toFile(), "r")) {
-      return checksumFile.readLong();
-    }
-  }
-
-  public static long calculate(final Path snapshotDirectory) throws IOException {
-    try (final var fileStream = Files.list(snapshotDirectory).sorted()) {
-      return createCombinedChecksum(fileStream.collect(Collectors.toList()));
-    }
-  }
-
-  public static void persist(final Path checksumPath, final long checksum) throws IOException {
-    try (final RandomAccessFile checksumFile = new RandomAccessFile(checksumPath.toFile(), "rwd")) {
-      checksumFile.writeLong(checksum);
-    }
-  }
-
-  /** computes a checksum for the files, in the order they're presented */
-  private static long createCombinedChecksum(final List<Path> paths) throws IOException {
-    final Checksum checksum = SnapshotChunkUtil.newChecksum();
-    final ByteBuffer readBuffer = ByteBuffer.allocate(IoUtil.BLOCK_SIZE);
-
-    for (final var path : paths) {
-      final byte[] chunkId = path.getFileName().toString().getBytes(StandardCharsets.UTF_8);
-      checksum.update(chunkId);
-
-      try (final FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
-        readBuffer.clear();
-        while (channel.read(readBuffer) > 0) {
-          readBuffer.flip();
-          checksum.update(readBuffer);
-          readBuffer.clear();
-        }
+      if (checksumFile.length() == 8) {
+        // compatibility mode
+        final long combinedChecksum = checksumFile.readLong();
+        return new SfvChecksum(combinedChecksum);
       }
+      final SfvChecksum sfvChecksum = new SfvChecksum();
+      String line;
+      while ((line = checksumFile.readLine()) != null) {
+        sfvChecksum.updateFromSfvFile(line);
+      }
+      return sfvChecksum;
     }
+  }
 
-    return checksum.getValue();
+  public static SfvChecksum calculate(final Path snapshotDirectory) throws IOException {
+    try (final var fileStream = Files.list(snapshotDirectory).sorted()) {
+      final SfvChecksum sfvChecksum =
+          createCombinedChecksum(fileStream.collect(Collectors.toList()));
+      sfvChecksum.setSnapshotDirectoryComment(snapshotDirectory.toString());
+      return sfvChecksum;
+    }
+  }
+
+  public static void persist(final Path checksumPath, final SfvChecksum checksum)
+      throws IOException {
+    try (final RandomAccessFile checksumFile = new RandomAccessFile(checksumPath.toFile(), "rwd")) {
+      final byte[] data = checksum.serializeSfvFileData();
+      checksumFile.write(data);
+      checksumFile.setLength(data.length);
+    }
+  }
+
+  /**
+   * computes a checksum for the files, in the order they're presented
+   *
+   * @return the SfvChecksum object
+   */
+  private static SfvChecksum createCombinedChecksum(final List<Path> files) throws IOException {
+    final SfvChecksum checksum = new SfvChecksum();
+    for (final var f : files) {
+      checksum.updateFromFile(f);
+    }
+    return checksum;
   }
 }

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -103,7 +103,7 @@ public class FileBasedSnapshotStoreTest {
   public void shouldNotLoadCorruptedSnapshot() throws Exception {
     // given
     final var persistedSnapshot = (FileBasedSnapshot) takeTransientSnapshot().persist().join();
-    SnapshotChecksum.persist(persistedSnapshot.getChecksumFile(), 0xCAFEL);
+    SnapshotChecksum.persist(persistedSnapshot.getChecksumFile(), new SfvChecksum(0xCAFEL));
 
     // when
     snapshotStore.close();
@@ -134,7 +134,7 @@ public class FileBasedSnapshotStoreTest {
     final var otherStore = createStore(snapshotsDir, pendingSnapshotsDir);
     final var corruptOlderSnapshot =
         (FileBasedSnapshot) takeTransientSnapshot(1, otherStore).persist().join();
-    SnapshotChecksum.persist(corruptOlderSnapshot.getChecksumFile(), 0xCAFEL);
+    SnapshotChecksum.persist(corruptOlderSnapshot.getChecksumFile(), new SfvChecksum(0xCAFEL));
 
     final var newerSnapshot =
         (FileBasedSnapshot) takeTransientSnapshot(2, snapshotStore).persist().join();
@@ -182,7 +182,7 @@ public class FileBasedSnapshotStoreTest {
     final var otherStore = createStore(snapshotsDir, pendingSnapshotsDir);
 
     // when - corrupting old snapshot and adding new valid snapshot
-    SnapshotChecksum.persist(olderSnapshot.getChecksumFile(), 0xCAFEL);
+    SnapshotChecksum.persist(olderSnapshot.getChecksumFile(), new SfvChecksum(0xCAFEL));
     final var newerSnapshot =
         (FileBasedSnapshot) takeTransientSnapshot(2, otherStore).persist().join();
 
@@ -200,7 +200,7 @@ public class FileBasedSnapshotStoreTest {
     final var otherStore = createStore(snapshotsDir, pendingSnapshotsDir);
     final var corruptSnapshot =
         (FileBasedSnapshot) takeTransientSnapshot(1, otherStore).persist().join();
-    SnapshotChecksum.persist(corruptSnapshot.getChecksumFile(), 0xCAFEL);
+    SnapshotChecksum.persist(corruptSnapshot.getChecksumFile(), new SfvChecksum(0xCAFEL));
 
     // when
     snapshotStore.close();

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SfvChecksumTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SfvChecksumTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.snapshots.impl;
+
+import static io.camunda.zeebe.snapshots.impl.SnapshotChecksumTest.createChunk;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class SfvChecksumTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private SfvChecksum sfvChecksum;
+
+  @Before
+  public void setUp() throws Exception {
+    sfvChecksum = new SfvChecksum();
+  }
+
+  @Test
+  public void shouldUseDefaultValueZeroWhenInitialized() {
+    // given
+    // when
+    // then
+    assertThat(sfvChecksum.getCombinedValue()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldReadCombinedValueFromComment() {
+    // given
+    final String[] sfvLines = {"; a simple comment to be ignored", "; combinedValue = bbaaccdd"};
+
+    // when
+    sfvChecksum.updateFromSfvFile(sfvLines);
+
+    // then
+    assertThat(sfvChecksum.getCombinedValue()).isEqualTo(0xbbaaccddL);
+  }
+
+  @Test
+  public void shouldReadAndWriteSameValues() throws IOException {
+    // given
+    final String[] givenSfvLines = {"; combinedValue = 12345678", "file1   aabbccdd"};
+    sfvChecksum.updateFromSfvFile(givenSfvLines);
+    final String serialized =
+        new String(sfvChecksum.serializeSfvFileData(), StandardCharsets.UTF_8);
+
+    // when
+    final String[] actualSfVlines = serialized.split(System.lineSeparator());
+
+    // then
+    assertThat(actualSfVlines).contains(givenSfvLines[0]);
+    assertThat(actualSfVlines).contains(givenSfvLines[1]);
+  }
+
+  @Test
+  public void shouldWriteSnapshotDirectoryCommentIfPresent() throws IOException {
+    // given
+    sfvChecksum.setSnapshotDirectoryComment("/foo/bar");
+
+    // when
+    final String serialized =
+        new String(sfvChecksum.serializeSfvFileData(), StandardCharsets.UTF_8);
+
+    // then
+    assertThat(serialized).contains("; snapshot directory = /foo/bar");
+  }
+
+  @Test
+  public void shouldContainHumanReadableInstructions() throws IOException {
+    // given
+
+    // when
+    final String serialized =
+        new String(sfvChecksum.serializeSfvFileData(), StandardCharsets.UTF_8);
+
+    // then
+    assertThat(serialized)
+        .contains("; This is an SFC checksum file for all files in the given directory.");
+    assertThat(serialized)
+        .contains("; You might use cksfv or another tool to validate these files manually.");
+    assertThat(serialized)
+        .contains("; This is an automatically created file - please do NOT modify.");
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenUsingPreDefinedChecksumFromSfv() throws IOException {
+    // given
+    final var folder = temporaryFolder.newFolder().toPath();
+    createChunk(folder, "file1.txt");
+
+    // when
+    sfvChecksum.updateFromSfvFile("; combinedValue = 12341234");
+
+    // then
+    assertThatThrownBy(() -> sfvChecksum.updateFromFile(folder))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
@@ -9,7 +9,9 @@ package io.camunda.zeebe.snapshots.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -47,7 +49,7 @@ public class SnapshotChecksumTest {
     createChunk(corruptedSnapshot, "file3.txt");
   }
 
-  private void createChunk(final Path snapshot, final String chunkName) throws IOException {
+  static void createChunk(final Path snapshot, final String chunkName) throws IOException {
     Files.writeString(
         snapshot.resolve(chunkName),
         chunkName,
@@ -58,10 +60,10 @@ public class SnapshotChecksumTest {
   @Test
   public void shouldGenerateTheSameChecksumForOneFile() throws Exception {
     // given
-    final var expectedChecksum = SnapshotChecksum.calculate(singleFileSnapshot);
+    final var expectedChecksum = SnapshotChecksum.calculate(singleFileSnapshot).getCombinedValue();
 
     // when
-    final var actual = SnapshotChecksum.calculate(singleFileSnapshot);
+    final var actual = SnapshotChecksum.calculate(singleFileSnapshot).getCombinedValue();
 
     // then
     assertThat(actual).isEqualTo(expectedChecksum);
@@ -70,11 +72,11 @@ public class SnapshotChecksumTest {
   @Test
   public void shouldGenerateDifferentChecksumWhenFileNameIsDifferent() throws Exception {
     // given
-    final var expectedChecksum = SnapshotChecksum.calculate(singleFileSnapshot);
+    final var expectedChecksum = SnapshotChecksum.calculate(singleFileSnapshot).getCombinedValue();
 
     // when
     Files.move(singleFileSnapshot.resolve("file1.txt"), singleFileSnapshot.resolve("renamed"));
-    final var actual = SnapshotChecksum.calculate(singleFileSnapshot);
+    final var actual = SnapshotChecksum.calculate(singleFileSnapshot).getCombinedValue();
 
     // then
     assertThat(actual).isNotEqualTo(expectedChecksum);
@@ -83,10 +85,11 @@ public class SnapshotChecksumTest {
   @Test
   public void shouldGenerateTheSameChecksumForMultipleFiles() throws Exception {
     // given
-    final var expectedChecksum = SnapshotChecksum.calculate(multipleFileSnapshot);
+    final var expectedChecksum =
+        SnapshotChecksum.calculate(multipleFileSnapshot).getCombinedValue();
 
     // when
-    final var actual = SnapshotChecksum.calculate(multipleFileSnapshot);
+    final var actual = SnapshotChecksum.calculate(multipleFileSnapshot).getCombinedValue();
 
     // then
     assertThat(actual).isEqualTo(expectedChecksum);
@@ -95,10 +98,10 @@ public class SnapshotChecksumTest {
   @Test
   public void shouldGenerateDifferentChecksumForDifferentFiles() throws Exception {
     // given
-    final var expectedChecksum = SnapshotChecksum.calculate(singleFileSnapshot);
+    final var expectedChecksum = SnapshotChecksum.calculate(singleFileSnapshot).getCombinedValue();
 
     // when
-    final var actual = SnapshotChecksum.calculate(multipleFileSnapshot);
+    final var actual = SnapshotChecksum.calculate(multipleFileSnapshot).getCombinedValue();
 
     // then
     assertThat(actual).isNotEqualTo(expectedChecksum);
@@ -115,7 +118,7 @@ public class SnapshotChecksumTest {
     final var actual = SnapshotChecksum.read(checksumPath);
 
     // then
-    assertThat(actual).isEqualTo(expectedChecksum);
+    assertThat(actual.getCombinedValue()).isEqualTo(expectedChecksum.getCombinedValue());
   }
 
   @Test
@@ -127,7 +130,7 @@ public class SnapshotChecksumTest {
 
     // when
     Files.delete(corruptedSnapshot.resolve("file1.txt"));
-    final var actualChecksum = SnapshotChecksum.calculate(corruptedSnapshot);
+    final var actualChecksum = SnapshotChecksum.calculate(corruptedSnapshot).getCombinedValue();
 
     // then
     assertThat(actualChecksum).isNotEqualTo(expectedChecksum);
@@ -147,9 +150,44 @@ public class SnapshotChecksumTest {
     final var expected = checksum.getValue();
 
     // when
-    final var actual = SnapshotChecksum.calculate(largeSnapshot);
+    final var actual = SnapshotChecksum.calculate(largeSnapshot).getCombinedValue();
 
     // then
     assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void shouldReadFormerSimpleChecksumFile() throws IOException {
+    // given
+    final Path temp = temporaryFolder.newFolder().toPath();
+    final File tempFile = new File(temp.toFile(), "checksum");
+    final long expectedChecksum = 0xccaaffeeL;
+    try (final RandomAccessFile file = new RandomAccessFile(tempFile, "rw"); ) {
+      file.writeLong(expectedChecksum);
+    }
+
+    // when
+    final SfvChecksum sfvChecksum = SnapshotChecksum.read(tempFile.toPath());
+    final long combinedValue = sfvChecksum.getCombinedValue();
+
+    // then
+    assertThat(combinedValue).isEqualTo(expectedChecksum);
+  }
+
+  @Test
+  public void shouldWriteTheNumberOfFiles() throws IOException {
+    // given
+    final var folder = temporaryFolder.newFolder().toPath();
+    createChunk(folder, "file1.txt");
+    createChunk(folder, "file2.txt");
+    createChunk(folder, "file3.txt");
+    final SfvChecksum sfvChecksum = SnapshotChecksum.calculate(folder);
+
+    // when
+    final String serialized =
+        new String(sfvChecksum.serializeSfvFileData(), StandardCharsets.UTF_8);
+
+    // then
+    assertThat(serialized).contains("; number of files used for combined value = 3");
   }
 }


### PR DESCRIPTION
## Description

Introduced SfvChecksum class, to improve the ability to detect broken snapshots.

## Related issues

closes #7903

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [/] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [/] There are unit/integration tests that verify all acceptance criterias of the issue
* [/] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
