### PR TITLE
chore(broker): omit cancel log message if transition already completed

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -32,6 +32,7 @@ final class PartitionTransitionProcess {
   private final long term;
   private final Role role;
   private boolean cancelRequested = false;
+  private boolean completed = false;
 
   PartitionTransitionProcess(
       final List<PartitionTransitionStep> pendingSteps,
@@ -64,6 +65,7 @@ final class PartitionTransitionProcess {
     if (cancelRequested) {
       LOG.info("Cancelling transition to {} on term {}", role, term);
       future.complete(null);
+      completed = true;
       return;
     }
 
@@ -91,7 +93,7 @@ final class PartitionTransitionProcess {
     if (pendingSteps.isEmpty()) {
       LOG.info("Transition to {} on term {} completed", role, term);
       future.complete(null);
-
+      completed = true;
       return;
     }
 
@@ -153,7 +155,9 @@ final class PartitionTransitionProcess {
   }
 
   void cancel() {
-    LOG.info("Received cancel signal for transition to {} on term {}", role, term);
+    if (!completed) {
+      LOG.info("Received cancel signal for transition to {} on term {}", role, term);
+    }
     cancelRequested = true;
   }
 }


### PR DESCRIPTION
## Description
The cancel message was always logged, regardless of whether the transition had already completed. This made reading logs a little confusing. 

Now, we track whether the transition was completed, and only if it was not completed we log the message.

Hint: currently cancel is always called on the previous transition. Arguably a better fix would be to only call cancel if the transition has not completed yet. However, since we had some issues in this area, I wanted to make a small change for now.

Feel free to reject this, if it's not good enough.

<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
