### PR TITLE
`RaftPartition` can step down if it is not the primary

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/primitive/partition/PartitionMetadata.java
+++ b/atomix/cluster/src/main/java/io/atomix/primitive/partition/PartitionMetadata.java
@@ -18,10 +18,10 @@ package io.atomix.primitive.partition;
 
 import io.atomix.cluster.MemberId;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Contains metadata about a partition. The metadata can be used to query for members of the
@@ -29,14 +29,14 @@ import java.util.Optional;
  */
 public class PartitionMetadata {
   private final PartitionId id;
-  private final List<MemberId> members;
+  private final Set<MemberId> members;
   private final Map<MemberId, Integer> priority;
   private final int targetPriority;
   private final MemberId primary;
 
   public PartitionMetadata(
       final PartitionId id,
-      final List<MemberId> members,
+      final Set<MemberId> members,
       final Map<MemberId, Integer> priority,
       final int targetPriority,
       final MemberId primary) {

--- a/atomix/cluster/src/main/java/io/atomix/primitive/partition/PartitionMetadata.java
+++ b/atomix/cluster/src/main/java/io/atomix/primitive/partition/PartitionMetadata.java
@@ -21,26 +21,30 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
- * A partition or shard is a group of controller nodes that are work together to maintain state. A
- * ONOS cluster is typically made of of one or partitions over which the the data is partitioned.
+ * Contains metadata about a partition. The metadata can be used to query for members of the
+ * partition and to get member priorities.
  */
 public class PartitionMetadata {
   private final PartitionId id;
   private final List<MemberId> members;
   private final Map<MemberId, Integer> priority;
   private final int targetPriority;
+  private final MemberId primary;
 
   public PartitionMetadata(
       final PartitionId id,
       final List<MemberId> members,
       final Map<MemberId, Integer> priority,
-      final int targetPriority) {
+      final int targetPriority,
+      final MemberId primary) {
     this.id = id;
     this.members = members;
     this.priority = priority;
     this.targetPriority = targetPriority;
+    this.primary = primary;
   }
 
   /**
@@ -65,11 +69,19 @@ public class PartitionMetadata {
    * Return the priority of the node if the node is a member of the replication group for this
    * partition. Otherwise return -1.
    *
-   * @param member
    * @return the priority of the member
    */
   public int getPriority(final MemberId member) {
     return priority.getOrDefault(member, -1);
+  }
+
+  /**
+   * Returns the primary member of the partition or null if there is no primary
+   *
+   * @return member id or null
+   */
+  public Optional<MemberId> getPrimary() {
+    return Optional.ofNullable(primary);
   }
 
   public int getTargetPriority() {
@@ -95,6 +107,8 @@ public class PartitionMetadata {
     return "PartitionMetadata{"
         + "id="
         + id
+        + ", primary="
+        + primary
         + ", members="
         + members
         + ", priority="

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -222,6 +222,23 @@ public class RaftPartition implements Partition, HealthMonitorable {
     return server.stepDown();
   }
 
+  public CompletableFuture<Void> stepDownIfNotPrimary() {
+    if (shouldStepDown()) {
+      return stepDown();
+    } else {
+      return CompletableFuture.completedFuture(null);
+    }
+  }
+
+  private boolean shouldStepDown() {
+    final var primary = partitionMetadata.getPrimary();
+    final var partitionConfig = config.getPartitionConfig();
+    return server != null
+        && partitionConfig.isPriorityElectionEnabled()
+        && primary.isPresent()
+        && primary.get() != server.getMemberId();
+  }
+
   public CompletableFuture<Void> goInactive() {
     return server.goInactive();
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -222,6 +222,15 @@ public class RaftPartition implements Partition, HealthMonitorable {
     return server.stepDown();
   }
 
+  /**
+   * Tries to step down if the following conditions are met:
+   *
+   * <ul>
+   *   <li>priority election is enabled
+   *   <li>the partition distributor determined a primary node
+   *   <li>this node is not the primary
+   * </ul>
+   */
   public CompletableFuture<Void> stepDownIfNotPrimary() {
     if (shouldStepDown()) {
       return stepDown();

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RoundRobinPartitionDistributor.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RoundRobinPartitionDistributor.java
@@ -70,7 +70,7 @@ public final class RoundRobinPartitionDistributor implements PartitionDistributo
               partitionId, membersForPartition, primary, sorted.size(), replicationFactor);
       metadata.add(
           new PartitionMetadata(
-              partitionId, membersForPartition, priorities, priorities.get(primary)));
+              partitionId, membersForPartition, priorities, priorities.get(primary), primary));
     }
     return metadata;
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RoundRobinPartitionDistributor.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RoundRobinPartitionDistributor.java
@@ -70,7 +70,11 @@ public final class RoundRobinPartitionDistributor implements PartitionDistributo
               partitionId, membersForPartition, primary, sorted.size(), replicationFactor);
       metadata.add(
           new PartitionMetadata(
-              partitionId, membersForPartition, priorities, priorities.get(primary), primary));
+              partitionId,
+              Set.copyOf(membersForPartition),
+              priorities,
+              priorities.get(primary),
+              primary));
     }
     return metadata;
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -329,6 +329,10 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
     return server.getTerm();
   }
 
+  public MemberId getMemberId() {
+    return localMemberId;
+  }
+
   private RaftStorage createRaftStorage() {
     final RaftStorageConfig storageConfig = config.getStorageConfig();
     return RaftStorage.builder()

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributor.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributor.java
@@ -11,13 +11,13 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.partition.PartitionDistributor;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
+import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * A {@link PartitionDistributor} implementation which takes in a provided, fixed mapping which
@@ -28,7 +28,6 @@ import java.util.Set;
  * intentionally not publicly instantiable to reduce the risk of configuration errors.
  */
 public final class FixedPartitionDistributor implements PartitionDistributor {
-  private static final Random RANDOM = new Random();
   private final Map<PartitionId, Set<FixedDistributionMember>> distribution;
 
   FixedPartitionDistributor(final Map<PartitionId, Set<FixedDistributionMember>> distribution) {
@@ -68,10 +67,7 @@ public final class FixedPartitionDistributor implements PartitionDistributor {
       final Set<MemberId> clusterMembers,
       final int replicationFactor,
       final PartitionId partitionId) {
-    final var members = new ArrayList<MemberId>();
-    final var priorities = new HashMap<MemberId, Integer>();
     final var configuredMembers = distribution.get(partitionId);
-    int targetPriority = 0;
 
     if (configuredMembers == null) {
       throw new IllegalStateException(
@@ -80,22 +76,23 @@ public final class FixedPartitionDistributor implements PartitionDistributor {
               partitionId.id()));
     }
 
-    for (final var member : configuredMembers) {
-      final var priority = member.getPriority();
+    final var priorities =
+        configuredMembers.stream()
+            .collect(
+                Collectors.toMap(
+                    FixedDistributionMember::getId, FixedDistributionMember::getPriority));
+    final int targetPriority = Collections.max(priorities.values());
 
-      members.add(member.getId());
-      priorities.put(member.getId(), priority);
-      if (priority >= targetPriority) {
-        targetPriority = priority;
-      }
-    }
+    final var members = priorities.keySet();
+    final var primaries =
+        priorities.entrySet().stream()
+            .filter(entry -> entry.getValue() == targetPriority)
+            .map(Entry::getKey)
+            .collect(Collectors.toList());
 
     MemberId primary = null;
-    // if every member has a different priority we can use the member with the highest priority as
-    // the primary
-    // TODO: We can probably relax this to only check that the `targetPriority` is unique.
-    if (priorities.size() == members.size()) {
-      primary = members.get(targetPriority);
+    if (primaries.size() == 1) {
+      primary = primaries.get(0);
     }
 
     ensureMembersArePartOfCluster(clusterMembers, partitionId, members);
@@ -104,15 +101,10 @@ public final class FixedPartitionDistributor implements PartitionDistributor {
     return new PartitionMetadata(partitionId, members, priorities, targetPriority, primary);
   }
 
-  private FixedDistributionMember randomMember(final Set<FixedDistributionMember> members) {
-    final var randomIndex = RANDOM.nextInt(members.size());
-    return members.stream().skip(randomIndex).findFirst().orElseThrow();
-  }
-
   private void ensureMembersArePartOfCluster(
       final Set<MemberId> clusterMembers,
       final PartitionId partitionId,
-      final ArrayList<MemberId> members) {
+      final Set<MemberId> members) {
     if (!clusterMembers.containsAll(members)) {
       final var unknownMembers = new HashSet<>(members);
       unknownMembers.removeAll(clusterMembers);
@@ -126,9 +118,7 @@ public final class FixedPartitionDistributor implements PartitionDistributor {
   }
 
   private void ensurePartitionIsFullyReplicated(
-      final int replicationFactor,
-      final PartitionId partitionId,
-      final ArrayList<MemberId> members) {
+      final int replicationFactor, final PartitionId partitionId, final Set<MemberId> members) {
     if (members.size() != replicationFactor) {
       throw new IllegalStateException(
           String.format(

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorTest.java
@@ -128,6 +128,33 @@ final class FixedPartitionDistributorTest {
         .containsExactlyInAnyOrderElementsOf(expectedDistribution);
   }
 
+  @Test
+  void shouldNotAssignPrimaryIfMoreThanOnePotentialPrimary() {
+    // given
+    final var expectedDistribution =
+        Set.of(
+            // expect a partition without assigned primary
+            new PartitionMetadata(
+                partition(1), Set.of(node(0), node(1)), Map.of(node(0), 2), 2, null));
+    final var distributor =
+        new FixedPartitionDistributorBuilder(PARTITION_GROUP_NAME)
+            // two members with the same priority
+            .assignMember(1, 0, 2)
+            .assignMember(1, 1, 2)
+            .build();
+    final var clusterMembers = Set.of(node(0), node(1));
+    final var sortedPartitionIds = List.of(partition(1));
+
+    // when
+    final var distribution =
+        distributor.distributePartitions(clusterMembers, sortedPartitionIds, 2);
+
+    // then
+    assertThat(distribution)
+        .as("should distribute the partitions as expected")
+        .containsExactlyInAnyOrderElementsOf(expectedDistribution);
+  }
+
   private PartitionId partition(final int id) {
     return PartitionId.from(PARTITION_GROUP_NAME, id);
   }

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorTest.java
@@ -76,9 +76,17 @@ final class FixedPartitionDistributorTest {
     final var expectedDistribution =
         Set.of(
             new PartitionMetadata(
-                partition(1), List.of(node(0), node(1)), Map.of(node(0), 1, node(1), 2), 2),
+                partition(1),
+                List.of(node(0), node(1)),
+                Map.of(node(0), 1, node(1), 2),
+                2,
+                node(1)),
             new PartitionMetadata(
-                partition(2), List.of(node(0), node(1)), Map.of(node(0), 2, node(1), 1), 2));
+                partition(2),
+                List.of(node(0), node(1)),
+                Map.of(node(0), 2, node(1), 1),
+                2,
+                node(0)));
     final var distributor =
         new FixedPartitionDistributorBuilder(PARTITION_GROUP_NAME)
             .assignMember(1, 0, 1)
@@ -104,8 +112,8 @@ final class FixedPartitionDistributorTest {
     // given
     final var expectedDistribution =
         Set.of(
-            new PartitionMetadata(partition(1), List.of(node(0)), Map.of(node(0), 2), 2),
-            new PartitionMetadata(partition(2), List.of(node(0)), Map.of(node(0), 2), 2));
+            new PartitionMetadata(partition(1), List.of(node(0)), Map.of(node(0), 2), 2, node(0)),
+            new PartitionMetadata(partition(2), List.of(node(0)), Map.of(node(0), 2), 2, node(0)));
     final var distributor =
         new FixedPartitionDistributorBuilder(PARTITION_GROUP_NAME)
             .assignMember(1, 0, 2)

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorTest.java
@@ -76,14 +76,10 @@ final class FixedPartitionDistributorTest {
     final var expectedDistribution =
         Set.of(
             new PartitionMetadata(
-                partition(1),
-                List.of(node(0), node(1)),
-                Map.of(node(0), 1, node(1), 2),
-                2,
-                node(1)),
+                partition(1), Set.of(node(0), node(1)), Map.of(node(0), 1, node(1), 2), 2, node(1)),
             new PartitionMetadata(
                 partition(2),
-                List.of(node(0), node(1)),
+                Set.of(node(0), node(1)),
                 Map.of(node(0), 2, node(1), 1),
                 2,
                 node(0)));
@@ -112,8 +108,8 @@ final class FixedPartitionDistributorTest {
     // given
     final var expectedDistribution =
         Set.of(
-            new PartitionMetadata(partition(1), List.of(node(0)), Map.of(node(0), 2), 2, node(0)),
-            new PartitionMetadata(partition(2), List.of(node(0)), Map.of(node(0), 2), 2, node(0)));
+            new PartitionMetadata(partition(1), Set.of(node(0)), Map.of(node(0), 2), 2, node(0)),
+            new PartitionMetadata(partition(2), Set.of(node(0)), Map.of(node(0), 2), 2, node(0)));
     final var distributor =
         new FixedPartitionDistributorBuilder(PARTITION_GROUP_NAME)
             .assignMember(1, 0, 2)


### PR DESCRIPTION
## Description

First step towards on-demand best-effort do-it-yourself leader rebalancing :tada: 
Here we add a method to `RaftPartition` that causes a stepdown if all conditions are met:
* Priority Election is enabled
* The partition distributor determined a primary node
* We are not the primary node 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8223 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
