### PR TITLE
Add release script for benchmark images

### DIFF
--- a/benchmarks/project/release.sh
+++ b/benchmarks/project/release.sh
@@ -1,4 +1,15 @@
 #!/bin/bash -eu
+# Usage: ./release.sh [-p] VERSION
+# Example usage:
+#   $ ./release.sh 1.2.4
+# This script will build the Docker images for the worker and starter applications in this project,
+# for the given version. The `VERSION` should be the semantic version, and match the tag that you
+# want to build. The script will checkout that tag in a temporary worktree, and run the docker
+# commands from that worktree.
+#
+# By default, the script is interactive, and it will ask the user whether or not to push the images.
+# You can specify the `-p` flag to automatically push, or the environment variable PUSH=1, e.g.:
+#   $ ./release.sh -p 1.2.4
 
 WORKTREE="$(pwd)/.release"
 function cleanup() {

--- a/benchmarks/project/release.sh
+++ b/benchmarks/project/release.sh
@@ -1,0 +1,77 @@
+#!/bin/bash -eu
+
+WORKTREE="$(pwd)/.release"
+function cleanup() {
+  if [ -d "${WORKTREE}" ]; then
+    popd > /dev/null 2>&1
+	  echo "Cleaning up release worktree at ${WORKTREE}"
+	  git worktree remove -f "${WORKTREE}"
+	  rm -rf "${WORKTREE}"
+  fi
+}
+trap cleanup INT TERM EXIT HUP
+
+function killChildren()  {
+  local children
+  children="$(jobs -p)"
+
+  if [ -n "${children}" ]; then
+    echo "${children}" | xargs kill -TERM
+  fi
+}
+
+# Ensure this runs in a subshell so we have our own trap function
+pushImages() {
+  trap killChildren INT TERM HUP
+  docker push "gcr.io/zeebe-io/starter:$TAG" 1>/dev/null &
+  docker push "gcr.io/zeebe-io/worker:$TAG" 1>/dev/null &
+	wait
+}
+
+if [ "$#" -eq "0" ]; then
+  echo "Usage: ./release.sh [-p] VERSION"
+  echo "For example, to release version 1.2.4:"
+  echo "  $ ./release.sh 1.2.4"
+  echo "This will build and ask the user whether to push or not"
+  echo "If you wish to push without being asked, use the \`-p\` flag. e.g.:"
+  echo "  $ ./release.sh -p 1.2.4"
+  echo "This will build and push automatically without any user interaction"
+  exit 0
+fi
+
+if [ "${1:-}" == "-p" ]; then
+  PUSH=1
+  shift
+fi
+
+VERSION=${1:-}
+if [ -n "$VERSION" ]; then
+	echo "Checking out release worktree under .worktree/release. In case of interruption, make sure to manually clean it up afterwards"
+	git worktree add -d -q "${WORKTREE}" "${VERSION}"
+	pushd "${WORKTREE}/benchmarks/project" > /dev/null 2>&1
+fi
+
+TAG=${VERSION:-SNAPSHOT}
+echo "Building gcr.io/zeebe-io/starter:${TAG}"
+docker build -t "gcr.io/zeebe-io/starter:${TAG}" --target starter .
+
+echo "Building gcr.io/zeebe-io/worker:${TAG}"
+docker build -t "gcr.io/zeebe-io/worker:${TAG}" --target worker .
+
+PUSH=${PUSH:-0}
+if [ "${PUSH}" -ne "1" ]; then
+	read -p "Push images? (y/n) " -n 1 -r
+  echo
+
+	if [[ $REPLY =~ ^[Yy]$ ]]
+	then
+		PUSH=1
+	fi
+fi
+
+if [ "$PUSH" -eq "1" ]; then
+	echo "Pushing image gcr.io/zeebe-io/starter:$TAG and gcr.io/zeebe-io/worker:$TAG"
+  (pushImages)
+else
+	echo "Skipping push..."
+fi

--- a/benchmarks/project/release.sh
+++ b/benchmarks/project/release.sh
@@ -58,7 +58,7 @@ fi
 VERSION=${1:-}
 if [ -n "$VERSION" ]; then
 	echo "Checking out release worktree under .worktree/release. In case of interruption, make sure to manually clean it up afterwards"
-	git worktree add -d -q "${WORKTREE}" "${VERSION}"
+	git worktree add -q "${WORKTREE}" "${VERSION}"
 	pushd "${WORKTREE}/benchmarks/project" > /dev/null 2>&1
 fi
 


### PR DESCRIPTION
## Description

This PR adds a release script for the benchmark worker/starter images which will checkout the version you need in a worktree (so isolated), build the images for that version, and optionally push them. To use, you would go to the benchmarks/project folder and run `./release.sh -p VERSION`, e.g. `./release.sh -p 1.2.4`.

This should hopefully simplify the release process a little bit by allowing people to just run this script instead of multiple shell commands.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
