### PR TITLE
Expand bors status checks to also run smoketests

### DIFF
--- a/.github/workflows/os-smoke-test.yml
+++ b/.github/workflows/os-smoke-test.yml
@@ -2,12 +2,12 @@ name: OS Support Smoke Test
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, staging, trying ]
   pull_request:
     branches: [ develop ]
 
 jobs:
-  build:
+  smoke-test:
     name: Run smoke tests on ${{ matrix.os }}
     timeout-minutes: 10
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/os-smoke-test.yml
+++ b/.github/workflows/os-smoke-test.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   smoke-test:
+    # This name is hard-referenced from bors.toml
+    # Remember to update that if this name, or the matrix.os changes
     name: Run smoke tests on ${{ matrix.os }}
     timeout-minutes: 10
     runs-on: ${{ matrix.os }}

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,6 @@
 status = [
-  "continuous-integration/jenkins/branch"
+  "continuous-integration/jenkins/branch",
+  "smoke-test"
 ]
 
 required_approvals = 1

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,8 @@
 status = [
   "continuous-integration/jenkins/branch",
-  "smoke-test"
+  "Run smoke tests on macos-latest",
+  "Run smoke tests on windows-latest",
+  "Run smoke tests on ubuntu-latest"
 ]
 
 required_approvals = 1


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

We run all kinds of checks again a pull request, but only the jenkins ci is used by bors to decide whether or not to merge a PR. We should expand the different checks that bors waits for before merging.

This PR makes sure the smoke tests are run as well for commits pushed by bors (`staging` and `trying`). It also makes bors wait with merging until the status of the `smoke-test` job is success.

## Related issues

<!-- Which issues are closed by this PR or are related -->

NA

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
