### PR TITLE
Enable priority election by default

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -23,7 +23,7 @@ public class RaftPartitionConfig {
 
   private static final Duration DEFAULT_ELECTION_TIMEOUT = Duration.ofMillis(2500);
   private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(250);
-  private static final boolean DEFAULT_PRIORITY_ELECTION = false;
+  private static final boolean DEFAULT_PRIORITY_ELECTION = true;
   private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(5);
   private static final int DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT = 3;
   private static final Duration DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT = Duration.ofSeconds(0);
@@ -164,7 +164,7 @@ public class RaftPartitionConfig {
     return preferSnapshotReplicationThreshold;
   }
 
-  public void setPreferSnapshotReplicationThreshold(int preferSnapshotReplicationThreshold) {
+  public void setPreferSnapshotReplicationThreshold(final int preferSnapshotReplicationThreshold) {
     this.preferSnapshotReplicationThreshold = preferSnapshotReplicationThreshold;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -20,7 +20,7 @@ public class ExperimentalCfg implements ConfigurationEntry {
   public static final int DEFAULT_MAX_APPENDS_PER_FOLLOWER = 2;
   public static final DataSize DEFAULT_MAX_APPEND_BATCH_SIZE = DataSize.ofKilobytes(32);
   public static final boolean DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH = false;
-  public static final boolean DEFAULT_ENABLE_PRIORITY_ELECTION = false;
+  public static final boolean DEFAULT_ENABLE_PRIORITY_ELECTION = true;
 
   private int maxAppendsPerFollower = DEFAULT_MAX_APPENDS_PER_FOLLOWER;
   private DataSize maxAppendBatchSize = DEFAULT_MAX_APPEND_BATCH_SIZE;

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftRolesTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftRolesTest.java
@@ -263,6 +263,7 @@ public final class RaftRolesTest {
         RaftPartitionGroup.builder("normal")
             .withNumPartitions(partitionCount)
             .withPartitionSize(memberIds.size())
+            .withPriorityElection(false)
             .withMembers(memberIds)
             .withDataDirectory(
                 new File(new File(atomixClusterRule.getDataDir(), "log"), "" + nodeId))

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -477,7 +477,7 @@ public final class BrokerCfgTest {
   }
 
   @Test
-  public void shouldDisablePriorityElectionByDefault() {
+  public void shouldEnablePriorityElectionByDefault() {
     // given
     final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
 
@@ -485,7 +485,7 @@ public final class BrokerCfgTest {
     final ExperimentalCfg experimentalCfg = cfg.getExperimental();
 
     // then
-    assertThat(experimentalCfg.isEnablePriorityElection()).isFalse();
+    assertThat(experimentalCfg.isEnablePriorityElection()).isTrue();
   }
 
   @Test

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -536,7 +536,7 @@
       # As a result, it tries to distributed the leaders uniformly across the brokers. Note that it is only a best-effort strategy.
       # It is not guaranteed to be a strictly uniform distribution.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENABLEPRIORITYELECTION
-      # enablePriorityElection = false;
+      # enablePriorityElection = true;
 
       # This setting allows you to configure how partitions are distributed amongst the node of the
       # clusters. It currently supports to partitioning schemes: ROUND_ROBIN, and FIXED.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -474,7 +474,7 @@
       # As a result, it tries to distributed the leaders uniformly across the brokers. Note that it is only a best-effort strategy.
       # It is not guaranteed to be a strictly uniform distribution.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENABLEPRIORITYELECTION
-      # enablePriorityElection = false;
+      # enablePriorityElection = true;
 
       # This setting allows you to configure how partitions are distributed amongst the node of the
       # clusters. It currently supports to partitioning schemes: ROUND_ROBIN, and FIXED.

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FixedPartitionDistributionIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FixedPartitionDistributionIT.java
@@ -90,6 +90,7 @@ final class FixedPartitionDistributionIT {
         ZeebeTestContainerDefaults.defaultTestImage().asCanonicalNameString());
     broker
         .withEnv("ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING_SCHEME", "FIXED")
+        .withEnv("ZEEBE_BROKER_EXPERIMENTAL_ENABLE_PRIORITY_ELECTION", "false")
         .withEnv("ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING_FIXED_0_PARTITIONID", "1")
         .withEnv("ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING_FIXED_0_NODES_0_NODEID", "1")
         .withEnv("ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING_FIXED_0_NODES_1_NODEID", "2")


### PR DESCRIPTION
## Description

Switches two flags to enable priority election by default and updates the configuration template that we distribute.

## Related issues

closes #8236 