### PR TITLE
Validate user task assignments

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidator.java
@@ -103,21 +103,14 @@ public final class ZeebeExpressionValidator<T extends ModelElementInstance>
     }
   }
 
-  public static boolean isBracketedListOfValues(final Expression staticExp) {
+  public static boolean isListOfCsv(final Expression staticExp) {
     final String value = staticExp.getExpression();
-    if (!value.startsWith("[")) {
-      return false;
-    }
-    if (!value.endsWith("]")) {
-      return false;
-    }
-    final var bracketsTrimmed = value.substring(1, value.length() - 1);
-    if (bracketsTrimmed.isEmpty()) {
+    if (value.isEmpty()) {
       return true;
     }
-    final var values = bracketsTrimmed.split(",");
-    if (values.length < StringUtils.countMatches(bracketsTrimmed, ",") + 1) {
-      // one of the values was an empty string, e.g. [a,,c]
+    final var values = value.split(",");
+    if (values.length < StringUtils.countMatches(value, ",") + 1) {
+      // one of the values was an empty string, e.g. 'a,,c'
       return false;
     }
     return Arrays.stream(values).noneMatch(String::isEmpty);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.validation.ZeebeExpre
 import io.camunda.zeebe.model.bpmn.instance.ConditionExpression;
 import io.camunda.zeebe.model.bpmn.instance.Message;
 import io.camunda.zeebe.model.bpmn.instance.TimerEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
@@ -98,6 +99,19 @@ public final class ZeebeRuntimeValidators {
                         ? definition.getTimeCycle().getTextContent()
                         : null,
                 ExpressionVerification::isOptional)
+            .build(expressionLanguage),
+        // ----------------------------------------
+        ZeebeExpressionValidator.verifyThat(ZeebeAssignmentDefinition.class)
+            .hasValidExpression(
+                ZeebeAssignmentDefinition::getAssignee, ExpressionVerification::isOptional)
+            .hasValidExpression(
+                ZeebeAssignmentDefinition::getCandidateGroups,
+                expression ->
+                    expression
+                        .isOptional()
+                        .ifStaticItSatisfies(
+                            ZeebeExpressionValidator::isBracketedListOfValues,
+                            "be a bracketed list of comma-separated values, e.g. '[a,b,c]'"))
             .build(expressionLanguage),
         // ----------------------------------------
         new TimerCatchEventExpressionValidator(expressionLanguage, expressionProcessor));

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -109,9 +109,9 @@ public final class ZeebeRuntimeValidators {
                 expression ->
                     expression
                         .isOptional()
-                        .ifStaticItSatisfies(
-                            ZeebeExpressionValidator::isBracketedListOfValues,
-                            "be a bracketed list of comma-separated values, e.g. '[a,b,c]'"))
+                        .satisfiesIfStatic(
+                            ZeebeExpressionValidator::isListOfCsv,
+                            "be a list of comma-separated values, e.g. 'a,b,c'"))
             .build(expressionLanguage),
         // ----------------------------------------
         new TimerCatchEventExpressionValidator(expressionLanguage, expressionProcessor));

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -26,7 +26,7 @@ import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 
 public final class ZeebeRuntimeValidators {
 
-  public static final Collection<ModelElementValidator<?>> getValidators(
+  public static Collection<ModelElementValidator<?>> getValidators(
       final ExpressionLanguage expressionLanguage, final ExpressionProcessor expressionProcessor) {
     return List.of(
         // ----------------------------------------

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidatorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidatorTest.java
@@ -21,46 +21,43 @@ import org.junit.jupiter.params.provider.MethodSource;
 class ZeebeExpressionValidatorTest {
 
   @Nested
-  @DisplayName("ZeebeExpressionValidator.isBracketedListOfValues(Expression)")
+  @DisplayName("ZeebeExpressionValidator.isListOfCsv(Expression)")
   @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-  class IsBracketedListOfValues {
+  class IsListOfValues {
 
     @ParameterizedTest
-    @MethodSource("bracketedLists")
-    void shouldAcceptBracketedLists(final String value) {
+    @MethodSource("csv")
+    void shouldAcceptCsv(final String value) {
       final var expression = new StaticExpression(value);
-      assertThat(ZeebeExpressionValidator.isBracketedListOfValues(expression)).isTrue();
+      assertThat(ZeebeExpressionValidator.isListOfCsv(expression)).isTrue();
     }
 
     @ParameterizedTest
-    @MethodSource("notBracketedLists")
-    void shouldRejectNotBracketedLists(final String value) {
+    @MethodSource("notCsv")
+    void shouldRejectNotCsv(final String value) {
       final var expression = new StaticExpression(value);
-      assertThat(ZeebeExpressionValidator.isBracketedListOfValues(expression)).isFalse();
+      assertThat(ZeebeExpressionValidator.isListOfCsv(expression)).isFalse();
     }
 
-    Stream<Arguments> bracketedLists() {
-      return Stream.of(
-          Arguments.of("[]"),
-          Arguments.of("[a]"),
-          Arguments.of("[a,b]"),
-          Arguments.of("[a,b,c]"),
-          Arguments.of("[\"abcd\",\"efgh\",\"ijkl\"]"),
-          Arguments.of("[1]"),
-          Arguments.of("[1,2]"),
-          Arguments.of("[1,a,3]"),
-          Arguments.of("[[]]"),
-          Arguments.of("[[],[]]"));
-    }
-
-    Stream<Arguments> notBracketedLists() {
+    Stream<Arguments> csv() {
       return Stream.of(
           Arguments.of(""),
-          Arguments.of("["),
-          Arguments.of("]"),
-          Arguments.of("[,]"),
-          Arguments.of("[a,,c]"),
-          Arguments.of("[,b,]"));
+          Arguments.of("a"),
+          Arguments.of("a,b"),
+          Arguments.of("a,b,c"),
+          Arguments.of("\"abcd\",\"efgh\",\"ijkl\""),
+          Arguments.of("1"),
+          Arguments.of("1,2"),
+          Arguments.of("1,a,3"));
+    }
+
+    Stream<Arguments> notCsv() {
+      return Stream.of(
+          Arguments.of(","),
+          Arguments.of("a,"),
+          Arguments.of(",b"),
+          Arguments.of(",b,"),
+          Arguments.of("a,,c"));
     }
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidatorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidatorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.el.impl.StaticExpression;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ZeebeExpressionValidatorTest {
+
+  @Nested
+  @DisplayName("ZeebeExpressionValidator.isBracketedListOfValues(Expression)")
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  class IsBracketedListOfValues {
+
+    @ParameterizedTest
+    @MethodSource("bracketedLists")
+    void shouldAcceptBracketedLists(final String value) {
+      final var expression = new StaticExpression(value);
+      assertThat(ZeebeExpressionValidator.isBracketedListOfValues(expression)).isTrue();
+    }
+
+    @ParameterizedTest
+    @MethodSource("notBracketedLists")
+    void shouldRejectNotBracketedLists(final String value) {
+      final var expression = new StaticExpression(value);
+      assertThat(ZeebeExpressionValidator.isBracketedListOfValues(expression)).isFalse();
+    }
+
+    Stream<Arguments> bracketedLists() {
+      return Stream.of(
+          Arguments.of("[]"),
+          Arguments.of("[a]"),
+          Arguments.of("[a,b]"),
+          Arguments.of("[a,b,c]"),
+          Arguments.of("[\"abcd\",\"efgh\",\"ijkl\"]"),
+          Arguments.of("[1]"),
+          Arguments.of("[1,2]"),
+          Arguments.of("[1,a,3]"),
+          Arguments.of("[[]]"),
+          Arguments.of("[[],[]]"));
+    }
+
+    Stream<Arguments> notBracketedLists() {
+      return Stream.of(
+          Arguments.of(""),
+          Arguments.of("["),
+          Arguments.of("]"),
+          Arguments.of("[,]"),
+          Arguments.of("[a,,c]"),
+          Arguments.of("[,b,]"));
+    }
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.model.bpmn.traversal.ModelWalker;
 import io.camunda.zeebe.model.bpmn.validation.ValidationVisitor;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -74,7 +73,7 @@ public final class ZeebeRuntimeValidationTest {
             .conditionExpression(INVALID_EXPRESSION)
             .endEvent()
             .done(),
-        Arrays.asList(expect(ConditionExpression.class, INVALID_EXPRESSION_MESSAGE))
+        List.of(expect(ConditionExpression.class, INVALID_EXPRESSION_MESSAGE))
       },
       {
         // static expression
@@ -85,7 +84,7 @@ public final class ZeebeRuntimeValidationTest {
             .condition(STATIC_EXPRESSION)
             .endEvent()
             .done(),
-        Arrays.asList(expect(ConditionExpression.class, STATIC_EXPRESSION_MESSAGE))
+        List.of(expect(ConditionExpression.class, STATIC_EXPRESSION_MESSAGE))
       },
       {
         // not a valid expression
@@ -94,7 +93,7 @@ public final class ZeebeRuntimeValidationTest {
             .serviceTask("task", s -> s.zeebeInputExpression(INVALID_EXPRESSION, "foo"))
             .endEvent()
             .done(),
-        Arrays.asList(expect(ZeebeInput.class, INVALID_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeInput.class, INVALID_EXPRESSION_MESSAGE))
       },
       {
         // static expression
@@ -103,7 +102,7 @@ public final class ZeebeRuntimeValidationTest {
             .serviceTask("task", s -> s.zeebeInput(STATIC_EXPRESSION, "bar"))
             .endEvent()
             .done(),
-        Arrays.asList(expect(ZeebeInput.class, STATIC_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeInput.class, STATIC_EXPRESSION_MESSAGE))
       },
       {
         // empty expression
@@ -112,7 +111,7 @@ public final class ZeebeRuntimeValidationTest {
             .serviceTask("task", s -> s.zeebeInput("", "bar"))
             .endEvent()
             .done(),
-        Arrays.asList(expect(ZeebeInput.class, MISSING_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeInput.class, MISSING_EXPRESSION_MESSAGE))
       },
       {
         // empty path expression
@@ -121,7 +120,7 @@ public final class ZeebeRuntimeValidationTest {
             .serviceTask("task", s -> s.zeebeInputExpression("foo", ""))
             .endEvent()
             .done(),
-        Arrays.asList(expect(ZeebeInput.class, MISSING_PATH_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeInput.class, MISSING_PATH_EXPRESSION_MESSAGE))
       },
       {
         // invalid target expression
@@ -130,7 +129,7 @@ public final class ZeebeRuntimeValidationTest {
             .serviceTask("task", s -> s.zeebeInputExpression("foo", INVALID_PATH_EXPRESSION))
             .endEvent()
             .done(),
-        Arrays.asList(expect(ZeebeInput.class, INVALID_PATH_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeInput.class, INVALID_PATH_EXPRESSION_MESSAGE))
       },
       { // not a valid expression
         Bpmn.createExecutableProcess("process")
@@ -138,7 +137,7 @@ public final class ZeebeRuntimeValidationTest {
             .serviceTask("task", s -> s.zeebeOutputExpression(INVALID_EXPRESSION, "foo"))
             .endEvent()
             .done(),
-        Arrays.asList(expect(ZeebeOutput.class, INVALID_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeOutput.class, INVALID_EXPRESSION_MESSAGE))
       },
       {
         // static expression
@@ -147,7 +146,7 @@ public final class ZeebeRuntimeValidationTest {
             .serviceTask("task", s -> s.zeebeOutput(STATIC_EXPRESSION, "bar"))
             .endEvent()
             .done(),
-        Arrays.asList(expect(ZeebeOutput.class, STATIC_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeOutput.class, STATIC_EXPRESSION_MESSAGE))
       },
       {
         // empty expression
@@ -156,7 +155,7 @@ public final class ZeebeRuntimeValidationTest {
             .serviceTask("task", s -> s.zeebeOutput("", "bar"))
             .endEvent()
             .done(),
-        Arrays.asList(expect(ZeebeOutput.class, MISSING_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeOutput.class, MISSING_EXPRESSION_MESSAGE))
       },
       {
         // invalid target expression
@@ -165,7 +164,7 @@ public final class ZeebeRuntimeValidationTest {
             .serviceTask("task", s -> s.zeebeOutputExpression("foo", INVALID_PATH_EXPRESSION))
             .endEvent()
             .done(),
-        Arrays.asList(expect(ZeebeOutput.class, INVALID_PATH_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeOutput.class, INVALID_PATH_EXPRESSION_MESSAGE))
       },
       {
         // empty path expression
@@ -174,7 +173,7 @@ public final class ZeebeRuntimeValidationTest {
             .serviceTask("task", s -> s.zeebeOutputExpression("foo", ""))
             .endEvent()
             .done(),
-        Arrays.asList(expect(ZeebeOutput.class, MISSING_PATH_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeOutput.class, MISSING_PATH_EXPRESSION_MESSAGE))
       },
       {
         // name expression is invalid
@@ -184,7 +183,7 @@ public final class ZeebeRuntimeValidationTest {
             .message(b -> b.name("message").zeebeCorrelationKeyExpression(INVALID_EXPRESSION))
             .endEvent()
             .done(),
-        Arrays.asList(expect(ZeebeSubscription.class, INVALID_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeSubscription.class, INVALID_EXPRESSION_MESSAGE))
       },
       {
         // static expression
@@ -194,7 +193,7 @@ public final class ZeebeRuntimeValidationTest {
             .message(b -> b.name("message").zeebeCorrelationKey(STATIC_EXPRESSION))
             .endEvent()
             .done(),
-        Arrays.asList(expect(ZeebeSubscription.class, STATIC_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeSubscription.class, STATIC_EXPRESSION_MESSAGE))
       },
       {
         Bpmn.createExecutableProcess("process")
@@ -203,7 +202,7 @@ public final class ZeebeRuntimeValidationTest {
             .message(b -> b.name("message").zeebeCorrelationKeyExpression(INVALID_EXPRESSION))
             .endEvent()
             .done(),
-        Arrays.asList(expect(ZeebeSubscription.class, INVALID_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeSubscription.class, INVALID_EXPRESSION_MESSAGE))
       },
       {
         // static expression
@@ -213,7 +212,7 @@ public final class ZeebeRuntimeValidationTest {
             .message(b -> b.name("message").zeebeCorrelationKey(STATIC_EXPRESSION))
             .endEvent()
             .done(),
-        Arrays.asList(expect(ZeebeSubscription.class, STATIC_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeSubscription.class, STATIC_EXPRESSION_MESSAGE))
       },
       {
         // input collection expression is not supported
@@ -223,7 +222,7 @@ public final class ZeebeRuntimeValidationTest {
                 "task",
                 t -> t.multiInstance(m -> m.zeebeInputCollectionExpression(INVALID_EXPRESSION)))
             .done(),
-        Arrays.asList(expect(ZeebeLoopCharacteristics.class, INVALID_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeLoopCharacteristics.class, INVALID_EXPRESSION_MESSAGE))
       },
       {
         // input collection expression is static
@@ -232,7 +231,7 @@ public final class ZeebeRuntimeValidationTest {
             .serviceTask(
                 "task", t -> t.multiInstance(m -> m.zeebeInputCollection(STATIC_EXPRESSION)))
             .done(),
-        Arrays.asList(expect(ZeebeLoopCharacteristics.class, STATIC_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeLoopCharacteristics.class, STATIC_EXPRESSION_MESSAGE))
       },
       {
         // output element expression is not supported
@@ -246,7 +245,7 @@ public final class ZeebeRuntimeValidationTest {
                             m.zeebeInputCollectionExpression("x")
                                 .zeebeOutputElementExpression(INVALID_EXPRESSION)))
             .done(),
-        Arrays.asList(expect(ZeebeLoopCharacteristics.class, INVALID_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeLoopCharacteristics.class, INVALID_EXPRESSION_MESSAGE))
       },
       {
         // output element  expression is static
@@ -260,7 +259,7 @@ public final class ZeebeRuntimeValidationTest {
                             m.zeebeInputCollectionExpression("x")
                                 .zeebeOutputElement(STATIC_EXPRESSION)))
             .done(),
-        Arrays.asList(expect(ZeebeLoopCharacteristics.class, STATIC_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeLoopCharacteristics.class, STATIC_EXPRESSION_MESSAGE))
       },
       {
         // output element expression is not supported
@@ -275,7 +274,7 @@ public final class ZeebeRuntimeValidationTest {
                                 .zeebeOutputCollection("bar")
                                 .zeebeOutputElementExpression(INVALID_EXPRESSION)))
             .done(),
-        Arrays.asList(expect(ZeebeLoopCharacteristics.class, INVALID_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeLoopCharacteristics.class, INVALID_EXPRESSION_MESSAGE))
       },
       {
         // process id expression is not supported
@@ -283,7 +282,7 @@ public final class ZeebeRuntimeValidationTest {
             .startEvent()
             .callActivity("call", c -> c.zeebeProcessIdExpression(INVALID_EXPRESSION))
             .done(),
-        Arrays.asList(expect(ZeebeCalledElement.class, INVALID_EXPRESSION_MESSAGE))
+        List.of(expect(ZeebeCalledElement.class, INVALID_EXPRESSION_MESSAGE))
       },
       {
         /* message on start event has expression that contains a variable reference
@@ -294,7 +293,7 @@ public final class ZeebeRuntimeValidationTest {
             .startEvent()
             .message(messageBuilder -> messageBuilder.nameExpression("variableReference"))
             .done(),
-        Arrays.asList(
+        List.of(
             expect(
                 StartEvent.class,
                 "Expected constant expression but found '=variableReference', which could not be evaluated without context: "
@@ -308,7 +307,7 @@ public final class ZeebeRuntimeValidationTest {
             .startEvent()
             .message(messageBuilder -> messageBuilder.nameExpression("false"))
             .done(),
-        Arrays.asList(
+        List.of(
             expect(
                 StartEvent.class,
                 "Expected constant expression of type String for message name '=false', but was BOOLEAN"))
@@ -320,7 +319,7 @@ public final class ZeebeRuntimeValidationTest {
             .serviceTask(
                 "task", task -> task.zeebeJobType("test").zeebeInputExpression("x", "null"))
             .done(),
-        Arrays.asList(
+        List.of(
             expect(
                 ZeebeInput.class,
                 "Expected path expression 'null' but is one of the reserved words (null, true, false, function, if, then, else, for, between, instance, of)."))
@@ -332,7 +331,7 @@ public final class ZeebeRuntimeValidationTest {
             .serviceTask(
                 "task", task -> task.zeebeJobType("test").zeebeOutputExpression("x", "true"))
             .done(),
-        Arrays.asList(
+        List.of(
             expect(
                 ZeebeOutput.class,
                 "Expected path expression 'true' but is one of the reserved words (null, true, false, function, if, then, else, for, between, instance, of)."))

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ConditionExpression;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
@@ -336,6 +337,33 @@ public final class ZeebeRuntimeValidationTest {
                 ZeebeOutput.class,
                 "Expected path expression 'true' but is one of the reserved words (null, true, false, function, if, then, else, for, between, instance, of)."))
       },
+      {
+        /* invalid assignee expression */
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("task", b -> b.zeebeAssigneeExpression(INVALID_EXPRESSION))
+            .done(),
+        List.of(expect(ZeebeAssignmentDefinition.class, INVALID_EXPRESSION_MESSAGE))
+      },
+      {
+        /* invalid candidateGroups expression */
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("task", b -> b.zeebeCandidateGroupsExpression(INVALID_EXPRESSION))
+            .done(),
+        List.of(expect(ZeebeAssignmentDefinition.class, INVALID_EXPRESSION_MESSAGE))
+      },
+      {
+        /* invalid candidateGroups static value */
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("task", b -> b.zeebeCandidateGroups("a,b,c"))
+            .done(),
+        List.of(
+            expect(
+                ZeebeAssignmentDefinition.class,
+                "Expected static value to be a bracketed list of comma-separated values, e.g. '[a,b,c]', but found 'a,b,c'"))
+      }
     };
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -357,12 +357,12 @@ public final class ZeebeRuntimeValidationTest {
         /* invalid candidateGroups static value */
         Bpmn.createExecutableProcess("process")
             .startEvent()
-            .userTask("task", b -> b.zeebeCandidateGroups("a,b,c"))
+            .userTask("task", b -> b.zeebeCandidateGroups("1,,"))
             .done(),
         List.of(
             expect(
                 ZeebeAssignmentDefinition.class,
-                "Expected static value to be a bracketed list of comma-separated values, e.g. '[a,b,c]', but found 'a,b,c'"))
+                "Expected static value to be a list of comma-separated values, e.g. 'a,b,c', but found '1,,'"))
       }
     };
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Adds runtime validations to make sure that user task assignments comply with the requirements.

Specifically, it verifies the `assignee` and `candidateGroups` attributes of the `zeebe:AssignmentDefinition` extension element. Both attributes are optional, and can be either a static value or a FEEL expression. For candidate groups special rules apply when it is a static value.

No validation is added to make sure either attributes is provided on an assignment definition element. Additional care must be taken for this when implementing #8055.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8054 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
