### PR TITLE
fix(broker): use user provided configuration when building raft partition

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -186,6 +186,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
@@ -70,7 +70,12 @@ final class RaftPartitionGroupFactory {
             .withFreeDiskSpace(dataCfg.getFreeDiskSpaceReplicationWatermark())
             .withJournalIndexDensity(dataCfg.getLogIndexDensity())
             .withPriorityElection(experimentalCfg.isEnablePriorityElection())
-            .withPartitionDistributor(partitionDistributor);
+            .withPartitionDistributor(partitionDistributor)
+            .withElectionTimeout(clusterCfg.getElectionTimeout())
+            .withHeartbeatInterval(clusterCfg.getHeartbeatInterval())
+            .withRequestTimeout(experimentalCfg.getRaft().getRequestTimeout())
+            .withMaxQuorumResponseTimeout(experimentalCfg.getRaft().getMaxQuorumResponseTimeout())
+            .withMinStepDownFailureCount(experimentalCfg.getRaft().getMinStepDownFailureCount());
 
     final int maxMessageSize = (int) networkCfg.getMaxMessageSizeInBytes();
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.partitioning;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.atomix.raft.partition.RaftPartitionGroupConfig;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
+import io.camunda.zeebe.snapshots.ReceivableSnapshotStoreFactory;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.unit.DataSize;
+
+class RaftPartitionGroupFactoryTest {
+
+  private static final ReceivableSnapshotStoreFactory SNAPSHOT_STORE_FACTORY =
+      (directory, partitionId) -> mock(ReceivableSnapshotStore.class);
+
+  private final RaftPartitionGroupFactory factory = new RaftPartitionGroupFactory();
+  private final BrokerCfg brokerCfg = new BrokerCfg();
+
+  @Test
+  void shouldSetElectionTimeout() {
+    // given
+    final Duration expected = Duration.ofSeconds(15);
+    brokerCfg.getCluster().setElectionTimeout(expected);
+
+    // when
+    final var config = buildRaftPartitionGroup();
+
+    // then
+    assertThat(config.getPartitionConfig().getElectionTimeout()).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldSetHeartbeatInterval() {
+    // given
+    final Duration expected = Duration.ofSeconds(10);
+    brokerCfg.getCluster().setHeartbeatInterval(expected);
+
+    // when
+    final var config = buildRaftPartitionGroup();
+
+    // then
+    assertThat(config.getPartitionConfig().getHeartbeatInterval()).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldSetRaftRequestTimeout() {
+    // given
+    final Duration expected = Duration.ofSeconds(17);
+    brokerCfg.getExperimental().getRaft().setRequestTimeout(expected);
+
+    // when
+    final var config = buildRaftPartitionGroup();
+
+    // then
+    assertThat(config.getPartitionConfig().getRequestTimeout()).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldSetRaftMaxQuorumResponseTimeout() {
+    // given
+    final Duration expected = Duration.ofSeconds(13);
+    brokerCfg.getExperimental().getRaft().setMaxQuorumResponseTimeout(expected);
+
+    // when
+    final var config = buildRaftPartitionGroup();
+
+    // then
+    assertThat(config.getPartitionConfig().getMaxQuorumResponseTimeout()).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldSetRaftMinStepDownFailureCount() {
+    // given
+    final int expected = 8;
+    brokerCfg.getExperimental().getRaft().setMinStepDownFailureCount(expected);
+
+    // when
+    final var config = buildRaftPartitionGroup();
+
+    // then
+    assertThat(config.getPartitionConfig().getMinStepDownFailureCount()).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldSetMaxAppendBatchSize() {
+    // given
+    final DataSize expected = DataSize.ofMegabytes(123);
+    brokerCfg.getExperimental().setMaxAppendBatchSize(expected);
+
+    // when
+    final var config = buildRaftPartitionGroup();
+
+    // then
+    assertThat(config.getPartitionConfig().getMaxAppendBatchSize()).isEqualTo(expected.toBytes());
+  }
+
+  @Test
+  void shouldSetMaxAppendsPerFollower() {
+    // given
+    final int expected = 11;
+    brokerCfg.getExperimental().setMaxAppendsPerFollower(expected);
+
+    // when
+    final var config = buildRaftPartitionGroup();
+
+    // then
+    assertThat(config.getPartitionConfig().getMaxAppendsPerFollower()).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldEnablePriorityElection() {
+    // given
+    brokerCfg.getExperimental().setEnablePriorityElection(true);
+
+    // when
+    final var config = buildRaftPartitionGroup();
+
+    // then
+    assertThat(config.getPartitionConfig().isPriorityElectionEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldDisablePriorityElection() {
+    // given
+    brokerCfg.getExperimental().setEnablePriorityElection(false);
+
+    // when
+    final var config = buildRaftPartitionGroup();
+
+    // then
+    assertThat(config.getPartitionConfig().isPriorityElectionEnabled()).isFalse();
+  }
+
+  private RaftPartitionGroupConfig buildRaftPartitionGroup() {
+    final var partitionGroup = factory.buildRaftPartitionGroup(brokerCfg, SNAPSHOT_STORE_FACTORY);
+    return (RaftPartitionGroupConfig) partitionGroup.config();
+  }
+}


### PR DESCRIPTION
## Description

Recently I found out that some of the exposed parameters are not used when building raft partitions. Some of these parameters were added as part of #6320 in PRs #7394, #7406 . But some of the code got removed during another refactoring. In this PR we added the missing code back as well as added tests to verify that parameters are set correctly.

## Related issues

Related #6320 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
