### PR TITLE
Close journal readers to remove references to compacted segments

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -78,6 +78,29 @@ public final class RaftMemberContext {
     failures = 0;
     failureTime = 0;
 
+    if (reader != null) {
+      closeReader();
+      openReader(log);
+    }
+  }
+
+  private void closeReader() {
+    if (reader != null) {
+      reader.close();
+      reader = null;
+    }
+  }
+
+  public void openReplicationContext(final RaftLog log) {
+    resetState(log);
+    openReader(log);
+  }
+
+  public void closeReplicationContext() {
+    closeReader();
+  }
+
+  private void openReader(final RaftLog log) {
     switch (member.getType()) {
       case PASSIVE:
         reader = log.openCommittedReader();

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -57,7 +57,6 @@ import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.StorageException;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
-import io.atomix.raft.storage.log.RaftLogReader;
 import io.atomix.raft.storage.system.MetaStore;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.utils.concurrent.ComposableFuture;
@@ -112,7 +111,6 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private final RaftReplicationMetrics replicationMetrics;
   private final MetaStore meta;
   private final RaftLog raftLog;
-  private final RaftLogReader logReader;
   private final ReceivableSnapshotStore persistedSnapshotStore;
   private final LogCompactor logCompactor;
   private volatile State state = State.ACTIVE;
@@ -186,7 +184,6 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
     // Construct the core log, reader, writer, and compactor.
     raftLog = storage.openLog();
-    logReader = raftLog.openUncommittedReader();
 
     // Open the snapshot store.
     persistedSnapshotStore = storage.getPersistedSnapshotStore();
@@ -878,15 +875,6 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   /**
-   * Returns the server log reader.
-   *
-   * @return The log reader.
-   */
-  public RaftLogReader getLogReader() {
-    return logReader;
-  }
-
-  /**
    * Returns the cluster service.
    *
    * @return the cluster service
@@ -1100,7 +1088,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     return partitionConfig.getPreferSnapshotReplicationThreshold();
   }
 
-  public void setPreferSnapshotReplicationThreshold(int snapshotReplicationThreshold) {
+  public void setPreferSnapshotReplicationThreshold(final int snapshotReplicationThreshold) {
     partitionConfig.setPreferSnapshotReplicationThreshold(snapshotReplicationThreshold);
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -200,17 +200,17 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
   }
 
   private ApplicationEntry findLastZeebeEntry() {
-    final RaftLogReader reader = raft.getLogReader();
-    reader.seekToAsqn(Long.MAX_VALUE);
+    try (final RaftLogReader reader = raft.getLog().openUncommittedReader()) {
+      reader.seekToAsqn(Long.MAX_VALUE);
 
-    if (reader.hasNext()) {
-      final IndexedRaftLogEntry lastEntry = reader.next();
-      if (lastEntry != null && lastEntry.isApplicationEntry()) {
-        return lastEntry.getApplicationEntry();
+      if (reader.hasNext()) {
+        final IndexedRaftLogEntry lastEntry = reader.next();
+        if (lastEntry != null && lastEntry.isApplicationEntry()) {
+          return lastEntry.getApplicationEntry();
+        }
       }
+      return null;
     }
-
-    return null;
   }
 
   /** Cancels the timers. */

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -32,7 +32,6 @@ import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.PersistedRaftRecord;
 import io.atomix.raft.storage.log.RaftLog;
-import io.atomix.raft.storage.log.RaftLogReader;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
@@ -91,9 +90,6 @@ public class LeaderRoleTest {
     // since we mock RaftContext we should simulate leader close on transition
     doAnswer(i -> leaderRole.stop().join()).when(context).transition(Role.FOLLOWER);
     when(context.getMembershipService()).thenReturn(mock(ClusterMembershipService.class));
-
-    final RaftLogReader reader = mock(RaftLogReader.class);
-    when(context.getLogReader()).thenReturn(reader);
   }
 
   @Test

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -17,6 +17,7 @@ package io.atomix.raft.roles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
@@ -61,7 +62,7 @@ public class LeaderRoleTest {
 
   @Before
   public void setup() {
-    context = Mockito.mock(RaftContext.class);
+    context = Mockito.mock(RaftContext.class, RETURNS_DEEP_STUBS);
 
     when(context.getName()).thenReturn("leader");
     when(context.getElectionTimeout()).thenReturn(Duration.ofMillis(100));
@@ -90,6 +91,8 @@ public class LeaderRoleTest {
     // since we mock RaftContext we should simulate leader close on transition
     doAnswer(i -> leaderRole.stop().join()).when(context).transition(Role.FOLLOWER);
     when(context.getMembershipService()).thenReturn(mock(ClusterMembershipService.class));
+
+    when(context.getCluster().getRemoteMemberStates()).thenReturn(List.of());
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.Broker;
+import io.camunda.zeebe.it.util.GrpcClientRule;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
+import org.springframework.util.unit.DataSize;
+
+public class ReaderCloseTest {
+
+  public final Timeout testTimeout = Timeout.seconds(120);
+  public final ClusteringRule clusteringRule =
+      new ClusteringRule(
+          1,
+          3,
+          3,
+          config -> {
+            config.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(8));
+            config.getData().setLogSegmentSize(DataSize.ofKilobytes(8));
+            // no exporters so that segments are immediately compacted after a snapshot.
+            config.setExporters(Map.of());
+          });
+  public final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
+
+  @Rule
+  public RuleChain ruleChain =
+      RuleChain.outerRule(testTimeout).around(clusteringRule).around(clientRule);
+
+  // Regression test for https://github.com/camunda-cloud/zeebe/issues/7767
+  @Test
+  public void shouldDeleteCompactedSegmentsFiles() throws IOException {
+    // given
+    fillSegments();
+
+    // when
+    clusteringRule.triggerAndWaitForSnapshots();
+
+    // then
+    for (final Broker broker : clusteringRule.getBrokers()) {
+      assertThatFilesOfDeletedSegmentsDoesNotExist(broker);
+    }
+  }
+
+  // Regression test for https://github.com/camunda-cloud/zeebe/issues/7767
+  @Test
+  public void shouldDeleteCompactedSegmentsFilesAfterLeaderChange() throws IOException {
+    // given
+    fillSegments();
+    final var leaderId = clusteringRule.getLeaderForPartition(1).getNodeId();
+    final var followerId =
+        clusteringRule.getOtherBrokerObjects(leaderId).stream()
+            .findAny()
+            .orElseThrow()
+            .getConfig()
+            .getCluster()
+            .getNodeId();
+    clusteringRule.forceClusterToHaveNewLeader(followerId);
+
+    // when
+    clusteringRule.triggerAndWaitForSnapshots();
+
+    // then
+    for (final Broker broker : clusteringRule.getBrokers()) {
+      assertThatFilesOfDeletedSegmentsDoesNotExist(broker);
+    }
+  }
+
+  private void assertThatFilesOfDeletedSegmentsDoesNotExist(final Broker leader)
+      throws IOException {
+    final var segmentDirectory = clusteringRule.getSegmentsDirectory(leader);
+    try (final var stream =
+        Files.newDirectoryStream(segmentDirectory, path -> !path.toFile().isDirectory())) {
+      stream.forEach(
+          path ->
+              assertThat(isEitherLogOrRaftMetaFiles(path))
+                  .as(
+                      "The files in the segment directory should be either valid log segments or raft config and metadata. %s",
+                      path)
+                  .isTrue());
+    }
+  }
+
+  private boolean isEitherLogOrRaftMetaFiles(final Path path) {
+    final var filename = path.getFileName().toString();
+    return filename.endsWith(".log")
+        || filename.endsWith(".conf")
+        || filename.endsWith(".meta")
+        || filename.endsWith(".lock");
+  }
+
+  public void fillSegments() {
+    clusteringRule.runUntilSegmentsFilled(
+        clusteringRule.getBrokers(),
+        2,
+        () ->
+            clientRule
+                .getClient()
+                .newPublishMessageCommand()
+                .messageName("msg")
+                .correlationKey("key")
+                .send()
+                .join());
+  }
+}


### PR DESCRIPTION
## Description

The readers in Raft were preventing the the segments from deleting. To fix this
1. Removed the long living reader in RaftContext
2. Open and Close readers in RaftMemberContext explicitly in LeaderRole as they are only used if the role is leader.

## Related issues

closes #7767

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [x] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
