### PR TITLE
In the model API, a business rule task can reference a DMN decision

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
@@ -212,6 +212,7 @@ import io.camunda.zeebe.model.bpmn.impl.instance.di.ShapeImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.di.StyleImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.di.WaypointImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeAssignmentDefinitionImpl;
+import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeCalledDecisionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeCalledElementImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeFormDefinitionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeHeaderImpl;
@@ -641,6 +642,7 @@ public class Bpmn {
     ZeebeFormDefinitionImpl.registerType(bpmnModelBuilder);
     ZeebeUserTaskFormImpl.registerType(bpmnModelBuilder);
     ZeebeAssignmentDefinitionImpl.registerType(bpmnModelBuilder);
+    ZeebeCalledDecisionImpl.registerType(bpmnModelBuilder);
   }
 
   /** @return the {@link Model} instance to use */

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBusinessRuleTaskBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBusinessRuleTaskBuilder.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.model.bpmn.builder;
 
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 
 /** @author Sebastian Menski */
 public abstract class AbstractBusinessRuleTaskBuilder<B extends AbstractBusinessRuleTaskBuilder<B>>
@@ -38,6 +39,43 @@ public abstract class AbstractBusinessRuleTaskBuilder<B extends AbstractBusiness
    */
   public B implementation(final String implementation) {
     element.setImplementation(implementation);
+    return myself;
+  }
+
+  /**
+   * Sets a static id of the decision that is called.
+   *
+   * @param decisionId the id of the decision
+   * @return the builder object
+   */
+  public B zeebeCalledDecisionId(final String decisionId) {
+    final ZeebeCalledDecision calledDecision =
+        getCreateSingleExtensionElement(ZeebeCalledDecision.class);
+    calledDecision.setDecisionId(decisionId);
+    return myself;
+  }
+
+  /**
+   * Sets a dynamic id of the decision that is called. The id is retrieved from the given
+   * expression.
+   *
+   * @param decisionIdExpression the expression for the id of the decision
+   * @return the builder object
+   */
+  public B zeebeCalledDecisionIdExpression(final String decisionIdExpression) {
+    return zeebeCalledDecisionId(asZeebeExpression(decisionIdExpression));
+  }
+
+  /**
+   * Sets the name of the result variable.
+   *
+   * @param resultVariable the name of the result variable
+   * @return the builder object
+   */
+  public B zeebeResultVariable(final String resultVariable) {
+    final ZeebeCalledDecision calledDecision =
+        getCreateSingleExtensionElement(ZeebeCalledDecision.class);
+    calledDecision.setResultVariable(resultVariable);
     return myself;
   }
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -41,6 +41,10 @@ public class ZeebeConstants {
   public static final String ATTRIBUTE_ASSIGNEE = "assignee";
   public static final String ATTRIBUTE_CANDIDATE_GROUPS = "candidateGroups";
 
+  public static final String ATTRIBUTE_DECISION_ID = "decisionId";
+
+  public static final String ATTRIBUTE_RESULT_VARIABLE = "resultVariable";
+
   public static final String ELEMENT_HEADER = "header";
   public static final String ELEMENT_INPUT = "input";
   public static final String ELEMENT_IO_MAPPING = "ioMapping";
@@ -64,4 +68,6 @@ public class ZeebeConstants {
   public static final String USER_TASK_FORM_KEY_CAMUNDA_FORMS_FORMAT = "camunda-forms";
   /** Form key location used for forms embedded in the same BPMN file, i.e. zeebeUserTaskForm */
   public static final String USER_TASK_FORM_KEY_BPMN_LOCATION = "bpmn";
+
+  public static final String ELEMENT_CALLED_DECISION = "calledDecision";
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -64,10 +64,10 @@ public class ZeebeConstants {
 
   public static final String ELEMENT_CALLED_ELEMENT = "calledElement";
 
+  public static final String ELEMENT_CALLED_DECISION = "calledDecision";
+
   /** Form key format used for camunda-forms format */
   public static final String USER_TASK_FORM_KEY_CAMUNDA_FORMS_FORMAT = "camunda-forms";
   /** Form key location used for forms embedded in the same BPMN file, i.e. zeebeUserTaskForm */
   public static final String USER_TASK_FORM_KEY_BPMN_LOCATION = "bpmn";
-
-  public static final String ELEMENT_CALLED_DECISION = "calledDecision";
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeCalledDecisionImpl.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeCalledDecisionImpl.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.impl.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.attribute.Attribute;
+
+public class ZeebeCalledDecisionImpl extends BpmnModelElementInstanceImpl
+    implements ZeebeCalledDecision {
+
+  private static Attribute<String> decisionIdAttribute;
+  private static Attribute<String> resultVariableAttribute;
+
+  public ZeebeCalledDecisionImpl(final ModelTypeInstanceContext instanceContext) {
+    super(instanceContext);
+  }
+
+  public static void registerType(final ModelBuilder modelBuilder) {
+    final ModelElementTypeBuilder typeBuilder =
+        modelBuilder
+            .defineType(ZeebeCalledDecision.class, ZeebeConstants.ELEMENT_CALLED_DECISION)
+            .namespaceUri(BpmnModelConstants.ZEEBE_NS)
+            .instanceProvider(ZeebeCalledDecisionImpl::new);
+
+    decisionIdAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_DECISION_ID)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .required()
+            .build();
+
+    resultVariableAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_RESULT_VARIABLE)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .required()
+            .build();
+
+    typeBuilder.build();
+  }
+
+  @Override
+  public String getDecisionId() {
+    return decisionIdAttribute.getValue(this);
+  }
+
+  @Override
+  public void setDecisionId(final String decisionId) {
+    decisionIdAttribute.setValue(this, decisionId);
+  }
+
+  @Override
+  public String getResultVariable() {
+    return resultVariableAttribute.getValue(this);
+  }
+
+  @Override
+  public void setResultVariable(final String resultVariable) {
+    resultVariableAttribute.setValue(this, resultVariable);
+  }
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledDecision.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledDecision.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+
+/** Zeebe extension element for a called decision. It can be used for business rule tasks. */
+public interface ZeebeCalledDecision extends BpmnModelElementInstance {
+
+  /** @return the id of the called decision */
+  String getDecisionId();
+
+  /**
+   * Sets the id of the called decision.
+   *
+   * @param decisionId the id of the decision
+   */
+  void setDecisionId(String decisionId);
+
+  /** @return the name of the result variable */
+  String getResultVariable();
+
+  /**
+   * Sets the name of the result variable.
+   *
+   * @param resultVariable the name of the result variable
+   */
+  void setResultVariable(String resultVariable);
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledDecision.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledDecision.java
@@ -20,11 +20,11 @@ import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
 /** Zeebe extension element for a called decision. It can be used for business rule tasks. */
 public interface ZeebeCalledDecision extends BpmnModelElementInstance {
 
-  /** @return the id of the called decision */
+  /** @return the id of the decision that is called */
   String getDecisionId();
 
   /**
-   * Sets the id of the called decision.
+   * Sets the id of the decision that is called.
    *
    * @param decisionId the id of the decision
    */

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/BusinessRuleTaskBuilderTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/BusinessRuleTaskBuilderTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+import org.junit.jupiter.api.Test;
+
+public class BusinessRuleTaskBuilderTest {
+
+  @Test
+  void shouldSetDecisionId() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .businessRuleTask("task", task -> task.zeebeCalledDecisionId("decision-id-1"))
+            .done();
+
+    // then
+    final ModelElementInstance businessRuleTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) businessRuleTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeCalledDecision.class))
+        .hasSize(1)
+        .extracting(ZeebeCalledDecision::getDecisionId)
+        .containsExactly("decision-id-1");
+  }
+
+  @Test
+  void shouldSetDecisionIdExpression() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .businessRuleTask(
+                "task", task -> task.zeebeCalledDecisionIdExpression("decisionIdExpr"))
+            .done();
+
+    // then
+    final ModelElementInstance businessRuleTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) businessRuleTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeCalledDecision.class))
+        .hasSize(1)
+        .extracting(ZeebeCalledDecision::getDecisionId)
+        .containsExactly("=decisionIdExpr");
+  }
+
+  @Test
+  void shouldSetResultVariable() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .businessRuleTask("task", task -> task.zeebeResultVariable("result"))
+            .done();
+
+    // then
+    final ModelElementInstance businessRuleTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) businessRuleTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeCalledDecision.class))
+        .hasSize(1)
+        .extracting(ZeebeCalledDecision::getResultVariable)
+        .containsExactly("result");
+  }
+
+  @Test
+  void shouldSetDecisionIdAndResultVariable() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .businessRuleTask(
+                "task",
+                task -> task.zeebeCalledDecisionId("decision-id-1").zeebeResultVariable("result"))
+            .done();
+
+    // then
+    final ModelElementInstance businessRuleTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) businessRuleTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeCalledDecision.class))
+        .hasSize(1)
+        .extracting(ZeebeCalledDecision::getDecisionId, ZeebeCalledDecision::getResultVariable)
+        .containsExactly(tuple("decision-id-1", "result"));
+  }
+}

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledDecisionTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledDecisionTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+public class ZeebeCalledDecisionTest extends BpmnModelElementInstanceTest {
+
+  @Override
+  public TypeAssumption getTypeAssumption() {
+    return new TypeAssumption(BpmnModelConstants.ZEEBE_NS, false);
+  }
+
+  @Override
+  public Collection<ChildElementAssumption> getChildElementAssumptions() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Collection<AttributeAssumption> getAttributesAssumptions() {
+    return Arrays.asList(
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "decisionId", false, true),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "resultVariable", false, true));
+  }
+}


### PR DESCRIPTION
## Description

* add the new Zeebe extension element `calledDecision` with the attributes `decisionId` and `resultVariable`
* extend the builder of business rule tasks to define the called decision 
 
## Related issues

closes #8060 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
