### PR TITLE
Allow configuring secure inter-cluster communication for the gateway

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
@@ -25,6 +25,7 @@ import io.atomix.utils.Builder;
 import io.atomix.utils.Version;
 import io.atomix.utils.net.Address;
 import io.camunda.zeebe.util.VersionUtil;
+import java.io.File;
 import java.util.Collection;
 import java.util.Properties;
 
@@ -216,6 +217,47 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
    */
   public AtomixClusterBuilder withMembershipProvider(final NodeDiscoveryProvider locationProvider) {
     config.setDiscoveryConfig(locationProvider.config());
+    return this;
+  }
+
+  /**
+   * Enables TLS encryption of the messaging service.
+   *
+   * @param certificateChainPath the certificate chain to use
+   * @param privateKeyPath the private key of the chain
+   * @return the cluster builder
+   * @see io.atomix.cluster.messaging.MessagingConfig#setTlsEnabled(boolean)
+   * @see io.atomix.cluster.messaging.MessagingConfig#setCertificateChain(String)
+   * @see io.atomix.cluster.messaging.MessagingConfig#setPrivateKey(String)
+   */
+  public AtomixClusterBuilder withSecurity(
+      final String certificateChainPath, final String privateKeyPath) {
+    config
+        .getMessagingConfig()
+        .setTlsEnabled(true)
+        .setCertificateChain(certificateChainPath)
+        .setPrivateKey(privateKeyPath);
+
+    return this;
+  }
+
+  /**
+   * Enables TLS encryption of the messaging service.
+   *
+   * @param certificateChain the certificate chain to use
+   * @param privateKey the private key of the chain
+   * @return the cluster builder
+   * @see io.atomix.cluster.messaging.MessagingConfig#setTlsEnabled(boolean)
+   * @see io.atomix.cluster.messaging.MessagingConfig#setCertificateChain(String)
+   * @see io.atomix.cluster.messaging.MessagingConfig#setPrivateKey(String)
+   */
+  public AtomixClusterBuilder withSecurity(final File certificateChain, final File privateKey) {
+    config
+        .getMessagingConfig()
+        .setTlsEnabled(true)
+        .setCertificateChain(certificateChain)
+        .setPrivateKey(privateKey);
+
     return this;
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
@@ -248,8 +248,8 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
    * @param privateKey the private key of the chain
    * @return the cluster builder
    * @see io.atomix.cluster.messaging.MessagingConfig#setTlsEnabled(boolean)
-   * @see io.atomix.cluster.messaging.MessagingConfig#setCertificateChain(String)
-   * @see io.atomix.cluster.messaging.MessagingConfig#setPrivateKey(String)
+   * @see io.atomix.cluster.messaging.MessagingConfig#setCertificateChain(File)
+   * @see io.atomix.cluster.messaging.MessagingConfig#setPrivateKey(File)
    */
   public AtomixClusterBuilder withSecurity(final File certificateChain, final File privateKey) {
     config

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
@@ -143,14 +143,54 @@ public class MessagingConfig implements Config {
 
   /**
    * Sets the certificate chain to use for inter-cluster communication. If using a self-signed
+   * certificate, or one which is not widely trusted, this must be the complete chain. Convenience
+   * method to pass in a path for {@link #setCertificateChain(File)}.
+   *
+   * <p>Mandatory if TLS is enabled.
+   *
+   * @param certificateChainPath a file containing the certificate chain
+   * @return this config for chaining
+   * @throws IllegalArgumentException if the certificate chain is null
+   * @throws IllegalArgumentException if the certificate chain points to a file which does not exist
+   * @throws IllegalArgumentException if the certificate chain points to a file which cannot be read
+   */
+  public MessagingConfig setCertificateChain(final String certificateChainPath) {
+    if (certificateChainPath == null) {
+      throw new IllegalArgumentException(
+          "Expected a certificate chain in order to enable inter-cluster communication security, "
+              + "but none given");
+    }
+
+    return setCertificateChain(new File(certificateChainPath));
+  }
+
+  /**
+   * Sets the certificate chain to use for inter-cluster communication. If using a self-signed
    * certificate, or one which is not widely trusted, this must be the complete chain.
    *
    * <p>Mandatory if TLS is enabled.
    *
    * @param certificateChain a file containing the certificate chain
    * @return this config for chaining
+   * @throws IllegalArgumentException if the certificate chain is null
+   * @throws IllegalArgumentException if the certificate chain points to a file which does not exist
+   * @throws IllegalArgumentException if the certificate chain points to a file which cannot be read
    */
   public MessagingConfig setCertificateChain(final File certificateChain) {
+    if (certificateChain == null) {
+      throw new IllegalArgumentException(
+          "Expected a certificate chain in order to enable inter-cluster communication security, "
+              + "but none given");
+    }
+
+    if (!certificateChain.canRead()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected the node's inter-cluster communication certificate to be at %s, but either "
+                  + "the file is missing or it is not readable",
+              certificateChain));
+    }
+
     this.certificateChain = certificateChain;
     return this;
   }
@@ -161,14 +201,53 @@ public class MessagingConfig implements Config {
   }
 
   /**
+   * Sets the private key of the certificate chain. Convenience method to pass in a path for {@link
+   * #setPrivateKey(File)}.
+   *
+   * <p>Mandatory if TLS is enabled.
+   *
+   * @param privateKeyPath the private key of the associated certificate chain
+   * @return this config for chaining
+   * @throws IllegalArgumentException if the private key is null
+   * @throws IllegalArgumentException if the private key points to a file which does not exist
+   * @throws IllegalArgumentException if the private key points to a file which cannot be read
+   */
+  public MessagingConfig setPrivateKey(final String privateKeyPath) {
+    if (privateKeyPath == null) {
+      throw new IllegalArgumentException(
+          "Expected a private key in order to enable inter-cluster communication security, but none"
+              + " given");
+    }
+
+    return setPrivateKey(new File(privateKeyPath));
+  }
+
+  /**
    * Sets the private key of the certificate chain.
    *
    * <p>Mandatory if TLS is enabled.
    *
    * @param privateKey the private key of the associated certificate chain
    * @return this config for chaining
+   * @throws IllegalArgumentException if the private key is null
+   * @throws IllegalArgumentException if the private key points to a file which does not exist
+   * @throws IllegalArgumentException if the private key points to a file which cannot be read
    */
   public MessagingConfig setPrivateKey(final File privateKey) {
+    if (privateKey == null) {
+      throw new IllegalArgumentException(
+          "Expected a private key in order to enable inter-cluster communication security, but none"
+              + " given");
+    }
+
+    if (!privateKey.canRead()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected the node's inter-cluster communication private key to be at %s, but either "
+                  + "the file is missing or it is not readable",
+              privateKey));
+    }
+
     this.privateKey = privateKey;
     return this;
   }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -317,7 +317,12 @@ public final class NettyMessagingService implements ManagedMessagingService {
                       new DefaultThreadFactory("netty-messaging-timeout-"));
               localConnection = new LocalClientConnection(handlers);
               started.set(true);
-              log.info("Started");
+
+              log.info(
+                  "Started messaging service bound to {}, advertising {}, and using {}",
+                  bindingAddresses,
+                  advertisedAddress,
+                  config.isTlsEnabled() ? "TLS" : "plaintext");
             })
         .thenApply(v -> this);
   }

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -133,6 +133,36 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-test-util</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -134,6 +134,24 @@
       <artifactId>spring-context</artifactId>
     </dependency>
 
+    <!--
+      the following are only used in tests, but we cannot scope them as tests as they're transitive
+      dependencies required at runtime by other modules; if we scope them as tests here, they will
+      be omitted from the resulting artifact, causing ClassNotFoundException errors at runtime
+      -->
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+    </dependency>
+
+    <!-- /end -->
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
@@ -143,18 +161,6 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-handler</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.agrona</groupId>
-      <artifactId>agrona</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
@@ -103,22 +103,28 @@ public class StandaloneGateway
 
   @Override
   public void onApplicationEvent(final ContextClosedEvent event) {
-    try {
-      gateway.stop();
-    } catch (final Exception e) {
-      LOG.warn("Failed to gracefully shutdown gRPC gateway", e);
+    if (gateway != null) {
+      try {
+        gateway.stop();
+      } catch (final Exception e) {
+        LOG.warn("Failed to gracefully shutdown gRPC gateway", e);
+      }
     }
 
-    try {
-      atomixCluster.stop().orTimeout(10, TimeUnit.SECONDS).join();
-    } catch (final Exception e) {
-      LOG.warn("Failed to gracefully shutdown cluster services", e);
+    if (atomixCluster != null) {
+      try {
+        atomixCluster.stop().orTimeout(10, TimeUnit.SECONDS).join();
+      } catch (final Exception e) {
+        LOG.warn("Failed to gracefully shutdown cluster services", e);
+      }
     }
 
-    try {
-      actorScheduler.close();
-    } catch (final Exception e) {
-      LOG.warn("Failed to gracefully shutdown actor scheduler", e);
+    if (actorScheduler != null) {
+      try {
+        actorScheduler.close();
+      } catch (final Exception e) {
+        LOG.warn("Failed to gracefully shutdown actor scheduler", e);
+      }
     }
 
     LogManager.shutdown();

--- a/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-final class StandaloneGatewayTest {
+final class StandaloneGatewaySecurityTest {
   private SelfSignedCertificate certificate;
   private StandaloneGateway gateway;
 

--- a/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewayTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewayTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
+import io.camunda.zeebe.gateway.impl.configuration.ClusterCfg;
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.camunda.zeebe.gateway.impl.configuration.NetworkCfg;
+import io.camunda.zeebe.gateway.impl.configuration.SecurityCfg;
+import io.camunda.zeebe.test.util.asserts.SslAssert;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import java.net.InetSocketAddress;
+import org.agrona.CloseHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class StandaloneGatewayTest {
+  private SelfSignedCertificate certificate;
+  private StandaloneGateway gateway;
+
+  @BeforeEach
+  void beforeEach() throws Exception {
+    certificate = new SelfSignedCertificate();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    CloseHelper.quietClose(gateway);
+  }
+
+  @Test
+  void shouldStartWithTlsEnabled() throws Exception {
+    // given
+    final GatewayCfg cfg = createGatewayCfg();
+
+    // when
+    gateway = buildGateway(cfg);
+    gateway.run();
+
+    // then
+    final var clusterAddress =
+        new InetSocketAddress(cfg.getCluster().getHost(), cfg.getCluster().getPort());
+    SslAssert.assertThat(clusterAddress).isSecuredBy(certificate);
+  }
+
+  @Test
+  void shouldNotStartWithTlsEnabledAndWrongCert() {
+    // given
+    final GatewayCfg cfg = createGatewayCfg();
+    cfg.getCluster().getSecurity().setCertificateChainPath("/tmp/i-dont-exist.crt");
+
+    // when
+    gateway = buildGateway(cfg);
+
+    // then
+    assertThatCode(() -> gateway.run())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Expected the configured cluster security certificate chain path "
+                + "'/tmp/i-dont-exist.crt' to point to a readable file, but it does not");
+  }
+
+  @Test
+  void shouldNotStartWithTlsEnabledAndWrongKey() {
+    // given
+    final GatewayCfg cfg = createGatewayCfg();
+    cfg.getCluster().getSecurity().setPrivateKeyPath("/tmp/i-dont-exist.key");
+
+    // when
+    gateway = buildGateway(cfg);
+
+    // then
+    assertThatCode(() -> gateway.run())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Expected the configured cluster security private key path '/tmp/i-dont-exist.key' to "
+                + "point to a readable file, but it does not");
+  }
+
+  @Test
+  void shouldNotStartWithTlsEnabledAndNoPrivateKey() {
+    // given
+    final GatewayCfg cfg = createGatewayCfg();
+    cfg.getCluster().getSecurity().setPrivateKeyPath(null);
+
+    // when
+    gateway = buildGateway(cfg);
+
+    // then
+    assertThatCode(() -> gateway.run())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Expected to have a valid private key path for cluster security, but none was configured");
+  }
+
+  @Test
+  void shouldNotStartWithTlsEnabledAndNoCert() {
+    // given
+    final GatewayCfg cfg = createGatewayCfg();
+    cfg.getCluster().getSecurity().setCertificateChainPath(null);
+
+    // when
+    gateway = buildGateway(cfg);
+
+    // then
+    assertThatCode(() -> gateway.run())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Expected to have a valid certificate chain path for cluster security, but none "
+                + "configured");
+  }
+
+  private GatewayCfg createGatewayCfg() {
+    final var gatewayAddress = SocketUtil.getNextAddress();
+    final var clusterAddress = SocketUtil.getNextAddress();
+    return new GatewayCfg()
+        .setNetwork(
+            new NetworkCfg()
+                .setHost(gatewayAddress.getHostName())
+                .setPort(gatewayAddress.getPort()))
+        .setCluster(
+            new ClusterCfg()
+                .setHost(clusterAddress.getHostName())
+                .setPort(clusterAddress.getPort())
+                .setSecurity(
+                    new SecurityCfg()
+                        .setEnabled(true)
+                        .setCertificateChainPath(certificate.certificate().getAbsolutePath())
+                        .setPrivateKeyPath(certificate.privateKey().getAbsolutePath())));
+  }
+
+  private StandaloneGateway buildGateway(final GatewayCfg gatewayCfg) {
+    return new StandaloneGateway(gatewayCfg, new SpringGatewayBridge());
+  }
+}

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -146,6 +146,13 @@
       <artifactId>netty-common</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-test-util</artifactId>

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ClusterCfg.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ClusterCfg.java
@@ -27,6 +27,7 @@ public final class ClusterCfg {
   private String host = DEFAULT_CLUSTER_HOST;
   private int port = DEFAULT_CLUSTER_PORT;
   private MembershipCfg membership = new MembershipCfg();
+  private SecurityCfg security = new SecurityCfg();
 
   public String getMemberId() {
     return memberId;
@@ -90,9 +91,18 @@ public final class ClusterCfg {
     this.membership = membership;
   }
 
+  public SecurityCfg getSecurity() {
+    return security;
+  }
+
+  public ClusterCfg setSecurity(final SecurityCfg security) {
+    this.security = security;
+    return this;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(contactPoint, requestTimeout, clusterName, memberId, host, port);
+    return Objects.hash(contactPoint, requestTimeout, clusterName, memberId, host, port, security);
   }
 
   @Override
@@ -109,6 +119,7 @@ public final class ClusterCfg {
         && Objects.equals(requestTimeout, that.requestTimeout)
         && Objects.equals(clusterName, that.clusterName)
         && Objects.equals(memberId, that.memberId)
+        && Objects.equals(security, that.security)
         && Objects.equals(host, that.host);
   }
 
@@ -131,6 +142,8 @@ public final class ClusterCfg {
         + '\''
         + ", port="
         + port
+        + ", security="
+        + security
         + '}';
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
@@ -7,23 +7,21 @@
  */
 package io.camunda.zeebe.gateway.security;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.zeebe.gateway.Gateway;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.gateway.impl.configuration.NetworkCfg;
 import io.camunda.zeebe.gateway.impl.configuration.SecurityCfg;
 import io.camunda.zeebe.util.sched.ActorScheduler;
-import java.io.IOException;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
-public final class SecurityTest {
-  @Rule public final ExpectedException thrown = ExpectedException.none();
+final class SecurityTest {
   private Gateway gateway;
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (gateway != null) {
       gateway.stop();
@@ -32,77 +30,75 @@ public final class SecurityTest {
   }
 
   @Test
-  public void shouldNotStartWithTlsEnabledAndWrongCert() throws IOException {
+  void shouldNotStartWithTlsEnabledAndWrongCert() {
     // given
     final GatewayCfg cfg = createGatewayCfg();
     cfg.getSecurity()
         .setCertificateChainPath(
             cfg.getSecurity().getCertificateChainPath().replaceAll("test-chain", "wrong-chain"));
 
-    // then
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage(
-        String.format(
-            "Expected to find a certificate chain file at the provided location '%s' but none was found.",
-            cfg.getSecurity().getCertificateChainPath()));
-
     // when
     gateway = buildGateway(cfg);
-    gateway.start();
+
+    // then
+    assertThatCode(() -> gateway.start())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Expected to find a certificate chain file at the provided location '%s' but none was found.",
+            cfg.getSecurity().getCertificateChainPath());
   }
 
   @Test
-  public void shouldNotStartWithTlsEnabledAndWrongKey() throws IOException {
+  void shouldNotStartWithTlsEnabledAndWrongKey() {
     // given
     final GatewayCfg cfg = createGatewayCfg();
     cfg.getSecurity()
         .setPrivateKeyPath(
             cfg.getSecurity().getPrivateKeyPath().replaceAll("test-server", "wrong-server"));
 
-    // then
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage(
-        String.format(
-            "Expected to find a private key file at the provided location '%s' but none was found.",
-            cfg.getSecurity().getPrivateKeyPath()));
-
     // when
     gateway = buildGateway(cfg);
-    gateway.start();
+
+    // then
+    assertThatCode(() -> gateway.start())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Expected to find a private key file at the provided location '%s' but none was found.",
+            cfg.getSecurity().getPrivateKeyPath());
   }
 
   @Test
-  public void shouldNotStartWithTlsEnabledAndNoPrivateKey() throws IOException {
+  void shouldNotStartWithTlsEnabledAndNoPrivateKey() {
     // given
     final GatewayCfg cfg = createGatewayCfg();
     cfg.getSecurity().setPrivateKeyPath(null);
 
-    // then
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage(
-        "Expected to find a valid path to a private key but none was found. "
-            + "Edit the gateway configuration file to provide one or to disable TLS.");
-
     // when
     gateway = buildGateway(cfg);
-    gateway.start();
+
+    // then
+    assertThatCode(() -> gateway.start())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Expected to find a valid path to a private key but none was found. "
+                + "Edit the gateway configuration file to provide one or to disable TLS.");
   }
 
   @Test
-  public void shouldNotStartWithTlsEnabledAndNoCert() throws IOException {
+  void shouldNotStartWithTlsEnabledAndNoCert() {
     // given
     final GatewayCfg cfg = createGatewayCfg();
     cfg.getSecurity().setCertificateChainPath(null);
 
-    // then
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage(
-        "Expected to find a valid path to a certificate chain but none was found. "
-            + "Edit the gateway configuration file to provide one or to disable TLS.");
-
     // when
     gateway = buildGateway(cfg);
-    gateway.start();
+
+    // then
+    assertThatCode(() -> gateway.start())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Expected to find a valid path to a certificate chain but none was found. "
+                + "Edit the gateway configuration file to provide one or to disable TLS.");
   }
 
   private GatewayCfg createGatewayCfg() {

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
@@ -140,7 +140,6 @@ final class SecurityTest {
     final var clusterAddress = SocketUtil.getNextAddress();
     final var atomix =
         AtomixCluster.builder()
-            // avoid port collisions when using the default port
             .withAddress(Address.from(clusterAddress.getHostName(), clusterAddress.getPort()))
             .build();
     final var actorScheduler = ActorScheduler.newActorScheduler().build();

--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -119,6 +119,21 @@
       <artifactId>grpc-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/SslAssert.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/SslAssert.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.asserts;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.zeebe.test.util.netty.NettySslClient;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import java.net.SocketAddress;
+import java.security.cert.Certificate;
+import org.agrona.collections.MutableReference;
+import org.assertj.core.api.AbstractObjectAssert;
+
+/**
+ * An assertion class to assert SSL/TLS properties of a given {@link SocketAddress}. It uses {@link
+ * NettySslClient} under the hood to connect to the remote address.
+ */
+public final class SslAssert extends AbstractObjectAssert<SslAssert, SocketAddress> {
+  public SslAssert(final SocketAddress address) {
+    super(address, SslAssert.class);
+  }
+
+  public static SslAssert assertThat(final SocketAddress address) {
+    return new SslAssert(address);
+  }
+
+  /**
+   * Asserts that this address ({@link #actual}) is secured via SSL or TLS using the given
+   * self-signed certificate.
+   *
+   * <p>This assertion will fail if the address:
+   *
+   * <ul>
+   *   <li>is not reachable
+   *   <li>is not secured by SSL/TLS, e.g. is using plaintext TCP
+   *   <li>is not secured with the given certificate
+   * </ul>
+   *
+   * Example usage:
+   *
+   * <pre>{@code
+   * final SelfSignedCertificate certificate = new SelfSignedCertificate();
+   * final SocketAddress address = new InetSocketAddress("localhost", 8080);
+   * SslAssert.assertThat(address).isSecuredBy(certificate);
+   * }</pre>
+   *
+   * @param certificate the self signed certificate that should be used to secure the endpoint
+   * @return this assertion for chaining
+   * @throws AssertionError when {@link #actual} is not reachable
+   * @throws AssertionError when {@link #actual} is null
+   * @throws AssertionError when {@code certificate} is null
+   * @throws AssertionError when {@link #actual} is using plaintext
+   * @throws AssertionError when {@link #actual} is secured, but not with the given {@code
+   *     certificate}
+   * @see NettySslClient#getRemoteCertificateChain(SocketAddress)
+   */
+  public SslAssert isSecuredBy(final SelfSignedCertificate certificate) {
+    objects.assertNotNull(info, actual, "address");
+    objects.assertNotNull(info, certificate, "self signed certificate");
+
+    final var client = NettySslClient.ofSelfSigned(certificate);
+    final MutableReference<Certificate[]> certificateChain = new MutableReference<>();
+
+    // piggy back off assertThatCode in order to fail and keep the resulting exception as the cause
+    // of the generated AssertionError; using any of the protected methods, such as failWithMessage
+    // would cause us to lose this information
+    assertThatCode(() -> certificateChain.set(client.getRemoteCertificateChain(actual)))
+        .describedAs("Failed to extract certificate from address %s", actual)
+        .doesNotThrowAnyException();
+
+    if (certificateChain.get().length == 0) {
+      throw failure("No certificate reported by remote peer %s", actual);
+    }
+
+    objects.assertEqual(info, certificateChain.get()[0], certificate.cert());
+    return myself;
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/netty/NettySslClient.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/netty/NettySslClient.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.netty;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.concurrent.Future;
+import java.io.UncheckedIOException;
+import java.net.SocketAddress;
+import java.security.cert.Certificate;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLPeerUnverifiedException;
+
+/**
+ * A simple Netty based client which only connects to SSL/TLS secured connections and extracts their
+ * certificates.
+ *
+ * <p>While it can take any {@link SslContext}, it's most likely that for testing you will use it in
+ * combination with a {@link SelfSignedCertificate}, via the factory method {@link
+ * NettySslClient#ofSelfSigned(SelfSignedCertificate)}.
+ *
+ * <p>If you simply want to assert whether or not an endpoint is secured with a given certificate,
+ * look at {@link io.camunda.zeebe.test.util.asserts.SslAssert}. This custom AssertJ assertion
+ * reuses this class to perform its assertions.
+ */
+public final class NettySslClient {
+  private final SslContext sslContext;
+
+  public NettySslClient(final SslContext sslContext) {
+    this.sslContext = sslContext;
+  }
+
+  /**
+   * Returns a client which implicitly trusts the given {@link SelfSignedCertificate}.
+   *
+   * @param certificate the certificate to trust
+   * @return a new gullible client
+   */
+  public static NettySslClient ofSelfSigned(final SelfSignedCertificate certificate) {
+    try {
+      return new NettySslClient(
+          SslContextBuilder.forClient().trustManager(certificate.certificate()).build());
+    } catch (final SSLException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /**
+   * Extracts the certificate chain used by the remote peer at {@code address} after performing a
+   * successful SSL/TLS handshake.
+   *
+   * <p>The operation will fail if it fails to connect within 10 seconds, or if the address is
+   * otherwise unreachable. Similarly, it will fail if the SSL handshake fails.
+   *
+   * @param address the remote address to connect to
+   * @return the certificate chain used by the remote server
+   */
+  public Certificate[] getRemoteCertificateChain(final SocketAddress address) {
+    final CompletableFuture<Certificate[]> certificates = new CompletableFuture<>();
+    final var executor = new NioEventLoopGroup(1);
+
+    try {
+      final var channel =
+          new Bootstrap()
+              .handler(new SslCertificateExtractor(certificates))
+              .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5_000)
+              .group(executor)
+              .channel(NioSocketChannel.class)
+              .connect(address)
+              .addListener(onConnect -> onChannelConnect(address, certificates, onConnect))
+              .channel();
+      channel.closeFuture().addListener(onClose -> onChannelClose(address, certificates, onClose));
+
+      final Certificate[] certificateChain = certificates.orTimeout(10, TimeUnit.SECONDS).join();
+      channel.close();
+
+      return certificateChain;
+    } finally {
+      executor.shutdownGracefully(10, 100, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private void onChannelConnect(
+      final SocketAddress address,
+      final CompletableFuture<Certificate[]> certificates,
+      final Future<? super Void> onConnect) {
+    if (!onConnect.isSuccess()) {
+      final var errorMessage =
+          String.format("Failed to establish a secure connection to %s", address);
+      certificates.completeExceptionally(getErrorWithOptionalCause(onConnect, errorMessage));
+    }
+  }
+
+  private void onChannelClose(
+      final SocketAddress address,
+      final CompletableFuture<Certificate[]> certificates,
+      final Future<? super Void> onClose) {
+    final var errorMessage =
+        String.format(
+            "Channel to remote peer %s was unexpectedly closed before any certificates were "
+                + "extracted",
+            address);
+    certificates.completeExceptionally(getErrorWithOptionalCause(onClose, errorMessage));
+  }
+
+  private Throwable getErrorWithOptionalCause(
+      final Future<? super Void> onClose, final String errorMessage) {
+    final Throwable error;
+    if (onClose.cause() != null) {
+      error = new IllegalStateException(errorMessage, onClose.cause());
+    } else {
+      error = new IllegalStateException(errorMessage);
+    }
+    return error;
+  }
+
+  private final class SslCertificateExtractor extends ChannelInitializer<SocketChannel> {
+    private final CompletableFuture<Certificate[]> extractedCertificate;
+
+    public SslCertificateExtractor(final CompletableFuture<Certificate[]> extractedCertificate) {
+      this.extractedCertificate = extractedCertificate;
+    }
+
+    @Override
+    protected void initChannel(final SocketChannel channel) {
+      final var sslHandler = sslContext.newHandler(channel.alloc());
+      channel.pipeline().addLast("tls", sslHandler);
+      sslHandler
+          .handshakeFuture()
+          .addListener(onHandshake -> extractCertificate(sslHandler, onHandshake));
+    }
+
+    private void extractCertificate(
+        final SslHandler sslHandler, final Future<? super Channel> onHandshake)
+        throws SSLPeerUnverifiedException {
+      if (onHandshake.isSuccess()) {
+        extractedCertificate.complete(sslHandler.engine().getSession().getPeerCertificates());
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR extends the gateway configuration to also allow specifying security configuration settings, and enable TLS for inter-cluster messaging. The configuration is added in the `ClusterCfg` of the gateway, which is currently used to configure its underlying `AtomixCluster`. Validation is performed in the `StandaloneGateway`, which is where we create the `AtomixCluster` for that artifact. Otherwise, for the embedded gateway, that's done in the broker since it shares the same `AtomixCluster`.

Additionally, this PR includes some testing utilities to validate that an endpoint is secured by the expected SSL certificate. This will get reused in later PRs, and we can also think about using it for other tests where we use self signed certificates instead of using files bundled in the test resources.

## Related issues

relates to #5272 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
