### PR TITLE
Start API messaging service independently from `CommandApiServiceStep`

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStep.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import io.atomix.cluster.messaging.MessagingConfig;
+import io.atomix.cluster.messaging.impl.NettyMessagingService;
+import io.atomix.utils.net.Address;
+import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.util.sched.ConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import java.util.List;
+import org.slf4j.Logger;
+
+public class ApiMessagingServiceStep extends AbstractBrokerStartupStep {
+  private static final Logger LOG = Loggers.SYSTEM_LOGGER;
+
+  @Override
+  void startupInternal(
+      final BrokerStartupContext brokerStartupContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> startupFuture) {
+    final var brokerCfg = brokerStartupContext.getBrokerConfiguration();
+    final var commandApiCfg = brokerCfg.getNetwork().getCommandApi();
+    final var securityCfg = brokerCfg.getNetwork().getSecurity();
+
+    final var messagingConfig = new MessagingConfig();
+    messagingConfig.setInterfaces(List.of(commandApiCfg.getHost()));
+    messagingConfig.setPort(commandApiCfg.getPort());
+
+    if (securityCfg.isEnabled()) {
+      messagingConfig
+          .setTlsEnabled(true)
+          .setCertificateChain(securityCfg.getCertificateChainPath())
+          .setPrivateKey(securityCfg.getPrivateKeyPath());
+    }
+
+    final var messagingService =
+        new NettyMessagingService(
+            brokerCfg.getCluster().getClusterName(),
+            Address.from(commandApiCfg.getAdvertisedHost(), commandApiCfg.getAdvertisedPort()),
+            messagingConfig);
+
+    messagingService
+        .start()
+        .whenComplete(
+            (createdMessagingService, error) -> {
+              /* here we don't use "createdMessagingService" because it is only a
+               * MessagingService, but we need a ManagedMessagingService. At the time of this
+               * writing createdMessagingService == messagingService, so we use this instead.
+               */
+              if (error != null) {
+                startupFuture.completeExceptionally(error);
+              } else {
+                concurrencyControl.run(
+                    () -> {
+                      LOG.debug(
+                          "Bound API to {}, using advertised address {} ",
+                          messagingService.bindingAddresses(),
+                          messagingService.address());
+                      brokerStartupContext.setApiMessagingService(messagingService);
+                      startupFuture.complete(brokerStartupContext);
+                    });
+              }
+            });
+  }
+
+  @Override
+  void shutdownInternal(
+      final BrokerStartupContext brokerShutdownContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> shutdownFuture) {
+    final var messagingService = brokerShutdownContext.getApiMessagingService();
+    if (messagingService == null) {
+      shutdownFuture.complete(brokerShutdownContext);
+      return;
+    }
+    messagingService
+        .stop()
+        .whenComplete(
+            (of, error) -> {
+              if (error != null) {
+                shutdownFuture.completeExceptionally(error);
+              } else {
+                concurrencyControl.run(
+                    () -> {
+                      brokerShutdownContext.setApiMessagingService(null);
+                      shutdownFuture.complete(brokerShutdownContext);
+                    });
+              }
+            });
+  }
+
+  @Override
+  public String getName() {
+    return "API Messaging Service";
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -73,9 +73,9 @@ public interface BrokerStartupContext {
 
   void setCommandApiServerTransport(AtomixServerTransport commandApiServerTransport);
 
-  ManagedMessagingService getCommandApiMessagingService();
+  ManagedMessagingService getApiMessagingService();
 
-  void setCommandApiMessagingService(ManagedMessagingService commandApiMessagingService);
+  void setApiMessagingService(ManagedMessagingService commandApiMessagingService);
 
   SubscriptionApiCommandMessageHandlerService getSubscriptionApiService();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -174,13 +174,12 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   }
 
   @Override
-  public ManagedMessagingService getCommandApiMessagingService() {
+  public ManagedMessagingService getApiMessagingService() {
     return commandApiMessagingService;
   }
 
   @Override
-  public void setCommandApiMessagingService(
-      final ManagedMessagingService commandApiMessagingService) {
+  public void setApiMessagingService(final ManagedMessagingService commandApiMessagingService) {
     this.commandApiMessagingService = commandApiMessagingService;
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -55,6 +55,7 @@ public final class BrokerStartupProcess {
 
     result.add(new ClusterServicesStep());
 
+    result.add(new ApiMessagingServiceStep());
     result.add(new CommandApiServiceStep());
     result.add(new SubscriptionApiStep());
     result.add(new LeaderManagementRequestHandlerStep());

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStepTest.java
@@ -145,6 +145,23 @@ class ApiMessagingServiceStepTest {
     }
 
     @Test
+    void shouldCompleteFutureExceptionally() {
+      // given
+      final var failingMessagingService = mock(ManagedMessagingService.class);
+      final var exception = new Exception();
+      when(failingMessagingService.stop()).thenReturn(CompletableFuture.failedFuture(exception));
+      testBrokerStartupContext.setApiMessagingService(failingMessagingService);
+
+      // when
+      sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);
+
+      // then
+      await().until(shutdownFuture::isCompletedExceptionally);
+      assertThat(shutdownFuture.getException()).isEqualTo(exception);
+      assertThat(testBrokerStartupContext.getApiMessagingService()).isNotNull();
+    }
+
+    @Test
     void shouldCompleteFuture() {
       // when
       sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStepTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.messaging.ManagedMessagingService;
+import io.camunda.zeebe.broker.SpringBrokerBridge;
+import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.util.sched.ActorScheduler;
+import io.camunda.zeebe.util.sched.TestConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApiMessagingServiceStepTest {
+  private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
+  private static final BrokerCfg TEST_BROKER_CONFIG = new BrokerCfg();
+  private static final BrokerInfo TEST_BROKER_INFO = new BrokerInfo(0, "localhost");
+  private static final Duration TIME_OUT = Duration.ofSeconds(10);
+
+  static {
+    final var commandApiCfg = TEST_BROKER_CONFIG.getNetwork().getCommandApi();
+    commandApiCfg.setHost("localhost");
+    commandApiCfg.setAdvertisedHost("localhost");
+  }
+
+  private final ActorScheduler mockActorSchedulingService = mock(ActorScheduler.class);
+  private BrokerStartupContextImpl testBrokerStartupContext;
+  private final ApiMessagingServiceStep sut = new ApiMessagingServiceStep();
+
+  @BeforeEach
+  void setUp() {
+    when(mockActorSchedulingService.submitActor(any()))
+        .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
+
+    testBrokerStartupContext =
+        new BrokerStartupContextImpl(
+            TEST_BROKER_INFO,
+            TEST_BROKER_CONFIG,
+            mock(SpringBrokerBridge.class),
+            mockActorSchedulingService,
+            mock(BrokerHealthCheckService.class),
+            mock(ExporterRepository.class),
+            Collections.emptyList());
+    testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
+  }
+
+  @Test
+  void shouldHaveDescriptiveName() {
+    // when
+    final var actual = sut.getName();
+
+    // then
+    assertThat(actual).isSameAs("API Messaging Service");
+  }
+
+  @Nested
+  class StartupBehavior {
+    private ActorFuture<BrokerStartupContext> startupFuture;
+
+    @BeforeEach
+    void setUp() {
+      startupFuture = CONCURRENCY_CONTROL.createFuture();
+
+      final var port = SocketUtil.getNextAddress().getPort();
+      final var commandApiCfg = TEST_BROKER_CONFIG.getNetwork().getCommandApi();
+      commandApiCfg.setPort(port);
+      commandApiCfg.setAdvertisedPort(port);
+    }
+
+    @AfterEach
+    void tearDown() {
+      final var messagingService = testBrokerStartupContext.getApiMessagingService();
+      if (messagingService != null) {
+        messagingService.stop().join();
+      }
+    }
+
+    @Test
+    void shouldCompleteFuture() {
+      // when
+      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+
+      // then
+      assertThat(startupFuture).succeedsWithin(TIME_OUT);
+      assertThat(startupFuture.join()).isNotNull();
+    }
+
+    @Test
+    void shouldStartAndInstallMessagingService() {
+      // when
+      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+      await().until(startupFuture::isDone);
+
+      // then
+      final var messagingService = testBrokerStartupContext.getApiMessagingService();
+      assertThat(messagingService).isNotNull();
+      assertThat(messagingService.isRunning()).isTrue();
+    }
+  }
+
+  @Nested
+  class ShutdownBehavior {
+    private ManagedMessagingService mockManagedMessagingService;
+    private ActorFuture<BrokerStartupContext> shutdownFuture;
+
+    @BeforeEach
+    void setUp() {
+      mockManagedMessagingService = mock(ManagedMessagingService.class);
+      when(mockManagedMessagingService.stop()).thenReturn(CompletableFuture.completedFuture(null));
+      shutdownFuture = CONCURRENCY_CONTROL.createFuture();
+      testBrokerStartupContext.setApiMessagingService(mockManagedMessagingService);
+    }
+
+    @Test
+    void shouldStopAndUninstallMessagingService() {
+      // when
+      sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);
+      await().until(shutdownFuture::isDone);
+
+      // then
+      verify(mockManagedMessagingService).stop();
+      final var messagingService = testBrokerStartupContext.getApiMessagingService();
+      assertThat(messagingService).isNull();
+    }
+
+    @Test
+    void shouldCompleteFuture() {
+      // when
+      sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);
+
+      // then
+      assertThat(shutdownFuture).succeedsWithin(TIME_OUT);
+      assertThat(shutdownFuture.join()).isNotNull();
+    }
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -791,7 +791,7 @@ public final class ClusteringRule extends ExternalResource {
    * messages until a segment is full, thus triggering log compaction.
    */
   public void runUntilSegmentsFilled(
-      final Collection<Broker> brokers, final int segmentCount, Runnable runnable) {
+      final Collection<Broker> brokers, final int segmentCount, final Runnable runnable) {
     while (brokers.stream().map(this::getSegmentsCount).allMatch(count -> count <= segmentCount)) {
       runnable.run();
     }


### PR DESCRIPTION
We will reuse the messaging service for new handlers so here we make some changes to start this service independently of the `CommandApiServiceStep`. This is preparation for https://github.com/camunda-cloud/zeebe/issues/8224

I've decided to do this in a separate PR because I have a feeling that a PR for https://github.com/camunda-cloud/zeebe/issues/8224 would get too large otherwise.

I would have liked to rename the `CommandApiCfg` to `BrokerApiCfg` but as this naming is used in our config I guess that'd be a breaking change.

## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #8224 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
