### PR TITLE
Configurable threshold for preferring snapshot replication

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -492,6 +492,21 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
       return this;
     }
 
+    /**
+     * Sets the threshold for preferring snapshot replication. When a follower lags behind by more
+     * than the threshold, the leader prefers sending a snapshot over replicating records.
+     *
+     * @param preferSnapshotReplicationThreshold the threshold to use
+     * @return this builder for chaining
+     */
+    public Builder withPreferSnapshotReplicationThreshold(
+        final int preferSnapshotReplicationThreshold) {
+      config
+          .getPartitionConfig()
+          .setPreferSnapshotReplicationThreshold(preferSnapshotReplicationThreshold);
+      return this;
+    }
+
     @Override
     public RaftPartitionGroup build() {
       return new RaftPartitionGroup(config);

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -493,8 +493,9 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
     }
 
     /**
-     * Sets the threshold for preferring snapshot replication. When a follower lags behind by more
-     * than the threshold, the leader prefers sending a snapshot over replicating records.
+     * Sets the threshold for preferring snapshot replication. The unit is <i>number of records</i>
+     * by which a follower may lag behind before the leader starts to prefer replicating snapshots
+     * instead of records.
      *
      * @param preferSnapshotReplicationThreshold the threshold to use
      * @return this builder for chaining

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
@@ -75,7 +75,9 @@ final class RaftPartitionGroupFactory {
             .withHeartbeatInterval(clusterCfg.getHeartbeatInterval())
             .withRequestTimeout(experimentalCfg.getRaft().getRequestTimeout())
             .withMaxQuorumResponseTimeout(experimentalCfg.getRaft().getMaxQuorumResponseTimeout())
-            .withMinStepDownFailureCount(experimentalCfg.getRaft().getMinStepDownFailureCount());
+            .withMinStepDownFailureCount(experimentalCfg.getRaft().getMinStepDownFailureCount())
+            .withPreferSnapshotReplicationThreshold(
+                experimentalCfg.getRaft().getPreferSnapshotReplicationThreshold());
 
     final int maxMessageSize = (int) networkCfg.getMaxMessageSizeInBytes();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
@@ -14,10 +14,12 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
   private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(5);
   private static final Duration DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT = Duration.ofSeconds(0);
   private static final int DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT = 3;
+  private static final int DEFAULT_PREFER_SNAPSHOT_REPLICATION_THRESHOLD = 100;
 
   private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
   private Duration maxQuorumResponseTimeout = DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT;
   private int minStepDownFailureCount = DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT;
+  private int preferSnapshotReplicationThreshold = DEFAULT_PREFER_SNAPSHOT_REPLICATION_THRESHOLD;
 
   public Duration getRequestTimeout() {
     return requestTimeout;
@@ -41,5 +43,13 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
 
   public void setMinStepDownFailureCount(final int minStepDownFailureCount) {
     this.minStepDownFailureCount = minStepDownFailureCount;
+  }
+
+  public int getPreferSnapshotReplicationThreshold() {
+    return preferSnapshotReplicationThreshold;
+  }
+
+  public void setPreferSnapshotReplicationThreshold(final int preferSnapshotReplicationThreshold) {
+    this.preferSnapshotReplicationThreshold = preferSnapshotReplicationThreshold;
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
@@ -141,6 +141,18 @@ class RaftPartitionGroupFactoryTest {
     assertThat(config.getPartitionConfig().isPriorityElectionEnabled()).isFalse();
   }
 
+  @Test
+  void shouldSetPreferSnapshotReplicationThreshold() {
+    // given
+    brokerCfg.getExperimental().getRaft().setPreferSnapshotReplicationThreshold(1000);
+
+    // when
+    final var config = buildRaftPartitionGroup();
+
+    // then
+    assertThat(config.getPartitionConfig().getPreferSnapshotReplicationThreshold()).isEqualTo(1000);
+  }
+
   private RaftPartitionGroupConfig buildRaftPartitionGroup() {
     final var partitionGroup = factory.buildRaftPartitionGroup(brokerCfg, SNAPSHOT_STORE_FACTORY);
     return (RaftPartitionGroupConfig) partitionGroup.config();

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfgTest.java
@@ -86,4 +86,27 @@ public class ExperimentalCfgTest {
     // then
     assertThat(raft.getMinStepDownFailureCount()).isEqualTo(10);
   }
+
+  @Test
+  public void shouldSetPreferSnapshotReplicationThresholdFromConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
+    final var raft = cfg.getExperimental().getRaft();
+
+    // then
+    assertThat(raft.getPreferSnapshotReplicationThreshold()).isEqualTo(500);
+  }
+
+  @Test
+  public void shouldSetPreferSnapshotReplicationThresholdFromEnv() {
+    // given
+    environment.put("zeebe.broker.experimental.raft.preferSnapshotReplicationThreshold", "10");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
+    final var raft = cfg.getExperimental().getRaft();
+
+    // then
+    assertThat(raft.getPreferSnapshotReplicationThreshold()).isEqualTo(10);
+  }
 }

--- a/broker/src/test/resources/system/experimental-cfg.yaml
+++ b/broker/src/test/resources/system/experimental-cfg.yaml
@@ -6,5 +6,6 @@ zeebe:
         requestTimeout: 10s
         maxQuorumResponseTimeout: 8s
         minStepDownFailureCount: 5
+        preferSnapshotReplicationThreshold: 500
       queryApi:
         enabled: true

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -630,8 +630,8 @@
         # maxQuorumResponseTimeout = 0ms
 
         # Threshold used by the leader to decide between replicating a snapshot or records.
-        # If a follower lags behind by more than the threshold, the leader will prefer replicating
-        # snapshots.
+        # The unit is number of records by which the follower may lag behind before the leader
+        # prefers replicating snapshots instead of records.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_PREFERSNAPSHOTREPLICATIONTHRESHOLD.
         # preferSnapshotReplicationThreshold = 100
 

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -629,6 +629,12 @@
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_MAXQUORUMRESPONSETIMEOUT
         # maxQuorumResponseTimeout = 0ms
 
+        # Threshold used by the leader to decide between replicating a snapshot or records.
+        # If a follower lags behind by more than the threshold, the leader will prefer replicating
+        # snapshots.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_PREFERSNAPSHOTREPLICATIONTHRESHOLD.
+        # preferSnapshotReplicationThreshold = 100
+
       # Allows to configure RocksDB properties, which is used for state management.
       # rocksdb:
         # Specify custom column family options overwriting Zeebe's own defaults.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -566,6 +566,12 @@
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_MAXQUORUMRESPONSETIMEOUT
         # maxQuorumResponseTimeout = 0ms
 
+        # Threshold used by the leader to decide between replicating a snapshot or records.
+        # If a follower lags behind by more than the threshold, the leader will prefer replicating
+        # snapshots.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_PREFERSNAPSHOTREPLICATIONTHRESHOLD.
+        # preferSnapshotReplicationThreshold = 100
+
       # Allows to configure RocksDB properties, which is used for state management.
       # rocksdb:
         # Specify custom column family options overwriting Zeebe's own defaults.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -567,8 +567,8 @@
         # maxQuorumResponseTimeout = 0ms
 
         # Threshold used by the leader to decide between replicating a snapshot or records.
-        # If a follower lags behind by more than the threshold, the leader will prefer replicating
-        # snapshots.
+        # The unit is number of records by which the follower may lag behind before the leader
+        # prefers replicating snapshots instead of records.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_PREFERSNAPSHOTREPLICATIONTHRESHOLD.
         # preferSnapshotReplicationThreshold = 100
 


### PR DESCRIPTION
## Description

Because the threshold has come up a couple of times recently I've added an experimental configuration for this:

`zeebe.broker.experimental.raft.preferSnapshotReplicationThreshold`

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7968 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
