### PR TITLE
New asymmetric network partition IT test

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/AsymmetricNetworkPartitionIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/AsymmetricNetworkPartitionIT.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.Capability;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.BrokerInfo;
+import io.camunda.zeebe.client.api.response.PartitionInfo;
+import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
+import io.zeebe.containers.ZeebeBrokerNode;
+import io.zeebe.containers.ZeebeContainer;
+import io.zeebe.containers.cluster.ZeebeCluster;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.agrona.CloseHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Container.ExecResult;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+import org.testcontainers.utility.DockerImageName;
+
+public class AsymmetricNetworkPartitionIT {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AsymmetricNetworkPartitionIT.class);
+  private ZeebeCluster cluster;
+
+  @SuppressWarnings("unused")
+  @RegisterExtension
+  final ContainerLogsDumper logsWatcher =
+      new ContainerLogsDumper(() -> cluster.getBrokers(), LOGGER);
+
+  private ZeebeClient zeebeClient;
+
+  @SuppressWarnings("unused")
+  public static Stream<Arguments> provideTestCases() {
+    return Stream.of(
+        Arguments.of(
+            "Deployment distribution",
+            (Consumer<ZeebeClient>)
+                (client) -> { // given
+                  final var process =
+                      Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
+                  client.newDeployCommand().addProcessModel(process, "process.bpmn").send().join();
+                },
+            (Consumer<ZeebeClient>)
+                (client) -> { // then
+                  final var topology = client.newTopologyRequest().send().join();
+
+                  final var partitions =
+                      IntStream.range(1, topology.getPartitionsCount() + 1)
+                          .boxed()
+                          .collect(Collectors.toSet());
+
+                  Awaitility.await("should be able to create instances on all partitions")
+                      .ignoreExceptions()
+                      .atMost(Duration.ofMinutes(1))
+                      .until(
+                          () -> {
+                            final var processInstanceEvent =
+                                client
+                                    .newCreateInstanceCommand()
+                                    .bpmnProcessId("process")
+                                    .latestVersion()
+                                    .send()
+                                    .join();
+
+                            return Protocol.decodePartitionId(
+                                processInstanceEvent.getProcessInstanceKey());
+                          },
+                          (partitionId) -> {
+                            LOGGER.info("Instance created on partition: {}", partitionId);
+                            partitions.remove(partitionId);
+                            return partitions.isEmpty();
+                          });
+                }));
+  }
+
+  @AfterEach
+  void afterEach() {
+    CloseHelper.quietCloseAll(cluster, zeebeClient);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTestCases")
+  public void shouldWithstandAsymmetricNetworkPartition(
+      final String name, final Consumer<ZeebeClient> given, final Consumer<ZeebeClient> then)
+      throws IOException, InterruptedException {
+    // given
+    LOGGER.info("Run test {}", name);
+    setupZeebeCluster();
+    zeebeClient = cluster.newClientBuilder().build();
+
+    final var topology = zeebeClient.newTopologyRequest().send().join();
+    final var leaderOfPartitionOne = getPartitionLeader(topology, 1);
+    final var leaderOfPartitionThree = getPartitionLeader(topology, 3);
+    assertThat(leaderOfPartitionOne.getNodeId()).isNotEqualTo(leaderOfPartitionThree.getNodeId());
+
+    final var ipAddress =
+        getContainerIpAddress(getContainerForNodeId(leaderOfPartitionOne.getNodeId()));
+    setupAsymmetricNetworkPartition(
+        ipAddress, getContainerForNodeId(leaderOfPartitionThree.getNodeId()));
+
+    given.accept(zeebeClient);
+
+    // when
+    removeAsymmetricNetworkPartition(
+        ipAddress, getContainerForNodeId(leaderOfPartitionThree.getNodeId()));
+
+    // then
+    then.accept(zeebeClient);
+  }
+
+  private BrokerInfo getPartitionLeader(final Topology topology, final int partition) {
+    return topology.getBrokers().stream()
+        .filter(
+            b ->
+                b.getPartitions().stream()
+                    .filter(p -> p.getPartitionId() == partition)
+                    .anyMatch(PartitionInfo::isLeader))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private void removeAsymmetricNetworkPartition(
+      final String ipAddress, final ZeebeBrokerNode<? extends GenericContainer<?>> brokerNode)
+      throws IOException, InterruptedException {
+    LOGGER.info(
+        "{}",
+        runCommandInContainer(brokerNode, "ip route del unreachable " + ipAddress).getStdout());
+  }
+
+  /**
+   * Set the given ip address unreachable for the given container.
+   *
+   * @param ipAddress the ip address which should be unreachable
+   * @param brokerNode the broker container which should be updated
+   * @throws IOException Can be thrown during running commands in the container
+   * @throws InterruptedException Can be thrown during running commands in the container
+   */
+  private void setupAsymmetricNetworkPartition(
+      final String ipAddress, final ZeebeBrokerNode<? extends GenericContainer<?>> brokerNode)
+      throws IOException, InterruptedException {
+    runCommandInContainer(brokerNode, "apt update");
+    runCommandInContainer(brokerNode, "apt install -y iproute2");
+    LOGGER.info(
+        "{}",
+        runCommandInContainer(brokerNode, "ip route add unreachable " + ipAddress).getStdout());
+  }
+
+  private ZeebeBrokerNode<? extends GenericContainer<?>> getContainerForNodeId(final int nodeId) {
+    return cluster.getBrokers().get(nodeId);
+  }
+
+  private String getContainerIpAddress(
+      final ZeebeBrokerNode<? extends GenericContainer<?>> leaderOneNode) {
+    return leaderOneNode
+        .getCurrentContainerInfo()
+        .getNetworkSettings()
+        .getNetworks()
+        .values()
+        .stream()
+        .findFirst()
+        .orElseThrow()
+        .getIpAddress();
+  }
+
+  private ExecResult runCommandInContainer(
+      final ZeebeBrokerNode<? extends GenericContainer<?>> container, final String command)
+      throws IOException, InterruptedException {
+    LOGGER.info("Run command: {}", command);
+
+    final var commands = command.split(" ");
+    final var execResult = container.execInContainer(commands);
+
+    if (execResult.getExitCode() == 0) {
+      LOGGER.info("Command {} was successful.", command);
+    } else {
+      LOGGER.error("Command {} failed with code: {}", command, execResult.getExitCode());
+      LOGGER.error("Stderr: {}", execResult.getStderr());
+    }
+
+    return execResult;
+  }
+
+  /** Set ups Zeebe Cluster with necessary capabilities in order to create network partitions. */
+  private void setupZeebeCluster() {
+    cluster =
+        ZeebeCluster.builder()
+            .withImage(DockerImageName.parse("camunda/zeebe:SNAPSHOT"))
+            .withBrokersCount(3)
+            .withEmbeddedGateway(true)
+            .withPartitionsCount(3)
+            .withReplicationFactor(3)
+            .build();
+    cluster
+        .getBrokers()
+        .forEach(
+            (nodeId, broker) -> {
+              ((ZeebeContainer) broker)
+                  .withCreateContainerCmdModifier(
+                      (CreateContainerCmd it) ->
+                          it.withHostConfig(it.getHostConfig().withCapAdd(Capability.NET_ADMIN)));
+
+              // smaller sizes to make the tests faster
+              broker
+                  .withEnv("ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE", "1MB")
+                  .withEnv("ZEEBE_BROKER_DATA_LOGSEGMENTSIZE", "16MB");
+            });
+    cluster.start();
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/AsymmetricNetworkPartitionIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/AsymmetricNetworkPartitionIT.java
@@ -23,8 +23,11 @@ import java.io.IOException;
 import java.util.stream.Stream;
 import org.agrona.CloseHelper;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,8 +48,11 @@ public class AsymmetricNetworkPartitionIT {
   private ZeebeClient zeebeClient;
 
   @SuppressWarnings("unused")
-  public static Stream<AsymmetricNetworkPartitionTestCase> provideTestCases() {
-    return Stream.of(new DeploymentDistributionTestCase(), new MessageCorrelationTestCase());
+  public static Stream<Arguments> provideTestCases() {
+    return Stream.of(
+        Arguments.arguments(
+            Named.named("Deployment distribution", new DeploymentDistributionTestCase())),
+        Arguments.arguments(Named.named("Message correlation", new MessageCorrelationTestCase())));
   }
 
   @AfterEach
@@ -54,13 +60,13 @@ public class AsymmetricNetworkPartitionIT {
     CloseHelper.quietCloseAll(cluster, zeebeClient);
   }
 
-  @ParameterizedTest
+  @DisplayName("Withstand Asymmetric Network Partition")
+  @ParameterizedTest(name = "{index}: {0}")
   @MethodSource("provideTestCases")
   public void shouldWithstandAsymmetricNetworkPartition(
       final AsymmetricNetworkPartitionTestCase asymmetricNetworkPartitionTestCase)
       throws IOException, InterruptedException {
     // given
-    LOGGER.info("Run test {}", asymmetricNetworkPartitionTestCase.getName());
     setupZeebeCluster();
     zeebeClient = cluster.newClientBuilder().build();
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/AsymmetricNetworkPartitionIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/AsymmetricNetworkPartitionIT.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.it.clustering.network;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.model.Capability;
@@ -155,8 +156,11 @@ public class AsymmetricNetworkPartitionIT {
     if (execResult.getExitCode() == 0) {
       LOGGER.info("Command {} was successful.", command);
     } else {
-      LOGGER.error("Command {} failed with code: {}", command, execResult.getExitCode());
-      LOGGER.error("Stderr: {}", execResult.getStderr());
+      final var errorMessage =
+          String.format(
+              "Command '%s' failed with code: %d stderr: '%s'",
+              command, execResult.getExitCode(), execResult.getStderr());
+      fail(errorMessage);
     }
 
     return execResult;

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/AsymmetricNetworkPartitionIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/AsymmetricNetworkPartitionIT.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.it.clustering;
+package io.camunda.zeebe.it.clustering.network;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/AsymmetricNetworkPartitionIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/AsymmetricNetworkPartitionIT.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.GenericContainer;
 
-public class AsymmetricNetworkPartitionIT {
+final class AsymmetricNetworkPartitionIT {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AsymmetricNetworkPartitionIT.class);
   private ZeebeCluster cluster;

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/AsymmetricNetworkPartitionIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/AsymmetricNetworkPartitionIT.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.client.api.response.BrokerInfo;
 import io.camunda.zeebe.client.api.response.PartitionInfo;
 import io.camunda.zeebe.client.api.response.Topology;
 import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
+import io.camunda.zeebe.test.util.testcontainers.ZeebeTestContainerDefaults;
 import io.zeebe.containers.ZeebeBrokerNode;
 import io.zeebe.containers.ZeebeContainer;
 import io.zeebe.containers.cluster.ZeebeCluster;
@@ -34,7 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.utility.DockerImageName;
 
 public class AsymmetricNetworkPartitionIT {
 
@@ -170,7 +170,7 @@ public class AsymmetricNetworkPartitionIT {
   private void setupZeebeCluster() {
     cluster =
         ZeebeCluster.builder()
-            .withImage(DockerImageName.parse("camunda/zeebe:SNAPSHOT"))
+            .withImage(ZeebeTestContainerDefaults.defaultTestImage())
             .withBrokersCount(3)
             .withEmbeddedGateway(true)
             .withPartitionsCount(3)

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/AsymmetricNetworkPartitionTestCase.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/AsymmetricNetworkPartitionTestCase.java
@@ -1,0 +1,40 @@
+package io.camunda.zeebe.it.clustering.network;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import java.util.concurrent.CompletableFuture;
+
+interface AsymmetricNetworkPartitionTestCase {
+
+  /** @return the name of the test case */
+  String getName();
+
+  /**
+   * The given part is called before the asymmetric partition is set up. This can be used by the
+   * test case to setup own resources or for example deploy processes etc.
+   *
+   * @param client the zeebe client which can be used by the test case
+   */
+  void given(ZeebeClient client);
+
+  /**
+   * The when part is called when the asymmetric partition is set up. This can be used by the test
+   * case to start certain things, which might complete later, for that case the a future can be
+   * returned. It is allowed to return null here, if there is nothing to wait for.
+   *
+   * @param client the zeebe client which can be used by the test case
+   * @return the future which can be awaited in the then part, or null
+   */
+  CompletableFuture<?> when(ZeebeClient client);
+
+  /**
+   * The then part is called when the asymmetric partition is taken down again and we expect that
+   * everything should work again. Here the test can verify whether things are distributed or
+   * completed.
+   *
+   * <p>For example with the given future, which might be created by the when part.
+   *
+   * @param client the zeebe client which can be used by the test case
+   * @param whenFuture the future which can be awaited, or null
+   */
+  void then(ZeebeClient client, CompletableFuture<?> whenFuture);
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/AsymmetricNetworkPartitionTestCase.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/AsymmetricNetworkPartitionTestCase.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
 package io.camunda.zeebe.it.clustering.network;
 
 import io.camunda.zeebe.client.ZeebeClient;

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/AsymmetricNetworkPartitionTestCase.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/AsymmetricNetworkPartitionTestCase.java
@@ -5,9 +5,6 @@ import java.util.concurrent.CompletableFuture;
 
 interface AsymmetricNetworkPartitionTestCase {
 
-  /** @return the name of the test case */
-  String getName();
-
   /**
    * The given part is called before the asymmetric partition is set up. This can be used by the
    * test case to setup own resources or for example deploy processes etc.

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/DeploymentDistributionTestCase.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/DeploymentDistributionTestCase.java
@@ -1,0 +1,62 @@
+package io.camunda.zeebe.it.clustering.network;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.Protocol;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+public class DeploymentDistributionTestCase implements AsymmetricNetworkPartitionTestCase {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(DeploymentDistributionTestCase.class);
+
+  @Override
+  public String getName() {
+    return "Deployment distribution";
+  }
+
+  @Override
+  public void given(final ZeebeClient client) {}
+
+  @Override
+  public CompletableFuture<?> when(final ZeebeClient client) {
+    final var process = Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
+    client.newDeployCommand().addProcessModel(process, "process.bpmn").send().join();
+    return null;
+  }
+
+  @Override
+  public void then(final ZeebeClient client, final CompletableFuture<?> whenFuture) {
+    final var topology = client.newTopologyRequest().send().join();
+
+    final var partitions =
+        IntStream.range(1, topology.getPartitionsCount() + 1).boxed().collect(Collectors.toSet());
+
+    Awaitility.await("should be able to create instances on all partitions")
+        .ignoreExceptions()
+        .atMost(Duration.ofMinutes(1))
+        .until(
+            () -> {
+              final var processInstanceEvent =
+                  client
+                      .newCreateInstanceCommand()
+                      .bpmnProcessId("process")
+                      .latestVersion()
+                      .send()
+                      .join();
+
+              return Protocol.decodePartitionId(processInstanceEvent.getProcessInstanceKey());
+            },
+            (partitionId) -> {
+              LOGGER.info("Instance created on partition: {}", partitionId);
+              partitions.remove(partitionId);
+              return partitions.isEmpty();
+            });
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/DeploymentDistributionTestCase.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/DeploymentDistributionTestCase.java
@@ -17,11 +17,6 @@ public class DeploymentDistributionTestCase implements AsymmetricNetworkPartitio
       LoggerFactory.getLogger(DeploymentDistributionTestCase.class);
 
   @Override
-  public String getName() {
-    return "Deployment distribution";
-  }
-
-  @Override
   public void given(final ZeebeClient client) {}
 
   @Override

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/DeploymentDistributionTestCase.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/DeploymentDistributionTestCase.java
@@ -18,7 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 
-public class DeploymentDistributionTestCase implements AsymmetricNetworkPartitionTestCase {
+final class DeploymentDistributionTestCase implements AsymmetricNetworkPartitionTestCase {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(DeploymentDistributionTestCase.class);

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/DeploymentDistributionTestCase.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/DeploymentDistributionTestCase.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
 package io.camunda.zeebe.it.clustering.network;
 
 import io.camunda.zeebe.client.ZeebeClient;

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/MessageCorrelationTestCase.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/MessageCorrelationTestCase.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
 package io.camunda.zeebe.it.clustering.network;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/MessageCorrelationTestCase.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/MessageCorrelationTestCase.java
@@ -13,11 +13,6 @@ import java.util.concurrent.CompletableFuture;
 public class MessageCorrelationTestCase implements AsymmetricNetworkPartitionTestCase {
 
   @Override
-  public String getName() {
-    return "Message correlation";
-  }
-
-  @Override
   public void given(final ZeebeClient client) {
     final var process =
         Bpmn.createExecutableProcess("process")

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/MessageCorrelationTestCase.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/MessageCorrelationTestCase.java
@@ -1,0 +1,60 @@
+package io.camunda.zeebe.it.clustering.network;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+public class MessageCorrelationTestCase implements AsymmetricNetworkPartitionTestCase {
+
+  @Override
+  public String getName() {
+    return "Message correlation";
+  }
+
+  @Override
+  public void given(final ZeebeClient client) {
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateCatchEvent()
+            .message(msg -> msg.name("msg").zeebeCorrelationKeyExpression("key"))
+            .endEvent()
+            .done();
+    client.newDeployCommand().addProcessModel(process, "process.bpmn").send().join();
+    // make sure that the message is correlated to correct partition
+    assertThat(SubscriptionUtil.getSubscriptionPartitionId(BufferUtil.wrapString("key"), 3))
+        .describedAs("message should correlated to partition three")
+        .isEqualTo(3);
+
+    client
+        .newPublishMessageCommand()
+        .messageName("msg")
+        .correlationKey("key")
+        .timeToLive(Duration.ofMinutes(30))
+        .send()
+        .join();
+  }
+
+  @Override
+  public CompletableFuture<?> when(final ZeebeClient client) {
+    return (CompletableFuture<?>)
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId("process")
+            .latestVersion()
+            .variables(Map.of("key", "key"))
+            .withResult()
+            .send();
+  }
+
+  @Override
+  public void then(final ZeebeClient client, final CompletableFuture<?> whenFuture) {
+    whenFuture.join(); // await the process instance completion
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/MessageCorrelationTestCase.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/MessageCorrelationTestCase.java
@@ -17,7 +17,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-public class MessageCorrelationTestCase implements AsymmetricNetworkPartitionTestCase {
+final class MessageCorrelationTestCase implements AsymmetricNetworkPartitionTestCase {
 
   @Override
   public void given(final ZeebeClient client) {


### PR DESCRIPTION
## Description

Adds a new parameterized test which should allow to easily write tests for asymmetric network partitions and gives a blue print for other network partition tests. It should help to extend for further cases. It uses test containers and configures the brokers in a way such that it is possible to set ip routes to unreachable. During the test a asymmetric network partition is established.

One test was added for deployment distributions and another for message correlation, it can be extend for further cases later.

See related discussion here https://github.com/camunda-cloud/zeebe/pull/8356

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda-cloud/zeebe/issues/8349

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
