### PR TITLE
fix(engine): update the key generator on replay

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ContinuouslyReplayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ContinuouslyReplayTest.java
@@ -62,8 +62,6 @@ public class ContinuouslyReplayTest {
               processingState.entrySet().stream()
                   .filter(entry -> entry.getKey() != ZbColumnFamilies.DEFAULT)
                   // ignores transient states
-                  .filter(entry -> entry.getKey() != ZbColumnFamilies.KEY)
-                  // on followers we don't need to reset the key
                   // this will happen anyway then on leader replay
                   .forEach(
                       entry -> {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FailOverReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FailOverReplicationTest.java
@@ -235,6 +235,7 @@ public class FailOverReplicationTest {
             .filter(k -> k != -1L)
             .toArray(Long[]::new);
 
+    assertThat(newKeys).isNotEmpty();
     assertThat(previousKeys)
         .describedAs("Keys should always be unique for different entities.")
         .doesNotContain(newKeys);


### PR DESCRIPTION
## Description

On replay, update the key generator with the replayed record's key. This fixes an issue where the follower would restart with a snapshot where nothing needed to be replayed, and would thus not update its generated key, leading to processing starting with the wrong key and duplicate keys, causing state inconsistencies.

## Related issues

closes #8129

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
