### PR TITLE
feat(clients/zbctl): improve help message on commands with time.Duration flag

### DIFF
--- a/benchmarks/project/zbench/internal/commands/worker.go
+++ b/benchmarks/project/zbench/internal/commands/worker.go
@@ -95,7 +95,7 @@ func init() {
 
 	workerCmd.
 		Flags().
-		DurationVar(&workerJobTimeoutFlag, "timeout", 10*time.Second, "Specify the time before a job is made activatable again")
+		DurationVar(&workerJobTimeoutFlag, "timeout", 10*time.Second, "Specify the time before a job is made activatable again. Example values: 300ms, 50s or 1m")
 
 	workerCmd.
 		Flags().

--- a/clients/go/cmd/zbctl/internal/commands/activateJobs.go
+++ b/clients/go/cmd/zbctl/internal/commands/activateJobs.go
@@ -16,10 +16,11 @@ package commands
 
 import (
 	"context"
+	"time"
+
 	"github.com/camunda-cloud/zeebe/clients/go/pkg/commands"
 	"github.com/camunda-cloud/zeebe/clients/go/pkg/pb"
 	"github.com/spf13/cobra"
-	"time"
 )
 
 const (
@@ -76,7 +77,7 @@ func init() {
 	activateCmd.AddCommand(activateJobsCmd)
 	activateJobsCmd.Flags().Int32Var(&maxJobsToActivateFlag, "maxJobsToActivate", 1, "Specify the maximum amount of jobs to activate")
 	activateJobsCmd.Flags().StringVar(&activateJobsWorkerFlag, "worker", DefaultJobWorkerName, "Specify the name of the worker")
-	activateJobsCmd.Flags().DurationVar(&activateJobsTimeoutFlag, "timeout", commands.DefaultJobTimeout, "Specify the timeout of the activated job")
+	activateJobsCmd.Flags().DurationVar(&activateJobsTimeoutFlag, "timeout", commands.DefaultJobTimeout, "Specify the timeout of the activated job. Example values: 300ms, 50s or 1m")
 	activateJobsCmd.Flags().StringSliceVar(&activateJobsFetchVariablesFlag, "variables", []string{}, "Specify the list of variable names which should be fetch on job activation (comma-separated)")
-	activateJobsCmd.Flags().DurationVar(&activateJobsRequestTimeoutFlag, "requestTimeout", 0, "Specify the request timeout")
+	activateJobsCmd.Flags().DurationVar(&activateJobsRequestTimeoutFlag, "requestTimeout", 0, "Specify the request timeout. Example values: 300ms, 50s or 1m")
 }

--- a/clients/go/cmd/zbctl/internal/commands/createWorker.go
+++ b/clients/go/cmd/zbctl/internal/commands/createWorker.go
@@ -18,16 +18,17 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/camunda-cloud/zeebe/clients/go/pkg/commands"
-	"github.com/camunda-cloud/zeebe/clients/go/pkg/entities"
-	"github.com/camunda-cloud/zeebe/clients/go/pkg/worker"
-	"github.com/camunda-cloud/zeebe/clients/go/pkg/zbc"
-	"github.com/spf13/cobra"
 	"io"
 	"log"
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/camunda-cloud/zeebe/clients/go/pkg/commands"
+	"github.com/camunda-cloud/zeebe/clients/go/pkg/entities"
+	"github.com/camunda-cloud/zeebe/clients/go/pkg/worker"
+	"github.com/camunda-cloud/zeebe/clients/go/pkg/zbc"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -161,10 +162,10 @@ func init() {
 	}
 
 	createWorkerCmd.Flags().StringVar(&createWorkerNameFlag, "name", DefaultJobWorkerName, "Specify the worker name")
-	createWorkerCmd.Flags().DurationVar(&createWorkerTimeoutFlag, "timeout", commands.DefaultJobTimeout, "Specify the duration no other worker should work on job activated by this worker")
-	createWorkerCmd.Flags().DurationVar(&createWorkerRequestTimeoutFlag, "requestTimeout", zbc.DefaultRequestTimeout, "Specify the timeout for a request")
+	createWorkerCmd.Flags().DurationVar(&createWorkerTimeoutFlag, "timeout", commands.DefaultJobTimeout, "Specify the duration no other worker should work on job activated by this worker. Example values: 300ms, 50s or 1m")
+	createWorkerCmd.Flags().DurationVar(&createWorkerRequestTimeoutFlag, "requestTimeout", zbc.DefaultRequestTimeout, "Specify the timeout for a request. Example values: 300ms, 50s or 1m")
 	createWorkerCmd.Flags().IntVar(&createWorkerMaxJobsActiveFlag, "maxJobsActive", worker.DefaultJobWorkerMaxJobActive, "Specify the maximum number of jobs which will be activated for this worker at the same time")
 	createWorkerCmd.Flags().IntVar(&createWorkerConcurrencyFlag, "concurrency", worker.DefaultJobWorkerConcurrency, "Specify the maximum number of concurrent spawned goroutines to complete jobs")
-	createWorkerCmd.Flags().DurationVar(&createWorkerPollIntervalFlag, "pollInterval", worker.DefaultJobWorkerPollInterval, "Specify the maximal interval between polling for new jobs")
+	createWorkerCmd.Flags().DurationVar(&createWorkerPollIntervalFlag, "pollInterval", worker.DefaultJobWorkerPollInterval, "Specify the maximal interval between polling for new jobs. Example values: 300ms, 50s or 1m")
 	createWorkerCmd.Flags().Float64Var(&createWorkerPollThresholdFlag, "pollThreshold", worker.DefaultJobWorkerPollThreshold, "Specify the threshold of buffered activated jobs before polling for new jobs, i.e. pollThreshold * maxJobsActive")
 }

--- a/clients/go/cmd/zbctl/internal/commands/publishMessage.go
+++ b/clients/go/cmd/zbctl/internal/commands/publishMessage.go
@@ -16,8 +16,9 @@ package commands
 
 import (
 	"context"
-	"github.com/spf13/cobra"
 	"time"
+
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -61,7 +62,7 @@ func init() {
 
 	publishMessageCmd.Flags().StringVar(&publishMessageCorrelationKey, "correlationKey", "", "Specify message correlation key")
 	publishMessageCmd.Flags().StringVar(&publishMessageID, "messageId", "", "Specify the unique id of the message")
-	publishMessageCmd.Flags().DurationVar(&publishMessageTTL, "ttl", 5*time.Second, "Specify the time to live of the message")
+	publishMessageCmd.Flags().DurationVar(&publishMessageTTL, "ttl", 5*time.Second, "Specify the time to live of the message. Example values: 300ms, 50s or 1m")
 	publishMessageCmd.Flags().StringVar(&publishMessageVariables, "variables", "{}", "Specify message variables as JSON string")
 
 	if err := publishMessageCmd.MarkFlagRequired("correlationKey"); err != nil {


### PR DESCRIPTION
## Description

This PR adds example values for every time.Duration flag. 

I've not changed two flags. The workerCompletionDelayFlag and workerPollingDelayFlag specifically request for a delay in milliseconds in their help message. I'm not sure if this would also work with these commands. In theory it should work fine.

Additional change: Go fmt for the correct import ordering. 🏕️ 

## Related issues

related PR https://github.com/camunda-cloud/zeebe/pull/8013

closes #8022

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
