### PR TITLE
Deprecate zeebe-test module for removal

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -2,6 +2,11 @@
 
 JUnit test rules for Zeebe applications.
 
+## 🚨 Deprecation Warning 🚨
+
+This module is deprecated and will be removed in a future release.
+See [8143](https://github.com/camunda-cloud/zeebe/issues/8143) for more information.
+
 ## Usage example
 
 Add `zeebe-test` as test dependency to your project.

--- a/test/src/main/java/io/camunda/zeebe/test/ClientRule.java
+++ b/test/src/main/java/io/camunda/zeebe/test/ClientRule.java
@@ -13,6 +13,11 @@ import java.util.Properties;
 import java.util.function.Supplier;
 import org.junit.rules.ExternalResource;
 
+/**
+ * @deprecated since 1.3.0. See issue <a
+ *     href="https://github.com/camunda-cloud/zeebe/issues/8143">8143</a> for more information.
+ */
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class ClientRule extends ExternalResource {
 
   private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(2);

--- a/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
+++ b/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
@@ -51,6 +51,11 @@ import org.junit.runners.model.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated since 1.3.0. See issue <a
+ *     href="https://github.com/camunda-cloud/zeebe/issues/8143">8143</a> for more information.
+ */
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class EmbeddedBrokerRule extends ExternalResource {
 
   public static final String DEFAULT_CONFIG_FILE = "zeebe.test.cfg.yaml";

--- a/test/src/main/java/io/camunda/zeebe/test/ProcessInstanceAssert.java
+++ b/test/src/main/java/io/camunda/zeebe/test/ProcessInstanceAssert.java
@@ -25,6 +25,11 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
 
+/**
+ * @deprecated since 1.3.0. See issue <a
+ *     href="https://github.com/camunda-cloud/zeebe/issues/8143">8143</a> for more information.
+ */
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class ProcessInstanceAssert
     extends AbstractAssert<ProcessInstanceAssert, ProcessInstanceEvent> {
   private static final ZeebeObjectMapper OBJECT_MAPPER = new ZeebeObjectMapper();

--- a/test/src/main/java/io/camunda/zeebe/test/ZeebeTestRule.java
+++ b/test/src/main/java/io/camunda/zeebe/test/ZeebeTestRule.java
@@ -21,6 +21,11 @@ import org.junit.rules.ExternalResource;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
+/**
+ * @deprecated since 1.3.0. See issue <a
+ *     href="https://github.com/camunda-cloud/zeebe/issues/8143">8143</a> for more information.
+ */
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class ZeebeTestRule extends ExternalResource {
   protected final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();

--- a/test/src/main/java/io/camunda/zeebe/test/exporter/ExporterIntegrationRule.java
+++ b/test/src/main/java/io/camunda/zeebe/test/exporter/ExporterIntegrationRule.java
@@ -115,7 +115,11 @@ import org.junit.rules.ExternalResource;
  *
  * NOTE: calls to the various configure methods are additive, so it is possible to configure more
  * than one exporter, as long as the IDs are different.
+ *
+ * @deprecated since 1.3.0. See issue <a
+ *     href="https://github.com/camunda-cloud/zeebe/issues/8143">8143</a> for more information.
  */
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class ExporterIntegrationRule extends ExternalResource {
 
   public static final BpmnModelInstance SAMPLE_PROCESS =

--- a/test/src/main/java/io/camunda/zeebe/test/exporter/ExporterTestHarness.java
+++ b/test/src/main/java/io/camunda/zeebe/test/exporter/ExporterTestHarness.java
@@ -32,7 +32,11 @@ import org.slf4j.LoggerFactory;
  * ExporterTestHarness provides utilities to write unit tests for concrete implementations of the
  * {@link Exporter} interface, by simulating the lifecycle that it would have on a live broker while
  * allowing callers to control the execution flow.
+ *
+ * @deprecated since 1.3.0. See issue <a
+ *     href="https://github.com/camunda-cloud/zeebe/issues/8143">8143</a> for more information.
  */
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class ExporterTestHarness {
 
   private final Logger logger = LoggerFactory.getLogger("io.camunda.zeebe.broker.exporter");
@@ -96,7 +100,7 @@ public class ExporterTestHarness {
    * @param configFile pointer to a yaml configuration file
    */
   public void configure(final String id, final File configFile) throws Exception {
-    try (InputStream configStream = new FileInputStream(configFile)) {
+    try (final InputStream configStream = new FileInputStream(configFile)) {
       configure(id, configStream);
     }
   }

--- a/test/src/main/java/io/camunda/zeebe/test/exporter/MockConfiguration.java
+++ b/test/src/main/java/io/camunda/zeebe/test/exporter/MockConfiguration.java
@@ -10,7 +10,13 @@ package io.camunda.zeebe.test.exporter;
 import io.camunda.zeebe.exporter.api.context.Configuration;
 import java.util.Map;
 
-/** A mock implementation of {@link Configuration} providing easy control over all properties. */
+/**
+ * A mock implementation of {@link Configuration} providing easy control over all properties.
+ *
+ * @deprecated since 1.3.0. See issue <a
+ *     href="https://github.com/camunda-cloud/zeebe/issues/8143">8143</a> for more information.
+ */
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class MockConfiguration<T> implements Configuration {
 
   private String id;

--- a/test/src/main/java/io/camunda/zeebe/test/exporter/MockContext.java
+++ b/test/src/main/java/io/camunda/zeebe/test/exporter/MockContext.java
@@ -11,6 +11,11 @@ import io.camunda.zeebe.exporter.api.context.Configuration;
 import io.camunda.zeebe.exporter.api.context.Context;
 import org.slf4j.Logger;
 
+/**
+ * @deprecated since 1.3.0. See issue <a
+ *     href="https://github.com/camunda-cloud/zeebe/issues/8143">8143</a> for more information.
+ */
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class MockContext implements Context {
 
   private Logger logger;

--- a/test/src/main/java/io/camunda/zeebe/test/exporter/MockController.java
+++ b/test/src/main/java/io/camunda/zeebe/test/exporter/MockController.java
@@ -14,6 +14,11 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
+/**
+ * @deprecated since 1.3.0. See issue <a
+ *     href="https://github.com/camunda-cloud/zeebe/issues/8143">8143</a> for more information.
+ */
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class MockController implements Controller {
 
   public static final long UNKNOWN_POSITION = -1;

--- a/test/src/main/java/io/camunda/zeebe/test/exporter/MockScheduledTask.java
+++ b/test/src/main/java/io/camunda/zeebe/test/exporter/MockScheduledTask.java
@@ -12,7 +12,11 @@ import java.time.Duration;
 /**
  * Represents a single scheduled task through {@link MockController#scheduleTask(Duration,
  * Runnable)}. A call to its {@link #run()} method will only execute the underlying task once.
+ *
+ * @deprecated since 1.3.0. See issue <a
+ *     href="https://github.com/camunda-cloud/zeebe/issues/8143">8143</a> for more information.
  */
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class MockScheduledTask implements Runnable {
 
   private Duration delay;

--- a/test/src/main/java/io/camunda/zeebe/test/exporter/record/ExporterMappedObject.java
+++ b/test/src/main/java/io/camunda/zeebe/test/exporter/record/ExporterMappedObject.java
@@ -10,6 +10,11 @@ package io.camunda.zeebe.test.exporter.record;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.broker.exporter.ExporterObjectMapper;
 
+/**
+ * @deprecated since 1.3.0. See issue <a
+ *     href="https://github.com/camunda-cloud/zeebe/issues/8143">8143</a> for more information.
+ */
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class ExporterMappedObject {
 
   protected static final ExporterObjectMapper OBJECT_MAPPER = new ExporterObjectMapper();

--- a/test/src/main/java/io/camunda/zeebe/test/exporter/record/MockRecord.java
+++ b/test/src/main/java/io/camunda/zeebe/test/exporter/record/MockRecord.java
@@ -14,6 +14,11 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import java.util.Objects;
 
+/**
+ * @deprecated since 1.3.0. See issue <a
+ *     href="https://github.com/camunda-cloud/zeebe/issues/8143">8143</a> for more information.
+ */
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class MockRecord extends ExporterMappedObject implements Record, Cloneable {
 
   private long position = 0;

--- a/test/src/main/java/io/camunda/zeebe/test/exporter/record/MockRecordMetadata.java
+++ b/test/src/main/java/io/camunda/zeebe/test/exporter/record/MockRecordMetadata.java
@@ -14,6 +14,11 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import java.util.Objects;
 
+/**
+ * @deprecated since 1.3.0. See issue <a
+ *     href="https://github.com/camunda-cloud/zeebe/issues/8143">8143</a> for more information.
+ */
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class MockRecordMetadata extends ExporterMappedObject implements Cloneable {
 
   private Intent intent = ProcessInstanceCreationIntent.CREATE;

--- a/test/src/main/java/io/camunda/zeebe/test/exporter/record/MockRecordStream.java
+++ b/test/src/main/java/io/camunda/zeebe/test/exporter/record/MockRecordStream.java
@@ -10,6 +10,11 @@ package io.camunda.zeebe.test.exporter.record;
 import io.camunda.zeebe.test.util.stream.StreamWrapper;
 import java.util.stream.Stream;
 
+/**
+ * @deprecated since 1.3.0. See issue <a
+ *     href="https://github.com/camunda-cloud/zeebe/issues/8143">8143</a> for more information.
+ */
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class MockRecordStream extends StreamWrapper<MockRecord, MockRecordStream> {
 
   public MockRecordStream(final Stream<MockRecord> wrappedStream) {

--- a/test/src/main/java/io/camunda/zeebe/test/exporter/record/MockRecordValue.java
+++ b/test/src/main/java/io/camunda/zeebe/test/exporter/record/MockRecordValue.java
@@ -9,6 +9,11 @@ package io.camunda.zeebe.test.exporter.record;
 
 import io.camunda.zeebe.protocol.record.RecordValue;
 
+/**
+ * @deprecated since 1.3.0. See issue <a
+ *     href="https://github.com/camunda-cloud/zeebe/issues/8143">8143</a> for more information.
+ */
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class MockRecordValue extends ExporterMappedObject implements RecordValue {
 
   public MockRecordValue() {}

--- a/test/src/main/java/io/camunda/zeebe/test/exporter/record/MockRecordValueWithVariables.java
+++ b/test/src/main/java/io/camunda/zeebe/test/exporter/record/MockRecordValueWithVariables.java
@@ -10,6 +10,11 @@ package io.camunda.zeebe.test.exporter.record;
 import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
 import java.util.Map;
 
+/**
+ * @deprecated since 1.3.0. See issue <a
+ *     href="https://github.com/camunda-cloud/zeebe/issues/8143">8143</a> for more information.
+ */
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class MockRecordValueWithVariables extends MockRecordValue
     implements RecordValueWithVariables {
 


### PR DESCRIPTION
## Description

This annotates all public classes in the `zeebe-test` module with `@Deprecated(since = "1.3.0", forRemoval = true)`.
We still use a number of these classes internally which now trigger deprecation warnings. Once we remove the `zeebe-test` module for 1.4.0 we will migrate some of our tests to `zeebe-test-container` and move some classes from `zeebe-test` to our internal `zeebe-test-util` module where they no longer need to be annotated with `@Deprecated`.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #8143 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
