### PR TITLE
Raise incident when candidate groups expression does not evaluate to array of strings

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
@@ -59,12 +59,7 @@ class ExpressionProcessorTest {
       return Stream.of(
           Arguments.of("= []", List.of()),
           Arguments.of("= [\"a\"]", List.of("a")),
-          Arguments.of("= [\"a\",\"b\"]", List.of("a", "b")),
-          // todo: move the arguments below to notArrayOfStringsExpressions once we find a better
-          //  implementation to check each of the elements in the list to be of type string
-          Arguments.of("= [1,2,3]", List.of("1", "2", "3")),
-          Arguments.of("= [{},{}]", List.of("{}", "{}")),
-          Arguments.of("= [null]", List.of("null")));
+          Arguments.of("= [\"a\",\"b\"]", List.of("a", "b")));
     }
 
     Stream<Arguments> notArrayOfStringsExpressions() {
@@ -77,7 +72,16 @@ class ExpressionProcessorTest {
           Arguments.of(
               "= {}", "Expected result of the expression ' {}' to be 'ARRAY', but was 'OBJECT'."),
           Arguments.of(
-              "[]", "Expected result of the expression '[]' to be 'ARRAY', but was 'STRING'."));
+              "[]", "Expected result of the expression '[]' to be 'ARRAY', but was 'STRING'."),
+          Arguments.of(
+              "= [1,2,3]",
+              "Expected result of the expression ' [1,2,3]' to be 'ARRAY' containing 'STRING' items, but was 'ARRAY' containing at least one non-'STRING' item."),
+          Arguments.of(
+              "= [{},{}]",
+              "Expected result of the expression ' [{},{}]' to be 'ARRAY' containing 'STRING' items, but was 'ARRAY' containing at least one non-'STRING' item."),
+          Arguments.of(
+              "= [null]",
+              "Expected result of the expression ' [null]' to be 'ARRAY' containing 'STRING' items, but was 'ARRAY' containing at least one non-'STRING' item."));
     }
   }
 }

--- a/expression-language/src/main/java/io/camunda/zeebe/el/EvaluationResult.java
+++ b/expression-language/src/main/java/io/camunda/zeebe/el/EvaluationResult.java
@@ -87,4 +87,14 @@ public interface EvaluationResult {
    * @return the evaluation result, or {@code null} if it is not an array
    */
   List<DirectBuffer> getList();
+
+  /**
+   * Use {@link #getType()} to check if the result is of the type {@link ResultType#ARRAY}. Note
+   * that, this method differs from {@link #getList()} in that it returns {@code null} if any of the
+   * array items is not of type {@link ResultType#STRING}.
+   *
+   * @return the evaluation result, or {@code null} if it is not an array, or {@code null} if any of
+   *     the items in the array is not a string.
+   */
+  List<String> getListOfStrings();
 }

--- a/expression-language/src/main/java/io/camunda/zeebe/el/impl/EvaluationFailure.java
+++ b/expression-language/src/main/java/io/camunda/zeebe/el/impl/EvaluationFailure.java
@@ -85,4 +85,9 @@ public final class EvaluationFailure implements EvaluationResult {
   public List<DirectBuffer> getList() {
     return null;
   }
+
+  @Override
+  public List<String> getListOfStrings() {
+    return null;
+  }
 }

--- a/expression-language/src/main/java/io/camunda/zeebe/el/impl/StaticExpression.java
+++ b/expression-language/src/main/java/io/camunda/zeebe/el/impl/StaticExpression.java
@@ -35,7 +35,7 @@ public final class StaticExpression implements Expression, EvaluationResult {
 
     try {
       treatAsNumber(expression);
-    } catch (NumberFormatException e) {
+    } catch (final NumberFormatException e) {
       treatAsString(expression);
     }
   }
@@ -124,6 +124,11 @@ public final class StaticExpression implements Expression, EvaluationResult {
 
   @Override
   public List<DirectBuffer> getList() {
+    return null;
+  }
+
+  @Override
+  public List<String> getListOfStrings() {
     return null;
   }
 }

--- a/expression-language/src/main/scala/io/camunda/zeebe/el/impl/feel/FeelEvaluationResult.scala
+++ b/expression-language/src/main/scala/io/camunda/zeebe/el/impl/feel/FeelEvaluationResult.scala
@@ -79,4 +79,19 @@ class FeelEvaluationResult(
     case ValList(array) => array.map(value => cloneBuffer(messagePackTransformer(value))).asJava
     case _ => null
   }
+
+  override def getListOfStrings: util.List[String] = result match {
+    case ValList(array) => array.map {
+      case ValString(string) => string
+      case _ => null
+    }.foldLeft(List[String]())((acc, next) => {
+      if (acc == null) {
+        acc
+      } else if (next == null) {
+        null
+      } else {
+        acc :+ next
+      }
+    }).asJava
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

> Note, I use the word **array** here to indicate the Result Type of the evaluation result and the word **list** to indicate the return type of the new method to retrieve this specific result.

Previously, the candidate groups expression evaluation result was transformed to a list of strings using our knowledge of the feel-engine. Specifically, it assumed that the result is a message pack formatted object. This information was used to transform each item in the array of the evaluation result to a string type. That includes all non-string types, like numbers, objects and other arrays. The items were then collected in a list.

This switches that implementation to a Scala based solution that does not require the usage of message pack and restricts the evaluations to array of strings specifically. If one or more of the items in the array is not a string, it evaluates to null (in the same fashion as other failures to evaluate to the correct type). The items are only collected in a list, if all items are strings.

This change in implementation is used to raise an incident in the case that the expression evaluated to something different than an array of strings.

Some alternative solutions were tried out, but discarded:
- using message pack to find out the specific type of each of the items: this still kept the dependency on the message pack parts, which is an implementation detail that we shouldn't rely on.
- providing a more general `getListOf(ResultType itemType)` (or equivalent) method to evaluation result: this can work, but was quite some effort to get right. Even then, it's unclear whether this is the direction we want to take, e.g. we could also consider taking this a step further and providing a more recursive typing approach (perhaps more like generics). We should probably re-evaluate the current ResultType implementation to deal with this. @saig0 agreed that we should first solve this issue in a simple way. We can then look for improving the evaluation result class if we have a real need for it.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8303

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
