### PR TITLE
Make ZeebeObjectMapper use a preconfigured one

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeObjectMapper.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeObjectMapper.java
@@ -39,7 +39,7 @@ public final class ZeebeObjectMapper implements JsonMapper {
     this(new ObjectMapper());
   }
   
-  public ZeebeObjectMapper(ObjectMapper objectMapper){
+  public ZeebeObjectMapper(ObjectMapper objectMapper) {
     this.objectMapper = objectMapper;
     this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeObjectMapper.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeObjectMapper.java
@@ -36,8 +36,12 @@ public final class ZeebeObjectMapper implements JsonMapper {
   private final ObjectMapper objectMapper;
 
   public ZeebeObjectMapper() {
-    objectMapper = new ObjectMapper();
-    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    this(new ObjectMapper());
+    this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  }
+  
+  public ZeebeObjectMapper(ObjectMapper objectMapper){
+    this.objectMapper = objectMapper;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeObjectMapper.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeObjectMapper.java
@@ -37,11 +37,11 @@ public final class ZeebeObjectMapper implements JsonMapper {
 
   public ZeebeObjectMapper() {
     this(new ObjectMapper());
-    this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
   }
   
   public ZeebeObjectMapper(ObjectMapper objectMapper){
     this.objectMapper = objectMapper;
+    this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeObjectMapper.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeObjectMapper.java
@@ -38,7 +38,7 @@ public final class ZeebeObjectMapper implements JsonMapper {
   public ZeebeObjectMapper() {
     this(new ObjectMapper());
   }
-  
+
   public ZeebeObjectMapper(ObjectMapper objectMapper) {
     this.objectMapper = objectMapper;
     this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);


### PR DESCRIPTION
ATM, it is not possible to configure the ZeebeObjectMapper with a provided and preconfigured ObjectMapper. This makes it impossible to configure the used ObjectMapper (for example to use JSR310 java.time Library). This change will not affect the other implementations in first place.

It just adds the possibility to use my own ObjectMapper containing all required features for my worker.

## Description

I have added another constructor to ZeebeObjectMapper

## Related issues

No related issue so far

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
