### PR TITLE
Create a new module for DMN

### DIFF
--- a/dmn/pom.xml
+++ b/dmn/pom.xml
@@ -16,11 +16,6 @@
   <dependencies>
 
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-util</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.camunda.bpm.extension.dmn.scala</groupId>
       <artifactId>dmn-engine</artifactId>
     </dependency>

--- a/dmn/pom.xml
+++ b/dmn/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>zeebe-parent</artifactId>
+    <version>1.3.0-SNAPSHOT</version>
+    <relativePath>../parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>dmn</artifactId>
+  <name>Zeebe DMN Engine</name>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.camunda.bpm.extension.dmn.scala</groupId>
+      <artifactId>dmn-engine</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.camunda.bpm.model</groupId>
+      <artifactId>camunda-dmn-model</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/dmn/src/main/java/io/camunda/zeebe/dmn/DecisionEngine.java
+++ b/dmn/src/main/java/io/camunda/zeebe/dmn/DecisionEngine.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.dmn;
+
+import java.io.InputStream;
+
+/**
+ * Parses and evaluates DMN decisions. A decision can be parsed and stored as object. A parsed
+ * decision needs to be used to evaluate the decision with a given variable context.
+ */
+public interface DecisionEngine {
+
+  /**
+   * Parses the given DMN resource into a parsed decision object.
+   *
+   * <p>If the DMN is not valid then it returns a result object that contains the failure message,
+   * instead of throwing an exception.
+   *
+   * @param dmnResource the DMN resource as input stream
+   * @return the parsed decision, or the failure message if the DMN is not valid
+   */
+  ParsedDecisionRequirementsGraph parse(InputStream dmnResource);
+}

--- a/dmn/src/main/java/io/camunda/zeebe/dmn/DecisionEngineFactory.java
+++ b/dmn/src/main/java/io/camunda/zeebe/dmn/DecisionEngineFactory.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.dmn;
+
+import io.camunda.zeebe.dmn.impl.DmnScalaDecisionEngine;
+
+/** The entry point to create a new {@link DecisionEngine}. */
+public final class DecisionEngineFactory {
+
+  /** @return a new instance of the {@link DecisionEngine} */
+  public static DecisionEngine createDecisionEngine() {
+    return new DmnScalaDecisionEngine();
+  }
+}

--- a/dmn/src/main/java/io/camunda/zeebe/dmn/ParsedDecision.java
+++ b/dmn/src/main/java/io/camunda/zeebe/dmn/ParsedDecision.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.dmn;
+
+/** A parsed DMN decision. A decision is contained in a decision requirements graph (DRG). */
+public interface ParsedDecision {
+
+  /** @return the name of the decision */
+  String getName();
+
+  /** @return the id of the decision */
+  String getId();
+}

--- a/dmn/src/main/java/io/camunda/zeebe/dmn/ParsedDecisionRequirementsGraph.java
+++ b/dmn/src/main/java/io/camunda/zeebe/dmn/ParsedDecisionRequirementsGraph.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.dmn;
+
+import java.util.Collection;
+
+/** A parsed DMN decision requirements graph (DRG). */
+public interface ParsedDecisionRequirementsGraph {
+
+  /** @return the id of the DRG, or {@code null} if the DMN is not valid */
+  String getId();
+
+  /** @return the name of the DRG, or {@code null} if the DMN is not valid */
+  String getName();
+
+  /** @return the namespace of the DRG, or {@code null} if the DMN is not valid */
+  String getNamespace();
+
+  /**
+   * @return the decisions that are contained in the DRG, or an empty collection if the DMN is not
+   *     valid
+   */
+  Collection<ParsedDecision> getDecisions();
+
+  /** @return {@code true} if the DMN is valid */
+  boolean isValid();
+
+  /**
+   * Returns the reason why the DMN is not valid. Use {@link #isValid()} to check if the DMN is
+   * valid or not.
+   *
+   * @return the failure message if the DMN is not valid, or {@code null} if the DMN is valid
+   */
+  String getFailureMessage();
+}

--- a/dmn/src/main/java/io/camunda/zeebe/dmn/impl/DmnScalaDecisionEngine.java
+++ b/dmn/src/main/java/io/camunda/zeebe/dmn/impl/DmnScalaDecisionEngine.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.dmn.impl;
+
+import io.camunda.zeebe.dmn.DecisionEngine;
+import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
+import java.io.InputStream;
+import org.camunda.dmn.DmnEngine;
+
+/**
+ * A wrapper around the DMN-Scala decision engine.
+ *
+ * <p>
+ * <li><a href="https://github.com/camunda-community-hub/dmn-scala">GitHub Repository</a>
+ * <li><a href="https://github.com/camunda-community-hub/dmn-scala">Documentation</a>
+ */
+public final class DmnScalaDecisionEngine implements DecisionEngine {
+
+  private final DmnEngine dmnEngine;
+
+  public DmnScalaDecisionEngine() {
+    dmnEngine = new DmnEngine.Builder().build();
+  }
+
+  @Override
+  public ParsedDecisionRequirementsGraph parse(final InputStream dmnResource) {
+    if (dmnResource == null) {
+      throw new IllegalArgumentException("The input stream must not be null");
+    }
+
+    try {
+      final var parseResult = dmnEngine.parse(dmnResource);
+
+      if (parseResult.isLeft()) {
+        final DmnEngine.Failure failure = parseResult.left().get();
+        final var failureMessage = failure.message();
+
+        return new ParseFailureMessage(failureMessage);
+
+      } else {
+        final var parsedDmn = parseResult.right().get();
+
+        return ParsedDmnScalaDrg.of(parsedDmn);
+      }
+
+    } catch (Exception e) {
+      final var failureMessage = e.getMessage();
+      return new ParseFailureMessage(failureMessage);
+    }
+  }
+}

--- a/dmn/src/main/java/io/camunda/zeebe/dmn/impl/ParseFailureMessage.java
+++ b/dmn/src/main/java/io/camunda/zeebe/dmn/impl/ParseFailureMessage.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.dmn.impl;
+
+import io.camunda.zeebe.dmn.ParsedDecision;
+import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
+import java.util.Collections;
+import java.util.List;
+
+public final class ParseFailureMessage implements ParsedDecisionRequirementsGraph {
+
+  private final String failureMessage;
+
+  public ParseFailureMessage(final String failureMessage) {
+    this.failureMessage = failureMessage;
+  }
+
+  @Override
+  public String getFailureMessage() {
+    return failureMessage;
+  }
+
+  @Override
+  public boolean isValid() {
+    return false;
+  }
+
+  @Override
+  public String getId() {
+    return null;
+  }
+
+  @Override
+  public String getName() {
+    return null;
+  }
+
+  @Override
+  public String getNamespace() {
+    return null;
+  }
+
+  @Override
+  public List<ParsedDecision> getDecisions() {
+    return Collections.emptyList();
+  }
+}

--- a/dmn/src/main/java/io/camunda/zeebe/dmn/impl/ParsedDmnScalaDecision.java
+++ b/dmn/src/main/java/io/camunda/zeebe/dmn/impl/ParsedDmnScalaDecision.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.dmn.impl;
+
+import io.camunda.zeebe.dmn.ParsedDecision;
+
+public final class ParsedDmnScalaDecision implements ParsedDecision {
+
+  private final String decisionId;
+  private final String decisionName;
+
+  public ParsedDmnScalaDecision(final String decisionId, final String decisionName) {
+    this.decisionId = decisionId;
+    this.decisionName = decisionName;
+  }
+
+  @Override
+  public String getName() {
+    return decisionName;
+  }
+
+  @Override
+  public String getId() {
+    return decisionId;
+  }
+}

--- a/dmn/src/main/java/io/camunda/zeebe/dmn/impl/ParsedDmnScalaDrg.java
+++ b/dmn/src/main/java/io/camunda/zeebe/dmn/impl/ParsedDmnScalaDrg.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.dmn.impl;
+
+import io.camunda.zeebe.dmn.ParsedDecision;
+import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.camunda.bpm.model.dmn.DmnModelInstance;
+import org.camunda.bpm.model.dmn.instance.Definitions;
+import org.camunda.dmn.parser.ParsedDmn;
+
+public final class ParsedDmnScalaDrg implements ParsedDecisionRequirementsGraph {
+
+  private final ParsedDmn parsedDmn;
+  private final String decisionRequirementsId;
+  private final String decisionRequirementsName;
+  private final String decisionRequirementsNamespace;
+  private final List<ParsedDecision> decisions;
+
+  private ParsedDmnScalaDrg(
+      final ParsedDmn parsedDmn,
+      final String decisionRequirementsId,
+      final String decisionRequirementsName,
+      final String decisionRequirementsNamespace,
+      final List<ParsedDecision> decisions) {
+    this.parsedDmn = parsedDmn;
+    this.decisionRequirementsId = decisionRequirementsId;
+    this.decisionRequirementsName = decisionRequirementsName;
+    this.decisionRequirementsNamespace = decisionRequirementsNamespace;
+    this.decisions = decisions;
+  }
+
+  @Override
+  public boolean isValid() {
+    return true;
+  }
+
+  @Override
+  public String getFailureMessage() {
+    return null;
+  }
+
+  @Override
+  public String getId() {
+    return decisionRequirementsId;
+  }
+
+  @Override
+  public String getName() {
+    return decisionRequirementsName;
+  }
+
+  @Override
+  public String getNamespace() {
+    return decisionRequirementsNamespace;
+  }
+
+  @Override
+  public Collection<ParsedDecision> getDecisions() {
+    return decisions;
+  }
+
+  public ParsedDmn getParsedDmn() {
+    return parsedDmn;
+  }
+
+  public static ParsedDmnScalaDrg of(final ParsedDmn parsedDmn) {
+
+    final DmnModelInstance modelInstance = parsedDmn.model();
+    final Definitions definitions = modelInstance.getDefinitions();
+    final String id = definitions.getId();
+    final String name = definitions.getName();
+    final String namespace = definitions.getNamespace();
+    final List<ParsedDecision> parsedDecisions = getParsedDecisions(parsedDmn);
+
+    return new ParsedDmnScalaDrg(parsedDmn, id, name, namespace, parsedDecisions);
+  }
+
+  private static List<ParsedDecision> getParsedDecisions(final ParsedDmn parsedDmn) {
+    final var decisions = new ArrayList<ParsedDecision>();
+
+    parsedDmn
+        .decisions()
+        .foreach(
+            decision -> {
+              final var parsedDecision = new ParsedDmnScalaDecision(decision.id(), decision.name());
+              return decisions.add(parsedDecision);
+            });
+
+    return decisions;
+  }
+}

--- a/dmn/src/test/java/io/camunda/zeebe/dmn/DmnParsingTest.java
+++ b/dmn/src/test/java/io/camunda/zeebe/dmn/DmnParsingTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.dmn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.io.InputStream;
+import org.junit.jupiter.api.Test;
+
+class DmnParsingTest {
+
+  private static final String VALID_DECISION_TABLE = "/decision-table.dmn";
+  private static final String INVALID_DECISION_TABLE =
+      "/decision-table-with-invalid-expression.dmn";
+  private static final String VALID_DRG = "/drg-force-user.dmn";
+
+  private final DecisionEngine decisionEngine = DecisionEngineFactory.createDecisionEngine();
+
+  @Test
+  void shouldRejectInvalidInputStream() {
+    // given
+    final InputStream inputStream = null;
+
+    // when/then
+    assertThatThrownBy(() -> decisionEngine.parse(inputStream))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("The input stream must not be null");
+  }
+
+  @Test
+  void shouldParseDecisionTable() {
+    // given
+    final var inputStream = getClass().getResourceAsStream(VALID_DECISION_TABLE);
+
+    // when
+    final var parsedDrg = decisionEngine.parse(inputStream);
+
+    // then
+    assertThat(parsedDrg.isValid())
+        .describedAs("Expect that the DMN is parsed successfully")
+        .isTrue();
+
+    assertThat(parsedDrg.getId()).isEqualTo("force-users");
+    assertThat(parsedDrg.getName()).isEqualTo("Force Users");
+    assertThat(parsedDrg.getNamespace()).isEqualTo("http://camunda.org/schema/1.0/dmn");
+
+    assertThat(parsedDrg.getDecisions())
+        .hasSize(1)
+        .extracting(ParsedDecision::getId, ParsedDecision::getName)
+        .contains(tuple("jedi-or-sith", "Jedi or Sith"));
+
+    assertThat(parsedDrg.getFailureMessage()).isNull();
+  }
+
+  @Test
+  void shouldReturnAllParsedDecisions() {
+    // given
+    final var inputStream = getClass().getResourceAsStream(VALID_DRG);
+
+    // when
+    final var parsedDrg = decisionEngine.parse(inputStream);
+
+    // then
+    assertThat(parsedDrg.isValid())
+        .describedAs("Expect that the DMN is parsed successfully")
+        .isTrue();
+
+    assertThat(parsedDrg.getDecisions())
+        .hasSize(2)
+        .extracting(ParsedDecision::getId, ParsedDecision::getName)
+        .contains(tuple("jedi-or-sith", "Jedi or Sith"), tuple("force-user", "Which force user?"));
+  }
+
+  @Test
+  void shouldReportParseFailure() {
+    // given
+    final var inputStream = getClass().getResourceAsStream(INVALID_DECISION_TABLE);
+
+    // when
+    final var parsedDrg = decisionEngine.parse(inputStream);
+
+    // then
+    assertThat(parsedDrg.isValid())
+        .describedAs("Expect that the DMN is not parsed successfully")
+        .isFalse();
+
+    assertThat(parsedDrg.getFailureMessage())
+        .startsWith("FEEL unary-tests: failed to parse expression");
+
+    assertThat(parsedDrg.getId()).isNull();
+    assertThat(parsedDrg.getName()).isNull();
+    assertThat(parsedDrg.getNamespace()).isNull();
+    assertThat(parsedDrg.getDecisions()).isEmpty();
+  }
+}

--- a/dmn/src/test/java/io/camunda/zeebe/dmn/DmnParsingTest.java
+++ b/dmn/src/test/java/io/camunda/zeebe/dmn/DmnParsingTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +25,7 @@ class DmnParsingTest {
   private final DecisionEngine decisionEngine = DecisionEngineFactory.createDecisionEngine();
 
   @Test
-  void shouldRejectInvalidInputStream() {
+  void shouldRejectEmptyInputStream() {
     // given
     final InputStream inputStream = null;
 
@@ -32,6 +33,22 @@ class DmnParsingTest {
     assertThatThrownBy(() -> decisionEngine.parse(inputStream))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("The input stream must not be null");
+  }
+
+  @Test
+  void shouldRejectInvalidInputStream() {
+    // given
+    final InputStream inputStream = new ByteArrayInputStream("invalid DMN".getBytes());
+
+    // when
+    final var parsedDrg = decisionEngine.parse(inputStream);
+
+    // then
+    assertThat(parsedDrg.isValid())
+        .describedAs("Expect that the DMN is not parsed successfully")
+        .isFalse();
+
+    assertThat(parsedDrg.getFailureMessage()).startsWith("Failed to parse DMN");
   }
 
   @Test

--- a/dmn/src/test/resources/decision-table-with-invalid-expression.dmn
+++ b/dmn/src/test/resources/decision-table-with-invalid-expression.dmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force-users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <decision id="jediOrSith" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="faction" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utwb1e">
+        <inputEntry id="UnaryTests_1v3sd4m">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tgh8k1">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1bwgcym">
+        <inputEntry id="UnaryTests_0n1ewm3">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19xnlkw">
+          <text>"Sith"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jediOrSith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/dmn/src/test/resources/decision-table.dmn
+++ b/dmn/src/test/resources/decision-table.dmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force-users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <decision id="jedi-or-sith" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="faction" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utwb1e">
+        <inputEntry id="UnaryTests_1v3sd4m">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tgh8k1">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1bwgcym">
+        <inputEntry id="UnaryTests_0n1ewm3">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19xnlkw">
+          <text>"Sith"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi-or-sith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/dmn/src/test/resources/drg-force-user.dmn
+++ b/dmn/src/test/resources/drg-force-user.dmn
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="force-users" name="force-users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <decision id="jedi-or-sith" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="faction" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utwb1e">
+        <inputEntry id="UnaryTests_1v3sd4m">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tgh8k1">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1bwgcym">
+        <inputEntry id="UnaryTests_0n1ewm3">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19xnlkw">
+          <text>"Sith"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="force-user" name="Which force user?">
+    <informationRequirement id="InformationRequirement_1o8esai">
+      <requiredDecision href="#jedi-or-sith" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_07g94t1" hitPolicy="FIRST">
+      <input id="InputClause_0qnqj25" label="Jedi or Sith">
+        <inputExpression id="LiteralExpression_00lcyt5" typeRef="string">
+          <text>faction</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_1xjidd8">
+          <text>"Jedi","Sith"</text>
+        </inputValues>
+      </input>
+      <input id="InputClause_0k64hys" label="Body height">
+        <inputExpression id="LiteralExpression_0ib6fnk" typeRef="number">
+          <text>height</text>
+        </inputExpression>
+      </input>
+      <output id="OutputClause_0hhe1yo" label="Force user" name="force-user" typeRef="string" />
+      <rule id="DecisionRule_13zidc5">
+        <inputEntry id="UnaryTests_056skcq">
+          <text>"Jedi"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0l4xksq">
+          <text>&gt; 190</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0hclhw3">
+          <text>"Mace Windu"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0uin2hk">
+        <description></description>
+        <inputEntry id="UnaryTests_16maepk">
+          <text>"Jedi"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0rv0nwf">
+          <text>&gt; 180</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0t82c11">
+          <text>"Obi-Wan Kenobi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0mpio0p">
+        <inputEntry id="UnaryTests_09eicyc">
+          <text>"Jedi"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bekl8k">
+          <text>&lt; 70</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0brx3vt">
+          <text>"Yoda"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_06paffx">
+        <inputEntry id="UnaryTests_1baiid4">
+          <text>"Sith"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fcdq0i">
+          <text>&gt; 200</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_02oibi4">
+          <text>"Darth Vader"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1ua4pcl">
+        <inputEntry id="UnaryTests_1s1h3nm">
+          <text>"Sith"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1pnvw8p">
+          <text>&gt; 170</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1w1n2rc">
+          <text>"Darth Sidius"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_00ew25e">
+        <inputEntry id="UnaryTests_07uxyug">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1he6fym">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_07i3sc8">
+          <text>"unknown"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi-or-sith">
+        <dc:Bounds height="80" width="180" x="160" y="280" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_1sb3tre" dmnElementRef="force-user">
+        <dc:Bounds height="80" width="180" x="280" y="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="DMNEdge_0gt1p1u" dmnElementRef="InformationRequirement_1o8esai">
+        <di:waypoint x="250" y="280" />
+        <di:waypoint x="370" y="180" />
+        <di:waypoint x="370" y="160" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -93,6 +93,7 @@
     <version.netflix.concurrency>0.3.6</version.netflix.concurrency>
     <version.zeebe-test-container>3.1.0</version.zeebe-test-container>
     <version.feel-scala>1.13.3</version.feel-scala>
+    <version.dmn-scala>1.7.1</version.dmn-scala>
     <version.rest-assured>4.4.0</version.rest-assured>
     <version.spring>5.3.13</version.spring>
     <version.spring-boot>2.5.6</version.spring-boot>
@@ -694,6 +695,18 @@
         <groupId>org.camunda.feel</groupId>
         <artifactId>feel-engine</artifactId>
         <version>${version.feel-scala}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.camunda.bpm.extension.dmn.scala</groupId>
+        <artifactId>dmn-engine</artifactId>
+        <version>${version.dmn-scala}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.camunda.bpm.model</groupId>
+        <artifactId>camunda-dmn-model</artifactId>
+        <version>${version.camunda}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <module>protocol-jackson</module>
     <module>zb-db</module>
     <module>expression-language</module>
+    <module>dmn</module>
     <module>snapshot</module>
     <module>journal</module>
     <module>qa</module>


### PR DESCRIPTION
## Description

* create a new module `dmn` for parsing and evaluating of DMN decisions
* add a method to parse a DMN decision
* the parsed decision is returned as an object and should be used to evaluate the decision
* if the DMN is not valid then return an object that contains the failure message
  * decided against the usage of `Either` to align with the evaluation method (that will be added later)
  * if the evaluation fails then it should return the failure message but also the history of the evaluated decision (see #8235) 
  * the result of a successful evaluation is similar to a not successful one - so, we probably want to use the same result restructure instead of an `Either` type  

## Related issues

closes #8063 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
