### PR TITLE
[Backport stable/1.1] fix(snapshot): take snapshot after pending snapshot is added

### DIFF
--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.snapshots.SnapshotId;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.sched.Actor;
+import io.camunda.zeebe.util.sched.ActorThread;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.io.IOException;
@@ -318,11 +319,30 @@ public final class FileBasedSnapshotStore extends Actor
   }
 
   private void addPendingSnapshot(final PersistableSnapshot pendingSnapshot) {
-    actor.call(() -> pendingSnapshots.add(pendingSnapshot));
+    final Runnable action = () -> pendingSnapshots.add(pendingSnapshot);
+
+    if (!isCurrentActor()) {
+      actor.call(action);
+    } else {
+      action.run();
+    }
   }
 
   void removePendingSnapshot(final PersistableSnapshot pendingSnapshot) {
     pendingSnapshots.remove(pendingSnapshot);
+  }
+
+  private boolean isCurrentActor() {
+    final var currentActorThread = ActorThread.current();
+
+    if (currentActorThread != null) {
+      final var task = currentActorThread.getCurrentTask();
+      if (task != null) {
+        return task.getActor() == this;
+      }
+    }
+
+    return false;
   }
 
   private void observeSnapshotSize(final FileBasedSnapshot persistedSnapshot) {


### PR DESCRIPTION
## Description

backports #8219 

## Related issues

relates to #8212 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
