### PR TITLE
feat(elastic/exporter): expose configuration options

### DIFF
--- a/broker/src/test/resources/system/elasticexporter.yaml
+++ b/broker/src/test/resources/system/elasticexporter.yaml
@@ -25,6 +25,9 @@ zeebe:
         #     prefix: zeebe-record
         #     createTemplate: true
         #
+        #     numberOfShards: 3
+        #     numberOfReplicas: 0
+        #
         #     command: false
         #     event: true
         #     rejection: false

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -498,6 +498,9 @@
         #     prefix: zeebe-record
         #     createTemplate: true
         #
+        #     numberOfShards: 3
+        #     numberOfReplicas: 0
+        #
         #     command: false
         #     event: true
         #     rejection: false
@@ -515,6 +518,7 @@
         #     processInstance: true
         #     processInstanceCreation: false
         #     processMessageSubscription: false
+
     # experimental
       # Be aware that all configuration's which are part of the experimental section
       # are subject to change and can be dropped at any time.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -436,6 +436,9 @@
         #     prefix: zeebe-record
         #     createTemplate: true
         #
+        #     numberOfShards: 3
+        #     numberOfReplicas: 0
+        #
         #     command: false
         #     event: true
         #     rejection: false
@@ -453,7 +456,6 @@
         #     processInstance: true
         #     processInstanceCreation: false
         #     processMessageSubscription: false
-
 
     # experimental
       # Be aware that all configuration's which are part of the experimental section

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -102,6 +102,20 @@ public class ElasticsearchExporter implements Exporter {
           "The bulk memory limit is set to more than {} bytes. It is recommended to set the limit between 5 to 15 MB.",
           RECOMMENDED_MAX_BULK_MEMORY_LIMIT);
     }
+
+    final Integer numberOfShards = configuration.index.getNumberOfShards();
+    if (numberOfShards != null && numberOfShards < 1) {
+      throw new ExporterException(
+          String.format(
+              "Elasticsearch numberOfShards must be >= 1. Current value: %d", numberOfShards));
+    }
+
+    final Integer numberOfReplicas = configuration.index.getNumberOfReplicas();
+    if (numberOfReplicas != null && numberOfReplicas < 0) {
+      throw new ExporterException(
+          String.format(
+              "Elasticsearch numberOfReplicas must be >= 0. Current value: %d", numberOfReplicas));
+    }
   }
 
   protected ElasticsearchClient createClient() {

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -124,6 +124,26 @@ public class ElasticsearchExporterConfiguration {
     public boolean processInstanceCreation = false;
     public boolean processMessageSubscription = false;
 
+    // index settings
+    private Integer numberOfShards = null;
+    private Integer numberOfReplicas = null;
+
+    public Integer getNumberOfShards() {
+      return numberOfShards;
+    }
+
+    public void setNumberOfShards(Integer numberOfShards) {
+      this.numberOfShards = numberOfShards;
+    }
+
+    public Integer getNumberOfReplicas() {
+      return numberOfReplicas;
+    }
+
+    public void setNumberOfReplicas(Integer numberOfReplicas) {
+      this.numberOfReplicas = numberOfReplicas;
+    }
+
     @Override
     public String toString() {
       return "IndexConfiguration{"

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
@@ -75,6 +75,7 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
       final Integer numberOfReplicas = settings.getNumberOfReplicas();
 
       final int expectedNumberOfShards = numberOfShardsForIndex(indexName);
+      final int expectedNumberOfReplicas = numberOfReplicasForIndex();
 
       assertThat(numberOfShards)
           .withFailMessage(
@@ -83,9 +84,9 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
           .isEqualTo(expectedNumberOfShards);
       assertThat(numberOfReplicas)
           .withFailMessage(
-              "Expected number of replicas of index %s to be 0 but was %d",
-              indexName, numberOfReplicas)
-          .isEqualTo(0);
+              "Expected number of replicas of index %s to be %d but was %d",
+              indexName, expectedNumberOfReplicas, numberOfReplicas)
+          .isEqualTo(expectedNumberOfReplicas);
     }
   }
 
@@ -120,8 +121,18 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
     return MAPPER.convertValue(jsonNode, new TypeReference<>() {});
   }
 
+  private int numberOfReplicasForIndex() {
+    if (configuration != null && configuration.index.getNumberOfReplicas() != null) {
+      return configuration.index.getNumberOfReplicas();
+    } else {
+      return 0;
+    }
+  }
+
   private int numberOfShardsForIndex(final String indexName) {
-    if (indexName.startsWith(
+    if (configuration != null && configuration.index.getNumberOfShards() != null) {
+      return configuration.index.getNumberOfShards();
+    } else if (indexName.startsWith(
             esClient.indexPrefixForValueTypeWithDelimiter(ValueType.PROCESS_INSTANCE))
         || indexName.startsWith(esClient.indexPrefixForValueTypeWithDelimiter(ValueType.JOB))) {
       return 3;

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfigurationIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfigurationIT.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.exporter.api.ExporterException;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.test.util.TestUtil;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import org.junit.Test;
+
+public class ElasticsearchExporterConfigurationIT
+    extends AbstractElasticsearchExporterIntegrationTestCase {
+
+  @Test
+  public void shouldPropagateNumberOfShardsAndReplicas() {
+    // given
+    elastic.start();
+
+    configuration = getDefaultConfiguration();
+
+    // change number of shards and replicas
+    configuration.index.setNumberOfShards(5);
+    configuration.index.setNumberOfReplicas(4);
+
+    esClient = createElasticsearchClient(configuration);
+
+    // when
+    exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
+    exporterBrokerRule.start();
+    exporterBrokerRule.publishMessage("message", "123");
+
+    // then
+    RecordingExporter.messageRecords()
+        .withCorrelationKey("123")
+        .withName("message")
+        .forEach(r -> TestUtil.waitUntil(() -> wasExported(r)));
+    assertIndexSettings();
+  }
+
+  @Test
+  public void shouldFailWhenNumberOfShardsIsLessOne() {
+    // given
+    elastic.start();
+
+    configuration = getDefaultConfiguration();
+
+    // change number of shards
+    configuration.index.setNumberOfShards(-1);
+
+    esClient = createElasticsearchClient(configuration);
+
+    // when
+    exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
+
+    // then
+    assertThatThrownBy(() -> exporterBrokerRule.start())
+        .isInstanceOf(IllegalStateException.class)
+        .getRootCause()
+        .isInstanceOf(ExporterException.class)
+        .hasMessageContaining("numberOfShards must be >= 1. Current value: -1");
+  }
+
+  @Test
+  public void shouldFailWhenNumberOfReplicasIsLessZero() {
+    // given
+    elastic.start();
+
+    configuration = getDefaultConfiguration();
+
+    // change number replicas
+    configuration.index.setNumberOfReplicas(-1);
+
+    esClient = createElasticsearchClient(configuration);
+
+    // when
+    exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
+
+    // then
+    assertThatThrownBy(() -> exporterBrokerRule.start())
+        .isInstanceOf(IllegalStateException.class)
+        .getRootCause()
+        .isInstanceOf(ExporterException.class)
+        .hasMessageContaining("numberOfReplicas must be >= 0. Current value: -1");
+  }
+
+  private boolean wasExported(final Record<?> record) {
+    try {
+      return esClient.getDocument(record) != null;
+    } catch (final Exception e) {
+      // suppress exception in order to retry and see if it was exported yet or not
+      // the exception can occur since elastic may not be ready yet, or maybe the index hasn't been
+      // created yet, etc.
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
## Description

The user can configure the number of shards and replicas. These configuration values are propagated to the component and index templates, therefore the following happens:

* Validation of the configuration options that the configured number of shards is >= 1 and number of replicas >= 0
* Replace the number of shards and replicas in the templates

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8004 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
