### PR TITLE
Add temporary variable migration

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/TemporaryVariables.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/TemporaryVariables.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.instance;
+
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import org.agrona.DirectBuffer;
+
+public class TemporaryVariables extends UnpackedObject implements DbValue {
+  private final BinaryProperty valueProp = new BinaryProperty("temporaryVariables");
+
+  public TemporaryVariables() {
+    declareProperty(valueProp);
+  }
+
+  public DirectBuffer get() {
+    return valueProp.getValue();
+  }
+
+  public void set(final DirectBuffer value) {
+    valueProp.setValue(value);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
@@ -15,12 +15,16 @@ import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
+import io.camunda.zeebe.engine.state.instance.TemporaryVariables;
+import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableMigrationState;
 import io.camunda.zeebe.engine.state.mutable.MutablePendingMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutablePendingProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public class DbMigrationState implements MutableMigrationState {
 
@@ -47,6 +51,8 @@ public class DbMigrationState implements MutableMigrationState {
       processSubscriptionSentTimeCompositeKey;
   private final ColumnFamily<DbCompositeKey<DbLong, DbCompositeKey<DbLong, DbString>>, DbNil>
       processSubscriptionSentTimeColumnFamily;
+
+  private final ColumnFamily<DbLong, TemporaryVariables> temporaryVariableColumnFamily;
 
   public DbMigrationState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
@@ -82,6 +88,15 @@ public class DbMigrationState implements MutableMigrationState {
             transactionContext,
             processSubscriptionSentTimeCompositeKey,
             DbNil.INSTANCE);
+
+    final DbLong temporaryVariablesKeyInstance = new DbLong();
+    final TemporaryVariables temporaryVariablesValue = new TemporaryVariables();
+    temporaryVariableColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.TEMPORARY_VARIABLE_STORE,
+            transactionContext,
+            temporaryVariablesKeyInstance,
+            temporaryVariablesValue);
   }
 
   @Override
@@ -143,6 +158,27 @@ public class DbMigrationState implements MutableMigrationState {
           }
 
           processSubscriptionSentTimeColumnFamily.delete(key);
+        });
+  }
+
+  @Override
+  public void migrateTemporaryVariables(
+      final MutableEventScopeInstanceState eventScopeInstanceState) {
+    temporaryVariableColumnFamily.forEach(
+        (key, value) -> {
+          // Event scope key can be a static value. Together with the
+          final long eventScopeKey = -1L;
+          // Element id will not be used, therefore a dummy id will be generated.
+          final String elementId = "migrated-variable-" + key.getValue();
+          final DirectBuffer elementIdBuffer = new UnsafeBuffer(elementId.getBytes());
+
+          // We always use triggerStartEvent() here. This is because this method creates an event
+          // trigger with the passed parameters without doing any checks beforehand. This is
+          // sufficient for this migration.
+          eventScopeInstanceState.triggerStartEvent(
+              key.getValue(), eventScopeKey, elementIdBuffer, value.get());
+
+          temporaryVariableColumnFamily.delete(key);
         });
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/TemporaryVariableMigration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/TemporaryVariableMigration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration;
+
+import io.camunda.zeebe.engine.state.ZbColumnFamilies;
+import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+
+/** Reads out the temporary variable column and creates an EventTrigger for reach of them. */
+public class TemporaryVariableMigration implements MigrationTask {
+
+  @Override
+  public String getIdentifier() {
+    return TemporaryVariableMigration.class.getSimpleName();
+  }
+
+  @Override
+  public boolean needsToRun(final ZeebeState zeebeState) {
+    return !zeebeState.isEmpty(ZbColumnFamilies.TEMPORARY_VARIABLE_STORE);
+  }
+
+  @Override
+  public void runMigration(final MutableZeebeState zeebeState) {
+    zeebeState
+        .getMigrationState()
+        .migrateTemporaryVariables(zeebeState.getEventScopeInstanceState());
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/TemporaryVariables.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/TemporaryVariables.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.engine.state.instance;
+package io.camunda.zeebe.engine.state.migration;
 
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
@@ -10,10 +10,12 @@ package io.camunda.zeebe.engine.state.mutable;
 public interface MutableMigrationState {
 
   void migrateMessageSubscriptionSentTime(
-      MutableMessageSubscriptionState messageSubscriptionState,
-      MutablePendingMessageSubscriptionState transientState);
+      final MutableMessageSubscriptionState messageSubscriptionState,
+      final MutablePendingMessageSubscriptionState transientState);
 
   void migrateProcessMessageSubscriptionSentTime(
-      MutableProcessMessageSubscriptionState persistentSate,
+      final MutableProcessMessageSubscriptionState persistentSate,
       final MutablePendingProcessMessageSubscriptionState transientState);
+
+  void migrateTemporaryVariables(final MutableEventScopeInstanceState eventScopeInstanceState);
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_3/LegacyDbTemporaryVariablesState.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_3/LegacyDbTemporaryVariablesState.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration.to_1_3;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.engine.state.ZbColumnFamilies;
+import io.camunda.zeebe.engine.state.instance.TemporaryVariables;
+import org.agrona.DirectBuffer;
+
+public class LegacyDbTemporaryVariablesState {
+
+  private final DbLong temporaryVariablesKeyInstance;
+  private final TemporaryVariables temporaryVariables;
+  private final ColumnFamily<DbLong, TemporaryVariables> temporaryVariableColumnFamily;
+
+  public LegacyDbTemporaryVariablesState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    temporaryVariablesKeyInstance = new DbLong();
+    temporaryVariables = new TemporaryVariables();
+    temporaryVariableColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.TEMPORARY_VARIABLE_STORE,
+            transactionContext,
+            temporaryVariablesKeyInstance,
+            temporaryVariables);
+  }
+
+  public void put(final DirectBuffer variables) {
+    temporaryVariables.reset();
+    temporaryVariables.set(variables);
+
+    temporaryVariableColumnFamily.put(temporaryVariablesKeyInstance, temporaryVariables);
+  }
+
+  public boolean isEmpty() {
+    return temporaryVariableColumnFamily.isEmpty();
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_3/LegacyDbTemporaryVariablesState.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_3/LegacyDbTemporaryVariablesState.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
-import io.camunda.zeebe.engine.state.instance.TemporaryVariables;
+import io.camunda.zeebe.engine.state.migration.TemporaryVariables;
 import org.agrona.DirectBuffer;
 
 public class LegacyDbTemporaryVariablesState {
@@ -33,9 +33,10 @@ public class LegacyDbTemporaryVariablesState {
             temporaryVariables);
   }
 
-  public void put(final DirectBuffer variables) {
+  public void put(final long key, final DirectBuffer variables) {
     temporaryVariables.reset();
     temporaryVariables.set(variables);
+    temporaryVariablesKeyInstance.wrapLong(key);
 
     temporaryVariableColumnFamily.put(temporaryVariablesKeyInstance, temporaryVariables);
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_3/TemporaryVariableMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_3/TemporaryVariableMigrationTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration.to_1_3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.state.ZbColumnFamilies;
+import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.engine.state.migration.TemporaryVariableMigration;
+import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.util.ZeebeStateExtension;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+public class TemporaryVariableMigrationTest {
+
+  final TemporaryVariableMigration sutMigration = new TemporaryVariableMigration();
+
+  @Nested
+  public class MockBasedTests {
+
+    @Test
+    public void noMigrationNeededWhenColumnIsEmpty() {
+      // given
+      final var mockZeebeState = mock(ZeebeState.class);
+
+      // when
+      when(mockZeebeState.isEmpty(ZbColumnFamilies.TEMPORARY_VARIABLE_STORE)).thenReturn(true);
+      final var actual = sutMigration.needsToRun(mockZeebeState);
+
+      // then
+      assertThat(actual).isFalse();
+    }
+
+    @Test
+    public void migrationNeededWhenColumnIsNotEmpty() {
+      // given
+      final var mockZeebeState = mock(ZeebeState.class);
+
+      // when
+      when(mockZeebeState.isEmpty(ZbColumnFamilies.TEMPORARY_VARIABLE_STORE)).thenReturn(false);
+      final var actual = sutMigration.needsToRun(mockZeebeState);
+
+      // then
+      assertThat(actual).isTrue();
+    }
+
+    @Test
+    public void migrationCallsMethodInMigrationState() {
+      // given
+      final var mockZeebeState = mock(MutableZeebeState.class, RETURNS_DEEP_STUBS);
+
+      // when
+      sutMigration.runMigration(mockZeebeState);
+
+      // then
+      verify(mockZeebeState.getMigrationState())
+          .migrateTemporaryVariables(mockZeebeState.getEventScopeInstanceState());
+
+      verifyNoMoreInteractions(mockZeebeState.getMigrationState());
+    }
+  }
+
+  @Nested
+  @ExtendWith(ZeebeStateExtension.class)
+  public class BlackboxTest {
+
+    private ZeebeDb<ZbColumnFamilies> zeebeDb;
+    private MutableZeebeState zeebeState;
+    private TransactionContext transactionContext;
+    private LegacyDbTemporaryVariablesState legacyTemporaryVariablesState;
+
+    @BeforeEach
+    public void setUp() {
+      // given database with legacy records
+      legacyTemporaryVariablesState =
+          new LegacyDbTemporaryVariablesState(zeebeDb, transactionContext);
+      final DirectBuffer variables = new UnsafeBuffer("variables".getBytes());
+      legacyTemporaryVariablesState.put(variables);
+    }
+
+    @Test
+    public void migrationNeedsToRun() {
+      // given database with legacy records
+
+      // when
+      final var actual = sutMigration.needsToRun(zeebeState);
+
+      // then
+      assertThat(actual).describedAs("Migration should run").isTrue();
+      assertThat(legacyTemporaryVariablesState.isEmpty()).isFalse();
+    }
+
+    @Test
+    public void afterMigrationRunNoFurtherMigrationIsNeeded() {
+      // given database with legacy records
+
+      // when
+      sutMigration.runMigration(zeebeState);
+      final var actual = sutMigration.needsToRun(zeebeState);
+
+      // then
+      assertThat(actual).describedAs("Migration should run").isFalse();
+      assertThat(legacyTemporaryVariablesState.isEmpty()).isTrue();
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
With the removal of temporary variables in #6982  we need a migration in order to map existing temporary variables to event triggers. 
Without this migration it would be possible for a broker to have temporary variables in the store, get updated to the latest version and lose access to the variables.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8114 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
