### PR TITLE
[Backport stable/1.2] fix: set default encoding to UTF-8

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -164,6 +164,7 @@
             -Xms128m
             --illegal-access=deny
             -XX:+ExitOnOutOfMemoryError
+            -Dfile.encoding=UTF-8
           </extraJvmArguments>
           <repositoryLayout>flat</repositoryLayout>
           <useWildcardClassPath>true</useWildcardClassPath>


### PR DESCRIPTION
Backport of the relevant commit in #8580 

Here we only add the extra argument as a safety guard, the docker image for 1.2 already sets the correct locale. 