### PR TITLE
Fix ZeebePartition can be closed when there are ongoing transitions

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -57,6 +57,7 @@ public final class ZeebePartition extends Actor
   private final PartitionTransition transition;
   private CompletableActorFuture<Void> closeFuture;
   private ActorFuture<Void> currentTransitionFuture;
+  private boolean closing = false;
 
   public ZeebePartition(
       final PartitionStartupAndTransitionContextImpl transitionContext,
@@ -143,38 +144,22 @@ public final class ZeebePartition extends Actor
 
   @Override
   protected void onActorClosing() {
-    context.getRaftPartition().getServer().removeSnapshotReplicationListener(this);
-    context.getRaftPartition().removeRoleChangeListener(this);
-
-    transitionToInactive()
+    // Already transitioned to inactive
+    startupProcess
+        .shutdown(actor, startupContext)
         .onComplete(
-            (nothing, err) -> {
-              context
-                  .getComponentHealthMonitor()
-                  .removeComponent(context.getRaftPartition().name());
+            (newStartupContext, error) -> {
+              if (error != null) {
+                LOG.error(error.getMessage(), error);
+              }
 
-              startupProcess
-                  .shutdown(actor, startupContext)
-                  .onComplete(
-                      (newStartupContext, error) -> {
-                        if (error != null) {
-                          LOG.error(error.getMessage(), error);
-                        }
+              // reset contexts to null to not have lingering references that could
+              // cause OOM problems in tests which start/stop partitions
+              startupContext = null;
+              context = null;
 
-                        // reset contexts to null to not have lingering references that could
-                        // cause OOM problems in tests which start/stop partitions
-                        startupContext = null;
-                        context = null;
-
-                        closeFuture.complete(null);
-                      });
+              closeFuture.complete(null);
             });
-  }
-
-  @Override
-  protected void onActorCloseRequested() {
-    LOG.debug("Closing ZeebePartition {}", context.getPartitionId());
-    context.getComponentHealthMonitor().removeComponent(zeebePartitionHealth.getName());
   }
 
   @Override
@@ -186,10 +171,19 @@ public final class ZeebePartition extends Actor
     closeFuture = new CompletableActorFuture<>();
 
     actor.run(
-        () ->
-            // allows to await current transition to avoid concurrent modifications and
-            // transitioning
-            currentTransitionFuture.onComplete((nothing, err) -> super.closeAsync()));
+        () -> {
+          LOG.debug("Closing ZeebePartition {}", context.getPartitionId());
+          closing = true;
+
+          removeListeners();
+          context.getComponentHealthMonitor().removeComponent(zeebePartitionHealth.getName());
+
+          final var inactiveTransitionFuture = transitionToInactive();
+
+          // allows to await current transition to avoid concurrent modifications and
+          // transitioning
+          inactiveTransitionFuture.onComplete((nothing, err) -> super.closeAsync());
+        });
 
     return closeFuture;
   }
@@ -210,7 +204,12 @@ public final class ZeebePartition extends Actor
   @Override
   @Deprecated // will be removed from public API of ZeebePartition
   public void onNewRole(final Role newRole, final long newTerm) {
-    actor.run(() -> onRoleChange(newRole, newTerm));
+    actor.run(
+        () -> {
+          if (!closing) {
+            onRoleChange(newRole, newTerm);
+          }
+        });
   }
 
   private void onRoleChange(final Role newRole, final long newTerm) {
@@ -298,6 +297,12 @@ public final class ZeebePartition extends Actor
     context.getRaftPartition().addRoleChangeListener(this);
     context.getComponentHealthMonitor().addFailureListener(this);
     context.getRaftPartition().getServer().addSnapshotReplicationListener(this);
+  }
+
+  private void removeListeners() {
+    context.getRaftPartition().removeRoleChangeListener(this);
+    context.getComponentHealthMonitor().removeFailureListener(this);
+    context.getRaftPartition().getServer().removeSnapshotReplicationListener(this);
   }
 
   @Override
@@ -455,14 +460,24 @@ public final class ZeebePartition extends Actor
     // restart from a new state. So we transition to Inactive to close existing services. The
     // services will be reinstalled when snapshot replication is completed.
     // We do not want to mark it as unhealthy, hence we don't reuse transitionToInactive()
-    actor.run(() -> currentTransitionFuture = transition.toInactive(context.getCurrentTerm()));
+    actor.run(
+        () -> {
+          if (!closing) {
+            currentTransitionFuture = transition.toInactive(context.getCurrentTerm());
+          }
+        });
   }
 
   @Override
   public void onSnapshotReplicationCompleted(final long term) {
     // Snapshot is received only by the followers. Hence we can safely assume that we have to
     // re-install follower services.
-    actor.run(() -> currentTransitionFuture = followerTransition(term));
+    actor.run(
+        () -> {
+          if (!closing) {
+            currentTransitionFuture = followerTransition(term);
+          }
+        });
   }
 
   public ActorFuture<Role> getCurrentRole() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -99,7 +99,11 @@ final class PartitionTransitionProcess {
   }
 
   ActorFuture<Void> prepare(final long newTerm, final Role newRole) {
-    LOG.info("Prepare transition from {} on term {} to {}", role, term, newRole);
+    LOG.info(
+        "Prepare transition from {} on term {} to {}",
+        context.getCurrentRole(),
+        context.getCurrentTerm(),
+        newRole);
     final ActorFuture<Void> prepareFuture = concurrencyControl.createFuture();
 
     if (stepsToPrepare.isEmpty()) {
@@ -119,8 +123,8 @@ final class PartitionTransitionProcess {
 
           LOG.info(
               "Prepare transition from {} on term {} to {} - preparing {}",
-              role,
-              term,
+              context.getCurrentRole(),
+              context.getCurrentTerm(),
               newRole,
               nextPrepareStep.getName());
 
@@ -143,7 +147,10 @@ final class PartitionTransitionProcess {
     }
 
     if (stepsToPrepare.isEmpty()) {
-      LOG.info("Preparing transition from {} on term {} completed", role, term);
+      LOG.info(
+          "Preparing transition from {} on term {} completed",
+          context.getCurrentRole(),
+          context.getCurrentTerm());
       future.complete(null);
 
       return;


### PR DESCRIPTION
## Description

This problem was identified via flaky test #7981 

When ZeebePartition#closeAsync is called, it waits for the currentTransition to be completed before actor#closeAsync is executed. However, if there was a new transition that happened between these two calls, there is a good chance that that transition gets stuck because actor#closeAsync will discard jobs from actor queue. As a result transitionToInactive triggered by the close will never gets completed and thus ZeebePartition is not closed.

In this PR,
* Added a test that can reproduced the behaviour without this fix
* Ensure that no ongoing transitions when actor#closeAsync is called. This will ensure that the actor can be safely closed.

## Related issues

closes #7981 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
