### PR TITLE
fix: set default encoding to UTF-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,25 +21,10 @@ RUN chmod +x -R ${TMP_DIR}/bin/
 RUN chmod 0775 ${TMP_DIR} ${TMP_DIR}/data
 
 # Building prod image
-FROM eclipse-temurin:17 as jre-build
-
-# Create a custom Java runtime
-RUN $JAVA_HOME/bin/jlink \
-   --add-modules ALL-MODULE-PATH \
-   --strip-debug \
-   --no-man-pages \
-   --no-header-files \
-   --compress=2 \
-   --output jre17-with-all-modules
-
-# Define your base image
-FROM ubuntu:focal as prod
-ENV JAVA_HOME=/opt/java/openjdk
-ENV PATH "${JAVA_HOME}/bin:${PATH}"
-COPY --from=jre-build /jre17-with-all-modules $JAVA_HOME
+FROM eclipse-temurin:17-jre-focal as prod
 
 # Building dev image
-FROM eclipse-temurin:17 as dev
+FROM eclipse-temurin:17-jdk-focal as dev
 RUN echo "running DEV pre-install commands"
 RUN apt-get update
 RUN curl -sSL https://github.com/jvm-profiling-tools/async-profiler/releases/download/v1.7.1/async-profiler-1.7.1-linux-x64.tar.gz | tar xzv

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -217,7 +217,8 @@
           <copyConfigurationDirectory>true</copyConfigurationDirectory>
           <extraJvmArguments>-Xms128m
             --illegal-access=deny
-            -XX:+ExitOnOutOfMemoryError</extraJvmArguments>
+            -XX:+ExitOnOutOfMemoryError
+            -Dfile.encoding=UTF-8</extraJvmArguments>
           <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
           <platforms>
             <platform>windows</platform>
@@ -244,7 +245,7 @@
               <goal>assemble</goal>
             </goals>
             <phase>package</phase>
-            <configuration />
+            <configuration></configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## Description

* Sets the default encoding to UTF-8
* Switches the prod base image to `eclipse-temurin:17-jre-focal` which sets a system locale


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8579

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
