### PR TITLE
docs: fix code example for `ClockActuatorClient`

### DIFF
--- a/test-util/src/main/java/io/camunda/zeebe/test/util/actuator/ClockActuatorClient.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/actuator/ClockActuatorClient.java
@@ -26,9 +26,9 @@ import java.time.Instant;
  *
  * <pre>
  * final var zeebeContainer = new ZeebeContainer();
- * zeebeContainer.withEnv("zeebe.clock.controllable", "true") .start()
+ * zeebeContainer.withEnv("ZEEBE_CLOCK_CONTROLLED", "true") .start()
  * final var clockClient = new ClockActuatorClient(zeebeContainer.getExternalMonitoringAddress());
- * clockClient.setClock(Instant.now().minus(Duration.ofDays(1)));
+ * clockClient.pinZeebeTime(Instant.now().minus(Duration.ofDays(1)));
  * </pre>
  */
 public final class ClockActuatorClient {


### PR DESCRIPTION
## Description

As we don't have a public client in zeebe-test-container yet (https://github.com/camunda-community-hub/zeebe-test-container/issues/223) it's important that at least the code example for our internal client is up to date to avoid confusion. 