### PR TITLE
feat(engine): support completion condition for multi-instance

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContainerProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContainerProcessor.java
@@ -77,11 +77,13 @@ public interface BpmnElementContainerProcessor<T extends ExecutableFlowElement>
    * @param flowScopeContext process instance-related data of the element container
    * @param childContext process instance-related data of the child element that is completed. At
    *     this point in time the element has already been removed from the state.
+   * @param satisfiesCompletionCondition the evaluation result of completion condition
    */
   void afterExecutionPathCompleted(
       final T element,
       final BpmnElementContext flowScopeContext,
-      final BpmnElementContext childContext);
+      final BpmnElementContext childContext,
+      final Boolean satisfiesCompletionCondition);
 
   /**
    * A child element is terminated. Terminate the element container if it has no more active child

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -102,7 +102,8 @@ public final class CallActivityProcessor
   public void afterExecutionPathCompleted(
       final ExecutableCallActivity element,
       final BpmnElementContext callActivityContext,
-      final BpmnElementContext childContext) {
+      final BpmnElementContext childContext,
+      final Boolean satisfiesCompletionCondition) {
     final var currentState = callActivityContext.getIntent();
 
     if (currentState == ProcessInstanceIntent.ELEMENT_ACTIVATED) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
@@ -79,7 +79,8 @@ public final class EventSubProcessProcessor
   public void afterExecutionPathCompleted(
       final ExecutableFlowElementContainer element,
       final BpmnElementContext flowScopeContext,
-      final BpmnElementContext childContext) {
+      final BpmnElementContext childContext,
+      final Boolean satisfiesCompletionCondition) {
     if (stateBehavior.canBeCompleted(childContext)) {
       stateTransitionBehavior.completeElement(flowScopeContext);
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -124,7 +124,8 @@ public final class ProcessProcessor
   public void afterExecutionPathCompleted(
       final ExecutableFlowElementContainer element,
       final BpmnElementContext flowScopeContext,
-      final BpmnElementContext childContext) {
+      final BpmnElementContext childContext,
+      final Boolean satisfiesCompletionCondition) {
 
     if (stateBehavior.canBeCompleted(childContext)) {
       stateTransitionBehavior.completeElement(flowScopeContext);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -97,7 +97,8 @@ public final class SubProcessProcessor
   public void afterExecutionPathCompleted(
       final ExecutableFlowElementContainer element,
       final BpmnElementContext flowScopeContext,
-      final BpmnElementContext childContext) {
+      final BpmnElementContext childContext,
+      final Boolean satisfiesCompletionCondition) {
     if (stateBehavior.canBeCompleted(childContext)) {
       stateTransitionBehavior.completeElement(flowScopeContext);
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableLoopCharacteristics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableLoopCharacteristics.java
@@ -15,6 +15,8 @@ public class ExecutableLoopCharacteristics {
 
   private final boolean isSequential;
 
+  private final Optional<Expression> completionCondition;
+
   private final Expression inputCollection;
   private final Optional<DirectBuffer> inputElement;
 
@@ -23,11 +25,13 @@ public class ExecutableLoopCharacteristics {
 
   public ExecutableLoopCharacteristics(
       final boolean isSequential,
+      final Optional<Expression> completionCondition,
       final Expression inputCollection,
       final Optional<DirectBuffer> inputElement,
       final Optional<DirectBuffer> outputCollection,
       final Optional<Expression> outputElement) {
     this.isSequential = isSequential;
+    this.completionCondition = completionCondition;
     this.inputCollection = inputCollection;
     this.inputElement = inputElement;
     this.outputCollection = outputCollection;
@@ -40,6 +44,10 @@ public class ExecutableLoopCharacteristics {
 
   public Expression getInputCollection() {
     return inputCollection;
+  }
+
+  public Optional<Expression> getCompletionCondition() {
+    return completionCondition;
   }
 
   public Optional<DirectBuffer> getInputElement() {
@@ -59,6 +67,8 @@ public class ExecutableLoopCharacteristics {
     return "ExecutableLoopCharacteristics{"
         + "isSequential="
         + isSequential
+        + "completionCondition="
+        + completionCondition
         + ", inputCollection="
         + inputCollection
         + ", inputElement="

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/MultiInstanceActivityTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/MultiInstanceActivityTransformer.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutablePro
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
 import io.camunda.zeebe.model.bpmn.instance.Activity;
+import io.camunda.zeebe.model.bpmn.instance.CompletionCondition;
 import io.camunda.zeebe.model.bpmn.instance.LoopCharacteristics;
 import io.camunda.zeebe.model.bpmn.instance.MultiInstanceLoopCharacteristics;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
@@ -83,6 +84,12 @@ public final class MultiInstanceActivityTransformer implements ModelElementTrans
 
     final boolean isSequential = elementLoopCharacteristics.isSequential();
 
+    final Optional<Expression> completionCondition =
+        Optional.ofNullable(elementLoopCharacteristics.getCompletionCondition())
+            .map(CompletionCondition::getTextContent)
+            .filter(e -> !e.isEmpty())
+            .map(context.getExpressionLanguage()::parseExpression);
+
     final ZeebeLoopCharacteristics zeebeLoopCharacteristics =
         elementLoopCharacteristics.getSingleExtensionElement(ZeebeLoopCharacteristics.class);
 
@@ -107,6 +114,11 @@ public final class MultiInstanceActivityTransformer implements ModelElementTrans
             .map(e -> context.getExpressionLanguage().parseExpression(e));
 
     return new ExecutableLoopCharacteristics(
-        isSequential, inputCollection, inputElement, outputCollection, outputElement);
+        isSequential,
+        completionCondition,
+        inputCollection,
+        inputElement,
+        outputCollection,
+        outputElement);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.validation.ZeebeExpressionValidator.ExpressionVerification;
 import io.camunda.zeebe.model.bpmn.instance.ConditionExpression;
 import io.camunda.zeebe.model.bpmn.instance.Message;
+import io.camunda.zeebe.model.bpmn.instance.MultiInstanceLoopCharacteristics;
 import io.camunda.zeebe.model.bpmn.instance.TimerEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
@@ -122,6 +123,15 @@ public final class ZeebeRuntimeValidators {
                 ZeebeCalledDecision::getDecisionId, ExpressionVerification::isMandatory)
             .build(expressionLanguage),
         // ----------------------------------------
-        new ZeebeTaskHeadersValidator());
+        new ZeebeTaskHeadersValidator(),
+        // ----------------------------------------
+        ZeebeExpressionValidator.verifyThat(MultiInstanceLoopCharacteristics.class)
+            .hasValidExpression(
+                loopCharacteristics ->
+                    loopCharacteristics.getCompletionCondition() != null
+                        ? loopCharacteristics.getCompletionCondition().getTextContent()
+                        : null,
+                ExpressionVerification::isOptional)
+            .build(expressionLanguage));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -14,9 +14,11 @@ import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.VariablesLookup;
+import io.camunda.zeebe.engine.processing.deployment.model.transformer.ExpressionTransformer;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ConditionExpression;
+import io.camunda.zeebe.model.bpmn.instance.MultiInstanceLoopCharacteristics;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
@@ -385,6 +387,20 @@ public final class ZeebeRuntimeValidationTest {
                     RESERVED_TASK_HEADER_KEY,
                     Protocol.RESERVED_HEADER_NAME_PREFIX)))
       },
+      {
+        /* invalid completion condition expression */
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.multiInstance(
+                        m ->
+                            m.completionCondition(
+                                ExpressionTransformer.asFeelExpressionString(INVALID_EXPRESSION))))
+            .done(),
+        List.of(expect(MultiInstanceLoopCharacteristics.class, INVALID_EXPRESSION_MESSAGE))
+      }
     };
   }
 


### PR DESCRIPTION
## Description

Support completion condition expression for multi-instance.

Multi-instance loop-characteristics with a `<completionCondition>` are now used by Zeebe.
Zeebe expects the completion condition to be a FEEL-expression that evaluates to a `boolean`.
Processes that contain an unparsable completion condition are rejected.

The completion condition expression is evaluated each time an instance of a multi-instance element completes.
The expression is expected to evaluate to a boolean, if it doesn't an incident is raised.
The expression is evaluated at the scope of the instance element, not at the scope of the multi-instance element.
If it evaluates to `false`, the normal completion behavior of the multi-instance body is used.
If it evaluates to `true`, any still active child instances of the multi-instance are terminated and the multi-instance element is completed.

## Related issues

closes #5439

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [x] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
