### PR TITLE
Synchronize DB access

### DIFF
--- a/benchmarks/setup/pihme-hardening-synchronized/Makefile
+++ b/benchmarks/setup/pihme-hardening-synchronized/Makefile
@@ -1,0 +1,64 @@
+namespace ?= pihme-hardening-synchronized
+
+.PHONY: all
+all: zeebe starter timer simpleStarter worker
+
+.PHONY: zeebe
+zeebe:
+	-helm install --namespace $(namespace) $(namespace) zeebe/zeebe-cluster-helm -f zeebe-values.yaml --skip-crds
+	-kubectl apply -n $(namespace) -f curator-cronjob.yaml
+	-kubectl apply -n $(namespace) -f curator-configmap.yaml
+
+# Generates templates from the zeebe helm charts, useful to make some more specific changes which are not doable by the values file.
+# To apply the templates use k apply -f zeebe-cluster/templates/
+.PHONY: zeebe-template
+zeebe-template:
+	-helm template $(namespace) zeebe/zeebe-cluster-helm -f zeebe-values.yaml --skip-crds --output-dir .
+
+.PHONY: update
+update:
+	-helm upgrade --namespace $(namespace) $(namespace) zeebe/zeebe-cluster-helm -f zeebe-values.yaml
+
+.PHONY: starter
+starter:
+	kubectl apply -n $(namespace) -f starter.yaml
+
+.PHONY: timer
+timer:
+	kubectl apply -n $(namespace) -f timer.yaml
+
+.PHONY: simpleStarter
+simpleStarter:
+	kubectl apply -n $(namespace) -f simpleStarter.yaml
+
+.PHONY: worker
+worker:
+	kubectl apply -n $(namespace) -f worker.yaml
+
+
+.PHONY: clean
+clean: clean-starter clean-timer clean-simpleStarter clean-worker clean-zeebe
+
+.PHONY: clean-zeebe
+clean-zeebe:
+	-helm --namespace $(namespace) uninstall $(namespace)
+	-kubectl delete -n $(namespace) -f curator-cronjob.yaml
+	-kubectl delete -n $(namespace) -f curator-configmap.yaml
+	-kubectl delete -n $(namespace) pvc -l app.kubernetes.io/instance=$(namespace)
+	-kubectl delete -n $(namespace) pvc -l app=elasticsearch-master
+
+.PHONY: clean-starter
+clean-starter:
+	-kubectl delete -n $(namespace) -f starter.yaml
+
+.PHONY: clean-timer
+clean-timer:
+	-kubectl delete -n $(namespace) -f timer.yaml
+
+.PHONY: clean-simpleStarter
+clean-simpleStarter:
+	-kubectl delete -n $(namespace) -f simpleStarter.yaml
+
+.PHONY: clean-worker
+clean-worker:
+	-kubectl delete -n $(namespace) -f worker.yaml

--- a/benchmarks/setup/pihme-hardening-synchronized/curator-configmap.yaml
+++ b/benchmarks/setup/pihme-hardening-synchronized/curator-configmap.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: curator-config
+  labels:
+    app: curator
+data:
+  action_file.yml: |-
+    ---
+    # Remember, leave a key empty if there is no value.  None will be a string,
+    # not a Python "NoneType"
+    #
+    # Also remember that all examples have 'disable_action' set to True.  If you
+    # want to use this action as a template, be sure to set this to False after
+    # copying it.
+    actions:
+      # delete indicies which are older then one day
+      1:
+        action: delete_indices
+        description: "Clean up ES by deleting old indices"
+        options:
+          timeout_override:
+          continue_if_exception: False
+          disable_action: False
+          ignore_empty_list: True
+        filters:
+        - filtertype: age
+          source: name
+          direction: older
+          timestring: '%Y-%m-%d'
+          unit: days
+          unit_count: 1
+          field:
+          stats_result:
+          epoch:
+          exclude: False
+      # or delete indicies which exceed the total size of 10 gig
+      2:
+        action: delete_indices
+        description: "Clean up ES by deleting old indices"
+        options:
+          timeout_override:
+          continue_if_exception: False
+          disable_action: False
+          ignore_empty_list: True
+        filters:
+        - filtertype: space
+          disk_space: 10
+          source: name
+          timestring: '%Y-%m-%d'
+  config.yml: |-
+    ---
+    # Remember, leave a key empty if there is no value.  None will be a string,
+    # not a Python "NoneType"
+    client:
+      hosts:
+        - elasticsearch-master-headless
+      port: 9200
+      url_prefix:
+      use_ssl: False
+      certificate:
+      client_cert:
+      client_key:
+      ssl_no_validate: False
+      http_auth:
+      timeout: 30
+      master_only: False
+    logging:
+      loglevel: INFO
+      logfile:
+      logformat: default
+      blacklist: ['elasticsearch', 'urllib3']

--- a/benchmarks/setup/pihme-hardening-synchronized/curator-cronjob.yaml
+++ b/benchmarks/setup/pihme-hardening-synchronized/curator-cronjob.yaml
@@ -1,0 +1,29 @@
+# https://medium.com/@hagaibarel/running-curator-as-a-kubernetes-cronjob-19eaab9afd3b
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: curator
+  labels:
+    app: curator
+spec:
+  schedule: "*/15 * * * *" # at every 15th minute
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - image: bobrik/curator:5.7.6
+            name: curator
+            args: ["--config", "/etc/config/config.yml", "/etc/config/action_file.yml"]
+            volumeMounts:
+            - name: config
+              mountPath: /etc/config
+          volumes:
+          - name: config
+            configMap:
+              name: curator-config
+          restartPolicy: OnFailure

--- a/benchmarks/setup/pihme-hardening-synchronized/simpleStarter.yaml
+++ b/benchmarks/setup/pihme-hardening-synchronized/simpleStarter.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  labels:
+    app: simple
+spec:
+  selector:
+    matchLabels:
+      app: simple
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: simple
+    spec:
+      containers:
+      - name: simple
+        image: gcr.io/zeebe-io/starter:SNAPSHOT
+        imagePullPolicy: Always
+        env:
+          - name: JAVA_OPTIONS
+            value: >-
+              -Dapp.brokerUrl=pihme-hardening-synchronized-zeebe-gateway:26500
+              -Dapp.starter.rate=300
+              -Dzeebe.client.requestTimeout=62000
+              -XX:+HeapDumpOnOutOfMemoryError
+              -Dapp.starter.bpmnXmlPath=bpmn/simpleProcess.bpmn
+              -Dapp.starter.processId=simpleProcess
+          - name: LOG_LEVEL
+            value: "warn"
+        resources:
+          limits:
+            cpu: 2
+            memory: 2Gi
+          requests:
+            cpu: 2
+            memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: zeebe
+    app.kubernetes.io/instance: pihme-hardening-synchronized
+    app.kubernetes.io/name: zeebe-cluster
+  name: simple
+spec:
+  clusterIP: None
+  ports:
+  - name: http
+    port: 9600
+    protocol: TCP
+    targetPort: 9600
+  publishNotReadyAddresses: true
+  selector:
+    app: simple
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/benchmarks/setup/pihme-hardening-synchronized/starter.yaml
+++ b/benchmarks/setup/pihme-hardening-synchronized/starter.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+    spec:
+      containers:
+      - name: starter
+        image: gcr.io/zeebe-io/starter:SNAPSHOT
+        imagePullPolicy: Always
+        env:
+          - name: JAVA_OPTIONS
+            value: >-
+              -Dapp.brokerUrl=pihme-hardening-synchronized-zeebe-gateway:26500
+              -Dapp.starter.rate=200
+              -Dapp.starter.durationLimit=0
+              -Dzeebe.client.requestTimeout=62000
+              -XX:+HeapDumpOnOutOfMemoryError
+          - name: LOG_LEVEL
+            value: "warn"
+        resources:
+          limits:
+            cpu: 2
+            memory: 2Gi
+          requests:
+            cpu: 2
+            memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: zeebe
+    app.kubernetes.io/instance: pihme-hardening-synchronized
+    app.kubernetes.io/name: zeebe-cluster
+  name: starter
+spec:
+  clusterIP: None
+  ports:
+  - name: http
+    port: 9600
+    protocol: TCP
+    targetPort: 9600
+  publishNotReadyAddresses: true
+  selector:
+    app: starter
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/benchmarks/setup/pihme-hardening-synchronized/timer.yaml
+++ b/benchmarks/setup/pihme-hardening-synchronized/timer.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: timer
+  labels:
+    app: timer
+spec:
+  selector:
+    matchLabels:
+      app: timer
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: timer
+    spec:
+      containers:
+      - name: timer
+        image: gcr.io/zeebe-io/starter:SNAPSHOT
+        imagePullPolicy: Always
+        env:
+          - name: JAVA_OPTIONS
+            value: >-
+              -Dapp.brokerUrl=pihme-hardening-synchronized-zeebe-gateway:26500
+              -Dapp.starter.rate=300
+              -Dzeebe.client.requestTimeout=62000
+              -XX:+HeapDumpOnOutOfMemoryError
+              -Dapp.starter.bpmnXmlPath=bpmn/timerProcess.bpmn
+              -Dapp.starter.processId=timerProcess
+          - name: LOG_LEVEL
+            value: "warn"
+        resources:
+          limits:
+            cpu: 2
+            memory: 2Gi
+          requests:
+            cpu: 2
+            memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: zeebe
+    app.kubernetes.io/instance: pihme-hardening-synchronized
+    app.kubernetes.io/name: zeebe-cluster
+  name: timer
+spec:
+  clusterIP: None
+  ports:
+  - name: http
+    port: 9600
+    protocol: TCP
+    targetPort: 9600
+  publishNotReadyAddresses: true
+  selector:
+    app: timer
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/benchmarks/setup/pihme-hardening-synchronized/worker.yaml
+++ b/benchmarks/setup/pihme-hardening-synchronized/worker.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 12
+  template:
+    metadata:
+      labels:
+        app: worker
+    spec:
+      containers:
+      - name: worker
+        image: gcr.io/zeebe-io/worker:SNAPSHOT
+        imagePullPolicy: Always
+        env:
+          - name: JAVA_OPTIONS
+            value: >-
+              -Dapp.brokerUrl=pihme-hardening-synchronized-zeebe-gateway:26500
+              -Dzeebe.client.requestTimeout=62000
+              -Dapp.worker.capacity=120
+              -Dapp.worker.pollingDelay=1ms
+              -Dapp.worker.completionDelay=50ms
+              -XX:+HeapDumpOnOutOfMemoryError
+          - name: LOG_LEVEL
+            value: "warn"
+        resources:
+          limits:
+            cpu: 4
+            memory: 2Gi
+          requests:
+            cpu: 1
+            memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: zeebe
+    app.kubernetes.io/instance: pihme-hardening-synchronized
+    app.kubernetes.io/name: zeebe-cluster
+  name: worker
+spec:
+  clusterIP: None
+  ports:
+  - name: http
+    port: 9600
+    protocol: TCP
+    targetPort: 9600
+  publishNotReadyAddresses: true
+  selector:
+    app: worker
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/benchmarks/setup/pihme-hardening-synchronized/zeebe-values.yaml
+++ b/benchmarks/setup/pihme-hardening-synchronized/zeebe-values.yaml
@@ -1,0 +1,133 @@
+image:
+  repository: gcr.io/zeebe-io/zeebe
+  tag: pihme-hardening-synchronized
+  pullPolicy: Always
+
+# ZEEBE CFG
+clusterSize: 3
+partitionCount: 3
+replicationFactor: 3
+cpuThreadCount: 4
+ioThreadCount: 4
+gatewayMetrics: true
+
+podSecurityContext:
+  capabilities:
+        add: ["NET_ADMIN"]
+
+gateway:
+  replicas: 1
+  logLevel: debug
+  env:
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe-gateway
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
+    - name: ZEEBE_LOG_LEVEL
+      value: DEBUG
+    - name: ZEEBE_GATEWAY_MONITORING_ENABLED
+      value: "true"
+    - name: ZEEBE_GATEWAY_THREADS_MANAGEMENTTHREADS
+      value: "4"
+  resources:
+    limits:
+      cpu: 2
+      memory: 2Gi
+    requests:
+      cpu: 2
+      memory: 1Gi
+
+# Uncomment to add custom YAML configuration
+# This will overwrite anything at the application.yml location
+# zeebeCfg: {}
+
+# JavaOpts:
+# DEFAULTS
+JavaOpts: >-
+  -XX:MaxRAMPercentage=25.0
+  -XX:+ExitOnOutOfMemoryError
+  -XX:+HeapDumpOnOutOfMemoryError
+  -XX:HeapDumpPath=/usr/local/zeebe/data
+  -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log
+  -Xlog:gc*:file=/usr/local/zeebe/data/gc.log:time:filecount=7,filesize=8M
+
+# Environment variables
+env:
+  # Enable JSON logging for google cloud stackdriver
+  - name: ZEEBE_LOG_APPENDER
+    value: Stackdriver
+  - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+    value: zeebe-broker
+  - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+  # Avoid tons of noise when exporting larger payloads
+  - name: ZEEBE_BROKER_EXECUTION_METRICS_EXPORTER_ENABLED
+    value: "true"
+  - name: ATOMIX_LOG_LEVEL
+    value: INFO
+  - name: ZEEBE_LOG_LEVEL
+    value: DEBUG
+  - name: ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK
+    value: "0.8"
+  - name: ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK
+    value: "0.9"
+
+# RESOURCES
+resources:
+  limits:
+    cpu: 5
+    memory: 12Gi
+  requests:
+    cpu: 5
+    memory: 12Gi
+
+# PVC
+pvcAccessMode: ["ReadWriteOnce"]
+pvcSize: 128Gi
+pvcStorageClassName: ssd
+
+
+# ELASTIC
+elasticsearch:
+  enabled: true
+  imageTag: 7.13.2
+
+  replicas: 3
+  minimumMasterNodes: 2
+
+  volumeClaimTemplate:
+    accessModes: [ "ReadWriteOnce" ]
+    storageClassName: "ssd"
+    resources:
+      requests:
+        storage: 50Gi
+
+  esJavaOpts: "-Xmx4g -Xms4g"
+
+  resources:
+    requests:
+      cpu: 3
+      memory: 8Gi
+    limits:
+      cpu: 3
+      memory: 8Gi
+
+# KIBANA
+kibana:
+  enabled: false
+
+# PROMETHEUS
+prometheus:
+  enabled: false
+
+  servicemonitor:
+    enabled: true
+

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ZeebeDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ZeebeDbState.java
@@ -184,11 +184,6 @@ public class ZeebeDbState implements MutableZeebeState {
   }
 
   @Override
-  public KeyGenerator getKeyGenerator() {
-    return keyGenerator;
-  }
-
-  @Override
   public MutablePendingMessageSubscriptionState getPendingMessageSubscriptionState() {
     return messageSubscriptionState;
   }
@@ -199,12 +194,22 @@ public class ZeebeDbState implements MutableZeebeState {
   }
 
   @Override
+  public KeyGenerator getKeyGenerator() {
+    return keyGenerator;
+  }
+
+  @Override
+  public MutableLastProcessedPositionState getLastProcessedPositionState() {
+    return lastProcessedPositionState;
+  }
+
+  @Override
   public int getPartitionId() {
     return partitionId;
   }
 
   @Override
-  public boolean isEmpty(final ZbColumnFamilies column) {
+  public synchronized boolean isEmpty(final ZbColumnFamilies column) {
     final var newContext = zeebeDb.createContext();
     return zeebeDb.isEmpty(column, newContext);
   }
@@ -221,7 +226,7 @@ public class ZeebeDbState implements MutableZeebeState {
    * @param <KeyType> the key type of the column family
    * @param <ValueType> the value type of the column family
    */
-  public <KeyType extends DbKey, ValueType extends DbValue> void forEach(
+  public synchronized <KeyType extends DbKey, ValueType extends DbValue> void forEach(
       final ZbColumnFamilies columnFamily,
       final KeyType keyInstance,
       final ValueType valueInstance,
@@ -236,10 +241,5 @@ public class ZeebeDbState implements MutableZeebeState {
 
   public KeyGeneratorControls getKeyGeneratorControls() {
     return keyGenerator;
-  }
-
-  @Override
-  public MutableLastProcessedPositionState getLastProcessedPositionState() {
-    return lastProcessedPositionState;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -101,13 +101,13 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   }
 
   @Override
-  public ElementInstance newInstance(
+  public synchronized ElementInstance newInstance(
       final long key, final ProcessInstanceRecord value, final ProcessInstanceIntent state) {
     return newInstance(null, key, value, state);
   }
 
   @Override
-  public ElementInstance newInstance(
+  public synchronized ElementInstance newInstance(
       final ElementInstance parent,
       final long key,
       final ProcessInstanceRecord value,
@@ -126,7 +126,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   }
 
   @Override
-  public void removeInstance(final long key) {
+  public synchronized void removeInstance(final long key) {
     final ElementInstance instance = getInstance(key);
 
     if (instance != null) {
@@ -156,26 +156,27 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   }
 
   @Override
-  public void updateInstance(final ElementInstance scopeInstance) {
+  public synchronized void updateInstance(final ElementInstance scopeInstance) {
     writeElementInstance(scopeInstance);
   }
 
   @Override
-  public void updateInstance(final long key, final Consumer<ElementInstance> modifier) {
+  public synchronized void updateInstance(
+      final long key, final Consumer<ElementInstance> modifier) {
     final var scopeInstance = getInstance(key);
     modifier.accept(scopeInstance);
     updateInstance(scopeInstance);
   }
 
   @Override
-  public void setAwaitResultRequestMetadata(
+  public synchronized void setAwaitResultRequestMetadata(
       final long processInstanceKey, final AwaitProcessInstanceResultMetadata metadata) {
     elementInstanceKey.wrapLong(processInstanceKey);
     awaitProcessInstanceResultMetadataColumnFamily.put(elementInstanceKey, metadata);
   }
 
   @Override
-  public void incrementNumberOfTakenSequenceFlows(
+  public synchronized void incrementNumberOfTakenSequenceFlows(
       final long flowScopeKey,
       final DirectBuffer gatewayElementId,
       final DirectBuffer sequenceFlowElementId) {
@@ -196,7 +197,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   }
 
   @Override
-  public void decrementNumberOfTakenSequenceFlows(
+  public synchronized void decrementNumberOfTakenSequenceFlows(
       final long flowScopeKey, final DirectBuffer gatewayElementId) {
     this.flowScopeKey.wrapLong(flowScopeKey);
     this.gatewayElementId.wrapBuffer(gatewayElementId);
@@ -224,14 +225,14 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   }
 
   @Override
-  public ElementInstance getInstance(final long key) {
+  public synchronized ElementInstance getInstance(final long key) {
     elementInstanceKey.wrapLong(key);
     final ElementInstance elementInstance = elementInstanceColumnFamily.get(elementInstanceKey);
     return copyElementInstance(elementInstance);
   }
 
   @Override
-  public List<ElementInstance> getChildren(final long parentKey) {
+  public synchronized List<ElementInstance> getChildren(final long parentKey) {
     final List<ElementInstance> children = new ArrayList<>();
     final ElementInstance parentInstance = getInstance(parentKey);
     if (parentInstance != null) {
@@ -251,14 +252,14 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   }
 
   @Override
-  public AwaitProcessInstanceResultMetadata getAwaitResultRequestMetadata(
+  public synchronized AwaitProcessInstanceResultMetadata getAwaitResultRequestMetadata(
       final long processInstanceKey) {
     elementInstanceKey.wrapLong(processInstanceKey);
     return awaitProcessInstanceResultMetadataColumnFamily.get(elementInstanceKey);
   }
 
   @Override
-  public int getNumberOfTakenSequenceFlows(
+  public synchronized int getNumberOfTakenSequenceFlows(
       final long flowScopeKey, final DirectBuffer gatewayElementId) {
     this.flowScopeKey.wrapLong(flowScopeKey);
     this.gatewayElementId.wrapBuffer(gatewayElementId);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
@@ -58,7 +58,7 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
   }
 
   @Override
-  public boolean createIfNotExists(
+  public synchronized boolean createIfNotExists(
       final long eventScopeKey, final Collection<DirectBuffer> interruptingIds) {
     this.eventScopeKey.wrapLong(eventScopeKey);
     boolean wasCreated = false;
@@ -72,7 +72,7 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
   }
 
   @Override
-  public void createInstance(
+  public synchronized void createInstance(
       final long eventScopeKey, final Collection<DirectBuffer> interruptingIds) {
     eventScopeInstance.reset();
 
@@ -86,7 +86,7 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
   }
 
   @Override
-  public void deleteInstance(final long eventScopeKey) {
+  public synchronized void deleteInstance(final long eventScopeKey) {
     eventTriggerScopeKey.wrapLong(eventScopeKey);
 
     eventTriggerColumnFamily.whileEqualPrefix(
@@ -99,7 +99,7 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
   }
 
   @Override
-  public EventTrigger pollEventTrigger(final long eventScopeKey) {
+  public synchronized EventTrigger pollEventTrigger(final long eventScopeKey) {
     eventTriggerScopeKey.wrapLong(eventScopeKey);
     final EventTrigger[] next = new EventTrigger[1];
     eventTriggerColumnFamily.whileEqualPrefix(
@@ -114,7 +114,7 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
   }
 
   @Override
-  public boolean triggerEvent(
+  public synchronized boolean triggerEvent(
       final long eventScopeKey,
       final long eventKey,
       final DirectBuffer elementId,
@@ -137,7 +137,7 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
   }
 
   @Override
-  public void triggerStartEvent(
+  public synchronized void triggerStartEvent(
       final long processDefinitionKey,
       final long eventKey,
       final DirectBuffer elementId,
@@ -146,21 +146,21 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
   }
 
   @Override
-  public void deleteTrigger(final long eventScopeKey, final long eventKey) {
+  public synchronized void deleteTrigger(final long eventScopeKey, final long eventKey) {
     eventTriggerScopeKey.wrapLong(eventScopeKey);
     eventTriggerEventKey.wrapLong(eventKey);
     deleteTrigger(eventTriggerKey);
   }
 
   @Override
-  public EventScopeInstance getInstance(final long eventScopeKey) {
+  public synchronized EventScopeInstance getInstance(final long eventScopeKey) {
     this.eventScopeKey.wrapLong(eventScopeKey);
     final EventScopeInstance instance = eventScopeInstanceColumnFamily.get(this.eventScopeKey);
     return instance != null ? new EventScopeInstance(instance) : null;
   }
 
   @Override
-  public EventTrigger peekEventTrigger(final long eventScopeKey) {
+  public synchronized EventTrigger peekEventTrigger(final long eventScopeKey) {
     eventTriggerScopeKey.wrapLong(eventScopeKey);
     final EventTrigger[] next = new EventTrigger[1];
     eventTriggerColumnFamily.whileEqualPrefix(
@@ -174,7 +174,7 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
   }
 
   @Override
-  public boolean isAcceptingEvent(final long eventScopeKey) {
+  public synchronized boolean isAcceptingEvent(final long eventScopeKey) {
     this.eventScopeKey.wrapLong(eventScopeKey);
     final EventScopeInstance instance = eventScopeInstanceColumnFamily.get(this.eventScopeKey);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartEventSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartEventSubscriptionState.java
@@ -59,7 +59,8 @@ public final class DbMessageStartEventSubscriptionState
   }
 
   @Override
-  public void put(final long key, final MessageStartEventSubscriptionRecord subscription) {
+  public synchronized void put(
+      final long key, final MessageStartEventSubscriptionRecord subscription) {
     messageStartEventSubscription.setKey(key).setRecord(subscription);
 
     messageName.wrapBuffer(subscription.getMessageNameBuffer());
@@ -71,7 +72,7 @@ public final class DbMessageStartEventSubscriptionState
   }
 
   @Override
-  public void remove(final long processDefinitionKey, final DirectBuffer messageName) {
+  public synchronized void remove(final long processDefinitionKey, final DirectBuffer messageName) {
     this.processDefinitionKey.wrapLong(processDefinitionKey);
     this.messageName.wrapBuffer(messageName);
 
@@ -80,7 +81,7 @@ public final class DbMessageStartEventSubscriptionState
   }
 
   @Override
-  public boolean exists(final MessageStartEventSubscriptionRecord subscription) {
+  public synchronized boolean exists(final MessageStartEventSubscriptionRecord subscription) {
     messageName.wrapBuffer(subscription.getMessageNameBuffer());
     processDefinitionKey.wrapLong(subscription.getProcessDefinitionKey());
 
@@ -88,7 +89,7 @@ public final class DbMessageStartEventSubscriptionState
   }
 
   @Override
-  public void visitSubscriptionsByMessageName(
+  public synchronized void visitSubscriptionsByMessageName(
       final DirectBuffer messageName, final MessageStartEventSubscriptionVisitor visitor) {
 
     this.messageName.wrapBuffer(messageName);
@@ -100,7 +101,7 @@ public final class DbMessageStartEventSubscriptionState
   }
 
   @Override
-  public void visitSubscriptionsByProcessDefinition(
+  public synchronized void visitSubscriptionsByProcessDefinition(
       final long processDefinitionKey, final MessageStartEventSubscriptionVisitor visitor) {
     this.processDefinitionKey.wrapLong(processDefinitionKey);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
@@ -74,7 +74,7 @@ public final class DbMessageSubscriptionState
   }
 
   @Override
-  public void onRecovered(final ReadonlyProcessingContext context) {
+  public synchronized void onRecovered(final ReadonlyProcessingContext context) {
     subscriptionColumnFamily.forEach(
         subscription -> {
           if (subscription.isCorrelating()) {
@@ -84,14 +84,15 @@ public final class DbMessageSubscriptionState
   }
 
   @Override
-  public MessageSubscription get(final long elementInstanceKey, final DirectBuffer messageName) {
+  public synchronized MessageSubscription get(
+      final long elementInstanceKey, final DirectBuffer messageName) {
     this.messageName.wrapBuffer(messageName);
     this.elementInstanceKey.wrapLong(elementInstanceKey);
     return subscriptionColumnFamily.get(elementKeyAndMessageName);
   }
 
   @Override
-  public void visitSubscriptions(
+  public synchronized void visitSubscriptions(
       final DirectBuffer messageName,
       final DirectBuffer correlationKey,
       final MessageSubscriptionVisitor visitor) {
@@ -107,7 +108,7 @@ public final class DbMessageSubscriptionState
   }
 
   @Override
-  public boolean existSubscriptionForElementInstance(
+  public synchronized boolean existSubscriptionForElementInstance(
       final long elementInstanceKey, final DirectBuffer messageName) {
     this.elementInstanceKey.wrapLong(elementInstanceKey);
     this.messageName.wrapBuffer(messageName);
@@ -116,7 +117,7 @@ public final class DbMessageSubscriptionState
   }
 
   @Override
-  public void put(final long key, final MessageSubscriptionRecord record) {
+  public synchronized void put(final long key, final MessageSubscriptionRecord record) {
     elementInstanceKey.wrapLong(record.getElementInstanceKey());
     messageName.wrapBuffer(record.getMessageNameBuffer());
 
@@ -130,7 +131,7 @@ public final class DbMessageSubscriptionState
   }
 
   @Override
-  public void updateToCorrelatingState(final MessageSubscriptionRecord record) {
+  public synchronized void updateToCorrelatingState(final MessageSubscriptionRecord record) {
     final var messageKey = record.getMessageKey();
     var messageVariables = record.getVariablesBuffer();
     if (record == messageSubscription.getRecord()) {
@@ -155,13 +156,14 @@ public final class DbMessageSubscriptionState
   }
 
   @Override
-  public void updateToCorrelatedState(final MessageSubscription subscription) {
+  public synchronized void updateToCorrelatedState(final MessageSubscription subscription) {
     updateCorrelatingFlag(subscription, false);
     transientState.remove(subscription.getRecord());
   }
 
   @Override
-  public boolean remove(final long elementInstanceKey, final DirectBuffer messageName) {
+  public synchronized boolean remove(
+      final long elementInstanceKey, final DirectBuffer messageName) {
     this.elementInstanceKey.wrapLong(elementInstanceKey);
     this.messageName.wrapBuffer(messageName);
 
@@ -176,7 +178,7 @@ public final class DbMessageSubscriptionState
   }
 
   @Override
-  public void remove(final MessageSubscription subscription) {
+  public synchronized void remove(final MessageSubscription subscription) {
     subscriptionColumnFamily.delete(elementKeyAndMessageName);
 
     final var record = subscription.getRecord();
@@ -214,13 +216,14 @@ public final class DbMessageSubscriptionState
   }
 
   @Override
-  public void visitSubscriptionBefore(
+  public synchronized void visitSubscriptionBefore(
       final long deadline, final MessageSubscriptionVisitor visitor) {
     transientState.visitSubscriptionBefore(deadline, visitor);
   }
 
   @Override
-  public void updateCommandSentTime(final MessageSubscriptionRecord record, final long sentTime) {
+  public synchronized void updateCommandSentTime(
+      final MessageSubscriptionRecord record, final long sentTime) {
     transientState.updateCommandSentTime(record, sentTime);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
@@ -54,7 +54,7 @@ public final class DbProcessMessageSubscriptionState
   }
 
   @Override
-  public void onRecovered(final ReadonlyProcessingContext context) {
+  public synchronized void onRecovered(final ReadonlyProcessingContext context) {
     subscriptionColumnFamily.forEach(
         subscription -> {
           if (subscription.isOpening() || subscription.isClosing()) {
@@ -64,7 +64,7 @@ public final class DbProcessMessageSubscriptionState
   }
 
   @Override
-  public void put(final long key, final ProcessMessageSubscriptionRecord record) {
+  public synchronized void put(final long key, final ProcessMessageSubscriptionRecord record) {
     wrapSubscriptionKeys(record.getElementInstanceKey(), record.getMessageNameBuffer());
 
     processMessageSubscription.reset();
@@ -76,19 +76,20 @@ public final class DbProcessMessageSubscriptionState
   }
 
   @Override
-  public void updateToOpenedState(final ProcessMessageSubscriptionRecord record) {
+  public synchronized void updateToOpenedState(final ProcessMessageSubscriptionRecord record) {
     update(record, s -> s.setRecord(record).setOpened());
     transientState.remove(record);
   }
 
   @Override
-  public void updateToClosingState(final ProcessMessageSubscriptionRecord record) {
+  public synchronized void updateToClosingState(final ProcessMessageSubscriptionRecord record) {
     update(record, s -> s.setRecord(record).setClosing());
     transientState.add(record);
   }
 
   @Override
-  public boolean remove(final long elementInstanceKey, final DirectBuffer messageName) {
+  public synchronized boolean remove(
+      final long elementInstanceKey, final DirectBuffer messageName) {
     final ProcessMessageSubscription subscription =
         getSubscription(elementInstanceKey, messageName);
     final boolean found = subscription != null;
@@ -99,7 +100,7 @@ public final class DbProcessMessageSubscriptionState
   }
 
   @Override
-  public ProcessMessageSubscription getSubscription(
+  public synchronized ProcessMessageSubscription getSubscription(
       final long elementInstanceKey, final DirectBuffer messageName) {
     wrapSubscriptionKeys(elementInstanceKey, messageName);
 
@@ -107,7 +108,7 @@ public final class DbProcessMessageSubscriptionState
   }
 
   @Override
-  public void visitElementSubscriptions(
+  public synchronized void visitElementSubscriptions(
       final long elementInstanceKey, final ProcessMessageSubscriptionVisitor visitor) {
     this.elementInstanceKey.wrapLong(elementInstanceKey);
 
@@ -119,7 +120,7 @@ public final class DbProcessMessageSubscriptionState
   }
 
   @Override
-  public boolean existSubscriptionForElementInstance(
+  public synchronized boolean existSubscriptionForElementInstance(
       final long elementInstanceKey, final DirectBuffer messageName) {
     wrapSubscriptionKeys(elementInstanceKey, messageName);
 
@@ -127,14 +128,14 @@ public final class DbProcessMessageSubscriptionState
   }
 
   @Override
-  public void visitSubscriptionBefore(
+  public synchronized void visitSubscriptionBefore(
       final long deadline, final ProcessMessageSubscriptionVisitor visitor) {
 
     transientState.visitSubscriptionBefore(deadline, visitor);
   }
 
   @Override
-  public void updateSentTime(
+  public synchronized void updateSentTime(
       final ProcessMessageSubscriptionRecord record, final long commandSentTime) {
     transientState.updateSentTime(record, commandSentTime);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
@@ -85,7 +85,7 @@ public class DbMigrationState implements MutableMigrationState {
   }
 
   @Override
-  public void migrateMessageSubscriptionSentTime(
+  public synchronized void migrateMessageSubscriptionSentTime(
       final MutableMessageSubscriptionState messageSubscriptionState,
       final MutablePendingMessageSubscriptionState transientState) {
 
@@ -108,7 +108,7 @@ public class DbMigrationState implements MutableMigrationState {
   }
 
   @Override
-  public void migrateProcessMessageSubscriptionSentTime(
+  public synchronized void migrateProcessMessageSubscriptionSentTime(
       final MutableProcessMessageSubscriptionState persistentState,
       final MutablePendingProcessMessageSubscriptionState transientState) {
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBlackListState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBlackListState.java
@@ -62,7 +62,7 @@ public final class DbBlackListState implements MutableBlackListState {
   }
 
   @Override
-  public boolean isOnBlacklist(final TypedRecord record) {
+  public synchronized boolean isOnBlacklist(final TypedRecord record) {
     final UnpackedObject value = record.getValue();
     if (value instanceof ProcessInstanceRelated) {
       final long processInstanceKey = ((ProcessInstanceRelated) value).getProcessInstanceKey();
@@ -74,7 +74,7 @@ public final class DbBlackListState implements MutableBlackListState {
   }
 
   @Override
-  public boolean tryToBlacklist(
+  public synchronized boolean tryToBlacklist(
       final TypedRecord<?> typedRecord, final Consumer<Long> onBlacklistingInstance) {
     final Intent intent = typedRecord.getIntent();
     if (shouldBeBlacklisted(intent)) {
@@ -89,7 +89,7 @@ public final class DbBlackListState implements MutableBlackListState {
   }
 
   @Override
-  public void blacklistProcessInstance(final long processInstanceKey) {
+  public synchronized void blacklistProcessInstance(final long processInstanceKey) {
     blacklist(processInstanceKey);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbLastProcessedPositionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbLastProcessedPositionState.java
@@ -33,13 +33,13 @@ public final class DbLastProcessedPositionState implements MutableLastProcessedP
   }
 
   @Override
-  public long getLastSuccessfulProcessedRecordPosition() {
+  public synchronized long getLastSuccessfulProcessedRecordPosition() {
     final LastProcessedPosition position = positionColumnFamily.get(positionKey);
     return position != null ? position.get() : NO_EVENTS_PROCESSED;
   }
 
   @Override
-  public void markAsProcessed(final long position) {
+  public synchronized void markAsProcessed(final long position) {
     this.position.set(position);
     positionColumnFamily.put(positionKey, this.position);
   }


### PR DESCRIPTION
## Description

This PR adds the `synchronized` keyword to all state methods. The change was motivated by the recent bug which led to concurrent calls to these classes. The root cause was identified by @Zelldon and is being addressed in #8101.

The PR proposes an additional safety net by protecting the called methods from synchronized access. The benefit of this approach is that concurrent access is prevented at runtime.

## Review Hints
- One common objection to using synchronized is the risk of dead and live locks. However, since we program with the assumption of single threaded access anyway, those should not occur. Also, if they occur one could argue that this is the better outcome than the danger of dirty reads and writes
- Second objection often is performance impact. I ran a benchmark http://34.77.165.228/d/I4lo7_EZk/zeebe?orgId=1&refresh=10s&var-DS_PROMETHEUS=Prometheus&var-namespace=pihme-hardening-synchronized&var-pod=All&var-partition=All It ran for more than a week now and it is without the fix to the original bug. I couldn't see any performance impact. However, this might be due to the benchmark not reaching the performance limits.
- Also note that I made the changes before Nico backported the standardization of Idea code formatting templates. So there is some reordering. Maybe I should repeat the changes with these standardized settings, but I wanted to test the waters first
- @Zelldon I added you as reviewer, because I saw you squirm when I mentioned this option to you a week ago. So feel free to weigh in on this one.

## Related issues

related to #7988 and other related bugs

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

* [ ] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [X] The change has been verified by a QA run
* [X] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
