### PR TITLE
[backport - sort of - 1.2] Prevent multiple stream processors - fix and narrow test

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImpl.java
@@ -139,7 +139,7 @@ public final class NewPartitionTransitionImpl implements PartitionTransition {
     if (lastTransition == null) {
       nextTransition.start(nextTransitionFuture);
     } else {
-      final var cleanupFuture = lastTransition.cleanup(term, role);
+      final var cleanupFuture = nextTransition.cleanup(term, role);
       cleanupFuture.onComplete(
           (ok, error) -> {
             if (error != null) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -73,10 +73,13 @@ final class PartitionTransitionProcess {
 
           LOG.info(
               format("Transition to %s on term %d - executing %s", role, term, nextStep.getName()));
-
-          nextStep
-              .transitionTo(context, term, role)
-              .onComplete((ok, error) -> onStepCompletion(future, error));
+          try {
+            nextStep
+                .transitionTo(context, term, role)
+                .onComplete((ok, error) -> onStepCompletion(future, error));
+          } catch (final Exception e) {
+            future.completeExceptionally(e);
+          }
         });
   }
 
@@ -126,9 +129,14 @@ final class PartitionTransitionProcess {
                   "Preparation before transition to %s on term %d - executing %s",
                   role, term, nextCleanupStep.getName()));
 
-          nextCleanupStep
-              .prepareTransition(context, newTerm, newRole)
-              .onComplete((ok, error) -> onCleanupStepCompletion(future, error, newTerm, newRole));
+          try {
+            nextCleanupStep
+                .prepareTransition(context, newTerm, newRole)
+                .onComplete(
+                    (ok, error) -> onCleanupStepCompletion(future, error, newTerm, newRole));
+          } catch (final Exception e) {
+            future.completeExceptionally(e);
+          }
         });
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -27,7 +27,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
   }
 
   // Used for testing
-  StreamProcessorTransitionStep(
+  public StreamProcessorTransitionStep(
       final Supplier<StreamProcessorBuilder> streamProcessorBuilderSupplier) {
     this.streamProcessorBuilderSupplier = streamProcessorBuilderSupplier;
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -77,14 +77,13 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
     if (shouldInstallOnTransition(targetRole, currentRole)
         || (context.getStreamProcessor() == null && targetRole != Role.INACTIVE)) {
       final StreamProcessor streamProcessor = createStreamProcessor(context, targetRole);
+      context.setStreamProcessor(streamProcessor);
       final ActorFuture<Void> openFuture = streamProcessor.openAsync(!context.shouldProcess());
       final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
 
       openFuture.onComplete(
           (nothing, err) -> {
             if (err == null) {
-              context.setStreamProcessor(streamProcessor);
-
               // Have to pause/resume it here in case the state changed after streamProcessor was
               // created
               if (!context.shouldProcess()) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/NewPartitionTransitionImplTest.java
@@ -7,16 +7,21 @@
  */
 package io.camunda.zeebe.broker.system.partitions.impl;
 
+import static java.time.Duration.ofSeconds;
 import static java.util.List.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -24,6 +29,12 @@ import io.atomix.raft.RaftServer;
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.StreamProcessorTransitionStep;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorBuilder;
+import io.camunda.zeebe.util.health.HealthMonitor;
+import io.camunda.zeebe.util.sched.Actor;
+import io.camunda.zeebe.util.sched.ActorScheduler;
 import io.camunda.zeebe.util.sched.ConcurrencyControl;
 import io.camunda.zeebe.util.sched.TestConcurrencyControl;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
@@ -114,6 +125,8 @@ class NewPartitionTransitionImplTest {
 
     when(mockStep2.transitionTo(any(), anyLong(), any()))
         .thenReturn(TEST_CONCURRENCY_CONTROL.completedFuture(null));
+    when(mockStep2.prepareTransition(any(), anyLong(), any()))
+        .thenReturn(TEST_CONCURRENCY_CONTROL.completedFuture(null));
 
     final var sut = new NewPartitionTransitionImpl(of(spyStep1, mockStep2), mockContext);
     sut.setConcurrencyControl(TEST_CONCURRENCY_CONTROL);
@@ -136,8 +149,8 @@ class NewPartitionTransitionImplTest {
     assertThat(secondTransitionFuture.isCompletedExceptionally()).isFalse();
 
     // the first transition was cancelled before the second step
+    verify(mockStep2).prepareTransition(mockContext, secondTerm, secondRole);
     verify(mockStep2, never()).transitionTo(mockContext, DEFAULT_TERM, DEFAULT_ROLE);
-    verify(mockStep2, never()).prepareTransition(mockContext, secondTerm, secondRole);
 
     final var invocationRecorder = inOrder(spyStep1, mockStep2);
     // first transition sequence
@@ -315,10 +328,118 @@ class NewPartitionTransitionImplTest {
     verify(mockStep1, never()).transitionTo(mockContext, secondTerm, secondRole);
     verify(mockStep2, never()).transitionTo(mockContext, secondTerm, secondRole);
 
-    assertThatThrownBy(() -> secondTransitionFuture.join())
+    assertThatThrownBy(secondTransitionFuture::join)
         .isInstanceOf(CompletionException.class)
         .getCause()
         .isSameAs(testException);
+  }
+
+  @Test // regression test for #8044
+  void shouldCloseAllCreatedInstancesOfStreamProcessor() {
+    // given
+    final var actorScheduler = ActorScheduler.newActorScheduler().build();
+    actorScheduler.start();
+    final var actor = new Actor() {};
+
+    actorScheduler.submitActor(actor);
+
+    when(mockContext.getComponentHealthMonitor()).thenReturn(mock(HealthMonitor.class));
+
+    final var mockStreamProcessor1 = mock(StreamProcessor.class);
+    when(mockStreamProcessor1.openAsync(anyBoolean()))
+        .thenReturn(TEST_CONCURRENCY_CONTROL.createCompletedFuture());
+    when(mockStreamProcessor1.closeAsync())
+        .thenReturn(TEST_CONCURRENCY_CONTROL.createCompletedFuture());
+    final var mockStreamProcessor2 = mock(StreamProcessor.class);
+    when(mockStreamProcessor2.openAsync(anyBoolean()))
+        .thenReturn(TEST_CONCURRENCY_CONTROL.createCompletedFuture());
+    when(mockStreamProcessor2.closeAsync())
+        .thenReturn(TEST_CONCURRENCY_CONTROL.createCompletedFuture());
+
+    final var mockStreamProcessorBuilder = mock(StreamProcessorBuilder.class);
+    when(mockStreamProcessorBuilder.logStream(any())).thenReturn(mockStreamProcessorBuilder);
+    when(mockStreamProcessorBuilder.actorSchedulingService(any()))
+        .thenReturn(mockStreamProcessorBuilder);
+    when(mockStreamProcessorBuilder.zeebeDb(any())).thenReturn(mockStreamProcessorBuilder);
+    when(mockStreamProcessorBuilder.eventApplierFactory(any()))
+        .thenReturn(mockStreamProcessorBuilder);
+    when(mockStreamProcessorBuilder.nodeId(anyInt())).thenReturn(mockStreamProcessorBuilder);
+    when(mockStreamProcessorBuilder.commandResponseWriter(any()))
+        .thenReturn(mockStreamProcessorBuilder);
+    when(mockStreamProcessorBuilder.listener(any())).thenReturn(mockStreamProcessorBuilder);
+    when(mockStreamProcessorBuilder.streamProcessorFactory(any()))
+        .thenReturn(mockStreamProcessorBuilder);
+    when(mockStreamProcessorBuilder.streamProcessorMode(any()))
+        .thenReturn(mockStreamProcessorBuilder);
+
+    when(mockStreamProcessorBuilder.build()).thenReturn(mockStreamProcessor1, mockStreamProcessor2);
+
+    // a shorthand for "let the getter return the last value that was passed to the setter"
+    doAnswer(
+            answer ->
+                when(mockContext.getStreamProcessor())
+                    .thenReturn((StreamProcessor) answer.getArguments()[0]))
+        .when(mockContext)
+        .setStreamProcessor(any());
+
+    final var mockStepBefore = mockStep1;
+    when(mockStepBefore.prepareTransition(any(), anyLong(), any()))
+        .thenReturn(TEST_CONCURRENCY_CONTROL.createCompletedFuture());
+
+    final var streamProcessorStep =
+        new StreamProcessorTransitionStep(() -> mockStreamProcessorBuilder);
+    final var mockStepAfter = mockStep2;
+    when(mockStepAfter.prepareTransition(any(), anyLong(), any()))
+        .thenReturn(TEST_CONCURRENCY_CONTROL.createCompletedFuture());
+
+    final var sut =
+        new NewPartitionTransitionImpl(
+            of(mockStepBefore, streamProcessorStep, mockStepAfter), mockContext);
+    sut.setConcurrencyControl(actor);
+
+    // when
+
+    // first transition to FOLLOWER; will complete regularly and create a stream processor
+    when(mockStepBefore.transitionTo(mockContext, DEFAULT_TERM, Role.FOLLOWER))
+        .thenReturn(TEST_CONCURRENCY_CONTROL.createCompletedFuture());
+    when(mockStepAfter.transitionTo(mockContext, DEFAULT_TERM, Role.FOLLOWER))
+        .thenReturn(TEST_CONCURRENCY_CONTROL.createCompletedFuture());
+    final var transition1Future =
+        sut.transitionTo(DEFAULT_TERM, Role.FOLLOWER); // creates stream processor
+
+    transition1Future.join(); // wait for first transition to complete
+
+    // second transition to CANDIDATE; will be paused on the first step and cancelled before the
+    // stream processor step
+    final ActorFuture<Void> testFutureOfFirstStepInSecondTransition =
+        TEST_CONCURRENCY_CONTROL.createFuture();
+    when(mockStepBefore.transitionTo(mockContext, DEFAULT_TERM, Role.CANDIDATE))
+        .thenReturn(testFutureOfFirstStepInSecondTransition);
+    final var transition2Future = sut.transitionTo(DEFAULT_TERM, Role.CANDIDATE);
+
+    // third transition to LEADER; will cancel current transition 2; will complete regularly and
+    // create a stream processor
+    when(mockStepBefore.transitionTo(mockContext, DEFAULT_TERM, Role.LEADER))
+        .thenReturn(TEST_CONCURRENCY_CONTROL.createCompletedFuture());
+    when(mockStepAfter.transitionTo(mockContext, DEFAULT_TERM, Role.LEADER))
+        .thenReturn(TEST_CONCURRENCY_CONTROL.createCompletedFuture());
+
+    final var transition3Future =
+        sut.transitionTo(DEFAULT_TERM, Role.LEADER); // creates stream processor
+
+    testFutureOfFirstStepInSecondTransition.complete(null); // resume transition 2
+
+    // then
+    assertThat(transition1Future).succeedsWithin(ofSeconds(10));
+    assertThat(transition2Future).succeedsWithin(ofSeconds(10));
+    assertThat(transition3Future).succeedsWithin(ofSeconds(10));
+
+    verify(mockStreamProcessorBuilder, times(2)).build();
+    verify(mockStreamProcessor1).closeAsync();
+    verify(mockStreamProcessor2, never()).closeAsync();
+
+    // cleanup
+    actorScheduler.stop();
   }
 
   private final class WaitingTransitionStep implements PartitionTransitionStep {


### PR DESCRIPTION
## Description

Changes the transition logic as follows:
- preparation/cleanup is done for all steps (not just the steps started by the last iteration)
- preparation/cleanup is done in the context of the next transition, not in the context of the last transition.

As a consequence, preparation/cleanup will be executed more often than transitionTo. This can also be seen in the log for the new test case. Essentially, when a transition is "skipped" then only it's transitionTo is skipped, but the cleanup is executed anyway. I think one could improve that by making the cleanup react to the cancel signal, but I want to be conservative here. Also, multiple cleanup calls should be fast, because if a cleanup succeeds it sets e.g. the stream processor to null in the context, and any subsequent call will do nothing if it finds no stream processor.

Previously:
- The old transition did clean up the steps that were started by it
- The cleanup assumed that the transitionTo will immediately follow, but this was not a given. The transitionTo might be cancelled, and might eventually transition to a completely different role.
- So in essence, it did prepare for a role that maybe never came.


## Related issues

closes #8044
subset of #8059 
Essentially the same changes as #8062 (develop branch)

## Review Hints
This PR is a subset of #8059. It contains the fix and commits related to the first round of review comments. 
It does not contain the property based test, which is still the object of further discussion.

The purpose of this PR is to separate consensus from ongoing discussions.

The property based test has been run and in my mind validated the fix. Last week I also ran it with chains of six consecutive transitions and found no inconsistency. This gives me the confidence to merge the fix into the stable branch.

Please also indicate whether you think we need to add the property based test to `stable/1.2`. In my mind, it will be sufficient to introduce it in develop.

<!-- Cut-off marker
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
