### PR TITLE
Avoid duplicated event triggers for message start events

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
-import io.camunda.zeebe.engine.processing.bpmn.BpmnProcessingException;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.Failure;
@@ -22,8 +21,6 @@ import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.instance.EventTrigger;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
-import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
-import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Optional;
@@ -131,38 +128,9 @@ public final class BpmnEventSubscriptionBehavior {
   }
 
   public void activateTriggeredStartEvent(
-      final BpmnElementContext context, final EventTrigger triggeredEvent) {
-    final long processDefinitionKey = context.getProcessDefinitionKey();
-    final long processInstanceKey = context.getProcessInstanceKey();
+      final BpmnElementContext context, final EventTrigger eventTrigger) {
 
-    final var process = processState.getProcessByKey(context.getProcessDefinitionKey());
-    if (process == null) {
-      // this should never happen because processes are never deleted.
-      throw new BpmnProcessingException(
-          context, String.format(NO_PROCESS_FOUND_MESSAGE, processDefinitionKey));
-    }
-
-    eventTriggerBehavior.processEventTriggered(
-        triggeredEvent.getEventKey(),
-        processDefinitionKey,
-        processInstanceKey,
-        processDefinitionKey, /* the event scope for the start event is the process definition */
-        triggeredEvent.getElementId());
-
-    eventRecord.reset();
-    eventRecord.wrap(context.getRecordValue());
-
-    final var record =
-        eventRecord
-            .setElementId(triggeredEvent.getElementId())
-            .setBpmnElementType(BpmnElementType.START_EVENT)
-            .setProcessInstanceKey(processInstanceKey)
-            .setVersion(process.getVersion())
-            .setBpmnProcessId(process.getBpmnProcessId())
-            .setFlowScopeKey(processInstanceKey);
-
-    final var newEventInstanceKey = keyGenerator.nextKey();
-    commandWriter.appendFollowUpCommand(
-        newEventInstanceKey, ProcessInstanceIntent.ACTIVATE_ELEMENT, record);
+    activateTriggeredEvent(
+        context.getProcessDefinitionKey(), context.getProcessInstanceKey(), eventTrigger, context);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -169,8 +169,7 @@ public final class EventAppliers implements EventApplier {
             state.getMessageStartEventSubscriptionState()));
     register(
         MessageStartEventSubscriptionIntent.CORRELATED,
-        new MessageStartEventSubscriptionCorrelatedApplier(
-            state.getMessageState(), state.getEventScopeInstanceState()));
+        new MessageStartEventSubscriptionCorrelatedApplier(state.getMessageState()));
     register(
         MessageStartEventSubscriptionIntent.DELETED,
         new MessageStartEventSubscriptionDeletedApplier(

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartEventSubscriptionCorrelatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartEventSubscriptionCorrelatedApplier.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
@@ -19,13 +18,9 @@ public final class MessageStartEventSubscriptionCorrelatedApplier
         MessageStartEventSubscriptionIntent, MessageStartEventSubscriptionRecord> {
 
   private final MutableMessageState messageState;
-  private final MutableEventScopeInstanceState eventScopeInstanceState;
 
-  public MessageStartEventSubscriptionCorrelatedApplier(
-      final MutableMessageState messageState,
-      final MutableEventScopeInstanceState eventScopeInstanceState) {
+  public MessageStartEventSubscriptionCorrelatedApplier(final MutableMessageState messageState) {
     this.messageState = messageState;
-    this.eventScopeInstanceState = eventScopeInstanceState;
   }
 
   @Override
@@ -41,12 +36,5 @@ public final class MessageStartEventSubscriptionCorrelatedApplier
       messageState.putActiveProcessInstance(value.getBpmnProcessIdBuffer(), correlationKey);
       messageState.putProcessInstanceCorrelationKey(value.getProcessInstanceKey(), correlationKey);
     }
-
-    // write the event trigger for the start event
-    eventScopeInstanceState.triggerStartEvent(
-        value.getProcessDefinitionKey(),
-        value.getMessageKey(),
-        value.getStartEventIdBuffer(),
-        value.getVariablesBuffer());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
@@ -49,13 +49,6 @@ final class ProcessInstanceElementActivatingApplier
     createEventScope(elementInstanceKey, value);
     cleanupSequenceFlowsTaken(value);
 
-    final var eventTrigger =
-        eventScopeInstanceState.peekEventTrigger(value.getProcessDefinitionKey());
-    if (eventTrigger != null && value.getElementIdBuffer().equals(eventTrigger.getElementId())) {
-      moveVariablesToNewEventScope(
-          eventTrigger, value.getProcessDefinitionKey(), elementInstanceKey);
-    }
-
     final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
     elementInstanceState.newInstance(
         flowScopeInstance, elementInstanceKey, value, ProcessInstanceIntent.ELEMENT_ACTIVATING);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.timer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.state.instance.TimerInstance;
 import io.camunda.zeebe.engine.util.EngineRule;
@@ -374,12 +375,12 @@ public final class TimerStartEventTest {
                 .withProcessDefinitionKey(processDefinitionKey)
                 .skipUntil(r -> r.getPosition() >= triggerRecordPosition)
                 .limit(4))
-        .extracting(Record::getIntent)
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
         .containsExactly(
-            ProcessInstanceIntent.ACTIVATE_ELEMENT, // causes the flow node activation
-            ProcessInstanceIntent.ELEMENT_ACTIVATING, // causes the flow node activation
-            ProcessInstanceIntent.ELEMENT_ACTIVATED, // input mappings applied
-            ProcessInstanceIntent.ACTIVATE_ELEMENT); // triggers the start event
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATING));
   }
 
   @Test

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/VariableRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/VariableRecordStream.java
@@ -38,4 +38,9 @@ public final class VariableRecordStream
   public VariableRecordStream withProcessInstanceKey(final long processInstanceKey) {
     return valueFilter(v -> v.getProcessInstanceKey() == processInstanceKey);
   }
+
+  /** @return only the variables that are created in the process instance scope (i.e. root scope) */
+  public VariableRecordStream filterProcessInstanceScope() {
+    return valueFilter(v -> v.getScopeKey() == v.getProcessInstanceKey());
+  }
 }


### PR DESCRIPTION
## Description

* currently, we create two event triggers if a message start event is triggered - one in the correlated applier and one by write a `ProcessEvent: triggering` event
* as a result, we may use the wrong message variables if two messages are published in a short time
* fix the issue by avoiding creating another event trigger in the correlated applier
* write the message variables as local variables of the start event, similar to other elements

## Related issues

closes #8068

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
