### PR TITLE
refactor(broker): re-enable new transition logic

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -21,7 +21,7 @@ public class ExperimentalCfg implements ConfigurationEntry {
   public static final DataSize DEFAULT_MAX_APPEND_BATCH_SIZE = DataSize.ofKilobytes(32);
   public static final boolean DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH = false;
   public static final boolean DEFAULT_ENABLE_PRIORITY_ELECTION = false;
-  public static final boolean DEFAULT_NEW_TRANSITION_LOGIC_ENABLED = false;
+  public static final boolean DEFAULT_NEW_TRANSITION_LOGIC_ENABLED = true;
 
   private boolean newTransitionLogicEnabled = DEFAULT_NEW_TRANSITION_LOGIC_ENABLED;
   private int maxAppendsPerFollower = DEFAULT_MAX_APPENDS_PER_FOLLOWER;
@@ -111,7 +111,7 @@ public class ExperimentalCfg implements ConfigurationEntry {
     return newTransitionLogicEnabled;
   }
 
-  public void setNewTransitionLogicEnabled(boolean newTransitionLogicEnabled) {
+  public void setNewTransitionLogicEnabled(final boolean newTransitionLogicEnabled) {
     this.newTransitionLogicEnabled = newTransitionLogicEnabled;
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfgTest.java
@@ -109,7 +109,7 @@ public class ExperimentalCfgTest {
     final var experimental = cfg.getExperimental();
 
     // then
-    assertThat(experimental.isNewTransitionLogicEnabled()).isFalse();
+    assertThat(experimental.isNewTransitionLogicEnabled()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
## Description
Re-enables new transition logic in `stable/1.2`

Please cast your vote of confidence.

@npepinpe I included you not so much for a review, but more to intervene in case you have other ideas, like switching the feature flag on the testbench first, canary rollout to trial users or things like that.

## Related issues

closes #8044

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
