### PR TITLE
feat: add processing queue panel

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -88,7 +88,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1633608121108,
+  "iteration": 1633930524100,
   "links": [],
   "panels": [
     {
@@ -1430,6 +1430,121 @@
       "id": 203,
       "panels": [
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Shows the processing queue size over time. Processing queue defines, what is already appended but not yet processed by the stream processor.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 2
+          },
+          "hiddenSeries": false,
+          "id": 272,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by (partition) (zeebe_log_appender_last_appended_position{namespace=~\"$namespace\", partition=~\"$partition\"}) - sum by (partition) (zeebe_stream_processor_last_processed_position{namespace=~\"$namespace\", partition=~\"$partition\"})",
+              "interval": "",
+              "legendFormat": "Partition {{partition}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [
+            {
+              "$$hashKey": "object:2366",
+              "colorMode": "warning",
+              "fill": true,
+              "line": true,
+              "op": "gt",
+              "value": 100,
+              "yaxis": "left"
+            },
+            {
+              "$$hashKey": "object:2372",
+              "colorMode": "critical",
+              "fill": true,
+              "line": true,
+              "op": "gt",
+              "value": 150,
+              "yaxis": "left"
+            }
+          ],
+          "timeRegions": [],
+          "title": "Processing Queue size",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:2345",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:2346",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
           "datasource": "${DS_PROMETHEUS}",
           "description": "Shows how many positions are not updated by exporters per partition. Means what is the difference between last committed exporter position and committed log position.",
           "fieldConfig": {
@@ -1456,7 +1571,7 @@
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 2
+            "y": 9
           },
           "id": 192,
           "options": {
@@ -1504,7 +1619,7 @@
             "h": 4,
             "w": 7,
             "x": 12,
-            "y": 2
+            "y": 9
           },
           "id": 196,
           "pageSize": null,
@@ -1585,7 +1700,7 @@
             "h": 4,
             "w": 5,
             "x": 19,
-            "y": 2
+            "y": 9
           },
           "id": 200,
           "pageSize": null,
@@ -1678,7 +1793,7 @@
             "h": 6,
             "w": 5,
             "x": 0,
-            "y": 6
+            "y": 13
           },
           "id": 194,
           "options": {
@@ -1725,7 +1840,7 @@
             "h": 6,
             "w": 7,
             "x": 5,
-            "y": 6
+            "y": 13
           },
           "id": 199,
           "pageSize": null,
@@ -1806,7 +1921,7 @@
             "h": 12,
             "w": 5,
             "x": 12,
-            "y": 6
+            "y": 13
           },
           "id": 198,
           "pageSize": null,
@@ -1893,7 +2008,7 @@
             "h": 12,
             "w": 7,
             "x": 17,
-            "y": 6
+            "y": 13
           },
           "id": 268,
           "pageSize": null,
@@ -1986,7 +2101,7 @@
             "h": 6,
             "w": 5,
             "x": 0,
-            "y": 12
+            "y": 19
           },
           "id": 189,
           "options": {
@@ -2034,7 +2149,7 @@
             "h": 6,
             "w": 7,
             "x": 5,
-            "y": 12
+            "y": 19
           },
           "id": 201,
           "pageSize": null,


### PR DESCRIPTION
## Description

Adds a new panel which shows the processing queue size over time. If you fine with this new panel, we can think about removing the gauges and tables, which show the numbers. I feel they are not really useful tbh.

I introduced thresholds as help to find out when the queue size is to big.


Normal cluster:

![normal](https://user-images.githubusercontent.com/2758593/136741746-025095d7-8bdf-4b87-a27c-9e340c659602.png)


Abnormal cluster:

![abnormal](https://user-images.githubusercontent.com/2758593/136741760-e43c83e7-89a5-4bb5-80f4-60c0a811f68a.png)


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
