### PR TITLE
Reject usage of reserved task headers

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -120,6 +120,8 @@ public final class ZeebeRuntimeValidators {
         ZeebeExpressionValidator.verifyThat(ZeebeCalledDecision.class)
             .hasValidExpression(
                 ZeebeCalledDecision::getDecisionId, ExpressionVerification::isMandatory)
-            .build(expressionLanguage));
+            .build(expressionLanguage),
+        // ----------------------------------------
+        new ZeebeTaskHeadersValidator());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeTaskHeadersValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeTaskHeadersValidator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
+import io.camunda.zeebe.protocol.Protocol;
+import java.util.Set;
+import java.util.function.Predicate;
+import org.agrona.Strings;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class ZeebeTaskHeadersValidator implements ModelElementValidator<ZeebeTaskHeaders> {
+
+  private static final Set<String> RESTRICTED_HEADERS =
+      Set.of(
+          Protocol.USER_TASK_ASSIGNEE_HEADER_NAME,
+          Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME,
+          Protocol.USER_TASK_FORM_KEY_HEADER_NAME);
+
+  @Override
+  public Class<ZeebeTaskHeaders> getElementType() {
+    return ZeebeTaskHeaders.class;
+  }
+
+  @Override
+  public void validate(
+      final ZeebeTaskHeaders element, final ValidationResultCollector validationResultCollector) {
+    element.getHeaders().stream()
+        .map(ZeebeHeader::getKey)
+        .filter(Predicate.not(Strings::isEmpty))
+        .filter(RESTRICTED_HEADERS::contains)
+        .map(key -> String.format("Attribute 'key' may not use restricted header '%s'", key))
+        .forEach(message -> validationResultCollector.addError(0, message));
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -56,8 +56,10 @@ public final class ZeebeRuntimeValidationTest {
   private static final String INVALID_PATH_EXPRESSION = "a ? b";
   private static final String INVALID_PATH_EXPRESSION_MESSAGE =
       "Expected path expression 'a ? b' but doesn't match the pattern '[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)*'.";
-  private static final String RESTRICTED_TASK_HEADER_MESSAGE =
-      "Attribute 'key' may not use restricted header '%s'";
+  private static final String RESERVED_TASK_HEADER_KEY =
+      Protocol.RESERVED_HEADER_NAME_PREFIX + "reserved-header-key";
+  private static final String RESERVED_TASK_HEADER_MESSAGE =
+      "Attribute 'key' contains '%s', but header keys starting with '%s' are reserved for internal use.";
   public BpmnModelInstance modelInstance;
 
   @Parameter(0)
@@ -350,19 +352,6 @@ public final class ZeebeRuntimeValidationTest {
         List.of(expect(ZeebeAssignmentDefinition.class, INVALID_EXPRESSION_MESSAGE))
       },
       {
-        /* restricted header key: assignee */
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .userTask("task")
-            .zeebeTaskHeader(Protocol.USER_TASK_ASSIGNEE_HEADER_NAME, STATIC_EXPRESSION)
-            .done(),
-        List.of(
-            expect(
-                ZeebeTaskHeaders.class,
-                String.format(
-                    RESTRICTED_TASK_HEADER_MESSAGE, Protocol.USER_TASK_ASSIGNEE_HEADER_NAME)))
-      },
-      {
         /* invalid candidateGroups expression */
         Bpmn.createExecutableProcess("process")
             .startEvent()
@@ -382,31 +371,19 @@ public final class ZeebeRuntimeValidationTest {
                 "Expected static value to be a list of comma-separated values, e.g. 'a,b,c', but found '1,,'"))
       },
       {
-        /* restricted header key: candidate groups */
+        /* reserved header key */
         Bpmn.createExecutableProcess("process")
             .startEvent()
             .userTask("task")
-            .zeebeTaskHeader(Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME, STATIC_EXPRESSION)
+            .zeebeTaskHeader(RESERVED_TASK_HEADER_KEY, STATIC_EXPRESSION)
             .done(),
         List.of(
             expect(
                 ZeebeTaskHeaders.class,
                 String.format(
-                    RESTRICTED_TASK_HEADER_MESSAGE,
-                    Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME)))
-      },
-      {
-        /* restricted header key: form key */
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .userTask("task")
-            .zeebeTaskHeader(Protocol.USER_TASK_FORM_KEY_HEADER_NAME, STATIC_EXPRESSION)
-            .done(),
-        List.of(
-            expect(
-                ZeebeTaskHeaders.class,
-                String.format(
-                    RESTRICTED_TASK_HEADER_MESSAGE, Protocol.USER_TASK_FORM_KEY_HEADER_NAME)))
+                    RESERVED_TASK_HEADER_MESSAGE,
+                    RESERVED_TASK_HEADER_KEY,
+                    Protocol.RESERVED_HEADER_NAME_PREFIX)))
       },
     };
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
@@ -65,15 +65,20 @@ public final class Protocol {
   /** Job typ used for user tasks handled by Camunda Cloud Tasklist */
   public static final String USER_TASK_JOB_TYPE = "io.camunda.zeebe:userTask";
 
+  /** Prefix for key of reserved task headers */
+  public static final String RESERVED_HEADER_NAME_PREFIX = "io.camunda.zeebe:";
+
   /** Task header key used for user tasks to contain form key from BPMN XML */
-  public static final String USER_TASK_FORM_KEY_HEADER_NAME = "io.camunda.zeebe:formKey";
+  public static final String USER_TASK_FORM_KEY_HEADER_NAME =
+      RESERVED_HEADER_NAME_PREFIX + "formKey";
 
   /** Task header key used for assignee */
-  public static final String USER_TASK_ASSIGNEE_HEADER_NAME = "io.camunda.zeebe:assignee";
+  public static final String USER_TASK_ASSIGNEE_HEADER_NAME =
+      RESERVED_HEADER_NAME_PREFIX + "assignee";
 
   /** Task header key used for candidate groups */
   public static final String USER_TASK_CANDIDATE_GROUPS_HEADER_NAME =
-      "io.camunda.zeebe:candidateGroups";
+      RESERVED_HEADER_NAME_PREFIX + "candidateGroups";
 
   public static long encodePartitionId(final int partitionId, final long key) {
     return ((long) partitionId << KEY_BITS) + key;


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

It's easy for users to make mistakes when trying to use the new task assignments feature. 

Consider a user that wants to specify the candidate groups. They should define it using the `candidateGroups` attribute of the `TaskAssignment` extension element, but they are also able to directly specify a task header using the special header key `io.camunda.zeebe:candidateGroups`. However, when they use the task headers directly, the type of provided value cannot be checked and an incorrect value will not lead to an incident. Instead, the incorrect value is sent to Tasklist which 'silently' discards it (i.e. it logs a warning, but this is not visible to CCSaaS users). The user sees the task in Tasklist, but not the associated candidate groups. They will wonder what happened and it's unclear. Instead, we should protect the user from making this mistake. 

In addition, directly specifying the task headers also leads to issues when the TaskAssignment is specified as well. It would be unclear to the user which value will be used and what will happen (i.e. we will overwrite it with the result from the TaskAssignment). 

To protect the user from these situations, this adds validations to restrict users from specifying any of the restricted task headers:
- `io.camunda.zeebe:assignee`
- `io.camunda.zeebe:candidateGroups`
- `io.camunda.zeebe:formKey`

The validation message is based on the [ZeebeElementValidator's attribute message](https://github.com/camunda-cloud/zeebe/blob/cac9835ab456d72e71b4081b168fd0b06d36862b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeElementValidator.java#L50), but it differs from our [Error-Guidelines](https://github.com/camunda-cloud/zeebe/wiki/Error-Guidelines). Reviewer, I'd love to hear your opinion on which would be better.

Finally, please note that these changes could be considered breaking changes because they further restrict what is allowed. However, in Zeebe's context we generally don't consider such changes to warrant a major version bump.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8304 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
