### PR TITLE
Reset last written position

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/LastProcessingPositions.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/LastProcessingPositions.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+/**
+ * Contains positions which are related to the last processing, and are used to restore the
+ * processing state machine.
+ */
+public class LastProcessingPositions {
+
+  /** The last command position, which the processing state machine has processed successfully. */
+  private final long lastProcessedPosition;
+  /** The last written record position on the log. */
+  private final long lastWrittenPosition;
+
+  public LastProcessingPositions(final long lastProcessedPosition, final long lastWrittenPosition) {
+    this.lastProcessedPosition = lastProcessedPosition;
+    this.lastWrittenPosition = lastWrittenPosition;
+  }
+
+  public long getLastProcessedPosition() {
+    return lastProcessedPosition;
+  }
+
+  public long getLastWrittenPosition() {
+    return lastWrittenPosition;
+  }
+
+  @Override
+  public String toString() {
+    return "["
+        + "lastProcessedPosition: "
+        + lastProcessedPosition
+        + ", lastWrittenPosition: "
+        + lastWrittenPosition
+        + ']';
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -446,15 +446,21 @@ public final class ProcessingStateMachine {
     return !onErrorHandlingLoop;
   }
 
-  public void startProcessing(final long lastProcessedPosition) {
+  public void startProcessing(final LastProcessingPositions lastProcessingPositions) {
     // Replay ends at the end of the log and returns the lastSourceEventPosition
     // which is equal to the last processed position
     // we need to seek to the next record after that position where the processing should start
     // Be aware on processing we ignore events, so we will process the next command
+    final var lastProcessedPosition = lastProcessingPositions.getLastProcessedPosition();
     logStreamReader.seekToNextEvent(lastProcessedPosition);
     if (lastSuccessfulProcessedEventPosition == StreamProcessor.UNSET_POSITION) {
       lastSuccessfulProcessedEventPosition = lastProcessedPosition;
     }
+
+    if (lastWrittenEventPosition == StreamProcessor.UNSET_POSITION) {
+      lastWrittenEventPosition = lastProcessingPositions.getLastWrittenPosition();
+    }
+
     actor.submit(this::readNextEvent);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateMachine.java
@@ -38,8 +38,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
 
   private static final Logger LOG = Loggers.PROCESSOR_LOGGER;
 
-  private static final String LOG_STMT_REPLAY_FINISHED =
-      "Processor finished replay at event position {}";
+  private static final String LOG_STMT_REPLAY_FINISHED = "Processor finished replay, with {}";
   private static final String ERROR_INCONSISTENT_LOG =
       "Expected that position '%d' of current event is higher then position '%d' of last event, but was not. Inconsistent log detected!";
   private static final String ERROR_MSG_EXPECTED_TO_READ_METADATA =
@@ -75,7 +74,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
   private long lastReadRecordPosition = StreamProcessor.UNSET_POSITION;
   private long lastReplayedEventPosition = StreamProcessor.UNSET_POSITION;
 
-  private ActorFuture<Long> recoveryFuture;
+  private ActorFuture<LastProcessingPositions> recoveryFuture;
   private ZeebeDbTransaction zeebeDbTransaction;
   private final StreamProcessorMode streamProcessorMode;
   private final LogStream logStream;
@@ -113,7 +112,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
    *
    * @return a ActorFuture with the position of the last processed command
    */
-  ActorFuture<Long> startRecover(final long snapshotPosition) {
+  ActorFuture<LastProcessingPositions> startRecover(final long snapshotPosition) {
     recoveryFuture = new CompletableActorFuture<>();
     this.snapshotPosition = snapshotPosition;
     lastSourceEventPosition =
@@ -230,11 +229,19 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
 
   /**
    * Ends the replay and sets some important properties, especially completes the replay future with
-   * the last source event, which has caused the last applied event.
+   * the last processing positions.
    */
   private void onRecordsReplayed() {
-    LOG.info(LOG_STMT_REPLAY_FINISHED, lastReadRecordPosition);
-    recoveryFuture.complete(lastSourceEventPosition);
+    final var lastProcessingPositions =
+        new LastProcessingPositions(
+            // the last source pos. is the last processed command by the processing state machine
+            lastSourceEventPosition,
+            // the last read position on replay, will be used as the last written for
+            // the processing state machine
+            lastReadRecordPosition);
+
+    LOG.info(LOG_STMT_REPLAY_FINISHED, lastProcessingPositions);
+    recoveryFuture.complete(lastProcessingPositions);
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -368,7 +368,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
           if (isInReplayOnlyMode()) {
             return replayStateMachine.getLastReplayedEventPosition();
           } else {
-            return processingStateMachine.getLastWrittenEventPosition();
+            return processingStateMachine.getLastWrittenPosition();
           }
         });
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -72,7 +72,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private CompletableActorFuture<Void> closeFuture = CompletableActorFuture.completed(null);
   private volatile long lastTickTime;
   private boolean shouldProcess = true;
-  private ActorFuture<Long> replayCompletedFuture;
+  private ActorFuture<LastProcessingPositions> replayCompletedFuture;
 
   protected StreamProcessor(final StreamProcessorBuilder processorBuilder) {
     actorSchedulingService = processorBuilder.getActorSchedulingService();
@@ -152,12 +152,12 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
       } else {
         replayCompletedFuture.onComplete(
-            (lastSourceEventPosition, error) -> {
+            (lastProcessingPositions, error) -> {
               if (error != null) {
                 LOG.error("The replay of events failed.", error);
                 onFailure(error);
               } else {
-                onRecovered(lastSourceEventPosition);
+                onRecovered(lastProcessingPositions);
                 // observe recovery time
                 startRecoveryTimer.close();
               }
@@ -303,7 +303,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     return zeebeState;
   }
 
-  private void onRecovered(final long lastSourceEventPosition) {
+  private void onRecovered(final LastProcessingPositions lastProcessingPositions) {
     phase = Phase.PROCESSING;
 
     // enable writing records to the stream
@@ -313,7 +313,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
     // start reading
     lifecycleAwareListeners.forEach(l -> l.onRecovered(processingContext));
-    processingStateMachine.startProcessing(lastSourceEventPosition);
+    processingStateMachine.startProcessing(lastProcessingPositions);
     if (!shouldProcess) {
       setStateToPausedAndNotifyListeners();
     }


### PR DESCRIPTION
## Description

Previously the last written position was not reset on starting the processing state machine, which could cause weird metric exports, because the gap between lastWritten and newWritten position was to high (over million and more). The replay state machine now returns all positions and initialized the processing state machine with it.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7218 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
