### PR TITLE
Allow to specify request timeout with create instance command

### DIFF
--- a/clients/go/cmd/zbctl/internal/commands/createInstance.go
+++ b/clients/go/cmd/zbctl/internal/commands/createInstance.go
@@ -17,16 +17,19 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/camunda-cloud/zeebe/clients/go/pkg/commands"
+	"github.com/camunda-cloud/zeebe/clients/go/pkg/zbc"
 
 	"github.com/spf13/cobra"
 )
 
 var (
-	createInstanceVersionFlag    int32
-	createInstanceVariablesFlag  string
-	createInstanceWithResultFlag []string
+	createInstanceVersionFlag        int32
+	createInstanceVariablesFlag      string
+	createInstanceWithResultFlag     []string
+	createInstanceRequestTimeoutFlag time.Duration
 )
 
 var createInstanceCmd = &cobra.Command{
@@ -54,7 +57,7 @@ var createInstanceCmd = &cobra.Command{
 			return err
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), createInstanceRequestTimeoutFlag)
 		defer cancel()
 
 		if createInstanceWithResultFlag == nil {
@@ -96,6 +99,10 @@ func init() {
 	createInstanceCmd.
 		Flags().
 		StringSliceVar(&createInstanceWithResultFlag, "withResult", nil, "Specify to await result of process, optional a list of variable names can be provided to limit the returned variables")
+
+	createInstanceCmd.
+		Flags().
+		DurationVar(&createInstanceRequestTimeoutFlag, "requestTimeout", zbc.DefaultRequestTimeout, "Specify the timeout for a request")
 
 	// hack to use --withResult without values
 	createInstanceCmd.Flag("withResult").NoOptDefVal = " "

--- a/clients/go/cmd/zbctl/internal/commands/createInstance.go
+++ b/clients/go/cmd/zbctl/internal/commands/createInstance.go
@@ -102,7 +102,7 @@ func init() {
 
 	createInstanceCmd.
 		Flags().
-		DurationVar(&createInstanceRequestTimeoutFlag, "requestTimeout", zbc.DefaultRequestTimeout, "Specify the timeout for a request")
+		DurationVar(&createInstanceRequestTimeoutFlag, "requestTimeout", zbc.DefaultRequestTimeout, "Specify the timeout for a request, example values: 300ms, 50s or 1m")
 
 	// hack to use --withResult without values
 	createInstanceCmd.Flag("withResult").NoOptDefVal = " "


### PR DESCRIPTION
## Description

I've added a flag to the create instance command to specify the request timeout. Additionally, I've taken the DefaultRequestTimeout from zbc as the default var. Similar as it is done in the create worker command. This changes the default request timeout in the command from 10s to 15s. 

## Related issues

closes #4516

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
