### PR TITLE
[Backport 1.2]: Feat: Processing has reached end

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -107,6 +107,10 @@ public final class ProcessingStateMachine {
   private final EventFilter eventFilter =
       new MetadataEventFilter(new RecordProtocolVersionFilter().and(PROCESSING_FILTER));
 
+  private final EventFilter commandFilter =
+      new MetadataEventFilter(
+          recordMetadata -> recordMetadata.getRecordType() != RecordType.COMMAND);
+
   private final MutableZeebeState zeebeState;
   private final MutableLastProcessedPositionState lastProcessedPositionState;
   private final RecordMetadata metadata = new RecordMetadata();
@@ -140,6 +144,7 @@ public final class ProcessingStateMachine {
   private int onErrorRetries;
   // Used for processing duration metrics
   private long processingStartTime;
+  private boolean reachedEnd = true;
 
   public ProcessingStateMachine(
       final ProcessingContext context, final BooleanSupplier shouldProcessNext) {
@@ -184,7 +189,18 @@ public final class ProcessingStateMachine {
   }
 
   private void tryToReadNextEvent() {
-    if (shouldProcessNext.getAsBoolean() && logStreamReader.hasNext() && currentProcessor == null) {
+    final var hasNext = logStreamReader.hasNext();
+
+    if (currentEvent != null) {
+      // All commands cause a follow-up event or rejection, which means the processor
+      // reached the end of the log if:
+      //  * the last record was an event or rejection
+      //  * and there is no next record on the log
+      final var previousEvent = currentEvent;
+      reachedEnd = commandFilter.applies(previousEvent) && !hasNext;
+    }
+
+    if (shouldProcessNext.getAsBoolean() && hasNext && currentProcessor == null) {
       currentEvent = logStreamReader.next();
 
       if (eventFilter.applies(currentEvent)) {
@@ -193,6 +209,17 @@ public final class ProcessingStateMachine {
         skipRecord();
       }
     }
+  }
+
+  /**
+   * Be aware this is a transient property which can change anytime, e.g. if a new command is
+   * written to the log.
+   *
+   * @return true if the ProcessingStateMachine has reached the end of the log and nothing is left
+   *     to being processed/applied, false otherwise
+   */
+  public boolean hasReachedEnd() {
+    return reachedEnd;
   }
 
   private void processEvent(final LoggedEvent event) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -413,6 +413,14 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
         });
   }
 
+  public ActorFuture<Boolean> hasProcessingReachedTheEnd() {
+    return actor.call(
+        () ->
+            processingStateMachine != null
+                && !isInReplayOnlyMode()
+                && processingStateMachine.hasReachedEnd());
+  }
+
   private void setStateToPausedAndNotifyListeners() {
     if (isInReplayOnlyMode() || !replayCompletedFuture.isDone()) {
       LOG.debug("Paused replay for partition {}", partitionId);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ReachEndOfLogTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ReachEndOfLogTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ReachEndOfLogTest {
+
+  @Rule public final EngineRule engineRule = EngineRule.singlePartition();
+
+  @Test
+  public void shouldReturnTrueIfNothingProcessed() {
+    // given
+
+    // when
+    final var reachedEnd = engineRule.hasReachedEnd();
+
+    // then
+    assertThat(reachedEnd).isTrue();
+  }
+
+  @Test
+  public void shouldReturnTrueAfterReachingEndOfTheLog() {
+    // given
+    engineRule
+        .deployment()
+        .withXmlResource(Bpmn.createExecutableProcess("process").startEvent().endEvent().done())
+        .deploy();
+
+    // when
+    engineRule.processInstance().ofBpmnProcessId("process").create();
+
+    // then
+    Awaitility.await("Processor should reach the end")
+        .atLeast(Duration.ofMillis(100))
+        .until(engineRule::hasReachedEnd, Boolean.TRUE::equals);
+  }
+
+  @Test
+  public void shouldReturnFalseIfNotReachedEndOfLog() {
+    // given
+    engineRule
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .manualTask("test")
+                .connectTo("test")
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engineRule.processInstance().ofBpmnProcessId("process").create();
+
+    // then
+    final var reachedEnd = engineRule.hasReachedEnd();
+    assertThat(reachedEnd).isFalse();
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateRandomizedPropertyTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ReplayStateRandomizedPropertyTest.java
@@ -157,11 +157,9 @@ public class ReplayStateRandomizedPropertyTest {
     Awaitility.await("await the last written record to be processed")
         .untilAsserted(
             () ->
-                assertThat(engineRule.getLastProcessedPosition())
-                    .describedAs(
-                        "Last written %d has to be processed %d",
-                        engineRule.getLastWrittenPosition(1), engineRule.getLastProcessedPosition())
-                    .isEqualTo(engineRule.getLastWrittenPosition(1)));
+                assertThat(engineRule.hasReachedEnd())
+                    .describedAs("Processing has reached end of the log.")
+                    .isTrue());
   }
 
   @Parameters(name = "{0}")

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -393,6 +393,10 @@ public final class EngineRule extends ExternalResource {
                     .isGreaterThanOrEqualTo(recordPosition));
   }
 
+  public boolean hasReachedEnd() {
+    return getStreamProcessor(PARTITION_ID).hasProcessingReachedTheEnd().join();
+  }
+
   private static final class VersatileBlob implements DbKey, DbValue {
 
     private final DirectBuffer genericBuffer = new UnsafeBuffer(0, 0);


### PR DESCRIPTION
## Description
I had to fix some cherry-pick conflicts.

Backports #8510 
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8328
closes #8397
<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
