### PR TITLE
fix: print correct json input

### DIFF
--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -212,11 +212,11 @@ func (s *integrationTestSuite) TestCommonCommands() {
 			}
 
 			if test.jsonOutput {
-				fmtJson, err := reformatJSON(cmdOut)
+				fmtJSON, err := reformatJSON(cmdOut)
 				if err != nil {
 					t.Fatalf("failed to reformat response JSON: %v\nErroneous JSON: %s", err, cmdOut)
 				}
-				cmdOut = fmtJson
+				cmdOut = fmtJSON
 
 				fmtGolden, err := reformatJSON(goldenOut)
 				if err != nil {

--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -212,15 +212,17 @@ func (s *integrationTestSuite) TestCommonCommands() {
 			}
 
 			if test.jsonOutput {
-				cmdOut, err = reformatJSON(cmdOut)
+				fmtJson, err := reformatJSON(cmdOut)
 				if err != nil {
-					t.Fatalf("failed to reformat response JSON: %v\nErroneous JSON: %v", err, cmdOut)
+					t.Fatalf("failed to reformat response JSON: %v\nErroneous JSON: %s", err, cmdOut)
 				}
+				cmdOut = fmtJson
 
-				goldenOut, err = reformatJSON(goldenOut)
+				fmtGolden, err := reformatJSON(goldenOut)
 				if err != nil {
-					t.Fatalf("failed to reformat golden JSON: %v\nErroneous JSON: %v", err, goldenOut)
+					t.Fatalf("failed to reformat golden JSON: %v\nErroneous JSON: %s", err, goldenOut)
 				}
+				goldenOut = fmtGolden
 			}
 
 			assertEq(t, test, goldenOut, cmdOut)


### PR DESCRIPTION
## Description

Previously on test failure, the input was overwritten by the return of the reformatJson function, which gave not much helpful error message. The return value is stored in a intermediate variable to be overwrite the real variable only in the case of success, such that we print the correct input.

### Before

```
=== RUN   TestZbctlWithInsecureGateway/TestCommonCommands/empty_activate_job
    main_test.go:217: failed to reformat response JSON: yolo
        Erroneous JSON: []
```

### With %v

```
=== RUN   TestZbctlWithInsecureGateway/TestCommonCommands/empty_activate_job
    main_test.go:217: failed to reformat response JSON: yolo
        Erroneous JSON: [123 10 32 32 34 106 111 98 115 34 58 32 91 93 10 125 10]
```

### Now with %s
```
=== RUN   TestZbctlWithInsecureGateway/TestCommonCommands/empty_activate_job
    main_test.go:217: failed to reformat response JSON: yolo
        Erroneous JSON: {
          "jobs": []
        }
```
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda-cloud/zeebe/issues/8284

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
