### PR TITLE
Use System time for metrics

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/RoleMetrics.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/RoleMetrics.java
@@ -25,7 +25,7 @@ public class RoleMetrics {
     partitionIdLabel = String.valueOf(partitionId);
   }
 
-  public void setLeaderTransitionLatency(final long latencyInMs) {
-    LEADER_TRANSITION_LATENCY.labels(partitionIdLabel).set(latencyInMs);
+  public Gauge.Timer startLeaderTransitionLatencyTimer() {
+    return LEADER_TRANSITION_LATENCY.labels(partitionIdLabel).startTimer();
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthStatus;
 import io.camunda.zeebe.util.sched.Actor;
-import io.camunda.zeebe.util.sched.clock.ActorClock;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import io.camunda.zeebe.util.startup.StartupProcess;
@@ -237,12 +236,12 @@ public final class ZeebePartition extends Actor
   }
 
   private ActorFuture<Void> leaderTransition(final long newTerm) {
-    final var installStartTime = ActorClock.currentTimeMillis();
+    final var installStartTime = System.currentTimeMillis();
     final var leaderTransitionFuture = transition.toLeader(newTerm);
     leaderTransitionFuture.onComplete(
         (success, error) -> {
           if (error == null) {
-            final var leaderTransitionLatency = ActorClock.currentTimeMillis() - installStartTime;
+            final var leaderTransitionLatency = System.currentTimeMillis() - installStartTime;
             roleMetrics.setLeaderTransitionLatency(leaderTransitionLatency);
             final List<ActorFuture<Void>> listenerFutures =
                 context.notifyListenersOfBecomingLeader(newTerm);

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -236,13 +236,12 @@ public final class ZeebePartition extends Actor
   }
 
   private ActorFuture<Void> leaderTransition(final long newTerm) {
-    final var installStartTime = System.currentTimeMillis();
+    final var latencyTimer = roleMetrics.startLeaderTransitionLatencyTimer();
     final var leaderTransitionFuture = transition.toLeader(newTerm);
     leaderTransitionFuture.onComplete(
         (success, error) -> {
           if (error == null) {
-            final var leaderTransitionLatency = System.currentTimeMillis() - installStartTime;
-            roleMetrics.setLeaderTransitionLatency(leaderTransitionLatency);
+            latencyTimer.close();
             final List<ActorFuture<Void>> listenerFutures =
                 context.notifyListenersOfBecomingLeader(newTerm);
             actor.runOnCompletion(

--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/ReplayMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/ReplayMetrics.java
@@ -51,8 +51,8 @@ public final class ReplayMetrics {
     REPLAY_EVENTS_COUNT.labels(partitionIdLabel).inc();
   }
 
-  public void replayDuration(final long started, final long processed) {
-    REPLAY_DURATION.labels(partitionIdLabel).observe((processed - started) / 1000f);
+  public Histogram.Timer startReplayDurationTimer() {
+    return REPLAY_DURATION.labels(partitionIdLabel).startTimer();
   }
 
   public void setLastSourcePosition(final long position) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/StreamProcessorMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/StreamProcessorMetrics.java
@@ -76,11 +76,8 @@ public final class StreamProcessorMetrics {
     PROCESSING_LATENCY.labels(partitionIdLabel).observe((processed - written) / 1000f);
   }
 
-  public void processingDuration(
-      final RecordType recordType, final long started, final long processed) {
-    PROCESSING_DURATION
-        .labels(recordType.name(), partitionIdLabel)
-        .observe((processed - started) / 1000f);
+  public Histogram.Timer startProcessingDurationTimer(final RecordType recordType) {
+    return PROCESSING_DURATION.labels(recordType.name(), partitionIdLabel).startTimer();
   }
 
   /** We only process commands. */

--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/StreamProcessorMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/StreamProcessorMetrics.java
@@ -102,8 +102,8 @@ public final class StreamProcessorMetrics {
     event(LABEL_SKIPPED);
   }
 
-  public void recoveryTime(final long durationMillis) {
-    STARTUP_RECOVERY_TIME.labels(partitionIdLabel).set(durationMillis);
+  public Gauge.Timer startRecoveryTimer() {
+    return STARTUP_RECOVERY_TIME.labels(partitionIdLabel).startTimer();
   }
 
   public void setLastProcessedPosition(final long position) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -30,7 +30,6 @@ import io.camunda.zeebe.util.retry.AbortableRetryStrategy;
 import io.camunda.zeebe.util.retry.RecoverableRetryStrategy;
 import io.camunda.zeebe.util.retry.RetryStrategy;
 import io.camunda.zeebe.util.sched.ActorControl;
-import io.camunda.zeebe.util.sched.clock.ActorClock;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import java.time.Duration;
 import java.util.function.BooleanSupplier;
@@ -205,7 +204,7 @@ public final class ProcessingStateMachine {
       return;
     }
 
-    processingStartTime = ActorClock.currentTimeMillis();
+    processingStartTime = System.currentTimeMillis();
 
     try {
       final UnifiedRecordValue value = recordValues.readRecordValue(event, metadata.getValueType());
@@ -405,7 +404,7 @@ public final class ProcessingStateMachine {
           notifyProcessedListener(typedEvent);
 
           metrics.processingDuration(
-              metadata.getRecordType(), processingStartTime, ActorClock.currentTimeMillis());
+              metadata.getRecordType(), processingStartTime, System.currentTimeMillis());
           // continue with next event
           currentProcessor = null;
           actor.submit(this::readNextEvent);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -30,7 +30,9 @@ import io.camunda.zeebe.util.retry.AbortableRetryStrategy;
 import io.camunda.zeebe.util.retry.RecoverableRetryStrategy;
 import io.camunda.zeebe.util.retry.RetryStrategy;
 import io.camunda.zeebe.util.sched.ActorControl;
+import io.camunda.zeebe.util.sched.clock.ActorClock;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.prometheus.client.Histogram;
 import java.time.Duration;
 import java.util.function.BooleanSupplier;
 import org.slf4j.Logger;
@@ -138,7 +140,7 @@ public final class ProcessingStateMachine {
   private volatile boolean onErrorHandlingLoop;
   private int onErrorRetries;
   // Used for processing duration metrics
-  private long processingStartTime;
+  private Histogram.Timer processingTimer;
 
   public ProcessingStateMachine(
       final ProcessingContext context, final BooleanSupplier shouldProcessNext) {
@@ -204,7 +206,11 @@ public final class ProcessingStateMachine {
       return;
     }
 
-    processingStartTime = System.currentTimeMillis();
+    // Here we need to get the current time, since we want to calculate
+    // how long it took between writing to the dispatcher and processing.
+    // In all other cases we should prefer to use the Prometheus Timer API.
+    final var processingStartTime = ActorClock.currentTimeMillis();
+    processingTimer = metrics.startProcessingDurationTimer(metadata.getRecordType());
 
     try {
       final UnifiedRecordValue value = recordValues.readRecordValue(event, metadata.getValueType());
@@ -403,8 +409,9 @@ public final class ProcessingStateMachine {
 
           notifyProcessedListener(typedEvent);
 
-          metrics.processingDuration(
-              metadata.getRecordType(), processingStartTime, System.currentTimeMillis());
+          // observe the processing duration
+          processingTimer.close();
+
           // continue with next event
           currentProcessor = null;
           actor.submit(this::readNextEvent);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateMachine.java
@@ -28,7 +28,6 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.util.retry.RecoverableRetryStrategy;
 import io.camunda.zeebe.util.retry.RetryStrategy;
 import io.camunda.zeebe.util.sched.ActorControl;
-import io.camunda.zeebe.util.sched.clock.ActorClock;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.util.function.BooleanSupplier;
@@ -157,7 +156,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
       if (logStreamBatchReader.hasNext()) {
         currentState = State.REPLAY_EVENT;
 
-        final var replayStartTime = ActorClock.currentTimeMillis();
+        final var replayStartTime = System.currentTimeMillis();
         final var batch = logStreamBatchReader.next();
         replayStrategy
             .runWithRetry(() -> tryToReplayBatch(batch), abortCondition)
@@ -166,7 +165,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
                   if (failure != null) {
                     throw new RuntimeException(failure);
                   } else {
-                    replayMetrics.replayDuration(replayStartTime, ActorClock.currentTimeMillis());
+                    replayMetrics.replayDuration(replayStartTime, System.currentTimeMillis());
                     // the position should be visible only after the batch is replayed successfully
                     lastSourceEventPosition =
                         Math.max(lastSourceEventPosition, batchSourceEventPosition);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -120,7 +120,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   protected void onActorStarted() {
     try {
       LOG.debug("Recovering state of partition {} from snapshot", partitionId);
-      final long startTime = ActorClock.currentTimeMillis();
+      final long startTime = System.currentTimeMillis();
       snapshotPosition = recoverFromSnapshot();
 
       initProcessors();
@@ -158,7 +158,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
                 onFailure(error);
               } else {
                 onRecovered(lastSourceEventPosition);
-                metrics.recoveryTime(ActorClock.currentTimeMillis() - startTime);
+                metrics.recoveryTime(System.currentTimeMillis() - startTime);
               }
             });
       }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -120,7 +120,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   protected void onActorStarted() {
     try {
       LOG.debug("Recovering state of partition {} from snapshot", partitionId);
-      final long startTime = System.currentTimeMillis();
+      final var startRecoveryTimer = metrics.startRecoveryTimer();
       snapshotPosition = recoverFromSnapshot();
 
       initProcessors();
@@ -158,7 +158,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
                 onFailure(error);
               } else {
                 onRecovered(lastSourceEventPosition);
-                metrics.recoveryTime(System.currentTimeMillis() - startTime);
+                // observe recovery time
+                startRecoveryTimer.close();
               }
             });
       }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.util.sched.Actor;
 import io.camunda.zeebe.util.sched.ScheduledTimer;
-import io.camunda.zeebe.util.sched.clock.ActorClock;
 import io.grpc.protobuf.StatusProto;
 import java.time.Duration;
 import java.util.HashMap;
@@ -232,7 +231,6 @@ public final class LongPollingActivateJobsHandler extends Actor implements Activ
   private void addTimeOut(
       final InFlightLongPollingActivateJobsRequestsState state,
       final LongPollingActivateJobsRequest request) {
-    ActorClock.currentTimeMillis();
     final Duration requestTimeout = request.getLongPollingTimeout(longPollingTimeout);
     final ScheduledTimer timeout =
         actor.runDelayed(

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/JournalMetrics.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/JournalMetrics.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.journal.file;
 
 import io.prometheus.client.Gauge;
+import io.prometheus.client.Gauge.Timer;
 import io.prometheus.client.Histogram;
 
 class JournalMetrics {
@@ -78,8 +79,8 @@ class JournalMetrics {
     SEGMENT_TRUNCATE_TIME.labels(logName).time(segmentTruncation);
   }
 
-  public void observeJournalOpenDuration(final long durationMillis) {
-    JOURNAL_OPEN_DURATION.labels(logName).set(durationMillis / 1000f);
+  public Timer startJournalOpenDurationTimer() {
+    return JOURNAL_OPEN_DURATION.labels(logName).startTimer();
   }
 
   public void incSegmentCount() {

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -232,7 +232,7 @@ public final class SegmentedJournal implements Journal {
 
   /** Opens the segments. */
   private synchronized void open() {
-    final long startTime = System.currentTimeMillis();
+    final var openDurationTimer = journalMetrics.startJournalOpenDurationTimer();
     // Load existing log segments from disk.
     for (final JournalSegment segment : loadSegments()) {
       segments.put(segment.descriptor().index(), segment);
@@ -255,7 +255,8 @@ public final class SegmentedJournal implements Journal {
       segments.put(1L, currentSegment);
       journalMetrics.incSegmentCount();
     }
-    journalMetrics.observeJournalOpenDuration(System.currentTimeMillis() - startTime);
+    // observe the journal open duration
+    openDurationTimer.close();
 
     // Delete files that were previously marked for deletion but did not get deleted because the
     // node was stopped. It is safe to delete it now since there are no readers opened for these

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/AppenderMetrics.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/AppenderMetrics.java
@@ -57,11 +57,11 @@ public class AppenderMetrics {
     LAST_APPENDED_POSITION.labels(partitionLabel).set(position);
   }
 
-  public void appendLatency(final long startTime, final long currentTime) {
-    WRITE_LATENCY.labels(partitionLabel).observe((currentTime - startTime) / 1000f);
+  public Histogram.Timer startAppendLatencyTimer() {
+    return WRITE_LATENCY.labels(partitionLabel).startTimer();
   }
 
-  public void commitLatency(final long startTime, final long currentTime) {
-    COMMIT_LATENCY.labels(partitionLabel).observe((currentTime - startTime) / 1000f);
+  public Histogram.Timer startCommitLatencyTimer() {
+    return COMMIT_LATENCY.labels(partitionLabel).startTimer();
   }
 }

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.util.health.HealthStatus;
 import io.camunda.zeebe.util.sched.Actor;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
+import io.prometheus.client.Histogram.Timer;
 import java.nio.ByteBuffer;
 import java.util.HashSet;
 import java.util.Map;
@@ -116,7 +117,12 @@ public class LogStorageAppender extends Actor implements HealthMonitorable {
     // Commit position is the position of the last event.
     appendBackpressureMetrics.newEntryToAppend();
     if (appendEntryLimiter.tryAcquire(positions.getRight())) {
-      final var listener = new Listener(this, positions.getRight(), System.currentTimeMillis());
+      final var listener =
+          new Listener(
+              this,
+              positions.getRight(),
+              appenderMetrics.startAppendLatencyTimer(),
+              appenderMetrics.startCommitLatencyTimer());
       logStorage.append(positions.getLeft(), positions.getRight(), copiedBuffer, listener);
 
       blockPeek.markCompleted();
@@ -225,19 +231,21 @@ public class LogStorageAppender extends Actor implements HealthMonitorable {
     actor.run(() -> appendEntryLimiter.onCommit(highestPosition));
   }
 
-  void notifyWritePosition(final long highestPosition, final long startTime) {
+  void notifyWritePosition(final long highestPosition, final Timer appendLatencyTimer) {
     actor.run(
         () -> {
           appenderMetrics.setLastAppendedPosition(highestPosition);
-          appenderMetrics.appendLatency(startTime, System.currentTimeMillis());
+          // observe append latency
+          appendLatencyTimer.close();
         });
   }
 
-  void notifyCommitPosition(final long highestPosition, final long startTime) {
+  void notifyCommitPosition(final long highestPosition, final Timer commitLatencyTimer) {
     actor.run(
         () -> {
           appenderMetrics.setLastCommittedPosition(highestPosition);
-          appenderMetrics.commitLatency(startTime, System.currentTimeMillis());
+          // observe commit latency
+          commitLatencyTimer.close();
         });
   }
 }

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthStatus;
 import io.camunda.zeebe.util.sched.Actor;
-import io.camunda.zeebe.util.sched.clock.ActorClock;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.nio.ByteBuffer;
@@ -117,7 +116,7 @@ public class LogStorageAppender extends Actor implements HealthMonitorable {
     // Commit position is the position of the last event.
     appendBackpressureMetrics.newEntryToAppend();
     if (appendEntryLimiter.tryAcquire(positions.getRight())) {
-      final var listener = new Listener(this, positions.getRight(), ActorClock.currentTimeMillis());
+      final var listener = new Listener(this, positions.getRight(), System.currentTimeMillis());
       logStorage.append(positions.getLeft(), positions.getRight(), copiedBuffer, listener);
 
       blockPeek.markCompleted();
@@ -230,7 +229,7 @@ public class LogStorageAppender extends Actor implements HealthMonitorable {
     actor.run(
         () -> {
           appenderMetrics.setLastAppendedPosition(highestPosition);
-          appenderMetrics.appendLatency(startTime, ActorClock.currentTimeMillis());
+          appenderMetrics.appendLatency(startTime, System.currentTimeMillis());
         });
   }
 
@@ -238,7 +237,7 @@ public class LogStorageAppender extends Actor implements HealthMonitorable {
     actor.run(
         () -> {
           appenderMetrics.setLastCommittedPosition(highestPosition);
-          appenderMetrics.commitLatency(startTime, ActorClock.currentTimeMillis());
+          appenderMetrics.commitLatency(startTime, System.currentTimeMillis());
         });
   }
 }


### PR DESCRIPTION

## Description

For most metrics, it doesn't make sense to use the ActorClock, since it is pinned between actor executions. To get an accurate view we have to use System time here.


Pointed out here https://github.com/camunda-cloud/zeebe/issues/7955#issuecomment-940731599

I run a benchmark to compare the numbers:

With the actor clock we see quite low numbers for processing and commit latency
![latencybug](https://user-images.githubusercontent.com/2758593/136990036-51406a4b-e6f5-495d-93c8-5bd623c1f222.png)

With the fix we can see much more accurate numbers
![latencyfix](https://user-images.githubusercontent.com/2758593/136990033-7204f1df-0779-4ccf-abbf-f27285ac1a55.png)

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
