### PR TITLE
fix(raft): notify role change listener only when transition completed

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -126,6 +126,8 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private final Random random;
   private PersistedSnapshot currentSnapshot;
 
+  private boolean ongoingTransition = false;
+
   @SuppressWarnings("java:S3077") // allow volatile here, health is immutable
   private volatile HealthReport health = HealthReport.healthy(this);
 
@@ -293,12 +295,24 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   /**
-   * Adds a role change listener.
+   * Adds a role change listener. If there isn't currently a transition ongoing the listener is
+   * called immediately after adding the listener.
    *
    * @param listener The role change listener.
    */
   public void addRoleChangeListener(final RaftRoleChangeListener listener) {
-    roleChangeListeners.add(listener);
+    threadContext.execute(
+        () -> {
+          roleChangeListeners.add(listener);
+
+          // When a transition is currently ongoing, then the given
+          // listener will be called when the transition completes.
+          if (!ongoingTransition) {
+            // Otherwise, the listener will called directly for the last
+            // completed transition.
+            listener.onNewRole(getRole(), getTerm());
+          }
+        });
   }
 
   /**
@@ -589,6 +603,8 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
     log.info("Transitioning to {}", role);
 
+    startTransition();
+
     // Close the old state.
     try {
       this.role.stop().get();
@@ -618,12 +634,24 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
             () -> {
               if (this.role == leaderRole) { // ensure no other role change happened in between
                 notifyRoleChangeListeners();
+                // Transitioning to leader completes
+                // once the initial entry gets committed
+                completeTransition();
               }
             });
       } else {
         notifyRoleChangeListeners();
+        completeTransition();
       }
     }
+  }
+
+  private void startTransition() {
+    ongoingTransition = true;
+  }
+
+  private void completeTransition() {
+    ongoingTransition = false;
   }
 
   private void notifyRoleChangeListeners() {

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -166,11 +166,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -123,7 +123,7 @@ public final class ZeebePartition extends Actor
 
               context = transitionContext.getPartitionContext();
 
-              registerListenersAndTriggerRoleChange();
+              registerListeners();
             });
   }
 
@@ -294,10 +294,9 @@ public final class ZeebePartition extends Actor
     return inactiveTransitionFuture;
   }
 
-  private void registerListenersAndTriggerRoleChange() {
+  private void registerListeners() {
     context.getRaftPartition().addRoleChangeListener(this);
     context.getComponentHealthMonitor().addFailureListener(this);
-    onRoleChange(context.getRaftPartition().getRole(), context.getRaftPartition().term());
     context.getRaftPartition().getServer().addSnapshotReplicationListener(this);
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -228,6 +228,7 @@ public class ZeebePartitionTest {
 
     // when
     schedulerRule.submitActor(partition);
+    partition.onNewRole(Role.FOLLOWER, 1);
     schedulerRule.workUntilDone();
     assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 
@@ -252,9 +253,11 @@ public class ZeebePartitionTest {
               return CompletableActorFuture.completed(null);
             });
     when(raft.getRole()).thenReturn(Role.LEADER);
+    when(raft.term()).thenReturn(1L);
 
     // when
     schedulerRule.submitActor(partition);
+    partition.onNewRole(raft.getRole(), raft.term());
     schedulerRule.workUntilDone();
     assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

* Removes calling `ZeebePartition#onRoleChange()` when registering the role change listener
* Raft notifies the role change listeners only when the transition is completed, and in the case of a leader transition, the initial entry gets committed
* Adjust some test cases to ensure that the actual test scenario is tested

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7862

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
