### PR TITLE
Fix flakiness in MessageCorrelationTest

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationTest.java
@@ -856,9 +856,13 @@ public final class MessageCorrelationTest {
     // when
     engine.message().withName("message").withCorrelationKey("key-1").publish();
 
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+    /* Improved wait statement. The first iteration of the wait statement produced flaky test results
+     * (see #7818) due to a bug (see #7995). To avoid the flakiness we analyzed the logs and found a
+     * more precise condition to wait for
+     */
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CORRELATED)
         .withProcessInstanceKey(processInstanceKey)
-        .withElementType(BpmnElementType.BOUNDARY_EVENT)
+        .withMessageName("message")
         .await();
 
     // complete the process instance by triggering the interrupting timer boundary event


### PR DESCRIPTION
## Description

This commit modifies the wait condition to circumvent the bug described in #7995.

As a result this test is no longer flaky. Before, the test failed 1 in ~150 times. With this change it did not fail once in 2000 iterations.

## Related issues

closes #7818

<!-- Cut-off marker
## Definition of Ready
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
