### PR TITLE
Document experimental query api

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -65,6 +65,8 @@ public final class BrokerCfgTest {
       "zeebe.broker.experimental.disableExplicitRaftFlush";
   private static final String ZEEBE_BROKER_EXPERIMENTAL_ENABLEPRIORITYELECTION =
       "zeebe.broker.experimental.enablePriorityElection";
+  private static final String ZEEBE_BROKER_EXPERIMENTAL_QUERYAPI_ENABLED =
+      "zeebe.broker.experimental.queryapi.enabled";
   private static final String ZEEBE_BROKER_DATA_DIRECTORY = "zeebe.broker.data.directory";
 
   private static final String ZEEBE_BROKER_NETWORK_HOST = "zeebe.broker.network.host";
@@ -511,6 +513,43 @@ public final class BrokerCfgTest {
 
     // then
     assertThat(experimentalCfg.isEnablePriorityElection()).isTrue();
+  }
+
+  @Test
+  public void shouldDisableQueryApiByDefault() {
+    // given
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
+
+    // when
+    final ExperimentalCfg experimentalCfg = cfg.getExperimental();
+
+    // then
+    assertThat(experimentalCfg.getQueryApi().isEnabled()).isFalse();
+  }
+
+  @Test
+  public void shouldSetEnableQueryApiFromConfig() {
+    // given
+    final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
+
+    // when
+    final ExperimentalCfg experimentalCfg = cfg.getExperimental();
+
+    // then
+    assertThat(experimentalCfg.getQueryApi().isEnabled()).isTrue();
+  }
+
+  @Test
+  public void shouldOverrideSetEnableQueryApiViaEnvironment() {
+    // given
+    environment.put(ZEEBE_BROKER_EXPERIMENTAL_QUERYAPI_ENABLED, "true");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
+    final ExperimentalCfg experimentalCfg = cfg.getExperimental();
+
+    // then
+    assertThat(experimentalCfg.getQueryApi().isEnabled()).isTrue();
   }
 
   @Test

--- a/broker/src/test/resources/system/experimental-cfg.yaml
+++ b/broker/src/test/resources/system/experimental-cfg.yaml
@@ -6,3 +6,5 @@ zeebe:
         requestTimeout: 10s
         maxQuorumResponseTimeout: 8s
         minStepDownFailureCount: 5
+      queryApi:
+        enabled: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -603,3 +603,20 @@
         # performance is a bit less predictable when disabling the WAL.
         # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_DISABLEWAL
         # disableWal: false
+
+      # Allows to configure the query API. By default, the broker only offers a command API, which
+      # is used by the gateway to pass commands it received along to the broker. Commands can then
+      # be processed. Zeebe does not directly support querying of brokers, instead it provides a way
+      # to export data to data lakes that can be queried. In highly specific cases, direct querying
+      # of a broker is necessary. For this, Zeebe provides a specialized query API. This query API
+      # can provide the `BPMN Process Id` belonging to a job, process instance or process
+      # definition. For easy access, a Java interface is provided to gateway interceptors, which
+      # you can retrieve using 
+      # `io.camunda.zeebe.gateway.interceptors.InterceptorUtil.getQueryApiKey()`. Please read our
+      # documentation on interceptors to learn more about creating and loading interceptors into the
+      # gateway. In addition, please have a look at the Javadoc on InterceptorUtil.getQueryApiKey()
+      # to see how to use this in practise.
+      # queryApi:
+        # Enables the query api in the broker.
+        # This setting can also be set using the environmentvariable ZEEBE_BROKER_EXPERIMENTAL_QUERYAPI_ENABLED
+        # enabled: false


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

The broker now contains an experimental query api which can be enabled through an experimental config option.

As part of using this API, a java interface is provided in the gateway to interceptors. How to access this is now also documented with the config option.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7993 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
