### PR TITLE
fix(polling): respect request timeout settings

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
@@ -7,16 +7,12 @@
  */
 package io.camunda.zeebe.gateway.impl.job;
 
-import io.camunda.zeebe.gateway.Loggers;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.slf4j.Logger;
 
 public final class InFlightLongPollingActivateJobsRequestsState {
-
-  private static final Logger LOGGER = Loggers.GATEWAY_LOGGER;
 
   private final String jobType;
   private final LongPollingMetrics metrics;
@@ -27,7 +23,7 @@ public final class InFlightLongPollingActivateJobsRequestsState {
   private int failedAttempts;
   private long lastUpdatedTime;
 
-  private AtomicBoolean ongoingNotification = new AtomicBoolean(false);
+  private final AtomicBoolean ongoingNotification = new AtomicBoolean(false);
 
   public InFlightLongPollingActivateJobsRequestsState(
       final String jobType, final LongPollingMetrics metrics) {
@@ -40,13 +36,6 @@ public final class InFlightLongPollingActivateJobsRequestsState {
     this.lastUpdatedTime = lastUpdatedTime;
   }
 
-  public void setFailedAttempts(final int failedAttempts) {
-    this.failedAttempts = failedAttempts;
-    if (failedAttempts == 0) {
-      activeRequestsToBeRepeated.addAll(activeRequests);
-    }
-  }
-
   public boolean shouldAttempt(final int attemptThreshold) {
     return failedAttempts < attemptThreshold;
   }
@@ -57,6 +46,13 @@ public final class InFlightLongPollingActivateJobsRequestsState {
 
   public int getFailedAttempts() {
     return failedAttempts;
+  }
+
+  public void setFailedAttempts(final int failedAttempts) {
+    this.failedAttempts = failedAttempts;
+    if (failedAttempts == 0) {
+      activeRequestsToBeRepeated.addAll(activeRequests);
+    }
   }
 
   public long getLastUpdatedTime() {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
@@ -47,6 +47,10 @@ public final class InFlightLongPollingActivateJobsRequestsState {
     }
   }
 
+  public boolean shouldAttempt(final int attemptThreshold) {
+    return failedAttempts < attemptThreshold;
+  }
+
   public void resetFailedAttempts() {
     setFailedAttempts(0);
   }
@@ -112,10 +116,11 @@ public final class InFlightLongPollingActivateJobsRequestsState {
 
   /**
    * Returns whether the request should be repeated. A request should be repeated if the failed
-   * attempts were reset to 0 (because new jobs became available) whilst the request was running
+   * attempts were reset to 0 (because new jobs became available) whilst the request was running,
+   * and if the request's long polling is enabled.
    */
   public boolean shouldBeRepeated(final LongPollingActivateJobsRequest request) {
-    return activeRequestsToBeRepeated.contains(request);
+    return activeRequestsToBeRepeated.contains(request) && !request.isLongPollingDisabled();
   }
 
   public boolean shouldNotifyAndStartNotification() {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -84,16 +84,45 @@ public final class LongPollingActivateJobsHandler extends Actor implements Activ
     activateJobs(longPollingRequest);
   }
 
+  protected void completeOrResubmitRequest(
+      final LongPollingActivateJobsRequest request, final boolean activateImmediately) {
+    if (request.isLongPollingDisabled()) {
+      // request is not supposed to use the
+      // long polling capabilities -> just
+      // complete the request
+      request.complete();
+      return;
+    }
+
+    if (request.isTimedOut()) {
+      // already timed out, nothing to do here
+      return;
+    }
+
+    final var type = request.getType();
+    final var state = getJobTypeState(type);
+
+    if (!request.hasScheduledTimer()) {
+      addTimeOut(state, request);
+    }
+
+    if (activateImmediately) {
+      activateJobs(request);
+    } else {
+      enqueueRequest(state, request);
+    }
+  }
+
   public void activateJobs(final LongPollingActivateJobsRequest request) {
     actor.run(
         () -> {
           final InFlightLongPollingActivateJobsRequestsState state =
               getJobTypeState(request.getType());
 
-          if (state.getFailedAttempts() < failedAttemptThreshold) {
+          if (state.shouldAttempt(failedAttemptThreshold)) {
             activateJobsUnchecked(state, request);
           } else {
-            completeOrEnqueueRequest(state, request);
+            completeOrResubmitRequest(request, false);
           }
         });
   }
@@ -168,15 +197,9 @@ public final class LongPollingActivateJobsHandler extends Actor implements Activ
         actor.submit(
             () -> {
               state.incrementFailedAttempts(currentTimeMillis());
-
               final boolean shouldBeRepeated = state.shouldBeRepeated(request);
               state.removeActiveRequest(request);
-
-              if (shouldBeRepeated) {
-                activateJobs(request);
-              } else {
-                completeOrEnqueueRequest(getJobTypeState(request.getType()), request);
-              }
+              completeOrResubmitRequest(request, shouldBeRepeated);
             });
       }
     } else {
@@ -219,26 +242,17 @@ public final class LongPollingActivateJobsHandler extends Actor implements Activ
     }
   }
 
-  private void completeOrEnqueueRequest(
+  private void enqueueRequest(
       final InFlightLongPollingActivateJobsRequestsState state,
       final LongPollingActivateJobsRequest request) {
-    if (request.isLongPollingDisabled()) {
-      request.complete();
-      return;
-    }
-    if (!request.isTimedOut()) {
-      LOG.trace(
-          "Worker '{}' asked for '{}' jobs of type '{}', but none are available. This request will"
-              + " be kept open until a new job of this type is created or until timeout of '{}'.",
-          request.getWorker(),
-          request.getMaxJobsToActivate(),
-          request.getType(),
-          request.getLongPollingTimeout(longPollingTimeout));
-      state.enqueueRequest(request);
-      if (!request.hasScheduledTimer()) {
-        addTimeOut(state, request);
-      }
-    }
+    LOG.trace(
+        "Worker '{}' asked for '{}' jobs of type '{}', but none are available. This request will"
+            + " be kept open until a new job of this type is created or until timeout of '{}'.",
+        request.getWorker(),
+        request.getMaxJobsToActivate(),
+        request.getType(),
+        request.getLongPollingTimeout(longPollingTimeout));
+    state.enqueueRequest(request);
   }
 
   private void addTimeOut(
@@ -249,8 +263,8 @@ public final class LongPollingActivateJobsHandler extends Actor implements Activ
         actor.runDelayed(
             requestTimeout,
             () -> {
-              state.removeRequest(request);
               request.timeout();
+              state.removeRequest(request);
             });
     request.setScheduledTimer(timeout);
   }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -84,7 +84,7 @@ public final class LongPollingActivateJobsHandler extends Actor implements Activ
     activateJobs(longPollingRequest);
   }
 
-  protected void completeOrResubmitRequest(
+  private void completeOrResubmitRequest(
       final LongPollingActivateJobsRequest request, final boolean activateImmediately) {
     if (request.isLongPollingDisabled()) {
       // request is not supposed to use the

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRequest.java
@@ -48,13 +48,13 @@ public final class LongPollingActivateJobsRequest {
       final ServerStreamObserver<ActivateJobsResponse> responseObserver,
       final String jobType,
       final String worker,
-      final int maxJobstoActivate,
+      final int maxJobsToActivate,
       final long longPollingTimeout) {
     this.request = request;
     this.responseObserver = responseObserver;
     this.jobType = jobType;
     this.worker = worker;
-    maxJobsToActivate = maxJobstoActivate;
+    this.maxJobsToActivate = maxJobsToActivate;
     this.longPollingTimeout =
         longPollingTimeout == 0 ? null : Duration.ofMillis(longPollingTimeout);
   }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/LongPollingActivateJobsTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/LongPollingActivateJobsTest.java
@@ -60,7 +60,7 @@ public final class LongPollingActivateJobsTest {
   private static final long LONG_POLLING_TIMEOUT = 5000;
   private static final long PROBE_TIMEOUT = 20000;
   private static final int FAILED_RESPONSE_THRESHOLD = 3;
-  protected final ControlledActorClock actorClock = new ControlledActorClock();
+  private final ControlledActorClock actorClock = new ControlledActorClock();
   @Rule public final ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule(actorClock);
   private LongPollingActivateJobsHandler handler;
   private ActivateJobsStub stub;
@@ -599,7 +599,7 @@ public final class LongPollingActivateJobsTest {
   }
 
   @Test
-  public void shouldCompleteRequestImmediatellyDespiteNotification() throws Exception {
+  public void shouldCompleteRequestImmediatelyDespiteNotification() throws Exception {
     // given
     final LongPollingActivateJobsRequest request =
         new LongPollingActivateJobsRequest(


### PR DESCRIPTION
## Description

* If long polling is disabled by the received request, then always complete the request immediately even when no jobs are activated.
* Ensure that the provided request timeout is respected so that the request completes at latest at the given timeout.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates #8310 
closes #8389 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
