### PR TITLE
Fixed a bug with line wrapping in zbctl status

### DIFF
--- a/clients/go/cmd/zbctl/internal/commands/status.go
+++ b/clients/go/cmd/zbctl/internal/commands/status.go
@@ -67,7 +67,7 @@ func (s StatusResponseWrapper) human() (string, error) {
 				roleToString(partition.Role),
 				healthToString(partition.Health)))
 
-			if p < len(broker.Partitions)-1 || b < len(broker.Partitions)-1 {
+			if p < len(broker.Partitions)-1 || b < len(resp.Brokers)-1 {
 				stringBuilder.WriteRune('\n')
 			}
 		}


### PR DESCRIPTION
## Description

I came across a bug where the line wrapping was not done correctly when fetching `zbctl status`.

## Related issues

I have not created an issue, yet I can provide an example:

```
Cluster size: 3
Partitions count: 2
Replication factor: 3
Gateway version: 1.2.4
Brokers:
  Broker 0 - zeebe-0.zeebe-broker-service.fa669840-fd18-48d1-99b1-b251c5f37709-zeebe.svc.cluster.local:26501
    Version: 1.2.4
    Partition 1 : Follower, Healthy
    Partition 2 : Follower, Healthy
  Broker 1 - zeebe-1.zeebe-broker-service.fa669840-fd18-48d1-99b1-b251c5f37709-zeebe.svc.cluster.local:26501
    Version: 1.2.4
    Partition 1 : Leader, Healthy
    Partition 2 : Leader, Healthy  Broker 2 - zeebe-2.zeebe-broker-service.fa669840-fd18-48d1-99b1-b251c5f37709-zeebe.svc.cluster.local:26501
    Version: 1.2.4
    Partition 1 : Follower, Healthy
    Partition 2 : Follower, Healthy

```
As you can see, the Broker 2 is not wrapped. This was because a line break was only done as long as the index for iterating Brokers or the index for iterating partitions was smaller than the amount of partitions -1.

My fix now compares the index of the Broker with the amount of brokers -1 and the index of the Partition with the amount of partitions -1.
<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [ ] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
