### PR TITLE
Add actor clock actuator endpoint 

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -92,6 +92,21 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
       <exclusions>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -11,6 +10,7 @@
   </parent>
 
   <artifactId>camunda-cloud-zeebe</artifactId>
+
   <packaging>jar</packaging>
 
   <name>Zeebe Distribution</name>
@@ -111,8 +111,8 @@
       <artifactId>micrometer-core</artifactId>
       <exclusions>
         <exclusion>
-          <!-- Conflicts with histogram in elasticsearch exporter dependency -->
           <groupId>org.hdrhistogram</groupId>
+          <!-- Conflicts with histogram in elasticsearch exporter dependency -->
           <artifactId>HdrHistogram</artifactId>
         </exclusion>
       </exclusions>
@@ -206,30 +206,30 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>appassembler-maven-plugin</artifactId>
         <configuration>
+          <assembleDirectory>${project.build.directory}/camunda-cloud-zeebe</assembleDirectory>
           <configurationDirectory>config</configurationDirectory>
           <copyConfigurationDirectory>true</copyConfigurationDirectory>
-          <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
           <extraJvmArguments>-Xms128m
             --illegal-access=deny
             -XX:+ExitOnOutOfMemoryError</extraJvmArguments>
-          <repositoryLayout>flat</repositoryLayout>
-          <useWildcardClassPath>true</useWildcardClassPath>
-          <repositoryName>lib</repositoryName>
-          <assembleDirectory>${project.build.directory}/camunda-cloud-zeebe</assembleDirectory>
+          <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
           <platforms>
             <platform>windows</platform>
             <platform>unix</platform>
           </platforms>
           <programs>
             <program>
-              <mainClass>io.camunda.zeebe.broker.StandaloneBroker</mainClass>
               <id>broker</id>
+              <mainClass>io.camunda.zeebe.broker.StandaloneBroker</mainClass>
             </program>
             <program>
-              <mainClass>io.camunda.zeebe.gateway.StandaloneGateway</mainClass>
               <id>gateway</id>
+              <mainClass>io.camunda.zeebe.gateway.StandaloneGateway</mainClass>
             </program>
           </programs>
+          <repositoryLayout>flat</repositoryLayout>
+          <repositoryName>lib</repositoryName>
+          <useWildcardClassPath>true</useWildcardClassPath>
         </configuration>
         <executions>
           <execution>
@@ -253,10 +253,12 @@
             <phase>package</phase>
             <configuration>
               <target>
-                <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl" tofile="${project.build.directory}/camunda-cloud-zeebe/bin/zbctl"></copy>
+                <?SORTPOM IGNORE?> <!-- ordering is important here, chmod needs to run after copying -->
                 <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.exe" tofile="${project.build.directory}/camunda-cloud-zeebe/bin/zbctl.exe"></copy>
                 <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.darwin" tofile="${project.build.directory}/camunda-cloud-zeebe/bin/zbctl.darwin"></copy>
+                <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl" tofile="${project.build.directory}/camunda-cloud-zeebe/bin/zbctl"></copy>
                 <chmod dir="${project.build.directory}/camunda-cloud-zeebe/bin" failonerror="${zbctl.force}" includes="zbctl*" perm="ugo+rx"></chmod>
+                <?SORTPOM RESUME?>
               </target>
             </configuration>
           </execution>
@@ -272,8 +274,8 @@
             </goals>
             <phase>package</phase>
             <configuration>
-              <attach>true</attach>
               <appendAssemblyId>false</appendAssemblyId>
+              <attach>true</attach>
               <descriptors>
                 <descriptor>src/main/assembly.xml</descriptor>
               </descriptors>

--- a/dist/src/main/java/io/camunda/zeebe/shared/ActorClockConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/ActorClockConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared;
+
+import io.camunda.zeebe.shared.management.ActorClockService;
+import io.camunda.zeebe.shared.management.ControlledActorClockService;
+import io.camunda.zeebe.util.sched.clock.ActorClock;
+import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
+import io.camunda.zeebe.util.sched.clock.DefaultActorClock;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.context.annotation.ApplicationScope;
+
+@SuppressWarnings("unused")
+@ConfigurationProperties("zeebe.clock")
+public final class ActorClockConfiguration {
+
+  private final ActorClock clock;
+  private final ActorClockService service;
+
+  @ConstructorBinding
+  public ActorClockConfiguration(@DefaultValue("false") final boolean controlled) {
+    if (controlled) {
+      final var controlledClock = new ControlledActorClock();
+      service = new ControlledActorClockService(controlledClock);
+      clock = controlledClock;
+    } else {
+      clock = new DefaultActorClock();
+      service = clock::getTimeMillis;
+    }
+  }
+
+  @Bean
+  @ApplicationScope
+  public ActorClock getClock() {
+    return clock;
+  }
+
+  @Bean
+  @ApplicationScope
+  public ActorClockService getClockService() {
+    return service;
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared.management;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.annotation.Selector;
+import org.springframework.boot.actuate.endpoint.annotation.Selector.Match;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
+import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * An actuator endpoint which exposes the current actor clock, provided there it can resolve a bean
+ * of type {@link ActorClockService} somewhere, and it's enabled via configuration (which by default
+ * it isn't).
+ *
+ * <p>NOTE: if the clock is not controllable (set via `zeebe.clock.controlled`), any write or delete
+ * operations will result in a 403 response.
+ */
+@Component
+@WebEndpoint(id = "clock", enableByDefault = false)
+public class ActorClockEndpoint {
+  private static final String PATH_PIN = "pin";
+  private static final String PATH_ADD = "add";
+
+  private final ActorClockService service;
+
+  @Autowired
+  public ActorClockEndpoint(final ActorClockService service) {
+    this.service = service;
+  }
+
+  /**
+   * GET /actuator/clock - returns the current instant of the clock in human-readable format using
+   * {@link java.time.format.DateTimeFormatter#ISO_INSTANT}.
+   *
+   * @return a 200 response carrying the current instant of the clock
+   */
+  @ReadOperation
+  public WebEndpointResponse<Response> getCurrentClock() {
+    final var instant = Instant.ofEpochMilli(service.epochMilli());
+    return new WebEndpointResponse<>(new Response(instant));
+  }
+
+  /**
+   * POST /actuator/clock/{operationKey} - modifies the current clock, either by `pin`ning it to the
+   * given `epochMilli` or by `add`ing a relative offset to it.
+   *
+   * <p>The expected usage is to send a JSON body with at least one of the fields. Both fields can
+   * be present as well, but only one will be used depending on the operation key.
+   *
+   * <p>For example, to pin the time to 1635672964533 (or Sun Oct 31 09:36:04 AM UTC 2021):
+   *
+   * <pre>{@code
+   * curl -X POST -H 'Content-Type: application/json' -d '{"epochMilli": 1635672964533}' "http://0.0.0.0:9600/actuator/clock/pin"
+   * "2021-10-31T09:36:04.533Z"%
+   * }</pre>
+   *
+   * To add a relative time offset:
+   *
+   * <pre>{@code
+   * curl -X POST -H 'Content-Type: application/json' -d '{"offsetMilli": 250}' "http://0.0.0.0:9600/actuator/clock/pin"
+   * "2021-10-31T09:36:04.783Z"%
+   * }</pre>
+   *
+   * NOTE: you can pass a negative offset to subtract time as well.
+   *
+   * @param operationKey the operation to execute; must be one of `pin` or `add`
+   * @param epochMilli the time at which the clock should be pinned
+   * @param offsetMilli the offset to add to the current time (pinned or not)
+   * @return 200 and the current clock time, or 400 if the request is malformed
+   */
+  @SuppressWarnings({"unused", "java:S1452"})
+  @WriteOperation
+  public WebEndpointResponse<?> modify(
+      @Selector(match = Match.SINGLE) final String operationKey,
+      final @Nullable Long epochMilli,
+      final @Nullable Long offsetMilli) {
+    if (PATH_PIN.equals(operationKey)) {
+      return pinTime(epochMilli);
+    } else if (PATH_ADD.equals(operationKey)) {
+      return addTime(offsetMilli);
+    } else {
+      return new WebEndpointResponse<>(
+          String.format(
+              "Expected to either `pin` or `add` to the clock, but no operation named `%s` is "
+                  + "known; make sure you wrote the correct path",
+              operationKey),
+          400);
+    }
+  }
+
+  /**
+   * DELETE /actuator/clock - will reset any modification to the current clock, which will unpin (if
+   * required) and start using the current system time.
+   *
+   * @return 200 and the current clock time
+   */
+  @SuppressWarnings("unused")
+  @DeleteOperation
+  public WebEndpointResponse<?> resetTime() {
+    final var clock = service.mutable();
+    if (clock.isEmpty()) {
+      return new WebEndpointResponse<>(
+          "Expected to reset the clock, but the clock is immutable", 403);
+    }
+
+    clock.get().resetTime();
+    return getCurrentClock();
+  }
+
+  private WebEndpointResponse<?> pinTime(final Long epochMilli) {
+    if (epochMilli == null) {
+      return new WebEndpointResponse<>(
+          "Expected pin the clock to the given `epochMilli`, but none given", 400);
+    }
+
+    final var clock = service.mutable();
+    if (clock.isEmpty()) {
+      return new WebEndpointResponse<>(
+          "Expected to pin the clock to the given time, but it is immutable", 403);
+    }
+
+    clock.get().pinTime(Instant.ofEpochMilli(epochMilli));
+    return getCurrentClock();
+  }
+
+  private WebEndpointResponse<?> addTime(final Long offsetMilli) {
+    if (offsetMilli == null) {
+      return new WebEndpointResponse<>(
+          "Expected to add `offsetMilli` to the clock, but none given", 400);
+    }
+
+    final var clock = service.mutable();
+    if (clock.isEmpty()) {
+      return new WebEndpointResponse<>(
+          "Expected to add time to the clock, but it is immutable", 403);
+    }
+
+    final var offset = Duration.of(offsetMilli, ChronoUnit.MILLIS);
+    clock.get().addTime(offset);
+    return getCurrentClock();
+  }
+
+  /** A response type for future proofing, in case the format needs to be changed in the future. */
+  protected static final class Response {
+    @JsonProperty("epochMilli")
+    protected final long epochMilli;
+
+    @JsonProperty("instant")
+    protected final Instant instant;
+
+    public Response(final Instant instant) {
+      this.instant = instant;
+      epochMilli = instant.toEpochMilli();
+    }
+
+    @SuppressWarnings("unused") // Used by Jackson deserialization
+    private Response() {
+      this.epochMilli = 0;
+      this.instant = null;
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockService.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared.management;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * A service which wraps an {@link io.camunda.zeebe.util.sched.clock.ActorClock} instance. We can't
+ * directly use an actor clock since the interface is by nature immutable, so instead we wrap it.
+ */
+@FunctionalInterface
+public interface ActorClockService {
+
+  /** @return the current instant of the clock */
+  long epochMilli();
+
+  /** @return a mutable variant of the underlying clock, or nothing if the clock is immutable */
+  default Optional<MutableClock> mutable() {
+    return Optional.empty();
+  }
+
+  /** A mutable variant of this service. */
+  interface MutableClock {
+    /**
+     * Adds the offset to the current clock.
+     *
+     * @param offset the time offset to add to the current time
+     */
+    void addTime(final Duration offset);
+
+    /**
+     * Pins the clock to the given time.
+     *
+     * @param time the time at which to pin the current clock
+     */
+    void pinTime(final Instant time);
+
+    /** Resets the clock to use the system time */
+    void resetTime();
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ControlledActorClockService.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ControlledActorClockService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared.management;
+
+import io.camunda.zeebe.shared.management.ActorClockService.MutableClock;
+import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * An implementation of {@link ActorClockService} which wraps a mutable clock, allowing for
+ * modification of the clock from the outside.
+ *
+ * <p>See {@link io.camunda.zeebe.shared.ActorClockConfiguration} on how to configure/wire it.
+ */
+public final class ControlledActorClockService implements ActorClockService, MutableClock {
+  private final ControlledActorClock clock;
+
+  public ControlledActorClockService(final ControlledActorClock clock) {
+    this.clock = clock;
+  }
+
+  @Override
+  public long epochMilli() {
+    return clock.getTimeMillis();
+  }
+
+  @Override
+  public Optional<MutableClock> mutable() {
+    return Optional.of(this);
+  }
+
+  @Override
+  public void addTime(final Duration offset) {
+    clock.addTime(offset);
+  }
+
+  @Override
+  public void pinTime(final Instant time) {
+    clock.setCurrentTime(time);
+  }
+
+  @Override
+  public void resetTime() {
+    clock.reset();
+  }
+}

--- a/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.gateway.impl.configuration.ClusterCfg;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.gateway.impl.configuration.NetworkCfg;
 import io.camunda.zeebe.gateway.impl.configuration.SecurityCfg;
+import io.camunda.zeebe.shared.ActorClockConfiguration;
 import io.camunda.zeebe.test.util.asserts.SslAssert;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -140,6 +141,7 @@ final class StandaloneGatewaySecurityTest {
   }
 
   private StandaloneGateway buildGateway(final GatewayCfg gatewayCfg) {
-    return new StandaloneGateway(gatewayCfg, new SpringGatewayBridge());
+    return new StandaloneGateway(
+        gatewayCfg, new SpringGatewayBridge(), new ActorClockConfiguration(false));
   }
 }

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ControlledActorClockEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ControlledActorClockEndpointTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.shared.management.ActorClockEndpoint.Response;
+import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactory;
+import org.assertj.core.api.ObjectAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class ControlledActorClockEndpointTest {
+
+  private final InstanceOfAssertFactory<Response, ObjectAssert<Response>> instanceOfRecord =
+      new InstanceOfAssertFactory<>(Response.class, Assertions::assertThat);
+
+  private final ActorClockEndpoint endpoint =
+      new ActorClockEndpoint(new ControlledActorClockService(new ControlledActorClock()));
+
+  @BeforeEach
+  private void resetClock() {
+    endpoint.resetTime();
+  }
+
+  @Test
+  void canRetrieveCurrentClock() {
+    final var response = endpoint.getCurrentClock();
+    assertThat(response.getStatus()).isEqualTo(200);
+  }
+
+  @Test
+  void canPinMutableClock() {
+    // given
+    final var millis = 1635672964533L;
+
+    // when
+    final var response = endpoint.modify("pin", millis, null);
+
+    // then
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(response.getBody())
+        .asInstanceOf(instanceOfRecord)
+        .satisfies((body) -> assertThat(body.epochMilli).isEqualTo(millis))
+        .isNotNull();
+  }
+
+  @Test
+  void canOffsetMutableClock() {
+    // given
+    final var offset = Duration.ofMinutes(10);
+
+    // when
+    final var response = endpoint.modify("add", null, offset.toMillis());
+
+    // then
+
+    // the minimum time we would expect the actor clock to have. It should have at least advanced
+    // by the offset we have specified.
+    final var offsetMinimum = Instant.now().plus(offset).truncatedTo(ChronoUnit.MILLIS);
+    // the maximum time we would expect the actor clock to have. This can be flaky, but only if the
+    // test thread is sleeping for more than one minute.
+    final var offsetMaximum = Instant.now().plus(offset.plus(Duration.ofMinutes(1)));
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(response.getBody())
+        .isNotNull()
+        .asInstanceOf(instanceOfRecord)
+        .satisfies((body) -> assertThat(body.instant).isBetween(offsetMinimum, offsetMaximum));
+  }
+
+  @Test
+  void offsetClockDoesAdvance() throws InterruptedException {
+    // given
+    final var offset = 10000L;
+    final var firstResponse = endpoint.modify("add", null, offset);
+    assertThat(firstResponse.getBody()).isNotNull();
+    final var firstMillis = ((Response) firstResponse.getBody()).epochMilli;
+
+    // when
+    Thread.sleep(100);
+    final var secondResponse = endpoint.getCurrentClock();
+    assertThat(secondResponse.getBody()).isNotNull();
+    final var secondMillis = secondResponse.getBody().epochMilli;
+
+    // then
+    assertThat(firstMillis).isLessThan(secondMillis);
+  }
+
+  @Test
+  void pinnedClockDoesNotAdvance() throws InterruptedException {
+    // given
+    final var millis = 1635672964533L;
+    final var firstResponse = endpoint.modify("pin", millis, null);
+    assertThat(firstResponse.getStatus()).isEqualTo(200);
+    assertThat(firstResponse.getBody())
+        .isNotNull()
+        .asInstanceOf(instanceOfRecord)
+        .satisfies((body) -> assertThat(body.epochMilli).isEqualTo(millis));
+
+    // when
+    Thread.sleep(100);
+    final var secondResponse = endpoint.getCurrentClock();
+
+    // then
+    assertThat(secondResponse.getBody()).isNotNull();
+    assertThat(secondResponse.getBody().epochMilli).isEqualTo(millis);
+  }
+
+  @Test
+  void instantMatchesEpochMilli() {
+    // when
+    final var response = endpoint.getCurrentClock();
+    assertThat(response.getBody()).isNotNull();
+    final var millis = response.getBody().epochMilli;
+    final var instant = response.getBody().instant;
+
+    // then
+    assertThat(Instant.ofEpochMilli(millis)).isEqualTo(instant);
+  }
+}

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -77,6 +77,24 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-jackson</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-snapshots</artifactId>
       <scope>test</scope>
     </dependency>

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.jackson.record.AbstractRecord;
+import io.camunda.zeebe.test.util.actuator.ClockActuatorClient;
+import io.camunda.zeebe.test.util.testcontainers.ZeebeTestContainerDefaults;
+import io.zeebe.containers.ZeebeContainer;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import org.agrona.CloseHelper;
+import org.awaitility.Awaitility;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Network;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+final class ControlledActorClockEndpointIT {
+  private static final String ELASTICSEARCH_HOST = "elasticsearch";
+  private static final String INDEX_PREFIX = "exporter-clock-test";
+  private Network network;
+  private ElasticsearchContainer elasticsearchContainer;
+  private ZeebeContainer zeebeContainer;
+  private ZeebeClient zeebeClient;
+  private final HttpClient httpClient = HttpClient.newHttpClient();
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  private ClockActuatorClient clockActuatorClient;
+
+  @BeforeEach
+  void startContainers() {
+    network = Network.newNetwork();
+    startElasticsearch();
+    startZeebe();
+  }
+
+  @AfterEach
+  void stopContainers() {
+    CloseHelper.closeAll(zeebeClient, zeebeContainer, elasticsearchContainer, network);
+  }
+
+  @Test
+  void testPinningTime() throws IOException, InterruptedException {
+    // given - Zeebe actor clock is pinned
+    final var pinnedAt = clockActuatorClient.pinZeebeTime(Instant.now().minus(Duration.ofDays(3)));
+    final var process = Bpmn.createExecutableProcess().startEvent().endEvent().done();
+
+    // when - producing records
+    zeebeClient.newDeployCommand().addProcessModel(process, "process.bpmn").send().join();
+
+    // then - records are exported with a timestamp matching the pinned time
+    waitForExportedRecords();
+    final var records = searchExportedRecords();
+    assertThat(records)
+        .isNotEmpty() // double check that we have exported some records
+        .allSatisfy(record -> assertThat(record.getTimestamp()).isEqualTo(pinnedAt.toEpochMilli()));
+  }
+
+  @Test
+  void testOffsetTime() throws IOException, InterruptedException {
+    // given - Zeebe actor clock is offset
+    final var beforeRecords = Instant.now();
+    final var offsetZeebeTime = clockActuatorClient.offsetZeebeTime(Duration.ofHours(5));
+    final var process = Bpmn.createExecutableProcess().startEvent().endEvent().done();
+
+    // when - producing records
+    zeebeClient.newDeployCommand().addProcessModel(process, "process.bpmn").send().join();
+
+    // then - records are exported with a timestamp matching the offset time
+    waitForExportedRecords();
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              final var records = searchExportedRecords();
+              assertThat(records)
+                  .isNotEmpty() // double check that we have exported some records
+                  .allSatisfy(
+                      (record) -> {
+                        final var timestamp = Instant.ofEpochMilli(record.getTimestamp());
+                        final var afterRecords = Instant.now();
+                        assertThat(timestamp)
+                            .isBefore(afterRecords.plus(offsetZeebeTime))
+                            .isAfter(beforeRecords.plus(offsetZeebeTime));
+                      });
+            });
+  }
+
+  private List<AbstractRecord<?>> searchExportedRecords() throws IOException, InterruptedException {
+    final var uri =
+        URI.create(
+            String.format(
+                "http://%s/%s*/_search",
+                elasticsearchContainer.getHttpHostAddress(), INDEX_PREFIX));
+    final var request = HttpRequest.newBuilder(uri).method("POST", BodyPublishers.noBody()).build();
+    final var response = httpClient.send(request, BodyHandlers.ofInputStream());
+    final var result = mapper.readValue(response.body(), EsSearchResponseDto.class);
+    if (result.esDocumentsWrapper == null) {
+      return Collections.emptyList();
+    }
+    return result.esDocumentsWrapper.documents.stream()
+        .map(esDocumentDto -> esDocumentDto.record)
+        .collect(Collectors.toList());
+  }
+
+  void startElasticsearch() {
+    final var version = RestClient.class.getPackage().getImplementationVersion();
+    elasticsearchContainer =
+        new ElasticsearchContainer(
+                DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+                    .withTag(version))
+            .withNetwork(network)
+            .withNetworkAliases(ELASTICSEARCH_HOST)
+            .withCreateContainerCmdModifier(
+                cmd ->
+                    Objects.requireNonNull(cmd.getHostConfig())
+                        .withMemory((long) (1024 * 1024 * 1024)));
+    elasticsearchContainer.start();
+  }
+
+  private void startZeebe() {
+    zeebeContainer =
+        new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
+            .withNetwork(network)
+            .withEnv(
+                "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME",
+                "io.camunda.zeebe.exporter.ElasticsearchExporter")
+            .withEnv(
+                "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL",
+                String.format("http://%s:9200", ELASTICSEARCH_HOST))
+            .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_DELAY", "1")
+            .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_SIZE", "1")
+            .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_PREFIX", INDEX_PREFIX)
+            .withEnv("ZEEBE_CLOCK_CONTROLLED", "true");
+    zeebeContainer.start();
+    zeebeClient =
+        ZeebeClient.newClientBuilder()
+            .usePlaintext()
+            .gatewayAddress(zeebeContainer.getExternalGatewayAddress())
+            .build();
+    clockActuatorClient = new ClockActuatorClient(zeebeContainer.getExternalMonitoringAddress());
+  }
+
+  /**
+   * Wait until all records are exported. We assume that all records are exported if the number of
+   * records is does not change for 5 seconds. Initialize the counter to one so that we expect at
+   * least one record and don't succeed if nothing is exported.
+   */
+  private void waitForExportedRecords() {
+    final AtomicInteger previouslySeenRecords = new AtomicInteger(1);
+    Awaitility.await("Waiting for a stable number of exported records")
+        .during(Duration.ofSeconds(5))
+        .until(
+            this::searchExportedRecords,
+            (records) -> {
+              final var now = records.size();
+              final var previous = previouslySeenRecords.getAndSet(now);
+              return now == previous;
+            });
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static final class EsDocumentDto {
+    @JsonProperty(value = "_source", required = true)
+    AbstractRecord<?> record;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static final class EsSearchResponseDto {
+    @JsonProperty(value = "hits", required = true)
+    EsDocumentsWrapper esDocumentsWrapper;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static final class EsDocumentsWrapper {
+      @JsonProperty(value = "hits", required = true)
+      final List<EsDocumentDto> documents = Collections.emptyList();
+    }
+  }
+}

--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -67,6 +67,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.msgpack</groupId>
       <artifactId>jackson-dataformat-msgpack</artifactId>
     </dependency>

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/actuator/ClockActuatorClient.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/actuator/ClockActuatorClient.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.actuator;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublisher;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Client for the {@code /actuator/clock} endpoint. Can be used to control the actor clock if
+ * `zeebe.clock.controllable` is set to `true`. Example: {@code}
+ *
+ * <pre>
+ * final var zeebeContainer = new ZeebeContainer();
+ * zeebeContainer.withEnv("zeebe.clock.controllable", "true") .start()
+ * final var clockClient = new ClockActuatorClient(zeebeContainer.getExternalMonitoringAddress());
+ * clockClient.setClock(Instant.now().minus(Duration.ofDays(1)));
+ * </pre>
+ */
+public final class ClockActuatorClient {
+  private final HttpClient httpClient = HttpClient.newBuilder().build();
+  private final ObjectWriter objectWriter = new ObjectMapper().writer();
+  private final String monitoringAddress;
+
+  public ClockActuatorClient(final String zeebeMonitoringAddress) {
+    monitoringAddress = zeebeMonitoringAddress;
+  }
+
+  public void resetZeebeTime() throws IOException, InterruptedException {
+    sendRequest("DELETE", "/actuator/clock", null);
+  }
+
+  public Instant pinZeebeTime(final Instant pinAt) throws IOException, InterruptedException {
+    sendRequest("POST", "/actuator/clock/pin", new PinRequestDto(pinAt));
+    return pinAt;
+  }
+
+  public Duration offsetZeebeTime(final Duration offsetBy)
+      throws IOException, InterruptedException {
+    sendRequest("POST", "/actuator/clock/add", new OffsetRequestDto(offsetBy));
+    return offsetBy;
+  }
+
+  private void sendRequest(final String method, final String endpoint, final RequestDto requestDto)
+      throws IOException, InterruptedException {
+    final var uri = URI.create(String.format("http://%s/%s", monitoringAddress, endpoint));
+    final BodyPublisher body;
+    if (requestDto == null) {
+      body = BodyPublishers.noBody();
+    } else {
+      body = BodyPublishers.ofByteArray(objectWriter.writeValueAsBytes(requestDto));
+    }
+    final var httpRequest =
+        HttpRequest.newBuilder(uri)
+            .method(method, body)
+            .header("Content-Type", "application/json")
+            .build();
+    final var httpResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
+    if (httpResponse.statusCode() != 200) {
+      throw new IllegalStateException("Pinning time failed: " + httpResponse.body());
+    }
+  }
+
+  private static final class PinRequestDto implements RequestDto {
+    @JsonProperty("epochMilli")
+    private final long epochMilli;
+
+    private PinRequestDto(final Instant pinAt) {
+      epochMilli = pinAt.toEpochMilli();
+    }
+  }
+
+  private static final class OffsetRequestDto implements RequestDto {
+    @JsonProperty("offsetMilli")
+    private final long offsetMilli;
+
+    private OffsetRequestDto(final Duration offsetBy) {
+      offsetMilli = offsetBy.toMillis();
+    }
+  }
+
+  private interface RequestDto {}
+}


### PR DESCRIPTION
## Description

Adds a new actuator `/actuator/clock/` that can control the actor clock if the config `zeebe.clock.controlled` is set to true.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5289

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
