### PR TITLE
Extend the deployment record for DMN decisions

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -52,6 +52,59 @@
                   "type": "text"
                 }
               }
+            },
+            "decisionRequirementsMetadata": {
+              "properties": {
+                "decisionRequirementsId": {
+                  "type": "keyword"
+                },
+                "decisionRequirementsName": {
+                  "type": "keyword"
+                },
+                "decisionRequirementsVersion": {
+                  "type": "long"
+                },
+                "decisionRequirementsKey": {
+                  "type": "long"
+                },
+                "namespace": {
+                  "type": "keyword"
+                },
+                "resourceName": {
+                  "type": "text"
+                },
+                "checksum": {
+                  "enabled": false
+                },
+                "duplicate": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "decisionsMetadata": {
+              "properties": {
+                "decisionId": {
+                  "type": "keyword"
+                },
+                "decisionName": {
+                  "type": "keyword"
+                },
+                "version": {
+                  "type": "long"
+                },
+                "decisionKey": {
+                  "type": "long"
+                },
+                "decisionRequirementsId": {
+                  "type": "keyword"
+                },
+                "decisionRequirementsKey": {
+                  "type": "long"
+                },
+                "duplicate": {
+                  "type": "boolean"
+                }
+              }
             }
           }
         }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRecord.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.deployment;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -29,13 +30,16 @@ public final class DecisionRecord extends UnifiedRecordValue implements Decision
   private final LongProperty decisionRequirementsKeyProp =
       new LongProperty("decisionRequirementsKey");
 
+  private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
+
   public DecisionRecord() {
     declareProperty(decisionIdProp)
         .declareProperty(decisionNameProp)
         .declareProperty(versionProp)
         .declareProperty(decisionKeyProp)
         .declareProperty(decisionRequirementsIdProp)
-        .declareProperty(decisionRequirementsKeyProp);
+        .declareProperty(decisionRequirementsKeyProp)
+        .declareProperty(isDuplicateProp);
   }
 
   @Override
@@ -70,7 +74,7 @@ public final class DecisionRecord extends UnifiedRecordValue implements Decision
 
   @Override
   public boolean isDuplicate() {
-    return false;
+    return isDuplicateProp.getValue();
   }
 
   public DecisionRecord setDecisionId(String decisionId) {
@@ -100,6 +104,11 @@ public final class DecisionRecord extends UnifiedRecordValue implements Decision
 
   public DecisionRecord setDecisionRequirementsKey(long decisionRequirementsKey) {
     decisionRequirementsKeyProp.setValue(decisionRequirementsKey);
+    return this;
+  }
+
+  public DecisionRecord markAsDuplicate() {
+    isDuplicateProp.setValue(true);
     return this;
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsMetadataRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsMetadataRecord.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.deployment;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsArray;
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
+import org.agrona.DirectBuffer;
+
+public class DecisionRequirementsMetadataRecord extends UnifiedRecordValue
+    implements DecisionRequirementsMetadataValue {
+
+  private final StringProperty decisionRequirementsIdProp =
+      new StringProperty("decisionRequirementsId");
+  private final StringProperty decisionRequirementsNameProp =
+      new StringProperty("decisionRequirementsName");
+  private final IntegerProperty decisionRequirementsVersionProp =
+      new IntegerProperty("decisionRequirementsVersion");
+  private final LongProperty decisionRequirementsKeyProp =
+      new LongProperty("decisionRequirementsKey");
+  private final StringProperty namespaceProp = new StringProperty("namespace");
+
+  private final StringProperty resourceNameProp = new StringProperty("resourceName");
+  private final BinaryProperty checksumProp = new BinaryProperty("checksum");
+
+  private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
+
+  public DecisionRequirementsMetadataRecord() {
+    declareProperty(decisionRequirementsIdProp)
+        .declareProperty(decisionRequirementsNameProp)
+        .declareProperty(decisionRequirementsVersionProp)
+        .declareProperty(decisionRequirementsKeyProp)
+        .declareProperty(namespaceProp)
+        .declareProperty(resourceNameProp)
+        .declareProperty(checksumProp)
+        .declareProperty(isDuplicateProp);
+  }
+
+  @Override
+  public String getDecisionRequirementsId() {
+    return bufferAsString(decisionRequirementsIdProp.getValue());
+  }
+
+  @Override
+  public String getDecisionRequirementsName() {
+    return bufferAsString(decisionRequirementsNameProp.getValue());
+  }
+
+  @Override
+  public int getDecisionRequirementsVersion() {
+    return decisionRequirementsVersionProp.getValue();
+  }
+
+  @Override
+  public long getDecisionRequirementsKey() {
+    return decisionRequirementsKeyProp.getValue();
+  }
+
+  @Override
+  public String getNamespace() {
+    return bufferAsString(namespaceProp.getValue());
+  }
+
+  @Override
+  public String getResourceName() {
+    return bufferAsString(resourceNameProp.getValue());
+  }
+
+  @Override
+  public byte[] getChecksum() {
+    return bufferAsArray(checksumProp.getValue());
+  }
+
+  @Override
+  public boolean isDuplicate() {
+    return isDuplicateProp.getValue();
+  }
+
+  public DecisionRequirementsMetadataRecord setDecisionRequirementsId(
+      String decisionRequirementsId) {
+    decisionRequirementsIdProp.setValue(decisionRequirementsId);
+    return this;
+  }
+
+  public DecisionRequirementsMetadataRecord setDecisionRequirementsName(
+      String decisionRequirementsName) {
+    decisionRequirementsNameProp.setValue(decisionRequirementsName);
+    return this;
+  }
+
+  public DecisionRequirementsMetadataRecord setDecisionRequirementsVersion(
+      int decisionRequirementsVersion) {
+    decisionRequirementsVersionProp.setValue(decisionRequirementsVersion);
+    return this;
+  }
+
+  public DecisionRequirementsMetadataRecord setDecisionRequirementsKey(
+      long decisionRequirementsKey) {
+    decisionRequirementsKeyProp.setValue(decisionRequirementsKey);
+    return this;
+  }
+
+  public DecisionRequirementsMetadataRecord setNamespace(String namespace) {
+    namespaceProp.setValue(namespace);
+    return this;
+  }
+
+  public DecisionRequirementsMetadataRecord setResourceName(String resourceName) {
+    resourceNameProp.setValue(resourceName);
+    return this;
+  }
+
+  public DecisionRequirementsMetadataRecord setChecksum(DirectBuffer checksum) {
+    checksumProp.setValue(checksum);
+    return this;
+  }
+
+  public DecisionRequirementsMetadataRecord markAsDuplicate() {
+    isDuplicateProp.setValue(true);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getDecisionRequirementsIdBuffer() {
+    return decisionRequirementsIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getDecisionRequirementsNameBuffer() {
+    return decisionRequirementsNameProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getNamespaceBuffer() {
+    return namespaceProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getResourceNameBuffer() {
+    return resourceNameProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getChecksumBuffer() {
+    return checksumProp.getValue();
+  }
+}

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -149,7 +149,7 @@ public final class JsonSerializableToJsonTest {
               return new CopiedRecord<>(
                   record, recordMetadata, key, 0, position, sourcePosition, timestamp);
             },
-        "{'valueType':'DEPLOYMENT','key':1234,'position':4321,'timestamp':2191,'recordType':'COMMAND','intent':'CREATE','partitionId':0,'rejectionType':'INVALID_ARGUMENT','rejectionReason':'fails','brokerVersion':'1.2.3','sourceRecordPosition':231,'value':{'processesMetadata':[{'version':12,'bpmnProcessId':'testProcess','resourceName':'resource','checksum':'Y2hlY2tzdW0=','processDefinitionKey':123, 'duplicate':false}],'resources':[{'resourceName':'resource','resource':'Y29udGVudHM='}]}}"
+        "{'valueType':'DEPLOYMENT','key':1234,'position':4321,'timestamp':2191,'recordType':'COMMAND','intent':'CREATE','partitionId':0,'rejectionType':'INVALID_ARGUMENT','rejectionReason':'fails','brokerVersion':'1.2.3','sourceRecordPosition':231,'value':{'processesMetadata':[{'version':12,'bpmnProcessId':'testProcess','resourceName':'resource','checksum':'Y2hlY2tzdW0=','processDefinitionKey':123, 'duplicate':false}],'resources':[{'resourceName':'resource','resource':'Y29udGVudHM='}],'decisionsMetadata':[],'decisionRequirementsMetadata':[]}}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       //////////////////////////////////// DeploymentRecord ///////////////////////////////////////
@@ -179,9 +179,30 @@ public final class JsonSerializableToJsonTest {
                   .setVersion(processVersion)
                   .setChecksum(checksum)
                   .markAsDuplicate();
+              record
+                  .decisionRequirementsMetadata()
+                  .add()
+                  .setDecisionRequirementsId("drg-id")
+                  .setDecisionRequirementsName("drg-name")
+                  .setDecisionRequirementsVersion(1)
+                  .setDecisionRequirementsKey(1L)
+                  .setNamespace("namespace")
+                  .setResourceName("resource-name")
+                  .setChecksum(checksum)
+                  .markAsDuplicate();
+              record
+                  .decisionsMetadata()
+                  .add()
+                  .setDecisionId("decision-id")
+                  .setDecisionName("decision-name")
+                  .setVersion(1)
+                  .setDecisionKey(2L)
+                  .setDecisionRequirementsKey(1L)
+                  .setDecisionRequirementsId("drg-id")
+                  .markAsDuplicate();
               return record;
             },
-        "{'resources':[{'resourceName':'resource','resource':'Y29udGVudHM='}],'processesMetadata':[{'checksum':'Y2hlY2tzdW0=','bpmnProcessId':'testProcess','version':12,'processDefinitionKey':123,'resourceName':'resource', 'duplicate':true}]}"
+        "{'resources':[{'resourceName':'resource','resource':'Y29udGVudHM='}],'processesMetadata':[{'checksum':'Y2hlY2tzdW0=','bpmnProcessId':'testProcess','version':12,'processDefinitionKey':123,'resourceName':'resource', 'duplicate':true}],'decisionsMetadata':[{'version':1,'decisionRequirementsId':'drg-id','decisionRequirementsKey':1,'decisionId':'decision-id','decisionName':'decision-name','decisionKey':2,'duplicate':true}],'decisionRequirementsMetadata':[{'decisionRequirementsId':'drg-id','decisionRequirementsName':'drg-name','decisionRequirementsVersion':1,'decisionRequirementsKey':1,'namespace':'namespace','resourceName':'resource-name','checksum':'Y2hlY2tzdW0=','duplicate':true}]}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       ////////////////////////////// DeploymentDistributionRecord /////////////////////////////////
@@ -202,7 +223,7 @@ public final class JsonSerializableToJsonTest {
       new Object[] {
         "Empty DeploymentRecord",
         (Supplier<UnifiedRecordValue>) DeploymentRecord::new,
-        "{'resources':[],'processesMetadata':[]}"
+        "{'resources':[],'processesMetadata':[],'decisionsMetadata':[],'decisionRequirementsMetadata':[]}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       //////////////////////////////////// ProcessRecord ///////////////////////////////////////

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DeploymentRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DeploymentRecordValue.java
@@ -17,6 +17,8 @@ package io.camunda.zeebe.protocol.record.value;
 
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import java.util.List;
@@ -30,5 +32,12 @@ public interface DeploymentRecordValue extends RecordValue {
   /** @return the resources to deploy */
   List<DeploymentResource> getResources();
 
+  /** @return the deployed processes */
   List<ProcessMetadataValue> getProcessesMetadata();
+
+  /** @return the deployed decisions */
+  List<DecisionRecordValue> getDecisionsMetadata();
+
+  /** @return the deployed decision requirements (DRGs) */
+  List<DecisionRequirementsMetadataValue> getDecisionRequirementsMetadata();
 }


### PR DESCRIPTION
## Description

* extend the deployment record by adding the metadata of the deployed decisions and DRGs
  * create a new record for DRG metadata that doesn't contain the resource, similar to `ProcessMetadata`
  * reusing parts of the existing DRG is not suitable because of the setters 
  * use `DecisionRecord` as metadata because it doesn't contain a resource (which is the main reason for metadata values)
* fill the deployment event during the transformation of the DMN resources
* adjust the ES template

## Related issues

closes #8072 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
