### PR TITLE
fix(snapshot): purge transient snapshots when newer snapshot exists

### DIFF
--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -393,20 +393,20 @@ public final class FileBasedSnapshotStore extends Actor
     }
   }
 
-  private void purgePendingSnapshots(final SnapshotId cutoffIndex) {
+  private void purgePendingSnapshots(final SnapshotId cutoffSnapshot) {
     LOGGER.trace(
         "Search for orphaned snapshots below oldest valid snapshot with index {} in {}",
-        cutoffIndex.getSnapshotIdAsString(),
+        cutoffSnapshot.getSnapshotIdAsString(),
         pendingDirectory);
 
     pendingSnapshots.stream()
-        .filter(pendingSnapshot -> pendingSnapshot.snapshotId().compareTo(cutoffIndex) < 0)
+        .filter(pendingSnapshot -> pendingSnapshot.snapshotId().compareTo(cutoffSnapshot) < 0)
         .forEach(PersistableSnapshot::abort);
 
     // If there are orphaned directories if a previous abort failed, delete them explicitly
     try (final var pendingSnapshotsDirectories = Files.newDirectoryStream(pendingDirectory)) {
       for (final var pendingSnapshot : pendingSnapshotsDirectories) {
-        purgePendingSnapshot(cutoffIndex, pendingSnapshot);
+        purgePendingSnapshot(cutoffSnapshot, pendingSnapshot);
       }
     } catch (final IOException e) {
       LOGGER.warn(
@@ -443,11 +443,14 @@ public final class FileBasedSnapshotStore extends Actor
     final var currentPersistedSnapshot = currentPersistedSnapshotRef.get();
 
     if (isCurrentSnapshotNewer(metadata)) {
+      final var currentPersistedSnapshotMetadata = currentPersistedSnapshot.getMetadata();
+
       LOGGER.debug(
           "Snapshot is older than the latest snapshot {}. Snapshot {} won't be committed.",
-          currentPersistedSnapshot.getMetadata(),
+          currentPersistedSnapshotMetadata,
           metadata);
-      purgePendingSnapshots(metadata);
+
+      purgePendingSnapshots(currentPersistedSnapshotMetadata);
       return currentPersistedSnapshot;
     }
 

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
@@ -216,6 +216,24 @@ public class FileBasedTransientSnapshotTest {
   }
 
   @Test
+  public void shouldRemoveTransientWhenCurrentSnapshotIsNewer() {
+    // given
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(10L, 10L, 10L, 10L).get();
+    transientSnapshot.take(this::writeSnapshot);
+    transientSnapshot.persist().join();
+
+    // when
+    final var oldSnapshot = snapshotStore.newTransientSnapshot(1L, 1L, 1L, 1L).get();
+    oldSnapshot.take(this::writeSnapshot);
+    oldSnapshot.persist().join();
+
+    // then
+    assertThat(pendingDir)
+        .as("transient and outdated snapshot has been deleted")
+        .isEmptyDirectory();
+  }
+
+  @Test
   public void shouldNotRemoveTransientSnapshotWithGreaterIdOnPersist() {
     // given
     final var newerTransientSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).get();


### PR DESCRIPTION
## Description

* Use the metadata from the current persistent snapshot as "cutoff" so that transient snapshot (which are older than the latest) are purged.

## Related issues

closes #8211 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
