### PR TITLE
[Backport stable/1.2] deps(maven): bump version.elasticsearch from 7.16.1 to 7.16.2

### DIFF
--- a/exporters/elasticsearch-exporter/docker-compose.yml
+++ b/exporters/elasticsearch-exporter/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.16.1
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.16.2
         ports:
             - "9200:9200"
             - "9300:9300"
@@ -12,7 +12,7 @@ services:
             - ES_JAVA_OPTS=-Xmx750m -Xms750m
 
     kibana:
-        image: docker.elastic.co/kibana/kibana:7.16.1
+        image: docker.elastic.co/kibana/kibana:7.16.2
         ports:
             - "5601:5601"
         links:

--- a/monitor/docker-compose.ope-ztl.yml
+++ b/monitor/docker-compose.ope-ztl.yml
@@ -7,7 +7,7 @@ volumes:
 services:
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.2
     container_name: elasticsearch
     environment:
       - discovery.type=single-node

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.commons-math>3.6.1</version.commons-math>
     <version.commons-codec>1.15</version.commons-codec>
     <version.docker-java-api>3.2.12</version.docker-java-api>
-    <version.elasticsearch>7.16.1</version.elasticsearch>
+    <version.elasticsearch>7.16.2</version.elasticsearch>
     <version.error-prone>2.9.0</version.error-prone>
     <version.grpc>1.40.1</version.grpc>
     <version.gson>2.8.9</version.gson>


### PR DESCRIPTION
Bumps `version.elasticsearch` from 7.16.1 to 7.16.2.

Updates `elasticsearch-x-content` from 7.16.1 to 7.16.2
- [Release notes](https://github.com/elastic/elasticsearch/releases)
- [Commits](https://github.com/elastic/elasticsearch/compare/v7.16.1...v7.16.2)

Updates `elasticsearch-rest-client` from 7.16.1 to 7.16.2
- [Release notes](https://github.com/elastic/elasticsearch/releases)
- [Commits](https://github.com/elastic/elasticsearch/compare/v7.16.1...v7.16.2)

---
updated-dependencies:
- dependency-name: org.elasticsearch:elasticsearch-x-content
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.elasticsearch.client:elasticsearch-rest-client
  dependency-type: direct:development
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
(cherry picked from commit 4f41e4f22ef52f01f09e0024df2b1f0b5013685e)