### PR TITLE
Promote priority election to non-experimental

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
@@ -69,7 +69,7 @@ final class RaftPartitionGroupFactory {
             .withFlushExplicitly(!experimentalCfg.isDisableExplicitRaftFlush())
             .withFreeDiskSpace(dataCfg.getFreeDiskSpaceReplicationWatermark())
             .withJournalIndexDensity(dataCfg.getLogIndexDensity())
-            .withPriorityElection(experimentalCfg.isEnablePriorityElection())
+            .withPriorityElection(clusterCfg.getRaft().isEnablePriorityElection())
             .withPartitionDistributor(partitionDistributor)
             .withElectionTimeout(clusterCfg.getElectionTimeout())
             .withHeartbeatInterval(clusterCfg.getHeartbeatInterval())

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -168,7 +168,7 @@ public final class SystemContext {
     for (final var partition : partitions) {
       final var members =
           validateFixedPartitionMembers(
-              cluster, partition, experimental.isEnablePriorityElection());
+              cluster, partition, cluster.getRaft().isEnablePriorityElection());
       partitionMembers.put(partition.getPartitionId(), members);
     }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -38,6 +38,7 @@ public final class ClusterCfg implements ConfigurationEntry {
   private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private MembershipCfg membership = new MembershipCfg();
+  private RaftCfg raft = new RaftCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -119,6 +120,14 @@ public final class ClusterCfg implements ConfigurationEntry {
     this.heartbeatInterval = heartbeatInterval;
   }
 
+  public RaftCfg getRaft() {
+    return raft;
+  }
+
+  public void setRaft(final RaftCfg raft) {
+    this.raft = raft;
+  }
+
   @Override
   public String toString() {
     return "ClusterCfg{"
@@ -143,6 +152,8 @@ public final class ClusterCfg implements ConfigurationEntry {
         + heartbeatInterval
         + ", electionTimeout="
         + electionTimeout
+        + ", raft="
+        + raft
         + '}';
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -20,14 +20,12 @@ public class ExperimentalCfg implements ConfigurationEntry {
   public static final int DEFAULT_MAX_APPENDS_PER_FOLLOWER = 2;
   public static final DataSize DEFAULT_MAX_APPEND_BATCH_SIZE = DataSize.ofKilobytes(32);
   public static final boolean DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH = false;
-  public static final boolean DEFAULT_ENABLE_PRIORITY_ELECTION = true;
 
   private int maxAppendsPerFollower = DEFAULT_MAX_APPENDS_PER_FOLLOWER;
   private DataSize maxAppendBatchSize = DEFAULT_MAX_APPEND_BATCH_SIZE;
   private boolean disableExplicitRaftFlush = DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH;
-  private boolean enablePriorityElection = DEFAULT_ENABLE_PRIORITY_ELECTION;
   private RocksdbCfg rocksdb = new RocksdbCfg();
-  private RaftCfg raft = new RaftCfg();
+  private ExperimentalRaftCfg raft = new ExperimentalRaftCfg();
   private PartitioningCfg partitioning = new PartitioningCfg();
   private QueryApiCfg queryApi = new QueryApiCfg();
 
@@ -73,19 +71,11 @@ public class ExperimentalCfg implements ConfigurationEntry {
     this.rocksdb = rocksdb;
   }
 
-  public boolean isEnablePriorityElection() {
-    return enablePriorityElection;
-  }
-
-  public void setEnablePriorityElection(final boolean enablePriorityElection) {
-    this.enablePriorityElection = enablePriorityElection;
-  }
-
-  public RaftCfg getRaft() {
+  public ExperimentalRaftCfg getRaft() {
     return raft;
   }
 
-  public void setRaft(final RaftCfg raft) {
+  public void setRaft(final ExperimentalRaftCfg raft) {
     this.raft = raft;
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+import java.time.Duration;
+
+public final class ExperimentalRaftCfg implements ConfigurationEntry {
+
+  private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(5);
+  private static final Duration DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT = Duration.ofSeconds(0);
+  private static final int DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT = 3;
+
+  private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+  private Duration maxQuorumResponseTimeout = DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT;
+  private int minStepDownFailureCount = DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT;
+
+  public Duration getRequestTimeout() {
+    return requestTimeout;
+  }
+
+  public void setRequestTimeout(final Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
+  }
+
+  public Duration getMaxQuorumResponseTimeout() {
+    return maxQuorumResponseTimeout;
+  }
+
+  public void setMaxQuorumResponseTimeout(final Duration maxQuorumResponseTimeout) {
+    this.maxQuorumResponseTimeout = maxQuorumResponseTimeout;
+  }
+
+  public int getMinStepDownFailureCount() {
+    return minStepDownFailureCount;
+  }
+
+  public void setMinStepDownFailureCount(final int minStepDownFailureCount) {
+    this.minStepDownFailureCount = minStepDownFailureCount;
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/RaftCfg.java
@@ -7,39 +7,21 @@
  */
 package io.camunda.zeebe.broker.system.configuration;
 
-import java.time.Duration;
-
 public final class RaftCfg implements ConfigurationEntry {
+  public static final boolean DEFAULT_ENABLE_PRIORITY_ELECTION = true;
 
-  private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(5);
-  private static final Duration DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT = Duration.ofSeconds(0);
-  private static final int DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT = 3;
+  private boolean enablePriorityElection = DEFAULT_ENABLE_PRIORITY_ELECTION;
 
-  private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
-  private Duration maxQuorumResponseTimeout = DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT;
-  private int minStepDownFailureCount = DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT;
-
-  public Duration getRequestTimeout() {
-    return requestTimeout;
+  public boolean isEnablePriorityElection() {
+    return enablePriorityElection;
   }
 
-  public void setRequestTimeout(final Duration requestTimeout) {
-    this.requestTimeout = requestTimeout;
+  public void setEnablePriorityElection(final boolean enablePriorityElection) {
+    this.enablePriorityElection = enablePriorityElection;
   }
 
-  public Duration getMaxQuorumResponseTimeout() {
-    return maxQuorumResponseTimeout;
-  }
-
-  public void setMaxQuorumResponseTimeout(final Duration maxQuorumResponseTimeout) {
-    this.maxQuorumResponseTimeout = maxQuorumResponseTimeout;
-  }
-
-  public int getMinStepDownFailureCount() {
-    return minStepDownFailureCount;
-  }
-
-  public void setMinStepDownFailureCount(final int minStepDownFailureCount) {
-    this.minStepDownFailureCount = minStepDownFailureCount;
+  @Override
+  public String toString() {
+    return "RaftCfg{" + "enablePriorityElection=" + enablePriorityElection + '}';
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
@@ -120,7 +120,7 @@ class RaftPartitionGroupFactoryTest {
   @Test
   void shouldEnablePriorityElection() {
     // given
-    brokerCfg.getExperimental().setEnablePriorityElection(true);
+    brokerCfg.getCluster().getRaft().setEnablePriorityElection(true);
 
     // when
     final var config = buildRaftPartitionGroup();
@@ -132,7 +132,7 @@ class RaftPartitionGroupFactoryTest {
   @Test
   void shouldDisablePriorityElection() {
     // given
-    brokerCfg.getExperimental().setEnablePriorityElection(false);
+    brokerCfg.getCluster().getRaft().setEnablePriorityElection(false);
 
     // when
     final var config = buildRaftPartitionGroup();

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -275,7 +275,7 @@ final class SystemContextTest {
     final var config = brokerCfg.getExperimental().getPartitioning();
     final var fixedPartition = new FixedPartitionCfg();
     final var nodes = List.of(new NodeCfg(), new NodeCfg());
-    brokerCfg.getExperimental().setEnablePriorityElection(true);
+    brokerCfg.getCluster().getRaft().setEnablePriorityElection(true);
     brokerCfg.getCluster().setClusterSize(2);
     config.setScheme(Scheme.FIXED);
     config.setFixed(List.of(fixedPartition));
@@ -301,7 +301,7 @@ final class SystemContextTest {
     final var config = brokerCfg.getExperimental().getPartitioning();
     final var fixedPartition = new FixedPartitionCfg();
     final var nodes = List.of(new NodeCfg(), new NodeCfg());
-    brokerCfg.getExperimental().setEnablePriorityElection(false);
+    brokerCfg.getCluster().getRaft().setEnablePriorityElection(false);
     brokerCfg.getCluster().setClusterSize(2);
     config.setScheme(Scheme.FIXED);
     config.setFixed(List.of(fixedPartition));

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -62,8 +62,8 @@ public final class BrokerCfgTest {
       "zeebe.broker.experimental.maxAppendBatchSize";
   private static final String ZEEBE_BROKER_EXPERIMENTAL_DISABLEEXPLICITRAFTFLUSH =
       "zeebe.broker.experimental.disableExplicitRaftFlush";
-  private static final String ZEEBE_BROKER_EXPERIMENTAL_ENABLEPRIORITYELECTION =
-      "zeebe.broker.experimental.enablePriorityElection";
+  private static final String ZEEBE_BROKER_CLUSTER_RAFT_ENABLEPRIORITYELECTION =
+      "zeebe.broker.cluster.raft.enablePriorityElection";
   private static final String ZEEBE_BROKER_EXPERIMENTAL_QUERYAPI_ENABLED =
       "zeebe.broker.experimental.queryapi.enabled";
   private static final String ZEEBE_BROKER_DATA_DIRECTORY = "zeebe.broker.data.directory";
@@ -466,14 +466,14 @@ public final class BrokerCfgTest {
   @Test
   public void shouldOverrideEnablePriorityElectionViaEnvironment() {
     // given
-    environment.put(ZEEBE_BROKER_EXPERIMENTAL_ENABLEPRIORITYELECTION, "true");
+    environment.put(ZEEBE_BROKER_CLUSTER_RAFT_ENABLEPRIORITYELECTION, "true");
 
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
-    final ExperimentalCfg experimentalCfg = cfg.getExperimental();
+    final ClusterCfg clusterCfg = cfg.getCluster();
 
     // then
-    assertThat(experimentalCfg.isEnablePriorityElection()).isTrue();
+    assertThat(clusterCfg.getRaft().isEnablePriorityElection()).isTrue();
   }
 
   @Test
@@ -482,10 +482,10 @@ public final class BrokerCfgTest {
     final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
 
     // when
-    final ExperimentalCfg experimentalCfg = cfg.getExperimental();
+    final ClusterCfg clusterCfg = cfg.getCluster();
 
     // then
-    assertThat(experimentalCfg.isEnablePriorityElection()).isTrue();
+    assertThat(clusterCfg.getRaft().isEnablePriorityElection()).isTrue();
   }
 
   @Test
@@ -494,10 +494,10 @@ public final class BrokerCfgTest {
     final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
 
     // when
-    final ExperimentalCfg experimentalCfg = cfg.getExperimental();
+    final ClusterCfg clusterCfg = cfg.getCluster();
 
     // then
-    assertThat(experimentalCfg.isEnablePriorityElection()).isTrue();
+    assertThat(clusterCfg.getRaft().isEnablePriorityElection()).isTrue();
   }
 
   @Test

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -270,6 +270,14 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_ELECTIONTIMEOUT.
       # electionTimeout: 2500ms
 
+      # Configure raft properties
+      # raft:
+        # When this flag is enabled, the leader election algorithm attempts to elect the leaders based on a pre-defined priority.
+        # As a result, it tries to distributed the leaders uniformly across the brokers. Note that it is only a best-effort strategy.
+        # It is not guaranteed to be a strictly uniform distribution.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_RAFT_ENABLEPRIORITYELECTION
+        # enablePriorityElection = true;
+
       # Configure parameters for SWIM protocol which is used to propagate cluster membership
       # information among brokers and gateways
       # membership:
@@ -532,12 +540,6 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_MAXAPPENDBATCHSIZE
       # maxAppendBatchSize = 32KB;
 
-      # When this flag is enabled, the leader election algorithm attempts to elect the leaders based on a pre-defined priority.
-      # As a result, it tries to distributed the leaders uniformly across the brokers. Note that it is only a best-effort strategy.
-      # It is not guaranteed to be a strictly uniform distribution.
-      # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENABLEPRIORITYELECTION
-      # enablePriorityElection = true;
-
       # This setting allows you to configure how partitions are distributed amongst the node of the
       # clusters. It currently supports to partitioning schemes: ROUND_ROBIN, and FIXED.
       #
@@ -597,7 +599,7 @@
         #       - nodeId: 2
         #         priority: 2
 
-      # Allows to configure specific raft properties
+      # Allows to configure experimental raft properties
       # raft:
         # Sets the timeout for all requests send by raft leaders and followers.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_REQUESTTIMEOUT

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -209,6 +209,14 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_ELECTIONTIMEOUT.
       # electionTimeout: 2500ms
 
+      # Configure raft properties
+      # raft:
+        # When this flag is enabled, the leader election algorithm attempts to elect the leaders based on a pre-defined priority.
+        # As a result, it tries to distributed the leaders uniformly across the brokers. Note that it is only a best-effort strategy.
+        # It is not guaranteed to be a strictly uniform distribution.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_RAFT_ENABLEPRIORITYELECTION
+        # enablePriorityElection = true;
+
       # Configure parameters for SWIM protocol which is used to propagate cluster membership
       # information among brokers and gateways
       # membership:
@@ -470,12 +478,6 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_MAXAPPENDBATCHSIZE
       # maxAppendBatchSize = 32KB;
 
-      # When this flag is enabled, the leader election algorithm attempts to elect the leaders based on a pre-defined priority.
-      # As a result, it tries to distributed the leaders uniformly across the brokers. Note that it is only a best-effort strategy.
-      # It is not guaranteed to be a strictly uniform distribution.
-      # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENABLEPRIORITYELECTION
-      # enablePriorityElection = true;
-
       # This setting allows you to configure how partitions are distributed amongst the node of the
       # clusters. It currently supports to partitioning schemes: ROUND_ROBIN, and FIXED.
       #
@@ -535,7 +537,7 @@
         #       - nodeId: 2
         #         priority: 2
 
-      # Allows to configure specific raft properties
+      # Allows to configure experimental raft properties
       # raft:
         # Sets the timeout for all requests send by raft leaders and followers.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_REQUESTTIMEOUT

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FixedPartitionDistributionIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FixedPartitionDistributionIT.java
@@ -89,8 +89,8 @@ final class FixedPartitionDistributionIT {
     broker.setDockerImageName(
         ZeebeTestContainerDefaults.defaultTestImage().asCanonicalNameString());
     broker
+        .withEnv("ZEEBE_BROKER_CLUSTER_RAFT_ENABLE_PRIORITY_ELECTION", "false")
         .withEnv("ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING_SCHEME", "FIXED")
-        .withEnv("ZEEBE_BROKER_EXPERIMENTAL_ENABLE_PRIORITY_ELECTION", "false")
         .withEnv("ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING_FIXED_0_PARTITIONID", "1")
         .withEnv("ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING_FIXED_0_NODES_0_NODEID", "1")
         .withEnv("ZEEBE_BROKER_EXPERIMENTAL_PARTITIONING_FIXED_0_NODES_1_NODEID", "2")


### PR DESCRIPTION
## Description

Introduces a new configuration section `zeebe.broker.cluster.raft` that allows to configure `enablePriorityElection`.
The old, experimental `RaftCfg` is renamed to `ExperimentalRaftCfg`.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8290

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
