### PR TITLE
Propagate issue details of unhealthy components

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -125,6 +125,8 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   // Used for randomizing election timeout
   private final Random random;
   private PersistedSnapshot currentSnapshot;
+
+  @SuppressWarnings("java:S3077") // allow volatile here, health is immutable
   private volatile HealthReport health = HealthReport.healthy(this);
 
   private long lastHeartbeat;

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -68,7 +68,7 @@ import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
-import io.camunda.zeebe.util.health.HealthStatus;
+import io.camunda.zeebe.util.health.HealthReport;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Random;
@@ -125,7 +125,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   // Used for randomizing election timeout
   private final Random random;
   private PersistedSnapshot currentSnapshot;
-  private volatile HealthStatus health = HealthStatus.HEALTHY;
+  private volatile HealthReport health = HealthReport.healthy(this);
 
   private long lastHeartbeat;
   private final RaftPartitionConfig partitionConfig;
@@ -242,11 +242,11 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private void notifyFailureListeners(final Throwable error) {
     try {
       if (error instanceof UnrecoverableException) {
-        health = HealthStatus.DEAD;
-        failureListeners.forEach(FailureListener::onUnrecoverableFailure);
+        health = HealthReport.dead(this).withIssue(error);
+        failureListeners.forEach((l) -> l.onUnrecoverableFailure(health));
       } else {
-        health = HealthStatus.UNHEALTHY;
-        failureListeners.forEach(FailureListener::onFailure);
+        health = HealthReport.unhealthy(this).withIssue(error);
+        failureListeners.forEach((l) -> l.onFailure(health));
       }
     } catch (final Exception e) {
       log.error("Could not notify failure listeners", e);
@@ -603,7 +603,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     }
 
     if (!this.role.role().active() && role.active()) {
-      health = HealthStatus.HEALTHY;
+      health = HealthReport.healthy(this);
       failureListeners.forEach(FailureListener::onRecovered);
     }
 
@@ -625,7 +625,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   @Override
-  public HealthStatus getHealthStatus() {
+  public HealthReport getHealthReport() {
     return health;
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -624,23 +624,6 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     }
   }
 
-  @Override
-  public HealthReport getHealthReport() {
-    return health;
-  }
-
-  /** Adds a failure listener which will be invoked when an uncaught exception occurs */
-  @Override
-  public void addFailureListener(final FailureListener listener) {
-    failureListeners.add(listener);
-  }
-
-  /** Remove a failure listener */
-  @Override
-  public void removeFailureListener(final FailureListener listener) {
-    failureListeners.remove(listener);
-  }
-
   private void notifyRoleChangeListeners() {
     try {
       roleChangeListeners.forEach(l -> l.onNewRole(role.role(), getTerm()));
@@ -897,8 +880,26 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
    *
    * @return The server name.
    */
+  @Override
   public String getName() {
     return name;
+  }
+
+  @Override
+  public HealthReport getHealthReport() {
+    return health;
+  }
+
+  /** Adds a failure listener which will be invoked when an uncaught exception occurs */
+  @Override
+  public void addFailureListener(final FailureListener listener) {
+    failureListeners.add(listener);
+  }
+
+  /** Remove a failure listener */
+  @Override
+  public void removeFailureListener(final FailureListener listener) {
+    failureListeners.remove(listener);
   }
 
   /**

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -28,7 +28,7 @@ import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.impl.RaftPartitionServer;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
-import io.camunda.zeebe.util.health.HealthStatus;
+import io.camunda.zeebe.util.health.HealthReport;
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
@@ -71,20 +71,6 @@ public class RaftPartition implements Partition, HealthMonitorable {
   public void removeRoleChangeListener(final RaftRoleChangeListener listener) {
     deferredRoleChangeListeners.remove(listener);
     server.removeRoleChangeListener(listener);
-  }
-
-  @Override
-  public HealthStatus getHealthStatus() {
-    return server.getHealthStatus();
-  }
-
-  @Override
-  public void addFailureListener(final FailureListener failureListener) {
-    server.addFailureListener(failureListener);
-  }
-
-  public void removeFailureListener(final FailureListener failureListener) {
-    server.removeFailureListener(failureListener);
   }
 
   /**
@@ -149,6 +135,26 @@ public class RaftPartition implements Partition, HealthMonitorable {
    */
   public String name() {
     return String.format(PARTITION_NAME_FORMAT, partitionId.group(), partitionId.id());
+  }
+
+  @Override
+  public String getName() {
+    return name();
+  }
+
+  @Override
+  public HealthReport getHealthReport() {
+    return server.getHealthReport();
+  }
+
+  @Override
+  public void addFailureListener(final FailureListener failureListener) {
+    server.addFailureListener(failureListener);
+  }
+
+  @Override
+  public void removeFailureListener(final FailureListener failureListener) {
+    server.removeFailureListener(failureListener);
   }
 
   /** Closes the partition. */

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -46,7 +46,7 @@ import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
-import io.camunda.zeebe.util.health.HealthStatus;
+import io.camunda.zeebe.util.health.HealthReport;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -221,8 +221,8 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
   }
 
   @Override
-  public HealthStatus getHealthStatus() {
-    return server.getContext().getHealthStatus();
+  public HealthReport getHealthReport() {
+    return server.getContext().getHealthReport();
   }
 
   @Override

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -53,6 +53,7 @@ import io.atomix.utils.concurrent.ThreadContext;
 import io.camunda.zeebe.journal.file.LogCorrupter;
 import io.camunda.zeebe.journal.file.record.CorruptedLogException;
 import io.camunda.zeebe.util.health.FailureListener;
+import io.camunda.zeebe.util.health.HealthReport;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
@@ -408,7 +409,7 @@ public class RaftTest extends ConcurrentTestCase {
     assertThat(firstLatch.await(2, TimeUnit.SECONDS)).isTrue();
     assertThat(secondLatch.await(1, TimeUnit.SECONDS)).isTrue();
 
-    assertEquals(Role.INACTIVE, server.getRole());
+    assertThat(server.getRole()).isEqualTo(Role.INACTIVE);
   }
 
   @Test
@@ -667,7 +668,7 @@ public class RaftTest extends ConcurrentTestCase {
     }
 
     @Override
-    public void onFailure() {
+    public void onFailure(final HealthReport report) {
       latch.countDown();
     }
 
@@ -675,6 +676,6 @@ public class RaftTest extends ConcurrentTestCase {
     public void onRecovered() {}
 
     @Override
-    public void onUnrecoverableFailure() {}
+    public void onUnrecoverableFailure(final HealthReport report) {}
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -70,6 +70,8 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   private LogStreamReader logStreamReader;
   private EventFilter eventFilter;
   private ExportersState state;
+
+  @SuppressWarnings("java:S3077") // allow volatile here, health is immutable
   private volatile HealthReport healthReport = HealthReport.healthy(this);
 
   private boolean inExportingPhase;

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -26,7 +26,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
-import io.camunda.zeebe.util.health.HealthStatus;
+import io.camunda.zeebe.util.health.HealthReport;
 import io.camunda.zeebe.util.retry.BackOffRetryStrategy;
 import io.camunda.zeebe.util.retry.EndlessRetryStrategy;
 import io.camunda.zeebe.util.retry.RetryStrategy;
@@ -70,7 +70,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   private LogStreamReader logStreamReader;
   private EventFilter eventFilter;
   private ExportersState state;
-  private volatile HealthStatus healthStatus = HealthStatus.HEALTHY;
+  private volatile HealthReport healthReport = HealthReport.healthy(this);
 
   private boolean inExportingPhase;
   private boolean isPaused;
@@ -235,16 +235,15 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     actor.fail();
 
     if (failure instanceof UnrecoverableException) {
-      healthStatus = HealthStatus.DEAD;
+      healthReport = HealthReport.dead(this).withIssue(failure);
 
       for (final var listener : listeners) {
-        listener.onUnrecoverableFailure();
+        listener.onUnrecoverableFailure(healthReport);
       }
     } else {
-      healthStatus = HealthStatus.UNHEALTHY;
-
+      healthReport = HealthReport.unhealthy(this).withIssue(failure);
       for (final var listener : listeners) {
-        listener.onFailure();
+        listener.onFailure(healthReport);
       }
     }
   }
@@ -435,8 +434,8 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   }
 
   @Override
-  public HealthStatus getHealthStatus() {
-    return healthStatus;
+  public HealthReport getHealthReport() {
+    return healthReport;
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -215,7 +215,7 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
     if (!isBrokerReady()) {
       return HealthStatus.UNHEALTHY;
     }
-    return healthMonitor.getHealthStatus();
+    return healthMonitor.getHealthReport().getStatus();
   }
 
   public void setBrokerStarted() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -106,7 +106,7 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
   public BrokerHealthCheckService(final BrokerInfo localBroker) {
     actorName = buildActorName(localBroker.getNodeId(), "HealthCheckService");
     nodeId = MemberId.from(String.valueOf(localBroker.getNodeId()));
-    healthMonitor = new CriticalComponentsHealthMonitor(actor, LOG);
+    healthMonitor = new CriticalComponentsHealthMonitor("Broker-" + nodeId, actor, LOG);
   }
 
   public void registerPartitionManager(final PartitionManager partitionManager) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionHealthBroadcaster.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionHealthBroadcaster.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.partitions;
 
 import io.camunda.zeebe.util.health.FailureListener;
+import io.camunda.zeebe.util.health.HealthReport;
 import io.camunda.zeebe.util.health.HealthStatus;
 
 /** Informs its delegate of partition health changes */
@@ -23,7 +24,7 @@ public final class PartitionHealthBroadcaster implements FailureListener {
   }
 
   @Override
-  public void onFailure() {
+  public void onFailure(final HealthReport report) {
     delegate.onHealthChanged(partitionId, HealthStatus.UNHEALTHY);
   }
 
@@ -33,7 +34,7 @@ public final class PartitionHealthBroadcaster implements FailureListener {
   }
 
   @Override
-  public void onUnrecoverableFailure() {
+  public void onUnrecoverableFailure(final HealthReport report) {
     delegate.onHealthChanged(partitionId, HealthStatus.DEAD);
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -78,7 +78,9 @@ public final class ZeebePartition extends Actor
     actorName =
         buildActorName(
             transitionContext.getNodeId(), "ZeebePartition", transitionContext.getPartitionId());
-    transitionContext.setComponentHealthMonitor(new CriticalComponentsHealthMonitor(actor, LOG));
+    transitionContext.setComponentHealthMonitor(
+        new CriticalComponentsHealthMonitor(
+            "Partition-" + transitionContext.getPartitionId(), actor, LOG));
     zeebePartitionHealth = new ZeebePartitionHealth(transitionContext.getPartitionId());
     healthMetrics = new HealthMetrics(transitionContext.getPartitionId());
     healthMetrics.setUnhealthy();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.health.CriticalComponentsHealthMonitor;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
+import io.camunda.zeebe.util.health.HealthReport;
 import io.camunda.zeebe.util.health.HealthStatus;
 import io.camunda.zeebe.util.sched.Actor;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
@@ -109,7 +110,7 @@ public final class ZeebePartition extends Actor
             (newStartupContext, error) -> {
               if (error != null) {
                 LOG.error(error.getMessage(), error);
-                handleUnrecoverableFailure();
+                handleUnrecoverableFailure(error);
                 close();
                 return;
               }
@@ -300,11 +301,11 @@ public final class ZeebePartition extends Actor
 
   @Override
   @Deprecated // will be removed from public API of ZeebePartition
-  public void onFailure() {
+  public void onFailure(final HealthReport report) {
     actor.run(
         () -> {
           healthMetrics.setUnhealthy();
-          failureListeners.forEach(FailureListener::onFailure);
+          failureListeners.forEach((l) -> l.onFailure(report));
         });
   }
 
@@ -320,8 +321,9 @@ public final class ZeebePartition extends Actor
 
   @Override
   @Deprecated // will be removed from public API of ZeebePartition
-  public void onUnrecoverableFailure() {
-    actor.run(this::handleUnrecoverableFailure);
+  public void onUnrecoverableFailure(final HealthReport report) {
+    // TODO: Can't use null here
+    actor.run(() -> handleUnrecoverableFailure(null));
   }
 
   private void onInstallFailure(final Throwable error) {
@@ -332,7 +334,7 @@ public final class ZeebePartition extends Actor
           context.getCurrentRole(),
           context.getCurrentTerm(),
           error);
-      handleUnrecoverableFailure();
+      handleUnrecoverableFailure(error);
     } else {
       handleRecoverableFailure();
     }
@@ -363,12 +365,13 @@ public final class ZeebePartition extends Actor
     }
   }
 
-  private void handleUnrecoverableFailure() {
+  private void handleUnrecoverableFailure(final Throwable error) {
+    final var report = HealthReport.dead(this).withIssue(error);
     healthMetrics.setDead();
-    zeebePartitionHealth.onUnrecoverableFailure();
+    zeebePartitionHealth.onUnrecoverableFailure(error);
     transitionToInactive();
     context.getRaftPartition().goInactive();
-    failureListeners.forEach(FailureListener::onUnrecoverableFailure);
+    failureListeners.forEach((l) -> l.onUnrecoverableFailure(report));
     context.notifyListenersOfBecomingInactive();
   }
 
@@ -377,8 +380,8 @@ public final class ZeebePartition extends Actor
   }
 
   @Override
-  public HealthStatus getHealthStatus() {
-    return context.getComponentHealthMonitor().getHealthStatus();
+  public HealthReport getHealthReport() {
+    return context.getComponentHealthMonitor().getHealthReport();
   }
 
   @Override
@@ -386,10 +389,10 @@ public final class ZeebePartition extends Actor
     actor.run(
         () -> {
           failureListeners.add(failureListener);
-          if (getHealthStatus() == HealthStatus.HEALTHY) {
+          if (getHealthReport().getStatus() == HealthStatus.HEALTHY) {
             failureListener.onRecovered();
           } else {
-            failureListener.onFailure();
+            failureListener.onFailure(getHealthReport());
           }
         });
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
@@ -36,21 +36,6 @@ class ZeebePartitionHealth implements HealthMonitorable {
     name = "ZeebePartition-" + partitionId;
   }
 
-  @Override
-  public HealthReport getHealthReport() {
-    return healthReport;
-  }
-
-  @Override
-  public void addFailureListener(final FailureListener failureListener) {
-    failureListeners.add(failureListener);
-  }
-
-  @Override
-  public void removeFailureListener(final FailureListener failureListener) {
-    failureListeners.remove(failureListener);
-  }
-
   private void updateHealthStatus() {
     final var previousStatus = healthReport;
     if (previousStatus.getStatus() == HealthStatus.DEAD) {
@@ -96,7 +81,23 @@ class ZeebePartitionHealth implements HealthMonitorable {
     healthReport = HealthReport.dead(this).withIssue(error);
   }
 
+  @Override
   public String getName() {
     return name;
+  }
+
+  @Override
+  public HealthReport getHealthReport() {
+    return healthReport;
+  }
+
+  @Override
+  public void addFailureListener(final FailureListener failureListener) {
+    failureListeners.add(failureListener);
+  }
+
+  @Override
+  public void removeFailureListener(final FailureListener failureListener) {
+    failureListeners.remove(failureListener);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.partitions;
 
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
+import io.camunda.zeebe.util.health.HealthReport;
 import io.camunda.zeebe.util.health.HealthStatus;
 import java.util.HashSet;
 import java.util.Set;
@@ -21,7 +22,7 @@ class ZeebePartitionHealth implements HealthMonitorable {
 
   private final String name;
   private final Set<FailureListener> failureListeners = new HashSet<>();
-  private HealthStatus healthStatus = HealthStatus.UNHEALTHY;
+  private HealthReport healthReport = HealthReport.unhealthy(this).withMessage("Initial state");
   /*
   Multiple factors determine ZeebePartition's health :
   * - servicesInstalled: indicates if role transition was successful and all services are installed
@@ -36,8 +37,8 @@ class ZeebePartitionHealth implements HealthMonitorable {
   }
 
   @Override
-  public HealthStatus getHealthStatus() {
-    return healthStatus;
+  public HealthReport getHealthReport() {
+    return healthReport;
   }
 
   @Override
@@ -51,28 +52,29 @@ class ZeebePartitionHealth implements HealthMonitorable {
   }
 
   private void updateHealthStatus() {
-    final var previousStatus = healthStatus;
-    if (previousStatus == HealthStatus.DEAD) {
+    final var previousStatus = healthReport;
+    if (previousStatus.getStatus() == HealthStatus.DEAD) {
       return;
     }
 
-    final boolean healthy = diskSpaceAvailable && servicesInstalled;
-    if (healthy) {
-      healthStatus = HealthStatus.HEALTHY;
+    if (!diskSpaceAvailable) {
+      healthReport = HealthReport.unhealthy(this).withMessage("Not enough disk space available");
+    } else if (!servicesInstalled) {
+      healthReport = HealthReport.unhealthy(this).withMessage("Services not installed");
     } else {
-      healthStatus = HealthStatus.UNHEALTHY;
+      healthReport = HealthReport.healthy(this);
     }
 
-    if (previousStatus != healthStatus) {
-      switch (healthStatus) {
+    if (previousStatus != healthReport) {
+      switch (healthReport.getStatus()) {
         case HEALTHY:
           failureListeners.forEach(FailureListener::onRecovered);
           break;
         case UNHEALTHY:
-          failureListeners.forEach(FailureListener::onFailure);
+          failureListeners.forEach((l) -> l.onFailure(healthReport));
           break;
         case DEAD:
-          failureListeners.forEach(FailureListener::onUnrecoverableFailure);
+          failureListeners.forEach((l) -> l.onUnrecoverableFailure(healthReport));
           break;
         default:
           break;
@@ -90,8 +92,8 @@ class ZeebePartitionHealth implements HealthMonitorable {
     updateHealthStatus();
   }
 
-  void onUnrecoverableFailure() {
-    healthStatus = HealthStatus.DEAD;
+  void onUnrecoverableFailure(final Throwable error) {
+    healthReport = HealthReport.dead(this).withIssue(error);
   }
 
   public String getName() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.snapshots.SnapshotException.SnapshotNotFoundException;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
-import io.camunda.zeebe.util.health.HealthStatus;
+import io.camunda.zeebe.util.health.HealthReport;
 import io.camunda.zeebe.util.sched.Actor;
 import io.camunda.zeebe.util.sched.SchedulingHints;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
@@ -58,7 +58,7 @@ public final class AsyncSnapshotDirector extends Actor
   private long lowerBoundSnapshotPosition;
   private boolean takingSnapshot;
   private boolean persistingSnapshot;
-  private volatile HealthStatus healthStatus = HealthStatus.HEALTHY;
+  private volatile HealthReport healthReport = HealthReport.healthy(this);
   private long commitPosition;
   private final int partitionId;
 
@@ -122,10 +122,10 @@ public final class AsyncSnapshotDirector extends Actor
         failure);
 
     resetStateOnFailure();
-    healthStatus = HealthStatus.UNHEALTHY;
+    healthReport = HealthReport.unhealthy(this).withIssue(failure);
 
     for (final var listener : listeners) {
-      listener.onFailure();
+      listener.onFailure(healthReport);
     }
   }
 
@@ -191,8 +191,8 @@ public final class AsyncSnapshotDirector extends Actor
   }
 
   @Override
-  public HealthStatus getHealthStatus() {
-    return healthStatus;
+  public HealthReport getHealthReport() {
+    return healthReport;
   }
 
   @Override
@@ -274,8 +274,8 @@ public final class AsyncSnapshotDirector extends Actor
   }
 
   private void onRecovered() {
-    if (healthStatus != HealthStatus.HEALTHY) {
-      healthStatus = HealthStatus.HEALTHY;
+    if (!healthReport.isHealthy()) {
+      healthReport = HealthReport.healthy(this);
       listeners.forEach(FailureListener::onRecovered);
     }
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -58,7 +58,10 @@ public final class AsyncSnapshotDirector extends Actor
   private long lowerBoundSnapshotPosition;
   private boolean takingSnapshot;
   private boolean persistingSnapshot;
+
+  @SuppressWarnings("java:S3077") // allow volatile here, health is immutable
   private volatile HealthReport healthReport = HealthReport.healthy(this);
+
   private long commitPosition;
   private final int partitionId;
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
@@ -76,7 +76,7 @@ public class StreamProcessorHealthTest {
                     mock(TypedRecordProcessor.class)));
 
     // then
-    waitUntil(() -> streamProcessor.getHealthStatus() == HealthStatus.HEALTHY);
+    waitUntil(() -> streamProcessor.getHealthReport().isHealthy());
   }
 
   @Test
@@ -101,7 +101,7 @@ public class StreamProcessorHealthTest {
   public void shouldMarkUnhealthyWhenProcessingOnWriteEventFails() {
     // given
     streamProcessor = getErrorProneStreamProcessor();
-    waitUntil(() -> streamProcessor.getHealthStatus() == HealthStatus.HEALTHY);
+    waitUntil(() -> streamProcessor.getHealthReport().isHealthy());
 
     // when
     shouldProcessingThrowException.set(false);
@@ -110,7 +110,7 @@ public class StreamProcessorHealthTest {
         ProcessInstanceIntent.ACTIVATE_ELEMENT, PROCESS_INSTANCE_RECORD);
 
     // then
-    waitUntil(() -> streamProcessor.getHealthStatus() == HealthStatus.UNHEALTHY);
+    waitUntil(() -> streamProcessor.getHealthReport().isUnhealthy());
   }
 
   @Test
@@ -138,17 +138,17 @@ public class StreamProcessorHealthTest {
     // given
     shouldFlushThrowException.set(true);
     streamProcessor = getErrorProneStreamProcessor();
-    waitUntil(() -> streamProcessor.getHealthStatus() == HealthStatus.HEALTHY);
+    waitUntil(() -> streamProcessor.getHealthReport().isHealthy());
 
     streamProcessorRule.writeCommand(
         ProcessInstanceIntent.ACTIVATE_ELEMENT, PROCESS_INSTANCE_RECORD);
-    waitUntil(() -> streamProcessor.getHealthStatus() == HealthStatus.UNHEALTHY);
+    waitUntil(() -> streamProcessor.getHealthReport().isUnhealthy());
 
     // when
     shouldFlushThrowException.set(false);
 
     // then
-    waitUntil(() -> streamProcessor.getHealthStatus() == HealthStatus.HEALTHY);
+    waitUntil(() -> streamProcessor.getHealthReport().isHealthy());
   }
 
   private StreamProcessor getErrorProneStreamProcessor() {
@@ -195,7 +195,7 @@ public class StreamProcessorHealthTest {
 
     public boolean hasHealthStatus(final HealthStatus healthStatus) {
       return actor
-          .call(() -> streamProcessor.getHealthStatus() == healthStatus)
+          .call(() -> streamProcessor.getHealthReport().getStatus() == healthStatus)
           .join(5, TimeUnit.SECONDS);
     }
   }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
@@ -74,7 +74,7 @@ public final class LogStorageAppenderHealthTest {
     schedulerRule.submitActor(appender).join();
 
     // then
-    waitUntil(() -> appender.getHealthStatus() == HealthStatus.UNHEALTHY);
+    waitUntil(() -> appender.getHealthReport().isUnhealthy());
   }
 
   @Test
@@ -88,7 +88,7 @@ public final class LogStorageAppenderHealthTest {
     schedulerRule.submitActor(appender).join();
 
     // then
-    waitUntil(() -> appender.getHealthStatus() == HealthStatus.UNHEALTHY);
+    waitUntil(() -> appender.getHealthReport().isUnhealthy());
   }
 
   @Test
@@ -108,7 +108,7 @@ public final class LogStorageAppenderHealthTest {
     // then
     latch.await();
     assertThat(latch.getCount()).isZero();
-    assertThat(appender.getHealthStatus()).isEqualTo(HealthStatus.HEALTHY);
+    assertThat(appender.getHealthReport().getStatus()).isEqualTo(HealthStatus.HEALTHY);
   }
 
   private class ControllableLogStorage extends Actor implements LogStorage {

--- a/util/src/main/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitor.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitor.java
@@ -30,7 +30,11 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
   private volatile HealthReport healthReport =
       HealthReport.unhealthy(this).withMessage("Components are not yet initialized");
 
-  public CriticalComponentsHealthMonitor(final ActorControl actor, final Logger log) {
+  private final String name;
+
+  public CriticalComponentsHealthMonitor(
+      final String name, final ActorControl actor, final Logger log) {
+    this.name = name;
     this.actor = actor;
     this.log = log;
   }
@@ -68,6 +72,11 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
           component.addFailureListener(monitoredComponent);
           calculateHealth();
         });
+  }
+
+  @Override
+  public String getName() {
+    return name;
   }
 
   @Override

--- a/util/src/main/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitor.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitor.java
@@ -195,7 +195,7 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
         return;
       }
 
-      log.warn("{} failed, marking it as unhealthy", componentName);
+      log.warn("{} failed, marking it as unhealthy: {}", componentName, healthReport);
       componentHealth.put(componentName, report);
       calculateHealth();
     }
@@ -215,7 +215,7 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
         return;
       }
 
-      log.error("{} failed, marking it as dead", componentName);
+      log.error("{} failed, marking it as dead: {}", componentName, report);
       componentHealth.put(componentName, report);
       calculateHealth();
     }

--- a/util/src/main/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitor.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitor.java
@@ -26,6 +26,7 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
   private final ActorControl actor;
   private final Logger log;
 
+  @SuppressWarnings("java:S3077") // allow volatile here, health is immutable
   private volatile HealthReport healthReport =
       HealthReport.unhealthy(this).withMessage("Components are not yet initialized");
 

--- a/util/src/main/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitor.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitor.java
@@ -13,18 +13,21 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
 /** Healthy only if all components are healthy */
 public class CriticalComponentsHealthMonitor implements HealthMonitor {
   private static final Duration HEALTH_MONITORING_PERIOD = Duration.ofSeconds(60);
   private final Map<String, MonitoredComponent> monitoredComponents = new HashMap<>();
-  private final Map<String, HealthStatus> componentHealth = new HashMap<>();
+  private final Map<String, HealthReport> componentHealth = new HashMap<>();
   private final Set<FailureListener> failureListeners = new HashSet<>();
   private final ActorControl actor;
   private final Logger log;
 
-  private volatile HealthStatus healthStatus = HealthStatus.UNHEALTHY;
+  private volatile HealthReport healthReport =
+      HealthReport.unhealthy(this).withMessage("Components are not yet initialized");
 
   public CriticalComponentsHealthMonitor(final ActorControl actor, final Logger log) {
     this.actor = actor;
@@ -38,7 +41,7 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
 
   @Override
   public void monitorComponent(final String componentName) {
-    actor.run(() -> componentHealth.put(componentName, HealthStatus.UNHEALTHY));
+    actor.run(() -> componentHealth.put(componentName, HealthReport.unknown(componentName)));
   }
 
   @Override
@@ -59,7 +62,7 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
         () -> {
           final var monitoredComponent = new MonitoredComponent(componentName, component);
           monitoredComponents.put(componentName, monitoredComponent);
-          componentHealth.put(componentName, component.getHealthStatus());
+          componentHealth.put(componentName, component.getHealthReport());
 
           component.addFailureListener(monitoredComponent);
           calculateHealth();
@@ -67,8 +70,8 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
   }
 
   @Override
-  public HealthStatus getHealthStatus() {
-    return healthStatus;
+  public HealthReport getHealthReport() {
+    return healthReport;
   }
 
   @Override
@@ -89,58 +92,63 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
   }
 
   private void calculateHealth() {
-    final var previousStatus = healthStatus;
-    healthStatus = calculateStatus();
+    final var previousReport = healthReport;
+    healthReport = calculateStatus();
 
-    if (previousStatus == healthStatus) {
+    if (previousReport == healthReport) {
       return;
     }
 
-    switch (healthStatus) {
+    switch (healthReport.getStatus()) {
       case HEALTHY:
         failureListeners.forEach(FailureListener::onRecovered);
         break;
 
       case UNHEALTHY:
-        failureListeners.forEach(FailureListener::onFailure);
+        failureListeners.forEach((l) -> l.onFailure(healthReport));
         break;
 
       case DEAD:
-        failureListeners.forEach(FailureListener::onUnrecoverableFailure);
+        failureListeners.forEach((l) -> l.onUnrecoverableFailure(healthReport));
         break;
 
       default:
-        log.warn("Unknown health status {}", healthStatus);
+        log.warn("Unknown health status {}", healthReport);
         break;
     }
 
-    logComponentStatus(healthStatus);
+    logComponentStatus(healthReport);
   }
 
-  private void logComponentStatus(final HealthStatus status) {
+  private void logComponentStatus(final HealthReport status) {
     log.debug(
         "Detected '{}' components. The current health status of components: {}",
-        status,
-        componentHealth);
+        status.getStatus(),
+        componentHealth.values());
   }
 
-  private HealthStatus calculateStatus() {
-    if (componentHealth.containsValue(HealthStatus.DEAD)) {
-      return HealthStatus.DEAD;
-    } else if (componentHealth.containsValue(HealthStatus.UNHEALTHY)) {
-      return HealthStatus.UNHEALTHY;
+  private HealthReport calculateStatus() {
+    final var componentByStatus =
+        componentHealth.values().stream()
+            .collect(Collectors.toMap(HealthReport::getStatus, Function.identity(), (l, r) -> l));
+    final var deadReport = componentByStatus.get(HealthStatus.DEAD);
+    final var unhealthyReport = componentByStatus.get(HealthStatus.UNHEALTHY);
+    if (deadReport != null) {
+      return HealthReport.dead(this).withIssue(deadReport);
+    } else if (unhealthyReport != null) {
+      return HealthReport.unhealthy(this).withIssue(unhealthyReport);
+    } else {
+      return HealthReport.healthy(this);
     }
-
-    return HealthStatus.HEALTHY;
   }
 
-  private HealthStatus getHealth(final String componentName) {
+  private HealthReport getHealth(final String componentName) {
     final var monitoredComponent = monitoredComponents.get(componentName);
     if (monitoredComponent != null) {
-      return monitoredComponent.component.getHealthStatus();
+      return monitoredComponent.component.getHealthReport();
     }
 
-    return HealthStatus.UNHEALTHY;
+    return HealthReport.unknown(componentName);
   }
 
   /**
@@ -158,8 +166,8 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
     }
 
     @Override
-    public void onFailure() {
-      actor.run(this::onComponentFailure);
+    public void onFailure(final HealthReport report) {
+      actor.run(() -> onComponentFailure(report));
     }
 
     @Override
@@ -168,17 +176,17 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
     }
 
     @Override
-    public void onUnrecoverableFailure() {
-      actor.run(this::onComponentDied);
+    public void onUnrecoverableFailure(final HealthReport report) {
+      actor.run(() -> onComponentDied(report));
     }
 
-    private void onComponentFailure() {
+    private void onComponentFailure(final HealthReport report) {
       if (!monitoredComponents.containsKey(componentName)) {
         return;
       }
 
       log.warn("{} failed, marking it as unhealthy", componentName);
-      componentHealth.put(componentName, HealthStatus.UNHEALTHY);
+      componentHealth.put(componentName, report);
       calculateHealth();
     }
 
@@ -188,17 +196,17 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
       }
 
       log.info("{} recovered, marking it as healthy", componentName);
-      componentHealth.put(componentName, HealthStatus.HEALTHY);
+      componentHealth.put(componentName, HealthReport.healthy(component));
       calculateHealth();
     }
 
-    private void onComponentDied() {
+    private void onComponentDied(final HealthReport report) {
       if (!monitoredComponents.containsKey(componentName)) {
         return;
       }
 
       log.error("{} failed, marking it as dead", componentName);
-      componentHealth.put(componentName, HealthStatus.DEAD);
+      componentHealth.put(componentName, report);
       calculateHealth();
     }
   }

--- a/util/src/main/java/io/camunda/zeebe/util/health/FailureListener.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/FailureListener.java
@@ -11,7 +11,7 @@ package io.camunda.zeebe.util.health;
 public interface FailureListener {
 
   /** Invoked when the health status becomes unhealthy. */
-  void onFailure();
+  void onFailure(HealthReport report);
 
   /**
    * Invoked when health status becomes healthy after being unhealthy for some time. A component can
@@ -24,5 +24,5 @@ public interface FailureListener {
    * Invoked when the health status becomes dead and the system can't become healthy again without
    * external intervention.
    */
-  void onUnrecoverableFailure();
+  void onUnrecoverableFailure(HealthReport report);
 }

--- a/util/src/main/java/io/camunda/zeebe/util/health/HealthIssue.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/HealthIssue.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util.health;
+
+/**
+ * A health issue contains information about the cause for unhealthy/dead components. It can either
+ * be a string message, a {@link Throwable} or another {@link HealthReport}.
+ */
+public final class HealthIssue {
+
+  private final String message;
+  private final Throwable throwable;
+  private final HealthReport cause;
+
+  private HealthIssue(final String message, final Throwable throwable, final HealthReport cause) {
+    this.message = message;
+    this.throwable = throwable;
+    this.cause = cause;
+  }
+
+  public static HealthIssue of(final String message) {
+    return new HealthIssue(message, null, null);
+  }
+
+  public static HealthIssue of(final Throwable throwable) {
+    return new HealthIssue(null, throwable, null);
+  }
+
+  public static HealthIssue of(final HealthReport cause) {
+    return new HealthIssue(null, null, cause);
+  }
+
+  @Override
+  public String toString() {
+    if (cause != null) {
+      return cause.toString();
+    }
+    if (message != null) {
+      return "'" + message + "'";
+    }
+    if (throwable != null) {
+      return throwable.toString();
+    }
+    return "unknown";
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public Throwable getThrowable() {
+    return throwable;
+  }
+
+  public HealthReport getCause() {
+    return cause;
+  }
+}

--- a/util/src/main/java/io/camunda/zeebe/util/health/HealthMonitorable.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/HealthMonitorable.java
@@ -27,7 +27,7 @@ public interface HealthMonitorable {
    *
    * @return health status
    */
-  HealthStatus getHealthStatus();
+  HealthReport getHealthReport();
 
   /**
    * Register a failure observer.

--- a/util/src/main/java/io/camunda/zeebe/util/health/HealthMonitorable.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/HealthMonitorable.java
@@ -11,6 +11,17 @@ package io.camunda.zeebe.util.health;
 public interface HealthMonitorable {
 
   /**
+   * Used by a HealthMonitor to get the name of this component. Most `HealthMonitorable`s override
+   * this method to return their actor name. If they don't override the method, the name of the
+   * class is returned.
+   *
+   * @return the name of this component
+   */
+  default String getName() {
+    return getClass().getSimpleName();
+  }
+
+  /**
    * Used by a HealthMonitor to get the health status of this component, typically invoked
    * periodically.
    *

--- a/util/src/main/java/io/camunda/zeebe/util/health/HealthReport.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/HealthReport.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util.health;
+
+import java.util.StringJoiner;
+
+/**
+ * A health report of a {@link #getComponentName() component}. If the status is not healthy, the
+ * report also contains a {@link #getIssue() issue}.
+ */
+public final class HealthReport {
+  private final HealthMonitorable component;
+  private final String componentName;
+  private final HealthStatus status;
+  private final HealthIssue issue;
+
+  private HealthReport(
+      final HealthMonitorable component, final HealthStatus status, final HealthIssue issue) {
+    this(component, component.getName(), status, issue);
+  }
+
+  private HealthReport(
+      final HealthMonitorable component,
+      final String componentName,
+      final HealthStatus status,
+      final HealthIssue issue) {
+    this.component = component;
+    this.componentName = componentName;
+    this.status = status;
+    this.issue = issue;
+  }
+
+  public static HealthReport unknown(final String componentName) {
+    return new HealthReport(null, componentName, HealthStatus.UNHEALTHY, null);
+  }
+
+  public static HealthReport healthy(final HealthMonitorable component) {
+    return new HealthReport(component, HealthStatus.HEALTHY, null);
+  }
+
+  public static HealthReportBuilder unhealthy(final HealthMonitorable component) {
+    return new HealthReportBuilder(component, HealthStatus.UNHEALTHY);
+  }
+
+  public static HealthReportBuilder dead(final HealthMonitorable component) {
+    return new HealthReportBuilder(component, HealthStatus.DEAD);
+  }
+
+  public boolean isHealthy() {
+    return status == HealthStatus.HEALTHY;
+  }
+
+  public boolean isNotHealthy() {
+    return status != HealthStatus.HEALTHY;
+  }
+
+  public boolean isUnhealthy() {
+    return status == HealthStatus.UNHEALTHY;
+  }
+
+  public boolean isDead() {
+    return status == HealthStatus.DEAD;
+  }
+
+  public String getComponentName() {
+    return componentName;
+  }
+
+  public HealthStatus getStatus() {
+    return status;
+  }
+
+  public HealthIssue getIssue() {
+    return issue;
+  }
+
+  @Override
+  public String toString() {
+    final var name = componentName == null ? component.getName() : componentName;
+    final var joiner = new StringJoiner(", ", name + "{", "}").add("status=" + status);
+    if (issue != null) {
+      joiner.add("issue=" + issue);
+    }
+    return joiner.toString();
+  }
+
+  public static final class HealthReportBuilder {
+    private final HealthMonitorable component;
+    private final HealthStatus status;
+
+    private HealthReportBuilder(final HealthMonitorable component, final HealthStatus status) {
+      this.component = component;
+      this.status = status;
+    }
+
+    public HealthReport withIssue(final HealthIssue issue) {
+      return new HealthReport(component, status, issue);
+    }
+
+    public HealthReport withMessage(final String message) {
+      return new HealthReport(component, status, HealthIssue.of(message));
+    }
+
+    public HealthReport withIssue(final Throwable e) {
+      return new HealthReport(component, status, HealthIssue.of(e));
+    }
+
+    public HealthReport withIssue(final HealthReport cause) {
+      return new HealthReport(component, status, HealthIssue.of(cause));
+    }
+  }
+}

--- a/util/src/test/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitorTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitorTest.java
@@ -37,7 +37,9 @@ public class CriticalComponentsHealthMonitorTest {
 
           @Override
           protected void onActorStarting() {
-            monitor = new CriticalComponentsHealthMonitor(actor, LoggerFactory.getLogger("test"));
+            monitor =
+                new CriticalComponentsHealthMonitor(
+                    "TestMonitor", actor, LoggerFactory.getLogger("test"));
             actorControl = actor;
           }
 


### PR DESCRIPTION
## Description

To provide more details when components become dead or unhealthy we are adding `HealthReport` and `HealthIssue` classes.
They can be arbitrarily nested to allow tracing issues back to a root cause.

`HealthMonitorable` and `FailureListener` are changed to use `HealthReport` instead of `HealthStatus`.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7759

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
