### PR TITLE
[Backport stable/1.1] fix(snapshot): create snapshot exporter position is -1

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -85,26 +85,43 @@ public class StateControllerImpl implements StateController, PersistedSnapshotLi
       return Optional.empty();
     }
 
-    final long exportedPosition = exporterPositionSupplier.applyAsLong(openDb());
-    final long snapshotPosition =
-        determineSnapshotPosition(lowerBoundSnapshotPosition, exportedPosition);
-    final var optionalIndexed = entrySupplier.getPreviousIndexedEntry(snapshotPosition);
-    if (optionalIndexed.isEmpty()) {
-      LOG.warn(
-          "Failed to take snapshot. Expected to find an indexed entry for determined snapshot position {} (processedPosition = {}, exportedPosition={}), but found no matching indexed entry which contains this position.",
-          snapshotPosition,
-          lowerBoundSnapshotPosition,
-          exportedPosition);
-      return Optional.empty();
-    }
+    long index = 0;
+    long term = 0;
+    long exportedPosition = exporterPositionSupplier.applyAsLong(openDb());
 
-    final var snapshotIndexedEntry = optionalIndexed.get();
-    final Optional<TransientSnapshot> transientSnapshot =
-        constructableSnapshotStore.newTransientSnapshot(
-            snapshotIndexedEntry.index(),
-            snapshotIndexedEntry.term(),
+    if (exportedPosition != -1) {
+
+      final long snapshotPosition =
+          determineSnapshotPosition(lowerBoundSnapshotPosition, exportedPosition);
+      final var optionalIndexed = entrySupplier.getPreviousIndexedEntry(snapshotPosition);
+
+      if (optionalIndexed.isEmpty()) {
+        LOG.warn(
+            "Failed to take snapshot. Expected to find an indexed entry for determined snapshot position {} (processedPosition = {}, exportedPosition={}), but found no matching indexed entry which contains this position.",
+            snapshotPosition,
             lowerBoundSnapshotPosition,
             exportedPosition);
+        return Optional.empty();
+      }
+
+      final var snapshotIndexedEntry = optionalIndexed.get();
+      index = snapshotIndexedEntry.index();
+      term = snapshotIndexedEntry.term();
+    } else {
+      final Optional<PersistedSnapshot> latestSnapshot =
+          constructableSnapshotStore.getLatestSnapshot();
+      exportedPosition = 0;
+
+      if (latestSnapshot.isPresent()) {
+        final PersistedSnapshot persistedSnapshot = latestSnapshot.get();
+        index = persistedSnapshot.getIndex();
+        term = persistedSnapshot.getTerm();
+      } // otherwise index/term remains 0
+    }
+
+    final var transientSnapshot =
+        constructableSnapshotStore.newTransientSnapshot(
+            index, term, lowerBoundSnapshotPosition, exportedPosition);
 
     transientSnapshot.ifPresent(this::takeSnapshot);
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -113,6 +113,9 @@ public class StateControllerImpl implements StateController, PersistedSnapshotLi
       exportedPosition = 0;
 
       if (latestSnapshot.isPresent()) {
+        // re-use index and term from the latest snapshot
+        // to ensure that the records from there are not
+        // compacted until they get exported
         final PersistedSnapshot persistedSnapshot = latestSnapshot.get();
         index = persistedSnapshot.getIndex();
         term = persistedSnapshot.getTerm();

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -319,6 +319,49 @@ public final class StateControllerImplTest {
     assertThat(runtimeDirectory).doesNotExist();
   }
 
+  @Test
+  public void shouldSetExporterPositionToZero() throws Exception {
+    // given
+    snapshotController.recover();
+    snapshotController.openDb();
+
+    exporterPosition.set(-1L);
+    final long snapshotPosition = 5;
+
+    // when
+    final var transientSnapshot = snapshotController.takeTransientSnapshot(snapshotPosition);
+
+    // then
+    final var snapshot = transientSnapshot.get().snapshotId();
+    assertThat(snapshot.getIndex()).isEqualTo(0);
+    assertThat(snapshot.getTerm()).isEqualTo(0);
+    assertThat(snapshot.getProcessedPosition()).isEqualTo(snapshotPosition);
+    assertThat(snapshot.getExportedPosition()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldKeepIndexAndTerm() throws Exception {
+    // given
+    snapshotController.recover();
+    snapshotController.openDb();
+
+    final long snapshotPosition = 5;
+    exporterPosition.set(4L);
+    takeSnapshot(snapshotPosition);
+
+    exporterPosition.set(-1L);
+
+    // when
+    final var transientSnapshot = snapshotController.takeTransientSnapshot(snapshotPosition);
+
+    // then
+    final var snapshot = transientSnapshot.get().snapshotId();
+    assertThat(snapshot.getIndex()).isEqualTo(4);
+    assertThat(snapshot.getTerm()).isEqualTo(1);
+    assertThat(snapshot.getProcessedPosition()).isEqualTo(snapshotPosition);
+    assertThat(snapshot.getExportedPosition()).isEqualTo(0);
+  }
+
   private File takeSnapshot(final long position) {
     final var snapshot = snapshotController.takeTransientSnapshot(position).orElseThrow();
     return snapshot.persist().join().getPath().toFile();

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -349,6 +349,8 @@ public final class StateControllerImplTest {
     exporterPosition.set(4L);
     takeSnapshot(snapshotPosition);
 
+    final var latestSnapshot = store.getLatestSnapshot().get();
+
     exporterPosition.set(-1L);
 
     // when
@@ -356,8 +358,8 @@ public final class StateControllerImplTest {
 
     // then
     final var snapshot = transientSnapshot.get().snapshotId();
-    assertThat(snapshot.getIndex()).isEqualTo(4);
-    assertThat(snapshot.getTerm()).isEqualTo(1);
+    assertThat(snapshot.getIndex()).isEqualTo(latestSnapshot.getIndex());
+    assertThat(snapshot.getTerm()).isEqualTo(latestSnapshot.getTerm());
     assertThat(snapshot.getProcessedPosition()).isEqualTo(snapshotPosition);
     assertThat(snapshot.getExportedPosition()).isEqualTo(0);
   }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/clustering/ClusteredSnapshotTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/clustering/ClusteredSnapshotTest.java
@@ -78,7 +78,7 @@ public class ClusteredSnapshotTest {
   }
 
   @Test
-  public void shouldTakeSnapshotsOnAllNodes() {
+  public void shouldTakeSnapshotsOnPartitionLeader() {
     // given
     ControllableExporter.updatePosition(true);
 
@@ -215,7 +215,10 @@ public class ClusteredSnapshotTest {
         .ignoreExceptions()
         .untilAsserted(
             () -> {
-              Assertions.assertThat(clusteringRule.getBrokers()).allSatisfy(consumer);
+              // assert only the partition leader
+              final var leader = clusteringRule.getLeaderForPartition(1);
+              final Broker broker = clusteringRule.getBroker(leader.getNodeId());
+              Assertions.assertThat(broker).satisfies(consumer);
             });
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/clustering/ClusteredSnapshotTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/clustering/ClusteredSnapshotTest.java
@@ -175,25 +175,19 @@ public class ClusteredSnapshotTest {
     restartCluster();
     publishMessages();
 
+    final var leaderId = clusteringRule.getLeaderForPartition(1).getNodeId();
+    final var leaderAdminService = clusteringRule.getBroker(leaderId).getBrokerAdminService();
+    final var expectedProcessedPosition =
+        leaderAdminService.getPartitionStatus().get(1).getProcessedPosition();
+
+    // expect
     awaitUntilAsserted(
         (broker) -> {
           triggerSnapshotRoutine();
-          clusteringRule.getBrokers().stream()
-              .filter(b -> !b.equals(broker))
-              .forEach(
-                  (b) -> {
-                    final SnapshotId snapshot = clusteringRule.getSnapshot(b).get();
-                    final long expectedProcessedPosition = snapshot.getProcessedPosition();
-                    assertThat(broker)
-                        .havingSnapshot()
-                        .withProcessedPosition(expectedProcessedPosition);
-                  });
-        });
-
-    // expect - each broker has created a snapshot with exported position = Long.MAX_VALUE
-    awaitUntilAsserted(
-        (broker) -> {
-          assertThat(broker).havingSnapshot().withExportedPosition(Long.MAX_VALUE);
+          assertThat(broker)
+              .havingSnapshot()
+              .withProcessedPosition(expectedProcessedPosition)
+              .withExportedPosition(Long.MAX_VALUE);
         });
 
     final Map<Integer, SnapshotId> snapshotsByBroker =

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/clustering/ClusteredSnapshotTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/clustering/ClusteredSnapshotTest.java
@@ -1,0 +1,398 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.it.clustering;
+
+import io.camunda.zeebe.broker.Broker;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.DataCfg;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import io.camunda.zeebe.client.api.response.BrokerInfo;
+import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.exporter.api.context.Context;
+import io.camunda.zeebe.exporter.api.context.Context.RecordFilter;
+import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.snapshots.SnapshotId;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.springframework.util.unit.DataSize;
+
+@RunWith(Parameterized.class)
+public class ClusteredSnapshotTest {
+
+  private static final Duration SNAPSHOT_INTERVAL = Duration.ofMinutes(5);
+
+  @Rule
+  public final ClusteringRule clusteringRule = new ClusteringRule(1, 3, 3, this::configureBroker);
+
+  @Parameter(0)
+  public Consumer<ClusteringRule> snapshotTrigger;
+
+  @Parameter(1)
+  public String description;
+
+  @Parameters(name = "{index}: {1}")
+  public static Object[][] snapshotTriggers() {
+    return new Object[][] {
+      new Object[] {
+        (Consumer<ClusteringRule>) ClusteringRule::triggerAndWaitForSnapshots,
+        "explicit trigger snapshot"
+      },
+      new Object[] {
+        (Consumer<ClusteringRule>) (rule) -> rule.getClock().addTime(SNAPSHOT_INTERVAL),
+        "implicit snapshot by advancing the clock"
+      }
+    };
+  }
+
+  @After
+  public void cleanUp() {
+    ControllableExporter.updatePosition(true);
+    ControllableExporter.EXPORTED_RECORDS.set(0);
+    ControllableExporter.RECORD_TYPE_FILTER.set(r -> true);
+    ControllableExporter.VALUE_TYPE_FILTER.set(r -> true);
+  }
+
+  @Test
+  public void shouldTakeSnapshotsOnAllNodes() {
+    // given
+    ControllableExporter.updatePosition(true);
+
+    publishMessages();
+    ControllableExporter.updatePosition(false);
+    publishMessages();
+
+    // when - then
+    awaitUntilAsserted(
+        (broker) -> {
+          triggerSnapshotRoutine();
+          assertThat(broker).havingSnapshot();
+        });
+  }
+
+  @Test
+  public void shouldIncludeExportedPositionInSnapshot() {
+    // given
+    ControllableExporter.updatePosition(true);
+
+    publishMessages();
+    ControllableExporter.updatePosition(false);
+    publishMessages();
+
+    // when - then
+    awaitUntilAsserted(
+        (broker) -> {
+          triggerSnapshotRoutine();
+          assertThat(broker)
+              .havingSnapshot()
+              .withExportedPosition(ControllableExporter.lastUpdatedPosition);
+        });
+  }
+
+  @Test
+  public void shouldTakeSnapshotWhenExporterPositionIsMinusOne() {
+    // given
+    // an exporter is configured, but nothing gets exported
+    ControllableExporter.updatePosition(false);
+    publishMessages();
+
+    // when
+    triggerSnapshotRoutine();
+
+    // then
+    awaitUntilAsserted(
+        (broker) -> {
+          assertThat(broker).havingSnapshot().withIndex(0).withTerm(0).withExportedPosition(0);
+        });
+  }
+
+  @Test
+  public void shouldKeepIndexAndTerm() {
+    // given
+    ControllableExporter.updatePosition(false);
+    removeExporters();
+    restartCluster();
+    publishMessages();
+    triggerSnapshotRoutine();
+
+    // expect - each broker has created a snapshot
+    awaitUntilAsserted(
+        (broker) -> {
+          assertThat(broker).havingSnapshot().withExportedPosition(Long.MAX_VALUE);
+        });
+
+    final Map<Integer, SnapshotId> snapshotsByBroker =
+        clusteringRule.getTopologyFromClient().getBrokers().stream()
+            .collect(Collectors.toMap(BrokerInfo::getNodeId, this::getSnapshot));
+
+    // when
+    configureExporters();
+    restartCluster();
+    publishMessages();
+    triggerSnapshotRoutine();
+
+    // then
+    awaitUntilAsserted(
+        (broker) -> {
+          final SnapshotId expectedSnapshot =
+              snapshotsByBroker.get(broker.getConfig().getCluster().getNodeId());
+          assertThat(broker)
+              .havingSnapshot()
+              .withIndex(expectedSnapshot.getIndex())
+              .withTerm(expectedSnapshot.getTerm());
+        });
+  }
+
+  @Test
+  public void shouldNotTakeNewSnapshot() {
+    // given
+    ControllableExporter.updatePosition(false);
+    removeExporters();
+    restartCluster();
+    publishMessages();
+
+    awaitUntilAsserted(
+        (broker) -> {
+          triggerSnapshotRoutine();
+          clusteringRule.getBrokers().stream()
+              .filter(b -> !b.equals(broker))
+              .forEach(
+                  (b) -> {
+                    final SnapshotId snapshot = clusteringRule.getSnapshot(b).get();
+                    final long expectedProcessedPosition = snapshot.getProcessedPosition();
+                    assertThat(broker)
+                        .havingSnapshot()
+                        .withProcessedPosition(expectedProcessedPosition);
+                  });
+        });
+
+    // expect - each broker has created a snapshot with exported position = Long.MAX_VALUE
+    awaitUntilAsserted(
+        (broker) -> {
+          assertThat(broker).havingSnapshot().withExportedPosition(Long.MAX_VALUE);
+        });
+
+    final Map<Integer, SnapshotId> snapshotsByBroker =
+        clusteringRule.getTopologyFromClient().getBrokers().stream()
+            .collect(Collectors.toMap(BrokerInfo::getNodeId, this::getSnapshot));
+
+    // when
+    configureExporters();
+    restartCluster();
+    triggerSnapshotRoutine();
+
+    // then
+    awaitUntilAsserted(
+        (broker) -> {
+          final SnapshotId expectedSnapshot =
+              snapshotsByBroker.get(broker.getConfig().getCluster().getNodeId());
+          assertThat(broker).havingSnapshot().isEqualTo(expectedSnapshot);
+        });
+  }
+
+  private void awaitUntilAsserted(Consumer<Broker> consumer) {
+    Awaitility.await()
+        .pollInterval(Duration.ofSeconds(1))
+        .timeout(Duration.ofSeconds(60))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              Assertions.assertThat(clusteringRule.getBrokers()).allSatisfy(consumer);
+            });
+  }
+
+  private void configureBroker(final BrokerCfg brokerCfg) {
+    brokerCfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(4));
+
+    final DataCfg data = brokerCfg.getData();
+    data.setLogSegmentSize(DataSize.ofKilobytes(4));
+    data.setLogIndexDensity(5);
+    data.setSnapshotPeriod(SNAPSHOT_INTERVAL);
+
+    configureExporter(brokerCfg);
+  }
+
+  private void configureExporters() {
+    clusteringRule.getBrokers().stream().map(Broker::getConfig).forEach(this::configureExporter);
+  }
+
+  private void configureExporter(final BrokerCfg brokerConfig) {
+    final ExporterCfg exporterConfig = new ExporterCfg();
+    exporterConfig.setClassName(ControllableExporter.class.getName());
+    brokerConfig.setExporters(Collections.singletonMap("snapshot-test-exporter", exporterConfig));
+  }
+
+  private void removeExporters() {
+    clusteringRule.getBrokers().forEach(this::removeExporter);
+  }
+
+  private void removeExporter(final Broker broker) {
+    final BrokerCfg brokerConfig = broker.getConfig();
+    brokerConfig.setExporters(Collections.emptyMap());
+  }
+
+  private void restartCluster() {
+    clusteringRule.restartCluster();
+  }
+
+  private void triggerSnapshotRoutine() {
+    snapshotTrigger.accept(clusteringRule);
+  }
+
+  private SnapshotId getSnapshot(final BrokerInfo brokerInfo) {
+    return clusteringRule.getSnapshot(brokerInfo.getNodeId()).get();
+  }
+
+  private void publishMessages() {
+    IntStream.range(0, 10).forEach(this::publishMaxMessageSizeMessage);
+  }
+
+  private void publishMaxMessageSizeMessage(final int key) {
+    clusteringRule
+        .getClient()
+        .newPublishMessageCommand()
+        .messageName("msg")
+        .correlationKey("msg-" + key)
+        .send()
+        .join();
+  }
+
+  private BrokerAssert assertThat(Broker broker) {
+    return new BrokerAssert(broker, clusteringRule);
+  }
+
+  public static class ControllableExporter implements Exporter {
+    static volatile boolean shouldExport = true;
+    static volatile long lastUpdatedPosition = -1;
+
+    static final AtomicLong EXPORTED_RECORDS = new AtomicLong(0);
+    static final AtomicReference<Predicate<RecordType>> RECORD_TYPE_FILTER =
+        new AtomicReference<>(r -> true);
+    static final AtomicReference<Predicate<ValueType>> VALUE_TYPE_FILTER =
+        new AtomicReference<>(r -> true);
+
+    private Controller controller;
+
+    static void updatePosition(final boolean flag) {
+      shouldExport = flag;
+    }
+
+    @Override
+    public void configure(final Context context) {
+      context.setFilter(
+          new RecordFilter() {
+            @Override
+            public boolean acceptType(final RecordType recordType) {
+              return RECORD_TYPE_FILTER.get().test(recordType);
+            }
+
+            @Override
+            public boolean acceptValue(final ValueType valueType) {
+              return VALUE_TYPE_FILTER.get().test(valueType);
+            }
+          });
+    }
+
+    @Override
+    public void open(final Controller controller) {
+      this.controller = controller;
+    }
+
+    @Override
+    public void export(final Record<?> record) {
+      if (shouldExport) {
+        lastUpdatedPosition = record.getPosition();
+        controller.updateLastExportedRecordPosition(lastUpdatedPosition);
+      }
+
+      EXPORTED_RECORDS.incrementAndGet();
+    }
+  }
+
+  private static class BrokerAssert extends AbstractAssert<BrokerAssert, Broker> {
+
+    private final ClusteringRule rule;
+
+    protected BrokerAssert(Broker actual, ClusteringRule rule) {
+      super(actual, BrokerAssert.class);
+      this.rule = rule;
+    }
+
+    public SnapshotAssert havingSnapshot() {
+      final var snapshot = rule.getSnapshot(actual);
+      Assertions.assertThat(snapshot.isPresent())
+          .withFailMessage("No snapshot exists for broker <%s>", actual)
+          .isTrue();
+      return new SnapshotAssert(snapshot.get());
+    }
+  }
+
+  private static class SnapshotAssert extends AbstractAssert<SnapshotAssert, SnapshotId> {
+
+    protected SnapshotAssert(SnapshotId actual) {
+      super(actual, SnapshotAssert.class);
+    }
+
+    public SnapshotAssert withIndex(long expected) {
+      Assertions.assertThat(actual.getIndex())
+          .withFailMessage(
+              "Expecting snapshot index <%s> but was <%s>", expected, actual.getIndex())
+          .isEqualTo(expected);
+      return myself;
+    }
+
+    public SnapshotAssert withTerm(long expected) {
+      Assertions.assertThat(actual.getTerm())
+          .withFailMessage("Expecting snapshot term <%s> but was <%s>", expected, actual.getTerm())
+          .isEqualTo(expected);
+      return myself;
+    }
+
+    public SnapshotAssert withProcessedPosition(long expected) {
+      Assertions.assertThat(actual.getProcessedPosition())
+          .withFailMessage(
+              "Expecting snapshot processed position <%s> but was <%s>",
+              expected, actual.getProcessedPosition())
+          .isEqualTo(expected);
+      return myself;
+    }
+
+    public SnapshotAssert withExportedPosition(long expected) {
+      Assertions.assertThat(actual.getExportedPosition())
+          .withFailMessage(
+              "Expecting snapshot exported position <%s> but was <%s>",
+              expected, actual.getExportedPosition())
+          .isEqualTo(expected);
+      return myself;
+    }
+
+    @Override
+    public SnapshotAssert isEqualTo(Object expected) {
+      return super.isEqualTo(expected);
+    }
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/clustering/ClusteringRule.java
@@ -720,8 +720,6 @@ public final class ClusteringRule extends ExternalResource {
   }
 
   public void triggerAndWaitForSnapshots() {
-    // Ensure that the exporter positions are distributed to the followers
-    getClock().addTime(Duration.ofSeconds(15));
     getBrokers().stream()
         .map(Broker::getBrokerAdminService)
         .forEach(BrokerAdminService::takeSnapshot);


### PR DESCRIPTION
## Description

backports #8176

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #7978

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
