### PR TITLE
Upgrade to Java 17

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -31,7 +31,7 @@
     <nexus.release.repository>https://app.camunda.com/nexus/content/repositories/zeebe-io/</nexus.release.repository>
     <nexus.sonatype.url>https://s01.oss.sonatype.org</nexus.sonatype.url>
 
-    <version.java>11</version.java>
+    <version.java>17</version.java>
     <plugin.version.javadoc>3.3.1</plugin.version.javadoc>
   </properties>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -31,7 +31,6 @@
     <nexus.release.repository>https://app.camunda.com/nexus/content/repositories/zeebe-io/</nexus.release.repository>
     <nexus.sonatype.url>https://s01.oss.sonatype.org</nexus.sonatype.url>
 
-    <version.java>17</version.java>
     <plugin.version.javadoc>3.3.1</plugin.version.javadoc>
   </properties>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -216,7 +216,6 @@
           <configurationDirectory>config</configurationDirectory>
           <copyConfigurationDirectory>true</copyConfigurationDirectory>
           <extraJvmArguments>-Xms128m
-            --illegal-access=deny
             -XX:+ExitOnOutOfMemoryError
             -Dfile.encoding=UTF-8</extraJvmArguments>
           <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>

--- a/gateway-protocol/pom.xml
+++ b/gateway-protocol/pom.xml
@@ -15,6 +15,10 @@
 
   <name>Zeebe Gateway Protocol</name>
 
+  <properties>
+    <version.java>8</version.java>
+  </properties>
+
   <build>
     <resources>
       <resource>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -26,6 +26,7 @@
   </licenses>
 
   <properties>
+    <version.java>17</version.java>
 
     <!-- Zeebe Community License v1.1 header -->
     <license.header>${maven.multiModuleProjectDirectory}/parent/COPYING-HEADER.txt</license.header>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1279,19 +1279,20 @@
             </dependency>
           </dependencies>
 
-<!-- Disabled due to https://issues.apache.org/jira/projects/MDEP/issues/MDEP-774 and https://issues.apache.org/jira/browse/MDEP-753
           <executions>
             <execution>
               <id>analyze-dependencies</id>
               <goals>
                 <goal>analyze-only</goal>
               </goals>
-              &lt;!&ndash; The analyze-only goal assumes that the test-compile phase has been executed &ndash;&gt;
+              <!-- The analyze-only goal assumes that the test-compile phase has been executed -->
               <phase>verify</phase>
               <configuration>
+                <!-- Disabled due to https://issues.apache.org/jira/projects/MDEP/issues/MDEP-774 and https://issues.apache.org/jira/browse/MDEP-753 -->
+                <skip>true</skip>
                 <failOnWarning>true</failOnWarning>
                 <outputXML>true</outputXML>
-                &lt;!&ndash; dependencies not directly used in all projects during tests &ndash;&gt;
+                <!-- dependencies not directly used in all projects during tests -->
                 <ignoredUnusedDeclaredDependencies combine.children="append">
                   <dep>org.apache.logging.log4j:log4j-slf4j-impl</dep>
                   <dep>org.apache.logging.log4j:log4j-core</dep>
@@ -1310,7 +1311,6 @@
               </configuration>
             </execution>
           </executions>
--->
         </plugin>
 
         <plugin>
@@ -1621,7 +1621,6 @@
                   <silent>true</silent>
                 </configuration>
               </execution>
-<!-- Disabled due to https://issues.apache.org/jira/projects/MDEP/issues/MDEP-774 and https://issues.apache.org/jira/browse/MDEP-753
               <execution>
                 <id>analyze-dependencies</id>
                 <goals>
@@ -1629,13 +1628,15 @@
                 </goals>
                 <phase>verify</phase>
                 <configuration>
+                  <!-- Disabled due to https://issues.apache.org/jira/projects/MDEP/issues/MDEP-774
+                  and https://issues.apache.org/jira/browse/MDEP-753 -->
+                  <skip>true</skip>
                   <ignoredUnusedDeclaredDependencies combine.children="append">
                     <dep>org.revapi:revapi-java</dep>
                     <dep>io.zeebe:flaky-test-extractor-maven-plugin</dep>
                   </ignoredUnusedDeclaredDependencies>
                 </configuration>
               </execution>
--->
             </executions>
           </plugin>
         </plugins>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1278,18 +1278,19 @@
             </dependency>
           </dependencies>
 
+<!-- Disabled due to https://issues.apache.org/jira/projects/MDEP/issues/MDEP-774 and https://issues.apache.org/jira/browse/MDEP-753
           <executions>
             <execution>
               <id>analyze-dependencies</id>
               <goals>
                 <goal>analyze-only</goal>
               </goals>
-              <!-- The analyze-only goal assumes that the test-compile phase has been executed -->
+              &lt;!&ndash; The analyze-only goal assumes that the test-compile phase has been executed &ndash;&gt;
               <phase>verify</phase>
               <configuration>
                 <failOnWarning>true</failOnWarning>
                 <outputXML>true</outputXML>
-                <!-- dependencies not directly used in all projects during tests -->
+                &lt;!&ndash; dependencies not directly used in all projects during tests &ndash;&gt;
                 <ignoredUnusedDeclaredDependencies combine.children="append">
                   <dep>org.apache.logging.log4j:log4j-slf4j-impl</dep>
                   <dep>org.apache.logging.log4j:log4j-core</dep>
@@ -1308,6 +1309,7 @@
               </configuration>
             </execution>
           </executions>
+-->
         </plugin>
 
         <plugin>
@@ -1618,6 +1620,7 @@
                   <silent>true</silent>
                 </configuration>
               </execution>
+<!-- Disabled due to https://issues.apache.org/jira/projects/MDEP/issues/MDEP-774 and https://issues.apache.org/jira/browse/MDEP-753
               <execution>
                 <id>analyze-dependencies</id>
                 <goals>
@@ -1631,6 +1634,7 @@
                   </ignoredUnusedDeclaredDependencies>
                 </configuration>
               </execution>
+-->
             </executions>
           </plugin>
         </plugins>

--- a/protocol-jackson/pom.xml
+++ b/protocol-jackson/pom.xml
@@ -15,6 +15,10 @@
 
   <name>Zeebe Protocol Jackson</name>
 
+  <properties>
+    <version.java>11</version.java>
+  </properties>
+
   <dependencies>
     <!--
       scoped as provided since the annotations are not retained at runtime and therefore it can be


### PR DESCRIPTION
## Description

* Explicitly set java version for modules that need to stay on Java 8 or 11
* Disable the dependency-analyzer plugin execution until https://issues.apache.org/jira/browse/MDEP-753 is fixed
* Upgrade the default version for Java to 17

## Related issues

closes #8030 