### PR TITLE
8148 add property for zeebedb

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
@@ -22,10 +22,14 @@ import io.atomix.raft.RaftServer;
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
+import io.camunda.zeebe.broker.system.partitions.StateController;
 import io.camunda.zeebe.broker.system.partitions.TestPartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.StreamProcessorTransitionStep;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.ZeebeDbPartitionTransitionStep;
+import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorBuilder;
+import io.camunda.zeebe.snapshots.TransientSnapshot;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import io.camunda.zeebe.util.sched.Actor;
 import io.camunda.zeebe.util.sched.ActorScheduler;
@@ -33,6 +37,7 @@ import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
@@ -112,6 +117,53 @@ public class RandomizedPartitionTransitionTest {
 
     assertThat(instanceTracker.getOpenedInstances())
         .describedAs("Active stream processors at end of transition sequence")
+        .hasSizeLessThan(2);
+  }
+
+  /**
+   * Verifies that during transitions at most one {@code ZeebeDb} is created. It sets up the
+   * following transition chain:
+   *
+   * <ol>
+   *   <li>Pausable dummy step
+   *   <li>{@code ZeebeDbPartitionTransitionStep}
+   * </ol>
+   *
+   * The first step is there to manipulate execution order. In particular, the step will wait for a
+   * countdown latch thus pausing transition execution. This in turn, allows scheduling successive
+   * transition which cancel their predecessors
+   *
+   * @param operations the operations to run
+   */
+  @Property(generation = GenerationMode.RANDOMIZED)
+  void atMostOneZeebeDbIsOpenAtAnyTime(
+      @ForAll("testOperations") final List<TestOperation> operations) {
+    LOGGER.debug(
+        format("Testing property 'atMostOneZeebeDbIsOpenAtAnyTime' on sequence %s", operations));
+
+    final var instanceTracker =
+        new PropertyAssertingInstanceTracker<ZeebeDb>() {
+          @Override
+          void assertProperties() {
+            if (opened.size() > 1) {
+              throw new IllegalStateException("More than one zeebe db opened at the same time");
+            }
+          }
+        };
+
+    final var firstStep = new PausableStep(operations);
+    final var zeebeDbStep = new ZeebeDbPartitionTransitionStep();
+
+    final var context = new TestPartitionTransitionContext();
+    context.setStateController(new TestStateController(instanceTracker));
+
+    final var sut = new NewPartitionTransitionImpl(of(firstStep, zeebeDbStep), context);
+    sut.setConcurrencyControl(actor);
+
+    runOperations(operations, sut);
+
+    assertThat(instanceTracker.getOpenedInstances())
+        .describedAs("Zeebe DB processes at end of transition sequence")
         .hasSizeLessThan(2);
   }
 
@@ -399,6 +451,43 @@ public class RandomizedPartitionTransitionTest {
     @Override
     public String getName() {
       return "RandomizedPartitionTransitionTest.testActor";
+    }
+  }
+
+  private static final class TestStateController implements StateController {
+
+    private final PropertyAssertingInstanceTracker<ZeebeDb> instanceTracker;
+    private ZeebeDb zeebeDb;
+
+    private TestStateController(final PropertyAssertingInstanceTracker<ZeebeDb> instanceTracker) {
+      this.instanceTracker = instanceTracker;
+    }
+
+    @Override
+    public ActorFuture<Optional<TransientSnapshot>> takeTransientSnapshot(
+        final long lowerBoundSnapshotPosition) {
+      throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
+    public ActorFuture<ZeebeDb> recover() {
+      zeebeDb = mock(ZeebeDb.class);
+      instanceTracker.registerCreation(zeebeDb);
+      instanceTracker.registerOpen(zeebeDb);
+      return CompletableActorFuture.completed(zeebeDb);
+    }
+
+    @Override
+    public ActorFuture<Void> closeDb() {
+      if (zeebeDb != null) {
+        instanceTracker.registerClose(zeebeDb);
+      }
+      return CompletableActorFuture.completed(null);
+    }
+
+    @Override
+    public void close() throws Exception {
+      throw new IllegalStateException("Not implemented");
     }
   }
 


### PR DESCRIPTION
## Description

Adds routine that verifies that only one DB will be active at a time.

## Related issues

closes #8148

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
