### PR TITLE
:camping:  Reduce benchmark resources

### DIFF
--- a/benchmarks/setup/default/starter.yaml
+++ b/benchmarks/setup/default/starter.yaml
@@ -31,10 +31,10 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 250Mi
+            memory: 256Mi
           requests:
-            cpu: 100m
-            memory: 128Mi
+            cpu: 250m
+            memory: 256Mi
 ---
 apiVersion: v1
 kind: Service

--- a/benchmarks/setup/default/starter.yaml
+++ b/benchmarks/setup/default/starter.yaml
@@ -30,11 +30,11 @@ spec:
             value: "warn"
         resources:
           limits:
-            cpu: 2
-            memory: 2Gi
+            cpu: 250m
+            memory: 250Mi
           requests:
-            cpu: 2
-            memory: 512Mi
+            cpu: 100m
+            memory: 128Mi
 ---
 apiVersion: v1
 kind: Service

--- a/benchmarks/setup/default/worker.yaml
+++ b/benchmarks/setup/default/worker.yaml
@@ -31,11 +31,11 @@ spec:
             value: "warn"
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 256Mi
           requests:
-            cpu: 50m
-            memory: 128Mi
+            cpu: 500m
+            memory: 256Mi
 ---
 apiVersion: v1
 kind: Service

--- a/benchmarks/setup/default/worker.yaml
+++ b/benchmarks/setup/default/worker.yaml
@@ -8,7 +8,7 @@ spec:
   selector:
     matchLabels:
       app: worker
-  replicas: 12
+  replicas: 6
   template:
     metadata:
       labels:
@@ -31,11 +31,11 @@ spec:
             value: "warn"
         resources:
           limits:
-            cpu: 4
-            memory: 2Gi
+            cpu: 100m
+            memory: 256Mi
           requests:
-            cpu: 1
-            memory: 512Mi
+            cpu: 50m
+            memory: 128Mi
 ---
 apiVersion: v1
 kind: Service

--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -16,7 +16,7 @@ podSecurityContext:
         add: ["NET_ADMIN"]
 
 gateway:
-  replicas: 1
+  replicas: 3
   logLevel: debug
   env:
     - name: ZEEBE_LOG_APPENDER
@@ -34,14 +34,14 @@ gateway:
     - name: ZEEBE_GATEWAY_MONITORING_ENABLED
       value: "true"
     - name: ZEEBE_GATEWAY_THREADS_MANAGEMENTTHREADS
-      value: "4"
+      value: "1"
   resources:
     limits:
-      cpu: 2
-      memory: 2Gi
+      cpu: 1
+      memory: 512Mi
     requests:
-      cpu: 2
-      memory: 1Gi
+      cpu: 250m
+      memory: 256Mi
 
 # Uncomment to add custom YAML configuration
 # This will overwrite anything at the application.yml location
@@ -83,11 +83,11 @@ env:
 # RESOURCES
 resources:
   limits:
-    cpu: 5
-    memory: 12Gi
+    cpu: 1
+    memory: 4Gi
   requests:
-    cpu: 5
-    memory: 12Gi
+    cpu: 500m
+    memory: 2Gi
 
 # PVC
 pvcAccessMode: ["ReadWriteOnce"]

--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -40,8 +40,8 @@ gateway:
       cpu: 1
       memory: 512Mi
     requests:
-      cpu: 250m
-      memory: 256Mi
+      cpu: 1
+      memory: 512Mi
 
 # Uncomment to add custom YAML configuration
 # This will overwrite anything at the application.yml location
@@ -86,8 +86,8 @@ resources:
     cpu: 5
     memory: 4Gi
   requests:
-    cpu: 2
-    memory: 2Gi
+    cpu: 5
+    memory: 4Gi
 
 # PVC
 pvcAccessMode: ["ReadWriteOnce"]

--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -83,10 +83,10 @@ env:
 # RESOURCES
 resources:
   limits:
-    cpu: 1
+    cpu: 5
     memory: 4Gi
   requests:
-    cpu: 500m
+    cpu: 2
     memory: 2Gi
 
 # PVC


### PR DESCRIPTION
## Description

Based on my recent experiments with the controller and other things I saw again that we are really wasteful with resources. Don't want to put the number here in this PR, regarding cost. In order to be a good boy scout I thought lets reduce a bit the resources, which I did in this PR. 

I also increased the Standalone Gateway replicas to three, so we have a similar setup which we want to have in CCloud and to avoid gaps in throughput, if one gateway dies. 

Resource reduction per deployment:

 * Starter by factor 4
 * Worker CPU by factor 40
 * Worker Memory by factor 8
 * Gateway we have some cost reduction but since we scaled it it is not that high
 * Broker Memory by factor 3
 * Broker CPU no reduction - here we can discuss whether we want this

This will reduce the node count we use.

Since you will review it when I'm not available feel free to close it if you think it is not applicable. Or just take it as christmas gift :gift: :smile: Or Iterate over it :shrug: 

### Benchmark

And of course I benchmarked it:

![general](https://user-images.githubusercontent.com/2758593/143262399-03de63be-228c-4c8b-9004-80ad3f744078.png)
![cpu](https://user-images.githubusercontent.com/2758593/143262395-c62eab65-7188-4da0-b724-34d9a9d19581.png)
![mem](https://user-images.githubusercontent.com/2758593/143262403-a4f4982b-d164-434f-9f97-1dbfbeb72a6b.png)




<!-- Please explain the changes you made here. -->

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [X] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
