### PR TITLE
Prevent multiple stream processors (develop branch

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import io.camunda.zeebe.util.sched.ActorControl;
 import io.camunda.zeebe.util.sched.ActorSchedulingService;
+import io.camunda.zeebe.util.sched.ConcurrencyControl;
 import io.camunda.zeebe.util.sched.ScheduledTimer;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import java.util.Collection;
@@ -79,6 +80,7 @@ public class PartitionStartupAndTransitionContextImpl
 
   private long currentTerm;
   private Role currentRole;
+  private ConcurrencyControl concurrencyControl;
 
   public PartitionStartupAndTransitionContextImpl(
       final int nodeId,
@@ -371,5 +373,15 @@ public class PartitionStartupAndTransitionContextImpl
 
   public ExporterRepository getExporterRepository() {
     return exporterRepository;
+  }
+
+  @Override
+  public ConcurrencyControl getConcurrencyControl() {
+    return concurrencyControl;
+  }
+
+  @Override
+  public void setConcurrencyControl(final ConcurrencyControl concurrencyControl) {
+    this.concurrencyControl = concurrencyControl;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.storage.atomix.AtomixLogStorage;
 import io.camunda.zeebe.util.sched.ActorSchedulingService;
+import io.camunda.zeebe.util.sched.ConcurrencyControl;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
@@ -61,6 +62,10 @@ public interface PartitionTransitionContext extends PartitionContext {
   Consumer<TypedRecord<?>> getOnProcessedListener();
 
   TypedRecordProcessorFactory getStreamProcessorFactory();
+
+  ConcurrencyControl getConcurrencyControl();
+
+  void setConcurrencyControl(ConcurrencyControl concurrencyControl);
 
   void setExporterDirector(ExporterDirector exporterDirector);
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
@@ -75,9 +75,8 @@ public final class PartitionTransitionImpl implements PartitionTransition {
               new PartitionTransitionProcess(steps, concurrencyControl, context, term, role);
           nextTransitionFuture.onComplete(
               (v, error) -> {
-                // term and role should only bet set after the transition is completed, since on
-                // clean up
-                // we expect old term and role to make decision based on that
+                // term and role should only bet se after the transition is completed, since on
+                // preparation we expect old term and role to make decision based on that
                 if (error == null) {
                   context.setCurrentTerm(term);
                   context.setCurrentRole(role);
@@ -136,11 +135,11 @@ public final class PartitionTransitionImpl implements PartitionTransition {
     if (lastTransition == null) {
       nextTransition.start(nextTransitionFuture);
     } else {
-      final var cleanupFuture = nextTransition.cleanup(term, role);
-      cleanupFuture.onComplete(
+      final var prepareFuture = nextTransition.prepare(term, role);
+      prepareFuture.onComplete(
           (ok, error) -> {
             if (error != null) {
-              LOG.error("Error during transition clean up: {}", error.getMessage(), error);
+              LOG.error("Error during transition preparation: {}", error.getMessage(), error);
               LOG.info("Aborting transition to {} on term {} due to error.", role, term);
               nextTransitionFuture.completeExceptionally(error);
             } else {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
@@ -136,7 +136,7 @@ public final class PartitionTransitionImpl implements PartitionTransition {
     if (lastTransition == null) {
       nextTransition.start(nextTransitionFuture);
     } else {
-      final var cleanupFuture = lastTransition.cleanup(term, role);
+      final var cleanupFuture = nextTransition.cleanup(term, role);
       cleanupFuture.onComplete(
           (ok, error) -> {
             if (error != null) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -43,6 +43,7 @@ final class PartitionTransitionProcess {
     pendingSteps.forEach(stepsToCleanUp::push);
     this.concurrencyControl = requireNonNull(concurrencyControl);
     this.context = requireNonNull(context);
+    context.setConcurrencyControl(concurrencyControl);
     this.term = term;
     this.role = requireNonNull(role);
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -27,7 +27,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
   }
 
   // Used for testing
-  StreamProcessorTransitionStep(
+  public StreamProcessorTransitionStep(
       final Supplier<StreamProcessorBuilder> streamProcessorBuilderSupplier) {
     this.streamProcessorBuilderSupplier = streamProcessorBuilderSupplier;
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -11,25 +11,25 @@ import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
-import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorBuilder;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorMode;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
-import java.util.function.Supplier;
+import java.util.function.BiFunction;
 
 public final class StreamProcessorTransitionStep implements PartitionTransitionStep {
 
-  private final Supplier<StreamProcessorBuilder> streamProcessorBuilderSupplier;
+  private final BiFunction<PartitionTransitionContext, Role, StreamProcessor>
+      streamProcessorCreator;
 
   public StreamProcessorTransitionStep() {
-    this(StreamProcessor::builder);
+    this(StreamProcessorTransitionStep::createStreamProcessor);
   }
 
   // Used for testing
   public StreamProcessorTransitionStep(
-      final Supplier<StreamProcessorBuilder> streamProcessorBuilderSupplier) {
-    this.streamProcessorBuilderSupplier = streamProcessorBuilderSupplier;
+      final BiFunction<PartitionTransitionContext, Role, StreamProcessor> streamProcessorCreator) {
+    this.streamProcessorCreator = streamProcessorCreator;
   }
 
   @Override
@@ -76,7 +76,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
 
     if (shouldInstallOnTransition(targetRole, currentRole)
         || (context.getStreamProcessor() == null && targetRole != Role.INACTIVE)) {
-      final StreamProcessor streamProcessor = createStreamProcessor(context, targetRole);
+      final StreamProcessor streamProcessor = streamProcessorCreator.apply(context, targetRole);
       final ActorFuture<Void> openFuture = streamProcessor.openAsync(!context.shouldProcess());
       final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
 
@@ -119,12 +119,11 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         || (newRole == Role.CANDIDATE && currentRole != Role.FOLLOWER);
   }
 
-  private StreamProcessor createStreamProcessor(
+  private static StreamProcessor createStreamProcessor(
       final PartitionTransitionContext context, final Role targetRole) {
     final StreamProcessorMode streamProcessorMode =
         targetRole == Role.LEADER ? StreamProcessorMode.PROCESSING : StreamProcessorMode.REPLAY;
-    return streamProcessorBuilderSupplier
-        .get()
+    return StreamProcessor.builder()
         .logStream(context.getLogStream())
         .actorSchedulingService(context.getActorSchedulingService())
         .zeebeDb(context.getZeebeDb())

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -78,14 +78,13 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
     if (shouldInstallOnTransition(targetRole, currentRole)
         || (context.getStreamProcessor() == null && targetRole != Role.INACTIVE)) {
       final StreamProcessor streamProcessor = streamProcessorCreator.apply(context, targetRole);
+      context.setStreamProcessor(streamProcessor);
       final ActorFuture<Void> openFuture = streamProcessor.openAsync(!context.shouldProcess());
       final ActorFuture<Void> future = concurrencyControl.createFuture();
 
       openFuture.onComplete(
           (nothing, err) -> {
             if (err == null) {
-              context.setStreamProcessor(streamProcessor);
-
               // Have to pause/resume it here in case the state changed after streamProcessor was
               // created
               if (!context.shouldProcess()) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.storage.atomix.AtomixLogStorage;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import io.camunda.zeebe.util.sched.ActorSchedulingService;
+import io.camunda.zeebe.util.sched.ConcurrencyControl;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.TestActorFuture;
 import java.util.Collection;
@@ -50,6 +51,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private BrokerCfg brokerCfg;
   private AsyncSnapshotDirector snapshotDirector;
   private QueryService queryService;
+  private ConcurrencyControl concurrencyControl;
 
   @Override
   public int getPartitionId() {
@@ -268,5 +270,15 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
 
   public void setStateController(final StateController stateController) {
     this.stateController = stateController;
+  }
+
+  @Override
+  public ConcurrencyControl getConcurrencyControl() {
+    return concurrencyControl;
+  }
+
+  @Override
+  public void setConcurrencyControl(final ConcurrencyControl concurrencyControl) {
+    this.concurrencyControl = concurrencyControl;
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStepTest.java
@@ -51,7 +51,7 @@ class StreamProcessorTransitionStepTest {
     when(streamProcessorFromPrevRole.closeAsync())
         .thenReturn(TestActorFuture.completedFuture(null));
 
-    step = new StreamProcessorTransitionStep(() -> streamProcessorBuilder);
+    step = new StreamProcessorTransitionStep((ctx, role) -> streamProcessor);
   }
 
   @ParameterizedTest

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStepTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorBuilder;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.util.health.HealthMonitor;
+import io.camunda.zeebe.util.sched.TestConcurrencyControl;
 import io.camunda.zeebe.util.sched.future.TestActorFuture;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +32,9 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class StreamProcessorTransitionStepTest {
+
+  private static final TestConcurrencyControl TEST_CONCURRENCY_CONTROL =
+      new TestConcurrencyControl();
 
   TestPartitionTransitionContext transitionContext = new TestPartitionTransitionContext();
   final StreamProcessorBuilder streamProcessorBuilder = spy(StreamProcessorBuilder.class);
@@ -43,6 +47,7 @@ class StreamProcessorTransitionStepTest {
   void setup() {
     transitionContext.setLogStream(mock(LogStream.class));
     transitionContext.setComponentHealthMonitor(mock(HealthMonitor.class));
+    transitionContext.setConcurrencyControl(TEST_CONCURRENCY_CONTROL);
 
     doReturn(streamProcessor).when(streamProcessorBuilder).build();
 


### PR DESCRIPTION
## Description
## Description
Changes the transition logic as follows:
- preparation/cleanup is done for all steps (not just the steps started by the last iteration)
- preparation/cleanup is done in the context of the next transition, not in the context of the last transition. 
- cleanup is renamed to preparation

As a consequence, preparation/cleanup will be executed more often than transitionTo. This can also be seen in the log for the new test case. Essentially, when a transition is "skipped" then only it's transitionTo is skipped, but the cleanup is executed anyway. I think one could improve that by making the cleanup react to the cancel signal, but I want to be conservative here. Also, multiple cleanup calls should be fast, because if a cleanup succeeds it sets e.g. the stream processor to null in the context, and any subsequent call will do nothing if it finds no stream processor.

Previously:
- The old transition did clean up the steps that were started by it
- The cleanup assumed that the transitionTo will immediately follow, but this was not a given. The transitionTo might be cancelled, and might eventually transition to a completely different role.
- So in essence, it did prepare for a role that maybe never came.

## Related issues
relates to #8044 (the issue it is trying to fix)
relates to #8059 (the PR for `stable/1.2` and also the source of review comments which have been implemented herein)

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
