### PR TITLE
Delay job header encoding to task activation

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
@@ -19,15 +21,22 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
+import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.collection.Tuple;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public final class BpmnJobBehavior {
 
   private final JobRecord jobRecord = new JobRecord().setVariables(DocumentValue.EMPTY_DOCUMENT);
+  private final HeaderEncoder headerEncoder = new HeaderEncoder();
 
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
@@ -90,10 +99,12 @@ public final class BpmnJobBehavior {
       final String jobType,
       final int retries) {
 
+    final var encodedHeaders = encodeHeaders(jobWorkerElement);
+
     jobRecord
         .setType(jobType)
         .setRetries(retries)
-        .setCustomHeaders(jobWorkerElement.getJobWorkerProperties().getEncodedHeaders())
+        .setCustomHeaders(encodedHeaders)
         .setBpmnProcessId(context.getBpmnProcessId())
         .setProcessDefinitionVersion(context.getProcessVersion())
         .setProcessDefinitionKey(context.getProcessDefinitionKey())
@@ -103,6 +114,11 @@ public final class BpmnJobBehavior {
 
     final var jobKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.CREATED, jobRecord);
+  }
+
+  private DirectBuffer encodeHeaders(final ExecutableJobWorkerElement element) {
+    final var headers = element.getJobWorkerProperties().getTaskHeaders();
+    return headerEncoder.encode(headers);
   }
 
   public void cancelJob(final BpmnElementContext context) {
@@ -121,6 +137,46 @@ public final class BpmnJobBehavior {
     if (state == State.ACTIVATABLE || state == State.ACTIVATED || state == State.FAILED) {
       final JobRecord job = jobState.getJob(jobKey);
       commandWriter.appendFollowUpCommand(jobKey, JobIntent.CANCEL, job);
+    }
+  }
+
+  private static final class HeaderEncoder {
+
+    private static final int INITIAL_SIZE_KEY_VALUE_PAIR = 128;
+
+    private final MsgPackWriter msgPackWriter = new MsgPackWriter();
+
+    public DirectBuffer encode(final Map<String, String> taskHeaders) {
+      if (taskHeaders == null || taskHeaders.isEmpty()) {
+        return JobRecord.NO_HEADERS;
+      }
+
+      final MutableDirectBuffer buffer = new UnsafeBuffer(0, 0);
+
+      final ExpandableArrayBuffer expandableBuffer =
+          new ExpandableArrayBuffer(INITIAL_SIZE_KEY_VALUE_PAIR * taskHeaders.size());
+
+      msgPackWriter.wrap(expandableBuffer, 0);
+      msgPackWriter.writeMapHeader(taskHeaders.size());
+
+      taskHeaders.forEach(
+          (k, v) -> {
+            if (isValidHeader(k, v)) {
+              final DirectBuffer key = wrapString(k);
+              msgPackWriter.writeString(key);
+
+              final DirectBuffer value = wrapString(v);
+              msgPackWriter.writeString(value);
+            }
+          });
+
+      buffer.wrap(expandableBuffer.byteArray(), 0, msgPackWriter.getOffset());
+
+      return buffer;
+    }
+
+    private boolean isValidHeader(final String key, final String value) {
+      return key != null && !key.isEmpty() && value != null && !value.isEmpty();
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/JobWorkerProperties.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/JobWorkerProperties.java
@@ -8,8 +8,7 @@
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
 import io.camunda.zeebe.el.Expression;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
-import org.agrona.DirectBuffer;
+import java.util.Map;
 
 /**
  * The properties of an element that is based on a job and should be processed by a job worker. For
@@ -19,7 +18,7 @@ public class JobWorkerProperties {
 
   private Expression type;
   private Expression retries;
-  private DirectBuffer encodedHeaders = JobRecord.NO_HEADERS;
+  private Map<String, String> taskHeaders = Map.of();
 
   public Expression getType() {
     return type;
@@ -37,11 +36,11 @@ public class JobWorkerProperties {
     this.retries = retries;
   }
 
-  public DirectBuffer getEncodedHeaders() {
-    return encodedHeaders;
+  public Map<String, String> getTaskHeaders() {
+    return taskHeaders;
   }
 
-  public void setEncodedHeaders(final DirectBuffer encodedHeaders) {
-    this.encodedHeaders = encodedHeaders;
+  public void setTaskHeaders(final Map<String, String> taskHeaders) {
+    this.taskHeaders = taskHeaders;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/JobWorkerElementTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/JobWorkerElementTransformer.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.transformer;
 
-import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
-
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.engine.Loggers;
@@ -22,12 +20,8 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
-import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
-import org.agrona.DirectBuffer;
-import org.agrona.ExpandableArrayBuffer;
-import org.agrona.MutableDirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 
 public final class JobWorkerElementTransformer<T extends FlowElement>
@@ -88,10 +82,10 @@ public final class JobWorkerElementTransformer<T extends FlowElement>
     final ZeebeTaskHeaders taskHeaders = element.getSingleExtensionElement(ZeebeTaskHeaders.class);
 
     if (taskHeaders != null) {
-      final List<ZeebeHeader> validHeaders =
+      final Map<String, String> validHeaders =
           taskHeaders.getHeaders().stream()
               .filter(this::isValidHeader)
-              .collect(Collectors.toList());
+              .collect(Collectors.toMap(ZeebeHeader::getKey, ZeebeHeader::getValue));
 
       if (validHeaders.size() < taskHeaders.getHeaders().size()) {
         LOG.warn(
@@ -100,35 +94,9 @@ public final class JobWorkerElementTransformer<T extends FlowElement>
       }
 
       if (!validHeaders.isEmpty()) {
-        final DirectBuffer encodedHeaders = encode(validHeaders);
-        jobWorkerProperties.setEncodedHeaders(encodedHeaders);
+        jobWorkerProperties.setTaskHeaders(validHeaders);
       }
     }
-  }
-
-  private DirectBuffer encode(final List<ZeebeHeader> taskHeaders) {
-    final MutableDirectBuffer buffer = new UnsafeBuffer(0, 0);
-
-    final ExpandableArrayBuffer expandableBuffer =
-        new ExpandableArrayBuffer(INITIAL_SIZE_KEY_VALUE_PAIR * taskHeaders.size());
-
-    msgPackWriter.wrap(expandableBuffer, 0);
-    msgPackWriter.writeMapHeader(taskHeaders.size());
-
-    taskHeaders.forEach(
-        h -> {
-          if (isValidHeader(h)) {
-            final DirectBuffer key = wrapString(h.getKey());
-            msgPackWriter.writeString(key);
-
-            final DirectBuffer value = wrapString(h.getValue());
-            msgPackWriter.writeString(value);
-          }
-        });
-
-    buffer.wrap(expandableBuffer.byteArray(), 0, msgPackWriter.getOffset());
-
-    return buffer;
   }
 
   private boolean isValidHeader(final ZeebeHeader header) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/JobWorkerElementTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/JobWorkerElementTransformer.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.model.bpmn.instance.FlowElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
-import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -28,10 +27,6 @@ public final class JobWorkerElementTransformer<T extends FlowElement>
     implements ModelElementTransformer<T> {
 
   private static final Logger LOG = Loggers.STREAM_PROCESSING;
-
-  private static final int INITIAL_SIZE_KEY_VALUE_PAIR = 128;
-
-  private final MsgPackWriter msgPackWriter = new MsgPackWriter();
 
   private final Class<T> type;
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

We want to add additional headers to the customHeaders property of JobRecord. These headers will only be available at the time of activating the task. Adding these headers to the encoded headers (bytes) is difficult. Instead, we can simply delay the encoding of the headers (it starts as a `java.lang.Map`) to the task activation, specifically to the moment when the job CREATED record is written.

The logic to encode the headers was also duplicated between the UserTaskTransformer and the JobWorkerElementTransformer. This duplication is removed with this changeset.

**About backwards compatibility** 
When creating this pull request, I initially thought that these changes might not be backwards compatible with existing process deployments. Specifically, the change to [JobWorkerProperties#21](https://github.com/camunda-cloud/zeebe/pull/8242/files#diff-5c6554da01e6ad4296b0453775cad365591d522ce45c875ae5dd6b75c9de21fcR21). I imagined that an already deployed Process would have the data for this class loaded from the state (from RocksDB), which wouldn't work because a DirectBuffer is not a Map. However, that's not how this works. The entire process is read from state, and then transformed at startup to have an in memory representation of it (which includes an instance of this JobWorkerProperties class). I've also tested this behavior locally: deploying a process with user task with headers to an empty broker running the code from develop and creating an instance of it, stopping the broker and updating it to this version, and finally creating another instance. Both instances came out the same after restart.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #8055

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
