### PR TITLE
Ensure leader always commits when replicated to quorum

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -204,10 +204,7 @@ final class LeaderAppender extends AbstractAppender {
       member.appendSucceeded();
       updateMatchIndex(member, response);
 
-      // If entries were committed to the replica then check commit indexes.
-      if (!request.entries().isEmpty()) {
-        commitEntries();
-      }
+      commitEntries();
 
       // If there are more entries to send then attempt to send another commit.
       if (hasMoreEntries(member)) {

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -253,23 +253,38 @@ public final class ControllableRaftContexts {
   }
 
   public void tickElectionTimeout(final int memberId) {
-    getDeterministicScheduler(memberId).tick(electionTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    tick(memberId, electionTimeout);
   }
 
   public void tickElectionTimeout(final MemberId memberId) {
-    getDeterministicScheduler(memberId).tick(electionTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    tick(memberId, electionTimeout);
   }
 
   public void tickHeartbeatTimeout(final int memberId) {
-    getDeterministicScheduler(memberId).tick(hearbeatTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    tick(memberId, hearbeatTimeout);
   }
 
   public void tickHeartbeatTimeout(final MemberId memberId) {
-    getDeterministicScheduler(memberId).tick(hearbeatTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    tick(memberId, hearbeatTimeout);
+  }
+
+  public void tickHeartbeatTimeout() {
+    tick(hearbeatTimeout);
+  }
+
+  public void tick(final Duration time) {
+    final var serverIds = raftServers.keySet();
+    serverIds.forEach(memberId -> tick(memberId, time));
+  }
+
+  public void tick(final int memberId, final Duration time) {
+    getDeterministicScheduler(memberId).tick(time.toMillis(), TimeUnit.MILLISECONDS);
+    getServerProtocol(memberId).tick(time.toMillis());
   }
 
   public void tick(final MemberId memberId, final Duration time) {
     getDeterministicScheduler(memberId).tick(time.toMillis(), TimeUnit.MILLISECONDS);
+    getServerProtocol(memberId).tick(time.toMillis());
   }
 
   // Execute an append on memberid. If memberid is not the the leader, the append will be rejected.

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -27,6 +27,7 @@ import io.atomix.raft.protocol.ControllableRaftServerProtocol;
 import io.atomix.raft.roles.LeaderRole;
 import io.atomix.raft.snapshot.TestSnapshotStore;
 import io.atomix.raft.storage.RaftStorage;
+import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLogReader;
 import io.atomix.raft.zeebe.NoopEntryValidator;
 import io.atomix.raft.zeebe.ZeebeLogAppender.AppendListener;
@@ -341,7 +342,7 @@ public final class ControllableRaftContexts {
     readers.values().forEach(RaftLogReader::close);
   }
 
-  public void assertOnlyOneLeader() {
+  public void assertAtMostOneLeader() {
     raftServers.values().forEach(s -> updateAndVerifyLeaderTerm(s));
   }
 
@@ -357,6 +358,71 @@ public final class ControllableRaftContexts {
       } else {
         leadersAtTerms.put(term, leader);
       }
+    }
+  }
+
+  // If a node is in CandidateRole, then it will update the term. But until the election is
+  // completed, there is no leader at that term.
+  public boolean hasLeaderAtTheLatestTerm() {
+    // update leadersAtTerms
+    assertAtMostOneLeader();
+
+    final var currentTerm =
+        raftServers.values().stream().map(RaftContext::getTerm).max(Long::compareTo).orElseThrow();
+    return leadersAtTerms.get(currentTerm) != null;
+  }
+
+  boolean hasCommittedAllEntries() {
+    return raftServers.values().stream()
+        .allMatch(
+            s -> {
+              final var lastCommittedEntry = getLastCommittedEntry(s);
+              final var lastUncommittedEntry = getLastUncommittedEntry(s);
+
+              return lastUncommittedEntry != null
+                  && lastUncommittedEntry.equals(lastCommittedEntry);
+            });
+  }
+
+  boolean hasReplicatedAllEntries() {
+    return raftServers.values().stream().map(this::getLastUncommittedEntry).distinct().count() == 1;
+  }
+
+  public void assertAllEntriesCommittedAndReplicatedToAll() {
+    raftServers
+        .values()
+        .forEach(
+            s -> {
+              final var lastCommittedEntry = getLastCommittedEntry(s);
+              final var lastUncommittedEntry = getLastUncommittedEntry(s);
+
+              assertThat(lastCommittedEntry)
+                  .describedAs("All entries should be committed")
+                  .isEqualTo(lastUncommittedEntry);
+            });
+
+    assertThat(hasReplicatedAllEntries())
+        .describedAs("All entries are replicated to all followers")
+        .isTrue();
+  }
+
+  private IndexedRaftLogEntry getLastUncommittedEntry(final RaftContext s) {
+    try (final var uncommittedReader = s.getLog().openUncommittedReader()) {
+      uncommittedReader.seekToLast();
+      if (uncommittedReader.hasNext()) {
+        return uncommittedReader.next();
+      }
+      return null;
+    }
+  }
+
+  private IndexedRaftLogEntry getLastCommittedEntry(final RaftContext s) {
+    try (final var committedReader = s.getLog().openCommittedReader()) {
+      committedReader.seekToLast();
+      if (committedReader.hasNext()) {
+        return committedReader.next();
+      }
+      return null;
     }
   }
 }


### PR DESCRIPTION
## Description

* Added a randomized liveness test similar to consistency test that already exists. This test was able to reproduce the bug in #8324 The new test verifies that in the presence of no message lost or delay raft can make progress - that means a leader will be elected, all entries are replicated to all followers, and all entries are committed.
* Leader will now commit entries when receiving response for a heartbeat, thus ensuring that it can make progress.

## Related issues

closes #8324

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
