### PR TITLE
Ensures the correct stage is marked as unstable on test failure

### DIFF
--- a/.ci/scripts/distribution/random-test-java.sh
+++ b/.ci/scripts/distribution/random-test-java.sh
@@ -14,7 +14,6 @@ MAVEN_PROPERTIES=(
   -Dsurefire.rerunFailingTestsCount=0
   -Dmaven.javadoc.skip=true
 )
-tempFile=$(mktemp)
 
 if [ ! -z "$SUREFIRE_FORK_COUNT" ]; then
   MAVEN_PROPERTIES+=("-DforkCount=$SUREFIRE_FORK_COUNT")
@@ -26,4 +25,7 @@ if [ ! -z "$JUNIT_THREAD_COUNT" ]; then
   MAVEN_PROPERTIES+=("-DjunitThreadCount=$JUNIT_THREAD_COUNT")
 fi
 
-mvn -o -B --fail-never -T "${MAVEN_PARALLELISM}" -s "${MAVEN_SETTINGS_XML}" test -P parallel-tests,include-random-tests "${MAVEN_PROPERTIES[@]}" | tee "${tempFile}"
+mvn -o -B --fail-never -T "${MAVEN_PARALLELISM}" -s "${MAVEN_SETTINGS_XML}" \
+  -P parallel-tests,include-random-tests \
+  "${MAVEN_PROPERTIES[@]}" \
+  test

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,14 +170,14 @@ pipeline {
 
                     post {
                         always {
-                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true, allowEmptyResults: true
+                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}.xml", keepLongStdio: true, allowEmptyResults: true
                         }
                     }
                 }
 
                 stage('Test (Random)') {
                     environment {
-                        SUREFIRE_REPORT_NAME_SUFFIX = 'java-testrun-random'
+                        SUREFIRE_REPORT_NAME_SUFFIX = 'random-testrun'
                         MAVEN_PARALLELISM = 2
                         SUREFIRE_FORK_COUNT = 6
                         JUNIT_THREAD_COUNT = 6
@@ -191,7 +191,7 @@ pipeline {
 
                     post {
                         always {
-                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true, allowEmptyResults: true
+                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}.xml", keepLongStdio: true, allowEmptyResults: true
                         }
                     }
                 }
@@ -209,7 +209,7 @@ pipeline {
 
                     post {
                         always {
-                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true, allowEmptyResults: true
+                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}.xml", keepLongStdio: true, allowEmptyResults: true
                         }
                     }
                 }
@@ -276,7 +276,7 @@ pipeline {
 
                             post {
                                 always {
-                                    junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true, allowEmptyResults: true
+                                    junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}.xml", keepLongStdio: true, allowEmptyResults: true
                                     stash allowEmpty: true, name: itFlakyTestStashName, includes: '**/FlakyTests.txt'
                                 }
 


### PR DESCRIPTION
## Description

Previously, when the `Test (Java)` or `Test (Random)` stages would fail due to failing tests (not flaky, but just test failure, resulting in an unstable/yellow build), it would often mark the other test stages as failed as well. This was because we use an environment variable `SUREFIRE_REPORT_SUFFIX_NAME` as to differentiate the test reports per stage. This works for the test part, in that maven sees the correct variable value. However, the post actions would grab more than the reports they were supposed to, since the one from the first stage was a prefix of the second one. So my bad :smile: 

This also caused the test results to be archived multiple times, resulting in a higher test count and possibly failure count reported.

This simply fixes it so when one stage is marked as unstable, only it is marked and not the other.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
