### PR TITLE
chore(elastic): update to elasticsearch 7.16.1

### DIFF
--- a/exporters/elasticsearch-exporter/docker-compose.yml
+++ b/exporters/elasticsearch-exporter/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.12.1
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.16.1
         ports:
             - "9200:9200"
             - "9300:9300"
@@ -12,7 +12,7 @@ services:
             - ES_JAVA_OPTS=-Xmx750m -Xms750m
 
     kibana:
-        image: docker.elastic.co/kibana/kibana:7.12.1
+        image: docker.elastic.co/kibana/kibana:7.16.1
         ports:
             - "5601:5601"
         links:

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -42,11 +42,11 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
-import org.elasticsearch.common.xcontent.DeprecationHandler;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.XContent;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.xcontent.DeprecationHandler;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xcontent.XContent;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 
 public class ElasticsearchClient {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.commons-math>3.6.1</version.commons-math>
     <version.commons-codec>1.15</version.commons-codec>
     <version.docker-java-api>3.2.8</version.docker-java-api>
-    <version.elasticsearch>7.13.2</version.elasticsearch>
+    <version.elasticsearch>7.16.1</version.elasticsearch>
     <version.error-prone>2.7.1</version.error-prone>
     <version.grpc>1.42.0</version.grpc>
     <version.gson>2.8.9</version.gson>


### PR DESCRIPTION
## Description

Update Elasticsearch to 7.16.1 for Zeebe 1.2 branch, related to https://www.elastic.co/guide/en/elasticsearch/reference/current/release-notes-7.16.1.html
