### PR TITLE
Expose Broker API to step down if not leader 

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/primitive/partition/PartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/primitive/partition/PartitionGroup.java
@@ -37,6 +37,14 @@ public interface PartitionGroup extends Configured<PartitionGroupConfig> {
   String name();
 
   /**
+   * Returns a partition by ID. Assumes that the partition ID belongs to this group.
+   *
+   * @param partitionId the partition identifier
+   * @return the partition or {@code null} if no partition with the given identifier exists
+   */
+  Partition getPartition(int partitionId);
+
+  /**
    * Returns a partition by ID.
    *
    * @param partitionId the partition identifier

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -113,6 +113,11 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
   }
 
   @Override
+  public RaftPartition getPartition(final int partitionId) {
+    return getPartition(PartitionId.from(name, partitionId));
+  }
+
+  @Override
   public RaftPartition getPartition(final PartitionId partitionId) {
     return partitions.get(partitionId);
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/AdminApiServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/AdminApiServiceStep.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
+import io.camunda.zeebe.util.sched.ConcurrencyControl;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+
+public class AdminApiServiceStep extends AbstractBrokerStartupStep {
+
+  @Override
+  public String getName() {
+    return "Admin API";
+  }
+
+  @Override
+  void startupInternal(
+      final BrokerStartupContext brokerStartupContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> startupFuture) {
+    final var schedulingService = brokerStartupContext.getActorSchedulingService();
+    final var transport = brokerStartupContext.getCommandApiServerTransport();
+    final var handler = new AdminApiRequestHandler(transport);
+
+    concurrencyControl.runOnCompletion(
+        schedulingService.submitActor(handler),
+        proceed(
+            () -> {
+              if (brokerStartupContext.getAdminApiService() == null) {
+                brokerStartupContext.addPartitionListener(handler);
+                brokerStartupContext.setAdminApiService(handler);
+              }
+              startupFuture.complete(brokerStartupContext);
+            },
+            startupFuture));
+  }
+
+  @Override
+  void shutdownInternal(
+      final BrokerStartupContext brokerShutdownContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> shutdownFuture) {
+    final var service = brokerShutdownContext.getAdminApiService();
+    if (service == null) {
+      shutdownFuture.complete(brokerShutdownContext);
+      return;
+    }
+    concurrencyControl.runOnCompletion(
+        service.closeAsync(),
+        proceed(
+            () -> {
+              brokerShutdownContext.setAdminApiService(null);
+              shutdownFuture.complete(brokerShutdownContext);
+            },
+            shutdownFuture));
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/AdminApiServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/AdminApiServiceStep.java
@@ -32,7 +32,6 @@ public class AdminApiServiceStep extends AbstractBrokerStartupStep {
         proceed(
             () -> {
               if (brokerStartupContext.getAdminApiService() == null) {
-                brokerStartupContext.addPartitionListener(handler);
                 brokerStartupContext.setAdminApiService(handler);
               }
               startupFuture.complete(brokerStartupContext);

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.broker.system.management.LeaderManagementRequestHandler;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
+import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
@@ -68,6 +69,10 @@ public interface BrokerStartupContext {
   CommandApiServiceImpl getCommandApiService();
 
   void setCommandApiService(CommandApiServiceImpl commandApiService);
+
+  AdminApiRequestHandler getAdminApiService();
+
+  void setAdminApiService(AdminApiRequestHandler adminApiService);
 
   AtomixServerTransport getCommandApiServerTransport();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.broker.system.management.LeaderManagementRequestHandler;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
+import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
@@ -51,6 +52,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private AtomixServerTransport commandApiServerTransport;
   private ManagedMessagingService commandApiMessagingService;
   private CommandApiServiceImpl commandApiService;
+  private AdminApiRequestHandler adminApiService;
   private SubscriptionApiCommandMessageHandlerService subscriptionApiService;
   private EmbeddedGatewayService embeddedGatewayService;
   private LeaderManagementRequestHandler leaderManagementRequestHandler;
@@ -161,6 +163,16 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public void setCommandApiService(final CommandApiServiceImpl commandApiService) {
     this.commandApiService = commandApiService;
+  }
+
+  @Override
+  public AdminApiRequestHandler getAdminApiService() {
+    return adminApiService;
+  }
+
+  @Override
+  public void setAdminApiService(final AdminApiRequestHandler adminApiService) {
+    this.adminApiService = adminApiService;
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -57,6 +57,7 @@ public final class BrokerStartupProcess {
 
     result.add(new ApiMessagingServiceStep());
     result.add(new CommandApiServiceStep());
+    result.add(new AdminApiServiceStep());
     result.add(new SubscriptionApiStep());
     result.add(new LeaderManagementRequestHandlerStep());
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -55,6 +55,9 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
                                   () ->
                                       forwardExceptions(
                                           () -> {
+                                            final var adminApi =
+                                                brokerStartupContext.getAdminApiService();
+                                            adminApi.injectPartitionManager(partitionManager);
                                             final var adminService =
                                                 brokerStartupContext.getBrokerAdminService();
                                             adminService.injectAdminAccess(

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
@@ -56,8 +56,7 @@ public final class ErrorResponseWriter implements BufferWriter {
     this.output = output;
   }
 
-  public <T> ErrorResponseWriter unsupportedMessage(
-      final String actualType, final T... expectedTypes) {
+  public <T> ErrorResponseWriter unsupportedMessage(final T actualType, final T... expectedTypes) {
     return errorCode(ErrorCode.UNSUPPORTED_MESSAGE)
         .errorMessage(
             String.format(UNSUPPORTED_MESSAGE_FORMAT, Arrays.toString(expectedTypes), actualType));

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
@@ -54,7 +54,7 @@ public class AdminApiRequestHandler extends ApiRequestHandler<ApiRequestReader, 
       return Either.left(errorWriter);
     }
     final var partition = partitionGroup.getPartition(partitionId);
-    partition.stepDownIfNotPrimary().join();
+    partition.stepDownIfNotPrimary();
 
     return Either.right(responseWriter);
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
@@ -53,8 +53,7 @@ public class AdminApiRequestHandler extends ApiRequestHandler<ApiRequestReader, 
       errorWriter.partitionLeaderMismatch(partitionId);
       return Either.left(errorWriter);
     }
-    final var fullPartitionId = new PartitionId(partitionGroup.name(), partitionId);
-    final var partition = partitionGroup.getPartition(fullPartitionId);
+    final var partition = partitionGroup.getPartition(partitionId);
     partition.stepDownIfNotPrimary().join();
 
     return Either.right(responseWriter);

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.adminapi;
+
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.raft.partition.RaftPartitionGroup;
+import io.camunda.zeebe.broker.PartitionListener;
+import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
+import io.camunda.zeebe.broker.transport.ApiRequestHandler;
+import io.camunda.zeebe.broker.transport.ErrorResponseWriter;
+import io.camunda.zeebe.engine.state.QueryService;
+import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.protocol.record.AdminRequestType;
+import io.camunda.zeebe.transport.RequestType;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+
+public class AdminApiRequestHandler extends ApiRequestHandler<ApiRequestReader, ApiResponseWriter>
+    implements PartitionListener {
+  private RaftPartitionGroup partitionGroup;
+  private final AtomixServerTransport transport;
+
+  public AdminApiRequestHandler(final AtomixServerTransport transport) {
+    super(new ApiRequestReader(), new ApiResponseWriter());
+    this.transport = transport;
+  }
+
+  @Override
+  protected Either<ErrorResponseWriter, ApiResponseWriter> handle(
+      final int partitionId,
+      final long requestId,
+      final ApiRequestReader requestReader,
+      final ApiResponseWriter responseWriter,
+      final ErrorResponseWriter errorWriter) {
+    if (requestReader.getMessageDecoder().type() == AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY) {
+      return stepDownIfNotLeader(responseWriter, partitionId, errorWriter);
+    }
+    return unknownRequest(errorWriter, requestReader.getMessageDecoder().type());
+  }
+
+  private Either<ErrorResponseWriter, ApiResponseWriter> unknownRequest(
+      final ErrorResponseWriter errorWriter, final AdminRequestType type) {
+    errorWriter.unsupportedMessage(type, AdminRequestType.values());
+    return Either.left(errorWriter);
+  }
+
+  private Either<ErrorResponseWriter, ApiResponseWriter> stepDownIfNotLeader(
+      final ApiResponseWriter responseWriter,
+      final int partitionId,
+      final ErrorResponseWriter errorWriter) {
+    if (partitionGroup == null) {
+      errorWriter.partitionLeaderMismatch(partitionId);
+      return Either.left(errorWriter);
+    }
+    final var fullPartitionId = new PartitionId(partitionGroup.name(), partitionId);
+    final var partition = partitionGroup.getPartition(fullPartitionId);
+    partition.stepDownIfNotPrimary().join();
+
+    return Either.right(responseWriter);
+  }
+
+  @Override
+  public ActorFuture<Void> onBecomingFollower(final int partitionId, final long term) {
+    return transport.unsubscribe(partitionId);
+  }
+
+  @Override
+  public ActorFuture<Void> onBecomingLeader(
+      final int partitionId,
+      final long term,
+      final LogStream logStream,
+      final QueryService queryService) {
+    return transport.subscribe(partitionId, RequestType.ADMIN, this);
+  }
+
+  @Override
+  public ActorFuture<Void> onBecomingInactive(final int partitionId, final long term) {
+    return transport.unsubscribe(partitionId);
+  }
+
+  public void injectPartitionManager(final PartitionManagerImpl partitionManager) {
+    partitionGroup = (RaftPartitionGroup) partitionManager.getPartitionGroup();
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
@@ -34,7 +34,7 @@ public class AdminApiRequestHandler extends ApiRequestHandler<ApiRequestReader, 
       final ApiResponseWriter responseWriter,
       final ErrorResponseWriter errorWriter) {
     if (requestReader.getMessageDecoder().type() == AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY) {
-      return stepDownIfNotLeader(responseWriter, partitionId, errorWriter);
+      return stepDownIfNotPrimary(responseWriter, partitionId, errorWriter);
     }
     return unknownRequest(errorWriter, requestReader.getMessageDecoder().type());
   }
@@ -45,7 +45,7 @@ public class AdminApiRequestHandler extends ApiRequestHandler<ApiRequestReader, 
     return Either.left(errorWriter);
   }
 
-  private Either<ErrorResponseWriter, ApiResponseWriter> stepDownIfNotLeader(
+  private Either<ErrorResponseWriter, ApiResponseWriter> stepDownIfNotPrimary(
       final ApiResponseWriter responseWriter,
       final int partitionId,
       final ErrorResponseWriter errorWriter) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/ApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/ApiRequestReader.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.adminapi;
+
+import io.camunda.zeebe.broker.transport.ApiRequestHandler.RequestReader;
+import io.camunda.zeebe.protocol.record.AdminRequestDecoder;
+import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
+import org.agrona.DirectBuffer;
+
+public class ApiRequestReader implements RequestReader<AdminRequestDecoder> {
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+  private final AdminRequestDecoder messageDecoder = new AdminRequestDecoder();
+
+  @Override
+  public void reset() {}
+
+  @Override
+  public AdminRequestDecoder getMessageDecoder() {
+    return messageDecoder;
+  }
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    messageDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/ApiResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/ApiResponseWriter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.adminapi;
+
+import io.camunda.zeebe.broker.transport.ApiRequestHandler.ResponseWriter;
+import io.camunda.zeebe.protocol.record.AdminResponseEncoder;
+import io.camunda.zeebe.protocol.record.ExecuteQueryResponseEncoder;
+import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
+import io.camunda.zeebe.transport.ServerOutput;
+import io.camunda.zeebe.transport.impl.ServerResponseImpl;
+import org.agrona.MutableDirectBuffer;
+
+public class ApiResponseWriter implements ResponseWriter {
+  private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final AdminResponseEncoder responseEncoder = new AdminResponseEncoder();
+  private final ServerResponseImpl response = new ServerResponseImpl();
+
+  @Override
+  public void tryWriteResponse(
+      final ServerOutput output, final int partitionId, final long requestId) {
+    try {
+      response.reset().writer(this).setPartitionId(partitionId).setRequestId(requestId);
+      output.sendResponse(response);
+    } finally {
+      reset();
+    }
+  }
+
+  @Override
+  public void reset() {}
+
+  @Override
+  public int getLength() {
+    return MessageHeaderEncoder.ENCODED_LENGTH + ExecuteQueryResponseEncoder.BLOCK_LENGTH;
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, int offset) {
+    headerEncoder.wrap(buffer, offset);
+
+    headerEncoder
+        .blockLength(responseEncoder.sbeBlockLength())
+        .templateId(responseEncoder.sbeTemplateId())
+        .schemaId(responseEncoder.sbeSchemaId())
+        .version(responseEncoder.sbeSchemaVersion());
+
+    offset += headerEncoder.encodedLength();
+
+    responseEncoder.wrap(buffer, offset);
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
@@ -151,7 +151,8 @@ public final class CommandApiServiceImpl extends Actor
 
   private void removeForPartitionId(final int partitionId) {
     limiter.removePartition(partitionId);
-    serverTransport.unsubscribe(partitionId);
+    serverTransport.unsubscribe(partitionId, RequestType.COMMAND);
+    serverTransport.unsubscribe(partitionId, RequestType.QUERY);
   }
 
   @Override

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
 import io.camunda.zeebe.broker.system.management.LeaderManagementRequestHandler;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.camunda.zeebe.util.sched.ActorScheduler;
@@ -83,6 +84,7 @@ class PartitionManagerStepTest {
               Collections.emptyList());
       testBrokerStartupContext.setLeaderManagementRequestHandler(
           mock(LeaderManagementRequestHandler.class, RETURNS_DEEP_STUBS));
+      testBrokerStartupContext.setAdminApiService(mock(AdminApiRequestHandler.class));
       testBrokerStartupContext.setBrokerAdminService(mock(BrokerAdminServiceImpl.class));
       testBrokerStartupContext.setClusterServices(
           mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS));

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
@@ -8,11 +8,10 @@
 package io.camunda.zeebe.broker.transport.adminapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.atomix.primitive.partition.PartitionId;
 import io.atomix.raft.partition.RaftPartition;
 import io.atomix.raft.partition.RaftPartitionGroup;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
@@ -48,7 +47,7 @@ public class AdminApiRequestHandlerTest {
     when(partitionManager.getPartitionGroup()).thenReturn(partitionGroup);
     when(partitionGroup.name()).thenReturn("test");
     when(raftPartition.stepDownIfNotPrimary()).thenReturn(CompletableFuture.completedFuture(null));
-    when(partitionGroup.getPartition(any(PartitionId.class))).thenReturn(raftPartition);
+    when(partitionGroup.getPartition(anyInt())).thenReturn(raftPartition);
     when(partitionManager.getPartitionGroup()).thenReturn(partitionGroup);
     handler = new AdminApiRequestHandler(transport);
     scheduler.submitActor(handler);

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.adminapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.raft.partition.RaftPartition;
+import io.atomix.raft.partition.RaftPartitionGroup;
+import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
+import io.camunda.zeebe.engine.state.QueryService;
+import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.protocol.impl.encoding.AdminRequest;
+import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
+import io.camunda.zeebe.protocol.impl.encoding.ErrorResponse;
+import io.camunda.zeebe.protocol.record.AdminRequestType;
+import io.camunda.zeebe.protocol.record.ErrorCode;
+import io.camunda.zeebe.transport.RequestType;
+import io.camunda.zeebe.transport.ServerOutput;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import io.camunda.zeebe.util.sched.testing.ControlledActorSchedulerRule;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AdminApiRequestHandlerTest {
+  @Rule public final ControlledActorSchedulerRule scheduler = new ControlledActorSchedulerRule();
+  final AtomixServerTransport transport = mock(AtomixServerTransport.class);
+  AdminApiRequestHandler handler;
+
+  @Before
+  public void setup() {
+    final var partitionManager = mock(PartitionManagerImpl.class);
+    final var partitionGroup = mock(RaftPartitionGroup.class);
+    final var raftPartition = mock(RaftPartition.class);
+    when(partitionManager.getPartitionGroup()).thenReturn(partitionGroup);
+    when(partitionGroup.name()).thenReturn("test");
+    when(raftPartition.stepDownIfNotPrimary()).thenReturn(CompletableFuture.completedFuture(null));
+    when(partitionGroup.getPartition(any(PartitionId.class))).thenReturn(raftPartition);
+    when(partitionManager.getPartitionGroup()).thenReturn(partitionGroup);
+    handler = new AdminApiRequestHandler(transport);
+    scheduler.submitActor(handler);
+    handler.injectPartitionManager(partitionManager);
+    handler.onBecomingLeader(0, 0, mock(LogStream.class), mock(QueryService.class));
+    scheduler.workUntilDone();
+  }
+
+  @Test
+  public void shouldRejectRequestWithInvalidType() {
+    // given
+    final var request = new AdminRequest();
+    request.setType(AdminRequestType.NULL_VAL);
+
+    // when
+    final var responseFuture = handleRequest(request);
+
+    // then
+    assertThat(responseFuture)
+        .succeedsWithin(Duration.ofMinutes(1))
+        .matches(Either::isLeft)
+        .matches(Either::isLeft)
+        .extracting(Either::getLeft)
+        .extracting(ErrorResponse::getErrorCode)
+        .isEqualTo(ErrorCode.UNSUPPORTED_MESSAGE);
+  }
+
+  @Test
+  public void shouldInitiateStepdown() {
+    // given
+    final var request = new AdminRequest();
+    request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
+
+    // when
+    final var responseFuture = handleRequest(request);
+
+    // then
+    assertThat(responseFuture).succeedsWithin(Duration.ofMinutes(1)).matches(Either::isRight);
+  }
+
+  @Test
+  public void shouldSubscribeOnBecomingLeader() {
+    // when
+    handler.onBecomingLeader(1, 1, mock(LogStream.class), mock(QueryService.class));
+    scheduler.workUntilDone();
+
+    // then
+    verify(transport).subscribe(1, RequestType.ADMIN, handler);
+  }
+
+  @Test
+  public void shouldUnsubscribeOnBecomingFollower() {
+    // when
+    handler.onBecomingFollower(0, 0);
+    scheduler.workUntilDone();
+
+    // then
+    verify(transport).unsubscribe(0);
+  }
+
+  @Test
+  public void shouldRejectRequestWhenPartitionsAreNotStarted() {
+    // given
+    final var partitionManager = mock(PartitionManagerImpl.class);
+    when(partitionManager.getPartitionGroup())
+        .thenReturn(null); // no partition group available, emulates partitions are not started
+    handler.injectPartitionManager(partitionManager);
+
+    final var request = new AdminRequest();
+    request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
+
+    // when
+    final var responseFuture = handleRequest(request);
+
+    // then
+    assertThat(responseFuture)
+        .succeedsWithin(Duration.ofMinutes(1))
+        .matches(Either::isLeft)
+        .matches(Either::isLeft)
+        .extracting(Either::getLeft)
+        .extracting(ErrorResponse::getErrorCode)
+        .isEqualTo(ErrorCode.PARTITION_LEADER_MISMATCH);
+  }
+
+  private CompletableFuture<Either<ErrorResponse, AdminResponse>> handleRequest(
+      final BufferWriter request) {
+    final var future = new CompletableFuture<Either<ErrorResponse, AdminResponse>>();
+    final ServerOutput serverOutput = createServerOutput(future);
+    final var requestBuffer = new UnsafeBuffer(new byte[request.getLength()]);
+    request.write(requestBuffer, 0);
+    handler.onRequest(serverOutput, 0, 0, requestBuffer, 0, request.getLength());
+    scheduler.workUntilDone();
+    return future;
+  }
+
+  private ServerOutput createServerOutput(
+      final CompletableFuture<Either<ErrorResponse, AdminResponse>> future) {
+    return serverResponse -> {
+      final var buffer = new ExpandableArrayBuffer();
+      serverResponse.write(buffer, 0);
+
+      final var error = new ErrorResponse();
+      if (error.tryWrap(buffer)) {
+        error.wrap(buffer, 0, serverResponse.getLength());
+        future.complete(Either.left(error));
+        return;
+      }
+
+      final var response = new AdminResponse();
+      try {
+        response.wrap(buffer, 0, serverResponse.getLength());
+        future.complete(Either.right(response));
+      } catch (final Exception e) {
+        future.completeExceptionally(e);
+      }
+    };
+  }
+}

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.encoding;
+
+import io.camunda.zeebe.protocol.record.AdminRequestDecoder;
+import io.camunda.zeebe.protocol.record.AdminRequestEncoder;
+import io.camunda.zeebe.protocol.record.AdminRequestType;
+import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
+import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public class AdminRequest implements BufferReader, BufferWriter {
+  private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+  private final AdminRequestEncoder bodyEncoder = new AdminRequestEncoder();
+  private final AdminRequestDecoder bodyDecoder = new AdminRequestDecoder();
+
+  private int partitionId;
+  private AdminRequestType type;
+
+  public AdminRequest reset() {
+    partitionId = AdminRequestEncoder.partitionIdNullValue();
+    type = AdminRequestType.NULL_VAL;
+    return this;
+  }
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    bodyDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
+    partitionId = bodyDecoder.partitionId();
+    type = bodyDecoder.type();
+  }
+
+  @Override
+  public int getLength() {
+    return headerEncoder.encodedLength() + bodyEncoder.sbeBlockLength();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    bodyEncoder
+        .wrapAndApplyHeader(buffer, offset, headerEncoder)
+        .partitionId(partitionId)
+        .type(type);
+  }
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  public void setPartitionId(final int partitionId) {
+    this.partitionId = partitionId;
+  }
+
+  public AdminRequestType getType() {
+    return type;
+  }
+
+  public void setType(final AdminRequestType type) {
+    this.type = type;
+  }
+}

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminResponse.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminResponse.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.encoding;
+
+import io.camunda.zeebe.protocol.record.AdminResponseDecoder;
+import io.camunda.zeebe.protocol.record.AdminResponseEncoder;
+import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
+import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public class AdminResponse implements BufferReader, BufferWriter {
+  private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+
+  private final AdminResponseEncoder bodyEncoder = new AdminResponseEncoder();
+  private final AdminResponseDecoder bodyDecoder = new AdminResponseDecoder();
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    bodyDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
+  }
+
+  @Override
+  public int getLength() {
+    return headerEncoder.encodedLength() + bodyEncoder.sbeBlockLength();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    bodyEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
+  }
+}

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -73,6 +73,10 @@
       <type name="patchVersion" primitiveType="int32"/>
     </composite>
 
+    <enum name="AdminRequestType" encodingType="uint8">
+      <validValue name="STEP_DOWN_IF_NOT_PRIMARY">0</validValue>
+    </enum>
+
   </types>
 
   <!-- L1 General Messages 0 - 99 -->
@@ -111,6 +115,14 @@
 
   <sbe:message name="ExecuteQueryResponse" id="31">
     <data name="bpmnProcessId" id="1" type="varDataEncoding"/>
+  </sbe:message>
+
+  <sbe:message name="AdminRequest" id="40">
+    <field name="partitionId" id="1" type="uint16"/>
+    <field name="type" id="4" type="AdminRequestType"/>
+  </sbe:message>
+
+  <sbe:message name="AdminResponse" id="41">
   </sbe:message>
 
   <!-- L2 Common Messages 200 - 399 -->

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -119,7 +119,7 @@
 
   <sbe:message name="AdminRequest" id="40">
     <field name="partitionId" id="1" type="uint16"/>
-    <field name="type" id="4" type="AdminRequestType"/>
+    <field name="type" id="2" type="AdminRequestType"/>
   </sbe:message>
 
   <sbe:message name="AdminResponse" id="41">

--- a/transport/src/main/java/io/camunda/zeebe/transport/RequestType.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/RequestType.java
@@ -20,6 +20,7 @@ public enum RequestType {
   // Supported request types
   COMMAND("command"),
   QUERY("query"),
+  ADMIN("admin"),
 
   // All other request types are considered unknown
   // This value exists mainly for testing purposes

--- a/transport/src/main/java/io/camunda/zeebe/transport/ServerTransport.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/ServerTransport.java
@@ -27,6 +27,7 @@ public interface ServerTransport extends ServerOutput, AutoCloseable {
    * requests.
    *
    * @param partitionId the partition, from which we should unsubscribe
+   * @param requestType
    */
-  ActorFuture<Void> unsubscribe(int partitionId);
+  ActorFuture<Void> unsubscribe(int partitionId, RequestType requestType);
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
@@ -77,7 +77,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
 
   @Override
   public ActorFuture<Void> unsubscribe(final int partitionId, final RequestType requestType) {
-    return actor.call(() -> removePartition(partitionId));
+    return actor.call(() -> removeRequestHandlers(partitionId, requestType));
   }
 
   private void removePartition(final int partitionId) {

--- a/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
@@ -66,9 +66,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
     return actor.call(
         () -> {
           final var topicName = topicName(partitionId, requestType);
-          if (LOG.isTraceEnabled()) {
-            LOG.trace("Subscribe for topic {}", topicName);
-          }
+          LOG.trace("Subscribe for topic {}", topicName);
           partitionsRequestMap.computeIfAbsent(partitionId, id -> new Long2ObjectHashMap<>());
           messagingService.registerHandler(
               topicName,
@@ -78,7 +76,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
   }
 
   @Override
-  public ActorFuture<Void> unsubscribe(final int partitionId) {
+  public ActorFuture<Void> unsubscribe(final int partitionId, final RequestType requestType) {
     return actor.call(() -> removePartition(partitionId));
   }
 
@@ -86,19 +84,17 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
     // to unsubscribe from the partition, we can simply unsubscribe from all possible request types
     // for that partition id, even if we're not yet subscribed to some
     Arrays.stream(RequestType.values())
-        .forEach(
-            requestType -> {
-              final var topicName = topicName(partitionId, requestType);
-              if (LOG.isTraceEnabled()) {
-                LOG.trace("Unsubscribe from topic {}", topicName);
-              }
-              messagingService.unregisterHandler(topicName);
-            });
-
+        .forEach(requestType -> removeRequestHandlers(partitionId, requestType));
     final var requestMap = partitionsRequestMap.remove(partitionId);
     if (requestMap != null) {
       requestMap.clear();
     }
+  }
+
+  private void removeRequestHandlers(final int partitionId, RequestType requestType) {
+    final var topicName = topicName(partitionId, requestType);
+    LOG.trace("Unsubscribe from topic {}", topicName);
+    messagingService.unregisterHandler(topicName);
   }
 
   private CompletableFuture<byte[]> handleAtomixRequest(

--- a/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
@@ -229,7 +229,7 @@ public class AtomixTransportTest {
         .join();
 
     // when
-    serverTransport.unsubscribe(0).join();
+    serverTransport.unsubscribe(0, RequestType.COMMAND).join();
 
     final var requestFuture =
         clientTransport.sendRequestWithRetry(


### PR DESCRIPTION
## Description

This introduces a new Admin API for the Broker.  The only supported request so far is `STEP_DOWN_IF_NOT_LEADER`. 
The handler has access to the Raft partitions by getting the partition manager injected after partitions are started. 

The handler is a `PartitionListener` so it subscribes and unsubscribes to messages when it transitions between leader, follower and inactive. This is optional behavior and could be removed as the `stepDownIfNotLeader` is a no-op when the broker is not the leader for this partition. 

## Related issues

closes #8224

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
