### PR TITLE
[Backport 1.2] test: increment time continuously

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorDistributionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorDistributionTest.java
@@ -15,12 +15,15 @@ import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.util.ControlledTestExporter;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionEvaluationListener;
+import org.awaitility.core.EvaluatedCondition;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -99,6 +102,7 @@ public final class ExporterDirectorDistributionTest {
 
     // then
     Awaitility.await("Active Director has distributed positions and passive has received it")
+        .conditionEvaluationListener(new ClockShifter(activeExporters.getClock()))
         .untilAsserted(
             () -> {
               assertThat(passiveExporterState.getPosition(EXPORTER_ID_1)).isEqualTo(position);
@@ -126,6 +130,7 @@ public final class ExporterDirectorDistributionTest {
 
     final var passiveExporterState = passiveExporters.getExportersState();
     Awaitility.await("Active Director has distributed positions and passive has received it")
+        .conditionEvaluationListener(new ClockShifter(activeExporters.getClock()))
         .untilAsserted(
             () -> {
               assertThat(passiveExporterState.getPosition(EXPORTER_ID_1)).isEqualTo(position);
@@ -145,5 +150,26 @@ public final class ExporterDirectorDistributionTest {
 
     // then - the exported position should not go back
     assertThat(passiveExporterState.getPosition(EXPORTER_ID_1)).isEqualTo(position);
+  }
+
+  /**
+   * Shifts the actor clock by the {@link this#DISTRIBUTION_INTERVAL} after an awaitility condition
+   * was evaluated.
+   *
+   * <p>This makes sure that even if we miss one export position event, we distribute the event
+   * later again, which makes tests less flaky.
+   */
+  private static final class ClockShifter implements ConditionEvaluationListener<Void> {
+
+    private final ControlledActorClock clock;
+
+    public ClockShifter(final ControlledActorClock clock) {
+      this.clock = clock;
+    }
+
+    @Override
+    public void conditionEvaluated(final EvaluatedCondition<Void> condition) {
+      clock.addTime(DISTRIBUTION_INTERVAL);
+    }
   }
 }


### PR DESCRIPTION
## Description

Backports #8508 problems with cherry-pick, because of the import order.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8475

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
