### PR TITLE
feat(gateway): add readiness health probe

### DIFF
--- a/dist/src/main/resources/application-gateway.properties
+++ b/dist/src/main/resources/application-gateway.properties
@@ -4,7 +4,9 @@
 # Health configuration
 management.endpoint.health.group.startup.include=gatewayStarted
 management.endpoint.health.group.startup.show-details=never
+management.endpoint.health.group.readiness.include=gatewayStarted
+management.endpoint.health.group.readiness.show-details=never
 management.endpoint.health.group.liveness.include=livenessGatewayResponsive,\
   livenessGatewayClusterAwareness,livenessGatewayPartitionLeaderAwareness,livenessMemory,\
   diskSpaceHealthIndicator
-management.endpoint.health.group.liveness.show-details=never
+management.endpoint.health.group.liveness.show-details=always

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayHealthProbeIntegrationTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayHealthProbeIntegrationTest.java
@@ -18,16 +18,19 @@ import io.restassured.specification.RequestSpecification;
 import io.zeebe.containers.ZeebeBrokerContainer;
 import io.zeebe.containers.ZeebeGatewayContainer;
 import io.zeebe.containers.ZeebePort;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.stream.Stream;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.junit.Test;
+import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
 import org.testcontainers.lifecycle.Startable;
 
-public class GatewayLivenessProbeIntegrationTest {
+public class GatewayHealthProbeIntegrationTest {
 
   public static final String PATH_LIVENESS_PROBE = "/live";
+  private static final String PATH_READINESS_PROBE = "/actuator/health/readiness";
 
   @Test
   public void shouldReportLivenessUpIfConnectedToBroker() {
@@ -108,6 +111,107 @@ public class GatewayLivenessProbeIntegrationTest {
 
     // --- when + then ---------------------------------------
     given().spec(gatewayServerSpec).when().get(PATH_LIVENESS_PROBE).then().statusCode(503);
+
+    // --- shutdown ------------------------------------------
+    gateway.stop();
+  }
+
+  @Test
+  public void shouldReportReadinessUpIfApplicationIsUp() {
+    // given
+    final ZeebeGatewayContainer gateway =
+        new ZeebeGatewayContainer(ZeebeTestContainerDefaults.defaultTestImage())
+            .withEnv("ZEEBE_GATEWAY_MONITORING_ENABLED", "true")
+            .withExposedPorts(ZeebePort.MONITORING.getPort())
+            .withoutTopologyCheck()
+            .withStartupCheckStrategy(new IsRunningStartupCheckStrategy());
+    gateway.start();
+    final Integer actuatorPort = gateway.getMappedPort(ZeebePort.MONITORING.getPort());
+    final String containerIPAddress = gateway.getExternalHost();
+
+    final RequestSpecification gatewayServerSpec =
+        new RequestSpecBuilder()
+            .setContentType(ContentType.JSON)
+            .setBaseUri("http://" + containerIPAddress)
+            .setPort(actuatorPort)
+            .addFilter(new ResponseLoggingFilter())
+            .addFilter(new RequestLoggingFilter())
+            .build();
+
+    // when
+    // then
+    // most of the readiness probes use a delayed health indicator which is scheduled at a fixed
+    // rate of 5 seconds, so it may take up to that and a bit more in the worst case once the
+    // gateway finds the broker
+    try {
+      Awaitility.await("wait until status turns UP")
+          .atMost(Duration.ofSeconds(10))
+          .pollInterval(Duration.ofMillis(100))
+          .untilAsserted(
+              () ->
+                  given()
+                      .spec(gatewayServerSpec)
+                      .when()
+                      .get(PATH_READINESS_PROBE)
+                      .then()
+                      .statusCode(200));
+    } catch (final ConditionTimeoutException e) {
+      // it can happen that a single request takes too long and causes awaitility to timeout,
+      // in which case we want to try a second time to run the request without timeout
+      given().spec(gatewayServerSpec).when().get(PATH_READINESS_PROBE).then().statusCode(200);
+    }
+
+    // --- shutdown ------------------------------------------
+    gateway.stop();
+  }
+
+  @Test
+  public void shouldReportReadinessUpIfNotAvailable() throws IOException, InterruptedException {
+    // given
+    final ZeebeGatewayContainer gateway =
+        new ZeebeGatewayContainer(ZeebeTestContainerDefaults.defaultTestImage())
+            .withEnv("ZEEBE_GATEWAY_MONITORING_ENABLED", "true")
+            .withExposedPorts(ZeebePort.MONITORING.getPort())
+            .withoutTopologyCheck()
+            .withStartupCheckStrategy(new IsRunningStartupCheckStrategy());
+    gateway.start();
+    final Integer actuatorPort = gateway.getMappedPort(ZeebePort.MONITORING.getPort());
+    final String containerIPAddress = gateway.getExternalHost();
+
+    final RequestSpecification gatewayServerSpec =
+        new RequestSpecBuilder()
+            .setContentType(ContentType.JSON)
+            .setBaseUri("http://" + containerIPAddress)
+            .setPort(actuatorPort)
+            .addFilter(new ResponseLoggingFilter())
+            .addFilter(new RequestLoggingFilter())
+            .build();
+
+    // when
+    // we are trying to kill process to make application unavailable
+    gateway.execInContainer("killbyname", "java");
+
+    // then
+    // most of the readiness probes use a delayed health indicator which is scheduled at a fixed
+    // rate of 5 seconds, so it may take up to that and a bit more in the worst case once the
+    // gateway finds the broker
+    try {
+      Awaitility.await("wait until status turns DOWN")
+          .atMost(Duration.ofSeconds(10))
+          .pollInterval(Duration.ofMillis(100))
+          .untilAsserted(
+              () ->
+                  given()
+                      .spec(gatewayServerSpec)
+                      .when()
+                      .get(PATH_READINESS_PROBE)
+                      .then()
+                      .statusCode(503));
+    } catch (final ConditionTimeoutException e) {
+      // it can happen that a single request takes too long and causes awaitility to timeout,
+      // in which case we want to try a second time to run the request without timeout
+      given().spec(gatewayServerSpec).when().get(PATH_READINESS_PROBE).then().statusCode(503);
+    }
 
     // --- shutdown ------------------------------------------
     gateway.stop();


### PR DESCRIPTION
## Description

**NOTE**: It is just a rebaised and tested copy of https://github.com/camunda-cloud/zeebe/pull/6945. I've lost access to this organization, so I have to create a separate PR :(

Also, as I can see the bug with the main method of started application is fixed. So we just need to create a health group in the configuration and test it. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6413

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
