### PR TITLE
Fix security issues with HTTP request smuggling in Netty

### DIFF
--- a/atomix/cluster/pom.xml
+++ b/atomix/cluster/pom.xml
@@ -55,9 +55,13 @@
       <groupId>io.netty</groupId>
     </dependency>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-classes-epoll</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
       <classifier>linux-x86_64</classifier>
-      <groupId>io.netty</groupId>
     </dependency>
     <dependency>
       <artifactId>commons-math3</artifactId>
@@ -256,6 +260,7 @@
             <!-- dependency used but plugin seems to report a false positive here -->
             <dependency>uk.co.real-logic:sbe-tool</dependency>
             <dependency>net.jqwik:jqwik</dependency>
+            <dependency>io.netty:netty-transport-native-epoll</dependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -68,8 +68,7 @@
     <version.mockito-jupiter>3.12.4</version.mockito-jupiter>
     <version.model>7.7.0</version.model>
     <version.msgpack>0.9.0</version.msgpack>
-    <version.netty-tcnative>2.0.43.Final</version.netty-tcnative>
-    <version.netty>4.1.68.Final</version.netty>
+    <version.netty>4.1.72.Final</version.netty>
     <version.objenesis>3.2</version.objenesis>
     <version.prometheus>0.12.0</version.prometheus>
     <version.protobuf>3.19.2</version.protobuf>
@@ -418,12 +417,6 @@
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-common-protos</artifactId>
         <version>${version.protobuf-common}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>${version.netty-tcnative}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

Bumps Netty to 4.1.72.Final. Additionally drops the unnecessary explicit dependency management of netty-tcnative as it's already present in the Netty BOM.

This fixes [CVE-2021-43797](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-43797), described in more details [here](https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-2314893).

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
