### PR TITLE
[Backport 1.2]  Update the key generator on replay 

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateMachine.java
@@ -73,7 +73,6 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
   private long batchSourceEventPosition = StreamProcessor.UNSET_POSITION;
 
   private long snapshotPosition;
-  private long highestRecordKey = -1L;
   private long lastReadRecordPosition = StreamProcessor.UNSET_POSITION;
   private long lastReplayedEventPosition = StreamProcessor.UNSET_POSITION;
 
@@ -234,9 +233,6 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
    * the last source event, which has caused the last applied event.
    */
   private void onRecordsReplayed() {
-    // restore the key generate with the highest key from the log
-    keyGeneratorControls.setKeyIfHigher(highestRecordKey);
-
     LOG.info(LOG_STMT_REPLAY_FINISHED, lastReadRecordPosition);
     recoveryFuture.complete(lastSourceEventPosition);
   }
@@ -267,8 +263,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
 
     // records from other partitions should not influence the key generator of this partition
     if (Protocol.decodePartitionId(currentRecordKey) == zeebeState.getPartitionId()) {
-      // remember the highest key on the stream to restore the key generator after replay
-      highestRecordKey = Math.max(currentRecordKey, highestRecordKey);
+      keyGeneratorControls.setKeyIfHigher(currentRecordKey);
     }
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ContinuouslyReplayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ContinuouslyReplayTest.java
@@ -62,8 +62,6 @@ public class ContinuouslyReplayTest {
               processingState.entrySet().stream()
                   .filter(entry -> entry.getKey() != ZbColumnFamilies.DEFAULT)
                   // ignores transient states
-                  .filter(entry -> entry.getKey() != ZbColumnFamilies.KEY)
-                  // on followers we don't need to reset the key
                   // this will happen anyway then on leader replay
                   .forEach(
                       entry -> {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FailOverReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FailOverReplicationTest.java
@@ -235,6 +235,7 @@ public class FailOverReplicationTest {
             .filter(k -> k != -1L)
             .toArray(Long[]::new);
 
+    assertThat(newKeys).isNotEmpty();
     assertThat(previousKeys)
         .describedAs("Keys should always be unique for different entities.")
         .doesNotContain(newKeys);


### PR DESCRIPTION
## Description

Backports the fix from https://github.com/camunda-cloud/zeebe/pull/8156 and adjusts the IT test to get it work with 1.2. Snapshot need to be taken so the new leader will not replay the complete log and start with the latest state he had.


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda-cloud/zeebe/issues/8129

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
