### PR TITLE
fix(logstreams): complete future when any error during opening an appender

### DIFF
--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamErrorTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamErrorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.logstreams.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.logstreams.storage.LogStorage;
+import io.camunda.zeebe.logstreams.util.SyncLogStream;
+import io.camunda.zeebe.util.sched.testing.ActorSchedulerRule;
+import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class LogStreamErrorTest {
+
+  @Rule public ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule();
+  final LogStorage mockLogStorage = mock(LogStorage.class);
+  private SyncLogStream logStream;
+
+  @Before
+  public void setup() {
+    logStream =
+        SyncLogStream.builder()
+            .withLogName("test-log")
+            .withLogStorage(mockLogStorage)
+            .withActorSchedulingService(actorSchedulerRule.get())
+            .build();
+
+    when(mockLogStorage.newReader()).thenThrow(new RuntimeException("reader cannot be created"));
+  }
+
+  @After
+  public void after() {
+    logStream.close();
+  }
+
+  @Test
+  public void shouldCompleteFutureWhenCreateWriterFailed() {
+    // given
+    final var writerFuture = logStream.getAsyncLogStream().newLogStreamRecordWriter();
+
+    // when
+    Awaitility.await().until(writerFuture::isDone);
+
+    // then
+    assertThat(writerFuture.isCompletedExceptionally()).isTrue();
+  }
+
+  @Test
+  public void shouldCompleteFutureWhenCreateBatchWriterFailed() {
+    // given
+    final var writerFuture = logStream.getAsyncLogStream().newLogStreamBatchWriter();
+
+    // when
+    Awaitility.await().until(writerFuture::isDone);
+
+    // then
+    assertThat(writerFuture.isCompletedExceptionally()).isTrue();
+  }
+}


### PR DESCRIPTION
## Description

Not all exceptions occuring during opening an appender was handled properly. In such cases the caller (StreamProcessor) waiting for the writer will wait for ever because the future is not completed. This commit adds a catch all exception to the openAppender which completes the future exceptionally.

## Related issues

Related #7992 

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
