### PR TITLE
Evaluate candidate groups expression on user task activation 

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -116,7 +116,7 @@ public final class BpmnJobBehavior {
       final JobProperties props) {
 
     final var taskHeaders = jobWorkerElement.getJobWorkerProperties().getTaskHeaders();
-    final var encodedHeaders = encodeHeaders(taskHeaders, props.getAssignee());
+    final var encodedHeaders = encodeHeaders(taskHeaders, props);
 
     jobRecord
         .setType(props.getType())
@@ -133,10 +133,16 @@ public final class BpmnJobBehavior {
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.CREATED, jobRecord);
   }
 
-  private DirectBuffer encodeHeaders(final Map<String, String> taskHeaders, final String assignee) {
+  private DirectBuffer encodeHeaders(
+      final Map<String, String> taskHeaders, final JobProperties props) {
     final var headers = new HashMap<>(taskHeaders);
+    final String assignee = props.getAssignee();
+    final String candidateGroups = props.getCandidateGroups();
     if (assignee != null) {
       headers.put(Protocol.USER_TASK_ASSIGNEE_HEADER_NAME, assignee);
+    }
+    if (candidateGroups != null) {
+      headers.put(Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME, candidateGroups);
     }
     return headerEncoder.encode(headers);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/ExpressionTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/ExpressionTransformer.java
@@ -52,15 +52,23 @@ public final class ExpressionTransformer {
   }
 
   /**
-   * Serializes a list of strings to a list-literal FEEL-expression, e.g. {@code List.of("a","b") =>
-   * "=[\"a\",\"b\"]"}.
+   * Serializes a list of strings to a list-literal, e.g. {@code List.of("a","b") =>
+   * "[\"a\",\"b\"]"}.
    *
    * @param values the list of string values to transform
-   * @return a string representation of the list literal FEEL-expression
+   * @return a string representation of the list literal
    */
-  public static String asListLiteralExpression(final List<String> values) {
+  public static String asListLiteral(final List<String> values) {
     return values.stream()
-        .map(value -> String.format("\"%s\"", value))
-        .collect(Collectors.joining(",", "=[", "]"));
+        .map(ExpressionTransformer::asStringLiteral)
+        .collect(Collectors.joining(",", "[", "]"));
+  }
+
+  private static String asStringLiteral(final String value) {
+    return String.format("\"%s\"", value);
+  }
+
+  public static String asFeelExpression(final String expression) {
+    return String.format("=%s", expression);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/ExpressionTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/ExpressionTransformer.java
@@ -68,7 +68,17 @@ public final class ExpressionTransformer {
     return String.format("\"%s\"", value);
   }
 
-  public static String asFeelExpression(final String expression) {
+  /**
+   * Transforms an expression string into a FEEL expression string.
+   *
+   * <p>Zeebe considers strings starting with `=` as FEEL expressions, and other strings as static
+   * values. For example, `author` is considered a static value `author`, while `= author` is
+   * considered a FEEL expression that evaluates to the value of the variable `author`.
+   *
+   * @param expression The actual expression string to convert into a FEEL expression
+   * @return The provided expression string prefixed by the `=` character
+   */
+  public static String asFeelExpressionString(final String expression) {
     return String.format("=%s", expression);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -80,7 +80,8 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
         // static candidateGroups must be in CSV format, but this is already checked by validator
         jobWorkerProperties.setCandidateGroups(
             ExpressionTransformer.parseListOfCsv(candidateGroups)
-                .map(ExpressionTransformer::asListLiteralExpression)
+                .map(ExpressionTransformer::asListLiteral)
+                .map(ExpressionTransformer::asFeelExpression)
                 .map(expressionLanguage::parseExpression)
                 .get());
       } else {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -81,7 +81,7 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
         jobWorkerProperties.setCandidateGroups(
             ExpressionTransformer.parseListOfCsv(candidateGroups)
                 .map(ExpressionTransformer::asListLiteral)
-                .map(ExpressionTransformer::asFeelExpression)
+                .map(ExpressionTransformer::asFeelExpressionString)
                 .map(expressionLanguage::parseExpression)
                 .get());
       } else {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.common;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.VariablesLookup;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ExpressionProcessorTest {
+
+  private static final ExpressionLanguage EXPRESSION_LANGUAGE =
+      ExpressionLanguageFactory.createExpressionLanguage();
+  private static final VariablesLookup EMPTY_LOOKUP = (x, y) -> null;
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  class EvaluateArrayOfStringsExpressionTest {
+
+    @ParameterizedTest
+    @MethodSource("arrayOfStringsExpressions")
+    void testSuccessfulEvaluations(final String expression, final List<String> expected) {
+      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, EMPTY_LOOKUP);
+      final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression(expression);
+      assertThat(processor.evaluateArrayOfStringsExpression(parsedExpression, -1L))
+          .isRight()
+          .extracting(Either::get)
+          .isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("notArrayOfStringsExpressions")
+    void testFailingEvaluations(final String expression, final String message) {
+      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, EMPTY_LOOKUP);
+      final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression(expression);
+      assertThat(processor.evaluateArrayOfStringsExpression(parsedExpression, -1L))
+          .isLeft()
+          .extracting(Either::getLeft)
+          .extracting(Failure::getMessage)
+          .isEqualTo(message);
+    }
+
+    Stream<Arguments> arrayOfStringsExpressions() {
+      return Stream.of(
+          Arguments.of("= []", List.of()),
+          Arguments.of("= [\"a\"]", List.of("a")),
+          Arguments.of("= [\"a\",\"b\"]", List.of("a", "b")),
+          // todo: move the arguments below to notArrayOfStringsExpressions once we find a better
+          //  implementation to check each of the elements in the list to be of type string
+          Arguments.of("= [1,2,3]", List.of("1", "2", "3")),
+          Arguments.of("= [{},{}]", List.of("{}", "{}")),
+          Arguments.of("= [null]", List.of("null")));
+    }
+
+    Stream<Arguments> notArrayOfStringsExpressions() {
+      return Stream.of(
+          Arguments.of(
+              "= \"a\"",
+              "Expected result of the expression ' \"a\"' to be 'ARRAY', but was 'STRING'."),
+          Arguments.of(
+              "= 1", "Expected result of the expression ' 1' to be 'ARRAY', but was 'NUMBER'."),
+          Arguments.of(
+              "= {}", "Expected result of the expression ' {}' to be 'ARRAY', but was 'OBJECT'."),
+          Arguments.of(
+              "[]", "Expected result of the expression '[]' to be 'ARRAY', but was 'STRING'."));
+    }
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/EitherAssert.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/EitherAssert.java
@@ -27,4 +27,12 @@ public final class EitherAssert<L, R>
 
     return myself;
   }
+
+  public EitherAssert<L, R> isLeft() {
+    if (actual.isRight()) {
+      failWithMessage("Expected <%s> to be left, but was right <%s>", actual, actual.get());
+    }
+
+    return myself;
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Adds the evaluation of `candidateGroups` expressions to the activation of user tasks. An unsuccessful evaluation results in a resolvable incident. A successfully evaluated `candidateGroups` expression is written into the custom headers of the corresponding job. This value must be evaluated as a list of strings and is written as a string-representation of a list of strings.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8055

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
