### PR TITLE
[Backport stable/1.2] fix(snapshot): create snapshot exporter position is -1

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -170,6 +170,9 @@ public class StateControllerImpl implements StateController {
       exportedPosition = 0;
 
       if (latestSnapshot.isPresent()) {
+        // re-use index and term from the latest snapshot
+        // to ensure that the records from there are not
+        // compacted until they get exported
         final PersistedSnapshot persistedSnapshot = latestSnapshot.get();
         index = persistedSnapshot.getIndex();
         term = persistedSnapshot.getTerm();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.logstreams.impl.Loggers;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.sched.ConcurrencyControl;
@@ -141,26 +142,43 @@ public class StateControllerImpl implements StateController {
       return;
     }
 
-    final long exportedPosition = exporterPositionSupplier.applyAsLong(db);
-    final long snapshotPosition =
-        determineSnapshotPosition(lowerBoundSnapshotPosition, exportedPosition);
-    final var optionalIndexed = entrySupplier.getPreviousIndexedEntry(snapshotPosition);
-    if (optionalIndexed.isEmpty()) {
-      future.completeExceptionally(
-          new IllegalStateException(
-              String.format(
-                  "Failed to take snapshot. Expected to find an indexed entry for determined snapshot position %d (processedPosition = %d, exportedPosition=%d), but found no matching indexed entry which contains this position.",
-                  snapshotPosition, lowerBoundSnapshotPosition, exportedPosition)));
-      return;
+    long index = 0;
+    long term = 0;
+    long exportedPosition = exporterPositionSupplier.applyAsLong(db);
+
+    if (exportedPosition != -1) {
+
+      final long snapshotPosition =
+          determineSnapshotPosition(lowerBoundSnapshotPosition, exportedPosition);
+      final var optionalIndexed = entrySupplier.getPreviousIndexedEntry(snapshotPosition);
+
+      if (optionalIndexed.isEmpty()) {
+        future.completeExceptionally(
+            new IllegalStateException(
+                String.format(
+                    "Failed to take snapshot. Expected to find an indexed entry for determined snapshot position %d (processedPosition = %d, exportedPosition=%d), but found no matching indexed entry which contains this position.",
+                    snapshotPosition, lowerBoundSnapshotPosition, exportedPosition)));
+        return;
+      }
+
+      final var snapshotIndexedEntry = optionalIndexed.get();
+      index = snapshotIndexedEntry.index();
+      term = snapshotIndexedEntry.term();
+    } else {
+      final Optional<PersistedSnapshot> latestSnapshot =
+          constructableSnapshotStore.getLatestSnapshot();
+      exportedPosition = 0;
+
+      if (latestSnapshot.isPresent()) {
+        final PersistedSnapshot persistedSnapshot = latestSnapshot.get();
+        index = persistedSnapshot.getIndex();
+        term = persistedSnapshot.getTerm();
+      } // otherwise index/term remains 0
     }
 
-    final var snapshotIndexedEntry = optionalIndexed.get();
-    final Optional<TransientSnapshot> transientSnapshot =
+    final var transientSnapshot =
         constructableSnapshotStore.newTransientSnapshot(
-            snapshotIndexedEntry.index(),
-            snapshotIndexedEntry.term(),
-            lowerBoundSnapshotPosition,
-            exportedPosition);
+            index, term, lowerBoundSnapshotPosition, exportedPosition);
 
     // Now takeSnapshot result can be either true, false or error.
     transientSnapshot.ifPresentOrElse(

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -338,6 +338,8 @@ public final class StateControllerImplTest {
     exporterPosition.set(4L);
     takeSnapshot(snapshotPosition);
 
+    final var latestSnapshot = store.getLatestSnapshot().get();
+
     exporterPosition.set(-1L);
 
     // when
@@ -345,8 +347,8 @@ public final class StateControllerImplTest {
 
     // then
     final var snapshot = transientSnapshot.get().snapshotId();
-    assertThat(snapshot.getIndex()).isEqualTo(4);
-    assertThat(snapshot.getTerm()).isEqualTo(1);
+    assertThat(snapshot.getIndex()).isEqualTo(latestSnapshot.getIndex());
+    assertThat(snapshot.getTerm()).isEqualTo(latestSnapshot.getTerm());
     assertThat(snapshot.getProcessedPosition()).isEqualTo(snapshotPosition);
     assertThat(snapshot.getExportedPosition()).isEqualTo(0);
   }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredSnapshotTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredSnapshotTest.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.zeebe.it.clustering;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.DataCfg;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import io.camunda.zeebe.client.api.response.BrokerInfo;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Context.RecordFilter;
@@ -19,13 +19,18 @@ import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.snapshots.SnapshotId;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -81,15 +86,11 @@ public class ClusteredSnapshotTest {
     publishMessages();
 
     // when - then
-    Awaitility.await()
-        .pollInterval(Duration.ofSeconds(1))
-        .timeout(Duration.ofSeconds(60))
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              snapshotTrigger.accept(clusteringRule);
-              assertThatSnapshotExists();
-            });
+    awaitUntilAsserted(
+        (broker) -> {
+          triggerSnapshotRoutine();
+          assertThat(broker).havingSnapshot();
+        });
   }
 
   @Test
@@ -105,7 +106,7 @@ public class ClusteredSnapshotTest {
 
     // then
     clusteringRule.waitForSnapshotAtBroker(clusteringRule.getBroker(followerId));
-    assertThat(clusteringRule.getSnapshot(followerId)).isPresent();
+    assertThat(clusteringRule.getBroker(followerId)).havingSnapshot();
   }
 
   @Test
@@ -118,30 +119,125 @@ public class ClusteredSnapshotTest {
     publishMessages();
 
     // when - then
+    awaitUntilAsserted(
+        (broker) -> {
+          triggerSnapshotRoutine();
+          assertThat(broker)
+              .havingSnapshot()
+              .withExportedPosition(ControllableExporter.lastUpdatedPosition);
+        });
+  }
+
+  @Test
+  public void shouldTakeSnapshotWhenExporterPositionIsMinusOne() {
+    // given
+    // an exporter is configured, but nothing gets exported
+    ControllableExporter.updatePosition(false);
+    publishMessages();
+
+    // when
+    triggerSnapshotRoutine();
+
+    // then
+    awaitUntilAsserted(
+        (broker) -> {
+          assertThat(broker).havingSnapshot().withIndex(0).withTerm(0).withExportedPosition(0);
+        });
+  }
+
+  @Test
+  public void shouldKeepIndexAndTerm() {
+    // given
+    ControllableExporter.updatePosition(false);
+    removeExporters();
+    restartCluster();
+    publishMessages();
+    triggerSnapshotRoutine();
+
+    // expect - each broker has created a snapshot
+    awaitUntilAsserted(
+        (broker) -> {
+          assertThat(broker).havingSnapshot().withExportedPosition(Long.MAX_VALUE);
+        });
+
+    final Map<Integer, SnapshotId> snapshotsByBroker =
+        clusteringRule.getTopologyFromClient().getBrokers().stream()
+            .collect(Collectors.toMap(BrokerInfo::getNodeId, this::getSnapshot));
+
+    // when
+    configureExporters();
+    restartCluster();
+    publishMessages();
+    triggerSnapshotRoutine();
+
+    // then
+    awaitUntilAsserted(
+        (broker) -> {
+          final SnapshotId expectedSnapshot =
+              snapshotsByBroker.get(broker.getConfig().getCluster().getNodeId());
+          assertThat(broker)
+              .havingSnapshot()
+              .withIndex(expectedSnapshot.getIndex())
+              .withTerm(expectedSnapshot.getTerm());
+        });
+  }
+
+  @Test
+  public void shouldNotTakeNewSnapshot() {
+    // given
+    ControllableExporter.updatePosition(false);
+    removeExporters();
+    restartCluster();
+    publishMessages();
+
+    awaitUntilAsserted(
+        (broker) -> {
+          triggerSnapshotRoutine();
+          clusteringRule.getBrokers().stream()
+              .filter(b -> !b.equals(broker))
+              .forEach(
+                  (b) -> {
+                    final SnapshotId snapshot = clusteringRule.getSnapshot(b).get();
+                    final long expectedProcessedPosition = snapshot.getProcessedPosition();
+                    assertThat(broker)
+                        .havingSnapshot()
+                        .withProcessedPosition(expectedProcessedPosition);
+                  });
+        });
+
+    // expect - each broker has created a snapshot with exported position = Long.MAX_VALUE
+    awaitUntilAsserted(
+        (broker) -> {
+          assertThat(broker).havingSnapshot().withExportedPosition(Long.MAX_VALUE);
+        });
+
+    final Map<Integer, SnapshotId> snapshotsByBroker =
+        clusteringRule.getTopologyFromClient().getBrokers().stream()
+            .collect(Collectors.toMap(BrokerInfo::getNodeId, this::getSnapshot));
+
+    // when
+    configureExporters();
+    restartCluster();
+    triggerSnapshotRoutine();
+
+    // then
+    awaitUntilAsserted(
+        (broker) -> {
+          final SnapshotId expectedSnapshot =
+              snapshotsByBroker.get(broker.getConfig().getCluster().getNodeId());
+          assertThat(broker).havingSnapshot().isEqualTo(expectedSnapshot);
+        });
+  }
+
+  private void awaitUntilAsserted(Consumer<Broker> consumer) {
     Awaitility.await()
         .pollInterval(Duration.ofSeconds(1))
         .timeout(Duration.ofSeconds(60))
         .ignoreExceptions()
         .untilAsserted(
             () -> {
-              snapshotTrigger.accept(clusteringRule);
-              assertThatSnapshotContainsExporterPosition();
+              Assertions.assertThat(clusteringRule.getBrokers()).allSatisfy(consumer);
             });
-  }
-
-  private void assertThatSnapshotContainsExporterPosition() {
-    clusteringRule
-        .getBrokers()
-        .forEach(
-            broker -> {
-              final var exportedPosition = ControllableExporter.lastUpdatedPosition;
-              final var snapshotAtFollower = clusteringRule.getSnapshot(broker).orElseThrow();
-              assertThat(snapshotAtFollower.getExportedPosition()).isEqualTo(exportedPosition);
-            });
-  }
-
-  private void assertThatSnapshotExists() {
-    clusteringRule.getBrokers().forEach(broker -> clusteringRule.getSnapshot(broker).orElseThrow());
   }
 
   private void configureBroker(final BrokerCfg brokerCfg) {
@@ -149,9 +245,38 @@ public class ClusteredSnapshotTest {
     data.setLogIndexDensity(5);
     data.setSnapshotPeriod(SNAPSHOT_INTERVAL);
 
-    final ExporterCfg exporterCfg = new ExporterCfg();
-    exporterCfg.setClassName(ControllableExporter.class.getName());
-    brokerCfg.setExporters(Collections.singletonMap("snapshot-test-exporter", exporterCfg));
+    configureExporter(brokerCfg);
+  }
+
+  private void configureExporters() {
+    clusteringRule.getBrokers().stream().map(Broker::getConfig).forEach(this::configureExporter);
+  }
+
+  private void configureExporter(final BrokerCfg brokerConfig) {
+    final ExporterCfg exporterConfig = new ExporterCfg();
+    exporterConfig.setClassName(ControllableExporter.class.getName());
+    brokerConfig.setExporters(Collections.singletonMap("snapshot-test-exporter", exporterConfig));
+  }
+
+  private void removeExporters() {
+    clusteringRule.getBrokers().forEach(this::removeExporter);
+  }
+
+  private void removeExporter(final Broker broker) {
+    final BrokerCfg brokerConfig = broker.getConfig();
+    brokerConfig.setExporters(Collections.emptyMap());
+  }
+
+  private void restartCluster() {
+    clusteringRule.restartCluster();
+  }
+
+  private void triggerSnapshotRoutine() {
+    snapshotTrigger.accept(clusteringRule);
+  }
+
+  private SnapshotId getSnapshot(final BrokerInfo brokerInfo) {
+    return clusteringRule.getSnapshot(brokerInfo.getNodeId()).get();
   }
 
   private void publishMessages() {
@@ -166,6 +291,10 @@ public class ClusteredSnapshotTest {
         .correlationKey("msg-" + key)
         .send()
         .join();
+  }
+
+  private BrokerAssert assertThat(Broker broker) {
+    return new BrokerAssert(broker, clusteringRule);
   }
 
   public static class ControllableExporter implements Exporter {
@@ -213,6 +342,69 @@ public class ClusteredSnapshotTest {
       }
 
       EXPORTED_RECORDS.incrementAndGet();
+    }
+  }
+
+  private static class BrokerAssert extends AbstractAssert<BrokerAssert, Broker> {
+
+    private final ClusteringRule rule;
+
+    protected BrokerAssert(Broker actual, ClusteringRule rule) {
+      super(actual, BrokerAssert.class);
+      this.rule = rule;
+    }
+
+    public SnapshotAssert havingSnapshot() {
+      final var snapshot = rule.getSnapshot(actual);
+      Assertions.assertThat(snapshot.isPresent())
+          .withFailMessage("No snapshot exists for broker <%s>", actual)
+          .isTrue();
+      return new SnapshotAssert(snapshot.get());
+    }
+  }
+
+  private static class SnapshotAssert extends AbstractAssert<SnapshotAssert, SnapshotId> {
+
+    protected SnapshotAssert(SnapshotId actual) {
+      super(actual, SnapshotAssert.class);
+    }
+
+    public SnapshotAssert withIndex(long expected) {
+      Assertions.assertThat(actual.getIndex())
+          .withFailMessage(
+              "Expecting snapshot index <%s> but was <%s>", expected, actual.getIndex())
+          .isEqualTo(expected);
+      return myself;
+    }
+
+    public SnapshotAssert withTerm(long expected) {
+      Assertions.assertThat(actual.getTerm())
+          .withFailMessage("Expecting snapshot term <%s> but was <%s>", expected, actual.getTerm())
+          .isEqualTo(expected);
+      return myself;
+    }
+
+    public SnapshotAssert withProcessedPosition(long expected) {
+      Assertions.assertThat(actual.getProcessedPosition())
+          .withFailMessage(
+              "Expecting snapshot processed position <%s> but was <%s>",
+              expected, actual.getProcessedPosition())
+          .isEqualTo(expected);
+      return myself;
+    }
+
+    public SnapshotAssert withExportedPosition(long expected) {
+      Assertions.assertThat(actual.getExportedPosition())
+          .withFailMessage(
+              "Expecting snapshot exported position <%s> but was <%s>",
+              expected, actual.getExportedPosition())
+          .isEqualTo(expected);
+      return myself;
+    }
+
+    @Override
+    public SnapshotAssert isEqualTo(Object expected) {
+      return super.isEqualTo(expected);
     }
   }
 }


### PR DESCRIPTION
## Description

backports #8176 

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #7978 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
