### PR TITLE
Export deployed decisions and DRGs to ES

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -186,6 +186,12 @@ public class ElasticsearchExporter implements Exporter {
       if (index.processMessageSubscription) {
         createValueIndexTemplate(ValueType.PROCESS_MESSAGE_SUBSCRIPTION);
       }
+      if (index.decisionRequirements) {
+        createValueIndexTemplate(ValueType.DECISION_REQUIREMENTS);
+      }
+      if (index.decision) {
+        createValueIndexTemplate(ValueType.DECISION);
+      }
     }
 
     indexTemplatesCreated = true;

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -79,6 +79,10 @@ public class ElasticsearchExporterConfiguration {
         return index.processInstanceCreation;
       case PROCESS_MESSAGE_SUBSCRIPTION:
         return index.processMessageSubscription;
+      case DECISION_REQUIREMENTS:
+        return index.decisionRequirements;
+      case DECISION:
+        return index.decision;
       default:
         return false;
     }
@@ -123,6 +127,8 @@ public class ElasticsearchExporterConfiguration {
     public boolean processInstance = true;
     public boolean processInstanceCreation = false;
     public boolean processMessageSubscription = false;
+    public boolean decisionRequirements = true;
+    public boolean decision = true;
 
     // index settings
     private Integer numberOfShards = null;
@@ -182,6 +188,10 @@ public class ElasticsearchExporterConfiguration {
           + processInstanceCreation
           + ", processMessageSubscription="
           + processMessageSubscription
+          + ", decisionRequirements="
+          + decisionRequirements
+          + ", decision="
+          + decision
           + '}';
     }
   }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-requirements-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-requirements-template.json
@@ -1,0 +1,54 @@
+{
+  "index_patterns": [
+    "zeebe-record_decision-requirements_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-decision-requirements": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "decisionRequirementsId": {
+              "type": "keyword"
+            },
+            "decisionRequirementsName": {
+              "type": "keyword"
+            },
+            "decisionRequirementsVersion": {
+              "type": "long"
+            },
+            "decisionRequirementsKey": {
+              "type": "long"
+            },
+            "namespace": {
+              "type": "keyword"
+            },
+            "resourceName": {
+              "type": "text"
+            },
+            "resource": {
+              "enabled": false
+            },
+            "checksum": {
+              "enabled": false
+            },
+            "duplicate": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-template.json
@@ -1,0 +1,48 @@
+{
+  "index_patterns": [
+    "zeebe-record_decision_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-decision": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "decisionId": {
+              "type": "keyword"
+            },
+            "decisionName": {
+              "type": "keyword"
+            },
+            "version": {
+              "type": "long"
+            },
+            "decisionKey": {
+              "type": "long"
+            },
+            "decisionRequirementsId": {
+              "type": "keyword"
+            },
+            "decisionRequirementsKey": {
+              "type": "long"
+            },
+            "duplicate": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterDmnRecordIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterDmnRecordIT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter;
+
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import org.junit.Before;
+import org.junit.Test;
+
+public final class ElasticsearchExporterDmnRecordIT
+    extends AbstractElasticsearchExporterIntegrationTestCase {
+
+  private static final String DMN_RESOURCE = "dmn/decision-table.dmn";
+
+  @Before
+  public void init() {
+    elastic.start();
+
+    configuration = getDefaultConfiguration();
+    esClient = createElasticsearchClient(configuration);
+
+    exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
+    exporterBrokerRule.start();
+  }
+
+  @Test
+  public void shouldExportDecisionRecord() {
+    // when
+    exporterBrokerRule.deployResourceFromClasspath(DMN_RESOURCE);
+
+    // then
+    await("index templates need to be created")
+        .atMost(Duration.ofMinutes(1))
+        .untilAsserted(this::assertIndexSettings);
+
+    final var decisionRecord = RecordingExporter.decisionRecords().getFirst();
+
+    assertRecordExported(decisionRecord);
+  }
+
+  @Test
+  public void shouldExportDecisionRequirementsRecord() {
+    // when
+    exporterBrokerRule.deployResourceFromClasspath(DMN_RESOURCE);
+
+    // then
+    await("index templates need to be created")
+        .atMost(Duration.ofMinutes(1))
+        .untilAsserted(this::assertIndexSettings);
+
+    final var decisionRequirementsRecord =
+        RecordingExporter.decisionRequirementsRecords().getFirst();
+
+    assertRecordExported(decisionRequirementsRecord);
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/records/ElasticsearchExporterDmnRecordIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/records/ElasticsearchExporterDmnRecordIT.java
@@ -5,10 +5,12 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.exporter;
+package io.camunda.zeebe.exporter.records;
 
 import static org.awaitility.Awaitility.await;
 
+import io.camunda.zeebe.exporter.AbstractElasticsearchExporterIntegrationTestCase;
+import io.camunda.zeebe.exporter.ElasticsearchExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import org.junit.Before;

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/records/ElasticsearchExporterJobRecordIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/records/ElasticsearchExporterJobRecordIT.java
@@ -5,12 +5,14 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.exporter;
+package io.camunda.zeebe.exporter.records;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import io.camunda.zeebe.client.api.worker.JobWorker;
+import io.camunda.zeebe.exporter.AbstractElasticsearchExporterIntegrationTestCase;
+import io.camunda.zeebe.exporter.ElasticsearchExporter;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;

--- a/exporters/elasticsearch-exporter/src/test/resources/dmn/decision-table.dmn
+++ b/exporters/elasticsearch-exporter/src/test/resources/dmn/decision-table.dmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force-users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <decision id="jedi-or-sith" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="faction" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utwb1e">
+        <inputEntry id="UnaryTests_1v3sd4m">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tgh8k1">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1bwgcym">
+        <inputEntry id="UnaryTests_0n1ewm3">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19xnlkw">
+          <text>"Sith"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi-or-sith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/test/src/main/java/io/camunda/zeebe/test/exporter/ExporterIntegrationRule.java
+++ b/test/src/main/java/io/camunda/zeebe/test/exporter/ExporterIntegrationRule.java
@@ -303,6 +303,20 @@ public class ExporterIntegrationRule extends ExternalResource {
   }
 
   /**
+   * Deploys the given classpath resource to the broker.
+   *
+   * @param classpathResource the resource to deploy
+   */
+  public void deployResourceFromClasspath(final String classpathResource) {
+    clientRule
+        .getClient()
+        .newDeployCommand()
+        .addResourceFromClasspath(classpathResource)
+        .send()
+        .join();
+  }
+
+  /**
    * Creates a process instance for the given process ID, with the given variables.
    *
    * @param processId BPMN process ID


### PR DESCRIPTION
## Description

* add new indexes for DMN records: decisions and decision-requirements
* export both DMN records by default

## Related issues

closes #8077

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
