### PR TITLE
Expose duplicate process field

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -2,7 +2,9 @@
   "index_patterns": [
     "zeebe-record_deployment_*"
   ],
-  "composed_of": ["zeebe-record"],
+  "composed_of": [
+    "zeebe-record"
+  ],
   "priority": 20,
   "version": 1,
   "template": {
@@ -35,6 +37,9 @@
                 },
                 "checksum": {
                   "enabled": false
+                },
+                "duplicate": {
+                  "type": "boolean"
                 }
               }
             },

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-template.json
@@ -36,6 +36,9 @@
             },
             "checksum": {
               "enabled": false
+            },
+            "duplicate": {
+              "type": "boolean"
             }
           }
         }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
@@ -50,6 +50,7 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
     return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
   }
 
+  @Override
   public int getVersion() {
     return versionProp.getValue();
   }
@@ -72,6 +73,11 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   public ProcessMetadata setChecksum(final DirectBuffer checksumBuffer) {
     checksumProp.setValue(checksumBuffer);
     return this;
+  }
+
+  @Override
+  public boolean isDuplicate() {
+    return isDuplicateProp.getValue();
   }
 
   public ProcessMetadata setResourceName(final String resourceName) {
@@ -145,10 +151,5 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   public ProcessMetadata markAsDuplicate() {
     isDuplicateProp.setValue(true);
     return this;
-  }
-
-  @JsonIgnore
-  public boolean isDuplicate() {
-    return isDuplicateProp.getValue();
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
@@ -53,6 +53,7 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
     return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
   }
 
+  @Override
   public int getVersion() {
     return versionProp.getValue();
   }
@@ -70,6 +71,11 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   @Override
   public byte[] getChecksum() {
     return BufferUtil.bufferAsArray(checksumProp.getValue());
+  }
+
+  @Override
+  public boolean isDuplicate() {
+    return false;
   }
 
   public ProcessRecord setChecksum(final DirectBuffer checksumBuffer) {

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.VersionInfo;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentDistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
@@ -200,6 +201,35 @@ public final class JsonSerializableToJsonTest {
         "Empty DeploymentRecord",
         (Supplier<UnifiedRecordValue>) DeploymentRecord::new,
         "{'resources':[],'processesMetadata':[]}"
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////////// ProcessRecord ///////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      new Object[] {
+        "ProcessRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final String resourceName = "resource";
+              final DirectBuffer resource = wrapString("contents");
+              final String bpmnProcessId = "testProcess";
+              final long processDefinitionKey = 123;
+
+              final int processVersion = 12;
+              final DirectBuffer checksum = wrapString("checksum");
+              final ProcessRecord record = new ProcessRecord();
+
+              record
+                  .setResourceName(wrapString(resourceName))
+                  .setResource(resource)
+                  .setBpmnProcessId(wrapString(bpmnProcessId))
+                  .setKey(processDefinitionKey)
+                  .setResourceName(wrapString(resourceName))
+                  .setVersion(processVersion)
+                  .setChecksum(checksum);
+
+              return record;
+            },
+        "{'resourceName':'resource','resource':'Y29udGVudHM=', 'checksum':'Y2hlY2tzdW0=','bpmnProcessId':'testProcess','version':12,'processDefinitionKey':123,'resourceName':'resource', 'duplicate':false}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       ///////////////////////////////////// ErrorRecord ///////////////////////////////////////////

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -146,7 +146,7 @@ public final class JsonSerializableToJsonTest {
               return new CopiedRecord<>(
                   record, recordMetadata, key, 0, position, sourcePosition, timestamp);
             },
-        "{'valueType':'DEPLOYMENT','key':1234,'position':4321,'timestamp':2191,'recordType':'COMMAND','intent':'CREATE','partitionId':0,'rejectionType':'INVALID_ARGUMENT','rejectionReason':'fails','brokerVersion':'1.2.3','sourceRecordPosition':231,'value':{'processesMetadata':[{'version':12,'bpmnProcessId':'testProcess','resourceName':'resource','checksum':'Y2hlY2tzdW0=','processDefinitionKey':123}],'resources':[{'resourceName':'resource','resource':'Y29udGVudHM='}]}}"
+        "{'valueType':'DEPLOYMENT','key':1234,'position':4321,'timestamp':2191,'recordType':'COMMAND','intent':'CREATE','partitionId':0,'rejectionType':'INVALID_ARGUMENT','rejectionReason':'fails','brokerVersion':'1.2.3','sourceRecordPosition':231,'value':{'processesMetadata':[{'version':12,'bpmnProcessId':'testProcess','resourceName':'resource','checksum':'Y2hlY2tzdW0=','processDefinitionKey':123, 'duplicate':false}],'resources':[{'resourceName':'resource','resource':'Y29udGVudHM='}]}}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       //////////////////////////////////// DeploymentRecord ///////////////////////////////////////
@@ -174,10 +174,11 @@ public final class JsonSerializableToJsonTest {
                   .setKey(processDefinitionKey)
                   .setResourceName(wrapString(resourceName))
                   .setVersion(processVersion)
-                  .setChecksum(checksum);
+                  .setChecksum(checksum)
+                  .markAsDuplicate();
               return record;
             },
-        "{'resources':[{'resourceName':'resource','resource':'Y29udGVudHM='}],'processesMetadata':[{'checksum':'Y2hlY2tzdW0=','bpmnProcessId':'testProcess','version':12,'processDefinitionKey':123,'resourceName':'resource'}]}"
+        "{'resources':[{'resourceName':'resource','resource':'Y29udGVudHM='}],'processesMetadata':[{'checksum':'Y2hlY2tzdW0=','bpmnProcessId':'testProcess','version':12,'processDefinitionKey':123,'resourceName':'resource', 'duplicate':true}]}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       ////////////////////////////// DeploymentDistributionRecord /////////////////////////////////

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -10,14 +10,21 @@
   },
   {
     "extension": "revapi.differences",
-    "id": "ignore-bpmnelementtype",
     "configuration": {
       "ignore": true,
-      "justification": "Ignore Enum order for BpmnElementType as ordinal() is not used and the elements are grouped in the enum.",
       "differences": [
         {
+          "justification": "Ignore Enum order for BpmnElementType as ordinal() is not used and the elements are grouped in the enum.",
           "code": "java.field.enumConstantOrderChanged",
           "classQualifiedName": "io.camunda.zeebe.protocol.record.value.BpmnElementType"
+        },
+        {
+          "justification": "Ignore new methods for Protocol Record Value interfaces, as these are not meant to be implemented but simply consumed; as such, new methods are perfectly fine to add",
+          "code": "java.method.addedToInterface",
+          "new": {
+            "matcher": "java-package",
+            "match": "/io\\.camunda\\.zeebe\\.protocol\\.record\\.value(\\..*)?/"
+          }
         }
       ]
     }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/ProcessMetadataValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/ProcessMetadataValue.java
@@ -33,4 +33,9 @@ public interface ProcessMetadataValue extends RecordValue {
 
   /** @return the checksum of the process (MD5) */
   byte[] getChecksum();
+
+  /**
+   * return true if the process is a duplicate (and has been deployed previously), false otherwise
+   */
+  boolean isDuplicate();
 }


### PR DESCRIPTION
## Description

Exposes the duplicate property on the ProcessMetadata and Process. As discussed (@saig0 ) on the Process it will always return false, since the ProcessRecord is only created for non duplicates but it was the easiest to implement.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6968 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
