### PR TITLE
Introduce a general `ApiRequestHandler` for `CommandApi` and `QueryApi`

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/ApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/ApiRequestHandler.java
@@ -77,6 +77,10 @@ public abstract class ApiRequestHandler<R extends RequestReader<?>, W extends Re
       final DirectBuffer buffer,
       final int offset,
       final int length) {
+    requestReader.reset();
+    responseWriter.reset();
+    errorResponseWriter.reset();
+
     try {
       requestReader.wrap(buffer, offset, length);
     } catch (final Exception e) {
@@ -101,10 +105,6 @@ public abstract class ApiRequestHandler<R extends RequestReader<?>, W extends Re
           .internalError(
               "Failed to handle request due to internal error; see the broker logs for more")
           .tryWriteResponse(serverOutput, partitionId, requestId);
-    } finally {
-      requestReader.reset();
-      responseWriter.reset();
-      errorResponseWriter.reset();
     }
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/ApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/ApiRequestHandler.java
@@ -83,6 +83,11 @@ public abstract class ApiRequestHandler<R extends RequestReader<?>, W extends Re
 
     try {
       requestReader.wrap(buffer, offset, length);
+    } catch (final RequestReaderException.InvalidTemplateException e) {
+      errorResponseWriter
+          .invalidMessageTemplate(e.actualTemplate, e.expectedTemplate)
+          .tryWriteResponseOrLogFailure(serverOutput, partitionId, requestId);
+      return;
     } catch (final Exception e) {
       LOG.error("Failed to deserialize message", e);
       errorResponseWriter
@@ -143,5 +148,14 @@ public abstract class ApiRequestHandler<R extends RequestReader<?>, W extends Re
      *     get access to the request data.
      */
     T getMessageDecoder();
+
+    /**
+     * @param buffer the buffer to read from
+     * @param offset the offset at which to start reading
+     * @param length the length of the values to read
+     * @throws RequestReaderException if reading the request failed
+     */
+    @Override
+    void wrap(DirectBuffer buffer, int offset, int length);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/ApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/ApiRequestHandler.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport;
+
+import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.broker.transport.ApiRequestHandler.RequestReader;
+import io.camunda.zeebe.broker.transport.ApiRequestHandler.ResponseWriter;
+import io.camunda.zeebe.transport.RequestHandler;
+import io.camunda.zeebe.transport.ServerOutput;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import io.camunda.zeebe.util.sched.Actor;
+import org.agrona.DirectBuffer;
+import org.agrona.sbe.MessageDecoderFlyweight;
+import org.slf4j.Logger;
+
+/**
+ * A {@link RequestHandler} that automatically decodes requests and encodes successful and error
+ * responses.
+ *
+ * @param <R> a {@link RequestReader} that reads the request
+ * @param <W> a {@link ResponseWriter} that writes the response
+ */
+public abstract class ApiRequestHandler<R extends RequestReader<?>, W extends ResponseWriter>
+    extends Actor implements RequestHandler {
+
+  public static final Logger LOG = Loggers.TRANSPORT_LOGGER;
+  private final ErrorResponseWriter errorResponseWriter = new ErrorResponseWriter();
+  private final R requestReader;
+  private final W responseWriter;
+
+  protected ApiRequestHandler(final R requestReader, final W responseWriter) {
+    this.requestReader = requestReader;
+    this.responseWriter = responseWriter;
+  }
+
+  /**
+   * Handles a request. The {@param requestReader} is populated at this point.
+   *
+   * @param partitionId the current partition id
+   * @param requestId the current request id
+   * @param requestReader a {@link R reader} that is already populated with the request data
+   * @param responseWriter a {@link W writer} that can be used to write successful responses
+   * @param errorWriter a {@link ErrorResponseWriter} that can be used to write error responses
+   * @return a {@link ErrorResponseWriter} when the handling failed, or a {@link W ResponseWriter}
+   *     when the handling was successful. Writes to the other writer will be ignored and are not
+   *     sent as a response.
+   */
+  protected abstract Either<ErrorResponseWriter, W> handle(
+      int partitionId,
+      long requestId,
+      R requestReader,
+      W responseWriter,
+      ErrorResponseWriter errorWriter);
+
+  @Override
+  public final void onRequest(
+      final ServerOutput serverOutput,
+      final int partitionId,
+      final long requestId,
+      final DirectBuffer buffer,
+      final int offset,
+      final int length) {
+    actor.submit(() -> handleRequest(serverOutput, partitionId, requestId, buffer, offset, length));
+  }
+
+  private void handleRequest(
+      final ServerOutput serverOutput,
+      final int partitionId,
+      final long requestId,
+      final DirectBuffer buffer,
+      final int offset,
+      final int length) {
+    try {
+      requestReader.wrap(buffer, offset, length);
+    } catch (final Exception e) {
+      LOG.error("Failed to deserialize message", e);
+      errorResponseWriter
+          .malformedRequest(e)
+          .tryWriteResponseOrLogFailure(serverOutput, partitionId, requestId);
+      return;
+    }
+
+    try {
+      final var result =
+          handle(partitionId, requestId, requestReader, responseWriter, errorResponseWriter);
+      if (result.isLeft()) {
+        result.getLeft().tryWriteResponse(serverOutput, partitionId, requestId);
+      } else {
+        result.get().tryWriteResponse(serverOutput, partitionId, requestId);
+      }
+    } catch (final Exception e) {
+      LOG.error("Error handling request on partition {}", partitionId, e);
+      errorResponseWriter
+          .internalError(
+              "Failed to handle request due to internal error; see the broker logs for more")
+          .tryWriteResponse(serverOutput, partitionId, requestId);
+    } finally {
+      requestReader.reset();
+      responseWriter.reset();
+      errorResponseWriter.reset();
+    }
+  }
+
+  /**
+   * Extension of {@link BufferWriter} that provides extra methods used by {@link ApiRequestHandler}
+   * implementations
+   */
+  public interface ResponseWriter extends BufferWriter {
+
+    /**
+     * Writes a successful response to the {@link ServerOutput}
+     *
+     * @param output the underlying {@link ServerOutput} that can be written to.
+     * @param partitionId the current partition id
+     * @param requestId the current request id
+     */
+    void tryWriteResponse(final ServerOutput output, final int partitionId, final long requestId);
+
+    /** Resets all internal state to prepare for sending the next response */
+    void reset();
+  }
+
+  /**
+   * Extension of {@link BufferReader} that provides extra methods used by {@link ApiRequestHandler}
+   * implementations.
+   *
+   * @param <T> the type of the message decoder.
+   */
+  public interface RequestReader<T extends MessageDecoderFlyweight> extends BufferReader {
+
+    /** Reset all internal state to prepare for reading the next request. */
+    void reset();
+
+    /**
+     * @return The message decoder which can be used by {@link ApiRequestHandler} implementations to
+     *     get access to the request data.
+     */
+    T getMessageDecoder();
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.commandapi;
+package io.camunda.zeebe.broker.transport;
 
 import static io.camunda.zeebe.util.StringUtil.getBytes;
 import static java.lang.String.format;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/RequestReaderException.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/RequestReaderException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport;
+
+public abstract class RequestReaderException extends RuntimeException {
+
+  public static final class InvalidTemplateException extends RequestReaderException {
+    final int expectedTemplate;
+    final int actualTemplate;
+
+    public InvalidTemplateException(final int expectedTemplate, final int actualTemplate) {
+      this.expectedTemplate = expectedTemplate;
+      this.actualTemplate = actualTemplate;
+    }
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -53,7 +53,7 @@ final class CommandApiRequestHandler
     }
   }
 
-  private Either<ErrorResponseWriter, CommandApiResponseWriter> handleExecuteCommandRequest(
+  public Either<ErrorResponseWriter, CommandApiResponseWriter> handleExecuteCommandRequest(
       final int partitionId,
       final long requestId,
       final CommandApiRequestReader reader,

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -43,14 +43,8 @@ final class CommandApiRequestHandler
       final CommandApiRequestReader requestReader,
       final CommandApiResponseWriter responseWriter,
       final ErrorResponseWriter errorWriter) {
-    final var templateId = requestReader.getMessageDecoder().sbeTemplateId();
-
-    if (templateId == ExecuteCommandRequestDecoder.TEMPLATE_ID) {
-      return handleExecuteCommandRequest(
-          partitionId, requestId, requestReader, responseWriter, errorWriter);
-    } else {
-      return Either.left(errorWriter);
-    }
+    return handleExecuteCommandRequest(
+        partitionId, requestId, requestReader, responseWriter, errorWriter);
   }
 
   private Either<ErrorResponseWriter, CommandApiResponseWriter> handleExecuteCommandRequest(

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -112,6 +112,7 @@ final class CommandApiRequestHandler
       return Either.right(responseWriter);
     } catch (final Exception ex) {
       LOG.error("Unexpected error on writing {} command", intent, ex);
+      errorWriter.internalError("Failed writing response", ex);
       return Either.left(errorWriter);
     } finally {
       if (!written) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -106,7 +106,7 @@ final class CommandApiRequestHandler
       return Either.right(responseWriter);
     } catch (final Exception ex) {
       LOG.error("Unexpected error on writing {} command", intent, ex);
-      errorWriter.internalError("Failed writing response: {}", ex);
+      errorWriter.internalError("Failed writing response: %s", ex);
       return Either.left(errorWriter);
     } finally {
       if (!written) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -106,7 +106,7 @@ final class CommandApiRequestHandler
       return Either.right(responseWriter);
     } catch (final Exception ex) {
       LOG.error("Unexpected error on writing {} command", intent, ex);
-      errorWriter.internalError("Failed writing response", ex);
+      errorWriter.internalError("Failed writing response: {}", ex);
       return Either.left(errorWriter);
     } finally {
       if (!written) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -53,7 +53,7 @@ final class CommandApiRequestHandler
     }
   }
 
-  public Either<ErrorResponseWriter, CommandApiResponseWriter> handleExecuteCommandRequest(
+  private Either<ErrorResponseWriter, CommandApiResponseWriter> handleExecuteCommandRequest(
       final int partitionId,
       final long requestId,
       final CommandApiRequestReader reader,

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -8,145 +8,93 @@
 package io.camunda.zeebe.broker.transport.commandapi;
 
 import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.broker.transport.ApiRequestHandler;
+import io.camunda.zeebe.broker.transport.ErrorResponseWriter;
 import io.camunda.zeebe.broker.transport.backpressure.BackpressureMetrics;
 import io.camunda.zeebe.broker.transport.backpressure.RequestLimiter;
 import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.camunda.zeebe.msgpack.UnpackedObject;
-import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
-import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
-import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
-import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
-import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
-import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.protocol.record.ExecuteCommandRequestDecoder;
-import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.record.RecordType;
-import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
-import io.camunda.zeebe.transport.RequestHandler;
-import io.camunda.zeebe.transport.ServerOutput;
-import java.util.EnumMap;
-import java.util.Map;
-import java.util.Queue;
-import java.util.function.Consumer;
-import org.agrona.DirectBuffer;
+import io.camunda.zeebe.util.Either;
 import org.agrona.collections.Int2ObjectHashMap;
-import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.slf4j.Logger;
 
-final class CommandApiRequestHandler implements RequestHandler {
+final class CommandApiRequestHandler
+    extends ApiRequestHandler<CommandApiRequestReader, CommandApiResponseWriter> {
   private static final Logger LOG = Loggers.TRANSPORT_LOGGER;
-
-  private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
-  private final ExecuteCommandRequestDecoder executeCommandRequestDecoder =
-      new ExecuteCommandRequestDecoder();
-  private final Queue<Runnable> cmdQueue = new ManyToOneConcurrentLinkedQueue<>();
-  private final Consumer<Runnable> cmdConsumer = Runnable::run;
 
   private final Int2ObjectHashMap<LogStreamRecordWriter> leadingStreams = new Int2ObjectHashMap<>();
   private final Int2ObjectHashMap<RequestLimiter<Intent>> partitionLimiters =
       new Int2ObjectHashMap<>();
-  private final RecordMetadata eventMetadata = new RecordMetadata();
-
-  private final ErrorResponseWriter errorResponseWriter = new ErrorResponseWriter();
-
-  private final Map<ValueType, UnpackedObject> recordsByType = new EnumMap<>(ValueType.class);
-  private final BackpressureMetrics metrics;
+  private final BackpressureMetrics metrics = new BackpressureMetrics();
   private boolean isDiskSpaceAvailable = true;
 
   CommandApiRequestHandler() {
-    metrics = new BackpressureMetrics();
-    initEventTypeMap();
+    super(new CommandApiRequestReader(), new CommandApiResponseWriter());
   }
 
-  private void initEventTypeMap() {
-    recordsByType.put(ValueType.DEPLOYMENT, new DeploymentRecord());
-    recordsByType.put(ValueType.JOB, new JobRecord());
-    recordsByType.put(ValueType.PROCESS_INSTANCE, new ProcessInstanceRecord());
-    recordsByType.put(ValueType.MESSAGE, new MessageRecord());
-    recordsByType.put(ValueType.JOB_BATCH, new JobBatchRecord());
-    recordsByType.put(ValueType.INCIDENT, new IncidentRecord());
-    recordsByType.put(ValueType.VARIABLE_DOCUMENT, new VariableDocumentRecord());
-    recordsByType.put(ValueType.PROCESS_INSTANCE_CREATION, new ProcessInstanceCreationRecord());
-  }
-
-  private void handleExecuteCommandRequest(
-      final ServerOutput output,
+  @Override
+  protected Either<ErrorResponseWriter, CommandApiResponseWriter> handle(
       final int partitionId,
       final long requestId,
-      final RecordMetadata eventMetadata,
-      final DirectBuffer buffer,
-      final int messageOffset,
-      final int messageLength) {
+      final CommandApiRequestReader requestReader,
+      final CommandApiResponseWriter responseWriter,
+      final ErrorResponseWriter errorWriter) {
+    final var templateId = requestReader.getMessageDecoder().sbeTemplateId();
+
+    if (templateId == ExecuteCommandRequestDecoder.TEMPLATE_ID) {
+      return handleExecuteCommandRequest(
+          partitionId, requestId, requestReader, responseWriter, errorWriter);
+    } else {
+      return Either.left(errorWriter);
+    }
+  }
+
+  private Either<ErrorResponseWriter, CommandApiResponseWriter> handleExecuteCommandRequest(
+      final int partitionId,
+      final long requestId,
+      final CommandApiRequestReader reader,
+      final CommandApiResponseWriter responseWriter,
+      final ErrorResponseWriter errorWriter) {
 
     if (!isDiskSpaceAvailable) {
-      errorResponseWriter
-          .resourceExhausted(
-              String.format(
-                  "Cannot accept requests for partition %d. Broker is out of disk space",
-                  partitionId))
-          .tryWriteResponse(output, partitionId, requestId);
-      return;
+      errorWriter.resourceExhausted(
+          String.format(
+              "Cannot accept requests for partition %d. Broker is out of disk space", partitionId));
+      return Either.left(errorWriter);
     }
 
-    executeCommandRequestDecoder.wrap(
-        buffer,
-        messageOffset + messageHeaderDecoder.encodedLength(),
-        messageHeaderDecoder.blockLength(),
-        messageHeaderDecoder.version());
+    final var command = reader.getMessageDecoder();
+    final var logStreamWriter = leadingStreams.get(partitionId);
+    final var limiter = partitionLimiters.get(partitionId);
 
-    final long key = executeCommandRequestDecoder.key();
+    final var eventType = command.valueType();
+    final var intent = Intent.fromProtocolValue(eventType, command.intent());
+    final var event = reader.event();
+    final var metadata = reader.metadata();
 
-    final LogStreamRecordWriter logStreamWriter = leadingStreams.get(partitionId);
+    metadata.requestId(requestId);
+    metadata.requestStreamId(partitionId);
+    metadata.recordType(RecordType.COMMAND);
+    metadata.intent(intent);
+    metadata.valueType(eventType);
 
     if (logStreamWriter == null) {
-      errorResponseWriter
-          .partitionLeaderMismatch(partitionId)
-          .tryWriteResponseOrLogFailure(output, partitionId, requestId);
-      return;
+      errorWriter.partitionLeaderMismatch(partitionId);
+      return Either.left(errorWriter);
     }
-
-    final ValueType eventType = executeCommandRequestDecoder.valueType();
-    final short intent = executeCommandRequestDecoder.intent();
-    final UnpackedObject event = recordsByType.get(eventType);
 
     if (event == null) {
-      errorResponseWriter
-          .unsupportedMessage(eventType.name(), recordsByType.keySet().toArray())
-          .tryWriteResponseOrLogFailure(output, partitionId, requestId);
-      return;
+      errorWriter.unsupportedMessage(
+          eventType.name(), CommandApiRequestReader.RECORDS_BY_TYPE.keySet().toArray());
+      return Either.left(errorWriter);
     }
-
-    final int eventOffset =
-        executeCommandRequestDecoder.limit() + ExecuteCommandRequestDecoder.valueHeaderLength();
-    final int eventLength = executeCommandRequestDecoder.valueLength();
-
-    event.reset();
-
-    try {
-      // verify that the event / command is valid
-      event.wrap(buffer, eventOffset, eventLength);
-    } catch (final RuntimeException e) {
-      LOG.error("Failed to deserialize message of type {} in client API", eventType.name(), e);
-
-      errorResponseWriter
-          .malformedRequest(e)
-          .tryWriteResponseOrLogFailure(output, partitionId, requestId);
-      return;
-    }
-
-    eventMetadata.recordType(RecordType.COMMAND);
-    final Intent eventIntent = Intent.fromProtocolValue(eventType, intent);
-    eventMetadata.intent(eventIntent);
-    eventMetadata.valueType(eventType);
 
     metrics.receivedRequest(partitionId);
-    final RequestLimiter<Intent> limiter = partitionLimiters.get(partitionId);
-    if (!limiter.tryAcquire(partitionId, requestId, eventIntent)) {
+    if (!limiter.tryAcquire(partitionId, requestId, intent)) {
       metrics.dropped(partitionId);
       LOG.trace(
           "Partition-{} receiving too many requests. Current limit {} inflight {}, dropping request {} from gateway",
@@ -154,15 +102,17 @@ final class CommandApiRequestHandler implements RequestHandler {
           limiter.getLimit(),
           limiter.getInflightCount(),
           requestId);
-      errorResponseWriter.resourceExhausted().tryWriteResponse(output, partitionId, requestId);
-      return;
+      errorWriter.resourceExhausted();
+      return Either.left(errorWriter);
     }
 
     boolean written = false;
     try {
-      written = writeCommand(eventMetadata, buffer, key, logStreamWriter, eventOffset, eventLength);
+      written = writeCommand(command.key(), metadata, event, logStreamWriter);
+      return Either.right(responseWriter);
     } catch (final Exception ex) {
-      LOG.error("Unexpected error on writing {} command", eventIntent, ex);
+      LOG.error("Unexpected error on writing {} command", intent, ex);
+      return Either.left(errorWriter);
     } finally {
       if (!written) {
         limiter.onIgnore(partitionId, requestId);
@@ -171,12 +121,10 @@ final class CommandApiRequestHandler implements RequestHandler {
   }
 
   private boolean writeCommand(
-      final RecordMetadata eventMetadata,
-      final DirectBuffer buffer,
       final long key,
-      final LogStreamRecordWriter logStreamWriter,
-      final int eventOffset,
-      final int eventLength) {
+      final RecordMetadata eventMetadata,
+      final UnpackedObject event,
+      final LogStreamRecordWriter logStreamWriter) {
     logStreamWriter.reset();
 
     if (key != ExecuteCommandRequestDecoder.keyNullValue()) {
@@ -186,10 +134,7 @@ final class CommandApiRequestHandler implements RequestHandler {
     }
 
     final long eventPosition =
-        logStreamWriter
-            .metadataWriter(eventMetadata)
-            .value(buffer, eventOffset, eventLength)
-            .tryWrite();
+        logStreamWriter.metadataWriter(eventMetadata).valueWriter(event).tryWrite();
 
     return eventPosition >= 0;
   }
@@ -198,7 +143,7 @@ final class CommandApiRequestHandler implements RequestHandler {
       final int partitionId,
       final LogStreamRecordWriter logStreamWriter,
       final RequestLimiter<Intent> limiter) {
-    cmdQueue.add(
+    actor.submit(
         () -> {
           leadingStreams.put(partitionId, logStreamWriter);
           partitionLimiters.put(partitionId, limiter);
@@ -206,7 +151,7 @@ final class CommandApiRequestHandler implements RequestHandler {
   }
 
   void removePartition(final int partitionId) {
-    cmdQueue.add(
+    actor.submit(
         () -> {
           leadingStreams.remove(partitionId);
           partitionLimiters.remove(partitionId);
@@ -214,7 +159,7 @@ final class CommandApiRequestHandler implements RequestHandler {
   }
 
   void onDiskSpaceNotAvailable() {
-    cmdQueue.add(
+    actor.submit(
         () -> {
           isDiskSpaceAvailable = false;
           LOG.debug("Broker is out of disk space. All client requests will be rejected");
@@ -222,53 +167,6 @@ final class CommandApiRequestHandler implements RequestHandler {
   }
 
   void onDiskSpaceAvailable() {
-    cmdQueue.add(() -> isDiskSpaceAvailable = true);
-  }
-
-  @Override
-  public void onRequest(
-      final ServerOutput output,
-      final int partitionId,
-      final long requestId,
-      final DirectBuffer buffer,
-      final int offset,
-      final int length) {
-    drainCommandQueue();
-
-    messageHeaderDecoder.wrap(buffer, offset);
-
-    final int templateId = messageHeaderDecoder.templateId();
-    final int clientVersion = messageHeaderDecoder.version();
-
-    if (clientVersion > Protocol.PROTOCOL_VERSION) {
-      errorResponseWriter
-          .invalidClientVersion(Protocol.PROTOCOL_VERSION, clientVersion)
-          .tryWriteResponse(output, partitionId, requestId);
-      return;
-    }
-
-    eventMetadata.reset();
-    eventMetadata.protocolVersion(clientVersion);
-    eventMetadata.requestId(requestId);
-    eventMetadata.requestStreamId(partitionId);
-
-    if (templateId == ExecuteCommandRequestDecoder.TEMPLATE_ID) {
-      handleExecuteCommandRequest(
-          output, partitionId, requestId, eventMetadata, buffer, offset, length);
-      return;
-    }
-
-    errorResponseWriter
-        .invalidMessageTemplate(templateId, ExecuteCommandRequestDecoder.TEMPLATE_ID)
-        .tryWriteResponse(output, partitionId, requestId);
-  }
-
-  private void drainCommandQueue() {
-    while (!cmdQueue.isEmpty()) {
-      final Runnable runnable = cmdQueue.poll();
-      if (runnable != null) {
-        cmdConsumer.accept(runnable);
-      }
-    }
+    actor.submit(() -> isDiskSpaceAvailable = true);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.commandapi;
+
+import io.camunda.zeebe.broker.transport.ApiRequestHandler.RequestReader;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
+import io.camunda.zeebe.protocol.record.ExecuteCommandRequestDecoder;
+import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.util.EnumMap;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+
+public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequestDecoder> {
+  static final Map<ValueType, UnpackedObject> RECORDS_BY_TYPE = new EnumMap<>(ValueType.class);
+
+  static {
+    RECORDS_BY_TYPE.put(ValueType.DEPLOYMENT, new DeploymentRecord());
+    RECORDS_BY_TYPE.put(ValueType.JOB, new JobRecord());
+    RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE, new ProcessInstanceRecord());
+    RECORDS_BY_TYPE.put(ValueType.MESSAGE, new MessageRecord());
+    RECORDS_BY_TYPE.put(ValueType.JOB_BATCH, new JobBatchRecord());
+    RECORDS_BY_TYPE.put(ValueType.INCIDENT, new IncidentRecord());
+    RECORDS_BY_TYPE.put(ValueType.VARIABLE_DOCUMENT, new VariableDocumentRecord());
+    RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE_CREATION, new ProcessInstanceCreationRecord());
+  }
+
+  private UnpackedObject event;
+  private final RecordMetadata eventMetadata = new RecordMetadata();
+  private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
+  private final ExecuteCommandRequestDecoder commandRequestDecoder =
+      new ExecuteCommandRequestDecoder();
+
+  @Override
+  public void reset() {
+    event.reset();
+    eventMetadata.reset();
+  }
+
+  @Override
+  public ExecuteCommandRequestDecoder getMessageDecoder() {
+    return commandRequestDecoder;
+  }
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    commandRequestDecoder.wrapAndApplyHeader(buffer, offset, messageHeaderDecoder);
+    final int eventOffset =
+        commandRequestDecoder.limit() + ExecuteCommandRequestDecoder.valueHeaderLength();
+    final int eventLength = commandRequestDecoder.valueLength();
+    eventMetadata.protocolVersion(messageHeaderDecoder.version());
+    event = RECORDS_BY_TYPE.get(commandRequestDecoder.valueType());
+    if (event != null) {
+      event.wrap(buffer, eventOffset, eventLength);
+    }
+  }
+
+  public UnpackedObject event() {
+    return event;
+  }
+
+  public RecordMetadata metadata() {
+    return eventMetadata;
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -47,7 +47,9 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
 
   @Override
   public void reset() {
-    event.reset();
+    if (event != null) {
+      event.reset();
+    }
     eventMetadata.reset();
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiResponseWriter.java
@@ -11,6 +11,10 @@ import io.camunda.zeebe.broker.transport.ApiRequestHandler.ResponseWriter;
 import io.camunda.zeebe.transport.ServerOutput;
 import org.agrona.MutableDirectBuffer;
 
+/**
+ * This is a no-op response writer. The reason for this is that the command API does not write a
+ * response directly, instead it relies on the engine to eventually write the response.
+ */
 public class CommandApiResponseWriter implements ResponseWriter {
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiResponseWriter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.commandapi;
+
+import io.camunda.zeebe.broker.transport.ApiRequestHandler.ResponseWriter;
+import io.camunda.zeebe.transport.ServerOutput;
+import org.agrona.MutableDirectBuffer;
+
+public class CommandApiResponseWriter implements ResponseWriter {
+
+  @Override
+  public void tryWriteResponse(
+      final ServerOutput output, final int partitionId, final long requestId) {}
+
+  @Override
+  public void reset() {}
+
+  @Override
+  public int getLength() {
+    return 0;
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {}
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.broker.system.configuration.QueryApiCfg;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.transport.backpressure.PartitionAwareRequestLimiter;
 import io.camunda.zeebe.broker.transport.backpressure.RequestLimiter;
+import io.camunda.zeebe.broker.transport.queryapi.QueryApiRequestHandler;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import io.camunda.zeebe.engine.state.QueryService;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiRequestHandler.java
@@ -9,17 +9,14 @@ package io.camunda.zeebe.broker.transport.queryapi;
 
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.system.configuration.QueryApiCfg;
-import io.camunda.zeebe.broker.transport.commandapi.ErrorResponseWriter;
+import io.camunda.zeebe.broker.transport.ApiRequestHandler;
+import io.camunda.zeebe.broker.transport.ErrorResponseWriter;
 import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.engine.state.QueryService.ClosedServiceException;
-import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.ExecuteQueryRequestDecoder;
-import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.transport.RequestHandler;
-import io.camunda.zeebe.transport.ServerOutput;
-import io.camunda.zeebe.util.sched.Actor;
+import io.camunda.zeebe.util.Either;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.Optional;
@@ -34,20 +31,17 @@ import org.agrona.collections.Int2ObjectHashMap;
  */
 @SuppressWarnings("removal")
 @Deprecated(forRemoval = true, since = "1.2.0")
-public final class QueryApiRequestHandler extends Actor implements RequestHandler {
+public final class QueryApiRequestHandler
+    extends ApiRequestHandler<QueryRequestReader, QueryResponseWriter> {
   private static final Set<ValueType> ACCEPTED_VALUE_TYPES =
       EnumSet.of(ValueType.PROCESS, ValueType.PROCESS_INSTANCE, ValueType.JOB);
 
   private final Map<Integer, QueryService> queryServicePerPartition = new Int2ObjectHashMap<>();
-  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
-  private final ExecuteQueryRequestDecoder messageDecoder = new ExecuteQueryRequestDecoder();
-
-  private final ErrorResponseWriter errorResponseWriter = new ErrorResponseWriter();
-  private final QueryResponseWriter queryResponseWriter = new QueryResponseWriter();
   private final QueryApiCfg config;
   private final String actorName;
 
   public QueryApiRequestHandler(final QueryApiCfg config, final int nodeId) {
+    super(new QueryRequestReader(), new QueryResponseWriter());
     this.config = config;
     actorName = buildActorName(nodeId, "QueryApi");
   }
@@ -71,76 +65,48 @@ public final class QueryApiRequestHandler extends Actor implements RequestHandle
   }
 
   @Override
-  public void onRequest(
-      final ServerOutput serverOutput,
+  protected Either<ErrorResponseWriter, QueryResponseWriter> handle(
       final int partitionId,
       final long requestId,
-      final DirectBuffer buffer,
-      final int offset,
-      final int length) {
-    actor.run(
-        () -> {
-          try {
-            handleRequest(serverOutput, partitionId, requestId, buffer, offset);
-          } catch (final Exception e) {
-            Loggers.TRANSPORT_LOGGER.error(
-                "Failed to handle query on partition {}", partitionId, e);
-            errorResponseWriter
-                .internalError(
-                    "Failed to handle query due to internal error; see the broker logs for"
-                        + " more")
-                .tryWriteResponse(serverOutput, partitionId, requestId);
-          }
-        });
-  }
-
-  private void handleRequest(
-      final ServerOutput serverOutput,
-      final int partitionId,
-      final long requestId,
-      final DirectBuffer buffer,
-      final int offset) {
+      final QueryRequestReader requestReader,
+      final QueryResponseWriter responseWriter,
+      final ErrorResponseWriter errorWriter) {
     if (!config.isEnabled()) {
-      errorResponseWriter
+      errorWriter
           .errorCode(ErrorCode.UNSUPPORTED_MESSAGE)
           .errorMessage(
               "Failed to handle query as the query API is disabled; did you configure"
-                  + " zeebe.broker.experimental.queryapi.enabled?")
-          .tryWriteResponse(serverOutput, partitionId, requestId);
-      return;
-    }
-
-    if (!decodeMessage(serverOutput, partitionId, requestId, buffer, offset)) {
-      return;
+                  + " zeebe.broker.experimental.queryapi.enabled?");
+      return Either.left(errorWriter);
     }
 
     final var queryService = queryServicePerPartition.get(partitionId);
     if (queryService == null) {
-      errorResponseWriter
-          .partitionLeaderMismatch(partitionId)
-          .tryWriteResponse(serverOutput, partitionId, requestId);
-      return;
+      errorWriter.partitionLeaderMismatch(partitionId);
+      return Either.left(errorWriter);
     }
 
     try {
-      handleQuery(serverOutput, partitionId, requestId, queryService);
+      return handleQuery(
+          queryServicePerPartition.get(partitionId),
+          requestReader.getMessageDecoder(),
+          responseWriter,
+          errorWriter);
     } catch (final ClosedServiceException e) {
       Loggers.TRANSPORT_LOGGER.debug(
           "Failed to handle query on partition {} as the query service was closed concurrently",
           partitionId,
           e);
-      errorResponseWriter
-          .partitionLeaderMismatch(partitionId)
-          .tryWriteResponse(serverOutput, partitionId, requestId);
+      errorWriter.partitionLeaderMismatch(partitionId);
+      return Either.left(errorWriter);
     }
   }
 
-  /** {@link #messageDecoder} here is guaranteed to hold a valid, decoded query. */
-  private void handleQuery(
-      final ServerOutput serverOutput,
-      final int partitionId,
-      final long requestId,
-      final QueryService queryService) {
+  private Either<ErrorResponseWriter, QueryResponseWriter> handleQuery(
+      final QueryService queryService,
+      final ExecuteQueryRequestDecoder messageDecoder,
+      final QueryResponseWriter responseWriter,
+      final ErrorResponseWriter errorResponseWriter) {
     final var key = messageDecoder.key();
 
     final Optional<DirectBuffer> bpmnProcessId;
@@ -155,85 +121,33 @@ public final class QueryApiRequestHandler extends Actor implements RequestHandle
         bpmnProcessId = queryService.getBpmnProcessIdForJob(key);
         break;
       default:
-        failOnInvalidValueType(serverOutput, partitionId, requestId);
-        return;
+        return Either.left(failOnInvalidValueType(messageDecoder, errorResponseWriter));
     }
 
     if (bpmnProcessId.isEmpty()) {
-      failOnResourceNotFound(serverOutput, partitionId, requestId, key);
-      return;
+      return Either.left(failOnResourceNotFound(key, messageDecoder, errorResponseWriter));
     }
 
-    queryResponseWriter
-        .bpmnProcessId(bpmnProcessId.get())
-        .tryWriteResponse(serverOutput, partitionId, requestId);
+    responseWriter.bpmnProcessId(bpmnProcessId.get());
+    return Either.right(responseWriter);
   }
 
-  private boolean decodeMessage(
-      final ServerOutput serverOutput,
-      final int partitionId,
-      final long requestId,
-      final DirectBuffer buffer,
-      final int offset) {
-    if (decodeMessageHeader(serverOutput, partitionId, requestId, buffer, offset)) {
-      return false;
-    }
-
-    messageDecoder.wrap(
-        buffer,
-        offset + headerDecoder.encodedLength(),
-        headerDecoder.blockLength(),
-        headerDecoder.version());
-
-    return true;
-  }
-
-  private boolean decodeMessageHeader(
-      final ServerOutput serverOutput,
-      final int partitionId,
-      final long requestId,
-      final DirectBuffer buffer,
-      final int offset) {
-    headerDecoder.wrap(buffer, offset);
-    final int templateId = headerDecoder.templateId();
-    final int clientVersion = headerDecoder.version();
-
-    if (clientVersion > Protocol.PROTOCOL_VERSION) {
-      errorResponseWriter
-          .invalidClientVersion(Protocol.PROTOCOL_VERSION, clientVersion)
-          .tryWriteResponse(serverOutput, partitionId, requestId);
-      return true;
-    }
-
-    if (templateId != ExecuteQueryRequestDecoder.TEMPLATE_ID) {
-      errorResponseWriter
-          .invalidMessageTemplate(templateId, ExecuteQueryRequestDecoder.TEMPLATE_ID)
-          .tryWriteResponse(serverOutput, partitionId, requestId);
-      return true;
-    }
-    return false;
-  }
-
-  private void failOnResourceNotFound(
-      final ServerOutput serverOutput,
-      final int partitionId,
-      final long requestId,
-      final long key) {
-    errorResponseWriter
+  private ErrorResponseWriter failOnResourceNotFound(
+      final long key,
+      final ExecuteQueryRequestDecoder messageDecoder,
+      final ErrorResponseWriter errorWriter) {
+    return errorWriter
         .errorCode(ErrorCode.PROCESS_NOT_FOUND)
         .errorMessage(
             "Expected to find the process ID for resource of type %s with key %d, but"
                 + " no such resource was found",
-            messageDecoder.valueType(), key)
-        .tryWriteResponse(serverOutput, partitionId, requestId);
+            messageDecoder.valueType(), key);
   }
 
-  private void failOnInvalidValueType(
-      final ServerOutput serverOutput, final int partitionId, final long requestId) {
-    errorResponseWriter
-        .internalError(
-            "Expected to handle query with value type of %s, but was %s",
-            ACCEPTED_VALUE_TYPES, messageDecoder.valueType())
-        .tryWriteResponse(serverOutput, partitionId, requestId);
+  private ErrorResponseWriter failOnInvalidValueType(
+      final ExecuteQueryRequestDecoder messageDecoder, final ErrorResponseWriter errorWriter) {
+    return errorWriter.internalError(
+        "Expected to handle query with value type of %s, but was %s",
+        ACCEPTED_VALUE_TYPES, messageDecoder.valueType());
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiRequestHandler.java
@@ -5,10 +5,11 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.commandapi;
+package io.camunda.zeebe.broker.transport.queryapi;
 
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.system.configuration.QueryApiCfg;
+import io.camunda.zeebe.broker.transport.commandapi.ErrorResponseWriter;
 import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.engine.state.QueryService.ClosedServiceException;
 import io.camunda.zeebe.protocol.Protocol;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryRequestReader.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.queryapi;
+
+import io.camunda.zeebe.broker.transport.ApiRequestHandler.RequestReader;
+import io.camunda.zeebe.protocol.record.ExecuteQueryRequestDecoder;
+import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
+import org.agrona.DirectBuffer;
+
+public class QueryRequestReader implements RequestReader<ExecuteQueryRequestDecoder> {
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+  private final ExecuteQueryRequestDecoder messageDecoder = new ExecuteQueryRequestDecoder();
+
+  @Override
+  public void reset() {
+    // nothing to reset here, decoders are re-wrapped for every request
+  }
+
+  @Override
+  public ExecuteQueryRequestDecoder getMessageDecoder() {
+    return messageDecoder;
+  }
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    messageDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryResponseWriter.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.commandapi;
+package io.camunda.zeebe.broker.transport.queryapi;
 
 import io.camunda.zeebe.protocol.record.ExecuteQueryResponseEncoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryResponseWriter.java
@@ -7,32 +7,37 @@
  */
 package io.camunda.zeebe.broker.transport.queryapi;
 
+import io.camunda.zeebe.broker.transport.ApiRequestHandler.ResponseWriter;
 import io.camunda.zeebe.protocol.record.ExecuteQueryResponseEncoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
 import io.camunda.zeebe.transport.ServerOutput;
 import io.camunda.zeebe.transport.impl.ServerResponseImpl;
-import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
-public final class QueryResponseWriter implements BufferWriter {
+public final class QueryResponseWriter implements ResponseWriter {
 
   private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
   private final ExecuteQueryResponseEncoder responseEncoder = new ExecuteQueryResponseEncoder();
   private final ServerResponseImpl response = new ServerResponseImpl();
   private final DirectBuffer bpmnProcessId = new UnsafeBuffer();
 
+  @Override
   public void tryWriteResponse(
       final ServerOutput output, final int partitionId, final long requestId) {
 
     try {
       response.reset().writer(this).setPartitionId(partitionId).setRequestId(requestId);
       output.sendResponse(response);
-
     } finally {
       reset();
     }
+  }
+
+  @Override
+  public void reset() {
+    bpmnProcessId.wrap(0, 0);
   }
 
   @Override
@@ -59,10 +64,6 @@ public final class QueryResponseWriter implements BufferWriter {
     responseEncoder.wrap(buffer, offset);
 
     responseEncoder.putBpmnProcessId(bpmnProcessId, 0, bpmnProcessId.capacity());
-  }
-
-  public void reset() {
-    bpmnProcessId.wrap(0, 0);
   }
 
   public QueryResponseWriter bpmnProcessId(final DirectBuffer bpmnProcessId) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/engine/RecordVersionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/engine/RecordVersionTest.java
@@ -116,7 +116,7 @@ public final class RecordVersionTest {
         .command()
         .put("resources", List.of(Map.of("resourceName", "process.bpmn", "resource", resource)))
         .done()
-        .send();
+        .sendAndAwait();
   }
 
   private long createProcessInstance(final String processId) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/engine/RecordVersionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/engine/RecordVersionTest.java
@@ -116,7 +116,7 @@ public final class RecordVersionTest {
         .command()
         .put("resources", List.of(Map.of("resourceName", "process.bpmn", "resource", resource)))
         .done()
-        .sendAndAwait();
+        .send();
   }
 
   private long createProcessInstance(final String processId) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/ApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/ApiRequestHandlerTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.zeebe.broker.transport.ApiRequestHandler.RequestReader;
+import io.camunda.zeebe.broker.transport.ApiRequestHandler.ResponseWriter;
+import io.camunda.zeebe.transport.ServerOutput;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.sched.ActorControl;
+import io.camunda.zeebe.util.sched.testing.ControlledActorSchedulerRule;
+import org.agrona.DirectBuffer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ApiRequestHandlerTest {
+
+  @Rule
+  public final ControlledActorSchedulerRule schedulerRule = new ControlledActorSchedulerRule();
+
+  private RequestReader<?> reader;
+  private ResponseWriter writer;
+  private TestApiRequestHandler handler;
+
+  @Before
+  public void setUp() {
+    reader = mock(RequestReader.class);
+    writer = mock(ResponseWriter.class);
+    handler = new TestApiRequestHandler(reader, writer);
+    schedulerRule.submitActor(handler);
+  }
+
+  @Test
+  public void shouldReadRequestBuffer() {
+    // given
+    final var buffer = mock(DirectBuffer.class);
+    final var output = mock(ServerOutput.class);
+
+    // when
+    handler.onRequest(output, 0, 0, buffer, 0, 1);
+    schedulerRule.workUntilDone();
+
+    // then
+    verify(reader).wrap(buffer, 0, 1);
+  }
+
+  @Test
+  public void shouldResetReaderAndWriter() {
+    // given
+    final var buffer = mock(DirectBuffer.class);
+    final var output = mock(ServerOutput.class);
+
+    // when
+    handler.onRequest(output, 0, 0, buffer, 0, 1);
+    schedulerRule.workUntilDone();
+
+    // then
+
+    verify(reader).reset();
+    verify(writer).reset();
+  }
+
+  @Test
+  public void shouldWriteResponse() {
+    // given
+    final var buffer = mock(DirectBuffer.class);
+    final var output = mock(ServerOutput.class);
+    final var partitionId = 12;
+    final var requestId = 34;
+    doThrow(new RuntimeException()).when(buffer).wrap(buffer, 0, 1);
+
+    // when
+    handler.onRequest(output, partitionId, requestId, buffer, 0, 1);
+    schedulerRule.workUntilDone();
+
+    // then
+    verify(writer).tryWriteResponse(output, partitionId, requestId);
+  }
+
+  private static class TestApiRequestHandler
+      extends ApiRequestHandler<RequestReader<?>, ResponseWriter> {
+    TestApiRequestHandler(
+        final RequestReader<?> requestReader, final ResponseWriter responseWriter) {
+      super(requestReader, responseWriter);
+    }
+
+    public ActorControl actor() {
+      return actor;
+    }
+
+    @Override
+    protected Either<ErrorResponseWriter, ResponseWriter> handle(
+        final int partitionId,
+        final long requestId,
+        final RequestReader<?> requestReader,
+        final ResponseWriter responseWriter,
+        final ErrorResponseWriter errorWriter) {
+      return Either.right(responseWriter);
+    }
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.commandapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.broker.transport.ErrorResponseWriter;
+import io.camunda.zeebe.broker.transport.backpressure.NoopRequestLimiter;
+import io.camunda.zeebe.broker.transport.backpressure.RequestLimiter;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerPublishMessageRequest;
+import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
+import io.camunda.zeebe.protocol.impl.encoding.ExecuteCommandRequest;
+import io.camunda.zeebe.protocol.record.ErrorCode;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import io.camunda.zeebe.util.sched.testing.ControlledActorSchedulerRule;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CommandApiRequestHandlerTest {
+  @Rule public final ControlledActorSchedulerRule scheduler = new ControlledActorSchedulerRule();
+  final CommandApiRequestHandler handler = new CommandApiRequestHandler();
+
+  @Before
+  public void setup() {
+    scheduler.submitActor(handler);
+    handler.addPartition(0, mock(LogStreamRecordWriter.class), new NoopRequestLimiter<>());
+    scheduler.workUntilDone();
+  }
+
+  @Test
+  public void shouldRejectCommandIfNotLeader() {
+    // given
+    final var request = new ExecuteCommandRequest();
+    handler.removePartition(0);
+    scheduler.workUntilDone();
+
+    // when
+    final var response = handleRequest(request);
+
+    // then
+    assertThat(response).matches(Either::isLeft);
+    assertThat(response.getLeft().getErrorCode()).isEqualTo(ErrorCode.PARTITION_LEADER_MISMATCH);
+  }
+
+  @Test
+  public void shouldRejectCommandWithoutEvent() {
+    // given
+    final var request = new ExecuteCommandRequest();
+
+    // when
+    final var response = handleRequest(request);
+
+    // then
+    assertThat(response).matches(Either::isLeft);
+    assertThat(response.getLeft().getErrorCode()).isEqualTo(ErrorCode.UNSUPPORTED_MESSAGE);
+  }
+
+  @Test
+  public void shouldRejectCommandWithUnknownEvent() {
+    // given
+    final var request = new ExecuteCommandRequest();
+    request.setValueType(ValueType.ERROR);
+
+    // when
+    final var response = handleRequest(request);
+
+    // then
+    assertThat(response).matches(Either::isLeft);
+    assertThat(response.getLeft().getErrorCode()).isEqualTo(ErrorCode.UNSUPPORTED_MESSAGE);
+  }
+
+  @Test
+  public void shouldRejectCommandIfResourcesExhausted() {
+    // given
+    final RequestLimiter<Intent> limiter = mock(RequestLimiter.class);
+    when(limiter.tryAcquire(anyInt(), anyLong(), any())).thenReturn(false);
+    handler.addPartition(0, mock(LogStreamRecordWriter.class), limiter);
+    scheduler.workUntilDone();
+
+    final var request =
+        new BrokerPublishMessageRequest("test", "1").setMessageId("1").setTimeToLive(0);
+    request.serializeValue();
+
+    // when
+    final var response = handleRequest(request);
+
+    // then
+    assertThat(response).matches(Either::isLeft);
+    assertThat(response.getLeft().getErrorCode()).isEqualTo(ErrorCode.RESOURCE_EXHAUSTED);
+  }
+
+  @Test
+  public void shouldWriteToLog() {
+    // given
+    final var logWriter = mock(LogStreamRecordWriter.class);
+    when(logWriter.metadataWriter(any())).thenReturn(logWriter);
+    when(logWriter.valueWriter(any())).thenReturn(logWriter);
+    handler.addPartition(0, logWriter, new NoopRequestLimiter<>());
+    scheduler.workUntilDone();
+
+    final var request =
+        new BrokerPublishMessageRequest("test", "1").setMessageId("1").setTimeToLive(0);
+    request.serializeValue();
+
+    // when
+    final var response = handleRequest(request);
+
+    // then
+    assertThat(response).matches(Either::isRight);
+    verify(logWriter).tryWrite();
+    verify(logWriter).reset();
+  }
+
+  private Either<ErrorResponseWriter, CommandApiResponseWriter> handleRequest(
+      final BufferWriter request) {
+    final var reader = new CommandApiRequestReader();
+    final var writer = new CommandApiResponseWriter();
+    final var errorWriter = new ErrorResponseWriter();
+    final var requestBuffer = new UnsafeBuffer(new byte[request.getLength()]);
+    request.write(requestBuffer, 0);
+    reader.wrap(requestBuffer, 0, requestBuffer.capacity());
+    return handler.handleExecuteCommandRequest(0, 0, reader, writer, errorWriter);
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
@@ -50,6 +50,24 @@ public class CommandApiRequestHandlerTest {
   }
 
   @Test
+  public void shouldRejectCommandWithInvalidTemplate() {
+    // given
+    final var request = new ExecuteQueryRequest();
+
+    // when
+    final var responseFuture = handleRequest(request);
+
+    // then
+    assertThat(responseFuture)
+        .succeedsWithin(Duration.ofMinutes(1))
+        .matches(Either::isLeft)
+        .matches(Either::isLeft)
+        .extracting(Either::getLeft)
+        .extracting(ErrorResponse::getErrorCode)
+        .isEqualTo(ErrorCode.INVALID_MESSAGE_TEMPLATE);
+  }
+
+  @Test
   public void shouldRejectCommandIfNotLeader() {
     // given
     final var request = new ExecuteCommandRequest();

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/ErrorResponseWriterTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/ErrorResponseWriterTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.transport.commandapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.broker.transport.ErrorResponseWriter;
 import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.ErrorResponseDecoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/QueryApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/QueryApiRequestHandlerTest.java
@@ -297,9 +297,9 @@ final class QueryApiRequestHandlerTest {
         .isEqualTo("OneProcessToFindThem");
   }
 
-  @DisplayName("should return INTERNAL_ERROR on exception thrown while handling the request")
+  @DisplayName("should return MALFORMED_REQUEST on exception thrown while reading the request")
   @Test
-  void internalError() {
+  void malformedRequest() {
     // given
     final QueryApiRequestHandler sut = createQueryApiRequestHandler(true);
 
@@ -313,9 +313,7 @@ final class QueryApiRequestHandlerTest {
         .extracting(Either::getLeft)
         .extracting(
             ErrorResponse::getErrorCode, error -> BufferUtil.bufferAsString(error.getErrorData()))
-        .containsExactly(
-            ErrorCode.INTERNAL_ERROR,
-            "Failed to handle query due to internal error; see the broker logs for more");
+        .contains(ErrorCode.MALFORMED_REQUEST);
   }
 
   private QueryApiRequestHandler createQueryApiRequestHandler(final boolean enabled) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/QueryApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/QueryApiRequestHandlerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.broker.system.configuration.QueryApiCfg;
+import io.camunda.zeebe.broker.transport.queryapi.QueryApiRequestHandler;
 import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.engine.state.QueryService.ClosedServiceException;
 import io.camunda.zeebe.protocol.impl.encoding.ErrorResponse;

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiIT.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiIT.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.commandapi;
+package io.camunda.zeebe.broker.transport.queryapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiRequestHandlerTest.java
@@ -5,13 +5,12 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.transport.commandapi;
+package io.camunda.zeebe.broker.transport.queryapi;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.broker.system.configuration.QueryApiCfg;
-import io.camunda.zeebe.broker.transport.queryapi.QueryApiRequestHandler;
 import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.engine.state.QueryService.ClosedServiceException;
 import io.camunda.zeebe.protocol.impl.encoding.ErrorResponse;


### PR DESCRIPTION
## Description

This is another refactoring in preparation for #8224. The CommandApi and QueryApi share a lot of code for decoding requests and encoding responses. We will introduce another API in #8224 which would then also require the same code again. Here I add an abstract `ApiRequestHandler` that is generic over a `RequestReader` and a `ResponseWriter` that coordinates the reading, writing and error handling. Every `ApiRequestHandler` is an actor.

The refactoring for the QueryApi was straight forward. However the refactoring for the CommandApi is a bit more involved as previously the CommandApi didn't use the actor model, instead relying on a command queue. Also, the separation between reading, handling and writing wasn't as clear as in the QueryApi.

I hope with this refactoring the CommandApi is much more readable and maintainable and we will also save code duplication for new APIs.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #8224

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
