### PR TITLE
[Backport stable/1.2] Document experimental query api

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -65,6 +65,8 @@ public final class BrokerCfgTest {
       "zeebe.broker.experimental.disableExplicitRaftFlush";
   private static final String ZEEBE_BROKER_EXPERIMENTAL_ENABLEPRIORITYELECTION =
       "zeebe.broker.experimental.enablePriorityElection";
+  private static final String ZEEBE_BROKER_EXPERIMENTAL_QUERYAPI_ENABLED =
+      "zeebe.broker.experimental.queryapi.enabled";
   private static final String ZEEBE_BROKER_DATA_DIRECTORY = "zeebe.broker.data.directory";
 
   private static final String ZEEBE_BROKER_NETWORK_HOST = "zeebe.broker.network.host";
@@ -511,6 +513,43 @@ public final class BrokerCfgTest {
 
     // then
     assertThat(experimentalCfg.isEnablePriorityElection()).isTrue();
+  }
+
+  @Test
+  public void shouldDisableQueryApiByDefault() {
+    // given
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
+
+    // when
+    final ExperimentalCfg experimentalCfg = cfg.getExperimental();
+
+    // then
+    assertThat(experimentalCfg.getQueryApi().isEnabled()).isFalse();
+  }
+
+  @Test
+  public void shouldSetEnableQueryApiFromConfig() {
+    // given
+    final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
+
+    // when
+    final ExperimentalCfg experimentalCfg = cfg.getExperimental();
+
+    // then
+    assertThat(experimentalCfg.getQueryApi().isEnabled()).isTrue();
+  }
+
+  @Test
+  public void shouldOverrideSetEnableQueryApiViaEnvironment() {
+    // given
+    environment.put(ZEEBE_BROKER_EXPERIMENTAL_QUERYAPI_ENABLED, "true");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
+    final ExperimentalCfg experimentalCfg = cfg.getExperimental();
+
+    // then
+    assertThat(experimentalCfg.getQueryApi().isEnabled()).isTrue();
   }
 
   @Test

--- a/broker/src/test/resources/system/experimental-cfg.yaml
+++ b/broker/src/test/resources/system/experimental-cfg.yaml
@@ -6,3 +6,5 @@ zeebe:
         requestTimeout: 10s
         maxQuorumResponseTimeout: 8s
         minStepDownFailureCount: 5
+      queryApi:
+        enabled: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -603,3 +603,20 @@
         # performance is a bit less predictable when disabling the WAL.
         # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_DISABLEWAL
         # disableWal: false
+
+      # Allows to configure the query API. By default, the broker only offers a command API, which
+      # is used by the gateway to pass commands it received along to the broker. Commands can then
+      # be processed. Zeebe does not directly support querying of brokers, instead it provides a way
+      # to export data to data lakes that can be queried. In highly specific cases, direct querying
+      # of a broker is necessary. For this, Zeebe provides a specialized query API. This query API
+      # can provide the `BPMN Process Id` belonging to a job, process instance or process
+      # definition. For easy access, a Java interface is provided to gateway interceptors, which
+      # you can retrieve using 
+      # `io.camunda.zeebe.gateway.interceptors.InterceptorUtil.getQueryApiKey()`. Please read our
+      # documentation on interceptors to learn more about creating and loading interceptors into the
+      # gateway. In addition, please have a look at the Javadoc on InterceptorUtil.getQueryApiKey()
+      # to see how to use this in practise.
+      # queryApi:
+        # Enables the query api in the broker.
+        # This setting can also be set using the environmentvariable ZEEBE_BROKER_EXPERIMENTAL_QUERYAPI_ENABLED
+        # enabled: false


### PR DESCRIPTION
# Description
Backport of #7994 to `stable/1.2`.

relates to #7993