### PR TITLE
Backport improved revapi configuration

### DIFF
--- a/bpmn-model/revapi.json
+++ b/bpmn-model/revapi.json
@@ -1,27 +1,30 @@
 [
   {
-    "extension": "revapi.differences",
+    "extension": "revapi.filter",
+    "justification": "Ignore everything not included in the module itself",
     "configuration": {
-      "justification": "Ignore new methods for Zeebe extensions, as these are not meant to be implemented but simply consumed; as such, new methods are perfectly fine to add",
-      "ignore": true,
-      "differences": [
-        {
-          "code": "java.method.addedToInterface",
-          "new": {
-            "matcher": "java-package",
-            "match": "/io\\.camunda\\.zeebe\\.model\\.bpmn\\.instance\\.zeebe(\\..*)?/"
-          }
-        }
-      ]
+      "archives": {
+        "include": [
+          "io\\.camunda:zeebe-bpmn-model:.*"
+        ]
+      }
     }
   },
   {
     "extension": "revapi.differences",
     "configuration": {
-      "justification": "The abstract builders are usually not used outside of this project; a caller uses the concrete builder that inherits from the abstract builder.",
       "ignore": true,
       "differences": [
         {
+          "justification": "Ignore new methods for Zeebe extensions, as these are not meant to be implemented but simply consumed; as such, new methods are perfectly fine to add",
+          "code": "java.method.addedToInterface",
+          "new": {
+            "matcher": "java-package",
+            "match": "/io\\.camunda\\.zeebe\\.model\\.bpmn\\.instance\\.zeebe(\\..*)?/"
+          }
+        },
+        {
+          "justification": "The abstract builders are usually not used outside of this project; a caller uses the concrete builder that inherits from the abstract builder.",
           "code": "java.class.nonFinalClassInheritsFromNewClass",
           "new": {
             "matcher": "java-package",
@@ -33,6 +36,14 @@
           "code": "java.class.noLongerInheritsFromClass",
           "old": "class io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeUserTaskFormImpl",
           "superClass": "io.camunda.zeebe.model.bpmn.impl.instance.BaseElementImpl"
+        },
+        {
+          "justification": "Validators are used only internally; they should not used or referenced from outside of the module",
+          "code": "java.class.removed",
+          "old": {
+            "matcher": "java-package",
+            "match": "io.camunda.zeebe.model.bpmn.validation.zeebe"
+          }
         }
       ]
     }

--- a/build-tools/src/main/resources/revapi/revapi.json
+++ b/build-tools/src/main/resources/revapi/revapi.json
@@ -1,23 +1,43 @@
 [
   {
-    "extension": "revapi.semver.ignore",
-    "configuration": {
-      "enabled": true,
-      "versionIncreaseAllows": {
-        "major": "breaking",
-        "minor": "nonBreaking",
-        "patch": "nonBreaking"
-      },
-      "passThroughDifferences": [
-        "java.class.nonPublicPartOfAPI"
-      ]
-    }
-  },
-  {
     "extension": "revapi.java",
     "configuration": {
       "reportUsesFor": "all-differences",
+      "missing-classes": {
+        "behavior": "ignore",
+        "ignoreMissingAnnotations": true
+      },
       "matchOverloads": false
+    }
+  },
+  {
+    "extension": "revapi.versions",
+    "configuration": {
+      "enabled": true,
+      "passThroughDifferences": [
+        "java.class.nonPublicPartOfAPI"
+      ],
+      "versionIncreaseAllows": {
+        "major": {
+          "severity": "BREAKING"
+        },
+        "minor": {
+          "classification": {
+            "BINARY": "NON_BREAKING",
+            "SOURCE": "BREAKING",
+            "SEMANTIC": "BREAKING",
+            "OTHER": "BREAKING"
+          }
+        },
+        "patch": {
+          "classification": {
+            "BINARY": "NON_BREAKING",
+            "SOURCE": "BREAKING",
+            "SEMANTIC": "BREAKING",
+            "OTHER": "BREAKING"
+          }
+        }
+      }
     }
   }
 ]

--- a/clients/java/revapi.json
+++ b/clients/java/revapi.json
@@ -22,10 +22,10 @@
   {
     "extension": "revapi.differences",
     "configuration": {
-      "justification": "Ignore new methods on all types, as these are not meant to be implemented but simply consumed; as such, new methods are perfectly fine to add",
       "ignore": true,
       "differences": [
         {
+          "justification": "Ignore new methods on all types, as these are not meant to be implemented but simply consumed; as such, new methods are perfectly fine to add",
           "code": "java.method.addedToInterface"
         }
       ]

--- a/exporter-api/revapi.json
+++ b/exporter-api/revapi.json
@@ -1,5 +1,16 @@
 [
   {
+    "extension": "revapi.filter",
+    "justification": "Ignore everything not included in the module itself",
+    "configuration": {
+      "archives": {
+        "include": [
+          "io\\.camunda:zeebe-exporter-api:.*"
+        ]
+      }
+    }
+  },
+  {
     "extension": "revapi.differences",
     "configuration": {
       "justification": "Ignore new methods on all types, as these are not meant to be implemented but simply consumed; as such, new methods are perfectly fine to add",

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -100,7 +100,7 @@
     <version.jmock>2.12.0</version.jmock>
     <version.json-smart>2.4.7</version.json-smart>
     <version.byte-buddy>1.11.5</version.byte-buddy>
-    <version.revapi>0.24.3</version.revapi>
+    <version.revapi>0.26.1</version.revapi>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.0.0</plugin.version.antrun>
@@ -127,7 +127,7 @@
     <plugin.version.maven-jar>3.2.0</plugin.version.maven-jar>
     <plugin.version.dependency-analyzer>1.11.1</plugin.version.dependency-analyzer>
     <plugin.version.jacoco>0.8.7</plugin.version.jacoco>
-    <plugin.version.revapi>0.14.3</plugin.version.revapi>
+    <plugin.version.revapi>0.14.6</plugin.version.revapi>
 
     <!-- maven extensions -->
     <extension.version.os-maven-plugin>1.7.0</extension.version.os-maven-plugin>
@@ -776,27 +776,6 @@
           <groupId>org.revapi</groupId>
           <artifactId>revapi-maven-plugin</artifactId>
           <version>${plugin.version.revapi}</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.revapi</groupId>
-              <artifactId>revapi-java</artifactId>
-              <version>${version.revapi}</version>
-            </dependency>
-            <dependency>
-              <groupId>io.camunda</groupId>
-              <artifactId>zeebe-build-tools</artifactId>
-              <version>${project.version}</version>
-            </dependency>
-          </dependencies>
-          <executions>
-            <execution>
-              <phase>verify</phase>
-              <id>check</id>
-              <goals>
-                <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
           <configuration>
             <!-- see the property's documentation as to why -->
             <checkDependencies>true</checkDependencies>
@@ -804,7 +783,11 @@
             <expandProperties>true</expandProperties>
             <!-- allows us to pre-defined ignored-changes, even when missing -->
             <failOnMissingConfigurationFiles>false</failOnMissingConfigurationFiles>
-            <analysisConfigurationFiles combine.children="append">
+            <analysisConfigurationFiles>
+              <!-- look for an optional relative configuration file -->
+              <configurationFile>
+                <path>revapi.json</path>
+              </configurationFile>
               <!-- uses the default configuration file packaged in build-tools -->
               <configurationFile>
                 <resource>revapi/revapi.json</resource>
@@ -819,7 +802,38 @@
               different branches which need to compare to different versions
               -->
             <oldVersion>${backwards.compat.version}</oldVersion>
+            <pipelineConfiguration>
+              <transformBlocks>
+                <!-- always execute the various differences plugins first which can exclude some
+                     differences for the semantic version checker -->
+                <block>
+                  <item>revapi.differences</item>
+                  <item>revapi.versions</item>
+                </block>
+              </transformBlocks>
+            </pipelineConfiguration>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.revapi</groupId>
+              <artifactId>revapi-java</artifactId>
+              <version>${version.revapi}</version>
+            </dependency>
+            <dependency>
+              <groupId>io.camunda</groupId>
+              <artifactId>zeebe-build-tools</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+          </dependencies>
+          <executions>
+            <execution>
+              <id>check</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <phase>verify</phase>
+            </execution>
+          </executions>
         </plugin>
 
         <!-- javadoc generation -->

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -1,36 +1,32 @@
 [
   {
-    "extension": "revapi.differences",
+    "extension": "revapi.filter",
+    "justification": "Ignore everything not included in the module itself",
     "configuration": {
-      "justification": "Ignore new methods on all types, as these are not meant to be implemented but simply consumed; as such, new methods are perfectly fine to add",
-      "ignore": true,
-      "differences": [
-        {
-          "code": "java.method.addedToInterface",
-          "new": {
-            "matcher": "java-package",
-            "match": "/io\\.camunda\\.zeebe\\.protocol\\.record(\\..*)?/"
-          }
-        }
-      ]
+      "archives": {
+        "include": ["io\\.camunda:zeebe-protocol:.*"]
+      }
     }
   },
   {
-    "extension": "revapi.filter",
+    "extension": "revapi.differences",
     "configuration": {
-      "justification": "The generated encoders/decoders are not meant to be used directly, and as such does not need to maintain any backwards compatibility guarantees.",
-      "elements": {
-        "exclude": [
-          {
-            "matcher": "java",
-            "match": "type ^* implements org.agrona.sbe.CompositeEncoderFlyweight {}"
-          },
-          {
-            "matcher": "java",
-            "match": "type ^* implements org.agrona.sbe.CompositeDecoderFlyweight {}"
+      "ignore": true,
+      "differences": [
+        {
+          "justification": "Ignore Enum order for BpmnElementType as ordinal() is not used and the elements are grouped in the enum.",
+          "code": "java.field.enumConstantOrderChanged",
+          "classQualifiedName": "io.camunda.zeebe.protocol.record.value.BpmnElementType"
+        },
+        {
+          "justification": "Ignore new methods for Protocol Record Value interfaces, as these are not meant to be implemented but simply consumed; as such, new methods are perfectly fine to add",
+          "code": "java.method.addedToInterface",
+          "new": {
+            "matcher": "java-package",
+            "match": "/io\\.camunda\\.zeebe\\.protocol\\.record\\.value(\\..*)?/"
           }
-        ]
-      }
+        }
+      ]
     }
   }
 ]

--- a/test/revapi.json
+++ b/test/revapi.json
@@ -1,32 +1,11 @@
 [
   {
     "extension": "revapi.filter",
+    "justification": "Ignore everything not included in the module itself",
     "configuration": {
-      "justification": "We expose certain external types on purpose, and for these, we can relax the compatibility guarantees.",
-      "elements": {
-        "exclude": [
-          {
-            "matcher": "java-package",
-            "match": "/org\\.assertj(\\..*)?/"
-          },
-          {
-            "matcher": "java-package",
-            "match": "io.camunda.zeebe.broker.system.configuration"
-          }
-        ]
-      }
-    }
-  },
-  {
-    "extension": "revapi.filter",
-    "configuration": {
-      "justification": "The client API is already checked in the module itself.",
-      "elements": {
-        "exclude": [
-          {
-            "matcher": "java-package",
-            "match": "io.camunda.zeebe.client"
-          }
+      "archives": {
+        "include": [
+          "io\\.camunda:zeebe-test:.*"
         ]
       }
     }


### PR DESCRIPTION
## Description

This PR backports the most recent configuration of revapi to 1.1 to avoid conflicts and bugs in the older, now unsupported plugins.

## Related issues

related to #8362 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
