### PR TITLE
Fixes flaky priority election timer test

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/impl/PriorityElectionTimerTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/impl/PriorityElectionTimerTest.java
@@ -23,23 +23,23 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.awaitility.Awaitility;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PriorityElectionTimerTest {
+final class PriorityElectionTimerTest {
 
   private final Logger log = LoggerFactory.getLogger(PriorityElectionTimerTest.class);
   private final SingleThreadContext threadContext = new SingleThreadContext("priorityElectionTest");
 
-  @After
-  public void after() {
+  @AfterEach
+  void afterEach() {
     threadContext.close();
   }
 
   @Test
-  public void shouldLowerPriorityNodeEventuallyStartsAnElection() {
+  void shouldLowerPriorityNodeEventuallyStartsAnElection() {
     // given
     final AtomicInteger triggerCount = new AtomicInteger();
 
@@ -55,7 +55,7 @@ public class PriorityElectionTimerTest {
   }
 
   @Test
-  public void shouldHighPriorityNodeStartElectionFirst() {
+  void shouldHighPriorityNodeStartElectionFirst() {
     // given
     final String highPrioId = "highPrioTimer";
     final String lowPrioId = "lowPrioTimer";

--- a/atomix/cluster/src/test/java/io/atomix/raft/impl/PriorityElectionTimerTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/impl/PriorityElectionTimerTest.java
@@ -15,16 +15,16 @@
  */
 package io.atomix.raft.impl;
 
-import static org.mockito.Mockito.spy;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.utils.concurrent.SingleThreadContext;
 import java.time.Duration;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,15 +57,16 @@ public class PriorityElectionTimerTest {
   @Test
   public void shouldHighPriorityNodeStartElectionFirst() {
     // given
-    final AtomicBoolean highPrioElectionTriggered = spy(new AtomicBoolean());
-    final AtomicBoolean lowPrioElectionTriggered = spy(new AtomicBoolean());
+    final String highPrioId = "highPrioTimer";
+    final String lowPrioId = "lowPrioTimer";
+    final List<String> electionOrder = new CopyOnWriteArrayList<>();
 
     final int targetPriority = 4;
     final PriorityElectionTimer timerHighPrio =
         new PriorityElectionTimer(
             Duration.ofMillis(100),
             threadContext,
-            () -> highPrioElectionTriggered.set(true),
+            () -> electionOrder.add(highPrioId),
             log,
             targetPriority,
             targetPriority);
@@ -74,7 +75,7 @@ public class PriorityElectionTimerTest {
         new PriorityElectionTimer(
             Duration.ofMillis(100),
             threadContext,
-            () -> lowPrioElectionTriggered.set(true),
+            () -> electionOrder.add(lowPrioId),
             log,
             targetPriority,
             1);
@@ -82,12 +83,16 @@ public class PriorityElectionTimerTest {
     // when
     timerLowPrio.reset();
     timerHighPrio.reset();
-    Awaitility.await().until(highPrioElectionTriggered::get);
-    Awaitility.await().until(lowPrioElectionTriggered::get);
 
     // then
-    final var inorder = Mockito.inOrder(highPrioElectionTriggered, lowPrioElectionTriggered);
-    inorder.verify(highPrioElectionTriggered).set(true);
-    inorder.verify(lowPrioElectionTriggered).set(true);
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertThat(electionOrder)
+                    .as("both elections should have been triggered eventually")
+                    .contains(highPrioId, lowPrioId));
+    assertThat(electionOrder.get(0))
+        .as("the first election triggered should have been the high priority election")
+        .isEqualTo(highPrioId);
   }
 }


### PR DESCRIPTION
## Description

This PR fixes a priority election timer test. The test currently uses two boolean flags which represent that the election was toggled, which it spies on. At the end, it then asserts that the `set` calls for each were called in the right order.

This can break since the timers renew themselves automatically, meaning that once the high prio timer has expired after 100ms, it will automatically renew itself, such that its trigger will be called after 100ms. It's possible then that it is called again before the low priority timer is called. The low priority timer has a target priority of 4, and an initial priority of 1. This means it has to do 3 rounds, so roughly 300ms, before it will actually trigger. This gives ample time to the high priority timer to trigger more than once.

The test is here rewritten to avoid relying on a strict ordering of method calls, and instead just checks that:

- the first timer called is the high priority timer
- the low priority timer is eventually called after (with any number of high priority calls in between)

## Related issues

closes #8377

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
