### PR TITLE
Ignore benchmark deletion before CW 5

### DIFF
--- a/createMedicCWBenchmark.sh
+++ b/createMedicCWBenchmark.sh
@@ -37,14 +37,15 @@ if [ $cw -gt 4 ]
 then
   nameOfOldestBenchmark=$(ls | grep medic-cw- | sort | head -n 1)
   ./deleteBenchmark.sh $nameOfOldestBenchmark
+
+  # commit that change
+  git commit -am "test(benchmark): rm $nameOfOldestBenchmark"
+  git push origin medic-cw-benchmarks
+
 else
   echo "We currently not support to delete benchmarks, before calendar week 5. Our deletion logic is not sophisticated enough. Please delete the benchmark manually."
 fi
 
-# commit that change
-
-git commit -am "test(benchmark): rm $nameOfOldestBenchmark"
-git push origin medic-cw-benchmarks
 
 # print out the name of the new benchmark so it can be easily copied
 nameOfNewestBenchmark=$(ls | grep medic-cw- | sort | tail -n 1)

--- a/createMedicCWBenchmark.sh
+++ b/createMedicCWBenchmark.sh
@@ -43,7 +43,11 @@ then
   git push origin medic-cw-benchmarks
 
 else
-  echo "We currently not support to delete benchmarks, before calendar week 5. Our deletion logic is not sophisticated enough. Please delete the benchmark manually."
+  set +x
+  echo -e "\e[31m!!!!!!!!!!!!!!"
+  echo -e "We currently not support to delete benchmarks, before calendar week 5. Our deletion logic is not sophisticated enough. Please delete the benchmark manually."
+  echo -e "!!!!!!!!!!!!!!\e[0m"
+  set -x
 fi
 
 

--- a/createMedicCWBenchmark.sh
+++ b/createMedicCWBenchmark.sh
@@ -32,10 +32,14 @@ git push origin medic-cw-benchmarks
 # delete older benchmark
 cd benchmarks/setup/
 
-nameOfOldestBenchmark=$(ls | grep medic-cw- | sort | head -n 1)
-
-./stopBenchmarks.sh $nameOfOldestBenchmark
-./deleteBenchmark.sh $nameOfOldestBenchmark
+cw=$(date +%V)
+if [ $cw -gt 4 ]
+then
+  nameOfOldestBenchmark=$(ls | grep medic-cw- | sort | head -n 1)
+  ./deleteBenchmark.sh $nameOfOldestBenchmark
+else
+  echo "We currently not support to delete benchmarks, before calendar week 5. Our deletion logic is not sophisticated enough. Please delete the benchmark manually."
+fi
 
 # commit that change
 


### PR DESCRIPTION
## Description

We have currently not the optimal logic to delete benchmarks before calendar week 5, since our naming schema contains only the calendar weeks. This means if we are in calendar week 2 we delete 01 and not 49. This commit turns off deletion for the begin of the year and print a notification to delete it manually.

<!-- Please explain the changes you made here. -->


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
