### PR TITLE
Gateway API for rebalancing the cluster

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/SpringBrokerBridge.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/SpringBrokerBridge.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker;
 
 import io.camunda.zeebe.broker.system.management.BrokerAdminService;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.springframework.stereotype.Component;
@@ -22,6 +23,7 @@ public class SpringBrokerBridge {
 
   private Supplier<BrokerHealthCheckService> healthCheckServiceSupplier;
   private Supplier<BrokerAdminService> adminServiceSupplier;
+  private Supplier<BrokerClient> brokerClient;
 
   public void registerBrokerHealthCheckServiceSupplier(
       final Supplier<BrokerHealthCheckService> healthCheckServiceSupplier) {
@@ -39,5 +41,13 @@ public class SpringBrokerBridge {
 
   public Optional<BrokerAdminService> getAdminService() {
     return Optional.ofNullable(adminServiceSupplier).map(Supplier::get);
+  }
+
+  public void registerBrokerClient(final Supplier<BrokerClient> brokerClient) {
+    this.brokerClient = brokerClient;
+  }
+
+  public Optional<BrokerClient> getBrokerClient() {
+    return Optional.ofNullable(brokerClient).map(Supplier::get);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
@@ -37,6 +37,10 @@ class EmbeddedGatewayServiceStep extends AbstractBrokerStartupStep {
 
     brokerStartupContext.setEmbeddedGatewayService(embeddedGatewayService);
 
+    final var springBridge = brokerStartupContext.getSpringBrokerBridge();
+    final var gateway = embeddedGatewayService.get();
+    springBridge.registerBrokerClient(gateway::getBrokerClient);
+
     startupFuture.complete(brokerStartupContext);
   }
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -197,6 +197,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/dist/src/main/java/io/camunda/zeebe/broker/management/BrokerRebalancingService.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/management/BrokerRebalancingService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.management;
+
+import io.camunda.zeebe.broker.SpringBrokerBridge;
+import io.camunda.zeebe.gateway.admin.BrokerAdminRequest;
+import io.camunda.zeebe.shared.management.RebalancingService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public final class BrokerRebalancingService implements RebalancingService {
+
+  private final SpringBrokerBridge bridge;
+
+  @Autowired
+  public BrokerRebalancingService(final SpringBrokerBridge bridge) {
+    this.bridge = bridge;
+  }
+
+  @Override
+  public void rebalanceCluster() {
+    final var client =
+        bridge.getBrokerClient().orElseThrow(() -> new IllegalStateException("No broker client"));
+    client
+        .getTopologyManager()
+        .getTopology()
+        .getPartitions()
+        .forEach(
+            (partition) -> {
+              final var request = new BrokerAdminRequest();
+              request.setPartitionId(partition);
+              request.stepDownIfNotPrimary();
+              client.sendRequest(request);
+            });
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/broker/management/BrokerRebalancingService.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/management/BrokerRebalancingService.java
@@ -26,7 +26,9 @@ public final class BrokerRebalancingService implements RebalancingService {
   @Override
   public void rebalanceCluster() {
     final var client =
-        bridge.getBrokerClient().orElseThrow(() -> new IllegalStateException("No broker client"));
+        bridge
+            .getBrokerClient()
+            .orElseThrow(() -> new IllegalStateException("No broker client available"));
     client
         .getTopologyManager()
         .getTopology()

--- a/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
@@ -98,6 +98,7 @@ public class StandaloneGateway
     actorScheduler = createActorScheduler(configuration);
     gateway = new Gateway(configuration, this::createBrokerClient, actorScheduler);
 
+    springGatewayBridge.registerBrokerClientSupplier(gateway::getBrokerClient);
     springGatewayBridge.registerGatewayStatusSupplier(gateway::getStatus);
     springGatewayBridge.registerClusterStateSupplier(
         () ->

--- a/dist/src/main/java/io/camunda/zeebe/gateway/management/GatewayRebalancingService.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/management/GatewayRebalancingService.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.management;
+
+import io.camunda.zeebe.gateway.admin.BrokerAdminRequest;
+import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
+import io.camunda.zeebe.shared.management.RebalancingService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public final class GatewayRebalancingService implements RebalancingService {
+
+  private final SpringGatewayBridge bridge;
+
+  @Autowired
+  public GatewayRebalancingService(final SpringGatewayBridge bridge) {
+    this.bridge = bridge;
+  }
+
+  @Override
+  public void rebalanceCluster() {
+    final var client =
+        bridge
+            .getBrokerClient()
+            .orElseThrow(() -> new IllegalStateException("No broker client available"));
+    client
+        .getTopologyManager()
+        .getTopology()
+        .getPartitions()
+        .forEach(
+            (partition) -> {
+              final var request = new BrokerAdminRequest();
+              request.setPartitionId(partition);
+              request.stepDownIfNotPrimary();
+              client.sendRequest(request);
+            });
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/RebalancingEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/RebalancingEndpoint.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared.management;
+
+import io.camunda.zeebe.gateway.Loggers;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
+import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@WebEndpoint(id = "rebalance")
+public final class RebalancingEndpoint {
+  private static final Logger LOG = Loggers.GATEWAY_LOGGER;
+
+  private final RebalancingService service;
+
+  @Autowired
+  public RebalancingEndpoint(final RebalancingService service) {
+    this.service = service;
+  }
+
+  @WriteOperation
+  public WebEndpointResponse<Void> rebalance() {
+    LOG.info("Rebalancing leaders of all partitions");
+    service.rebalanceCluster();
+    return new WebEndpointResponse<>();
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/RebalancingService.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/RebalancingService.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared.management;
+
+public interface RebalancingService {
+  void rebalanceCluster();
+}

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/RebalancingEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/RebalancingEndpointTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared.management;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.broker.SpringBrokerBridge;
+import io.camunda.zeebe.broker.management.BrokerRebalancingService;
+import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
+import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
+import io.camunda.zeebe.gateway.management.GatewayRebalancingService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+final class RebalancingEndpointTest {
+
+  @Test
+  void standaloneGatewaySendsRequestToAllPartitions() {
+    // given
+    final var partitions = List.of(1, 2, 3, 4, 5);
+    final var client = setupBrokerClient(partitions);
+    final var bridge = mock(SpringGatewayBridge.class);
+
+    when(bridge.getBrokerClient()).thenReturn(Optional.of(client));
+
+    final var service = new GatewayRebalancingService(bridge);
+    final var endpoint = new RebalancingEndpoint(service);
+
+    // when
+    endpoint.rebalance();
+
+    // then
+    verify(client, times(partitions.size())).sendRequest(any());
+  }
+
+  @Test
+  void embeddedGatewaySendsRequestToAllPartitions() {
+    // given
+    final var partitions = List.of(1, 2, 3, 4, 5);
+    final var client = setupBrokerClient(partitions);
+
+    final var bridge = mock(SpringBrokerBridge.class);
+
+    when(bridge.getBrokerClient()).thenReturn(Optional.of(client));
+
+    final var service = new BrokerRebalancingService(bridge);
+    final var endpoint = new RebalancingEndpoint(service);
+
+    // when
+    endpoint.rebalance();
+
+    // then
+    verify(client, times(partitions.size())).sendRequest(any());
+  }
+
+  private BrokerClient setupBrokerClient(final List<Integer> partitions) {
+    final var client = mock(BrokerClient.class);
+    final var topology = mock(BrokerClusterState.class);
+    final var topologyManager = mock(BrokerTopologyManager.class);
+
+    when(topology.getPartitions()).thenReturn(partitions);
+    when(topologyManager.getTopology()).thenReturn(topology);
+    when(client.getTopologyManager()).thenReturn(topologyManager);
+    return client;
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.admin;
+
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerRequest;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.camunda.zeebe.protocol.impl.encoding.AdminRequest;
+import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
+import io.camunda.zeebe.protocol.record.AdminRequestType;
+import io.camunda.zeebe.protocol.record.AdminResponseEncoder;
+import io.camunda.zeebe.transport.RequestType;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public class BrokerAdminRequest extends BrokerRequest<Void> {
+  private final AdminRequest request = new AdminRequest();
+  private final AdminResponse response = new AdminResponse();
+
+  public BrokerAdminRequest() {
+    super(AdminResponseEncoder.SCHEMA_ID, AdminResponseEncoder.TEMPLATE_ID);
+  }
+
+  public void stepDownIfNotPrimary() {
+    request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
+  }
+
+  @Override
+  public int getPartitionId() {
+    return request.getPartitionId();
+  }
+
+  @Override
+  public void setPartitionId(final int partitionId) {
+    request.setPartitionId(partitionId);
+  }
+
+  @Override
+  public boolean addressesSpecificPartition() {
+    return true;
+  }
+
+  @Override
+  public boolean requiresPartitionId() {
+    return true;
+  }
+
+  /** @return null to avoid writing any serialized value */
+  @Override
+  public BufferWriter getRequestWriter() {
+    return null;
+  }
+
+  @Override
+  protected void setSerializedValue(final DirectBuffer buffer) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected void wrapResponse(final DirectBuffer buffer) {
+    response.wrap(buffer, 0, buffer.capacity());
+  }
+
+  @Override
+  protected BrokerResponse<Void> readResponse() {
+    return new BrokerResponse<>(null);
+  }
+
+  @Override
+  protected Void toResponseDto(final DirectBuffer buffer) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getType() {
+    return "Admin#" + request.getType();
+  }
+
+  @Override
+  public RequestType getRequestType() {
+    return RequestType.ADMIN;
+  }
+
+  @Override
+  public int getLength() {
+    return request.getLength();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    request.write(buffer, offset);
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridge.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridge.java
@@ -39,11 +39,7 @@ public class SpringGatewayBridge {
   }
 
   public Optional<Status> getGatewayStatus() {
-    if (gatewayStatusSupplier != null) {
-      return Optional.of(gatewayStatusSupplier.get());
-    } else {
-      return Optional.empty();
-    }
+    return Optional.ofNullable(gatewayStatusSupplier).map(Supplier::get);
   }
 
   public Optional<BrokerClusterState> getClusterState() {
@@ -51,10 +47,6 @@ public class SpringGatewayBridge {
   }
 
   public Optional<BrokerClient> getBrokerClient() {
-    if (brokerClientSupplier != null) {
-      return Optional.of(brokerClientSupplier.get());
-    } else {
-      return Optional.empty();
-    }
+    return Optional.ofNullable(brokerClientSupplier).map(Supplier::get);
   }
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridge.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridge.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.impl;
 
 import io.camunda.zeebe.gateway.health.Status;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -22,6 +23,7 @@ public class SpringGatewayBridge {
 
   private Supplier<Status> gatewayStatusSupplier;
   private Supplier<Optional<BrokerClusterState>> clusterStateSupplier;
+  private Supplier<BrokerClient> brokerClientSupplier;
 
   public void registerGatewayStatusSupplier(final Supplier<Status> gatewayStatusSupplier) {
     this.gatewayStatusSupplier = gatewayStatusSupplier;
@@ -30,6 +32,10 @@ public class SpringGatewayBridge {
   public void registerClusterStateSupplier(
       final Supplier<Optional<BrokerClusterState>> clusterStateSupplier) {
     this.clusterStateSupplier = clusterStateSupplier;
+  }
+
+  public void registerBrokerClientSupplier(final Supplier<BrokerClient> brokerClientSupplier) {
+    this.brokerClientSupplier = brokerClientSupplier;
   }
 
   public Optional<Status> getGatewayStatus() {
@@ -42,5 +48,13 @@ public class SpringGatewayBridge {
 
   public Optional<BrokerClusterState> getClusterState() {
     return Optional.ofNullable(clusterStateSupplier).flatMap(Supplier::get);
+  }
+
+  public Optional<BrokerClient> getBrokerClient() {
+    if (brokerClientSupplier != null) {
+      return Optional.of(brokerClientSupplier.get());
+    } else {
+      return Optional.empty();
+    }
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/RebalancingEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/RebalancingEndpointIT.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.PartitionInfo;
+import io.camunda.zeebe.test.util.testcontainers.ZeebeTestContainerDefaults;
+import io.zeebe.containers.cluster.ZeebeCluster;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Network;
+
+final class RebalancingEndpointIT {
+  private final Network network = Network.newNetwork();
+
+  private final ZeebeCluster cluster =
+      ZeebeCluster.builder()
+          .withImage(ZeebeTestContainerDefaults.defaultTestImage())
+          .withEmbeddedGateway(true)
+          .withBrokersCount(3)
+          .withPartitionsCount(3)
+          .withReplicationFactor(3)
+          .withNetwork(network)
+          .build();
+
+  private ZeebeClient client;
+
+  @BeforeEach
+  void setup() {
+    cluster.start();
+    client = cluster.newClientBuilder().build();
+  }
+
+  @AfterEach
+  void teardown() {
+    cluster.stop();
+  }
+
+  @Test
+  void shouldRebalanceCluster() throws IOException, InterruptedException {
+    // given
+    badLeaderDistribution();
+
+    // when
+    triggerRebalancing();
+
+    // then
+    reachesGoodLeaderDistribution();
+  }
+
+  private void triggerRebalancing() throws IOException, InterruptedException {
+    final var gateway = cluster.getGateways().values().stream().findFirst().orElseThrow();
+    final var monitoringAddress = gateway.getExternalMonitoringAddress();
+    final var httpClient = HttpClient.newHttpClient();
+    final var request =
+        HttpRequest.newBuilder()
+            .POST(BodyPublishers.noBody())
+            .uri(URI.create("http://" + monitoringAddress + "/actuator/rebalance"))
+            .build();
+    final var response = httpClient.send(request, BodyHandlers.discarding());
+    assertThat(response.statusCode()).isEqualTo(200);
+  }
+
+  private void badLeaderDistribution() {
+    cluster.getBrokers().get(1).stop();
+    cluster.getBrokers().get(1).start();
+    waitForBadDistribution();
+  }
+
+  private void waitForBadDistribution() {
+    Awaitility.await("At least one broker is leader for more than one partition")
+        .timeout(Duration.ofSeconds(30))
+        .during(Duration.ofSeconds(10))
+        .until(
+            () ->
+                client.newTopologyRequest().send().join().getBrokers().stream()
+                    .anyMatch(
+                        brokerInfo ->
+                            brokerInfo.getPartitions().stream()
+                                    .filter(PartitionInfo::isLeader)
+                                    .count()
+                                > 1));
+  }
+
+  private void reachesGoodLeaderDistribution() {
+    Awaitility.await("All brokers are leader for exactly one partition")
+        .timeout(Duration.ofSeconds(30))
+        .during(Duration.ofSeconds(10))
+        .until(
+            () ->
+                client.newTopologyRequest().send().join().getBrokers().stream()
+                    .allMatch(
+                        brokerInfo ->
+                            brokerInfo.getPartitions().stream()
+                                    .filter(PartitionInfo::isLeader)
+                                    .count()
+                                == 1));
+  }
+}


### PR DESCRIPTION
## Description
Implements the Gateway API to rebalance the cluster by adding a new actuator `/actuator/rebalance` that accepts a POST and asynchronously sends all leaders the `Admin#stepDownIfNotPrimary` message.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8222
closes #8225 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [ ] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
