### PR TITLE
Add recreate benchmark script

### DIFF
--- a/createBenchmark.sh
+++ b/createBenchmark.sh
@@ -28,7 +28,7 @@ if ! docker info >/dev/null 2>&1; then
     exit 1
 fi
 
-mvn clean install -DskipTests -T1C
+mvn clean install -DskipTests -DskipChecks -T1C
 
 docker build --build-arg DISTBALL=dist/target/camunda-cloud-zeebe-*.tar.gz --build-arg APP_ENV=dev -t "gcr.io/zeebe-io/zeebe:$benchmark" .
 docker push "gcr.io/zeebe-io/zeebe:$benchmark"

--- a/recreateBenchmark.sh
+++ b/recreateBenchmark.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -eo pipefail
+
+# The purpose of this script is to make it easier for developers to recreate benchmarks.
+# As input the benchmark name is expected, which is used for the docker image tag and k8 namespace.
+# This script does the following:
+#
+# 1. Build the current branch (zeebe + benchmark-project)
+# 2. Build the docker images
+# 3. Publish the docker images
+# 4. Redeploys the benchmark
+
+# Contains OS specific sed function
+source benchmarks/setup/utils.sh
+
+function printUsageAndExit {
+  printf "\nUsage ./createBenchmark <benchmark-name>\n"
+  exit 1
+}
+
+if [[ -z $1 ]]
+then
+  echo "<benchmark-name> not provided"
+  printUsageAndExit
+fi
+benchmark=$1
+pwd=$(pwd)
+
+# DNS Label regex, see https://regex101.com/r/vjsrEy/2
+if [[ ! $benchmark =~ ^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$ ]]; then
+  echo "<benchmark-name> '$benchmark' not a valid DNS label"
+  echo "See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names"
+  printUsageAndExit
+fi
+
+set +e
+ns=$(kubectl get namespace "$benchmark")
+set -e
+if [[ ! "$ns" ]]; then
+  echo "Perhaps you meant to use ./createBenchmark.sh instead. Or consider switching your k8s context"
+  exit 1
+fi
+
+# Check if docker daemon is running
+if ! docker info >/dev/null 2>&1; then
+    echo "Docker daemon does not seem to be running, make sure it's running and retry"
+    exit 1
+fi
+
+set -x
+
+mvn clean install -DskipTests -DskipChecks -T1C
+
+docker build --build-arg DISTBALL=dist/target/camunda-cloud-zeebe-*.tar.gz --build-arg APP_ENV=dev -t "gcr.io/zeebe-io/zeebe:$benchmark" .
+docker push "gcr.io/zeebe-io/zeebe:$benchmark"
+
+cd "$pwd/benchmarks/project"
+sed_inplace "s/:SNAPSHOT/:$benchmark/" docker-compose.yml
+# Use --no-cache to force rebuild the image for the benchmark application. Without this changes to zeebe-client were not picked up. This can take longer to build.
+docker-compose build --no-cache
+docker-compose push
+git restore -- docker-compose.yml
+
+# Restart the pods by deleting them, this is not a rolling update
+# `make update` would not restart the pods, but once they restart the new image will be pulled because of pullPolicy: Always
+#
+# TODO: apply rolling updates with helm
+# see https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
+kubectl -n "$benchmark" get pods -l app.kubernetes.io/name=zeebe-cluster-helm -o=jsonpath='{.items..metadata.name}' \
+  | xargs kubectl -n "$benchmark" delete pod
+
+# Return where you started
+cd "$pwd"


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
One of the steps in the daily release process is to check whether there are new commits on the release branch. If there are any, the benchmark must be restarted. There did not exist any script for this yet, and the manual steps are not straight forward (e.g. `newBenchmark` will fail because the namespace is already in use).

To avoid these problems, a new `recreateBenchmark.sh` script is introduced that:
- checks whether the namespace already exists and if not suggests solutions
- rebuilds the project and the docker images
- redeploys the benchmark

This uses a special check for the benchmark name to be a valid DNS label. See #8455 for more details

## Related issues

<!-- Which issues are closed by this PR or are related -->

NA

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
