### PR TITLE
Fix NPE

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -100,8 +100,8 @@ public final class Broker implements AutoCloseable {
     try {
       brokerContext = brokerStartupActor.start().join();
 
-      startFuture.complete(this);
       healthCheckService.setBrokerStarted();
+      startFuture.complete(this);
     } catch (final Exception bootStrapException) {
       final BrokerCfg brokerCfg = getConfig();
       LOG.error(


### PR DESCRIPTION
## Description
The NPE could occur because it is possible to interrupt the startup procedure. When the startup procedure is interrupted, it finishes executing the current startup step, then aborts startup.
After startup is aborted, the shutdown commences, which - among others - sets the `healthCheckService` to null.

This led to a race condition where the `healthCheckService` was set to null before we could call it to set the broker as started.

Switching the order of statements fixes this race condition.

<!-- Please explain the changes you made here. -->

## Related issues

closes #8311

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
