### PR TITLE
Replace fmt-plugin with Spotless

### DIFF
--- a/.ci/scripts/distribution/analyse-java.sh
+++ b/.ci/scripts/distribution/analyse-java.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ef -o pipefail
 
-PROPERTIES=("-DskipTests -Dcheckstyle.skip")
+PROPERTIES=("-DskipTests -Dcheckstyle.skip -DautoFormat=false -DcheckFormat")
 GIT_URL=${GIT_URL:-$(git remote get-url origin)}
 GIT_BRANCH=${GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
 

--- a/.ci/scripts/distribution/analyse-java.sh
+++ b/.ci/scripts/distribution/analyse-java.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ef -o pipefail
 
-PROPERTIES=("-DskipTests -Dcheckstyle.skip -DautoFormat=false -DcheckFormat")
+PROPERTIES=("-DskipTests -Dcheckstyle.skip")
 GIT_URL=${GIT_URL:-$(git remote get-url origin)}
 GIT_BRANCH=${GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
 
@@ -33,4 +33,4 @@ else
 fi
 
 echo "Properties: ${PROPERTIES[@]}"
-mvn -B -s ${MAVEN_SETTINGS_XML} -P sonar sonar:sonar ${PROPERTIES[@]}
+mvn -B -s ${MAVEN_SETTINGS_XML} -P sonar -PcheckFormat,-autoFormat sonar:sonar ${PROPERTIES[@]}

--- a/.ci/scripts/distribution/build-java.sh
+++ b/.ci/scripts/distribution/build-java.sh
@@ -4,4 +4,4 @@
 LIMITS_CPU=${LIMITS_CPU:-$(getconf _NPROCESSORS_ONLN)}
 MAVEN_PARALLELISM=${MAVEN_PARALLELISM:-$LIMITS_CPU}
 
-mvn -B -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} -DskipTests clean install -Pspotbugs,prepare-offline -DautoFormat=false -DcheckFormat
+mvn -B -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} -DskipTests clean install -Pspotbugs,prepare-offline -PcheckFormat,-autoFormat

--- a/.ci/scripts/distribution/build-java.sh
+++ b/.ci/scripts/distribution/build-java.sh
@@ -4,4 +4,4 @@
 LIMITS_CPU=${LIMITS_CPU:-$(getconf _NPROCESSORS_ONLN)}
 MAVEN_PARALLELISM=${MAVEN_PARALLELISM:-$LIMITS_CPU}
 
-mvn -B -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} -DskipTests clean install -Pchecks,spotbugs,prepare-offline
+mvn -B -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} -DskipTests clean install -Pspotbugs,prepare-offline -DautoFormat=false -DcheckFormat

--- a/.ci/scripts/release/build-java.sh
+++ b/.ci/scripts/release/build-java.sh
@@ -2,4 +2,4 @@
 
 export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
 
-mvn -B -s ${MAVEN_SETTINGS_XML} -DskipTests clean install -Pchecks,prepare-offline
+mvn -B -s ${MAVEN_SETTINGS_XML} -DskipTests clean install -Pprepare-offline -DautoFormat=false -DcheckFormat

--- a/.ci/scripts/release/build-java.sh
+++ b/.ci/scripts/release/build-java.sh
@@ -2,4 +2,4 @@
 
 export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
 
-mvn -B -s ${MAVEN_SETTINGS_XML} -DskipTests clean install -Pprepare-offline -DautoFormat=false -DcheckFormat
+mvn -B -s ${MAVEN_SETTINGS_XML} -DskipTests clean install -Pprepare-offline -PcheckFormat,-autoFormat

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -3,4 +3,4 @@ extraction:
    index:
      java_version: "11"
      build_command:
-       mvn clean install -DskipTests -DskipChecks -DautoFormat=false
+       mvn clean install -DskipTests -DskipChecks -P-autoFormat

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -2,3 +2,5 @@ extraction:
  java:
    index:
      java_version: "11"
+     build_command:
+       mvn clean install -DskipTests -DskipChecks -DautoFormat=false

--- a/benchmarks/project/pom.xml
+++ b/benchmarks/project/pom.xml
@@ -123,11 +123,6 @@
       </plugin>
 
       <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>

--- a/benchmarks/project/pom.xml
+++ b/benchmarks/project/pom.xml
@@ -124,8 +124,8 @@
       </plugin>
 
       <plugin>
-        <groupId>com.coveo</groupId>
-        <artifactId>fmt-maven-plugin</artifactId>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
       </plugin>
 
       <plugin>

--- a/benchmarks/project/pom.xml
+++ b/benchmarks/project/pom.xml
@@ -32,7 +32,6 @@
     <!-- maven plugin versions -->
     <plugin.version.exec>1.6.0</plugin.version.exec>
     <plugin.version.shade>3.2.1</plugin.version.shade>
-    <plugin.version.fmt>2.9</plugin.version.fmt>
     <plugin.version.license>3.0</plugin.version.license>
   </properties>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1220,7 +1220,6 @@
             </execution>
           </executions>
         </plugin>
-        
 
         <!-- protobuf generation -->
         <plugin>
@@ -1746,11 +1745,11 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>com.coveo</groupId>
-            <artifactId>fmt-maven-plugin</artifactId>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
             <executions>
               <execution>
-                <id>format</id>
+                <id>spotless-check</id>
                 <goals>
                   <goal>check</goal>
                 </goals>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1202,6 +1202,7 @@
           <artifactId>spotless-maven-plugin</artifactId>
           <version>${plugin.version.spotless}</version>
           <configuration>
+            <ratchetFrom>origin/develop</ratchetFrom>
             <java>
               <googleJavaFormat>
                 <version>1.12.0</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -971,18 +971,6 @@
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
           <version>${plugin.version.sortpom}</version>
-          <executions>
-            <execution>
-              <id>sortpom</id>
-              <goals>
-                <goal>sort</goal>
-              </goals>
-              <phase>process-resources</phase>
-              <configuration>
-                <createBackupFile>false</createBackupFile>
-              </configuration>
-            </execution>
-          </executions>
         </plugin>
 
         <!-- Unit tests -->
@@ -1706,6 +1694,22 @@
                   <goal>apply</goal>
                 </goals>
                 <phase>process-sources</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>com.github.ekryd.sortpom</groupId>
+            <artifactId>sortpom-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>sortpom</id>
+                <goals>
+                  <goal>sort</goal>
+                </goals>
+                <phase>process-resources</phase>
+                <configuration>
+                  <createBackupFile>false</createBackupFile>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -158,10 +158,6 @@
     <skipITs>${skipTests}</skipITs>
     <jacoco.skip>${skipUTs}</jacoco.skip>
 
-    <!-- these properties allow us to enable disable the formatting profiles -->
-    <autoFormat>true</autoFormat>
-    <checkFormat>false</checkFormat>
-
     <!--
       you can use the following to disable specific check plugins. this can also be used to skip the
       formatting goals of these plugins. the approach taken is to use a single new property,
@@ -1658,13 +1654,7 @@
     <profile>
       <id>autoFormat</id>
       <activation>
-        <!-- the autoFormat property is true by default, but seems to not be read here, so we need
-        to activate this by default specifically -->
         <activeByDefault>true</activeByDefault>
-        <property>
-          <name>autoFormat</name>
-          <value>true</value>
-        </property>
       </activation>
       <build>
         <plugins>
@@ -1720,14 +1710,6 @@
     <!-- profile to perform strict validation checks -->
     <profile>
       <id>checkFormat</id>
-      <activation>
-        <!-- generally only the CI pipeline needs to be strict -->
-        <activeByDefault>false</activeByDefault>
-        <property>
-          <name>checkFormat</name>
-          <value>true</value>
-        </property>
-      </activation>
       <build>
         <plugins>
           <plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -176,6 +176,8 @@
     <enforcer.skip>${skipChecks}</enforcer.skip>
     <mdep.analyze.skip>${skipChecks}</mdep.analyze.skip>
     <sort.skip>${skipChecks}</sort.skip>
+    <spotless.apply.skip>${skipChecks}</spotless.apply.skip>
+    <spotless.checks.skip>${skipChecks}</spotless.checks.skip>
   </properties>
 
   <dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -118,7 +118,6 @@
     <plugin.version.compiler>3.8.1</plugin.version.compiler>
     <plugin.version.exec>3.0.0</plugin.version.exec>
     <plugin.version.failsafe>3.0.0-M5</plugin.version.failsafe>
-    <plugin.version.fmt>2.12</plugin.version.fmt>
     <plugin.version.license>4.1</plugin.version.license>
     <plugin.version.protobuf-maven-plugin>0.6.1</plugin.version.protobuf-maven-plugin>
     <plugin.version.proto-backwards-compatibility>1.0.7</plugin.version.proto-backwards-compatibility>
@@ -171,7 +170,6 @@
     <license.skip>${skipChecks}</license.skip>
     <enforcer.skip>${skipChecks}</enforcer.skip>
     <mdep.analyze.skip>${skipChecks}</mdep.analyze.skip>
-    <fmt.skip>${skipChecks}</fmt.skip>
     <sort.skip>${skipChecks}</sort.skip>
   </properties>
 
@@ -1183,21 +1181,6 @@
 
         <!-- Google code format plugin -->
         <plugin>
-          <groupId>com.coveo</groupId>
-          <artifactId>fmt-maven-plugin</artifactId>
-          <version>${plugin.version.fmt}</version>
-          <executions>
-            <execution>
-              <id>format</id>
-              <goals>
-                <goal>format</goal>
-              </goals>
-              <phase>process-sources</phase>
-            </execution>
-          </executions>
-        </plugin>
-
-        <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
           <version>${plugin.version.spotless}</version>
@@ -1695,32 +1678,6 @@
                   <goal>sonar</goal>
                 </goals>
                 <phase>verify</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <!-- profile to disable the fmt-plugin on unsupported jdks -->
-    <profile>
-      <id>fmt-plugin</id>
-      <activation>
-        <jdk>[,9)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.coveo</groupId>
-            <artifactId>fmt-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>format</id>
-                <goals>
-                  <goal>check</goal>
-                  <goal>format</goal>
-                </goals>
-                <phase>none</phase>
               </execution>
             </executions>
           </plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -116,28 +116,28 @@
     <plugin.version.build-helper>3.2.0</plugin.version.build-helper>
     <plugin.version.checkstyle>3.1.2</plugin.version.checkstyle>
     <plugin.version.compiler>3.8.1</plugin.version.compiler>
+    <plugin.version.dependency-analyzer>1.11.1</plugin.version.dependency-analyzer>
+    <plugin.version.dependency>3.1.2</plugin.version.dependency>
+    <plugin.version.enforcer>3.0.0-M3</plugin.version.enforcer>
     <plugin.version.exec>3.0.0</plugin.version.exec>
     <plugin.version.failsafe>3.0.0-M5</plugin.version.failsafe>
+    <plugin.version.flaky-tests>2.0.3</plugin.version.flaky-tests>
+    <plugin.version.jacoco>0.8.7</plugin.version.jacoco>
     <plugin.version.license>4.1</plugin.version.license>
-    <plugin.version.protobuf-maven-plugin>0.6.1</plugin.version.protobuf-maven-plugin>
+    <plugin.version.maven-jar>3.2.0</plugin.version.maven-jar>
     <plugin.version.proto-backwards-compatibility>1.0.7</plugin.version.proto-backwards-compatibility>
+    <plugin.version.protobuf-maven-plugin>0.6.1</plugin.version.protobuf-maven-plugin>
     <plugin.version.replacer>1.5.3</plugin.version.replacer>
     <plugin.version.resources>3.2.0</plugin.version.resources>
+    <plugin.version.revapi>0.14.5</plugin.version.revapi>
     <plugin.version.scala>4.5.4</plugin.version.scala>
     <plugin.version.shade>3.2.4</plugin.version.shade>
-    <plugin.version.surefire>3.0.0-M5</plugin.version.surefire>
-    <plugin.version.versions>2.8.1</plugin.version.versions>
-    <plugin.version.enforcer>3.0.0-M3</plugin.version.enforcer>
-    <plugin.version.dependency>3.1.2</plugin.version.dependency>
-    <plugin.version.spotbugs>4.4.2.2</plugin.version.spotbugs>
     <plugin.version.sonar>3.9.0.2155</plugin.version.sonar>
     <plugin.version.sortpom>3.0.0</plugin.version.sortpom>
-    <plugin.version.maven-jar>3.2.0</plugin.version.maven-jar>
-    <plugin.version.dependency-analyzer>1.11.1</plugin.version.dependency-analyzer>
-    <plugin.version.jacoco>0.8.7</plugin.version.jacoco>
-    <plugin.version.revapi>0.14.5</plugin.version.revapi>
-    <plugin.version.flaky-tests>2.0.3</plugin.version.flaky-tests>
+    <plugin.version.spotbugs>4.4.2.2</plugin.version.spotbugs>
     <plugin.version.spotless>2.17.3</plugin.version.spotless>
+    <plugin.version.surefire>3.0.0-M5</plugin.version.surefire>
+    <plugin.version.versions>2.8.1</plugin.version.versions>
 
     <!-- maven extensions -->
     <extension.version.os-maven-plugin>1.7.0</extension.version.os-maven-plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -931,7 +931,7 @@
               <goals>
                 <goal>format</goal>
               </goals>
-              <phase>compile</phase>
+              <phase>process-sources</phase>
             </execution>
           </executions>
         </plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1202,7 +1202,6 @@
           <artifactId>spotless-maven-plugin</artifactId>
           <version>${plugin.version.spotless}</version>
           <configuration>
-            <ratchetFrom>origin/develop</ratchetFrom>
             <java>
               <googleJavaFormat>
                 <version>1.12.0</version>
@@ -1217,6 +1216,9 @@
                 <goal>apply</goal>
               </goals>
               <phase>process-sources</phase>
+              <configuration>
+                <ratchetFrom>origin/develop</ratchetFrom>
+              </configuration>
             </execution>
           </executions>
         </plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -925,15 +925,6 @@
               <java>SLASHSTAR_STYLE</java>
             </mapping>
           </configuration>
-          <executions>
-            <execution>
-              <id>add-license</id>
-              <goals>
-                <goal>format</goal>
-              </goals>
-              <phase>process-sources</phase>
-            </execution>
-          </executions>
         </plugin>
 
         <!-- CHECKSTYLE -->
@@ -1689,6 +1680,19 @@
       </activation>
       <build>
         <plugins>
+          <plugin>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-license</id>
+                <goals>
+                  <goal>format</goal>
+                </goals>
+                <phase>process-sources</phase>
+              </execution>
+            </executions>
+          </plugin>
           <plugin>
             <groupId>com.diffplug.spotless</groupId>
             <artifactId>spotless-maven-plugin</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -158,11 +158,16 @@
     <skipITs>${skipTests}</skipITs>
     <jacoco.skip>${skipUTs}</jacoco.skip>
 
+    <!-- these properties allow us to enable disable the formatting profiles -->
+    <autoFormat>true</autoFormat>
+    <checkFormat>false</checkFormat>
+
     <!--
-      you can use the following to disable specific checks. the approach taken is to use a single
-      new property, skipChecks, which is the default value for pre-defined properties such as
-      checkstyle.skip. that way, you can use skipChecks, but you can also still use checkstyle.skip
-      if you only want to disable checkstyle
+      you can use the following to disable specific check plugins. this can also be used to skip the
+      formatting goals of these plugins. the approach taken is to use a single new property,
+      skipChecks, which is the default value for pre-defined properties such as checkstyle.skip.
+      that way, you can use skipChecks, but you can also still use checkstyle.skip if you only want
+      to disable checkstyle
       -->
     <skipChecks>false</skipChecks>
     <checkstyle.skip>${skipChecks}</checkstyle.skip>
@@ -1192,18 +1197,6 @@
               </googleJavaFormat>
             </java>
           </configuration>
-          <executions>
-            <execution>
-              <id>spotless-format</id>
-              <goals>
-                <goal>apply</goal>
-              </goals>
-              <phase>process-sources</phase>
-              <configuration>
-                <ratchetFrom>origin/develop</ratchetFrom>
-              </configuration>
-            </execution>
-          </executions>
         </plugin>
 
         <!-- protobuf generation -->
@@ -1387,11 +1380,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
       </plugin>
 
       <plugin>
@@ -1685,9 +1673,51 @@
       </build>
     </profile>
 
+    <!-- profile to auto format -->
+    <profile>
+      <id>autoFormat</id>
+      <activation>
+        <!-- the autoFormat property is true by default, but seems to not be read here, so we need
+        to activate this by default specifically -->
+        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>autoFormat</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <configuration>
+              <ratchetFrom>origin/develop</ratchetFrom>
+            </configuration>
+            <executions>
+              <execution>
+                <id>spotless-format</id>
+                <goals>
+                  <goal>apply</goal>
+                </goals>
+                <phase>process-sources</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <!-- profile to perform strict validation checks -->
     <profile>
-      <id>checks</id>
+      <id>checkFormat</id>
+      <activation>
+        <!-- generally only the CI pipeline needs to be strict -->
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>checkFormat</name>
+          <value>true</value>
+        </property>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -138,6 +138,7 @@
     <plugin.version.jacoco>0.8.7</plugin.version.jacoco>
     <plugin.version.revapi>0.14.5</plugin.version.revapi>
     <plugin.version.flaky-tests>2.0.3</plugin.version.flaky-tests>
+    <plugin.version.spotless>2.17.3</plugin.version.spotless>
 
     <!-- maven extensions -->
     <extension.version.os-maven-plugin>1.7.0</extension.version.os-maven-plugin>
@@ -1196,6 +1197,30 @@
           </executions>
         </plugin>
 
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>${plugin.version.spotless}</version>
+          <configuration>
+            <java>
+              <googleJavaFormat>
+                <version>1.12.0</version>
+                <style>GOOGLE</style>
+              </googleJavaFormat>
+            </java>
+          </configuration>
+          <executions>
+            <execution>
+              <id>spotless-format</id>
+              <goals>
+                <goal>apply</goal>
+              </goals>
+              <phase>process-sources</phase>
+            </execution>
+          </executions>
+        </plugin>
+        
+
         <!-- protobuf generation -->
         <plugin>
           <groupId>org.xolstice.maven.plugins</groupId>
@@ -1380,8 +1405,8 @@
       </plugin>
 
       <plugin>
-        <groupId>com.coveo</groupId>
-        <artifactId>fmt-maven-plugin</artifactId>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Replaces the `com.coveo:fmt-maven-plugin` plugin with [spotless](https://github.com/diffplug/spotless/tree/main/plugin-maven) and cleans up our build profiles regarding auto-formatting and formatting checks.

The fmt-plugin seems to no longer be maintained, or at least it is no longer maintained as well as other plugins. See https://github.com/camunda-cloud/zeebe/issues/7930#issuecomment-934258554. 

Switching to spotless means switching to an actively maintained project. Using it allows us to update the google-format to v1.12. Spotless works on our jdk8 build. Spotless supports [ratcheting](https://github.com/diffplug/spotless/tree/main/plugin-maven#how-can-i-enforce-formatting-gradually-aka-ratchet) to speed up our builds (~10s per build on our local measurements, should be at least 4 hours per year for our team 🎉 ) and might allow us to replace the different plugins we use related to formatting (sortpom, license, etc) with 1 plugin. We could even add markdown support in the future with some additional effort from our side.

This PR switches the fmt-plugin for the spotless plugin, updates the google-format to v1.12.0, enables ratcheting for faster local builds and disables the auto formatting on our CI pipeline.

It makes sense to review this PR on a per-commit basis.

## Related issues

<!-- Which issues are closed by this PR or are related -->

This is the result of slacktime for @oleschoenburg and @korthout.

relates to #7930 
relates to #7508 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [x] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)