### PR TITLE
[Backport stable/1.2] fix(raft): notify role change listener only when transition completed

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -344,15 +344,22 @@ public class RaftTest extends ConcurrentTestCase {
   public void testRoleChangeNotificationAfterInitialEntryOnLeader() throws Throwable {
     // given
     final List<RaftServer> servers = createServers(3);
-    final RaftServer leader = getLeader(servers).get();
+    final RaftServer previousLeader = getLeader(servers).get();
+    final long previousLeaderTerm = previousLeader.getTerm();
+
     final CountDownLatch transitionCompleted = new CountDownLatch(1);
+
     servers.forEach(
         server ->
             server.addRoleChangeListener(
-                (role, term) ->
-                    assertLastReadInitialEntry(role, term, server, transitionCompleted)));
+                (role, term) -> {
+                  if (term > previousLeaderTerm) {
+                    assertLastReadInitialEntry(role, term, server, transitionCompleted);
+                  }
+                }));
+
     // when
-    leader.stepDown();
+    previousLeader.stepDown();
 
     // then
     assertTrue(transitionCompleted.await(1000, TimeUnit.SECONDS));
@@ -468,7 +475,7 @@ public class RaftTest extends ConcurrentTestCase {
         s ->
             s.addRoleChangeListener(
                 (role, term) -> {
-                  if (role == Role.LEADER) {
+                  if (role == Role.LEADER && !s.equals(leader)) {
                     newLeaderId.set(s.getContext().getCluster().getLocalMember().memberId());
                     newLeaderElected.countDown();
                   }
@@ -575,6 +582,32 @@ public class RaftTest extends ConcurrentTestCase {
     // then
     // no response for previous poll requests, so send them again
     verify(followerServer, timeout(5000).atLeast(2)).poll(any(), any());
+  }
+
+  @Test
+  public void shouldNotifyListenerWhenNoTransitionIsOngoing() throws Throwable {
+    // given
+    final var listenerLatch = new CountDownLatch(1);
+    final AtomicReference<Role> roleWithinListener = new AtomicReference<>(null);
+    final AtomicLong termWithinListener = new AtomicLong(-1L);
+
+    final var server = createServers(1).get(0);
+
+    // expect
+    assertThat(server.isLeader()).isTrue();
+
+    // when
+    server.addRoleChangeListener(
+        (role, term) -> {
+          roleWithinListener.set(role);
+          termWithinListener.set(term);
+          listenerLatch.countDown();
+        });
+
+    // then
+    assertThat(listenerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+    assertThat(roleWithinListener.get()).isEqualTo(server.getRole());
+    assertThat(termWithinListener.get()).isEqualTo(server.getTerm());
   }
 
   private void appendEntries(final RaftServer leader, final int count) {

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -163,11 +163,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -129,10 +129,10 @@ public final class ZeebePartition extends Actor
 
                 context = transitionContext.getPartitionContext();
 
-                registerListenersAndTriggerRoleChange();
+                registerListeners();
               });
     } else {
-      registerListenersAndTriggerRoleChange();
+      registerListeners();
     }
   }
 
@@ -312,10 +312,9 @@ public final class ZeebePartition extends Actor
     return inactiveTransitionFuture;
   }
 
-  private void registerListenersAndTriggerRoleChange() {
+  private void registerListeners() {
     context.getRaftPartition().addRoleChangeListener(this);
     context.getComponentHealthMonitor().addFailureListener(this);
-    onRoleChange(context.getRaftPartition().getRole(), context.getRaftPartition().term());
     context.getRaftPartition().getServer().addSnapshotReplicationListener(this);
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -180,6 +180,7 @@ public class ZeebePartitionTest {
 
     // when
     schedulerRule.submitActor(partition);
+    partition.onNewRole(Role.FOLLOWER, 0);
     schedulerRule.workUntilDone();
     assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 
@@ -207,6 +208,7 @@ public class ZeebePartitionTest {
 
     // when
     schedulerRule.submitActor(partition);
+    partition.onNewRole(raft.getRole(), raft.term());
     schedulerRule.workUntilDone();
     assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTransitionIntegrationTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTransitionIntegrationTest.java
@@ -70,7 +70,6 @@ public class ZeebePartitionTransitionIntegrationTest {
 
     // then
     final InOrder inOrder = Mockito.inOrder(transition);
-    inOrder.verify(transition).toInactive();
     inOrder.verify(transition).toLeader(1);
     inOrder.verify(transition).toFollower(1);
     inOrder.verify(transition).toInactive();


### PR DESCRIPTION
## Description

backports #8285

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #7862

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
