### PR TITLE
Fixes MessageCorrelationTest#shouldCorrelateMessageAgainAfterRejection flakiness

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationTest.java
@@ -923,7 +923,6 @@ public final class MessageCorrelationTest {
         .extracting(Record::getRecordType, Record::getIntent)
         .containsSubsequence(
             tuple(RecordType.COMMAND_REJECTION, ProcessMessageSubscriptionIntent.CORRELATE),
-            tuple(RecordType.COMMAND, MessageSubscriptionIntent.REJECT),
             tuple(RecordType.EVENT, MessageSubscriptionIntent.REJECTED),
             tuple(RecordType.COMMAND, ProcessMessageSubscriptionIntent.CORRELATE));
 


### PR DESCRIPTION
## Description

This PR fixes the flaky test `MessageCorrelationTest#shouldCorrelateMessageAgainAfterRejection`. The test was asserting the ordering of a `COMMAND_REJECTION` for a `ProcessMessageSubscription.CORRELATE` command, followed by a `MessageSubscription.REJECT` command and its resulting `REJECTED` event, and finally a new `ProcessMessageSubscription.CORRELATE` command. However, due to the test implementation of the `PartitionCommandSender`, the ordering of the `COMMAND_REJECTION` and the `MessageSubscription.REJECT` command was not deterministic, resulting in flakiness. 

In this particular case, it's not necessary to assert the presence of the `MessageSubscription.REJECT` command, it's sufficient to just check for its result `MessageSubscription.REJECTED`, which is guaranteed to always be after the `COMMAND_REJECTION` but before the next `CORRELATE` command.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7749 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
