### PR TITLE
Use GitHub official CLI to manage releases

### DIFF
--- a/.ci/scripts/release/github-release.sh
+++ b/.ci/scripts/release/github-release.sh
@@ -1,32 +1,61 @@
 #!/bin/bash -xeu
 
-export GITHUB_TOKEN=${GITHUB_TOKEN_PSW}
-export GITHUB_ORG=camunda-cloud
-export GITHUB_REPO=zeebe
+if [ -x "$(which gh >/dev/null 2>&1)" ]; then
+  echo "Could not find the GitHub CLI utility; make sure to install it before calling this script"
+  echo "See https://github.com/cli/cli/blob/trunk/docs/install_linux.md for more on how to install it"
+  exit 1
+fi
 
-BINDIR=${BINDIR:-/tmp}
-GITHUB_RELEASE=${GITHUB_RELEASE:-"${BINDIR}/github-release"}
-"${GITHUB_RELEASE}" release --user "${GITHUB_ORG}" --repo "${GITHUB_REPO}" --tag "${RELEASE_VERSION}" --draft --name "Zeebe ${RELEASE_VERSION}" --description ""
+# Prepare environment, omitting sensitive information
+set +x; export GITHUB_TOKEN=${GITHUB_TOKEN_PSW}; set -x
+declare -a ASSETS=()
+declare -a GH_OPTIONS=()
 
-git tag "clients/go/v${RELEASE_VERSION}"
-git push origin "clients/go/v${RELEASE_VERSION}"
+# This is the list of base artifacts that we expect to upload as part of the release; we'll also
+# compute their sha1 sum and upload those as well, but no need to list that here. If there are new
+# binaries to ship with a Zeebe release, add them here.
+declare -a ARTIFACTS=( \
+  "dist/target/camunda-cloud-zeebe-${RELEASE_VERSION}.tar.gz" \
+  "dist/target/camunda-cloud-zeebe-${RELEASE_VERSION}.zip" \
+  "clients/go/cmd/zbctl/dist/zbctl" \
+  "clients/go/cmd/zbctl/dist/zbctl.exe" \
+  "clients/go/cmd/zbctl/dist/zbctl.darwin" \
+)
 
-function upload {
-  local -r buildDir="${1}"
-  local -r artifact="${2}"
-  local -r checksum="${artifact}.sha1sum"
+# Prepare assets
+CHECKSUM_DIR=$(mktemp -d)
+if [ ! -e "${CHECKSUM_DIR}" ]; then
+    >&2 echo "Failed to create temporary assets directory directory"
+    exit 1
+fi
+for artifact in "${ARTIFACTS[@]}"; do
+  filename=$(basename "${artifact}")
+  checksum="${CHECKSUM_DIR}/${filename}.sha1sum"
 
-  pushd "${buildDir}"
+  if [ ! -f "${artifact}" ]; then
+    echo "Expected to upload asset ${artifact} as part of the GitHub release, but no such file was found; are you sure the release went through correctly?"
+    exit 1
+  fi
 
   sha1sum "${artifact}" > "${checksum}"
-  "${GITHUB_RELEASE}" upload --user "${GITHUB_ORG}" --repo "${GITHUB_REPO}" --tag "${RELEASE_VERSION}" --name "${artifact}" --file "${artifact}"
-  "${GITHUB_RELEASE}" upload --user "${GITHUB_ORG}" --repo "${GITHUB_REPO}" --tag "${RELEASE_VERSION}" --name "${checksum}" --file "${checksum}"
+  sha1sumResult=$?
+  if [ ! -f "${checksum}" ]; then
+    echo "Failed to created checksum of artifact ${artifact} at ${checksum}; [sha1sum] exited with result ${sha1sumResult}. Check the logs for errors."
+    exit 1
+  fi
 
-  popd
-}
+  ASSETS+=("${artifact}" "${checksum}")
+done
 
-upload dist/target "camunda-cloud-zeebe-${RELEASE_VERSION}.tar.gz"
-upload dist/target "camunda-cloud-zeebe-${RELEASE_VERSION}.zip"
-upload clients/go/cmd/zbctl/dist zbctl
-upload clients/go/cmd/zbctl/dist zbctl.exe
-upload clients/go/cmd/zbctl/dist zbctl.darwin
+# Mark as pre-release already if it's an alpha or rc
+shopt -s nocasematch # set matching to case insensitive
+if [[ "${RELEASE_VERSION}" =~ ^.*-(alpha|rc|SNAPSHOT)[\d]*$ ]]; then
+  GH_OPTIONS+=(--prerelease)
+fi
+shopt -u nocasematch # reset it
+
+# Perform release: create draft, upload assets, etc.
+# See https://cli.github.com/manual/gh_release_create for more
+gh release create --repo "camunda-cloud/zeebe" --draft --notes "Release ${RELEASE_VERSION}" \
+  --title "${RELEASE_VERSION}" "${GH_OPTIONS[@]}" \
+  "${RELEASE_VERSION}" "${ASSETS[@]}"

--- a/.ci/scripts/release/post-github.sh
+++ b/.ci/scripts/release/post-github.sh
@@ -1,6 +1,11 @@
-#!/bin/bash
+#!/bin/bash -xue
 
-cd "clients/go/internal/embedded"
+# Publish Go tag for the release
+git tag "clients/go/v${RELEASE_VERSION}"
+git push origin "clients/go/v${RELEASE_VERSION}"
+
+# Prepare Go version for the next release
+pushd "clients/go/internal/embedded" || exit $?
 
 echo "${DEVELOPMENT_VERSION}" > data/VERSION
 "${GOPATH}/go-bindata" -pkg embedded -o embedded.go -prefix data/ data/

--- a/.ci/scripts/release/prepare.sh
+++ b/.ci/scripts/release/prepare.sh
@@ -1,8 +1,12 @@
 #!/bin/bash -xue
 
 # update apt repositories and install missing utilities
+# add GitHub packages Debian repository for gh
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | \
+      tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 apt update
-apt install -y gpg
+apt install -y gpg gh
 
 # remove origin and use GitHub App (reflected on filesystem and globally active)
 git remote remove origin
@@ -16,9 +20,3 @@ git config --global user.name "${GITHUB_TOKEN_USR}"
 gpg -q --allow-secret-key-import --import --no-tty --batch --yes "${GPG_SEC_KEY}"
 gpg -q --import --no-tty --batch --yes "${GPG_PUB_KEY}"
 rm "${GPG_SEC_KEY}" "${GPG_PUB_KEY}"
-
-# install binary tools; binary tools are installed outside of the repo to avoid dirtying it
-BINDIR=${BINDIR:-/tmp}
-curl -sL  https://github.com/github-release/github-release/releases/download/v0.10.0/linux-amd64-github-release.bz2 | bzip2 -fd - > github-release
-chmod +x github-release
-mv github-release "${BINDIR}/github-release"


### PR DESCRIPTION
## Description

This PR switches from using a third party github-release tool to using the official GitHub CLI (`gh`) tool to create and manage the release.

In order to always have the latest stable `gh` tool, the GitHub debian repository is added at the beginning in the prepare stage, and gh is installed directly from there.

The github-release.sh script is completely overhauled to use `gh`, with what I hope is improved error handling and helpful logging when things go wrong. The script also now avoids dirtying the state of the repo, in case anything else would need to run later and commit/push things.

Additionally moves creating the Go release tags to the post-github release stage.

## Related issues

closes #8409 
blocked by #8410

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
