### PR TITLE
Transform assignment definition on user task

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/JobWorkerProperties.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/JobWorkerProperties.java
@@ -18,6 +18,8 @@ public class JobWorkerProperties {
 
   private Expression type;
   private Expression retries;
+  private Expression assignee;
+  private Expression candidateGroups;
   private Map<String, String> taskHeaders = Map.of();
 
   public Expression getType() {
@@ -34,6 +36,22 @@ public class JobWorkerProperties {
 
   public void setRetries(final Expression retries) {
     this.retries = retries;
+  }
+
+  public Expression getAssignee() {
+    return assignee;
+  }
+
+  public void setAssignee(final Expression assignee) {
+    this.assignee = assignee;
+  }
+
+  public Expression getCandidateGroups() {
+    return candidateGroups;
+  }
+
+  public void setCandidateGroups(final Expression candidateGroups) {
+    this.candidateGroups = candidateGroups;
   }
 
   public Map<String, String> getTaskHeaders() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
@@ -86,7 +86,7 @@ public final class BpmnTransformer {
     step2Visitor.registerHandler(new ReceiveTaskTransformer());
     step2Visitor.registerHandler(new SequenceFlowTransformer());
     step2Visitor.registerHandler(new StartEventTransformer());
-    step2Visitor.registerHandler(new UserTaskTransformer());
+    step2Visitor.registerHandler(new UserTaskTransformer(expressionLanguage));
 
     step3Visitor = new TransformationVisitor();
     step3Visitor.registerHandler(new ContextProcessTransformer());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/ExpressionTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/ExpressionTransformer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.transformer;
+
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.util.Either;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Utility class to help with transforming expressions from strings to objects (i.e. parsing) and
+ * from objects to strings (i.e. serializing).
+ */
+public final class ExpressionTransformer {
+
+  private ExpressionTransformer() {
+    throw new IllegalStateException(
+        "Expected to instantiate this class, but it is a Utility class");
+  }
+
+  /**
+   * Parses a static value as a list of CSV, trimming any whitespace.
+   *
+   * @param value the static value to parse
+   * @return either a failure or a list of values (trimmed)
+   */
+  public static Either<Failure, List<String>> parseListOfCsv(final String value) {
+    if (value.isEmpty()) {
+      return Either.right(List.of());
+    }
+
+    final List<String> values =
+        Arrays.stream(value.split(","))
+            .filter(Predicate.not(String::isBlank))
+            .map(String::trim)
+            .collect(Collectors.toList());
+    if (values.size() < StringUtils.countMatches(value, ",") + 1) {
+      // one of the values was a blank string, e.g. 'a, ,c'
+      return Either.left(
+          new Failure("Expected to parse list of CSV, but " + value + " is not CSV"));
+    }
+
+    return Either.right(values);
+  }
+
+  /**
+   * Serializes a list of strings to a list-literal FEEL-expression, e.g. {@code List.of("a","b") =>
+   * "=[\"a\",\"b\"]"}.
+   *
+   * @param values the list of string values to transform
+   * @return a string representation of the list literal FEEL-expression
+   */
+  public static String asListLiteralExpression(final List<String> values) {
+    return values.stream()
+        .map(value -> String.format("\"%s\"", value))
+        .collect(Collectors.joining(",", "=[", "]"));
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -91,11 +91,9 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
   }
 
   private static String asListLiteralExpression(final List<String> values) {
-    return String.format(
-        "=[%s]",
-        values.stream()
-            .map(value -> String.format("\"%s\"", value))
-            .collect(Collectors.joining(",")));
+    return values.stream()
+        .map(value -> String.format("\"%s\"", value))
+        .collect(Collectors.joining(",", "=[", "]"));
   }
 
   private void transformTaskHeaders(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.transformer;
 
+import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.impl.StaticExpression;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerTask;
@@ -14,7 +15,9 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutablePro
 import io.camunda.zeebe.engine.processing.deployment.model.element.JobWorkerProperties;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
+import io.camunda.zeebe.engine.processing.deployment.model.validation.ZeebeExpressionValidator;
 import io.camunda.zeebe.model.bpmn.instance.UserTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
@@ -28,6 +31,12 @@ import org.slf4j.Logger;
 public final class UserTaskTransformer implements ModelElementTransformer<UserTask> {
 
   private static final Logger LOG = Loggers.STREAM_PROCESSING;
+
+  private final ExpressionLanguage expressionLanguage;
+
+  public UserTaskTransformer(final ExpressionLanguage expressionLanguage) {
+    this.expressionLanguage = expressionLanguage;
+  }
 
   @Override
   public Class<UserTask> getType() {
@@ -45,13 +54,48 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
     userTask.setJobWorkerProperties(jobWorkerProperties);
 
     transformTaskDefinition(jobWorkerProperties);
-
+    transformAssignmentDefinition(element, jobWorkerProperties);
     transformTaskHeaders(element, jobWorkerProperties);
   }
 
   private void transformTaskDefinition(final JobWorkerProperties jobWorkerProperties) {
     jobWorkerProperties.setType(new StaticExpression(Protocol.USER_TASK_JOB_TYPE));
     jobWorkerProperties.setRetries(new StaticExpression("1"));
+  }
+
+  private void transformAssignmentDefinition(
+      final UserTask element, final JobWorkerProperties jobWorkerProperties) {
+    final var assignmentDefinition =
+        element.getSingleExtensionElement(ZeebeAssignmentDefinition.class);
+    if (assignmentDefinition == null) {
+      return;
+    }
+    final var assignee = assignmentDefinition.getAssignee();
+    if (assignee != null && !assignee.isBlank()) {
+      jobWorkerProperties.setAssignee(expressionLanguage.parseExpression(assignee));
+    }
+    final var candidateGroups = assignmentDefinition.getCandidateGroups();
+    if (candidateGroups != null && !candidateGroups.isBlank()) {
+      final var candidateGroupsExpression = expressionLanguage.parseExpression(candidateGroups);
+      if (candidateGroupsExpression.isStatic()) {
+        // static candidateGroups must be in CSV format, but this is already checked by validator
+        jobWorkerProperties.setCandidateGroups(
+            ZeebeExpressionValidator.parseListOfCsv(candidateGroups)
+                .map(UserTaskTransformer::asListLiteralExpression)
+                .map(expressionLanguage::parseExpression)
+                .get());
+      } else {
+        jobWorkerProperties.setCandidateGroups(candidateGroupsExpression);
+      }
+    }
+  }
+
+  private static String asListLiteralExpression(final List<String> values) {
+    return String.format(
+        "=[%s]",
+        values.stream()
+            .map(value -> String.format("\"%s\"", value))
+            .collect(Collectors.joining(",")));
   }
 
   private void transformTaskHeaders(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutablePro
 import io.camunda.zeebe.engine.processing.deployment.model.element.JobWorkerProperties;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
-import io.camunda.zeebe.engine.processing.deployment.model.validation.ZeebeExpressionValidator;
 import io.camunda.zeebe.model.bpmn.instance.UserTask;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
@@ -80,20 +79,14 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
       if (candidateGroupsExpression.isStatic()) {
         // static candidateGroups must be in CSV format, but this is already checked by validator
         jobWorkerProperties.setCandidateGroups(
-            ZeebeExpressionValidator.parseListOfCsv(candidateGroups)
-                .map(UserTaskTransformer::asListLiteralExpression)
+            ExpressionTransformer.parseListOfCsv(candidateGroups)
+                .map(ExpressionTransformer::asListLiteralExpression)
                 .map(expressionLanguage::parseExpression)
                 .get());
       } else {
         jobWorkerProperties.setCandidateGroups(candidateGroupsExpression);
       }
     }
-  }
-
-  private static String asListLiteralExpression(final List<String> values) {
-    return values.stream()
-        .map(value -> String.format("\"%s\"", value))
-        .collect(Collectors.joining(",", "=[", "]"));
   }
 
   private void transformTaskHeaders(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidator.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.engine.processing.deployment.model.validation;
 
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -16,6 +18,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
@@ -104,16 +107,32 @@ public final class ZeebeExpressionValidator<T extends ModelElementInstance>
   }
 
   public static boolean isListOfCsv(final Expression staticExp) {
-    final String value = staticExp.getExpression();
+    return parseListOfCsv(staticExp.getExpression()).isRight();
+  }
+
+  /**
+   * Parses a static value as a list of CSV, trimming any whitespace.
+   *
+   * @param value the static value to parse
+   * @return either a failure or a list of values (trimmed)
+   */
+  public static Either<Failure, List<String>> parseListOfCsv(final String value) {
     if (value.isEmpty()) {
-      return true;
+      return Either.right(List.of());
     }
-    final var values = value.split(",");
-    if (values.length < StringUtils.countMatches(value, ",") + 1) {
-      // one of the values was an empty string, e.g. 'a,,c'
-      return false;
+
+    final List<String> values =
+        Arrays.stream(value.split(","))
+            .filter(Predicate.not(String::isBlank))
+            .map(String::trim)
+            .collect(Collectors.toList());
+    if (values.size() < StringUtils.countMatches(value, ",") + 1) {
+      // one of the values was a blank string, e.g. 'a, ,c'
+      return Either.left(
+          new Failure("Expected to parse list of CSV, but " + value + " is not CSV"));
     }
-    return Arrays.stream(values).noneMatch(String::isBlank);
+
+    return Either.right(values);
   }
 
   public static class Builder<T extends ModelElementInstance> {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidator.java
@@ -113,7 +113,7 @@ public final class ZeebeExpressionValidator<T extends ModelElementInstance>
       // one of the values was an empty string, e.g. 'a,,c'
       return false;
     }
-    return Arrays.stream(values).noneMatch(String::isEmpty);
+    return Arrays.stream(values).noneMatch(String::isBlank);
   }
 
   public static class Builder<T extends ModelElementInstance> {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidator.java
@@ -9,17 +9,13 @@ package io.camunda.zeebe.engine.processing.deployment.model.validation;
 
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
-import io.camunda.zeebe.engine.processing.common.Failure;
-import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.engine.processing.deployment.model.transformer.ExpressionTransformer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
@@ -107,32 +103,7 @@ public final class ZeebeExpressionValidator<T extends ModelElementInstance>
   }
 
   public static boolean isListOfCsv(final Expression staticExp) {
-    return parseListOfCsv(staticExp.getExpression()).isRight();
-  }
-
-  /**
-   * Parses a static value as a list of CSV, trimming any whitespace.
-   *
-   * @param value the static value to parse
-   * @return either a failure or a list of values (trimmed)
-   */
-  public static Either<Failure, List<String>> parseListOfCsv(final String value) {
-    if (value.isEmpty()) {
-      return Either.right(List.of());
-    }
-
-    final List<String> values =
-        Arrays.stream(value.split(","))
-            .filter(Predicate.not(String::isBlank))
-            .map(String::trim)
-            .collect(Collectors.toList());
-    if (values.size() < StringUtils.countMatches(value, ",") + 1) {
-      // one of the values was a blank string, e.g. 'a, ,c'
-      return Either.left(
-          new Failure("Expected to parse list of CSV, but " + value + " is not CSV"));
-    }
-
-    return Either.right(values);
+    return ExpressionTransformer.parseListOfCsv(staticExp.getExpression()).isRight();
   }
 
   public static class Builder<T extends ModelElementInstance> {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.activity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerTask;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class UserTaskTransformerTest {
+
+  private static final String TASK_ID = "user-task";
+
+  private final ExpressionLanguage expressionLanguage =
+      ExpressionLanguageFactory.createExpressionLanguage();
+  private final BpmnTransformer transformer = new BpmnTransformer(expressionLanguage);
+
+  private BpmnModelInstance processWithUserTask(final Consumer<UserTaskBuilder> userTaskModifier) {
+    return Bpmn.createExecutableProcess().startEvent().userTask(TASK_ID, userTaskModifier).done();
+  }
+
+  private ExecutableJobWorkerTask transformUserTask(final BpmnModelInstance userTask) {
+    final List<ExecutableProcess> processes = transformer.transformDefinitions(userTask);
+    return processes.get(0).getElementById(TASK_ID, ExecutableJobWorkerTask.class);
+  }
+
+  @Nested
+  class AssignmentDefinitionTests {
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class AssigneeTests {
+
+      Stream<Arguments> assignees() {
+        return Stream.of(
+            Arguments.of(null, null),
+            Arguments.of("", null),
+            Arguments.of(" ", null),
+            Arguments.of("frodo", "frodo"),
+            Arguments.of("=ring.bearer", "ring.bearer"));
+      }
+
+      @DisplayName("Should transform user task with assignee")
+      @ParameterizedTest
+      @MethodSource("assignees")
+      void shouldTransform(final String assignee, final String parsedExpression) {
+        final var userTask = transformUserTask(processWithUserTask(b -> b.zeebeAssignee(assignee)));
+        if (parsedExpression == null) {
+          assertThat(userTask.getJobWorkerProperties().getAssignee()).isNull();
+        } else {
+          assertThat(userTask.getJobWorkerProperties().getAssignee().getExpression())
+              .isEqualTo(parsedExpression);
+        }
+      }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class CandidateGroupsTests {
+
+      Stream<Arguments> candidateGroups() {
+        return Stream.of(
+            Arguments.of(null, null),
+            Arguments.of("", null),
+            Arguments.of(" ", null),
+            Arguments.of("humans", "[\"humans\"]"),
+            Arguments.of("humans,elves", "[\"humans\",\"elves\"]"),
+            Arguments.of(" humans , elves ", "[\"humans\",\"elves\"]"),
+            Arguments.of("=middle_earth.races", "middle_earth.races"),
+            Arguments.of("=[\"elves\",\"orcs\"]", "[\"elves\",\"orcs\"]"));
+      }
+
+      @DisplayName("Should transform user task with candidateGroups")
+      @ParameterizedTest
+      @MethodSource("candidateGroups")
+      void shouldTransform(final String candidateGroups, final String parsedExpression) {
+        final var userTask =
+            transformUserTask(processWithUserTask(b -> b.zeebeCandidateGroups(candidateGroups)));
+        if (parsedExpression == null) {
+          assertThat(userTask.getJobWorkerProperties().getCandidateGroups()).isNull();
+        } else {
+          assertThat(userTask.getJobWorkerProperties().getCandidateGroups().getExpression())
+              .isEqualTo(parsedExpression);
+        }
+      }
+    }
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidatorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidatorTest.java
@@ -29,14 +29,18 @@ class ZeebeExpressionValidatorTest {
     @MethodSource("csv")
     void shouldAcceptCsv(final String value) {
       final var expression = new StaticExpression(value);
-      assertThat(ZeebeExpressionValidator.isListOfCsv(expression)).isTrue();
+      assertThat(ZeebeExpressionValidator.isListOfCsv(expression))
+          .describedAs("\"%s\" is CSV", value)
+          .isTrue();
     }
 
     @ParameterizedTest
     @MethodSource("notCsv")
     void shouldRejectNotCsv(final String value) {
       final var expression = new StaticExpression(value);
-      assertThat(ZeebeExpressionValidator.isListOfCsv(expression)).isFalse();
+      assertThat(ZeebeExpressionValidator.isListOfCsv(expression))
+          .describedAs("\"%s\" is not CSV", value)
+          .isFalse();
     }
 
     Stream<Arguments> csv() {
@@ -48,7 +52,14 @@ class ZeebeExpressionValidatorTest {
           Arguments.of("\"abcd\",\"efgh\",\"ijkl\""),
           Arguments.of("1"),
           Arguments.of("1,2"),
-          Arguments.of("1,a,3"));
+          Arguments.of("1,a,3"),
+          Arguments.of(" a"),
+          Arguments.of("a "),
+          Arguments.of(" a "),
+          Arguments.of(" a,b "),
+          Arguments.of(" a ,b "),
+          Arguments.of(" a, b "),
+          Arguments.of(" a , b "));
     }
 
     Stream<Arguments> notCsv() {
@@ -57,7 +68,11 @@ class ZeebeExpressionValidatorTest {
           Arguments.of("a,"),
           Arguments.of(",b"),
           Arguments.of(",b,"),
-          Arguments.of("a,,c"));
+          Arguments.of("a,,c"),
+          Arguments.of("a, ,c"),
+          Arguments.of(" ,"),
+          Arguments.of(", "),
+          Arguments.of(" , "));
     }
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Adds transformation of the assignment definition to the user task transformer.

It changes the validation code, to parse instead of check, so that this code can be reused by the transformer.

Statically defined candidate groups are transformed from CSV to a list-of-strings literal as FEEL expression. This means that evaluation at user task activation can be done exactly the same, regardless of whether the candidate groups was defined as a static value or as an expression.

Lastly, this PR also fixes the CSV parsing to allow spaces at any place between or around the commas.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #8055 (does not yet close it, evaluation is still needed)

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
