### PR TITLE
New instance and job panels

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/JobMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/JobMetrics.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.metrics;
 
 import io.prometheus.client.Counter;
-import io.prometheus.client.Gauge;
 
 public final class JobMetrics {
 
@@ -18,14 +17,6 @@ public final class JobMetrics {
           .name("job_events_total")
           .help("Number of job events")
           .labelNames("action", "partition", "type")
-          .register();
-
-  private static final Gauge PENDING_JOBS =
-      Gauge.build()
-          .namespace("zeebe")
-          .name("pending_jobs_total")
-          .help("Number of pending jobs")
-          .labelNames("partition", "type")
           .register();
 
   private final String partitionIdLabel;
@@ -40,11 +31,6 @@ public final class JobMetrics {
 
   public void jobCreated(final String type) {
     jobEvent("created", type);
-    PENDING_JOBS.labels(partitionIdLabel, type).inc();
-  }
-
-  private void jobFinished(final String type) {
-    PENDING_JOBS.labels(partitionIdLabel, type).dec();
   }
 
   public void jobActivated(final String type, final int activatedJobs) {
@@ -57,7 +43,6 @@ public final class JobMetrics {
 
   public void jobCompleted(final String type) {
     jobEvent("completed", type);
-    jobFinished(type);
   }
 
   public void jobFailed(final String type) {
@@ -66,11 +51,9 @@ public final class JobMetrics {
 
   public void jobCanceled(final String type) {
     jobEvent("canceled", type);
-    jobFinished(type);
   }
 
   public void jobErrorThrown(final String type) {
     jobEvent("error thrown", type);
-    jobFinished(type);
   }
 }

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -88,7 +88,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1636355418008,
+  "iteration": 1636367540721,
   "links": [],
   "panels": [
     {
@@ -2234,7 +2234,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 26
+            "y": 3
           },
           "hideTimeOverride": false,
           "id": 12,
@@ -2298,7 +2298,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 26
+            "y": 3
           },
           "hideTimeOverride": false,
           "id": 13,
@@ -2368,7 +2368,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 31
+            "y": 8
           },
           "hiddenSeries": false,
           "id": 2,
@@ -2473,7 +2473,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 31
+            "y": 8
           },
           "hiddenSeries": false,
           "id": 3,
@@ -2579,7 +2579,7 @@
             "h": 6,
             "w": 9,
             "x": 0,
-            "y": 37
+            "y": 14
           },
           "hiddenSeries": false,
           "id": 4,
@@ -2679,7 +2679,7 @@
             "h": 6,
             "w": 7,
             "x": 9,
-            "y": 37
+            "y": 14
           },
           "hiddenSeries": false,
           "id": 266,
@@ -2780,7 +2780,7 @@
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 37
+            "y": 14
           },
           "hiddenSeries": false,
           "id": 267,
@@ -2866,43 +2866,42 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "$DS_PROMETHEUS",
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Shows the process instance creation rate over all partitions in the namespace. It will only count root process instances, so call activity process instance creations are excluded.",
           "fieldConfig": {
             "defaults": {
-              "custom": {},
-              "links": []
+              "custom": {}
             },
             "overrides": []
           },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 5,
-            "w": 24,
+            "h": 8,
+            "w": 6,
             "x": 0,
-            "y": 43
+            "y": 20
           },
           "hiddenSeries": false,
-          "id": 15,
+          "id": 290,
           "legend": {
             "avg": false,
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
           "lines": true,
           "linewidth": 1,
-          "links": [],
           "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
           "percentage": false,
           "pluginVersion": "7.4.5",
-          "pointradius": 5,
+          "pointradius": 2,
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
@@ -2911,35 +2910,20 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(zeebe_running_process_instances_total{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"})",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "Process Instance",
+              "expr": "sum(rate(zeebe_executed_instances_total{namespace=~\"$namespace\", pod=~\"$pod\", action=\"activated\"}[1m])) by (namespace)",
+              "interval": "",
+              "legendFormat": "Process instance creation {{namespace}}",
               "refId": "A"
-            },
-            {
-              "expr": "sum(zeebe_pending_jobs_total{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"})",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "Jobs",
-              "refId": "B"
-            },
-            {
-              "expr": "sum(zeebe_pending_incidents_total{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"})",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "Incidents",
-              "refId": "C"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Running Process Instances",
+          "title": "Process instance creation per second [1m]",
           "tooltip": {
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "individual"
           },
           "type": "graph",
@@ -2952,14 +2936,310 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:144",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:145",
               "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,
               "min": null,
               "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Shows the process instance completion rate over all partitions in the namespace. It will only count root process instances, so call activity process instance creations are excluded.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 6,
+            "y": 20
+          },
+          "hiddenSeries": false,
+          "id": 291,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(zeebe_executed_instances_total{namespace=~\"$namespace\", pod=~\"$pod\", action=\"completed\"}[1m])) by (namespace)",
+              "interval": "",
+              "legendFormat": "Process instance completion {{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Process instance completion per second [1m]",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:144",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
             },
             {
+              "$$hashKey": "object:145",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Shows the Job creation rate over all partitions in the namespace",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 12,
+            "y": 20
+          },
+          "hiddenSeries": false,
+          "id": 288,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(zeebe_job_events_total{namespace=~\"$namespace\", pod=~\"$pod\", action=\"created\"}[1m])) by (namespace)",
+              "interval": "",
+              "legendFormat": "Job creation {{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Job creation per second [1m]",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:144",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:145",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Shows the Job completion rate over all partitions in the namespace.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 20
+          },
+          "hiddenSeries": false,
+          "id": 289,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(zeebe_job_events_total{namespace=~\"$namespace\", pod=~\"$pod\", action=\"completed\"}[1m])) by (namespace)",
+              "interval": "",
+              "legendFormat": "Job completion {{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Job completion per second [1m]",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:144",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:145",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -3673,7 +3953,9 @@
             }
           ],
           "thresholds": [],
+          "timeFrom": null,
           "timeRegions": [],
+          "timeShift": null,
           "title": "GC Count per second [1m]",
           "tooltip": {
             "shared": true,
@@ -10668,5 +10950,5 @@
   "timezone": "",
   "title": "Zeebe",
   "uid": "I4lo7_EZk",
-  "version": 23
+  "version": 24
 }


### PR DESCRIPTION
## Description

 * Remove the process instance gauge, which was used to count the current running instances
 * Remove the job gauge, which was used to count the pending jobs

Boths metrics were error prone, and show misleading numbers if a fail-over or restart happened. To overcome this problem we use now counters, and show only the creation and completion rate separately. 


![onenamespace](https://user-images.githubusercontent.com/2758593/140731929-47828d5d-017c-41f2-8d07-682e0c2d5e90.png)


For multi namespace it looks like this:

![multiple-namespaces](https://user-images.githubusercontent.com/2758593/140731959-287b1c83-8111-488f-a145-6f60d4a304ff.png)


When we have starter and simple starter running, without workers it looks like this:

![starters](https://user-images.githubusercontent.com/2758593/140732000-76cc5613-46e8-4ee7-865a-175078139cfe.png)

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda-cloud/zeebe/issues/4657

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
