### PR TITLE
Feat: Processing has reached end

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -416,6 +416,14 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
         });
   }
 
+  public ActorFuture<Boolean> hasProcessingReachedTheEnd() {
+    return actor.call(
+        () ->
+            processingStateMachine != null
+                && !isInReplayOnlyMode()
+                && processingStateMachine.hasReachedEnd());
+  }
+
   private void setStateToPausedAndNotifyListeners() {
     if (isInReplayOnlyMode() || !replayCompletedFuture.isDone()) {
       LOG.debug("Paused replay for partition {}", partitionId);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ReachEndOfLogTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ReachEndOfLogTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ReachEndOfLogTest {
+
+  @Rule public final EngineRule engineRule = EngineRule.singlePartition();
+
+  @Test
+  public void shouldReturnTrueIfNothingProcessed() {
+    // given
+
+    // when
+    final var reachedEnd = engineRule.hasReachedEnd();
+
+    // then
+    assertThat(reachedEnd).isTrue();
+  }
+
+  @Test
+  public void shouldReturnTrueAfterReachingEndOfTheLog() {
+    // given
+    engineRule
+        .deployment()
+        .withXmlResource(Bpmn.createExecutableProcess("process").startEvent().endEvent().done())
+        .deploy();
+
+    // when
+    engineRule.processInstance().ofBpmnProcessId("process").create();
+
+    // then
+    Awaitility.await("Processor should reach the end")
+        .atLeast(Duration.ofMillis(100))
+        .until(engineRule::hasReachedEnd, Boolean.TRUE::equals);
+  }
+
+  @Test
+  public void shouldReturnFalseIfNotReachedEndOfLog() {
+    // given
+    engineRule
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .manualTask("test")
+                .connectTo("test")
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engineRule.processInstance().ofBpmnProcessId("process").create();
+
+    // then
+    final var reachedEnd = engineRule.hasReachedEnd();
+    assertThat(reachedEnd).isFalse();
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateRandomizedPropertyTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateRandomizedPropertyTest.java
@@ -157,11 +157,9 @@ public class ReplayStateRandomizedPropertyTest {
     Awaitility.await("await the last written record to be processed")
         .untilAsserted(
             () ->
-                assertThat(engineRule.getLastProcessedPosition())
-                    .describedAs(
-                        "Last written %d has to be processed %d",
-                        engineRule.getLastWrittenPosition(1), engineRule.getLastProcessedPosition())
-                    .isEqualTo(engineRule.getLastWrittenPosition(1)));
+                assertThat(engineRule.hasReachedEnd())
+                    .describedAs("Processing has reached end of the log.")
+                    .isTrue());
   }
 
   @Parameters(name = "{0}")

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -393,6 +393,10 @@ public final class EngineRule extends ExternalResource {
                     .isGreaterThanOrEqualTo(recordPosition));
   }
 
+  public boolean hasReachedEnd() {
+    return getStreamProcessor(PARTITION_ID).hasProcessingReachedTheEnd().join();
+  }
+
   private static final class VersatileBlob implements DbKey, DbValue {
 
     private final DirectBuffer genericBuffer = new UnsafeBuffer(0, 0);


### PR DESCRIPTION
## Description
As written here https://github.com/camunda-cloud/zeebe/issues/8397#issuecomment-1004695100
> Had a deeper look at the code and discussed the issue with @saig0 
> 
> It seems to be a concurrency issue with the `waitForProcessingToStop` https://github.com/camunda-cloud/zeebe/blob/develop/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateRandomizedPropertyTest.java#L156-L164 
> 
> Here we check the lastProcessedPosition https://github.com/camunda-cloud/zeebe/blob/0d96dab3d5027cbb36d8ada220ba6c618a72c97e/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java#L288-L290 which is updated on a different thread (actor stream processor thread) https://github.com/camunda-cloud/zeebe/blob/0d96dab3d5027cbb36d8ada220ba6c618a72c97e/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java#L199-L208
> 
> The lastWrittenPosition access the underlying stream https://github.com/camunda-cloud/zeebe/blob/develop/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java#L200
> 
> which can also be updated and read by different thread https://github.com/camunda-cloud/zeebe/blob/0d96dab3d5027cbb36d8ada220ba6c618a72c97e/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStream.java#L54
> 
> If I understand this correctly then we can run into issues where it seems we reached the end of the log but didn't and collect in the Test the wrong state content
> 
> https://github.com/camunda-cloud/zeebe/blob/0d96dab3d5027cbb36d8ada220ba6c618a72c97e/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateRandomizedPropertyTest.java#L106-L109
> 
> This cause that maybe state changes which occur later are failing the test.

Discussed with @saig0 possible solution and proposed to add a new property on the StreamProcessor which can be used to determine whether the StreamProcessor reached the end of the log.

**What it contains:**

Adds a new property to the ProcessingStateMachine which indicates whether
the processing has reached the end of the log. This is useful to
determine whether the engine is still processing, especially for the
randomized tests but also for tests and tools like eze or processing test this can
become useful (\cc @pihme ).

Uses this property in the randomized tests.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda-cloud/zeebe/issues/8328
closes https://github.com/camunda-cloud/zeebe/issues/8397

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
