### PR TITLE
Allow secure inter-cluster messaging between brokers and other nodes

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
@@ -223,27 +223,6 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
   /**
    * Enables TLS encryption of the messaging service.
    *
-   * @param certificateChainPath the certificate chain to use
-   * @param privateKeyPath the private key of the chain
-   * @return the cluster builder
-   * @see io.atomix.cluster.messaging.MessagingConfig#setTlsEnabled(boolean)
-   * @see io.atomix.cluster.messaging.MessagingConfig#setCertificateChain(String)
-   * @see io.atomix.cluster.messaging.MessagingConfig#setPrivateKey(String)
-   */
-  public AtomixClusterBuilder withSecurity(
-      final String certificateChainPath, final String privateKeyPath) {
-    config
-        .getMessagingConfig()
-        .setTlsEnabled(true)
-        .setCertificateChain(certificateChainPath)
-        .setPrivateKey(privateKeyPath);
-
-    return this;
-  }
-
-  /**
-   * Enables TLS encryption of the messaging service.
-   *
    * @param certificateChain the certificate chain to use
    * @param privateKey the private key of the chain
    * @return the cluster builder

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
@@ -143,29 +143,6 @@ public class MessagingConfig implements Config {
 
   /**
    * Sets the certificate chain to use for inter-cluster communication. If using a self-signed
-   * certificate, or one which is not widely trusted, this must be the complete chain. Convenience
-   * method to pass in a path for {@link #setCertificateChain(File)}.
-   *
-   * <p>Mandatory if TLS is enabled.
-   *
-   * @param certificateChainPath a file containing the certificate chain
-   * @return this config for chaining
-   * @throws IllegalArgumentException if the certificate chain is null
-   * @throws IllegalArgumentException if the certificate chain points to a file which does not exist
-   * @throws IllegalArgumentException if the certificate chain points to a file which cannot be read
-   */
-  public MessagingConfig setCertificateChain(final String certificateChainPath) {
-    if (certificateChainPath == null) {
-      throw new IllegalArgumentException(
-          "Expected a certificate chain in order to enable inter-cluster communication security, "
-              + "but none given");
-    }
-
-    return setCertificateChain(new File(certificateChainPath));
-  }
-
-  /**
-   * Sets the certificate chain to use for inter-cluster communication. If using a self-signed
    * certificate, or one which is not widely trusted, this must be the complete chain.
    *
    * <p>Mandatory if TLS is enabled.
@@ -198,28 +175,6 @@ public class MessagingConfig implements Config {
   /** @return the private key of the certificate chain */
   public File getPrivateKey() {
     return privateKey;
-  }
-
-  /**
-   * Sets the private key of the certificate chain. Convenience method to pass in a path for {@link
-   * #setPrivateKey(File)}.
-   *
-   * <p>Mandatory if TLS is enabled.
-   *
-   * @param privateKeyPath the private key of the associated certificate chain
-   * @return this config for chaining
-   * @throws IllegalArgumentException if the private key is null
-   * @throws IllegalArgumentException if the private key points to a file which does not exist
-   * @throws IllegalArgumentException if the private key points to a file which cannot be read
-   */
-  public MessagingConfig setPrivateKey(final String privateKeyPath) {
-    if (privateKeyPath == null) {
-      throw new IllegalArgumentException(
-          "Expected a private key in order to enable inter-cluster communication security, but none"
-              + " given");
-    }
-
-    return setPrivateKey(new File(privateKeyPath));
   }
 
   /**

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -233,6 +233,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStep.java
@@ -34,13 +34,21 @@ final class CommandApiServiceStep extends AbstractBrokerStartupStep {
       final BrokerStartupContext brokerStartupContext,
       final ConcurrencyControl concurrencyControl,
       final ActorFuture<BrokerStartupContext> startupFuture) {
-
     final var brokerCfg = brokerStartupContext.getBrokerConfiguration();
-
     final var socketCfg = brokerCfg.getNetwork().getCommandApi();
+    final var securityCfg = brokerCfg.getNetwork().getSecurity();
+
     final var messagingConfig = new MessagingConfig();
     messagingConfig.setInterfaces(List.of(socketCfg.getHost()));
     messagingConfig.setPort(socketCfg.getPort());
+
+    if (securityCfg.isEnabled()) {
+      messagingConfig
+          .setTlsEnabled(true)
+          .setCertificateChain(securityCfg.getCertificateChainPath())
+          .setPrivateKey(securityCfg.getPrivateKeyPath());
+    }
+
     final var messagingService =
         new NettyMessagingService(
             brokerCfg.getCluster().getClusterName(),

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionC
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import io.camunda.zeebe.util.sched.ActorScheduler;
 import io.camunda.zeebe.util.sched.clock.ActorClock;
-import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -242,10 +241,7 @@ public final class SystemContext {
           "Expected to have a valid private key path for network security, but none configured");
     }
 
-    final var certChain = new File(certificateChainPath);
-    final var privateKey = new File(privateKeyPath);
-
-    if (!certChain.canRead()) {
+    if (!certificateChainPath.canRead()) {
       throw new IllegalArgumentException(
           String.format(
               "Expected the configured network security certificate chain path '%s' to point to a"
@@ -253,7 +249,7 @@ public final class SystemContext {
               certificateChainPath));
     }
 
-    if (!privateKey.canRead()) {
+    if (!privateKeyPath.canRead()) {
       throw new IllegalArgumentException(
           String.format(
               "Expected the configured network security private key path '%s' to point to a "

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
@@ -26,6 +26,7 @@ public final class NetworkCfg implements ConfigurationEntry {
 
   private final CommandApiCfg commandApi = new CommandApiCfg();
   private InternalApiCfg internalApi = new InternalApiCfg();
+  private SecurityCfg security = new SecurityCfg();
 
   @Override
   public void init(final BrokerCfg brokerCfg, final String brokerBase) {
@@ -85,6 +86,14 @@ public final class NetworkCfg implements ConfigurationEntry {
     this.internalApi = internalApi;
   }
 
+  public SecurityCfg getSecurity() {
+    return security;
+  }
+
+  public void setSecurity(final SecurityCfg security) {
+    this.security = security;
+  }
+
   @Override
   public String toString() {
     return "NetworkCfg{"
@@ -100,6 +109,8 @@ public final class NetworkCfg implements ConfigurationEntry {
         + commandApi
         + ", internalApi="
         + internalApi
+        + ", security="
+        + security
         + '}';
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
@@ -31,6 +31,7 @@ public final class NetworkCfg implements ConfigurationEntry {
   @Override
   public void init(final BrokerCfg brokerCfg, final String brokerBase) {
     applyDefaults();
+    security.init(brokerCfg, brokerBase);
   }
 
   public void applyDefaults() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/SecurityCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/SecurityCfg.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+import java.util.Objects;
+
+public final class SecurityCfg {
+  private static final boolean DEFAULT_ENABLED = false;
+
+  private boolean enabled = DEFAULT_ENABLED;
+  private String certificateChainPath;
+  private String privateKeyPath;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public SecurityCfg setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+    return this;
+  }
+
+  public String getCertificateChainPath() {
+    return certificateChainPath;
+  }
+
+  public SecurityCfg setCertificateChainPath(final String certificateChainPath) {
+    this.certificateChainPath = certificateChainPath;
+    return this;
+  }
+
+  public String getPrivateKeyPath() {
+    return privateKeyPath;
+  }
+
+  public SecurityCfg setPrivateKeyPath(final String privateKeyPath) {
+    this.privateKeyPath = privateKeyPath;
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(enabled, certificateChainPath, privateKeyPath);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final var that = (SecurityCfg) o;
+    return enabled == that.enabled
+        && Objects.equals(certificateChainPath, that.certificateChainPath)
+        && Objects.equals(privateKeyPath, that.privateKeyPath);
+  }
+
+  @Override
+  public String toString() {
+    return "SecurityCfg{"
+        + "enabled="
+        + enabled
+        + ", certificateChainPath='"
+        + certificateChainPath
+        + "'"
+        + ", privateKeyPath='"
+        + privateKeyPath
+        + "'}";
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/SecurityCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/SecurityCfg.java
@@ -7,14 +7,28 @@
  */
 package io.camunda.zeebe.broker.system.configuration;
 
+import java.io.File;
+import java.nio.file.Path;
 import java.util.Objects;
 
-public final class SecurityCfg {
+public final class SecurityCfg implements ConfigurationEntry {
   private static final boolean DEFAULT_ENABLED = false;
 
   private boolean enabled = DEFAULT_ENABLED;
-  private String certificateChainPath;
-  private String privateKeyPath;
+  private File certificateChainPath;
+  private File privateKeyPath;
+
+  @Override
+  public void init(final BrokerCfg globalConfig, final String brokerBase) {
+    final var brokerBasePath = Path.of(brokerBase);
+    if (certificateChainPath != null) {
+      certificateChainPath = brokerBasePath.resolve(certificateChainPath.toPath()).toFile();
+    }
+
+    if (privateKeyPath != null) {
+      privateKeyPath = brokerBasePath.resolve(privateKeyPath.toPath()).toFile();
+    }
+  }
 
   public boolean isEnabled() {
     return enabled;
@@ -25,20 +39,20 @@ public final class SecurityCfg {
     return this;
   }
 
-  public String getCertificateChainPath() {
+  public File getCertificateChainPath() {
     return certificateChainPath;
   }
 
-  public SecurityCfg setCertificateChainPath(final String certificateChainPath) {
+  public SecurityCfg setCertificateChainPath(final File certificateChainPath) {
     this.certificateChainPath = certificateChainPath;
     return this;
   }
 
-  public String getPrivateKeyPath() {
+  public File getPrivateKeyPath() {
     return privateKeyPath;
   }
 
-  public SecurityCfg setPrivateKeyPath(final String privateKeyPath) {
+  public SecurityCfg setPrivateKeyPath(final File privateKeyPath) {
     this.privateKeyPath = privateKeyPath;
     return this;
   }

--- a/broker/src/test/java/io/camunda/zeebe/broker/BrokerNetworkSecurityTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/BrokerNetworkSecurityTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.SecurityCfg;
+import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
+import io.camunda.zeebe.test.util.asserts.SslAssert;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import java.net.SocketAddress;
+import java.security.cert.CertificateException;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public final class BrokerNetworkSecurityTest {
+  // must be public because it must be declared before BROKER, and checkstyle flags it if we set it
+  // anything else as a false positive
+  public static final SelfSignedCertificate CERTIFICATE;
+
+  @ClassRule
+  public static final EmbeddedBrokerRule BROKER =
+      new EmbeddedBrokerRule(BrokerNetworkSecurityTest::configureBroker);
+
+  static {
+    try {
+      CERTIFICATE = new SelfSignedCertificate();
+    } catch (final CertificateException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void shouldSecureCommandApi() {
+    // given
+    final SocketAddress commandApiAddress =
+        BROKER.getBrokerCfg().getNetwork().getCommandApi().getAddress();
+
+    // then
+    SslAssert.assertThat(commandApiAddress).isSecuredBy(CERTIFICATE);
+  }
+
+  @Test
+  public void shouldSecureInternalApi() {
+    // given
+    final SocketAddress internalApiAddress =
+        BROKER.getBrokerCfg().getNetwork().getInternalApi().getAddress();
+
+    // then
+    SslAssert.assertThat(internalApiAddress).isSecuredBy(CERTIFICATE);
+  }
+
+  private static void configureBroker(final BrokerCfg config) {
+    config
+        .getNetwork()
+        .setSecurity(
+            new SecurityCfg()
+                .setEnabled(true)
+                .setCertificateChainPath(CERTIFICATE.certificate().getAbsolutePath())
+                .setPrivateKeyPath(CERTIFICATE.privateKey().getAbsolutePath()));
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/BrokerNetworkSecurityTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/BrokerNetworkSecurityTest.java
@@ -14,53 +14,62 @@ import io.camunda.zeebe.test.util.asserts.SslAssert;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import java.net.SocketAddress;
 import java.security.cert.CertificateException;
+import org.agrona.LangUtil;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
 public final class BrokerNetworkSecurityTest {
-  // must be public because it must be declared before BROKER, and checkstyle flags it if we set it
-  // anything else as a false positive
-  public static final SelfSignedCertificate CERTIFICATE;
-
   @ClassRule
-  public static final EmbeddedBrokerRule BROKER =
-      new EmbeddedBrokerRule(BrokerNetworkSecurityTest::configureBroker);
-
-  static {
-    try {
-      CERTIFICATE = new SelfSignedCertificate();
-    } catch (final CertificateException e) {
-      throw new RuntimeException(e);
-    }
-  }
+  public static final SecuredEmbeddedBrokerRule BROKER_RULE = new SecuredEmbeddedBrokerRule();
 
   @Test
   public void shouldSecureCommandApi() {
     // given
     final SocketAddress commandApiAddress =
-        BROKER.getBrokerCfg().getNetwork().getCommandApi().getAddress();
+        BROKER_RULE.broker.getBrokerCfg().getNetwork().getCommandApi().getAddress();
 
     // then
-    SslAssert.assertThat(commandApiAddress).isSecuredBy(CERTIFICATE);
+    SslAssert.assertThat(commandApiAddress).isSecuredBy(BROKER_RULE.certificate);
   }
 
   @Test
   public void shouldSecureInternalApi() {
     // given
     final SocketAddress internalApiAddress =
-        BROKER.getBrokerCfg().getNetwork().getInternalApi().getAddress();
+        BROKER_RULE.broker.getBrokerCfg().getNetwork().getInternalApi().getAddress();
 
     // then
-    SslAssert.assertThat(internalApiAddress).isSecuredBy(CERTIFICATE);
+    SslAssert.assertThat(internalApiAddress).isSecuredBy(BROKER_RULE.certificate);
   }
 
-  private static void configureBroker(final BrokerCfg config) {
-    config
-        .getNetwork()
-        .setSecurity(
-            new SecurityCfg()
-                .setEnabled(true)
-                .setCertificateChainPath(CERTIFICATE.certificate())
-                .setPrivateKeyPath(CERTIFICATE.privateKey()));
+  private static final class SecuredEmbeddedBrokerRule extends ExternalResource {
+    private SelfSignedCertificate certificate;
+    private EmbeddedBrokerRule broker;
+
+    @Override
+    public Statement apply(final Statement base, final Description description) {
+      try {
+        certificate = new SelfSignedCertificate();
+      } catch (final CertificateException e) {
+        LangUtil.rethrowUnchecked(e);
+      }
+
+      broker = new EmbeddedBrokerRule(this::configureBroker);
+      final var statement = super.apply(base, description);
+      return broker.apply(statement, description);
+    }
+
+    private void configureBroker(final BrokerCfg config) {
+      config
+          .getNetwork()
+          .setSecurity(
+              new SecurityCfg()
+                  .setEnabled(true)
+                  .setCertificateChainPath(certificate.certificate())
+                  .setPrivateKeyPath(certificate.privateKey()));
+    }
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/BrokerNetworkSecurityTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/BrokerNetworkSecurityTest.java
@@ -60,7 +60,7 @@ public final class BrokerNetworkSecurityTest {
         .setSecurity(
             new SecurityCfg()
                 .setEnabled(true)
-                .setCertificateChainPath(CERTIFICATE.certificate().getAbsolutePath())
-                .setPrivateKeyPath(CERTIFICATE.privateKey().getAbsolutePath()));
+                .setCertificateChainPath(CERTIFICATE.certificate())
+                .setPrivateKeyPath(CERTIFICATE.privateKey()));
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -15,6 +15,8 @@ import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionC
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg.NodeCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import java.security.cert.CertificateException;
 import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -310,6 +312,85 @@ final class SystemContextTest {
 
     // when - then
     assertThatCode(() -> initSystemContext(brokerCfg)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldThrowExceptionWithNetworkSecurityEnabledAndWrongCert() throws CertificateException {
+    // given
+    final var certificate = new SelfSignedCertificate();
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg
+        .getNetwork()
+        .getSecurity()
+        .setEnabled(true)
+        .setPrivateKeyPath(certificate.privateKey().getAbsolutePath())
+        .setCertificateChainPath("/tmp/i-dont-exist.crt");
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Expected the configured network security certificate chain path "
+                + "'/tmp/i-dont-exist.crt' to point to a readable file, but it does not");
+  }
+
+  @Test
+  void shouldThrowExceptionWithNetworkSecurityEnabledAndWrongKey() throws CertificateException {
+    // given
+    final var certificate = new SelfSignedCertificate();
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg
+        .getNetwork()
+        .getSecurity()
+        .setEnabled(true)
+        .setPrivateKeyPath("/tmp/i-dont-exist.key")
+        .setCertificateChainPath(certificate.certificate().getAbsolutePath());
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Expected the configured network security private key path "
+                + "'/tmp/i-dont-exist.key' to point to a readable file, but it does not");
+  }
+
+  @Test
+  void shouldThrowExceptionWithNetworkSecurityEnabledAndNoPrivateKey() throws CertificateException {
+    // given
+    final var certificate = new SelfSignedCertificate();
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg
+        .getNetwork()
+        .getSecurity()
+        .setEnabled(true)
+        .setPrivateKeyPath(null)
+        .setCertificateChainPath(certificate.certificate().getAbsolutePath());
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Expected to have a valid private key path for network security, but none configured");
+  }
+
+  @Test
+  void shouldThrowExceptionWithNetworkSecurityEnabledAndNoCert() throws CertificateException {
+    // given
+    final var certificate = new SelfSignedCertificate();
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg
+        .getNetwork()
+        .getSecurity()
+        .setEnabled(true)
+        .setPrivateKeyPath(certificate.privateKey().getAbsolutePath())
+        .setCertificateChainPath(null);
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Expected to have a valid certificate chain path for network security, but none "
+                + "configured");
   }
 
   private SystemContext initSystemContext(final BrokerCfg brokerCfg) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionC
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import java.io.File;
 import java.security.cert.CertificateException;
 import java.time.Duration;
 import java.util.List;
@@ -323,8 +324,8 @@ final class SystemContextTest {
         .getNetwork()
         .getSecurity()
         .setEnabled(true)
-        .setPrivateKeyPath(certificate.privateKey().getAbsolutePath())
-        .setCertificateChainPath("/tmp/i-dont-exist.crt");
+        .setPrivateKeyPath(certificate.privateKey())
+        .setCertificateChainPath(new File("/tmp/i-dont-exist.crt"));
 
     // when - then
     assertThatCode(() -> initSystemContext(brokerCfg))
@@ -343,8 +344,8 @@ final class SystemContextTest {
         .getNetwork()
         .getSecurity()
         .setEnabled(true)
-        .setPrivateKeyPath("/tmp/i-dont-exist.key")
-        .setCertificateChainPath(certificate.certificate().getAbsolutePath());
+        .setPrivateKeyPath(new File("/tmp/i-dont-exist.key"))
+        .setCertificateChainPath(certificate.certificate());
 
     // when - then
     assertThatCode(() -> initSystemContext(brokerCfg))
@@ -364,7 +365,7 @@ final class SystemContextTest {
         .getSecurity()
         .setEnabled(true)
         .setPrivateKeyPath(null)
-        .setCertificateChainPath(certificate.certificate().getAbsolutePath());
+        .setCertificateChainPath(certificate.certificate());
 
     // when - then
     assertThatCode(() -> initSystemContext(brokerCfg))
@@ -382,7 +383,7 @@ final class SystemContextTest {
         .getNetwork()
         .getSecurity()
         .setEnabled(true)
-        .setPrivateKeyPath(certificate.privateKey().getAbsolutePath())
+        .setPrivateKeyPath(certificate.privateKey())
         .setCertificateChainPath(null);
 
     // when - then

--- a/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.shared.Profile;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.sched.ActorScheduler;
-import java.io.File;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
@@ -209,10 +208,7 @@ public class StandaloneGateway
               + "configured");
     }
 
-    final var certChain = new File(certificateChainPath);
-    final var privateKey = new File(privateKeyPath);
-
-    if (!certChain.canRead()) {
+    if (!certificateChainPath.canRead()) {
       throw new IllegalArgumentException(
           String.format(
               "Expected the configured cluster security certificate chain path '%s' to point to a"
@@ -220,7 +216,7 @@ public class StandaloneGateway
               certificateChainPath));
     }
 
-    if (!privateKey.canRead()) {
+    if (!privateKeyPath.canRead()) {
       throw new IllegalArgumentException(
           String.format(
               "Expected the configured cluster security private key path '%s' to point to a "
@@ -228,6 +224,6 @@ public class StandaloneGateway
               privateKeyPath));
     }
 
-    builder.withSecurity(certChain, privateKey);
+    builder.withSecurity(certificateChainPath, privateKeyPath);
   }
 }

--- a/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.gateway.impl.configuration.SecurityCfg;
 import io.camunda.zeebe.test.util.asserts.SslAssert;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import java.io.File;
 import java.net.InetSocketAddress;
 import org.agrona.CloseHelper;
 import org.junit.jupiter.api.AfterEach;
@@ -56,7 +57,7 @@ final class StandaloneGatewaySecurityTest {
   void shouldNotStartWithTlsEnabledAndWrongCert() {
     // given
     final GatewayCfg cfg = createGatewayCfg();
-    cfg.getCluster().getSecurity().setCertificateChainPath("/tmp/i-dont-exist.crt");
+    cfg.getCluster().getSecurity().setCertificateChainPath(new File("/tmp/i-dont-exist.crt"));
 
     // when
     gateway = buildGateway(cfg);
@@ -73,7 +74,7 @@ final class StandaloneGatewaySecurityTest {
   void shouldNotStartWithTlsEnabledAndWrongKey() {
     // given
     final GatewayCfg cfg = createGatewayCfg();
-    cfg.getCluster().getSecurity().setPrivateKeyPath("/tmp/i-dont-exist.key");
+    cfg.getCluster().getSecurity().setPrivateKeyPath(new File("/tmp/i-dont-exist.key"));
 
     // when
     gateway = buildGateway(cfg);
@@ -134,8 +135,8 @@ final class StandaloneGatewaySecurityTest {
                 .setSecurity(
                     new SecurityCfg()
                         .setEnabled(true)
-                        .setCertificateChainPath(certificate.certificate().getAbsolutePath())
-                        .setPrivateKeyPath(certificate.privateKey().getAbsolutePath())));
+                        .setCertificateChainPath(certificate.certificate())
+                        .setPrivateKeyPath(certificate.privateKey())));
   }
 
   private StandaloneGateway buildGateway(final GatewayCfg gatewayCfg) {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -33,7 +33,6 @@ import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.netty.NettyServerBuilder;
-import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.time.Duration;
@@ -154,36 +153,36 @@ public final class Gateway {
   }
 
   private void setSecurityConfig(final ServerBuilder<?> serverBuilder, final SecurityCfg security) {
-    if (security.getCertificateChainPath() == null) {
+    final var certificateChainPath = security.getCertificateChainPath();
+    final var privateKeyPath = security.getPrivateKeyPath();
+
+    if (certificateChainPath == null) {
       throw new IllegalArgumentException(
           "Expected to find a valid path to a certificate chain but none was found. "
               + "Edit the gateway configuration file to provide one or to disable TLS.");
     }
 
-    if (security.getPrivateKeyPath() == null) {
+    if (privateKeyPath == null) {
       throw new IllegalArgumentException(
           "Expected to find a valid path to a private key but none was found. "
               + "Edit the gateway configuration file to provide one or to disable TLS.");
     }
 
-    final File certChain = new File(security.getCertificateChainPath());
-    final File privateKey = new File(security.getPrivateKeyPath());
-
-    if (!certChain.exists()) {
+    if (!certificateChainPath.exists()) {
       throw new IllegalArgumentException(
           String.format(
               "Expected to find a certificate chain file at the provided location '%s' but none was found.",
-              security.getCertificateChainPath()));
+              certificateChainPath));
     }
 
-    if (!privateKey.exists()) {
+    if (!privateKeyPath.exists()) {
       throw new IllegalArgumentException(
           String.format(
               "Expected to find a private key file at the provided location '%s' but none was found.",
-              security.getPrivateKeyPath()));
+              privateKeyPath));
     }
 
-    serverBuilder.useTransportSecurity(certChain, privateKey);
+    serverBuilder.useTransportSecurity(certificateChainPath, privateKeyPath);
   }
 
   private BrokerClient buildBrokerClient() {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/SecurityCfg.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/SecurityCfg.java
@@ -9,13 +9,14 @@ package io.camunda.zeebe.gateway.impl.configuration;
 
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_TLS_ENABLED;
 
+import java.io.File;
 import java.util.Objects;
 
 public final class SecurityCfg {
 
   private boolean enabled = DEFAULT_TLS_ENABLED;
-  private String certificateChainPath;
-  private String privateKeyPath;
+  private File certificateChainPath;
+  private File privateKeyPath;
 
   public boolean isEnabled() {
     return enabled;
@@ -26,20 +27,20 @@ public final class SecurityCfg {
     return this;
   }
 
-  public String getCertificateChainPath() {
+  public File getCertificateChainPath() {
     return certificateChainPath;
   }
 
-  public SecurityCfg setCertificateChainPath(final String certificateChainPath) {
+  public SecurityCfg setCertificateChainPath(final File certificateChainPath) {
     this.certificateChainPath = certificateChainPath;
     return this;
   }
 
-  public String getPrivateKeyPath() {
+  public File getPrivateKeyPath() {
     return privateKeyPath;
   }
 
-  public SecurityCfg setPrivateKeyPath(final String privateKeyPath) {
+  public SecurityCfg setPrivateKeyPath(final File privateKeyPath) {
     this.privateKeyPath = privateKeyPath;
     return this;
   }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ResponsiveHealthIndicator.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ResponsiveHealthIndicator.java
@@ -59,7 +59,7 @@ public class ResponsiveHealthIndicator implements HealthIndicator {
       try {
         zeebeClient.newTopologyRequest().send().get();
         resultBuilder = Health.up();
-      } catch (Throwable t) {
+      } catch (final Throwable t) {
         resultBuilder = Health.down().withException(t);
       }
     }
@@ -85,7 +85,8 @@ public class ResponsiveHealthIndicator implements HealthIndicator {
 
     if (gatewayCfg.getSecurity().isEnabled()) {
       clientBuilder =
-          clientBuilder.caCertificatePath(gatewayCfg.getSecurity().getCertificateChainPath());
+          clientBuilder.caCertificatePath(
+              gatewayCfg.getSecurity().getCertificateChainPath().getAbsolutePath());
     } else {
       clientBuilder = clientBuilder.usePlaintext();
     }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.test.util.TestConfigurationFactory;
 import io.camunda.zeebe.util.Environment;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
@@ -43,8 +44,8 @@ public final class GatewayCfgTest {
     CUSTOM_CFG
         .getSecurity()
         .setEnabled(true)
-        .setCertificateChainPath("certificateChainPath")
-        .setPrivateKeyPath("privateKeyPath");
+        .setCertificateChainPath(new File("certificateChainPath"))
+        .setPrivateKeyPath(new File("privateKeyPath"));
     CUSTOM_CFG.getThreads().setManagementThreads(100);
     CUSTOM_CFG.getLongPolling().setEnabled(false);
     CUSTOM_CFG.getInterceptors().add(new InterceptorCfg());
@@ -194,9 +195,11 @@ public final class GatewayCfgTest {
         .getSecurity()
         .setEnabled(false)
         .setPrivateKeyPath(
-            getClass().getClassLoader().getResource("security/test-server.key.pem").getPath())
+            new File(
+                getClass().getClassLoader().getResource("security/test-server.key.pem").getPath()))
         .setCertificateChainPath(
-            getClass().getClassLoader().getResource("security/test-chain.cert.pem").getPath());
+            new File(
+                getClass().getClassLoader().getResource("security/test-chain.cert.pem").getPath()));
     expected.getLongPolling().setEnabled(false);
 
     expected.getInterceptors().add(new InterceptorCfg());

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ResponsiveHealthIndicatorTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ResponsiveHealthIndicatorTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.TopologyRequestStep1;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import java.io.File;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import org.junit.Test;
@@ -207,7 +208,9 @@ public class ResponsiveHealthIndicatorTest {
     securityEnabledGatewayCfg.getNetwork().setHost("testhost");
     securityEnabledGatewayCfg.getNetwork().setPort(1234);
     securityEnabledGatewayCfg.getSecurity().setEnabled(true);
-    securityEnabledGatewayCfg.getSecurity().setCertificateChainPath(CERTIFICATE_CHAIN_PATH);
+    securityEnabledGatewayCfg
+        .getSecurity()
+        .setCertificateChainPath(new File(CERTIFICATE_CHAIN_PATH));
     securityEnabledGatewayCfg.init();
 
     // when

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.test.util.asserts.SslAssert;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.camunda.zeebe.util.sched.ActorScheduler;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import java.io.File;
 import java.io.IOException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,7 +59,7 @@ final class SecurityTest {
   void shouldNotStartWithTlsEnabledAndWrongCert() {
     // given
     final GatewayCfg cfg = createGatewayCfg();
-    cfg.getSecurity().setCertificateChainPath("/tmp/i-dont-exist.crt");
+    cfg.getSecurity().setCertificateChainPath(new File("/tmp/i-dont-exist.crt"));
 
     // when
     gateway = buildGateway(cfg);
@@ -75,7 +76,7 @@ final class SecurityTest {
   void shouldNotStartWithTlsEnabledAndWrongKey() {
     // given
     final GatewayCfg cfg = createGatewayCfg();
-    cfg.getSecurity().setPrivateKeyPath("/tmp/i-dont-exist.key");
+    cfg.getSecurity().setPrivateKeyPath(new File("/tmp/i-dont-exist.key"));
 
     // when
     gateway = buildGateway(cfg);
@@ -132,8 +133,8 @@ final class SecurityTest {
         .setSecurity(
             new SecurityCfg()
                 .setEnabled(true)
-                .setCertificateChainPath(certificate.certificate().getAbsolutePath())
-                .setPrivateKeyPath(certificate.privateKey().getAbsolutePath()));
+                .setCertificateChainPath(certificate.certificate())
+                .setPrivateKeyPath(certificate.privateKey()));
   }
 
   private Gateway buildGateway(final GatewayCfg gatewayCfg) {

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -112,6 +112,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
       <scope>test</scope>

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/SecurityTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/SecurityTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.it.clustering.ClusteringRule;
 import io.camunda.zeebe.it.clustering.DeploymentClusteredTest;
 import io.camunda.zeebe.it.util.GrpcClientRule;
 import io.netty.util.NetUtil;
+import java.io.File;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -65,7 +66,7 @@ public final class SecurityTest {
     gatewayCfg
         .getSecurity()
         .setEnabled(true)
-        .setCertificateChainPath(certificatePath)
-        .setPrivateKeyPath(privateKeyPath);
+        .setCertificateChainPath(new File(certificatePath))
+        .setPrivateKeyPath(new File(privateKeyPath));
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/SecureClusteredMessagingIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/SecureClusteredMessagingIT.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.network;
+
+import io.atomix.utils.net.Address;
+import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.zeebe.test.util.asserts.SslAssert;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
+import io.camunda.zeebe.test.util.testcontainers.ZeebeTestContainerDefaults;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.zeebe.containers.ZeebeNode;
+import io.zeebe.containers.cluster.ZeebeCluster;
+import java.security.cert.CertificateException;
+import java.util.concurrent.TimeUnit;
+import org.agrona.CloseHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
+import org.testcontainers.utility.MountableFile;
+
+final class SecureClusteredMessagingIT {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SecureClusteredMessagingIT.class);
+
+  private Network network;
+  private ZeebeCluster cluster;
+
+  @SuppressWarnings("unused")
+  @RegisterExtension
+  final ContainerLogsDumper logsWatcher =
+      new ContainerLogsDumper(() -> cluster.getBrokers(), LOGGER);
+
+  private SelfSignedCertificate certificate;
+
+  @BeforeEach
+  void beforeEach() throws CertificateException {
+    network = Network.newNetwork();
+    certificate = new SelfSignedCertificate();
+  }
+
+  @AfterEach
+  void afterEach() {
+    CloseHelper.quietCloseAll(cluster, network);
+  }
+
+  @Test
+  void shouldFormAClusterWithTls() {
+    // given - a cluster with 2 standalone brokers, and 1 standalone gateway
+    cluster =
+        ZeebeCluster.builder()
+            .withGatewaysCount(1)
+            .withBrokersCount(2)
+            .withReplicationFactor(2)
+            .withEmbeddedGateway(false)
+            .build();
+    cluster.getBrokers().forEach((nodeId, broker) -> configureNode(broker));
+    cluster.getGateways().forEach((nodeId, gateway) -> configureNode(gateway));
+    cluster.start();
+
+    // when - note the client is using plaintext since we only care about inter-cluster TLS
+    final Topology topology;
+    try (final var client = cluster.newClientBuilder().usePlaintext().build()) {
+      topology = client.newTopologyRequest().send().join(15, TimeUnit.SECONDS);
+    }
+
+    // then - ensure the cluster is formed correctly and all inter-cluster communication endpoints
+    // are secured using the expected certificate
+    TopologyAssert.assertThat(topology).hasBrokersCount(2).isComplete(2, 1);
+    cluster
+        .getBrokers()
+        .forEach(
+            (id, broker) -> {
+              assertAddressIsSecured(id, broker.getExternalCommandAddress());
+              assertAddressIsSecured(id, broker.getExternalClusterAddress());
+            });
+    cluster
+        .getGateways()
+        .forEach((id, gateway) -> assertAddressIsSecured(id, gateway.getExternalClusterAddress()));
+  }
+
+  private void configureNode(final ZeebeNode<?> node) {
+    final var certChainPath = "/tmp/certChain.crt";
+    final var privateKeyPath = "/tmp/private.key";
+
+    // configure both the broker and gateway; it doesn't really matter if one sees the environment
+    // variables of the other
+    node.setDockerImageName(ZeebeTestContainerDefaults.defaultTestImage().asCanonicalNameString());
+    node.withEnv("ZEEBE_BROKER_NETWORK_SECURITY_ENABLED", "true")
+        .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_CERTIFICATECHAINPATH", certChainPath)
+        .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_PRIVATEKEYPATH", privateKeyPath)
+        .withEnv("ZEEBE_GATEWAY_CLUSTER_SECURITY_ENABLED", "true")
+        .withEnv("ZEEBE_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH", certChainPath)
+        .withEnv("ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH", privateKeyPath)
+        .withCopyFileToContainer(
+            MountableFile.forHostPath(certificate.certificate().toPath()), certChainPath)
+        .withCopyFileToContainer(
+            MountableFile.forHostPath(certificate.privateKey().toPath()), privateKeyPath);
+  }
+
+  private void assertAddressIsSecured(final Object nodeId, final String address) {
+    final var socketAddress = Address.from(address).socketAddress();
+    SslAssert.assertThat(socketAddress)
+        .as("node %s is not secured correctly", nodeId)
+        .isSecuredBy(certificate);
+  }
+}


### PR DESCRIPTION
## Description

This PR allows brokers to configure TLS for encrypted messaging between them and other nodes in the cluster. The security configuration is added directly to the network configuration, as it wasn't considered a useful case to have different configuration for different APIs. This can be changed later, but for simplicity we omitted it here.

TLS can be enabled on the brokers between nodes by setting `zeebe.broker.network.security.enabled=true`. If true, a certificate and a private key must be provided. These can be provided as `zeebe.broker.network.security.certificateChainPath` and `zeebe.broker.network.security.privateKeyPath`, respectively, and should point to readable files relative to the broker's working directory. The `certificateChainPath` must be either a X.509 certificate, or a certificate chain - that is, the certificate, followed by its chain of trust. This can be useful if you don't expect the certificate itself to be trusted by default on the other nodes, but one member of its chain is. The private key must then be the private key of the certificate itself.

This configuration is a bit verbose but done on purpose - that is, to align it with the gateway's security configuration, and to be forwards compatible with future planned transport changes.

The whole thing works with self signed certificates - however, if you wish to use one, then you must ensure all nodes are configured with the same self signed certificates. This is by design - the certificate chain you configure a broker with will be implicitly trusted by itself, so if another broker identifies with the same self signed certificate, it will trust it.

The broker will fail to start if `zeebe.broker.network.security.enabled=true`, and:

- the certificate chain and/or private key is not configured
- the certificate chain and/or private is not a readable file
- the private key does not match the certificate
- the certificate is not a X.509 certificate or certificate chain

## Related issues

closes #5272 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
