### PR TITLE
Require google-java-format plugin in IntelliJ-IDEA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/*
 !.idea/codeStyles
 !.idea/externalDependencies.xml
+!.idea/google-java-format.xml
 !.idea/saveactions_settings.xml
 target
 .classpath

--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="ExternalDependencies">
     <plugin id="com.dubreuia" />
+    <plugin id="google-java-format" />
   </component>
 </project>

--- a/.idea/google-java-format.xml
+++ b/.idea/google-java-format.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GoogleJavaFormatSettings">
+    <option name="enabled" value="true" />
+  </component>
+</project>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Similar to the save-actions plugin, we should require the use of the `google-java-format` IntelliJ-IDEA plugin. This helps IntelliJ-IDEA users to apply the same style for changes.

This plugin should already have been in use according to our contributing guide.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #8033 
relates to #7508

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
