### PR TITLE
Add interceptors to gateway templates

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -85,6 +85,31 @@
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_LONGPOLLING_ENABLED.
         # enabled: true
 
+      # interceptors:
+        # Configure interceptors below.
+        # Please consider reading our documentation on interceptors first.
+        #
+        # Each interceptors should be configured following this template:
+        #
+        # id:
+        #   identifier for this interceptor.
+        #   This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_INTERCEPTORS_0_ID.
+        # jarPath:
+        #   path (relative or absolute) to the JAR file containing the interceptor class and its dependencies.
+        #   all classes must be compiled for the same language version as Zeebe or lower.
+        #   This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_INTERCEPTORS_0_JARPATH.
+        # className:
+        #   entry point of the interceptor, a class which must:
+        #     - implement io.grpc.ServerInterceptor (see: https://grpc.github.io/grpc-java/javadoc/io/grpc/ServerInterceptor.html)
+        #     - have public visibility
+        #     - have a public default constructor (i.e. no-arg constructor)
+        #   This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_INTERCEPTORS_0_CLASSNAME.
+        #
+        # Example configuration for a single interceptor
+        # - id: example-interceptor
+        #   className: com.acme.ExampleInterceptor
+        #   jarPath: /path/to/interceptor/example-interceptor.jar
+
     # network:
       # This section contains the network configuration. Particularly, it allows to
       # configure the hosts and ports the broker should bind to. The broker exposes three sockets:

--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -154,3 +154,28 @@
       # Enables long polling for available jobs
       # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_LONGPOLLING_ENABLED.
       # enabled: true
+
+    # interceptors:
+      # Configure interceptors below.
+      # Please consider reading our documentation on interceptors first.
+      #
+      # Each interceptors should be configured following this template:
+      #
+      # id:
+      #   identifier for this interceptor.
+      #   This setting can also be overridden using the environment variable ZEEBE_GATEWAY_INTERCEPTORS_0_ID.
+      # jarPath:
+      #   path (relative or absolute) to the JAR file containing the interceptor class and its dependencies.
+      #   all classes must be compiled for the same language version as Zeebe or lower.
+      #   This setting can also be overridden using the environment variable ZEEBE_GATEWAY_INTERCEPTORS_0_JARPATH.
+      # className:
+      #   entry point of the interceptor, a class which must:
+      #     - implement io.grpc.ServerInterceptor (see: https://grpc.github.io/grpc-java/javadoc/io/grpc/ServerInterceptor.html)
+      #     - have public visibility
+      #     - have a public default constructor (i.e. no-arg constructor)
+      #   This setting can also be overridden using the environment variable ZEEBE_GATEWAY_INTERCEPTORS_0_CLASSNAME.
+      #
+      # Example configuration for a single interceptor
+      # - id: example-interceptor
+      #   className: com.acme.ExampleInterceptor
+      #   jarPath: /path/to/interceptor/example-interceptor.jar

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -48,6 +48,14 @@ public final class GatewayCfgTest {
     CUSTOM_CFG.getMonitoring().setEnabled(true).setHost("monitoringHost").setPort(1234);
     CUSTOM_CFG.getThreads().setManagementThreads(100);
     CUSTOM_CFG.getLongPolling().setEnabled(false);
+    CUSTOM_CFG.getInterceptors().add(new InterceptorCfg());
+    CUSTOM_CFG.getInterceptors().get(0).setId("example");
+    CUSTOM_CFG.getInterceptors().get(0).setClassName("io.camunda.zeebe.example.Interceptor");
+    CUSTOM_CFG.getInterceptors().get(0).setJarPath("./interceptor.jar");
+    CUSTOM_CFG.getInterceptors().add(new InterceptorCfg());
+    CUSTOM_CFG.getInterceptors().get(1).setId("example2");
+    CUSTOM_CFG.getInterceptors().get(1).setClassName("io.camunda.zeebe.example.Interceptor2");
+    CUSTOM_CFG.getInterceptors().get(1).setJarPath("./interceptor2.jar");
   }
 
   private final Map<String, String> environment = new HashMap<>();
@@ -166,7 +174,10 @@ public final class GatewayCfgTest {
             .getClassLoader()
             .getResource("security/test-chain.cert.pem")
             .getPath());
-    setEnv("zeebe.gateway.network.minKeepAliveInterval", Duration.ofSeconds(30).toString()); //
+    setEnv("zeebe.gateway.network.minKeepAliveInterval", Duration.ofSeconds(30).toString());
+    setEnv("zeebe.gateway.interceptors.0.id", "overwritten");
+    setEnv("zeebe.gateway.interceptors.0.className", "Overwritten");
+    setEnv("zeebe.gateway.interceptors.0.jarPath", "./overwritten.jar");
 
     final GatewayCfg expected = new GatewayCfg();
     expected
@@ -192,6 +203,11 @@ public final class GatewayCfgTest {
         .setCertificateChainPath(
             getClass().getClassLoader().getResource("security/test-chain.cert.pem").getPath());
     expected.getLongPolling().setEnabled(false);
+
+    expected.getInterceptors().add(new InterceptorCfg());
+    expected.getInterceptors().get(0).setId("overwritten");
+    expected.getInterceptors().get(0).setClassName("Overwritten");
+    expected.getInterceptors().get(0).setJarPath("./overwritten.jar");
 
     // when
     final GatewayCfg gatewayCfg = readCustomConfig();

--- a/gateway/src/test/resources/configuration/gateway.custom.yaml
+++ b/gateway/src/test/resources/configuration/gateway.custom.yaml
@@ -28,3 +28,11 @@ zeebe:
 
     longPolling:
       enabled: false
+
+    interceptors:
+      - id: example
+        className: io.camunda.zeebe.example.Interceptor
+        jarPath: ./interceptor.jar
+      - id: example2
+        className: io.camunda.zeebe.example.Interceptor2
+        jarPath: ./interceptor2.jar


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Interceptors can be configured using the gateway configurations. 

This documents the available configuration options for interceptors and verifies that these configurations can actually be altered using the configuration file and environment variables.

Since this feature became available in version 1.2, this pull request should be backported to 1.2.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7969 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
