### PR TITLE
Enable compression in netty

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.Lists;
 import io.atomix.cluster.discovery.NodeDiscoveryProvider;
+import io.atomix.cluster.messaging.MessagingConfig.CompressionAlgorithm;
 import io.atomix.cluster.protocol.GroupMembershipProtocol;
 import io.atomix.utils.Builder;
 import io.atomix.utils.Version;
@@ -236,6 +237,13 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
         .setTlsEnabled(true)
         .setCertificateChain(certificateChain)
         .setPrivateKey(privateKey);
+
+    return this;
+  }
+
+  public AtomixClusterBuilder withMessageCompression(
+      final CompressionAlgorithm messageCompression) {
+    config.getMessagingConfig().setCompressionAlgorithm(messageCompression);
 
     return this;
   }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
@@ -32,6 +32,7 @@ public class MessagingConfig implements Config {
   private boolean tlsEnabled = false;
   private File certificateChain;
   private File privateKey;
+  private CompressionAlgorithm compressionAlgorithm = CompressionAlgorithm.NONE;
 
   /**
    * Returns the local interfaces to which to bind the node.
@@ -131,6 +132,15 @@ public class MessagingConfig implements Config {
     return this;
   }
 
+  public CompressionAlgorithm getCompressionAlgorithm() {
+    return compressionAlgorithm;
+  }
+
+  public MessagingConfig setCompressionAlgorithm(final CompressionAlgorithm algorithm) {
+    compressionAlgorithm = algorithm;
+    return this;
+  }
+
   /**
    * The certificate chain to use for inter-cluster communication. This certificate is used for both
    * the server and the client.
@@ -205,5 +215,11 @@ public class MessagingConfig implements Config {
 
     this.privateKey = privateKey;
     return this;
+  }
+
+  public enum CompressionAlgorithm {
+    GZIP,
+    NONE,
+    SNAPPY
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -50,6 +50,10 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.compression.SnappyFrameDecoder;
+import io.netty.handler.codec.compression.SnappyFrameEncoder;
+import io.netty.handler.codec.compression.ZlibCodecFactory;
+import io.netty.handler.codec.compression.ZlibWrapper;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
@@ -790,6 +794,21 @@ public final class NettyMessagingService implements ManagedMessagingService {
       }
 
       channel.pipeline().addLast("handshake", new ClientHandshakeHandlerAdapter(future));
+
+      switch (config.getCompressionAlgorithm()) {
+        case GZIP:
+          channel.pipeline().addLast(ZlibCodecFactory.newZlibEncoder(ZlibWrapper.GZIP));
+          channel.pipeline().addLast(ZlibCodecFactory.newZlibDecoder(ZlibWrapper.GZIP));
+          break;
+        case SNAPPY:
+          channel.pipeline().addLast(new SnappyFrameEncoder());
+          channel.pipeline().addLast(new SnappyFrameDecoder());
+          break;
+        case NONE:
+          break;
+        default:
+          log.debug("Unknown compression algorithm. Proceeding without compression.");
+      }
     }
 
     @Override
@@ -811,6 +830,21 @@ public final class NettyMessagingService implements ManagedMessagingService {
       }
 
       channel.pipeline().addLast("handshake", new ServerHandshakeHandlerAdapter());
+
+      switch (config.getCompressionAlgorithm()) {
+        case GZIP:
+          channel.pipeline().addLast(ZlibCodecFactory.newZlibEncoder(ZlibWrapper.GZIP));
+          channel.pipeline().addLast(ZlibCodecFactory.newZlibDecoder(ZlibWrapper.GZIP));
+          break;
+        case SNAPPY:
+          channel.pipeline().addLast(new SnappyFrameEncoder());
+          channel.pipeline().addLast(new SnappyFrameDecoder());
+          break;
+        case NONE:
+          break;
+        default:
+          log.debug("Unknown compression algorithm. Proceeding without compression.");
+      }
     }
   }
 

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceCompressionTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceCompressionTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.messaging.ManagedMessagingService;
+import io.atomix.cluster.messaging.MessagingConfig;
+import io.atomix.cluster.messaging.MessagingConfig.CompressionAlgorithm;
+import io.atomix.utils.net.Address;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class NettyMessagingServiceCompressionTest {
+
+  @ParameterizedTest
+  @EnumSource(CompressionAlgorithm.class)
+  void shouldSendAndReceiveMessagesWhenCompressionEnabled(final CompressionAlgorithm algorithm) {
+    // given
+    final var senderAddress = Address.from(SocketUtil.getNextAddress().getPort());
+    final var config =
+        new MessagingConfig()
+            .setShutdownQuietPeriod(Duration.ofMillis(50))
+            .setCompressionAlgorithm(algorithm);
+
+    final var senderNetty =
+        (ManagedMessagingService)
+            new NettyMessagingService("test", senderAddress, config).start().join();
+
+    final var receiverAddress = Address.from(SocketUtil.getNextAddress().getPort());
+    final var receiverNetty =
+        (ManagedMessagingService)
+            new NettyMessagingService("test", receiverAddress, config).start().join();
+
+    final String subject = "subject";
+    final String requestString = "message";
+    final String responseString = "success";
+    receiverNetty.registerHandler(
+        subject,
+        (m, payload) -> {
+          final String message = new String(payload);
+          assertThat(message).isEqualTo(requestString);
+          return CompletableFuture.completedFuture(responseString.getBytes());
+        });
+
+    // when
+    final CompletableFuture<byte[]> response =
+        senderNetty.sendAndReceive(receiverAddress, subject, requestString.getBytes());
+
+    // then
+    final var result = response.join();
+    assertThat(new String(result)).isEqualTo(responseString);
+
+    // teardown
+    senderNetty.stop();
+    receiverNetty.stop();
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStep.java
@@ -39,6 +39,8 @@ public class ApiMessagingServiceStep extends AbstractBrokerStartupStep {
           .setPrivateKey(securityCfg.getPrivateKeyPath());
     }
 
+    messagingConfig.setCompressionAlgorithm(brokerCfg.getCluster().getMessageCompression());
+
     final var messagingService =
         new NettyMessagingService(
             brokerCfg.getCluster().getClusterName(),

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/AtomixClusterFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/AtomixClusterFactory.java
@@ -63,7 +63,8 @@ public final class AtomixClusterFactory {
                 Address.from(
                     networkCfg.getInternalApi().getAdvertisedHost(),
                     networkCfg.getInternalApi().getAdvertisedPort()))
-            .withMembershipProvider(discoveryProvider);
+            .withMembershipProvider(discoveryProvider)
+            .withMessageCompression(clusterCfg.getMessageCompression());
 
     final var securityCfg = networkCfg.getSecurity();
     if (securityCfg.isEnabled()) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.system.configuration;
 import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
 import static io.camunda.zeebe.util.StringUtil.LIST_SANITIZER;
 
+import io.atomix.cluster.messaging.MessagingConfig.CompressionAlgorithm;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
@@ -39,6 +40,7 @@ public final class ClusterCfg implements ConfigurationEntry {
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private MembershipCfg membership = new MembershipCfg();
   private RaftCfg raft = new RaftCfg();
+  private CompressionAlgorithm messageCompression = CompressionAlgorithm.NONE;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -128,6 +130,22 @@ public final class ClusterCfg implements ConfigurationEntry {
     this.raft = raft;
   }
 
+  public Duration getElectionTimeout() {
+    return electionTimeout;
+  }
+
+  public void setElectionTimeout(final Duration electionTimeout) {
+    this.electionTimeout = electionTimeout;
+  }
+
+  public CompressionAlgorithm getMessageCompression() {
+    return messageCompression;
+  }
+
+  public void setMessageCompression(final CompressionAlgorithm messageCompression) {
+    this.messageCompression = messageCompression;
+  }
+
   @Override
   public String toString() {
     return "ClusterCfg{"
@@ -146,22 +164,16 @@ public final class ClusterCfg implements ConfigurationEntry {
         + ", clusterName='"
         + clusterName
         + '\''
-        + ", membership="
-        + membership
         + ", heartbeatInterval="
         + heartbeatInterval
         + ", electionTimeout="
         + electionTimeout
+        + ", membership="
+        + membership
         + ", raft="
         + raft
+        + ", messageCompression="
+        + messageCompression
         + '}';
-  }
-
-  public Duration getElectionTimeout() {
-    return electionTimeout;
-  }
-
-  public void setElectionTimeout(final Duration electionTimeout) {
-    this.electionTimeout = electionTimeout;
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/CompressionCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/CompressionCfgTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.messaging.MessagingConfig.CompressionAlgorithm;
+import java.util.Map;
+import org.junit.Test;
+
+public final class CompressionCfgTest {
+
+  @Test
+  public void shouldConfigureCompressionAlgorithm() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("compression-cfg", Map.of());
+    final ClusterCfg config = cfg.getCluster();
+
+    // then
+    assertThat(config.getMessageCompression()).isEqualTo(CompressionAlgorithm.SNAPPY);
+  }
+
+  @Test
+  public void shouldSetDefaultCompression() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", Map.of());
+    final ClusterCfg config = cfg.getCluster();
+
+    // then
+    assertThat(config.getMessageCompression()).isEqualTo(CompressionAlgorithm.NONE);
+  }
+}

--- a/broker/src/test/resources/system/compression-cfg.yaml
+++ b/broker/src/test/resources/system/compression-cfg.yaml
@@ -1,0 +1,4 @@
+zeebe:
+  broker:
+    cluster:
+      messageCompression: "SNAPPY"

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -325,6 +325,15 @@
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SYNCINTERVAL
         # syncInterval: 10s
 
+      # Configure compression algorithm for all message sent between the brokers and between the broker and
+      # the gateway. Available options are NONE, GZIP and SNAPPY.
+      # This feature is useful when the network latency between the brokers is very high (for example when the brokers are deployed in different data centers).
+      # When latency is high, the network bandwidth is severely reduced. Hence enabling compression helps to improve the throughput.
+      # Note: When there is no latency enabling this may have a performance impact.
+      # Note: When this flag is enables, you must also enable compression in standalone gateway configuration.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MESSAGECOMPRESSION
+      # messageCompression: NONE
+
     # threads:
       # Controls the number of non-blocking CPU threads to be used. WARNING: You
       # should never specify a value that is larger than the number of physical cores

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -264,6 +264,14 @@
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SYNCINTERVAL
         # syncInterval: 10s
 
+      # Configure compression algorithm for all message sent between the brokers and between the broker and
+      # the gateway. Available options are NONE, GZIP and SNAPPY.
+      # This feature is useful when the network latency between the brokers is very high (for example when the brokers are deployed in different data centers).
+      # When latency is high, the network bandwidth is severely reduced. Hence enabling compression helps to improve the throughput.
+      # Note: When there is no latency enabling this may have a performance impact.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MESSAGECOMPRESSION
+      # messageCompression: NONE
+
     # threads:
       # Controls the number of non-blocking CPU threads to be used. WARNING: You
       # should never specify a value that is larger than the number of physical cores

--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -132,6 +132,15 @@
         # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH.
         # privateKeyPath:
 
+      # Configure compression algorithm for all message sent between the brokers and between the broker and
+      # the gateway. Available options are NONE, GZIP and SNAPPY.
+      # This feature is useful when the network latency between the brokers is very high (for example when the brokers are deployed in different data centers).
+      # When latency is high, the network bandwidth is severely reduced. Hence enabling compression helps to improve the throughput.
+      # Note: When there is no latency enabling this may have a performance impact.
+      # Note: When this flag is enables, you must also enable compression in standalone broker configuration.
+      # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_MESSAGECOMPRESSION
+      # messageCompression: NONE
+
     # threads:
       # Sets the number of threads the gateway will use to communicate with the broker cluster
       # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_THREADS_MANAGEMENTTHREADS.

--- a/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
@@ -166,7 +166,8 @@ public class StandaloneGateway
                 BootstrapDiscoveryProvider.builder()
                     .withNodes(Address.from(config.getContactPoint()))
                     .build())
-            .withMembershipProtocol(membershipProtocol);
+            .withMembershipProtocol(membershipProtocol)
+            .withMessageCompression(config.getMessageCompression());
 
     if (config.getSecurity().isEnabled()) {
       applyClusterSecurityConfig(config, builder);

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ClusterCfg.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ClusterCfg.java
@@ -15,6 +15,7 @@ import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CONTACT_POINT_PORT;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_REQUEST_TIMEOUT;
 
+import io.atomix.cluster.messaging.MessagingConfig.CompressionAlgorithm;
 import java.time.Duration;
 import java.util.Objects;
 
@@ -28,6 +29,7 @@ public final class ClusterCfg {
   private int port = DEFAULT_CLUSTER_PORT;
   private MembershipCfg membership = new MembershipCfg();
   private SecurityCfg security = new SecurityCfg();
+  private CompressionAlgorithm messageCompression = CompressionAlgorithm.NONE;
 
   public String getMemberId() {
     return memberId;
@@ -100,9 +102,26 @@ public final class ClusterCfg {
     return this;
   }
 
+  public CompressionAlgorithm getMessageCompression() {
+    return messageCompression;
+  }
+
+  public void setMessageCompression(final CompressionAlgorithm compressionAlgorithm) {
+    messageCompression = compressionAlgorithm;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(contactPoint, requestTimeout, clusterName, memberId, host, port, security);
+    return Objects.hash(
+        contactPoint,
+        requestTimeout,
+        clusterName,
+        memberId,
+        host,
+        port,
+        membership,
+        security,
+        messageCompression);
   }
 
   @Override
@@ -119,8 +138,10 @@ public final class ClusterCfg {
         && Objects.equals(requestTimeout, that.requestTimeout)
         && Objects.equals(clusterName, that.clusterName)
         && Objects.equals(memberId, that.memberId)
+        && Objects.equals(host, that.host)
+        && Objects.equals(membership, that.membership)
         && Objects.equals(security, that.security)
-        && Objects.equals(host, that.host);
+        && Objects.equals(messageCompression, that.messageCompression);
   }
 
   @Override
@@ -129,7 +150,7 @@ public final class ClusterCfg {
         + "contactPoint='"
         + contactPoint
         + '\''
-        + ", requestTimeout='"
+        + ", requestTimeout="
         + requestTimeout
         + ", clusterName='"
         + clusterName
@@ -142,8 +163,12 @@ public final class ClusterCfg {
         + '\''
         + ", port="
         + port
+        + ", membership="
+        + membership
         + ", security="
         + security
+        + ", messageCompression="
+        + messageCompression
         + '}';
   }
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/MembershipCfg.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/MembershipCfg.java
@@ -124,6 +124,72 @@ public final class MembershipCfg {
   }
 
   @Override
+  public int hashCode() {
+    int result = (broadcastUpdates ? 1 : 0);
+    result = 31 * result + (broadcastDisputes ? 1 : 0);
+    result = 31 * result + (notifySuspect ? 1 : 0);
+    result = 31 * result + (gossipInterval != null ? gossipInterval.hashCode() : 0);
+    result = 31 * result + gossipFanout;
+    result = 31 * result + (probeInterval != null ? probeInterval.hashCode() : 0);
+    result = 31 * result + (probeTimeout != null ? probeTimeout.hashCode() : 0);
+    result = 31 * result + suspectProbes;
+    result = 31 * result + (failureTimeout != null ? failureTimeout.hashCode() : 0);
+    result = 31 * result + (syncInterval != null ? syncInterval.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final MembershipCfg that = (MembershipCfg) o;
+
+    if (broadcastUpdates != that.broadcastUpdates) {
+      return false;
+    }
+    if (broadcastDisputes != that.broadcastDisputes) {
+      return false;
+    }
+    if (notifySuspect != that.notifySuspect) {
+      return false;
+    }
+    if (gossipFanout != that.gossipFanout) {
+      return false;
+    }
+    if (suspectProbes != that.suspectProbes) {
+      return false;
+    }
+    if (gossipInterval != null
+        ? !gossipInterval.equals(that.gossipInterval)
+        : that.gossipInterval != null) {
+      return false;
+    }
+    if (probeInterval != null
+        ? !probeInterval.equals(that.probeInterval)
+        : that.probeInterval != null) {
+      return false;
+    }
+    if (probeTimeout != null
+        ? !probeTimeout.equals(that.probeTimeout)
+        : that.probeTimeout != null) {
+      return false;
+    }
+    if (failureTimeout != null
+        ? !failureTimeout.equals(that.failureTimeout)
+        : that.failureTimeout != null) {
+      return false;
+    }
+    return syncInterval != null
+        ? syncInterval.equals(that.syncInterval)
+        : that.syncInterval == null;
+  }
+
+  @Override
   public String toString() {
     return "MembershipCfg{"
         + "broadcastUpdates="

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -391,6 +391,7 @@ public final class ClusteringRule extends ExternalResource {
                     .build())
             .withMembershipProtocol(
                 SwimMembershipProtocol.builder().withSyncInterval(Duration.ofSeconds(1)).build())
+            .withMessageCompression(gatewayCfg.getCluster().getMessageCompression())
             .build();
 
     atomixCluster.start().join();

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/NetworkCompressionTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/NetworkCompressionTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.network;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.messaging.MessagingConfig.CompressionAlgorithm;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.client.ZeebeClientBuilder;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.camunda.zeebe.it.clustering.ClusteringRule;
+import io.camunda.zeebe.it.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.it.util.GrpcClientRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
+
+public class NetworkCompressionTest {
+  public final Timeout testTimeout = Timeout.seconds(120);
+
+  public final ClusteringRule clusteringRule =
+      new ClusteringRule(
+          1,
+          3,
+          3,
+          this::configureClusterWithCompression,
+          this::configureGatewayWithCompression,
+          ZeebeClientBuilder::usePlaintext);
+
+  public final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
+
+  @Rule
+  public RuleChain ruleChain =
+      RuleChain.outerRule(testTimeout).around(clusteringRule).around(clientRule);
+
+  @Test
+  public void shouldCommunicateWhenCompressionEnabled() {
+    // given
+    final String processId = new BrokerClassRuleHelper().getBpmnProcessId();
+
+    // when
+    clientRule.deployProcess(
+        Bpmn.createExecutableProcess(processId).startEvent("start").endEvent("end").done());
+
+    final ProcessInstanceEvent processInstance =
+        clientRule
+            .getClient()
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .send()
+            .join();
+
+    // then - gateway to broker and broker to broker communication was successful
+    assertThat(processInstance.getBpmnProcessId()).isEqualTo(processId);
+  }
+
+  private void configureGatewayWithCompression(final GatewayCfg gatewayCfg) {
+    gatewayCfg.getCluster().setMessageCompression(CompressionAlgorithm.GZIP);
+  }
+
+  private void configureClusterWithCompression(final BrokerCfg brokerCfg) {
+    brokerCfg.getCluster().setMessageCompression(CompressionAlgorithm.GZIP);
+  }
+}


### PR DESCRIPTION
## Description

* Add two compression algorithms to netty (gzip, snappy)
* Compression can be enabled by configuration (default = disabled)
* When compression is enabled all messages sent between all brokers and gateway will be compressed.

In the spike, we observed that compression increased the throughput when network latency is high. In no latency test, we found that enabling compression has not significant performance impact. 

## Related issues

closes #8486

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [x] The impact of the changes is verified by a benchmark 

Documentation: 
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
