### PR TITLE
Zeebe model support for user task assignment definitions

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
@@ -211,6 +211,7 @@ import io.camunda.zeebe.model.bpmn.impl.instance.di.PlaneImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.di.ShapeImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.di.StyleImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.di.WaypointImpl;
+import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeAssignmentDefinitionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeCalledElementImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeFormDefinitionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeHeaderImpl;
@@ -639,6 +640,7 @@ public class Bpmn {
     ZeebeCalledElementImpl.registerType(bpmnModelBuilder);
     ZeebeFormDefinitionImpl.registerType(bpmnModelBuilder);
     ZeebeUserTaskFormImpl.registerType(bpmnModelBuilder);
+    ZeebeAssignmentDefinitionImpl.registerType(bpmnModelBuilder);
   }
 
   /** @return the {@link Model} instance to use */

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBaseElementBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBaseElementBuilder.java
@@ -123,6 +123,14 @@ public abstract class AbstractBaseElementBuilder<
     return getCreateSingleChild(element, typeClass);
   }
 
+  /**
+   * Provides a child element of the given type for which only 1 such child should exist. This
+   * method makes sure it is created if it does not yet exist.
+   *
+   * @param parent the element that is the parent of the requested child
+   * @param typeClass the type of the requested child
+   * @return the requested child
+   */
   protected <T extends BpmnModelElementInstance> T getCreateSingleChild(
       final BpmnModelElementInstance parent, final Class<T> typeClass) {
     final Collection<T> childrenOfType = parent.getChildElementsByType(typeClass);
@@ -143,6 +151,14 @@ public abstract class AbstractBaseElementBuilder<
     }
   }
 
+  /**
+   * Provides the extension element of the given type for which only 1 such extension element should
+   * exist. This method makes sure it is created if it does not yet exist. The specific element is a
+   * child of the extension elements of this element.
+   *
+   * @param typeClass the type of the requested extension element
+   * @return the requested extension element
+   */
   protected <T extends BpmnModelElementInstance> T getCreateSingleExtensionElement(
       final Class<T> typeClass) {
     final ExtensionElements extensionElements = getCreateSingleChild(ExtensionElements.class);

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractFlowNodeBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractFlowNodeBuilder.java
@@ -208,6 +208,12 @@ public abstract class AbstractFlowNodeBuilder<
     return createTargetBuilder(UserTask.class, id);
   }
 
+  public UserTaskBuilder userTask(final String id, final Consumer<UserTaskBuilder> consumer) {
+    final UserTaskBuilder builder = createTargetBuilder(UserTask.class, id);
+    consumer.accept(builder);
+    return builder;
+  }
+
   public BusinessRuleTaskBuilder businessRuleTask() {
     return createTargetBuilder(BusinessRuleTask.class);
   }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
@@ -21,6 +21,7 @@ import static io.camunda.zeebe.model.bpmn.impl.ZeebeConstants.USER_TASK_FORM_KEY
 
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.UserTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
@@ -76,6 +77,32 @@ public abstract class AbstractUserTaskBuilder<B extends AbstractUserTaskBuilder<
     zeebeUserTaskForm.setTextContent(userTaskForm);
     return zeebeFormKey(
         USER_TASK_FORM_KEY_CAMUNDA_FORMS_FORMAT, USER_TASK_FORM_KEY_BPMN_LOCATION, id);
+  }
+
+  @Override
+  public B zeebeAssignee(final String assignee) {
+    final ZeebeAssignmentDefinition assignment =
+        myself.getCreateSingleExtensionElement(ZeebeAssignmentDefinition.class);
+    assignment.setAssignee(assignee);
+    return myself;
+  }
+
+  @Override
+  public B zeebeAssigneeExpression(final String expression) {
+    return zeebeAssignee(asZeebeExpression(expression));
+  }
+
+  @Override
+  public B zeebeCandidateGroups(final String candidateGroups) {
+    final ZeebeAssignmentDefinition assignment =
+        myself.getCreateSingleExtensionElement(ZeebeAssignmentDefinition.class);
+    assignment.setCandidateGroups(candidateGroups);
+    return myself;
+  }
+
+  @Override
+  public B zeebeCandidateGroupsExpression(final String expression) {
+    return zeebeCandidateGroups(asZeebeExpression(expression));
   }
 
   public B zeebeTaskHeader(final String key, final String value) {

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
@@ -28,7 +28,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeUserTaskForm;
 
 /** @author Sebastian Menski */
 public abstract class AbstractUserTaskBuilder<B extends AbstractUserTaskBuilder<B>>
-    extends AbstractTaskBuilder<B, UserTask> {
+    extends AbstractTaskBuilder<B, UserTask> implements ZeebeUserTaskPropertiesBuilder<B> {
 
   protected AbstractUserTaskBuilder(
       final BpmnModelInstance modelInstance, final UserTask element, final Class<?> selfType) {
@@ -46,26 +46,12 @@ public abstract class AbstractUserTaskBuilder<B extends AbstractUserTaskBuilder<
     return myself;
   }
 
-  /** camunda extensions */
-
-  /**
-   * Sets the form key with the format 'format:location:id' of the build user task.
-   *
-   * @param format the format of the reference form
-   * @param location the location where the form is available
-   * @param id the id of the form
-   * @return the builder object
-   */
+  @Override
   public B zeebeFormKey(final String format, final String location, final String id) {
     return zeebeFormKey(String.format("%s:%s:%s", format, location, id));
   }
 
-  /**
-   * Sets the form key of the build user task.
-   *
-   * @param formKey the form key to set
-   * @return the builder object
-   */
+  @Override
   public B zeebeFormKey(final String formKey) {
     final ZeebeFormDefinition formDefinition =
         getCreateSingleExtensionElement(ZeebeFormDefinition.class);
@@ -73,13 +59,7 @@ public abstract class AbstractUserTaskBuilder<B extends AbstractUserTaskBuilder<
     return myself;
   }
 
-  /**
-   * Creates an new user task form with the given context, assuming it is of the format
-   * camunda-forms and embedded inside the diagram.
-   *
-   * @param userTaskForm the XML encoded user task form json in the camunda-forms format
-   * @return the builder object
-   */
+  @Override
   public B zeebeUserTaskForm(final String userTaskForm) {
     final ZeebeUserTaskForm zeebeUserTaskForm = createZeebeUserTaskForm();
     zeebeUserTaskForm.setTextContent(userTaskForm);
@@ -89,14 +69,7 @@ public abstract class AbstractUserTaskBuilder<B extends AbstractUserTaskBuilder<
         zeebeUserTaskForm.getId());
   }
 
-  /**
-   * Creates an new user task form with the given context, assuming it is of the format
-   * camunda-forms and embedded inside the diagram.
-   *
-   * @param id the unique identifier of the user task form element
-   * @param userTaskForm the XML encoded user task form json in the camunda-forms format
-   * @return the builder object
-   */
+  @Override
   public B zeebeUserTaskForm(final String id, final String userTaskForm) {
     final ZeebeUserTaskForm zeebeUserTaskForm = createZeebeUserTaskForm();
     zeebeUserTaskForm.setId(id);

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeUserTaskPropertiesBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeUserTaskPropertiesBuilder.java
@@ -54,4 +54,36 @@ public interface ZeebeUserTaskPropertiesBuilder<B extends ZeebeUserTaskPropertie
    * @return the builder object
    */
   B zeebeUserTaskForm(String id, String userTaskForm);
+
+  /**
+   * Sets a static assignee for the user task
+   *
+   * @param assignee the assignee of the user task
+   * @return the builder object
+   */
+  B zeebeAssignee(String assignee);
+
+  /**
+   * Sets a dynamic assignee for the user task that is retrieved from the given expression
+   *
+   * @param expression the expression for the assignee of the user task
+   * @return the builder object
+   */
+  B zeebeAssigneeExpression(String expression);
+
+  /**
+   * Sets a static candidateGroups for the user task
+   *
+   * @param candidateGroups the candidateGroups of the user task
+   * @return the builder object
+   */
+  B zeebeCandidateGroups(String candidateGroups);
+
+  /**
+   * Sets a dynamic candidateGroups for the user task that is retrieved from the given expression
+   *
+   * @param expression the expression for the candidateGroups of the user task
+   * @return the builder object
+   */
+  B zeebeCandidateGroupsExpression(String expression);
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeUserTaskPropertiesBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeUserTaskPropertiesBuilder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+/** A fluent builder for zeebe specific user task related properties. */
+public interface ZeebeUserTaskPropertiesBuilder<B extends ZeebeUserTaskPropertiesBuilder<B>> {
+
+  /**
+   * Sets the form key with the format 'format:location:id' of the build user task.
+   *
+   * @param format the format of the reference form
+   * @param location the location where the form is available
+   * @param id the id of the form
+   * @return the builder object
+   */
+  B zeebeFormKey(String format, String location, String id);
+
+  /**
+   * Sets the form key of the build user task.
+   *
+   * @param formKey the form key to set
+   * @return the builder object
+   */
+  B zeebeFormKey(String formKey);
+
+  /**
+   * Creates an new user task form with the given context, assuming it is of the format
+   * camunda-forms and embedded inside the diagram.
+   *
+   * @param userTaskForm the XML encoded user task form json in the camunda-forms format
+   * @return the builder object
+   */
+  B zeebeUserTaskForm(String userTaskForm);
+
+  /**
+   * Creates an new user task form with the given context, assuming it is of the format
+   * camunda-forms and embedded inside the diagram.
+   *
+   * @param id the unique identifier of the user task form element
+   * @param userTaskForm the XML encoded user task form json in the camunda-forms format
+   * @return the builder object
+   */
+  B zeebeUserTaskForm(String id, String userTaskForm);
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeUserTaskPropertiesBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeUserTaskPropertiesBuilder.java
@@ -37,8 +37,8 @@ public interface ZeebeUserTaskPropertiesBuilder<B extends ZeebeUserTaskPropertie
   B zeebeFormKey(String formKey);
 
   /**
-   * Creates an new user task form with the given context, assuming it is of the format
-   * camunda-forms and embedded inside the diagram.
+   * Creates a new user task form with the given context, assuming it is of the format camunda-forms
+   * and embedded inside the diagram.
    *
    * @param userTaskForm the XML encoded user task form json in the camunda-forms format
    * @return the builder object
@@ -46,8 +46,8 @@ public interface ZeebeUserTaskPropertiesBuilder<B extends ZeebeUserTaskPropertie
   B zeebeUserTaskForm(String userTaskForm);
 
   /**
-   * Creates an new user task form with the given context, assuming it is of the format
-   * camunda-forms and embedded inside the diagram.
+   * Creates a new user task form with the given context, assuming it is of the format camunda-forms
+   * and embedded inside the diagram.
    *
    * @param id the unique identifier of the user task form element
    * @param userTaskForm the XML encoded user task form json in the camunda-forms format

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -38,6 +38,9 @@ public class ZeebeConstants {
 
   public static final String ATTRIBUTE_FORM_KEY = "formKey";
 
+  public static final String ATTRIBUTE_ASSIGNEE = "assignee";
+  public static final String ATTRIBUTE_CANDIDATE_GROUPS = "candidateGroups";
+
   public static final String ELEMENT_HEADER = "header";
   public static final String ELEMENT_INPUT = "input";
   public static final String ELEMENT_IO_MAPPING = "ioMapping";
@@ -50,6 +53,8 @@ public class ZeebeConstants {
 
   public static final String ELEMENT_FORM_DEFINITION = "formDefinition";
   public static final String ELEMENT_USER_TASK_FORM = "userTaskForm";
+
+  public static final String ELEMENT_ASSIGNMENT_DEFINITION = "assignmentDefinition";
 
   public static final String ELEMENT_LOOP_CHARACTERISTICS = "loopCharacteristics";
 

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeAssignmentDefinitionImpl.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeAssignmentDefinitionImpl.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.impl.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.attribute.Attribute;
+
+public final class ZeebeAssignmentDefinitionImpl extends BpmnModelElementInstanceImpl
+    implements ZeebeAssignmentDefinition {
+
+  private static Attribute<String> assigneeAttribute;
+  private static Attribute<String> candidateGroupsAttribute;
+
+  public ZeebeAssignmentDefinitionImpl(final ModelTypeInstanceContext instanceContext) {
+    super(instanceContext);
+  }
+
+  public static void registerType(final ModelBuilder modelBuilder) {
+    final ModelElementTypeBuilder typeBuilder =
+        modelBuilder
+            .defineType(
+                ZeebeAssignmentDefinition.class, ZeebeConstants.ELEMENT_ASSIGNMENT_DEFINITION)
+            .namespaceUri(BpmnModelConstants.ZEEBE_NS)
+            .instanceProvider(ZeebeAssignmentDefinitionImpl::new);
+
+    assigneeAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_ASSIGNEE)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
+    candidateGroupsAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_CANDIDATE_GROUPS)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
+    typeBuilder.build();
+  }
+
+  @Override
+  public String getAssignee() {
+    return assigneeAttribute.getValue(this);
+  }
+
+  @Override
+  public void setAssignee(final String assignee) {
+    assigneeAttribute.setValue(this, assignee);
+  }
+
+  @Override
+  public String getCandidateGroups() {
+    return candidateGroupsAttribute.getValue(this);
+  }
+
+  @Override
+  public void setCandidateGroups(final String candidateGroups) {
+    candidateGroupsAttribute.setValue(this, candidateGroups);
+  }
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAssignmentDefinition.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAssignmentDefinition.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+
+public interface ZeebeAssignmentDefinition extends BpmnModelElementInstance {
+
+  String getAssignee();
+
+  void setAssignee(String assignee);
+
+  String getCandidateGroups();
+
+  void setCandidateGroups(String candidateGroups);
+}

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilderTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilderTest.java
@@ -27,6 +27,7 @@ import static io.camunda.zeebe.model.bpmn.BpmnTestConstants.TRANSACTION_ID;
 import static io.camunda.zeebe.model.bpmn.BpmnTestConstants.USER_TASK_ID;
 import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.BPMN20_NS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.Fail.fail;
 import static org.junit.Assert.assertEquals;
 
@@ -50,6 +51,7 @@ import io.camunda.zeebe.model.bpmn.instance.Escalation;
 import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.Event;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.FlowElement;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.model.bpmn.instance.Gateway;
@@ -74,6 +76,7 @@ import io.camunda.zeebe.model.bpmn.instance.TimeDuration;
 import io.camunda.zeebe.model.bpmn.instance.TimerEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.Transaction;
 import io.camunda.zeebe.model.bpmn.instance.UserTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
 import java.util.Collection;
 import java.util.List;
 import org.camunda.bpm.model.xml.Model;
@@ -2133,5 +2136,60 @@ public class ProcessBuilderTest {
     assertEquals("user", userName);
     final String endName = ((FlowElement) instance.getModelElementById("end")).getName();
     assertEquals("name", endName);
+  }
+
+  @Test
+  public void testUserTaskAssigneeCanBeSet() {
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("userTask1", task -> task.zeebeAssignee("user1"))
+            .endEvent()
+            .done();
+
+    final ModelElementInstance userTask = instance.getModelElementById("userTask1");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) userTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeAssignmentDefinition.class))
+        .hasSize(1)
+        .extracting(ZeebeAssignmentDefinition::getAssignee)
+        .containsExactly("user1");
+  }
+
+  @Test
+  public void testUserTaskCandidateGroupsCanBeSet() {
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("userTask1", task -> task.zeebeCandidateGroups("role1"))
+            .endEvent()
+            .done();
+
+    final ModelElementInstance userTask = instance.getModelElementById("userTask1");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) userTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeAssignmentDefinition.class))
+        .hasSize(1)
+        .extracting(ZeebeAssignmentDefinition::getCandidateGroups)
+        .containsExactly("role1");
+  }
+
+  @Test
+  public void testUserTaskAssigneeAndCandidateGroupsCanBothBeSet() {
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("userTask1", b -> b.zeebeAssignee("user1").zeebeCandidateGroups("role1"))
+            .endEvent()
+            .done();
+
+    final ModelElementInstance userTask = instance.getModelElementById("userTask1");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) userTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeAssignmentDefinition.class))
+        .hasSize(1)
+        .extracting(
+            ZeebeAssignmentDefinition::getAssignee, ZeebeAssignmentDefinition::getCandidateGroups)
+        .containsExactly(tuple("user1", "role1"));
   }
 }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAssignmentDefinitionTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAssignmentDefinitionTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+public final class ZeebeAssignmentDefinitionTest extends BpmnModelElementInstanceTest {
+
+  @Override
+  public TypeAssumption getTypeAssumption() {
+    return new TypeAssumption(BpmnModelConstants.ZEEBE_NS, false);
+  }
+
+  @Override
+  public Collection<ChildElementAssumption> getChildElementAssumptions() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Collection<AttributeAssumption> getAttributesAssumptions() {
+    return Arrays.asList(
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "assignee", false, false),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "candidateGroups", false, false));
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Adds assignment definitions to the bpmn-model module. 

Specifically, it adds support for `assignee` and `candidateGroups` as attributes of the extension element `AssignmentDefinition`, including methods to construct these using the bpmn builders.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8053 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
