### PR TITLE
I can deploy a DMN decision

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -199,6 +199,12 @@
         <version>${project.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>dmn</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
       <!-- ATOMIX -->
       <dependency>
         <groupId>io.camunda</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -70,6 +70,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>dmn</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-msgpack-value</artifactId>
     </dependency>
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.transform;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.BpmnFactory;
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
+import io.camunda.zeebe.engine.processing.deployment.transform.DeploymentTransformer.DeploymentResourceTransformer;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.state.KeyGenerator;
+import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.BaseElement;
+import io.camunda.zeebe.model.bpmn.instance.Process;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Collection;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.agrona.DirectBuffer;
+import org.agrona.io.DirectBufferInputStream;
+
+public final class BpmnResourceTransformer implements DeploymentResourceTransformer {
+
+  private final BpmnTransformer bpmnTransformer = BpmnFactory.createTransformer();
+
+  private final KeyGenerator keyGenerator;
+  private final StateWriter stateWriter;
+  private final Function<DeploymentResource, DirectBuffer> checksumGenerator;
+
+  private final BpmnValidator validator;
+  private final ProcessState processState;
+
+  public BpmnResourceTransformer(
+      final KeyGenerator keyGenerator,
+      final StateWriter stateWriter,
+      final Function<DeploymentResource, DirectBuffer> checksumGenerator,
+      final ProcessState processState,
+      final ExpressionProcessor expressionProcessor) {
+    this.keyGenerator = keyGenerator;
+    this.stateWriter = stateWriter;
+    this.checksumGenerator = checksumGenerator;
+    this.processState = processState;
+    validator = BpmnFactory.createValidator(expressionProcessor);
+  }
+
+  @Override
+  public Either<Failure, Void> transformResource(
+      final DeploymentResource resource, final DeploymentRecord record) {
+
+    final BpmnModelInstance definition = readProcessDefinition(resource);
+    final String validationError = validator.validate(definition);
+
+    if (validationError == null) {
+      // transform the model to avoid unexpected failures that are not covered by the validator
+      bpmnTransformer.transformDefinitions(definition);
+
+      return checkForDuplicateBpmnId(definition, resource, record)
+          .map(
+              ok -> {
+                transformProcessResource(record, resource, definition);
+                return null;
+              });
+
+    } else {
+      final var failureMessage =
+          String.format("'%s': %s", resource.getResourceName(), validationError);
+      return Either.left(new Failure(failureMessage));
+    }
+  }
+
+  private BpmnModelInstance readProcessDefinition(final DeploymentResource deploymentResource) {
+    final DirectBuffer resource = deploymentResource.getResourceBuffer();
+    final DirectBufferInputStream resourceStream = new DirectBufferInputStream(resource);
+    return Bpmn.readModelFromStream(resourceStream);
+  }
+
+  private Either<Failure, ?> checkForDuplicateBpmnId(
+      final BpmnModelInstance process,
+      final DeploymentResource resource,
+      final DeploymentRecord record) {
+
+    final var bpmnProcessIds =
+        process.getDefinitions().getChildElementsByType(Process.class).stream()
+            .map(BaseElement::getId)
+            .collect(Collectors.toList());
+
+    return record.getProcessesMetadata().stream()
+        .filter(metadata -> bpmnProcessIds.contains(metadata.getBpmnProcessId()))
+        .findFirst()
+        .map(
+            previousResource -> {
+              final var failureMessage =
+                  String.format(
+                      "Duplicated process id in resources '%s' and '%s'",
+                      previousResource.getResourceName(), resource.getResourceName());
+              return Either.left(new Failure(failureMessage));
+            })
+        .orElse(Either.right(null));
+  }
+
+  private void transformProcessResource(
+      final DeploymentRecord deploymentEvent,
+      final DeploymentResource deploymentResource,
+      final BpmnModelInstance definition) {
+    final Collection<Process> processes =
+        definition.getDefinitions().getChildElementsByType(Process.class);
+
+    for (final Process process : processes) {
+      if (process.isExecutable()) {
+        final String bpmnProcessId = process.getId();
+        final DeployedProcess lastProcess =
+            processState.getLatestProcessVersionByProcessId(BufferUtil.wrapString(bpmnProcessId));
+
+        final DirectBuffer lastDigest =
+            processState.getLatestVersionDigest(wrapString(bpmnProcessId));
+        final DirectBuffer resourceDigest = checksumGenerator.apply(deploymentResource);
+
+        // adds process record to deployment record
+        final var processMetadata = deploymentEvent.processesMetadata().add();
+        processMetadata
+            .setBpmnProcessId(BufferUtil.wrapString(process.getId()))
+            .setChecksum(resourceDigest)
+            .setResourceName(deploymentResource.getResourceNameBuffer());
+
+        final var isDuplicate =
+            isDuplicateOfLatest(deploymentResource, resourceDigest, lastProcess, lastDigest);
+        if (isDuplicate) {
+          processMetadata
+              .setVersion(lastProcess.getVersion())
+              .setKey(lastProcess.getKey())
+              .markAsDuplicate();
+        } else {
+          final var key = keyGenerator.nextKey();
+          processMetadata.setKey(key).setVersion(processState.getProcessVersion(bpmnProcessId) + 1);
+
+          stateWriter.appendFollowUpEvent(
+              key,
+              ProcessIntent.CREATED,
+              new ProcessRecord().wrap(processMetadata, deploymentResource.getResource()));
+        }
+      }
+    }
+  }
+
+  private boolean isDuplicateOfLatest(
+      final DeploymentResource deploymentResource,
+      final DirectBuffer resourceDigest,
+      final DeployedProcess lastProcess,
+      final DirectBuffer lastVersionDigest) {
+    return lastVersionDigest != null
+        && lastProcess != null
+        && lastVersionDigest.equals(resourceDigest)
+        && lastProcess.getResourceName().equals(deploymentResource.getResourceNameBuffer());
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.BpmnFactory;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
-import io.camunda.zeebe.engine.processing.deployment.transform.DeploymentTransformer.DeploymentResourceTransformer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
@@ -60,7 +59,7 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
 
   @Override
   public Either<Failure, Void> transformResource(
-      final DeploymentResource resource, final DeploymentRecord record) {
+      final DeploymentResource resource, final DeploymentRecord deployment) {
 
     final BpmnModelInstance definition = readProcessDefinition(resource);
     final String validationError = validator.validate(definition);
@@ -69,10 +68,10 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
       // transform the model to avoid unexpected failures that are not covered by the validator
       bpmnTransformer.transformDefinitions(definition);
 
-      return checkForDuplicateBpmnId(definition, resource, record)
+      return checkForDuplicateBpmnId(definition, resource, deployment)
           .map(
               ok -> {
-                transformProcessResource(record, resource, definition);
+                transformProcessResource(deployment, resource, definition);
                 return null;
               });
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentResourceTransformer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.transform;
+
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
+import io.camunda.zeebe.util.Either;
+
+interface DeploymentResourceTransformer {
+
+  /**
+   * Transform the given resource. As a result, the transformer should add the deployed resource to
+   * the deployment record and write an event for the resource (e.g. a process record).
+   *
+   * @param resource the resource to transform
+   * @param deployment the deployment to add the deployed resource to
+   * @return either {@link Either.Right} if the resource is transformed successfully, or {@link
+   *     Either.Left} if the transformation failed
+   */
+  Either<Failure, Void> transformResource(DeploymentResource resource, DeploymentRecord deployment);
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -149,15 +149,11 @@ public final class DeploymentTransformer {
         .orElse(UNKNOWN_RESOURCE);
   }
 
-  interface DeploymentResourceTransformer {
-    Either<Failure, Void> transformResource(DeploymentResource resource, DeploymentRecord record);
-  }
-
   private static class UnknownResourceTransformer implements DeploymentResourceTransformer {
 
     @Override
     public Either<Failure, Void> transformResource(
-        final DeploymentResource resource, final DeploymentRecord record) {
+        final DeploymentResource resource, final DeploymentRecord deployment) {
 
       final var failureMessage =
           String.format("%n'%s': unknown resource type", resource.getResourceName());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -7,9 +7,13 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.transform;
 
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapArray;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static java.util.Map.entry;
 
+import io.camunda.zeebe.dmn.DecisionEngine;
+import io.camunda.zeebe.dmn.DecisionEngineFactory;
+import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
@@ -23,13 +27,18 @@ import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.Process;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.io.ByteArrayInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
@@ -52,7 +61,8 @@ public final class DeploymentTransformer {
   private final Map<String, DeploymentResourceTransformer> resourceTransformers =
       Map.ofEntries(
           entry(".bpmn", new BpmnResourceTransformer()),
-          entry(".xml", new BpmnResourceTransformer()));
+          entry(".xml", new BpmnResourceTransformer()),
+          entry(".dmn", new DmnResourceTransformer()));
 
   private final ProcessRecord processRecord = new ProcessRecord();
 
@@ -240,6 +250,10 @@ public final class DeploymentTransformer {
         .orElse(UNKNOWN_RESOURCE);
   }
 
+  private DirectBuffer getChecksum(final DeploymentResource resource) {
+    return wrapArray(digestGenerator.digest(resource.getResource()));
+  }
+
   private interface DeploymentResourceTransformer {
     Either<Failure, Void> transformResource(DeploymentResource resource, DeploymentRecord record);
   }
@@ -271,6 +285,65 @@ public final class DeploymentTransformer {
             String.format("'%s': %s", resource.getResourceName(), validationError);
         return Either.left(new Failure(failureMessage));
       }
+    }
+  }
+
+  private class DmnResourceTransformer implements DeploymentResourceTransformer {
+
+    final DecisionEngine decisionEngine = DecisionEngineFactory.createDecisionEngine();
+
+    @Override
+    public Either<Failure, Void> transformResource(
+        final DeploymentResource resource, final DeploymentRecord record) {
+
+      final var dmnResource = new ByteArrayInputStream(resource.getResource());
+      final var parsedDrg = decisionEngine.parse(dmnResource);
+
+      if (parsedDrg.isValid()) {
+        writeRecords(resource, parsedDrg);
+        return Either.right(null);
+
+      } else {
+        final var failure = new Failure(parsedDrg.getFailureMessage());
+        return Either.left(failure);
+      }
+    }
+
+    private void writeRecords(final DeploymentResource resource,
+        final ParsedDecisionRequirementsGraph parsedDrg) {
+
+      final var decisionRequirementsKey = keyGenerator.nextKey();
+
+      stateWriter.appendFollowUpEvent(
+          decisionRequirementsKey,
+          DecisionRequirementsIntent.CREATED,
+          new DecisionRequirementsRecord()
+              .setDecisionRequirementsKey(decisionRequirementsKey)
+              .setDecisionRequirementsId(parsedDrg.getId())
+              .setDecisionRequirementsName(parsedDrg.getName())
+              .setDecisionRequirementsVersion(1)
+              .setNamespace(parsedDrg.getNamespace())
+              .setResourceName(resource.getResourceName())
+              .setResource(resource.getResourceBuffer())
+              .setChecksum(getChecksum(resource)));
+
+      parsedDrg
+          .getDecisions()
+          .forEach(
+              decision -> {
+                final var decisionKey = keyGenerator.nextKey();
+
+                stateWriter.appendFollowUpEvent(
+                    decisionKey,
+                    DecisionIntent.CREATED,
+                    new DecisionRecord()
+                        .setDecisionKey(decisionKey)
+                        .setDecisionId(decision.getId())
+                        .setDecisionName(decision.getName())
+                        .setVersion(1)
+                        .setDecisionRequirementsId(parsedDrg.getId())
+                        .setDecisionRequirementsKey(decisionRequirementsKey));
+              });
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -8,39 +8,24 @@
 package io.camunda.zeebe.engine.processing.deployment.transform;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapArray;
-import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static java.util.Map.entry;
 
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
-import io.camunda.zeebe.engine.processing.deployment.model.BpmnFactory;
-import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.KeyGenerator;
-import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
-import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ZeebeState;
-import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.model.bpmn.instance.Process;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.util.Either;
-import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.agrona.DirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
-import org.agrona.io.DirectBufferInputStream;
 import org.slf4j.Logger;
 
 public final class DeploymentTransformer {
@@ -52,30 +37,16 @@ public final class DeploymentTransformer {
 
   private final Map<String, DeploymentResourceTransformer> resourceTransformers;
 
-  private final ProcessRecord processRecord = new ProcessRecord();
-
-  private final BpmnTransformer bpmnTransformer = BpmnFactory.createTransformer();
-
-  private final BpmnValidator validator;
-  private final ProcessState processState;
-  private final KeyGenerator keyGenerator;
   private final MessageDigest digestGenerator;
-  // process id duplicate checking
-  private final Map<String, String> processIdToResourceName = new HashMap<>();
   // internal changes during processing
   private RejectionType rejectionType;
   private String rejectionReason;
-  private final StateWriter stateWriter;
 
   public DeploymentTransformer(
       final StateWriter stateWriter,
       final ZeebeState zeebeState,
       final ExpressionProcessor expressionProcessor,
       final KeyGenerator keyGenerator) {
-    this.stateWriter = stateWriter;
-    processState = zeebeState.getProcessState();
-    this.keyGenerator = keyGenerator;
-    validator = BpmnFactory.createValidator(expressionProcessor);
 
     try {
       // We get an alert by LGTM, since MD5 is a weak cryptographic hash function,
@@ -88,18 +59,30 @@ public final class DeploymentTransformer {
       throw new IllegalStateException(e);
     }
 
+    final var bpmnResourceTransformer =
+        new BpmnResourceTransformer(
+            keyGenerator,
+            stateWriter,
+            this::getChecksum,
+            zeebeState.getProcessState(),
+            expressionProcessor);
+    final var dmnResourceTransformer =
+        new DmnResourceTransformer(keyGenerator, stateWriter, this::getChecksum);
+
     resourceTransformers =
         Map.ofEntries(
-            entry(".bpmn", new BpmnResourceTransformer()),
-            entry(".xml", new BpmnResourceTransformer()),
-            entry(
-                ".dmn", new DmnResourceTransformer(keyGenerator, stateWriter, this::getChecksum)));
+            entry(".bpmn", bpmnResourceTransformer),
+            entry(".xml", bpmnResourceTransformer),
+            entry(".dmn", dmnResourceTransformer));
+  }
+
+  private DirectBuffer getChecksum(final DeploymentResource resource) {
+    return wrapArray(digestGenerator.digest(resource.getResource()));
   }
 
   public boolean transform(final DeploymentRecord deploymentEvent) {
     final StringBuilder errors = new StringBuilder();
     boolean success = true;
-    processIdToResourceName.clear();
 
     final Iterator<DeploymentResource> resourceIterator = deploymentEvent.resources().iterator();
     if (!resourceIterator.hasNext()) {
@@ -150,85 +133,6 @@ public final class DeploymentTransformer {
     return false;
   }
 
-  private String checkForDuplicateBpmnId(
-      final BpmnModelInstance model, final String currentResource) {
-    final Collection<Process> processes =
-        model.getDefinitions().getChildElementsByType(Process.class);
-
-    for (final Process process : processes) {
-      final String previousResource = processIdToResourceName.get(process.getId());
-      if (previousResource != null) {
-        return String.format(
-            "Duplicated process id in resources '%s' and '%s'", previousResource, currentResource);
-      }
-
-      processIdToResourceName.put(process.getId(), currentResource);
-    }
-
-    return null;
-  }
-
-  private void transformProcessResource(
-      final DeploymentRecord deploymentEvent,
-      final DeploymentResource deploymentResource,
-      final BpmnModelInstance definition) {
-    final Collection<Process> processes =
-        definition.getDefinitions().getChildElementsByType(Process.class);
-
-    for (final Process process : processes) {
-      if (process.isExecutable()) {
-        final String bpmnProcessId = process.getId();
-        final DeployedProcess lastProcess =
-            processState.getLatestProcessVersionByProcessId(BufferUtil.wrapString(bpmnProcessId));
-
-        final DirectBuffer lastDigest =
-            processState.getLatestVersionDigest(wrapString(bpmnProcessId));
-        final DirectBuffer resourceDigest =
-            new UnsafeBuffer(digestGenerator.digest(deploymentResource.getResource()));
-
-        // adds process record to deployment record
-        final var processMetadata = deploymentEvent.processesMetadata().add();
-        processMetadata
-            .setBpmnProcessId(BufferUtil.wrapString(process.getId()))
-            .setChecksum(resourceDigest)
-            .setResourceName(deploymentResource.getResourceNameBuffer());
-
-        final var isDuplicate =
-            isDuplicateOfLatest(deploymentResource, resourceDigest, lastProcess, lastDigest);
-        if (isDuplicate) {
-          processMetadata
-              .setVersion(lastProcess.getVersion())
-              .setKey(lastProcess.getKey())
-              .markAsDuplicate();
-        } else {
-          final var key = keyGenerator.nextKey();
-          processMetadata.setKey(key).setVersion(processState.getProcessVersion(bpmnProcessId) + 1);
-
-          processRecord.reset();
-          processRecord.wrap(processMetadata, deploymentResource.getResource());
-          stateWriter.appendFollowUpEvent(key, ProcessIntent.CREATED, processRecord);
-        }
-      }
-    }
-  }
-
-  private boolean isDuplicateOfLatest(
-      final DeploymentResource deploymentResource,
-      final DirectBuffer resourceDigest,
-      final DeployedProcess lastProcess,
-      final DirectBuffer lastVersionDigest) {
-    return lastVersionDigest != null
-        && lastProcess != null
-        && lastVersionDigest.equals(resourceDigest)
-        && lastProcess.getResourceName().equals(deploymentResource.getResourceNameBuffer());
-  }
-
-  private BpmnModelInstance readProcessDefinition(final DeploymentResource deploymentResource) {
-    final DirectBuffer resource = deploymentResource.getResourceBuffer();
-    final DirectBufferInputStream resourceStream = new DirectBufferInputStream(resource);
-    return Bpmn.readModelFromStream(resourceStream);
-  }
-
   public RejectionType getRejectionType() {
     return rejectionType;
   }
@@ -245,42 +149,8 @@ public final class DeploymentTransformer {
         .orElse(UNKNOWN_RESOURCE);
   }
 
-  private DirectBuffer getChecksum(final DeploymentResource resource) {
-    return wrapArray(digestGenerator.digest(resource.getResource()));
-  }
-
   interface DeploymentResourceTransformer {
     Either<Failure, Void> transformResource(DeploymentResource resource, DeploymentRecord record);
-  }
-
-  private class BpmnResourceTransformer implements DeploymentResourceTransformer {
-
-    @Override
-    public Either<Failure, Void> transformResource(
-        final DeploymentResource resource, final DeploymentRecord record) {
-
-      final BpmnModelInstance definition = readProcessDefinition(resource);
-      final String validationError = validator.validate(definition);
-
-      if (validationError == null) {
-        // transform the model to avoid unexpected failures that are not covered by the validator
-        bpmnTransformer.transformDefinitions(definition);
-
-        final String bpmnIdDuplicateError =
-            checkForDuplicateBpmnId(definition, resource.getResourceName());
-
-        if (bpmnIdDuplicateError == null) {
-          transformProcessResource(record, resource, definition);
-          return Either.right(null);
-        } else {
-          return Either.left(new Failure(bpmnIdDuplicateError));
-        }
-      } else {
-        final var failureMessage =
-            String.format("'%s': %s", resource.getResourceName(), validationError);
-        return Either.left(new Failure(failureMessage));
-      }
-    }
   }
 
   private static class UnknownResourceTransformer implements DeploymentResourceTransformer {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.transform;
+
+import io.camunda.zeebe.dmn.DecisionEngine;
+import io.camunda.zeebe.dmn.DecisionEngineFactory;
+import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.transform.DeploymentTransformer.DeploymentResourceTransformer;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.state.KeyGenerator;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
+import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
+import io.camunda.zeebe.util.Either;
+import java.io.ByteArrayInputStream;
+import java.util.function.Function;
+import org.agrona.DirectBuffer;
+
+public final class DmnResourceTransformer implements DeploymentResourceTransformer {
+
+  private final DecisionEngine decisionEngine = DecisionEngineFactory.createDecisionEngine();
+
+  private final KeyGenerator keyGenerator;
+  private final StateWriter stateWriter;
+  private final Function<DeploymentResource, DirectBuffer> checksumGenerator;
+
+  public DmnResourceTransformer(
+      final KeyGenerator keyGenerator,
+      final StateWriter stateWriter,
+      final Function<DeploymentResource, DirectBuffer> checksumGenerator) {
+    this.keyGenerator = keyGenerator;
+    this.stateWriter = stateWriter;
+    this.checksumGenerator = checksumGenerator;
+  }
+
+  @Override
+  public Either<Failure, Void> transformResource(
+      final DeploymentResource resource, final DeploymentRecord record) {
+
+    final var dmnResource = new ByteArrayInputStream(resource.getResource());
+    final var parsedDrg = decisionEngine.parse(dmnResource);
+
+    if (parsedDrg.isValid()) {
+      writeRecords(resource, parsedDrg);
+      return Either.right(null);
+
+    } else {
+      final var failure = new Failure(parsedDrg.getFailureMessage());
+      return Either.left(failure);
+    }
+  }
+
+  private void writeRecords(
+      final DeploymentResource resource, final ParsedDecisionRequirementsGraph parsedDrg) {
+
+    final var decisionRequirementsKey = keyGenerator.nextKey();
+
+    stateWriter.appendFollowUpEvent(
+        decisionRequirementsKey,
+        DecisionRequirementsIntent.CREATED,
+        new DecisionRequirementsRecord()
+            .setDecisionRequirementsKey(decisionRequirementsKey)
+            .setDecisionRequirementsId(parsedDrg.getId())
+            .setDecisionRequirementsName(parsedDrg.getName())
+            .setDecisionRequirementsVersion(1)
+            .setNamespace(parsedDrg.getNamespace())
+            .setResourceName(resource.getResourceName())
+            .setResource(resource.getResourceBuffer())
+            .setChecksum(checksumGenerator.apply(resource)));
+
+    parsedDrg
+        .getDecisions()
+        .forEach(
+            decision -> {
+              final var decisionKey = keyGenerator.nextKey();
+
+              stateWriter.appendFollowUpEvent(
+                  decisionKey,
+                  DecisionIntent.CREATED,
+                  new DecisionRecord()
+                      .setDecisionKey(decisionKey)
+                      .setDecisionId(decision.getId())
+                      .setDecisionName(decision.getName())
+                      .setVersion(1)
+                      .setDecisionRequirementsId(parsedDrg.getId())
+                      .setDecisionRequirementsKey(decisionRequirementsKey));
+            });
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.dmn.DecisionEngine;
 import io.camunda.zeebe.dmn.DecisionEngineFactory;
 import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
 import io.camunda.zeebe.engine.processing.common.Failure;
-import io.camunda.zeebe.engine.processing.deployment.transform.DeploymentTransformer.DeploymentResourceTransformer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
@@ -44,7 +43,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
 
   @Override
   public Either<Failure, Void> transformResource(
-      final DeploymentResource resource, final DeploymentRecord record) {
+      final DeploymentResource resource, final DeploymentRecord deployment) {
 
     final var dmnResource = new ByteArrayInputStream(resource.getResource());
     final var parsedDrg = decisionEngine.parse(dmnResource);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedEventRegistry.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedEventRegistry.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentDistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
@@ -57,6 +59,8 @@ public final class TypedEventRegistry {
     registry.put(ValueType.PROCESS, ProcessRecord.class);
     registry.put(ValueType.DEPLOYMENT_DISTRIBUTION, DeploymentDistributionRecord.class);
     registry.put(ValueType.PROCESS_EVENT, ProcessEventRecord.class);
+    registry.put(ValueType.DECISION, DecisionRecord.class);
+    registry.put(ValueType.DECISION_REQUIREMENTS, DecisionRequirementsRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentTest.java
@@ -440,9 +440,9 @@ public final class CreateDeploymentTest {
 
     // when
     final Record<DeploymentRecordValue> deployment =
-        ENGINE.deployment().withXmlResource("process1", modelInstance).deploy();
+        ENGINE.deployment().withXmlResource("process1.bpmn", modelInstance).deploy();
     final Record<DeploymentRecordValue> deployment2 =
-        ENGINE.deployment().withXmlResource("process2", modelInstance).deploy();
+        ENGINE.deployment().withXmlResource("process2.bpmn", modelInstance).deploy();
 
     // then
     assertThat(deployment.getValue().getProcessesMetadata().get(0).getVersion()).isEqualTo(1L);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentDmnTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentDmnTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class DeploymentDmnTest {
+
+  private static final String DMN_DECISION_TABLE = "/dmn/decision-table.dmn";
+  private static final String DMN_INVALID_EXPRESSION =
+      "/dmn/decision-table-with-invalid-expression.dmn";
+  private static final String DMN_WITH_TWO_DECISIONS = "/dmn/drg-force-user.dmn";
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDeployDmnResource() {
+    // when
+    final var deploymentEvent =
+        engine.deployment().withXmlClasspathResource(DMN_DECISION_TABLE).deploy();
+
+    // then
+    Assertions.assertThat(deploymentEvent).hasIntent(DeploymentIntent.CREATED);
+  }
+
+  @Test
+  public void shouldRejectInvalidDmnResource() {
+    // when
+    final var deploymentEvent =
+        engine
+            .deployment()
+            .withXmlClasspathResource(DMN_INVALID_EXPRESSION)
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(deploymentEvent.getRejectionReason())
+        .contains("FEEL unary-tests: failed to parse expression");
+  }
+
+  @Test
+  public void shouldWriteDecisionRequirementsRecord() throws IOException, NoSuchAlgorithmException {
+    // when
+    engine.deployment().withXmlClasspathResource(DMN_DECISION_TABLE).deploy();
+
+    // then
+    final var record = RecordingExporter.decisionRequirementsRecords().getFirst();
+
+    Assertions.assertThat(record)
+        .hasIntent(DecisionRequirementsIntent.CREATED)
+        .hasValueType(ValueType.DECISION_REQUIREMENTS)
+        .hasRecordType(RecordType.EVENT);
+
+    assertThat(record.getKey()).isPositive();
+
+    final var decisionRequirementsRecord = record.getValue();
+    assertThat(decisionRequirementsRecord.getDecisionRequirementsId()).isEqualTo("force-users");
+    assertThat(decisionRequirementsRecord.getDecisionRequirementsName()).isEqualTo("Force Users");
+    assertThat(decisionRequirementsRecord.getDecisionRequirementsKey()).isPositive();
+    assertThat(decisionRequirementsRecord.getDecisionRequirementsVersion()).isEqualTo(1);
+    assertThat(decisionRequirementsRecord.getNamespace())
+        .isEqualTo("http://camunda.org/schema/1.0/dmn");
+    assertThat(decisionRequirementsRecord.getResourceName()).isEqualTo(DMN_DECISION_TABLE);
+
+    final var dmnResource = getClass().getResourceAsStream(DMN_DECISION_TABLE).readAllBytes();
+
+    final var digestGenerator = MessageDigest.getInstance("MD5");
+    final byte[] checksum = digestGenerator.digest(dmnResource);
+
+    assertThat(decisionRequirementsRecord.getChecksum())
+        .describedAs("Expect the MD5 checksum of the DMN resource")
+        .isEqualTo(checksum);
+
+    assertThat(decisionRequirementsRecord.getResource())
+        .describedAs("Expect the same content as the DMN resource")
+        .isEqualTo(dmnResource);
+  }
+
+  @Test
+  public void shouldWriteDecisionRecord() {
+    // when
+    engine.deployment().withXmlClasspathResource(DMN_DECISION_TABLE).deploy();
+
+    // then
+    final var record = RecordingExporter.decisionRecords().getFirst();
+
+    Assertions.assertThat(record)
+        .hasIntent(DecisionIntent.CREATED)
+        .hasValueType(ValueType.DECISION)
+        .hasRecordType(RecordType.EVENT);
+
+    assertThat(record.getKey()).isPositive();
+
+    final var decisionRecord = record.getValue();
+    Assertions.assertThat(decisionRecord)
+        .hasDecisionId("jedi-or-sith")
+        .hasDecisionName("Jedi or Sith")
+        .hasDecisionRequirementsId("force-users")
+        .hasVersion(1);
+
+    assertThat(decisionRecord.getDecisionKey()).isPositive();
+    assertThat(decisionRecord.getDecisionRequirementsKey()).isPositive();
+  }
+
+  @Test
+  public void shouldWriteOneRecordForEachDecision() {
+    // when
+    engine.deployment().withXmlClasspathResource(DMN_WITH_TWO_DECISIONS).deploy();
+
+    // then
+    final var decisionRequirementsRecord =
+        RecordingExporter.decisionRequirementsRecords().getFirst();
+
+    final var decisionRequirementsId =
+        decisionRequirementsRecord.getValue().getDecisionRequirementsId();
+    final var decisionRequirementsKey =
+        decisionRequirementsRecord.getValue().getDecisionRequirementsKey();
+
+    final var decisionRecords = RecordingExporter.decisionRecords().limit(2).asList();
+
+    assertThat(decisionRecords)
+        .hasSize(2)
+        .extracting(Record::getValue)
+        .extracting(DecisionRecordValue::getDecisionId, DecisionRecordValue::getDecisionName)
+        .contains(tuple("jedi-or-sith", "Jedi or Sith"), tuple("force-user", "Which force user?"));
+
+    assertThat(decisionRecords)
+        .extracting(Record::getValue)
+        .allSatisfy(
+            record -> {
+              assertThat(record.getDecisionRequirementsId()).isEqualTo(decisionRequirementsId);
+              assertThat(record.getDecisionRequirementsKey()).isEqualTo(decisionRequirementsKey);
+            });
+
+    assertThat(decisionRecords.get(0).getKey())
+        .describedAs("Expect that the decision records have different keys")
+        .isNotEqualTo(decisionRecords.get(1).getKey());
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsNotificationTests.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsNotificationTests.java
@@ -57,7 +57,10 @@ public final class ActivatableJobsNotificationTests {
   @Before
   public void setup() {
     taskType = Strings.newRandomValidBpmnId();
-    ENGINE.deployment().withXmlResource(PROCESS_ID, MODEL_SUPPLIER.apply(taskType)).deploy();
+    ENGINE
+        .deployment()
+        .withXmlResource(PROCESS_ID + ".bpmn", MODEL_SUPPLIER.apply(taskType))
+        .deploy();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsTest.java
@@ -117,7 +117,10 @@ public final class ActivateJobsTest {
   @Test
   public void shouldAcceptEmptyWorker() {
     // given
-    ENGINE.deployment().withXmlResource(PROCESS_ID, MODEL_SUPPLIER.apply(taskType)).deploy();
+    ENGINE
+        .deployment()
+        .withXmlResource(PROCESS_ID + ".bpmn", MODEL_SUPPLIER.apply(taskType))
+        .deploy();
 
     final Duration timeout = Duration.ofMinutes(12);
 
@@ -137,7 +140,10 @@ public final class ActivateJobsTest {
   @Test
   public void shouldActivateSingleJob() {
     // given
-    ENGINE.deployment().withXmlResource(PROCESS_ID, MODEL_SUPPLIER.apply(taskType)).deploy();
+    ENGINE
+        .deployment()
+        .withXmlResource(PROCESS_ID + ".bpmn", MODEL_SUPPLIER.apply(taskType))
+        .deploy();
     final long firstInstanceKey = createProcessInstances(3, "{'foo':'bar'}").get(0);
 
     final long expectedJobKey =
@@ -272,7 +278,7 @@ public final class ActivateJobsTest {
     for (final String type : Arrays.asList(jobType, jobType2, jobType3)) {
       builder = builder.serviceTask(type, b -> b.zeebeJobType(type));
     }
-    ENGINE.deployment().withXmlResource(PROCESS_ID, builder.done()).deploy();
+    ENGINE.deployment().withXmlResource(PROCESS_ID + ".bpmn", builder.done()).deploy();
 
     final List<Long> processInstanceKeys = createProcessInstances(jobAmount, "{}");
 
@@ -308,7 +314,7 @@ public final class ActivateJobsTest {
             .endEvent()
             .done();
 
-    ENGINE.deployment().withXmlResource(PROCESS_ID, modelInstance).deploy();
+    ENGINE.deployment().withXmlResource(PROCESS_ID + ".bpmn", modelInstance).deploy();
     final long processInstanceKey = createProcessInstances(1, "{}").get(0);
     jobRecords(JobIntent.CREATED).withProcessInstanceKey(processInstanceKey).getFirst();
 
@@ -330,7 +336,10 @@ public final class ActivateJobsTest {
     final String worker = "testWorker";
     final Duration timeout = Duration.ofMinutes(4);
 
-    ENGINE.deployment().withXmlResource(PROCESS_ID, MODEL_SUPPLIER.apply(taskType)).deploy();
+    ENGINE
+        .deployment()
+        .withXmlResource(PROCESS_ID + ".bpmn", MODEL_SUPPLIER.apply(taskType))
+        .deploy();
     createProcessInstances(1, "{'foo':'bar'}");
     final Record<JobRecordValue> jobRecord =
         jobRecords(JobIntent.CREATED).withType(taskType).getFirst();
@@ -406,7 +415,10 @@ public final class ActivateJobsTest {
     final var headerSize = ByteValue.ofKilobytes(2);
     final var maxRecordSize = maxMessageSize - headerSize;
 
-    ENGINE.deployment().withXmlResource(PROCESS_ID, MODEL_SUPPLIER.apply(taskType)).deploy();
+    ENGINE
+        .deployment()
+        .withXmlResource(PROCESS_ID + ".bpmn", MODEL_SUPPLIER.apply(taskType))
+        .deploy();
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // since the variable update will write the variable twice, we need to split this off
@@ -481,7 +493,7 @@ public final class ActivateJobsTest {
 
   private List<Long> deployAndCreateJobs(
       final String type, final int amount, final String variables) {
-    ENGINE.deployment().withXmlResource(PROCESS_ID, MODEL_SUPPLIER.apply(type)).deploy();
+    ENGINE.deployment().withXmlResource(PROCESS_ID + ".bpmn", MODEL_SUPPLIER.apply(type)).deploy();
     final List<Long> instanceKeys = createProcessInstances(amount, variables);
 
     return jobRecords(JobIntent.CREATED)

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -320,7 +320,7 @@ public final class EngineRule extends ExternalResource {
   public Record<JobRecordValue> createJob(final String type, final String processId) {
     deployment()
         .withXmlResource(
-            processId,
+            processId + ".bpmn",
             Bpmn.createExecutableProcess(processId)
                 .startEvent("start")
                 .serviceTask("task", b -> b.zeebeJobType(type).done())

--- a/engine/src/test/resources/dmn/decision-table-with-invalid-expression.dmn
+++ b/engine/src/test/resources/dmn/decision-table-with-invalid-expression.dmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force-users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <decision id="jediOrSith" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="faction" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utwb1e">
+        <inputEntry id="UnaryTests_1v3sd4m">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tgh8k1">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1bwgcym">
+        <inputEntry id="UnaryTests_0n1ewm3">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19xnlkw">
+          <text>"Sith"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jediOrSith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/engine/src/test/resources/dmn/decision-table.dmn
+++ b/engine/src/test/resources/dmn/decision-table.dmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force-users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <decision id="jedi-or-sith" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="faction" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utwb1e">
+        <inputEntry id="UnaryTests_1v3sd4m">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tgh8k1">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1bwgcym">
+        <inputEntry id="UnaryTests_0n1ewm3">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19xnlkw">
+          <text>"Sith"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi-or-sith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/engine/src/test/resources/dmn/drg-force-user.dmn
+++ b/engine/src/test/resources/dmn/drg-force-user.dmn
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="force-users" name="force-users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <decision id="jedi-or-sith" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="faction" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utwb1e">
+        <inputEntry id="UnaryTests_1v3sd4m">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tgh8k1">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1bwgcym">
+        <inputEntry id="UnaryTests_0n1ewm3">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19xnlkw">
+          <text>"Sith"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="force-user" name="Which force user?">
+    <informationRequirement id="InformationRequirement_1o8esai">
+      <requiredDecision href="#jedi-or-sith" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_07g94t1" hitPolicy="FIRST">
+      <input id="InputClause_0qnqj25" label="Jedi or Sith">
+        <inputExpression id="LiteralExpression_00lcyt5" typeRef="string">
+          <text>faction</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_1xjidd8">
+          <text>"Jedi","Sith"</text>
+        </inputValues>
+      </input>
+      <input id="InputClause_0k64hys" label="Body height">
+        <inputExpression id="LiteralExpression_0ib6fnk" typeRef="number">
+          <text>height</text>
+        </inputExpression>
+      </input>
+      <output id="OutputClause_0hhe1yo" label="Force user" name="force-user" typeRef="string" />
+      <rule id="DecisionRule_13zidc5">
+        <inputEntry id="UnaryTests_056skcq">
+          <text>"Jedi"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0l4xksq">
+          <text>&gt; 190</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0hclhw3">
+          <text>"Mace Windu"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0uin2hk">
+        <description></description>
+        <inputEntry id="UnaryTests_16maepk">
+          <text>"Jedi"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0rv0nwf">
+          <text>&gt; 180</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0t82c11">
+          <text>"Obi-Wan Kenobi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0mpio0p">
+        <inputEntry id="UnaryTests_09eicyc">
+          <text>"Jedi"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1bekl8k">
+          <text>&lt; 70</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0brx3vt">
+          <text>"Yoda"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_06paffx">
+        <inputEntry id="UnaryTests_1baiid4">
+          <text>"Sith"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0fcdq0i">
+          <text>&gt; 200</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_02oibi4">
+          <text>"Darth Vader"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1ua4pcl">
+        <inputEntry id="UnaryTests_1s1h3nm">
+          <text>"Sith"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1pnvw8p">
+          <text>&gt; 170</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1w1n2rc">
+          <text>"Darth Sidius"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_00ew25e">
+        <inputEntry id="UnaryTests_07uxyug">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1he6fym">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_07i3sc8">
+          <text>"unknown"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi-or-sith">
+        <dc:Bounds height="80" width="180" x="160" y="280" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_1sb3tre" dmnElementRef="force-user">
+        <dc:Bounds height="80" width="180" x="280" y="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="DMNEdge_0gt1p1u" dmnElementRef="InformationRequirement_1o8esai">
+        <di:waypoint x="250" y="280" />
+        <di:waypoint x="370" y="180" />
+        <di:waypoint x="370" y="160" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRecord.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.deployment;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+
+public final class DecisionRecord extends UnifiedRecordValue implements DecisionRecordValue {
+
+  private final StringProperty decisionIdProp = new StringProperty("decisionId");
+  private final StringProperty decisionNameProp = new StringProperty("decisionName");
+  private final IntegerProperty versionProp = new IntegerProperty("version");
+  private final LongProperty decisionKeyProp = new LongProperty("decisionKey");
+
+  private final StringProperty decisionRequirementsIdProp =
+      new StringProperty("decisionRequirementsId");
+  private final LongProperty decisionRequirementsKeyProp =
+      new LongProperty("decisionRequirementsKey");
+
+  public DecisionRecord() {
+    declareProperty(decisionIdProp)
+        .declareProperty(decisionNameProp)
+        .declareProperty(versionProp)
+        .declareProperty(decisionKeyProp)
+        .declareProperty(decisionRequirementsIdProp)
+        .declareProperty(decisionRequirementsKeyProp);
+  }
+
+  @Override
+  public String getDecisionId() {
+    return bufferAsString(decisionIdProp.getValue());
+  }
+
+  @Override
+  public String getDecisionName() {
+    return bufferAsString(decisionNameProp.getValue());
+  }
+
+  @Override
+  public int getVersion() {
+    return versionProp.getValue();
+  }
+
+  @Override
+  public long getDecisionKey() {
+    return decisionKeyProp.getValue();
+  }
+
+  @Override
+  public String getDecisionRequirementsId() {
+    return bufferAsString(decisionRequirementsIdProp.getValue());
+  }
+
+  @Override
+  public long getDecisionRequirementsKey() {
+    return decisionRequirementsKeyProp.getValue();
+  }
+
+  @Override
+  public boolean isDuplicate() {
+    return false;
+  }
+
+  public DecisionRecord setDecisionId(String decisionId) {
+    decisionIdProp.setValue(decisionId);
+    return this;
+  }
+
+  public DecisionRecord setDecisionName(String decisionName) {
+    decisionNameProp.setValue(decisionName);
+    return this;
+  }
+
+  public DecisionRecord setVersion(int version) {
+    versionProp.setValue(version);
+    return this;
+  }
+
+  public DecisionRecord setDecisionKey(long decisionKey) {
+    decisionKeyProp.setValue(decisionKey);
+    return this;
+  }
+
+  public DecisionRecord setDecisionRequirementsId(String decisionRequirementsId) {
+    decisionRequirementsIdProp.setValue(decisionRequirementsId);
+    return this;
+  }
+
+  public DecisionRecord setDecisionRequirementsKey(long decisionRequirementsKey) {
+    decisionRequirementsKeyProp.setValue(decisionRequirementsKey);
+    return this;
+  }
+}

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRecord.java
@@ -9,11 +9,13 @@ package io.camunda.zeebe.protocol.impl.record.value.deployment;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import org.agrona.DirectBuffer;
 
 public final class DecisionRecord extends UnifiedRecordValue implements DecisionRecordValue {
 
@@ -99,5 +101,20 @@ public final class DecisionRecord extends UnifiedRecordValue implements Decision
   public DecisionRecord setDecisionRequirementsKey(long decisionRequirementsKey) {
     decisionRequirementsKeyProp.setValue(decisionRequirementsKey);
     return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getDecisionIdBuffer() {
+    return decisionIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getDecisionNameBuffer() {
+    return decisionNameProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getDecisionRequirementsIdBuffer() {
+    return decisionRequirementsIdProp.getValue();
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsRecord.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.deployment;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsArray;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
@@ -130,5 +131,25 @@ public final class DecisionRequirementsRecord extends UnifiedRecordValue
   public DecisionRequirementsRecord setResource(DirectBuffer resource) {
     resourceProp.setValue(resource);
     return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getDecisionRequirementsIdBuffer() {
+    return decisionRequirementsIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getDecisionRequirementsNameBuffer() {
+    return decisionRequirementsNameProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getNamespaceBuffer() {
+    return namespaceProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getResourceNameBuffer() {
+    return resourceNameProp.getValue();
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsRecord.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.deployment;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsArray;
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
+import org.agrona.DirectBuffer;
+
+public final class DecisionRequirementsRecord extends UnifiedRecordValue
+    implements DecisionRequirementsRecordValue {
+
+  private final StringProperty decisionRequirementsIdProp =
+      new StringProperty("decisionRequirementsId");
+  private final StringProperty decisionRequirementsNameProp =
+      new StringProperty("decisionRequirementsName");
+  private final IntegerProperty decisionRequirementsVersionProp =
+      new IntegerProperty("decisionRequirementsVersion");
+  private final LongProperty decisionRequirementsKeyProp =
+      new LongProperty("decisionRequirementsKey");
+  private final StringProperty namespaceProp = new StringProperty("namespace");
+
+  private final StringProperty resourceNameProp = new StringProperty("resourceName");
+  private final BinaryProperty checksumProp = new BinaryProperty("checksum");
+  private final BinaryProperty resourceProp = new BinaryProperty("resource");
+
+  public DecisionRequirementsRecord() {
+    declareProperty(decisionRequirementsIdProp)
+        .declareProperty(decisionRequirementsNameProp)
+        .declareProperty(decisionRequirementsVersionProp)
+        .declareProperty(decisionRequirementsKeyProp)
+        .declareProperty(namespaceProp)
+        .declareProperty(resourceNameProp)
+        .declareProperty(checksumProp)
+        .declareProperty(resourceProp);
+  }
+
+  @Override
+  public String getDecisionRequirementsId() {
+    return bufferAsString(decisionRequirementsIdProp.getValue());
+  }
+
+  @Override
+  public String getDecisionRequirementsName() {
+    return bufferAsString(decisionRequirementsNameProp.getValue());
+  }
+
+  @Override
+  public int getDecisionRequirementsVersion() {
+    return decisionRequirementsVersionProp.getValue();
+  }
+
+  @Override
+  public long getDecisionRequirementsKey() {
+    return decisionRequirementsKeyProp.getValue();
+  }
+
+  @Override
+  public String getNamespace() {
+    return bufferAsString(namespaceProp.getValue());
+  }
+
+  @Override
+  public String getResourceName() {
+    return bufferAsString(resourceNameProp.getValue());
+  }
+
+  @Override
+  public byte[] getChecksum() {
+    return bufferAsArray(checksumProp.getValue());
+  }
+
+  @Override
+  public boolean isDuplicate() {
+    return false;
+  }
+
+  @Override
+  public byte[] getResource() {
+    return bufferAsArray(resourceProp.getValue());
+  }
+
+  public DecisionRequirementsRecord setDecisionRequirementsId(String decisionRequirementsId) {
+    decisionRequirementsIdProp.setValue(decisionRequirementsId);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setDecisionRequirementsName(String decisionRequirementsName) {
+    decisionRequirementsNameProp.setValue(decisionRequirementsName);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setDecisionRequirementsVersion(
+      int decisionRequirementsVersion) {
+    decisionRequirementsVersionProp.setValue(decisionRequirementsVersion);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setDecisionRequirementsKey(long decisionRequirementsKey) {
+    decisionRequirementsKeyProp.setValue(decisionRequirementsKey);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setNamespace(String namespace) {
+    namespaceProp.setValue(namespace);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setResourceName(String resourceName) {
+    resourceNameProp.setValue(resourceName);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setChecksum(DirectBuffer checksum) {
+    checksumProp.setValue(checksum);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setResource(DirectBuffer resource) {
+    resourceProp.setValue(resource);
+    return this;
+  }
+}

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -17,6 +17,8 @@ import io.camunda.zeebe.protocol.impl.record.CopiedRecord;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.VersionInfo;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentDistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
@@ -732,6 +734,42 @@ public final class JsonSerializableToJsonTest {
         "Empty ProcessInstanceRecord",
         (Supplier<UnifiedRecordValue>) ProcessInstanceRecord::new,
         "{'bpmnProcessId':'','version':-1,'processDefinitionKey':-1,'processInstanceKey':-1,'elementId':'','flowScopeKey':-1,'bpmnElementType':'UNSPECIFIED','parentProcessInstanceKey':-1,'parentElementInstanceKey':-1}"
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// DecisionRecord  ///////////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "DecisionRecord",
+        (Supplier<UnifiedRecordValue>)
+            () ->
+                new DecisionRecord()
+                    .setDecisionId("decision-id")
+                    .setDecisionName("decision-name")
+                    .setVersion(1)
+                    .setDecisionKey(2L)
+                    .setDecisionRequirementsKey(3L)
+                    .setDecisionRequirementsId("decision-requirements-id"),
+        "{'decisionId': 'decision-id', 'decisionName': 'decision-name', 'version': 1, 'decisionKey': 2, 'decisionRequirementsKey': 3, 'decisionRequirementsId': 'decision-requirements-id', 'duplicate': false}"
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// DecisionRequirementsRecord  ///////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "DecisionRequirementsRecord",
+        (Supplier<UnifiedRecordValue>)
+            () ->
+                new DecisionRequirementsRecord()
+                    .setDecisionRequirementsId("decision-requirements-id")
+                    .setDecisionRequirementsName("decision-requirements-name")
+                    .setDecisionRequirementsVersion(1)
+                    .setDecisionRequirementsKey(2L)
+                    .setNamespace("namespace")
+                    .setResourceName("resource-name")
+                    .setResource(wrapString("resource"))
+                    .setChecksum(wrapString("checksum")),
+        "{'decisionRequirementsId': 'decision-requirements-id', 'decisionRequirementsName': 'decision-requirements-name', 'decisionRequirementsVersion': 1, 'decisionRequirementsKey': 2, 'namespace': 'namespace', 'resourceName': 'resource-name', 'resource': 'cmVzb3VyY2U=', 'checksum': 'Y2hlY2tzdW0=', 'duplicate': false}"
       },
     };
   }

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractDecisionRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractDecisionRecordValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.DecisionRecordValueBuilder.ImmutableDecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableDecisionRecordValue.class)
+public abstract class AbstractDecisionRecordValue
+    implements DecisionRecordValue, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractDecisionRequirementsRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractDecisionRequirementsRecordValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.DecisionRequirementsRecordValueBuilder.ImmutableDecisionRequirementsRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableDecisionRequirementsRecordValue.class)
+public abstract class AbstractDecisionRequirementsRecordValue
+    implements DecisionRequirementsRecordValue, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/ValueTypes.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/ValueTypes.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.protocol.jackson.record;
 
+import io.camunda.zeebe.protocol.jackson.record.DecisionRecordValueBuilder.ImmutableDecisionRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.DecisionRequirementsRecordValueBuilder.ImmutableDecisionRequirementsRecordValue;
 import io.camunda.zeebe.protocol.jackson.record.DeploymentDistributionRecordValueBuilder.ImmutableDeploymentDistributionRecordValue;
 import io.camunda.zeebe.protocol.jackson.record.DeploymentRecordValueBuilder.ImmutableDeploymentRecordValue;
 import io.camunda.zeebe.protocol.jackson.record.ErrorRecordValueBuilder.ImmutableErrorRecordValue;
@@ -26,6 +28,8 @@ import io.camunda.zeebe.protocol.jackson.record.TimerRecordValueBuilder.Immutabl
 import io.camunda.zeebe.protocol.jackson.record.VariableDocumentRecordValueBuilder.ImmutableVariableDocumentRecordValue;
 import io.camunda.zeebe.protocol.jackson.record.VariableRecordValueBuilder.ImmutableVariableRecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
@@ -59,6 +63,13 @@ final class ValueTypes {
   static {
     final Map<ValueType, ValueTypeInfo<?>> mapping = new EnumMap<>(ValueType.class);
 
+    mapping.put(
+        ValueType.DECISION,
+        new ValueTypeInfo<>(ImmutableDecisionRecordValue.class, DecisionIntent.class));
+    mapping.put(
+        ValueType.DECISION_REQUIREMENTS,
+        new ValueTypeInfo<>(
+            ImmutableDecisionRequirementsRecordValue.class, DecisionRequirementsIntent.class));
     mapping.put(
         ValueType.DEPLOYMENT,
         new ValueTypeInfo<>(ImmutableDeploymentRecordValue.class, DeploymentIntent.class));

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -27,16 +27,9 @@
           }
         },
         {
-          "justification": "Ignore Enum order for the default ValueType.NULL_VAL because it is not used.",
+          "justification": "Ignore Enum order for ValueType as ordinal() is not used",
           "code": "java.field.enumConstantOrderChanged",
-          "classQualifiedName": "io.camunda.zeebe.protocol.record.ValueType",
-          "fieldName": "NULL_VAL"
-        },
-        {
-          "justification": "Ignore Enum order for the default ValueType.SBE_UNKNOWN because it is not used.",
-          "code": "java.field.enumConstantOrderChanged",
-          "classQualifiedName": "io.camunda.zeebe.protocol.record.ValueType",
-          "fieldName": "SBE_UNKNOWN"
+          "classQualifiedName": "io.camunda.zeebe.protocol.record.ValueType"
         }
       ]
     }

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -25,6 +25,18 @@
             "matcher": "java-package",
             "match": "/io\\.camunda\\.zeebe\\.protocol\\.record\\.value(\\..*)?/"
           }
+        },
+        {
+          "justification": "Ignore Enum order for the default ValueType.NULL_VAL because it is not used.",
+          "code": "java.field.enumConstantOrderChanged",
+          "classQualifiedName": "io.camunda.zeebe.protocol.record.ValueType",
+          "fieldName": "NULL_VAL"
+        },
+        {
+          "justification": "Ignore Enum order for the default ValueType.SBE_UNKNOWN because it is not used.",
+          "code": "java.field.enumConstantOrderChanged",
+          "classQualifiedName": "io.camunda.zeebe.protocol.record.ValueType",
+          "fieldName": "SBE_UNKNOWN"
         }
       ]
     }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionIntent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum DecisionIntent implements Intent {
+  CREATED(0);
+
+  private final short value;
+
+  DecisionIntent(final int value) {
+    this.value = (short) value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return CREATED;
+      default:
+        return UNKNOWN;
+    }
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionRequirementsIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionRequirementsIntent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum DecisionRequirementsIntent implements Intent {
+  CREATED(0);
+
+  private final short value;
+
+  DecisionRequirementsIntent(final int value) {
+    this.value = (short) value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return CREATED;
+      default:
+        return UNKNOWN;
+    }
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -37,7 +37,9 @@ public interface Intent {
           ErrorIntent.class,
           ProcessIntent.class,
           DeploymentDistributionIntent.class,
-          ProcessEventIntent.class);
+          ProcessEventIntent.class,
+          DecisionIntent.class,
+          DecisionRequirementsIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN =
       new Intent() {
@@ -94,6 +96,10 @@ public interface Intent {
         return DeploymentDistributionIntent.from(intent);
       case PROCESS_EVENT:
         return ProcessEventIntent.from(intent);
+      case DECISION:
+        return DecisionIntent.from(intent);
+      case DECISION_REQUIREMENTS:
+        return DecisionRequirementsIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -143,6 +149,10 @@ public interface Intent {
         return DeploymentDistributionIntent.valueOf(intent);
       case PROCESS_EVENT:
         return ProcessEventIntent.valueOf(intent);
+      case DECISION:
+        return DecisionIntent.valueOf(intent);
+      case DECISION_REQUIREMENTS:
+        return DecisionRequirementsIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/DecisionRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/DecisionRecordValue.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value.deployment;
+
+import io.camunda.zeebe.protocol.record.RecordValue;
+
+/**
+ * Represents a deployed decision. A decision belongs to a decision requirements graph (DRG/DRD)
+ * that represents the DMN resource. The DMN resource itself is stored as part of the DRG (see
+ * {@link DecisionRequirementsRecordValue}).
+ */
+public interface DecisionRecordValue extends RecordValue {
+
+  /** @return the ID of the decision in the DMN */
+  String getDecisionId();
+
+  /** @return the name of the decision in the DMN */
+  String getDecisionName();
+
+  /** @return the version of the deployed decision */
+  int getVersion();
+
+  /** @return the key of the deployed decision */
+  long getDecisionKey();
+
+  /** @return the ID of the DRG in the DMN this decision belongs to */
+  String getDecisionRequirementsId();
+
+  /** @return the key of the deployed DRG this decision belongs to */
+  long getDecisionRequirementsKey();
+
+  /**
+   * @return {@code true} if the decision is a duplicate (and has been deployed previously),
+   *     otherwise {@code false}
+   */
+  boolean isDuplicate();
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/DecisionRequirementsMetadataValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/DecisionRequirementsMetadataValue.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value.deployment;
+
+/**
+ * The metadata of a deployed decision requirements graph (DRG/DRD). A DRG represents the DMN
+ * resource and all decisions of the DMN belongs to it. The metadata contains relevant properties of
+ * the DMN resource, except the binary DMN resource itself.
+ */
+public interface DecisionRequirementsMetadataValue {
+
+  /** @return the ID of the DRG in the DMN */
+  String getDecisionRequirementsId();
+
+  /** @return the name of the DRG in the DMN */
+  String getDecisionRequirementsName();
+
+  /** @return the version of the deployed DRG */
+  int getDecisionRequirementsVersion();
+
+  /** @return the key of the deployed DRG */
+  long getDecisionRequirementsKey();
+
+  /** @return the namespace of the DRG in the DMN */
+  String getNamespace();
+
+  /** @return the name of the resource through which this DRG was deployed */
+  String getResourceName();
+
+  /** @return the checksum of the DMN resource (MD5) */
+  byte[] getChecksum();
+
+  /**
+   * @return {@code true} if the DRG is a duplicate (and has been deployed previously), otherwise
+   *     {@code false}
+   */
+  boolean isDuplicate();
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/DecisionRequirementsRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/DecisionRequirementsRecordValue.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value.deployment;
+
+import io.camunda.zeebe.protocol.record.RecordValue;
+
+/**
+ * Represents a deployed decision requirements graph (DRG/DRD) for a DMN resource. The decisions of
+ * the DMN resource belongs to this DRG. The DMN resource itself is stored only in the DRG.
+ */
+public interface DecisionRequirementsRecordValue
+    extends RecordValue, DecisionRequirementsMetadataValue {
+
+  /** @return the binary DMN resource */
+  byte[] getResource();
+}

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -39,6 +39,8 @@
       <validValue name="PROCESS">22</validValue>
       <validValue name="DEPLOYMENT_DISTRIBUTION">23</validValue>
       <validValue name="PROCESS_EVENT">24</validValue>
+      <validValue name="DECISION">25</validValue>
+      <validValue name="DECISION_REQUIREMENTS">26</validValue>
     </enum>
 
     <enum name="RecordType" encodingType="uint8">

--- a/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
+++ b/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
@@ -44,6 +44,9 @@ public class IntentEncodingDecodingTest {
   @Parameters(name = "{0}")
   public static Collection<ParameterSet> parameters() {
     final List<ParameterSet> result = new ArrayList<>();
+    result.addAll(buildParameterSets(DecisionIntent.class, DecisionIntent::from));
+    result.addAll(
+        buildParameterSets(DecisionRequirementsIntent.class, DecisionRequirementsIntent::from));
     result.addAll(
         buildParameterSets(DeploymentDistributionIntent.class, DeploymentDistributionIntent::from));
     result.addAll(buildParameterSets(DeploymentIntent.class, DeploymentIntent::from));

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/StandaloneBrokerIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/StandaloneBrokerIT.java
@@ -79,7 +79,7 @@ final class StandaloneBrokerIT {
     try (final var client = createClient()) {
       await("until topology is complete").untilAsserted(() -> assertTopologyIsComplete(client));
 
-      client.newDeployCommand().addProcessModel(process, processId).send().join();
+      client.newDeployCommand().addProcessModel(process, processId + ".bpmn").send().join();
       return client
           .newCreateInstanceCommand()
           .bpmnProcessId(processId)

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/DecisionRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/DecisionRecordStream.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import java.util.stream.Stream;
+
+public class DecisionRecordStream
+    extends ExporterRecordStream<DecisionRecordValue, DecisionRecordStream> {
+
+  public DecisionRecordStream(final Stream<Record<DecisionRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected DecisionRecordStream supply(final Stream<Record<DecisionRecordValue>> wrappedStream) {
+    return new DecisionRecordStream(wrappedStream);
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/DecisionRequirementsRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/DecisionRequirementsRecordStream.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
+import java.util.stream.Stream;
+
+public class DecisionRequirementsRecordStream
+    extends ExporterRecordStream<
+        DecisionRequirementsRecordValue, DecisionRequirementsRecordStream> {
+
+  public DecisionRequirementsRecordStream(
+      Stream<Record<DecisionRequirementsRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected DecisionRequirementsRecordStream supply(
+      final Stream<Record<DecisionRequirementsRecordValue>> wrappedStream) {
+    return new DecisionRequirementsRecordStream(wrappedStream);
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -39,6 +39,8 @@ import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordVa
 import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import java.time.Duration;
 import java.util.Iterator;
@@ -243,6 +245,15 @@ public final class RecordingExporter implements Exporter {
   public static ProcessInstanceResultRecordStream processInstanceResultRecords() {
     return new ProcessInstanceResultRecordStream(
         records(ValueType.PROCESS_INSTANCE_RESULT, ProcessInstanceResultRecordValue.class));
+  }
+
+  public static DecisionRecordStream decisionRecords() {
+    return new DecisionRecordStream(records(ValueType.DECISION, DecisionRecordValue.class));
+  }
+
+  public static DecisionRequirementsRecordStream decisionRequirementsRecords() {
+    return new DecisionRequirementsRecordStream(
+        records(ValueType.DECISION_REQUIREMENTS, DecisionRequirementsRecordValue.class));
   }
 
   public static class RecordIterator implements Iterator<Record<?>> {


### PR DESCRIPTION
## Description

* added new records for DMN: `DecisionRecord` and `DecisionRequirementsRecord`
  * including new value types: `DECISION` and `DECISION_REQUIREMENTS`
  * including new intents: `DecisionIntent.CREATED` and `DecisionRequirementsIntent.CREATED` 
* split the DRG record into a metadata part that does not contain the DMN binary resource
  * the metadata record will be used for the deployment record eventually instead of the DRG record itself to avoid that the deployment contains the resource twice 
  * added a `duplicate` property for the metadata and to align with the process record  
* refactored the `DeploymentTransformer` to allow more than BPMN resources
  * extracted the BPMN transformer but without bigger changes 
* adjusted some test cases and added the `.bpmn` file extension to the resource name on deployment 
  * previously, the transformer did not check the file extension but assumed that it is a BPMN resource
  * now, the file extension is required because it is used to choose the transformer 
  * under the assumption that a BPMN file has a `.bpmn` file extension (e.g. by using the Camunda modeler), this behavior change should not affect users 

## Related issues

closes #8067

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
