### PR TITLE
Add debug logging to failing go integration tests

### DIFF
--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -214,12 +214,12 @@ func (s *integrationTestSuite) TestCommonCommands() {
 			if test.jsonOutput {
 				cmdOut, err = reformatJSON(cmdOut)
 				if err != nil {
-					t.Fatalf("failed to reformat JSON: %v", err)
+					t.Fatalf("failed to reformat response JSON: %v\nErroneous JSON: %v", err, cmdOut)
 				}
 
 				goldenOut, err = reformatJSON(goldenOut)
 				if err != nil {
-					t.Fatalf("failed to reformat JSON: %v", err)
+					t.Fatalf("failed to reformat golden JSON: %v\nErroneous JSON: %v", err, goldenOut)
 				}
 			}
 


### PR DESCRIPTION
## Description

It can happen that builds fail due to invalid JSON in the tests, most likely because the response is not a valid response but some error. Unfortunately it's hard to debug because we can't see the actual invalid output. This doesn't actually fix it, but it will help us figure out what the issue was next time.

On failure, the errors would mention something equivalent to `Expected JSON output to start with {, but was E`, which is definitely not enough to debug anything.

## Related issues

related to #8284

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
