### PR TITLE
[Backport stable/1.2] Fixes CVE-2021-22569 related to Protobuf

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -72,8 +72,8 @@
     <version.netty>4.1.68.Final</version.netty>
     <version.objenesis>3.2</version.objenesis>
     <version.prometheus>0.12.0</version.prometheus>
-    <version.protobuf>3.18.0</version.protobuf>
-    <version.protobuf-common>2.5.0</version.protobuf-common>
+    <version.protobuf>3.19.2</version.protobuf>
+    <version.protobuf-common>2.7.0</version.protobuf-common>
     <version.micrometer>1.7.4</version.micrometer>
     <version.rocksdbjni>6.22.1.1</version.rocksdbjni>
     <version.sbe>1.24.0</version.sbe>


### PR DESCRIPTION
## Description

Fixes a security issue for Protobuf. See https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-2331703 for more.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
