### PR TITLE
Extract UserTaskBuilderTest from ProcessBuilderTest

### DIFF
--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilderTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilderTest.java
@@ -27,7 +27,6 @@ import static io.camunda.zeebe.model.bpmn.BpmnTestConstants.TRANSACTION_ID;
 import static io.camunda.zeebe.model.bpmn.BpmnTestConstants.USER_TASK_ID;
 import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.BPMN20_NS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.Fail.fail;
 import static org.junit.Assert.assertEquals;
 
@@ -51,7 +50,6 @@ import io.camunda.zeebe.model.bpmn.instance.Escalation;
 import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.Event;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
-import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.FlowElement;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.model.bpmn.instance.Gateway;
@@ -76,7 +74,6 @@ import io.camunda.zeebe.model.bpmn.instance.TimeDuration;
 import io.camunda.zeebe.model.bpmn.instance.TimerEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.Transaction;
 import io.camunda.zeebe.model.bpmn.instance.UserTask;
-import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
 import java.util.Collection;
 import java.util.List;
 import org.camunda.bpm.model.xml.Model;
@@ -2136,60 +2133,5 @@ public class ProcessBuilderTest {
     assertEquals("user", userName);
     final String endName = ((FlowElement) instance.getModelElementById("end")).getName();
     assertEquals("name", endName);
-  }
-
-  @Test
-  public void testUserTaskAssigneeCanBeSet() {
-    final BpmnModelInstance instance =
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .userTask("userTask1", task -> task.zeebeAssignee("user1"))
-            .endEvent()
-            .done();
-
-    final ModelElementInstance userTask = instance.getModelElementById("userTask1");
-    final ExtensionElements extensionElements =
-        (ExtensionElements) userTask.getUniqueChildElementByType(ExtensionElements.class);
-    assertThat(extensionElements.getChildElementsByType(ZeebeAssignmentDefinition.class))
-        .hasSize(1)
-        .extracting(ZeebeAssignmentDefinition::getAssignee)
-        .containsExactly("user1");
-  }
-
-  @Test
-  public void testUserTaskCandidateGroupsCanBeSet() {
-    final BpmnModelInstance instance =
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .userTask("userTask1", task -> task.zeebeCandidateGroups("role1"))
-            .endEvent()
-            .done();
-
-    final ModelElementInstance userTask = instance.getModelElementById("userTask1");
-    final ExtensionElements extensionElements =
-        (ExtensionElements) userTask.getUniqueChildElementByType(ExtensionElements.class);
-    assertThat(extensionElements.getChildElementsByType(ZeebeAssignmentDefinition.class))
-        .hasSize(1)
-        .extracting(ZeebeAssignmentDefinition::getCandidateGroups)
-        .containsExactly("role1");
-  }
-
-  @Test
-  public void testUserTaskAssigneeAndCandidateGroupsCanBothBeSet() {
-    final BpmnModelInstance instance =
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .userTask("userTask1", b -> b.zeebeAssignee("user1").zeebeCandidateGroups("role1"))
-            .endEvent()
-            .done();
-
-    final ModelElementInstance userTask = instance.getModelElementById("userTask1");
-    final ExtensionElements extensionElements =
-        (ExtensionElements) userTask.getUniqueChildElementByType(ExtensionElements.class);
-    assertThat(extensionElements.getChildElementsByType(ZeebeAssignmentDefinition.class))
-        .hasSize(1)
-        .extracting(
-            ZeebeAssignmentDefinition::getAssignee, ZeebeAssignmentDefinition::getCandidateGroups)
-        .containsExactly(tuple("user1", "role1"));
   }
 }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/UserTaskBuilderTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/UserTaskBuilderTest.java
@@ -23,12 +23,12 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class UserTaskBuilderTest {
+class UserTaskBuilderTest {
 
   @Test
-  public void testUserTaskAssigneeCanBeSet() {
+  void testUserTaskAssigneeCanBeSet() {
     final BpmnModelInstance instance =
         Bpmn.createExecutableProcess("process")
             .startEvent()
@@ -46,7 +46,7 @@ public class UserTaskBuilderTest {
   }
 
   @Test
-  public void testUserTaskCandidateGroupsCanBeSet() {
+  void testUserTaskCandidateGroupsCanBeSet() {
     final BpmnModelInstance instance =
         Bpmn.createExecutableProcess("process")
             .startEvent()
@@ -64,7 +64,7 @@ public class UserTaskBuilderTest {
   }
 
   @Test
-  public void testUserTaskAssigneeAndCandidateGroupsCanBothBeSet() {
+  void testUserTaskAssigneeAndCandidateGroupsCanBothBeSet() {
     final BpmnModelInstance instance =
         Bpmn.createExecutableProcess("process")
             .startEvent()

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/UserTaskBuilderTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/UserTaskBuilderTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+import org.junit.Test;
+
+public class UserTaskBuilderTest {
+
+  @Test
+  public void testUserTaskAssigneeCanBeSet() {
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("userTask1", task -> task.zeebeAssignee("user1"))
+            .endEvent()
+            .done();
+
+    final ModelElementInstance userTask = instance.getModelElementById("userTask1");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) userTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeAssignmentDefinition.class))
+        .hasSize(1)
+        .extracting(ZeebeAssignmentDefinition::getAssignee)
+        .containsExactly("user1");
+  }
+
+  @Test
+  public void testUserTaskCandidateGroupsCanBeSet() {
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("userTask1", task -> task.zeebeCandidateGroups("role1"))
+            .endEvent()
+            .done();
+
+    final ModelElementInstance userTask = instance.getModelElementById("userTask1");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) userTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeAssignmentDefinition.class))
+        .hasSize(1)
+        .extracting(ZeebeAssignmentDefinition::getCandidateGroups)
+        .containsExactly("role1");
+  }
+
+  @Test
+  public void testUserTaskAssigneeAndCandidateGroupsCanBothBeSet() {
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("userTask1", b -> b.zeebeAssignee("user1").zeebeCandidateGroups("role1"))
+            .endEvent()
+            .done();
+
+    final ModelElementInstance userTask = instance.getModelElementById("userTask1");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) userTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeAssignmentDefinition.class))
+        .hasSize(1)
+        .extracting(
+            ZeebeAssignmentDefinition::getAssignee, ZeebeAssignmentDefinition::getCandidateGroups)
+        .containsExactly(tuple("user1", "role1"));
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The old ProcessBuilderTest is too tangled to easily split up, so this PR is rather short. It does not split up the entire test, but rather extracts the newly added lines in #8073 to a new test class and updates it to use junit 5.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8106

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
