### PR TITLE
[Proposal]: Add support for block / unblock address

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/ClusterCommunicationService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/ClusterCommunicationService.java
@@ -19,6 +19,7 @@ package io.atomix.cluster.messaging;
 import static io.atomix.utils.serializer.serializers.DefaultSerializers.BASIC;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.utils.net.Address;
 import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -322,4 +323,18 @@ public interface ClusterCommunicationService {
    * @param subject message subject
    */
   void unsubscribe(String subject);
+
+  /**
+   * All requests received by the given address are not transmitted to registered handlers.
+   *
+   * @param address to blocked address
+   */
+  void blockAddress(Address address);
+
+  /**
+   * All requests received by the given address are transmitted to registered handlers again.
+   *
+   * @param address to unblocked address
+   */
+  void unblockAddress(Address address);
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -619,6 +619,36 @@ public final class ClusteringRule extends ExternalResource {
     raftPartition.getServer().stepDown().join();
   }
 
+  public void disconnectOneWay(final int notAccepting, final int blocked) {
+    final var notAcceptingBroker = getBroker(notAccepting);
+    final var blockedBroker = getBroker(blocked);
+    final var atomix = notAcceptingBroker.getBrokerContext().getAtomixCluster();
+
+    final var network = blockedBroker.getConfig().getNetwork();
+    atomix
+        .getCommunicationService()
+        .blockAddress(new Address(network.getAdvertisedHost(), network.getInternalApi().getPort()));
+    atomix
+        .getCommunicationService()
+        .blockAddress(new Address(network.getAdvertisedHost(), network.getCommandApi().getPort()));
+  }
+
+  public void connectOneWay(final int notAccepting, final int blocked) {
+    final var notAcceptingBroker = getBroker(notAccepting);
+    final var blockedBroker = getBroker(blocked);
+    final var atomix = notAcceptingBroker.getBrokerContext().getAtomixCluster();
+
+    final var network = blockedBroker.getConfig().getNetwork();
+    atomix
+        .getCommunicationService()
+        .unblockAddress(
+            new Address(network.getAdvertisedHost(), network.getInternalApi().getPort()));
+    atomix
+        .getCommunicationService()
+        .unblockAddress(
+            new Address(network.getAdvertisedHost(), network.getCommandApi().getPort()));
+  }
+
   public void disconnect(final Broker broker) {
     final var atomix = broker.getBrokerContext().getAtomixCluster();
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/DeployClusteredIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/DeployClusteredIT.java
@@ -1,0 +1,175 @@
+package io.camunda.zeebe.it.clustering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.Capability;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
+import io.zeebe.containers.ZeebeBrokerNode;
+import io.zeebe.containers.ZeebeContainer;
+import io.zeebe.containers.cluster.ZeebeCluster;
+import java.io.IOException;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.agrona.CloseHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Container.ExecResult;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
+
+public class DeployClusteredIT {
+
+  private static final BpmnModelInstance PROCESS =
+      Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(FixedPartitionDistributionIT.class);
+
+  private Network network;
+  private ZeebeCluster cluster;
+
+  @SuppressWarnings("unused")
+  @RegisterExtension
+  final ContainerLogsDumper logsWatcher =
+      new ContainerLogsDumper(() -> cluster.getBrokers(), LOGGER);
+
+  @BeforeEach
+  void beforeEach() {
+    network = Network.newNetwork();
+  }
+
+  @AfterEach
+  void afterEach() {
+    CloseHelper.quietCloseAll(cluster, network);
+  }
+
+  @Test
+  void shouldDistributePartitions() throws IOException, InterruptedException {
+    // given
+    cluster =
+        ZeebeCluster.builder()
+            .withImage(DockerImageName.parse("camunda/zeebe:SNAPSHOT"))
+            .withBrokersCount(3)
+            .withEmbeddedGateway(true)
+            .withPartitionsCount(3)
+            //            .withBrokerConfig(
+            //                n -> {
+            //                  ((ZeebeContainer) n)
+            //                      .withCreateContainerCmdModifier(
+            //                          (CreateContainerCmd it) ->
+            //                              it.withHostConfig(
+            //
+            // HostConfig.newHostConfig().withCapAdd(Capability.NET_ADMIN)));
+            //                })
+            .withReplicationFactor(3)
+            .build();
+    cluster.getBrokers().forEach((nodeId, broker) -> configureBroker(broker));
+    cluster.start();
+
+    final Set<Integer> nodes = IntStream.range(0, 3).boxed().collect(Collectors.toSet());
+
+    final var zeebeClient = cluster.newClientBuilder().build();
+    final var topology = zeebeClient.newTopologyRequest().send().join();
+    final var leaderOfPartitionOne =
+        topology.getBrokers().stream()
+            .filter(b -> b.getPartitions().get(0).isLeader())
+            .findFirst()
+            .orElseThrow();
+
+    final var leaderOfPartitionThree =
+        topology.getBrokers().stream()
+            .filter(b -> b.getPartitions().get(2).isLeader())
+            .findFirst()
+            .orElseThrow();
+    assertThat(leaderOfPartitionOne.getNodeId()).isNotEqualTo(leaderOfPartitionThree.getNodeId());
+
+    nodes.remove(leaderOfPartitionOne.getNodeId());
+    nodes.remove(leaderOfPartitionThree.getNodeId());
+
+    final ZeebeBrokerNode<? extends GenericContainer<?>> leaderOneNode =
+        cluster.getBrokers().get(leaderOfPartitionOne.getNodeId());
+
+    runCommandInContainer(leaderOneNode, "apt update");
+    runCommandInContainer(leaderOneNode, "apt install -y iproute2");
+    final var results =
+        runCommandInContainer(leaderOneNode, "ip route").getStdout().trim().split(" ");
+    final var ipAddress = results[results.length - 1];
+
+    // alternative extract ip address
+    //    final var execResult = runCommandInContainer(leaderOneNode,
+    //        "ip route | grep 'src' | awk '{ print $NF }'");
+    //    final var ipAddress = execResult.getStdout();
+    //    LOGGER.info("Error IP {}", execResult.getStderr());
+    //    LOGGER.info("Returned IP {}", ipAddress);
+
+    final ZeebeBrokerNode<? extends GenericContainer<?>> leaderThreeNode =
+        cluster.getBrokers().get(leaderOfPartitionThree.getNodeId());
+
+    runCommandInContainer(leaderThreeNode, "apt update");
+    runCommandInContainer(leaderThreeNode, "apt install -y iproute2");
+    LOGGER.info(
+        "{}",
+        runCommandInContainer(leaderThreeNode, "ip route add unreachable " + ipAddress)
+            .getStdout());
+
+    //    LOGGER.info("{}", leaderThreeNode.execInContainer("ip", "route").getStdout());
+
+    zeebeClient.newDeployCommand().addProcessModel(PROCESS, "process.bpmn").send().join();
+
+    final var partitions = IntStream.range(1, 4).boxed().collect(Collectors.toSet());
+
+    while (!partitions.isEmpty()) {
+      final var processInstanceEvent =
+          zeebeClient
+              .newCreateInstanceCommand()
+              .bpmnProcessId("process")
+              .latestVersion()
+              .send()
+              .join();
+
+      final var partitionId =
+          Protocol.decodePartitionId(processInstanceEvent.getProcessInstanceKey());
+
+      LOGGER.info("Instance created on partition: {}", partitionId);
+      partitions.remove(partitionId);
+    }
+  }
+
+  private ExecResult runCommandInContainer(
+      final ZeebeBrokerNode<? extends GenericContainer<?>> container, final String command)
+      throws IOException, InterruptedException {
+    LOGGER.info("Run command: {}", command);
+
+    final var commands = command.split(" ");
+    final var execResult = container.execInContainer(commands);
+
+    if (execResult.getExitCode() == 0) {
+      LOGGER.info("Command {} was successful.", command);
+    } else {
+      LOGGER.info("Command {} failed with code: {}", command, execResult.getExitCode());
+      LOGGER.info("Stderr: {}", execResult.getStderr());
+    }
+
+    return execResult;
+  }
+
+  private void configureBroker(final ZeebeBrokerNode<?> broker) {
+    ((ZeebeContainer) broker)
+        .withCreateContainerCmdModifier(
+            (CreateContainerCmd it) ->
+                it.withHostConfig(it.getHostConfig().withCapAdd(Capability.NET_ADMIN)));
+
+    broker
+        .withEnv("ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE", "1MB")
+        .withEnv("ZEEBE_BROKER_DATA_LOGSEGMENTSIZE", "16MB");
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/GrpcClientRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/GrpcClientRule.java
@@ -178,6 +178,12 @@ public final class GrpcClientRule extends ExternalResource {
     return deploymentEvent.getProcesses().get(0).getProcessDefinitionKey();
   }
 
+  public long deployProcessWithoutAwait(final BpmnModelInstance modelInstance) {
+    final DeploymentEvent deploymentEvent =
+        getClient().newDeployCommand().addProcessModel(modelInstance, "process.bpmn").send().join();
+    return deploymentEvent.getProcesses().get(0).getProcessDefinitionKey();
+  }
+
   public long createProcessInstance(final long processDefinitionKey, final String variables) {
     return getClient()
         .newCreateInstanceCommand()


### PR DESCRIPTION
## Description

Hey Team, 

in order to make https://github.com/camunda-cloud/zeebe/issues/8349 possible I started to add something in the `ClusterCommunicationService` and wanted to validate with you whether this makes sense to you or I'm completely on the wrong track.

What we want to have is a way to disconnect node in different ways, so for example: not able to receive responses from a specific node, but from other nodes. Like creating asymmetric network partition.

This is useful for cases like https://github.com/camunda-cloud/zeebe/issues/7062

What do you think about that approach? Be aware it is a draft. I created an example test case to make it more visible. If you remove the connect call the test will fail.

 

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
