### PR TITLE
fix(gtw/jobs): ignore notifications if already scheduled

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.gateway.Loggers;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
 import java.util.LinkedList;
 import java.util.Queue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 
 public final class InFlightLongPollingActivateJobsRequestsState {
@@ -25,6 +26,8 @@ public final class InFlightLongPollingActivateJobsRequestsState {
   private final Queue<LongPollingActivateJobsRequest> pendingRequests = new LinkedList<>();
   private int failedAttempts;
   private long lastUpdatedTime;
+
+  private AtomicBoolean ongoingNotification = new AtomicBoolean(false);
 
   public InFlightLongPollingActivateJobsRequestsState(
       final String jobType, final LongPollingMetrics metrics) {
@@ -113,5 +116,13 @@ public final class InFlightLongPollingActivateJobsRequestsState {
    */
   public boolean shouldBeRepeated(final LongPollingActivateJobsRequest request) {
     return activeRequestsToBeRepeated.contains(request);
+  }
+
+  public boolean shouldNotifyAndStartNotification() {
+    return ongoingNotification.compareAndSet(false, true);
+  }
+
+  public void completeNotification() {
+    ongoingNotification.set(false);
   }
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -22,10 +22,10 @@ import io.camunda.zeebe.util.sched.Actor;
 import io.camunda.zeebe.util.sched.ScheduledTimer;
 import io.grpc.protobuf.StatusProto;
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 
 /**
@@ -44,7 +44,7 @@ public final class LongPollingActivateJobsHandler extends Actor implements Activ
 
   // jobType -> state
   private final Map<String, InFlightLongPollingActivateJobsRequestsState> jobTypeState =
-      new HashMap<>();
+      new ConcurrentHashMap<>();
   private final Duration longPollingTimeout;
   private final long probeTimeoutMillis;
   private final int failedAttemptThreshold;
@@ -127,7 +127,20 @@ public final class LongPollingActivateJobsHandler extends Actor implements Activ
   private void onNotification(final String jobType) {
     LOG.trace("Received jobs available notification for type {}.", jobType);
 
-    actor.run(() -> resetFailedAttemptsAndHandlePendingRequests(jobType));
+    // instead of calling #getJobTypeState(), do only a
+    // get to avoid the creation of a state instance.
+    final var state = jobTypeState.get(jobType);
+
+    if (state != null && state.shouldNotifyAndStartNotification()) {
+      LOG.trace("Handle jobs available notification for type {}.", jobType);
+      actor.run(
+          () -> {
+            resetFailedAttemptsAndHandlePendingRequests(jobType);
+            state.completeNotification();
+          });
+    } else {
+      LOG.trace("Ignore jobs available notification for type {}.", jobType);
+    }
   }
 
   private void onCompleted(


### PR DESCRIPTION
## Description

* Ignore incoming notifications if a notification is already scheduled/running for the given job type
* Changes the type from `HashMap` to `ConcurrentHashMap` of field `LongPollingActivateJobsHandler#jobTypeState` because it is accessed by different threads
  * Actor Thread who does reads and updates to the map
  * "Netty Threads" who notifies the gateway when newly jobs are available

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8267 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
