### PR TITLE
Add actor clock actuator endpoint

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -197,17 +197,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-test</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -11,6 +10,7 @@
   </parent>
 
   <artifactId>camunda-cloud-zeebe</artifactId>
+
   <packaging>jar</packaging>
 
   <name>Zeebe Distribution</name>
@@ -111,8 +111,8 @@
       <artifactId>micrometer-core</artifactId>
       <exclusions>
         <exclusion>
-          <!-- Conflicts with histogram in elasticsearch exporter dependency -->
           <groupId>org.hdrhistogram</groupId>
+          <!-- Conflicts with histogram in elasticsearch exporter dependency -->
           <artifactId>HdrHistogram</artifactId>
         </exclusion>
       </exclusions>
@@ -197,6 +197,17 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -206,30 +217,30 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>appassembler-maven-plugin</artifactId>
         <configuration>
+          <assembleDirectory>${project.build.directory}/camunda-cloud-zeebe</assembleDirectory>
           <configurationDirectory>config</configurationDirectory>
           <copyConfigurationDirectory>true</copyConfigurationDirectory>
-          <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
           <extraJvmArguments>-Xms128m
             --illegal-access=deny
             -XX:+ExitOnOutOfMemoryError</extraJvmArguments>
-          <repositoryLayout>flat</repositoryLayout>
-          <useWildcardClassPath>true</useWildcardClassPath>
-          <repositoryName>lib</repositoryName>
-          <assembleDirectory>${project.build.directory}/camunda-cloud-zeebe</assembleDirectory>
+          <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
           <platforms>
             <platform>windows</platform>
             <platform>unix</platform>
           </platforms>
           <programs>
             <program>
-              <mainClass>io.camunda.zeebe.broker.StandaloneBroker</mainClass>
               <id>broker</id>
+              <mainClass>io.camunda.zeebe.broker.StandaloneBroker</mainClass>
             </program>
             <program>
-              <mainClass>io.camunda.zeebe.gateway.StandaloneGateway</mainClass>
               <id>gateway</id>
+              <mainClass>io.camunda.zeebe.gateway.StandaloneGateway</mainClass>
             </program>
           </programs>
+          <repositoryLayout>flat</repositoryLayout>
+          <repositoryName>lib</repositoryName>
+          <useWildcardClassPath>true</useWildcardClassPath>
         </configuration>
         <executions>
           <execution>
@@ -253,10 +264,10 @@
             <phase>package</phase>
             <configuration>
               <target>
-                <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl" tofile="${project.build.directory}/camunda-cloud-zeebe/bin/zbctl"></copy>
+                <chmod dir="${project.build.directory}/camunda-cloud-zeebe/bin" failonerror="${zbctl.force}" includes="zbctl*" perm="ugo+rx"></chmod>
                 <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.exe" tofile="${project.build.directory}/camunda-cloud-zeebe/bin/zbctl.exe"></copy>
                 <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.darwin" tofile="${project.build.directory}/camunda-cloud-zeebe/bin/zbctl.darwin"></copy>
-                <chmod dir="${project.build.directory}/camunda-cloud-zeebe/bin" failonerror="${zbctl.force}" includes="zbctl*" perm="ugo+rx"></chmod>
+                <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl" tofile="${project.build.directory}/camunda-cloud-zeebe/bin/zbctl"></copy>
               </target>
             </configuration>
           </execution>
@@ -272,8 +283,8 @@
             </goals>
             <phase>package</phase>
             <configuration>
-              <attach>true</attach>
               <appendAssemblyId>false</appendAssemblyId>
+              <attach>true</attach>
               <descriptors>
                 <descriptor>src/main/assembly.xml</descriptor>
               </descriptors>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -92,6 +92,21 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
       <exclusions>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -264,10 +264,12 @@
             <phase>package</phase>
             <configuration>
               <target>
-                <chmod dir="${project.build.directory}/camunda-cloud-zeebe/bin" failonerror="${zbctl.force}" includes="zbctl*" perm="ugo+rx"></chmod>
+                <?SORTPOM IGNORE?> <!-- ordering is important here, chmod needs to run after copying -->
                 <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.exe" tofile="${project.build.directory}/camunda-cloud-zeebe/bin/zbctl.exe"></copy>
                 <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.darwin" tofile="${project.build.directory}/camunda-cloud-zeebe/bin/zbctl.darwin"></copy>
                 <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl" tofile="${project.build.directory}/camunda-cloud-zeebe/bin/zbctl"></copy>
+                <chmod dir="${project.build.directory}/camunda-cloud-zeebe/bin" failonerror="${zbctl.force}" includes="zbctl*" perm="ugo+rx"></chmod>
+                <?SORTPOM RESUME?>
               </target>
             </configuration>
           </execution>

--- a/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
@@ -34,6 +34,7 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextClosedEvent;
 
@@ -49,6 +50,7 @@ import org.springframework.context.event.ContextClosedEvent;
       "io.camunda.zeebe.shared",
       "io.camunda.zeebe.util.liveness"
     })
+@ConfigurationPropertiesScan(basePackages = {"io.camunda.zeebe.gateway", "io.camunda.zeebe.shared"})
 public class StandaloneGateway
     implements CommandLineRunner, ApplicationListener<ContextClosedEvent>, CloseableSilently {
   private static final Logger LOG = Loggers.GATEWAY_LOGGER;

--- a/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.impl.configuration.ClusterCfg;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.gateway.impl.configuration.MembershipCfg;
+import io.camunda.zeebe.shared.ActorClockConfiguration;
 import io.camunda.zeebe.shared.Profile;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.VersionUtil;
@@ -54,6 +55,7 @@ public class StandaloneGateway
 
   private final GatewayCfg configuration;
   private final SpringGatewayBridge springGatewayBridge;
+  private final ActorClockConfiguration clockConfig;
 
   private AtomixCluster atomixCluster;
   private Gateway gateway;
@@ -61,9 +63,12 @@ public class StandaloneGateway
 
   @Autowired
   public StandaloneGateway(
-      final GatewayCfg configuration, final SpringGatewayBridge springGatewayBridge) {
+      final GatewayCfg configuration,
+      final SpringGatewayBridge springGatewayBridge,
+      final ActorClockConfiguration clockConfig) {
     this.configuration = configuration;
     this.springGatewayBridge = springGatewayBridge;
+    this.clockConfig = clockConfig;
   }
 
   public static void main(final String[] args) {
@@ -187,6 +192,7 @@ public class StandaloneGateway
         .setCpuBoundActorThreadCount(config.getThreads().getManagementThreads())
         .setIoBoundActorThreadCount(0)
         .setSchedulerName("gateway-scheduler")
+        .setActorClock(clockConfig.getClock())
         .build();
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/ActorClockConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/ActorClockConfiguration.java
@@ -20,7 +20,7 @@ import org.springframework.web.context.annotation.ApplicationScope;
 
 @SuppressWarnings("unused")
 @ConfigurationProperties("zeebe.clock")
-public class ActorClockConfiguration {
+public final class ActorClockConfiguration {
 
   private final ActorClock clock;
   private final ActorClockService service;

--- a/dist/src/main/java/io/camunda/zeebe/shared/ActorClockConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/ActorClockConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared;
+
+import io.camunda.zeebe.shared.management.ActorClockService;
+import io.camunda.zeebe.shared.management.ControlledActorClockService;
+import io.camunda.zeebe.util.sched.clock.ActorClock;
+import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
+import io.camunda.zeebe.util.sched.clock.DefaultActorClock;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.context.annotation.ApplicationScope;
+
+@SuppressWarnings("unused")
+@ConfigurationProperties("zeebe.clock")
+public class ActorClockConfiguration {
+
+  private final ActorClock clock;
+  private final ActorClockService service;
+
+  @ConstructorBinding
+  public ActorClockConfiguration(@DefaultValue("false") final boolean controlled) {
+    if (controlled) {
+      final var controlledClock = new ControlledActorClock();
+      service = new ControlledActorClockService(controlledClock);
+      clock = controlledClock;
+    } else {
+      clock = new DefaultActorClock();
+      service = clock::getTimeMillis;
+    }
+  }
+
+  @Bean
+  @ApplicationScope
+  public ActorClock getClock() {
+    return clock;
+  }
+
+  @Bean
+  @ApplicationScope
+  public ActorClockService getClockService() {
+    return service;
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
@@ -159,8 +159,12 @@ public class ActorClockEndpoint {
     @JsonProperty("instant")
     private final Instant instant;
 
+    @JsonProperty("epochMilli")
+    private final long epochMilli;
+
     public Response(final Instant instant) {
       this.instant = instant;
+      epochMilli = instant.toEpochMilli();
     }
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
@@ -114,7 +114,8 @@ public class ActorClockEndpoint {
   public WebEndpointResponse<?> resetTime() {
     final var clock = service.mutable();
     if (clock.isEmpty()) {
-      return new WebEndpointResponse<>("Expected to reset the clock, but the it is immutable", 403);
+      return new WebEndpointResponse<>(
+          "Expected to reset the clock, but the clock is immutable", 403);
     }
 
     clock.get().resetTime();
@@ -155,16 +156,22 @@ public class ActorClockEndpoint {
   }
 
   /** A response type for future proofing, in case the format needs to be changed in the future. */
-  private static final class Response {
-    @JsonProperty("instant")
-    private final Instant instant;
-
+  protected static final class Response {
     @JsonProperty("epochMilli")
-    private final long epochMilli;
+    protected final long epochMilli;
+
+    @JsonProperty("instant")
+    protected final Instant instant;
 
     public Response(final Instant instant) {
       this.instant = instant;
       epochMilli = instant.toEpochMilli();
+    }
+
+    @SuppressWarnings("unused") // Used by Jackson deserialization
+    private Response() {
+      this.epochMilli = 0;
+      this.instant = null;
     }
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared.management;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.annotation.Selector;
+import org.springframework.boot.actuate.endpoint.annotation.Selector.Match;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
+import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * An actuator endpoint which exposes the current actor clock, provided there it can resolve a bean
+ * of type {@link ActorClockService} somewhere, and it's enabled via configuration (which by default
+ * it isn't).
+ *
+ * <p>NOTE: if the clock is not controllable (set via `zeebe.clock.controlled`), any write or delete
+ * operations will simply do nothing.
+ */
+@Component
+@WebEndpoint(id = "clock", enableByDefault = false)
+public class ActorClockEndpoint {
+  private static final String PATH_PIN = "pin";
+  private static final String PATH_ADD = "add";
+
+  private final ActorClockService service;
+
+  @Autowired
+  public ActorClockEndpoint(final ActorClockService service) {
+    this.service = service;
+  }
+
+  /**
+   * GET /actuator/clock - returns the current instant of the clock in human-readable format using
+   * {@link java.time.format.DateTimeFormatter#ISO_INSTANT}.
+   *
+   * @return a 200 response carrying the current instant of the clock
+   */
+  @ReadOperation
+  public WebEndpointResponse<Response> getCurrentClock() {
+    final var instant = Instant.ofEpochMilli(service.epochMilli());
+    return new WebEndpointResponse<>(new Response(instant));
+  }
+
+  /**
+   * POST /actuator/clock/{operationKey} - modifies the current clock, either by `pin`ning it to the
+   * given `epochMilli` or by `add`ing a relative offset to it.
+   *
+   * <p>The expected usage is to send a JSON body with at least one of the fields. Both fields can
+   * be present as well, but only one will be used depending on the operation key.
+   *
+   * <p>For example, to pin the time to 1635672964533 (or Sun Oct 31 09:36:04 AM UTC 2021):
+   *
+   * <pre>{@code
+   * curl -X POST -H 'Content-Type: application/json' -d '{"epochMilli": 1635672964533}' "http://0.0.0.0:9600/actuator/clock/pin"
+   * "2021-10-31T09:36:04.533Z"%
+   * }</pre>
+   *
+   * To add a relative time offset:
+   *
+   * <pre>{@code
+   * curl -X POST -H 'Content-Type: application/json' -d '{"offsetMilli": 250}' "http://0.0.0.0:9600/actuator/clock/pin"
+   * "2021-10-31T09:36:04.783Z"%
+   * }</pre>
+   *
+   * NOTE: you can pass a negative offset to subtract time as well.
+   *
+   * @param operationKey the operation to execute; must be one of `pin` or `add`
+   * @param epochMilli the time at which the clock should be pinned
+   * @param offsetMilli the offset to add to the current time (pinned or not)
+   * @return 200 and the current clock time, or 400 if the request is malformed
+   */
+  @SuppressWarnings({"unused", "java:S1452"})
+  @WriteOperation
+  public WebEndpointResponse<?> modify(
+      @Selector(match = Match.SINGLE) final String operationKey,
+      final @Nullable Long epochMilli,
+      final @Nullable Long offsetMilli) {
+    if (PATH_PIN.equals(operationKey)) {
+      return pinTime(epochMilli);
+    } else if (PATH_ADD.equals(operationKey)) {
+      return addTime(offsetMilli);
+    } else {
+      return new WebEndpointResponse<>(
+          String.format(
+              "Expected to either `pin` or `add` to the clock, but no operation named `%s` is "
+                  + "known; make sure you wrote the correct path",
+              operationKey),
+          400);
+    }
+  }
+
+  /**
+   * DELETE /actuator/clock - will reset any modification to the current clock, which will unpin (if
+   * required) and start using the current system time.
+   *
+   * @return 200 and the current clock time
+   */
+  @SuppressWarnings("unused")
+  @DeleteOperation
+  public WebEndpointResponse<?> resetTime() {
+    final var clock = service.mutable();
+    if (clock.isEmpty()) {
+      return new WebEndpointResponse<>("Expected to reset the clock, but the it is immutable", 403);
+    }
+
+    clock.get().resetTime();
+    return getCurrentClock();
+  }
+
+  private WebEndpointResponse<?> pinTime(final Long epochMilli) {
+    if (epochMilli == null) {
+      return new WebEndpointResponse<>(
+          "Expected pin the clock to the given `epochMilli`, but none given", 400);
+    }
+
+    final var clock = service.mutable();
+    if (clock.isEmpty()) {
+      return new WebEndpointResponse<>(
+          "Expected to pin the clock to the given time, but it is immutable", 403);
+    }
+
+    clock.get().pinTime(Instant.ofEpochMilli(epochMilli));
+    return getCurrentClock();
+  }
+
+  private WebEndpointResponse<?> addTime(final Long offsetMilli) {
+    if (offsetMilli == null) {
+      return new WebEndpointResponse<>(
+          "Expected to add `offsetMilli` to the clock, but none given", 400);
+    }
+
+    final var clock = service.mutable();
+    if (clock.isEmpty()) {
+      return new WebEndpointResponse<>(
+          "Expected to add time to the clock, but it is immutable", 403);
+    }
+
+    final var offset = Duration.of(offsetMilli, ChronoUnit.MILLIS);
+    clock.get().addTime(offset);
+    return getCurrentClock();
+  }
+
+  /** A response type for future proofing, in case the format needs to be changed in the future. */
+  private static final class Response {
+    @JsonProperty("instant")
+    private final Instant instant;
+
+    public Response(final Instant instant) {
+      this.instant = instant;
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Component;
  * it isn't).
  *
  * <p>NOTE: if the clock is not controllable (set via `zeebe.clock.controlled`), any write or delete
- * operations will simply do nothing.
+ * operations will result in a 403 response.
  */
 @Component
 @WebEndpoint(id = "clock", enableByDefault = false)
@@ -158,10 +158,10 @@ public class ActorClockEndpoint {
   /** A response type for future proofing, in case the format needs to be changed in the future. */
   protected static final class Response {
     @JsonProperty("epochMilli")
-    protected final long epochMilli;
+    final long epochMilli;
 
     @JsonProperty("instant")
-    protected final Instant instant;
+    final Instant instant;
 
     public Response(final Instant instant) {
       this.instant = instant;
@@ -170,8 +170,8 @@ public class ActorClockEndpoint {
 
     @SuppressWarnings("unused") // Used by Jackson deserialization
     private Response() {
-      this.epochMilli = 0;
-      this.instant = null;
+      epochMilli = 0;
+      instant = null;
     }
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockService.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared.management;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * A service which wraps an {@link io.camunda.zeebe.util.sched.clock.ActorClock} instance. We can't
+ * directly use an actor clock since the interface is by nature immutable, so instead we wrap it.
+ */
+public interface ActorClockService {
+
+  /** @return the current instant of the clock */
+  long epochMilli();
+
+  /** @return a mutable variant of the underlying clock, or nothing if the clock is immutable */
+  default Optional<MutableClock> mutable() {
+    return Optional.empty();
+  }
+
+  /** A mutable variant of this service. */
+  interface MutableClock {
+    /**
+     * Adds the offset to the current clock.
+     *
+     * @param offset the time offset to add to the current time
+     */
+    void addTime(final Duration offset);
+
+    /**
+     * Pins the clock to the given time.
+     *
+     * @param time the time at which to pin the current clock
+     */
+    void pinTime(final Instant time);
+
+    /** Resets the clock to use the system time */
+    void resetTime();
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockService.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockService.java
@@ -15,6 +15,7 @@ import java.util.Optional;
  * A service which wraps an {@link io.camunda.zeebe.util.sched.clock.ActorClock} instance. We can't
  * directly use an actor clock since the interface is by nature immutable, so instead we wrap it.
  */
+@FunctionalInterface
 public interface ActorClockService {
 
   /** @return the current instant of the clock */

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ControlledActorClockService.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ControlledActorClockService.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.shared.management.ActorClockService.MutableClock;
 import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Optional;
 
 /**
  * An implementation of {@link ActorClockService} which wraps a mutable clock, allowing for
@@ -28,6 +29,11 @@ public final class ControlledActorClockService implements ActorClockService, Mut
   @Override
   public long epochMilli() {
     return clock.getTimeMillis();
+  }
+
+  @Override
+  public Optional<MutableClock> mutable() {
+    return Optional.of(this);
   }
 
   @Override

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ControlledActorClockService.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ControlledActorClockService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared.management;
+
+import io.camunda.zeebe.shared.management.ActorClockService.MutableClock;
+import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * An implementation of {@link ActorClockService} which wraps a mutable clock, allowing for
+ * modification of the clock from the outside.
+ *
+ * <p>See {@link io.camunda.zeebe.shared.ActorClockConfiguration} on how to configure/wire it.
+ */
+public final class ControlledActorClockService implements ActorClockService, MutableClock {
+  private final ControlledActorClock clock;
+
+  public ControlledActorClockService(final ControlledActorClock clock) {
+    this.clock = clock;
+  }
+
+  @Override
+  public long epochMilli() {
+    return clock.getTimeMillis();
+  }
+
+  @Override
+  public void addTime(final Duration offset) {
+    clock.addTime(offset);
+  }
+
+  @Override
+  public void pinTime(final Instant time) {
+    clock.setCurrentTime(time);
+  }
+
+  @Override
+  public void resetTime() {
+    clock.reset();
+  }
+}

--- a/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.gateway.impl.configuration.ClusterCfg;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.gateway.impl.configuration.NetworkCfg;
 import io.camunda.zeebe.gateway.impl.configuration.SecurityCfg;
+import io.camunda.zeebe.shared.ActorClockConfiguration;
 import io.camunda.zeebe.test.util.asserts.SslAssert;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -140,6 +141,7 @@ final class StandaloneGatewaySecurityTest {
   }
 
   private StandaloneGateway buildGateway(final GatewayCfg gatewayCfg) {
-    return new StandaloneGateway(gatewayCfg, new SpringGatewayBridge());
+    return new StandaloneGateway(
+        gatewayCfg, new SpringGatewayBridge(), new ActorClockConfiguration(false));
   }
 }

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ControlledActorClockEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ControlledActorClockEndpointTest.java
@@ -10,94 +10,81 @@ package io.camunda.zeebe.shared.management;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.byLessThan;
 
-import io.camunda.zeebe.broker.StandaloneBroker;
+import io.camunda.zeebe.shared.management.ActorClockEndpoint.Response;
+import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
 import java.time.Instant;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactory;
+import org.assertj.core.api.ObjectAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(
-    webEnvironment = WebEnvironment.RANDOM_PORT,
-    classes = StandaloneBroker.class,
-    properties = "zeebe.clock.controlled=true")
-@ActiveProfiles("test")
 final class ControlledActorClockEndpointTest {
 
-  @Autowired private TestRestTemplate restTemplate;
+  private final InstanceOfAssertFactory<Response, ObjectAssert<Response>> instanceOfRecord =
+      new InstanceOfAssertFactory<>(Response.class, Assertions::assertThat);
+
+  private final ActorClockEndpoint endpoint =
+      new ActorClockEndpoint(new ControlledActorClockService(new ControlledActorClock()));
 
   @BeforeEach
   private void resetClock() {
-    restTemplate.delete("/actuator/clock/");
+    endpoint.resetTime();
   }
 
   @Test
   void canRetrieveCurrentClock() {
-    final var response =
-        restTemplate.getForEntity("/actuator/clock/", ActorClockEndpoint.Response.class);
-    assertThat(response.getStatusCode()).matches(HttpStatus::is2xxSuccessful);
+    final var response = endpoint.getCurrentClock();
+    assertThat(response.getStatus()).isEqualTo(200);
   }
 
   @Test
   void canPinMutableClock() {
     // given
     final var millis = 1635672964533L;
-    final var request = jsonRequest(String.format("{\"epochMilli\": %s}", millis));
 
     // when
-    final var response =
-        restTemplate.postForEntity(
-            "/actuator/clock/pin", request, ActorClockEndpoint.Response.class);
+    final var response = endpoint.modify("pin", millis, null);
 
     // then
-    assertThat(response.getStatusCode()).matches(HttpStatus::is2xxSuccessful);
-    assertThat(response.getBody()).isNotNull();
-    assertThat(response.getBody().epochMilli).isEqualTo(millis);
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(response.getBody())
+        .asInstanceOf(instanceOfRecord)
+        .satisfies((body) -> assertThat(body.epochMilli).isEqualTo(millis))
+        .isNotNull();
   }
 
   @Test
   void canOffsetMutableClock() {
     // given
     final var offset = 10000L;
-    final var request = jsonRequest(String.format("{\"offsetMilli\": %s}", offset));
 
     // when
-    final var response =
-        restTemplate.postForEntity(
-            "/actuator/clock/add", request, ActorClockEndpoint.Response.class);
+    final var response = endpoint.modify("add", null, offset);
 
     // then
-    assertThat(response.getStatusCode()).matches(HttpStatus::is2xxSuccessful);
-    assertThat(response.getBody()).isNotNull();
-    assertThat(response.getBody().epochMilli)
-        .isCloseTo(Instant.now().toEpochMilli(), byLessThan(offset));
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(response.getBody())
+        .isNotNull()
+        .asInstanceOf(instanceOfRecord)
+        .satisfies(
+            (body) ->
+                assertThat(body.epochMilli)
+                    .isCloseTo(Instant.now().toEpochMilli(), byLessThan(offset)));
   }
 
   @Test
   void offsetClockDoesAdvance() throws InterruptedException {
     // given
     final var offset = 10000L;
-    final var request = jsonRequest(String.format("{\"offsetMilli\": %s}", offset));
-    final var firstResponse =
-        restTemplate.postForEntity(
-            "/actuator/clock/add", request, ActorClockEndpoint.Response.class);
+    final var firstResponse = endpoint.modify("add", null, offset);
     assertThat(firstResponse.getBody()).isNotNull();
-    final var firstMillis = firstResponse.getBody().epochMilli;
+    final var firstMillis = ((Response) firstResponse.getBody()).epochMilli;
 
     // when
     Thread.sleep(100);
-    final var secondResponse =
-        restTemplate.getForEntity("/actuator/clock", ActorClockEndpoint.Response.class);
+    final var secondResponse = endpoint.getCurrentClock();
     assertThat(secondResponse.getBody()).isNotNull();
     final var secondMillis = secondResponse.getBody().epochMilli;
 
@@ -109,18 +96,16 @@ final class ControlledActorClockEndpointTest {
   void pinnedClockDoesNotAdvance() throws InterruptedException {
     // given
     final var millis = 1635672964533L;
-    final var request = jsonRequest(String.format("{\"epochMilli\": %s}", millis));
-    final var firstResponse =
-        restTemplate.postForEntity(
-            "/actuator/clock/pin", request, ActorClockEndpoint.Response.class);
-    assertThat(firstResponse.getStatusCode()).matches(HttpStatus::is2xxSuccessful);
-    assertThat(firstResponse.getBody()).isNotNull();
-    assertThat(firstResponse.getBody().epochMilli).isEqualTo(millis);
+    final var firstResponse = endpoint.modify("pin", millis, null);
+    assertThat(firstResponse.getStatus()).isEqualTo(200);
+    assertThat(firstResponse.getBody())
+        .isNotNull()
+        .asInstanceOf(instanceOfRecord)
+        .satisfies((body) -> assertThat(body.epochMilli).isEqualTo(millis));
 
     // when
     Thread.sleep(100);
-    final var secondResponse =
-        restTemplate.getForEntity("/actuator/clock", ActorClockEndpoint.Response.class);
+    final var secondResponse = endpoint.getCurrentClock();
 
     // then
     assertThat(secondResponse.getBody()).isNotNull();
@@ -130,19 +115,12 @@ final class ControlledActorClockEndpointTest {
   @Test
   void instantMatchesEpochMilli() {
     // when
-    final var response =
-        restTemplate.getForEntity("/actuator/clock", ActorClockEndpoint.Response.class);
+    final var response = endpoint.getCurrentClock();
     assertThat(response.getBody()).isNotNull();
     final var millis = response.getBody().epochMilli;
     final var instant = response.getBody().instant;
 
     // then
     assertThat(Instant.ofEpochMilli(millis)).isEqualTo(instant);
-  }
-
-  private HttpEntity<String> jsonRequest(String body) {
-    final var headers = new HttpHeaders();
-    headers.setContentType(MediaType.APPLICATION_JSON);
-    return new HttpEntity<>(body, headers);
   }
 }

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ControlledActorClockEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ControlledActorClockEndpointTest.java
@@ -71,7 +71,7 @@ final class ControlledActorClockEndpointTest {
         .satisfies(
             (body) ->
                 assertThat(body.epochMilli)
-                    .isCloseTo(Instant.now().toEpochMilli(), byLessThan(offset)));
+                    .isCloseTo(Instant.now().toEpochMilli(), byLessThan(offset + 1)));
   }
 
   @Test

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ControlledActorClockEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ControlledActorClockEndpointTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.byLessThan;
+
+import io.camunda.zeebe.broker.StandaloneBroker;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    classes = StandaloneBroker.class,
+    properties = "zeebe.clock.controlled=true")
+@ActiveProfiles("test")
+final class ControlledActorClockEndpointTest {
+
+  @Autowired private TestRestTemplate restTemplate;
+
+  @BeforeEach
+  private void resetClock() {
+    restTemplate.delete("/actuator/clock/");
+  }
+
+  @Test
+  void canRetrieveCurrentClock() {
+    final var response =
+        restTemplate.getForEntity("/actuator/clock/", ActorClockEndpoint.Response.class);
+    assertThat(response.getStatusCode()).matches(HttpStatus::is2xxSuccessful);
+  }
+
+  @Test
+  void canPinMutableClock() {
+    // given
+    final var millis = 1635672964533L;
+    final var request = jsonRequest(String.format("{\"epochMilli\": %s}", millis));
+
+    // when
+    final var response =
+        restTemplate.postForEntity(
+            "/actuator/clock/pin", request, ActorClockEndpoint.Response.class);
+
+    // then
+    assertThat(response.getStatusCode()).matches(HttpStatus::is2xxSuccessful);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().epochMilli).isEqualTo(millis);
+  }
+
+  @Test
+  void canOffsetMutableClock() {
+    // given
+    final var offset = 10000L;
+    final var request = jsonRequest(String.format("{\"offsetMilli\": %s}", offset));
+
+    // when
+    final var response =
+        restTemplate.postForEntity(
+            "/actuator/clock/add", request, ActorClockEndpoint.Response.class);
+
+    // then
+    assertThat(response.getStatusCode()).matches(HttpStatus::is2xxSuccessful);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().epochMilli)
+        .isCloseTo(Instant.now().toEpochMilli(), byLessThan(offset));
+  }
+
+  @Test
+  void offsetClockDoesAdvance() throws InterruptedException {
+    // given
+    final var offset = 10000L;
+    final var request = jsonRequest(String.format("{\"offsetMilli\": %s}", offset));
+    final var firstResponse =
+        restTemplate.postForEntity(
+            "/actuator/clock/add", request, ActorClockEndpoint.Response.class);
+    assertThat(firstResponse.getBody()).isNotNull();
+    final var firstMillis = firstResponse.getBody().epochMilli;
+
+    // when
+    Thread.sleep(100);
+    final var secondResponse =
+        restTemplate.getForEntity("/actuator/clock", ActorClockEndpoint.Response.class);
+    assertThat(secondResponse.getBody()).isNotNull();
+    final var secondMillis = secondResponse.getBody().epochMilli;
+
+    // then
+    assertThat(firstMillis).isLessThan(secondMillis);
+  }
+
+  @Test
+  void pinnedClockDoesNotAdvance() throws InterruptedException {
+    // given
+    final var millis = 1635672964533L;
+    final var request = jsonRequest(String.format("{\"epochMilli\": %s}", millis));
+    final var firstResponse =
+        restTemplate.postForEntity(
+            "/actuator/clock/pin", request, ActorClockEndpoint.Response.class);
+    assertThat(firstResponse.getStatusCode()).matches(HttpStatus::is2xxSuccessful);
+    assertThat(firstResponse.getBody()).isNotNull();
+    assertThat(firstResponse.getBody().epochMilli).isEqualTo(millis);
+
+    // when
+    Thread.sleep(100);
+    final var secondResponse =
+        restTemplate.getForEntity("/actuator/clock", ActorClockEndpoint.Response.class);
+
+    // then
+    assertThat(secondResponse.getBody()).isNotNull();
+    assertThat(secondResponse.getBody().epochMilli).isEqualTo(millis);
+  }
+
+  @Test
+  void instantMatchesEpochMilli() {
+    // when
+    final var response =
+        restTemplate.getForEntity("/actuator/clock", ActorClockEndpoint.Response.class);
+    assertThat(response.getBody()).isNotNull();
+    final var millis = response.getBody().epochMilli;
+    final var instant = response.getBody().instant;
+
+    // then
+    assertThat(Instant.ofEpochMilli(millis)).isEqualTo(instant);
+  }
+
+  private HttpEntity<String> jsonRequest(String body) {
+    final var headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return new HttpEntity<>(body, headers);
+  }
+}

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -72,6 +74,24 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-jackson</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
@@ -42,7 +42,7 @@ import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
-public class ControlledActorClockIT {
+public class ControlledActorClockEndpointIT {
   private static final String ELASTICSEARCH_HOST = "elasticsearch";
   private static final String INDEX_PREFIX = "exporter-clock-test";
   private Network network;

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockIT.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.jackson.record.AbstractRecord;
+import io.zeebe.containers.ZeebeContainer;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublisher;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Network;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+public class ControlledActorClockIT {
+  private static final String INDEX_PREFIX = "exporter-clock-test";
+  private ElasticsearchContainer elasticsearchContainer;
+  private ZeebeContainer zeebeContainer;
+  private ZeebeClient zeebeClient;
+  private final HttpClient httpClient = HttpClient.newHttpClient();
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @BeforeEach
+  void startContainers() {
+    final var network = Network.newNetwork();
+    startElasticsearch(network);
+    startZeebe(network);
+  }
+
+  @AfterEach
+  void stopContainers() {
+    zeebeContainer.stop();
+    elasticsearchContainer.stop();
+  }
+
+  @Test
+  void testPinningTime() throws IOException, InterruptedException {
+    // given - Zeebe actor clock is pinned
+    final var pinnedAt = pinZeebeTime();
+    final var process = Bpmn.createExecutableProcess().startEvent().endEvent().done();
+
+    // when - producing records
+    final var deployResult =
+        zeebeClient.newDeployCommand().addProcessModel(process, "process.bpmn").send().join();
+    zeebeClient
+        .newCreateInstanceCommand()
+        .processDefinitionKey(
+            deployResult.getProcesses().stream()
+                .findFirst()
+                .orElseThrow()
+                .getProcessDefinitionKey())
+        .send()
+        .join();
+
+    // then - records are exported with a timestamp matching the pinned time
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              final var records = searchExportedRecords();
+              assertThat(records).isNotNull();
+              assertThat(records.size())
+                  .isEqualTo(10); // deploy + instance produces exactly 10 records
+              assertThat(records)
+                  .allMatch((record) -> record.getTimestamp() == pinnedAt.toEpochMilli());
+            });
+  }
+
+  @Test
+  void testOffsetTime() throws IOException, InterruptedException {
+    // given - Zeebe actor clock is offset
+    final var beforeRecords = Instant.now();
+    final var offsetZeebeTime = offsetZeebeTime();
+    final var process = Bpmn.createExecutableProcess().startEvent().endEvent().done();
+
+    // when - producing records
+    final var deployResult =
+        zeebeClient.newDeployCommand().addProcessModel(process, "process.bpmn").send().join();
+    zeebeClient
+        .newCreateInstanceCommand()
+        .processDefinitionKey(
+            deployResult.getProcesses().stream()
+                .findFirst()
+                .orElseThrow()
+                .getProcessDefinitionKey())
+        .send()
+        .join();
+
+    // then - records are exported with a timestamp matching the offset time
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              final var records = searchExportedRecords();
+              assertThat(records).isNotNull();
+              assertThat(records.size())
+                  .isEqualTo(10); // deploy + instance produces exactly 10 records
+              assertThat(records)
+                  .allSatisfy(
+                      (record) -> {
+                        final var timestamp = Instant.ofEpochMilli(record.getTimestamp());
+                        final var afterRecords = Instant.now();
+                        assertThat(timestamp).isBefore(afterRecords.plus(offsetZeebeTime));
+                        assertThat(timestamp).isAfter(beforeRecords.plus(offsetZeebeTime));
+                      });
+            });
+  }
+
+  private List<AbstractRecord<?>> searchExportedRecords() throws IOException, InterruptedException {
+    final var uri =
+        URI.create(
+            String.format(
+                "http://%s/%s*/_search",
+                elasticsearchContainer.getHttpHostAddress(), INDEX_PREFIX));
+    final var request = HttpRequest.newBuilder(uri).method("POST", BodyPublishers.noBody()).build();
+    final var response = httpClient.send(request, BodyHandlers.ofInputStream());
+    final var result = mapper.readValue(response.body(), EsSearchResponseDto.class);
+    if (result.documentsWrapper == null) {
+      return null;
+    }
+    return result.documentsWrapper.documents.stream()
+        .map(esDocumentDto -> esDocumentDto.record)
+        .collect(Collectors.toList());
+  }
+
+  private Instant pinZeebeTime() throws IOException, InterruptedException {
+    final var pinAt = Instant.now().minus(Duration.ofDays(1));
+    final var body =
+        BodyPublishers.ofString(String.format("{\"epochMilli\": %s}", pinAt.toEpochMilli()));
+    zeebeRequest("/actuator/clock/pin", body);
+    return pinAt;
+  }
+
+  private Duration offsetZeebeTime() throws IOException, InterruptedException {
+    final var offsetBy = Duration.ofHours(3);
+    final var body =
+        BodyPublishers.ofString(String.format("{\"offsetMilli\": %s}", offsetBy.toMillis()));
+    zeebeRequest("/actuator/clock/add", body);
+    return offsetBy;
+  }
+
+  private void zeebeRequest(final String endpoint, final BodyPublisher body)
+      throws IOException, InterruptedException {
+    final var fullEndpoint =
+        URI.create(
+            String.format("http://%s/%s", zeebeContainer.getExternalAddress(9600), endpoint));
+    final var httpRequest =
+        HttpRequest.newBuilder(fullEndpoint)
+            .method("POST", body)
+            .header("Content-Type", "application/json")
+            .build();
+    final var httpResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
+    if (httpResponse.statusCode() != 200) {
+      throw new IllegalStateException("Pinning time failed: " + httpResponse.body());
+    }
+  }
+
+  void startElasticsearch(final Network network) {
+    final var version = RestClient.class.getPackage().getImplementationVersion();
+    elasticsearchContainer =
+        new ElasticsearchContainer(
+                DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+                    .withTag(version))
+            .withNetwork(network)
+            .withNetworkAliases("elasticsearch")
+            .withCreateContainerCmdModifier(
+                cmd ->
+                    Objects.requireNonNull(cmd.getHostConfig())
+                        .withMemory((long) (1024 * 1024 * 1024)));
+    elasticsearchContainer.start();
+  }
+
+  private void startZeebe(final Network network) {
+    zeebeContainer =
+        new ZeebeContainer(DockerImageName.parse("camunda/zeebe:current-test"))
+            .withNetwork(network)
+            .withEnv(
+                "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME",
+                "io.camunda.zeebe.exporter.ElasticsearchExporter")
+            .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL", "http://elasticsearch:9200")
+            .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_DELAY", "1")
+            .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_SIZE", "1")
+            .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_PREFIX", INDEX_PREFIX)
+            .withEnv("ZEEBE_CLOCK_CONTROLLED", "true");
+    zeebeContainer.start();
+    zeebeClient =
+        ZeebeClient.newClientBuilder()
+            .usePlaintext()
+            .gatewayAddress(zeebeContainer.getExternalGatewayAddress())
+            .build();
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class EsDocumentDto {
+    @JsonProperty(value = "_source", required = true)
+    AbstractRecord<?> record;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class EsSearchResponseDto {
+    @JsonProperty(value = "hits", required = true)
+    DocumentsWrapper documentsWrapper;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static final class DocumentsWrapper {
+      @JsonProperty(value = "hits", required = true)
+      final List<EsDocumentDto> documents = Collections.emptyList();
+    }
+  }
+}

--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -67,6 +67,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.msgpack</groupId>
       <artifactId>jackson-dataformat-msgpack</artifactId>
     </dependency>

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/actuator/ClockActuatorClient.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/actuator/ClockActuatorClient.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.actuator;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublisher;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.time.Instant;
+
+public class ClockActuatorClient {
+  private final HttpClient httpClient = HttpClient.newBuilder().build();
+  private final ObjectWriter objectWriter = new ObjectMapper().writer();
+  private final String zeebeMonitoringAddress;
+
+  public ClockActuatorClient(final String zeebeMonitoringAddress) {
+    this.zeebeMonitoringAddress = zeebeMonitoringAddress;
+  }
+
+  public void resetZeebeTime() throws IOException, InterruptedException {
+    zeebeRequest("DELETE", "/actuator/clock", null);
+  }
+
+  public Instant pinZeebeTime(final Instant pinAt) throws IOException, InterruptedException {
+    zeebeRequest("POST", "/actuator/clock/pin", new PinRequestDto(pinAt));
+    return pinAt;
+  }
+
+  public Duration offsetZeebeTime(final Duration offsetBy)
+      throws IOException, InterruptedException {
+    zeebeRequest("POST", "/actuator/clock/add", new OffsetRequestDto(offsetBy));
+    return offsetBy;
+  }
+
+  private void zeebeRequest(final String method, final String endpoint, final RequestDto requestDto)
+      throws IOException, InterruptedException {
+    final var uri = URI.create(String.format("http://%s/%s", zeebeMonitoringAddress, endpoint));
+    final BodyPublisher body;
+    if (requestDto == null) {
+      body = BodyPublishers.noBody();
+    } else {
+      body = BodyPublishers.ofByteArray(objectWriter.writeValueAsBytes(requestDto));
+    }
+    final var httpRequest =
+        HttpRequest.newBuilder(uri)
+            .method(method, body)
+            .header("Content-Type", "application/json")
+            .build();
+    final var httpResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
+    if (httpResponse.statusCode() != 200) {
+      throw new IllegalStateException("Pinning time failed: " + httpResponse.body());
+    }
+  }
+
+  private static final class PinRequestDto implements RequestDto {
+    @JsonProperty("epochMilli")
+    private final long epochMilli;
+
+    private PinRequestDto(final Instant pinAt) {
+      epochMilli = pinAt.toEpochMilli();
+    }
+  }
+
+  private static final class OffsetRequestDto implements RequestDto {
+    @JsonProperty("offsetMilli")
+    private final long offsetMilli;
+
+    private OffsetRequestDto(final Duration offsetBy) {
+      offsetMilli = offsetBy.toMillis();
+    }
+  }
+
+  private interface RequestDto {}
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
