### PR TITLE
Add id attribute for userTaskForm

### DIFF
--- a/bpmn-model/revapi.json
+++ b/bpmn-model/revapi.json
@@ -30,6 +30,12 @@
             "matcher": "java-package",
             "match": "io.camunda.zeebe.model.bpmn.builder"
           }
+        },
+        {
+          "justification": "No longer inherits from BaseElement",
+          "code": "java.class.noLongerInheritsFromClass",
+          "old": "class io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeUserTaskFormImpl",
+          "superClass": "io.camunda.zeebe.model.bpmn.impl.instance.BaseElementImpl"
         }
       ]
     }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeUserTaskFormImpl.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeUserTaskFormImpl.java
@@ -15,15 +15,21 @@
  */
 package io.camunda.zeebe.model.bpmn.impl.instance.zeebe;
 
+import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.BPMN_ATTRIBUTE_ID;
+
 import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
 import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
-import io.camunda.zeebe.model.bpmn.impl.instance.BaseElementImpl;
+import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeUserTaskForm;
 import org.camunda.bpm.model.xml.ModelBuilder;
 import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
 import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.attribute.Attribute;
 
-public class ZeebeUserTaskFormImpl extends BaseElementImpl implements ZeebeUserTaskForm {
+public class ZeebeUserTaskFormImpl extends BpmnModelElementInstanceImpl
+    implements ZeebeUserTaskForm {
+
+  protected static Attribute<String> idAttribute;
 
   public ZeebeUserTaskFormImpl(final ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
@@ -36,6 +42,18 @@ public class ZeebeUserTaskFormImpl extends BaseElementImpl implements ZeebeUserT
             .namespaceUri(BpmnModelConstants.ZEEBE_NS)
             .instanceProvider(ZeebeUserTaskFormImpl::new);
 
+    idAttribute = typeBuilder.stringAttribute(BPMN_ATTRIBUTE_ID).idAttribute().build();
+
     typeBuilder.build();
+  }
+
+  @Override
+  public String getId() {
+    return idAttribute.getValue(this);
+  }
+
+  @Override
+  public void setId(final String id) {
+    idAttribute.setValue(this, id);
   }
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeUserTaskForm.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeUserTaskForm.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.model.bpmn.instance.zeebe;
 
-import io.camunda.zeebe.model.bpmn.instance.BaseElement;
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
 
-public interface ZeebeUserTaskForm extends BaseElement {}
+public interface ZeebeUserTaskForm extends BpmnModelElementInstance {
+
+  String getId();
+
+  void setId(String id);
+}

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/UserTaskBuilderTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/UserTaskBuilderTest.java
@@ -89,7 +89,7 @@ class UserTaskBuilderTest {
     final BpmnModelInstance instance =
         Bpmn.createExecutableProcess("process")
             .startEvent()
-            .userTask("userTask1", task -> task.zeebeAssignee("user1"))
+            .userTask("userTask1")
             .zeebeUserTaskForm("{}")
             .endEvent()
             .done();
@@ -99,6 +99,6 @@ class UserTaskBuilderTest {
 
     assertThat(zeebeUserTaskForms).hasSize(1);
     final ZeebeUserTaskForm zeebeUserTaskForm = zeebeUserTaskForms.iterator().next();
-    assertThat(zeebeUserTaskForm.getId()).isNotNull();
+    assertThat(zeebeUserTaskForm.getId()).isNotEmpty();
   }
 }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/UserTaskBuilderTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/UserTaskBuilderTest.java
@@ -22,6 +22,8 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeUserTaskForm;
+import java.util.Collection;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.junit.jupiter.api.Test;
 
@@ -80,5 +82,23 @@ class UserTaskBuilderTest {
         .extracting(
             ZeebeAssignmentDefinition::getAssignee, ZeebeAssignmentDefinition::getCandidateGroups)
         .containsExactly(tuple("user1", "role1"));
+  }
+
+  @Test
+  void testUserTaskFormIdNotNull() {
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("userTask1", task -> task.zeebeAssignee("user1"))
+            .zeebeUserTaskForm("{}")
+            .endEvent()
+            .done();
+
+    final Collection<ZeebeUserTaskForm> zeebeUserTaskForms =
+        instance.getModelElementsByType(ZeebeUserTaskForm.class);
+
+    assertThat(zeebeUserTaskForms).hasSize(1);
+    final ZeebeUserTaskForm zeebeUserTaskForm = zeebeUserTaskForms.iterator().next();
+    assertThat(zeebeUserTaskForm.getId()).isNotNull();
   }
 }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeUserTaskFormTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeUserTaskFormTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
 import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
 public class ZeebeUserTaskFormTest extends BpmnModelElementInstanceTest {
 
@@ -29,7 +30,7 @@ public class ZeebeUserTaskFormTest extends BpmnModelElementInstanceTest {
 
   @Override
   public Collection<ChildElementAssumption> getChildElementAssumptions() {
-    return null;
+    return Collections.emptyList();
   }
 
   @Override

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeUserTaskFormTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeUserTaskFormTest.java
@@ -17,8 +17,8 @@ package io.camunda.zeebe.model.bpmn.instance.zeebe;
 
 import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
 import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 
 public class ZeebeUserTaskFormTest extends BpmnModelElementInstanceTest {
 
@@ -29,11 +29,11 @@ public class ZeebeUserTaskFormTest extends BpmnModelElementInstanceTest {
 
   @Override
   public Collection<ChildElementAssumption> getChildElementAssumptions() {
-    return Collections.emptyList();
+    return null;
   }
 
   @Override
   public Collection<AttributeAssumption> getAttributesAssumptions() {
-    return Collections.emptyList();
+    return Arrays.asList(new AttributeAssumption("id", true));
   }
 }


### PR DESCRIPTION
## Description

Add default id attribute for userTaskForm.

## Related issues
closes #8153 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
