### PR TITLE
Don't throw `BufferOverflowException` to trigger segment creation

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/JournalException.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/JournalException.java
@@ -52,9 +52,16 @@ public class JournalException extends RuntimeException {
     }
   }
 
-  /** Exception thrown when the segment is full and no records can be appended * */
+  /** Exception thrown when the segment is full and no records can be appended */
   public static class SegmentFull extends JournalException {
     public SegmentFull(final String message) {
+      super(message);
+    }
+  }
+
+  /** Exception thrown when the segment is too small to fit even one record */
+  public static class SegmentSizeTooSmall extends JournalException {
+    public SegmentSizeTooSmall(final String message) {
       super(message);
     }
   }

--- a/journal/src/main/java/io/camunda/zeebe/journal/JournalException.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/JournalException.java
@@ -51,4 +51,11 @@ public class JournalException extends RuntimeException {
       super(message);
     }
   }
+
+  /** Exception thrown when the segment is full and no records can be appended * */
+  public static class SegmentFull extends JournalException {
+    public SegmentFull(final String message) {
+      super(message);
+    }
+  }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/MappedJournalSegmentWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/MappedJournalSegmentWriter.java
@@ -179,11 +179,11 @@ class MappedJournalSegmentWriter {
       final int offset, final RecordData indexedRecord) {
     final var recordLength = serializer.writeData(indexedRecord, writeBuffer, offset);
     if (recordLength.isLeft()) {
-      return recordLength;
+      return Either.left(new SegmentFull("Not enough space to write record"));
     }
     final int nextEntryOffset = offset + recordLength.get();
     invalidateNextEntry(nextEntryOffset);
-    return recordLength;
+    return Either.right(recordLength.get());
   }
 
   private void invalidateNextEntry(final int position) {

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/MappedJournalSegmentWriter.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/MappedJournalSegmentWriter.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.journal.file;
 
 import io.camunda.zeebe.journal.JournalException.InvalidChecksum;
 import io.camunda.zeebe.journal.JournalException.InvalidIndex;
+import io.camunda.zeebe.journal.JournalException.SegmentFull;
 import io.camunda.zeebe.journal.JournalRecord;
 import io.camunda.zeebe.journal.file.record.CorruptedLogException;
 import io.camunda.zeebe.journal.file.record.JournalRecordReaderUtil;
@@ -26,7 +27,7 @@ import io.camunda.zeebe.journal.file.record.PersistedJournalRecord;
 import io.camunda.zeebe.journal.file.record.RecordData;
 import io.camunda.zeebe.journal.file.record.RecordMetadata;
 import io.camunda.zeebe.journal.file.record.SBESerializer;
-import java.nio.BufferOverflowException;
+import io.camunda.zeebe.util.Either;
 import java.nio.BufferUnderflowException;
 import java.nio.MappedByteBuffer;
 import org.agrona.DirectBuffer;
@@ -79,7 +80,7 @@ class MappedJournalSegmentWriter {
     }
   }
 
-  public JournalRecord append(final long asqn, final DirectBuffer data) {
+  public Either<SegmentFull, JournalRecord> append(final long asqn, final DirectBuffer data) {
     // Store the entry index.
     final long recordIndex = getNextIndex();
 
@@ -91,13 +92,13 @@ class MappedJournalSegmentWriter {
 
     final RecordData indexedRecord = new RecordData(recordIndex, asqn, data);
 
-    final int recordLength;
-    try {
-      recordLength = writeRecord(startPosition + frameLength + metadataLength, indexedRecord);
-    } catch (final BufferOverflowException boe) {
+    final var writeResult =
+        writeRecord(startPosition + frameLength + metadataLength, indexedRecord);
+    if (writeResult.isLeft()) {
       buffer.position(startPosition);
-      throw boe;
+      return Either.left(writeResult.getLeft());
     }
+    final int recordLength = writeResult.get();
 
     final long checksum =
         checksumGenerator.compute(
@@ -108,10 +109,10 @@ class MappedJournalSegmentWriter {
     FrameUtil.writeVersion(buffer, startPosition);
 
     buffer.position(startPosition + frameLength + metadataLength + recordLength);
-    return lastEntry;
+    return Either.right(lastEntry);
   }
 
-  public void append(final JournalRecord record) {
+  public Either<SegmentFull, Void> append(final JournalRecord record) {
     final long nextIndex = getNextIndex();
 
     // If the entry's index is not the expected next index in the segment, fail the append.
@@ -128,14 +129,14 @@ class MappedJournalSegmentWriter {
 
     final RecordData indexedRecord = new RecordData(record.index(), record.asqn(), record.data());
 
-    final int recordLength;
-    try {
-      recordLength = writeRecord(startPosition + frameLength + metadataLength, indexedRecord);
-    } catch (final BufferOverflowException boe) {
+    final var writeResult =
+        writeRecord(startPosition + frameLength + metadataLength, indexedRecord);
+    if (writeResult.isLeft()) {
       buffer.position(startPosition);
-      throw boe;
+      return Either.left(writeResult.getLeft());
     }
 
+    final int recordLength = writeResult.get();
     final long checksum =
         checksumGenerator.compute(
             buffer, startPosition + frameLength + metadataLength, recordLength);
@@ -151,6 +152,7 @@ class MappedJournalSegmentWriter {
     FrameUtil.writeVersion(buffer, startPosition);
 
     buffer.position(startPosition + frameLength + metadataLength + recordLength);
+    return Either.right(null);
   }
 
   private void updateLastWrittenEntry(
@@ -173,9 +175,13 @@ class MappedJournalSegmentWriter {
     return recordMetadata;
   }
 
-  private int writeRecord(final int offset, final RecordData indexedRecord) {
+  private Either<SegmentFull, Integer> writeRecord(
+      final int offset, final RecordData indexedRecord) {
     final var recordLength = serializer.writeData(indexedRecord, writeBuffer, offset);
-    final int nextEntryOffset = offset + recordLength;
+    if (recordLength.isLeft()) {
+      return recordLength;
+    }
+    final int nextEntryOffset = offset + recordLength.get();
     invalidateNextEntry(nextEntryOffset);
     return recordLength;
   }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/record/JournalRecordSerializer.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/record/JournalRecordSerializer.java
@@ -21,18 +21,18 @@ import org.agrona.MutableDirectBuffer;
 public interface JournalRecordSerializer {
 
   /**
-   * Writes a {@link RecordData} to the buffer). Throws {@link java.nio.BufferOverflowException} if
-   * there is not enough space to write the record.
+   * Writes a {@link RecordData} to the buffer.
    *
    * @param record to write
    * @param buffer to which the record will be written
    * @param offset the offset in the buffer at which the data will be written
    * @return the number of bytes that were written to the buffer
+   * @throws java.nio.BufferOverflowException if there is not enough space to write the record.
    */
   int writeData(RecordData record, MutableDirectBuffer buffer, int offset);
 
   /**
-   * Writes a {@link RecordMetadata} to the buffer)
+   * Writes a {@link RecordMetadata} to the buffer.
    *
    * @param metadata to write
    * @param buffer to which the metadata will be written

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/record/JournalRecordSerializer.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/record/JournalRecordSerializer.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.zeebe.journal.file.record;
 
+import io.camunda.zeebe.journal.JournalException.SegmentFull;
+import io.camunda.zeebe.util.Either;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 
@@ -26,10 +28,10 @@ public interface JournalRecordSerializer {
    * @param record to write
    * @param buffer to which the record will be written
    * @param offset the offset in the buffer at which the data will be written
-   * @return the number of bytes that were written to the buffer
-   * @throws java.nio.BufferOverflowException if there is not enough space to write the record.
+   * @return Either an error if there is not enough space or the number of bytes that were written
+   *     to the buffer
    */
-  int writeData(RecordData record, MutableDirectBuffer buffer, int offset);
+  Either<SegmentFull, Integer> writeData(RecordData record, MutableDirectBuffer buffer, int offset);
 
   /**
    * Writes a {@link RecordMetadata} to the buffer.

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/record/JournalRecordSerializer.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/record/JournalRecordSerializer.java
@@ -15,8 +15,8 @@
  */
 package io.camunda.zeebe.journal.file.record;
 
-import io.camunda.zeebe.journal.JournalException.SegmentFull;
 import io.camunda.zeebe.util.Either;
+import java.nio.BufferOverflowException;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 
@@ -31,7 +31,8 @@ public interface JournalRecordSerializer {
    * @return Either an error if there is not enough space or the number of bytes that were written
    *     to the buffer
    */
-  Either<SegmentFull, Integer> writeData(RecordData record, MutableDirectBuffer buffer, int offset);
+  Either<BufferOverflowException, Integer> writeData(
+      RecordData record, MutableDirectBuffer buffer, int offset);
 
   /**
    * Writes a {@link RecordMetadata} to the buffer.

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
@@ -142,7 +142,7 @@ class SegmentedJournalReaderTest {
     final var record = new RecordData(Long.MAX_VALUE, Long.MAX_VALUE, data);
     final var serializer = new SBESerializer();
     final ByteBuffer buffer = ByteBuffer.allocate(128);
-    return serializer.writeData(record, new UnsafeBuffer(buffer), 0)
+    return serializer.writeData(record, new UnsafeBuffer(buffer), 0).get()
         + serializer.getMetadataLength();
   }
 }

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -613,7 +613,7 @@ class SegmentedJournalTest {
     final var record = new RecordData(1, 1, data);
     final var serializer = new SBESerializer();
     final ByteBuffer buffer = ByteBuffer.allocate(128);
-    return serializer.writeData(record, new UnsafeBuffer(buffer), 0)
+    return serializer.writeData(record, new UnsafeBuffer(buffer), 0).get()
         + FrameUtil.getLength()
         + serializer.getMetadataLength();
   }

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/record/SBESerializerTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/record/SBESerializerTest.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.journal.file.record;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.nio.BufferOverflowException;
+import io.camunda.zeebe.util.Either;
 import java.nio.ByteBuffer;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -50,7 +50,7 @@ public class SBESerializerTest {
   @Test
   public void shouldWriteRecord() {
     // given - when
-    final var recordWrittenLength = serializer.writeData(record, writeBuffer, 0);
+    final var recordWrittenLength = serializer.writeData(record, writeBuffer, 0).get();
 
     // then
     assertThat(recordWrittenLength).isPositive();
@@ -59,7 +59,7 @@ public class SBESerializerTest {
   @Test
   public void shouldReadRecord() {
     // given
-    final var length = serializer.writeData(record, writeBuffer, 0);
+    final var length = serializer.writeData(record, writeBuffer, 0).get();
 
     // when
     final var recordRead = serializer.readData(writeBuffer, 0, length);
@@ -131,7 +131,7 @@ public class SBESerializerTest {
     final int offset = 10;
 
     // when
-    final var recordWrittenLength = serializer.writeData(record, writeBuffer, offset);
+    final var recordWrittenLength = serializer.writeData(record, writeBuffer, offset).get();
     final var readData = serializer.readData(writeBuffer, offset, recordWrittenLength);
 
     // then
@@ -157,7 +157,6 @@ public class SBESerializerTest {
     final int offset = writeBuffer.capacity() - 1;
 
     // when - then
-    assertThatThrownBy(() -> serializer.writeData(record, writeBuffer, offset))
-        .isInstanceOf(BufferOverflowException.class);
+    assertThat(serializer.writeData(record, writeBuffer, offset)).matches(Either::isLeft);
   }
 }


### PR DESCRIPTION
## Description

Instead of throwing a `BufferOverFlowException` and catching it in the `SegmentedJournalWriter` we now return a `Either<SegmentFull, Integer>` to indicate if writing was successful. If creating a new segment does not resolve the error we throw the `SegmentFull` exception.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7606 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
