### PR TITLE
[Backport stable/1.2] fix(log/stream): ensure the appender future always gets completed

### DIFF
--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.logstreams.impl.log;
 
 import io.camunda.zeebe.dispatcher.Dispatcher;
 import io.camunda.zeebe.dispatcher.Dispatchers;
+import io.camunda.zeebe.dispatcher.Subscription;
 import io.camunda.zeebe.logstreams.impl.Loggers;
 import io.camunda.zeebe.logstreams.log.LogRecordAwaiter;
 import io.camunda.zeebe.logstreams.log.LogStream;
@@ -135,11 +136,29 @@ public final class LogStreamImpl extends Actor
 
   @Override
   protected void handleFailure(final Throwable failure) {
-    if (failure instanceof UnrecoverableException) {
-      onUnrecoverableFailure();
+    onFailure(failure);
+  }
+
+  private void onFailure(final Throwable failure) {
+    LOG.error(
+        "Unexpected error in Log Stream {} in phase {}.",
+        getName(),
+        actor.getLifecyclePhase(),
+        failure);
+
+    if (appenderFuture != null && !appenderFuture.isDone()) {
+      // the appender future is not done yet ->
+      // log stream was currently trying to
+      // open the log storage appender but did
+      // not succeed yet
+      appenderFuture.completeExceptionally(failure);
     }
 
-    super.handleFailure(failure);
+    if (failure instanceof UnrecoverableException) {
+      onUnrecoverableFailure();
+    } else {
+      onFailure();
+    }
   }
 
   @Override
@@ -159,25 +178,23 @@ public final class LogStreamImpl extends Actor
 
   @Override
   public ActorFuture<LogStreamRecordWriter> newLogStreamRecordWriter() {
-    // this should be replaced after refactoring the actor control
-    if (actor.isClosed()) {
-      return CompletableActorFuture.completedExceptionally(new RuntimeException("Actor is closed"));
-    }
-
-    final var writerFuture = new CompletableActorFuture<LogStreamRecordWriter>();
-    actor.run(() -> createWriter(writerFuture, LogStreamWriterImpl::new));
-    return writerFuture;
+    return newLogStreamWriter(LogStreamWriterImpl::new);
   }
 
   @Override
   public ActorFuture<LogStreamBatchWriter> newLogStreamBatchWriter() {
+    return newLogStreamWriter(LogStreamBatchWriterImpl::new);
+  }
+
+  private <T extends LogStreamWriter> ActorFuture<T> newLogStreamWriter(
+      final WriterCreator<T> logStreamCreator) {
     // this should be replaced after refactoring the actor control
     if (actor.isClosed()) {
       return CompletableActorFuture.completedExceptionally(new RuntimeException("Actor is closed"));
     }
 
-    final var writerFuture = new CompletableActorFuture<LogStreamBatchWriter>();
-    actor.run(() -> createWriter(writerFuture, LogStreamBatchWriterImpl::new));
+    final var writerFuture = new CompletableActorFuture<T>();
+    actor.run(() -> createWriter(writerFuture, logStreamCreator));
     return writerFuture;
   }
 
@@ -208,13 +225,13 @@ public final class LogStreamImpl extends Actor
 
   private <T extends LogStreamWriter> void createWriter(
       final CompletableActorFuture<T> writerFuture, final WriterCreator<T> creator) {
+
+    final var onOpenAppenderConsumer = onOpenAppender(writerFuture, creator);
+
     if (appender != null) {
-      writerFuture.complete(creator.create(partitionId, writeBuffer));
-    } else if (appenderFuture != null) {
-      appenderFuture.onComplete(onOpenAppender(writerFuture, creator));
+      onOpenAppenderConsumer.accept(appender, null);
     } else {
-      appenderFuture = new CompletableActorFuture<>();
-      openAppender().onComplete(onOpenAppender(writerFuture, creator));
+      openAppender().onComplete(onOpenAppenderConsumer);
     }
   }
 
@@ -231,17 +248,29 @@ public final class LogStreamImpl extends Actor
 
   private ActorFuture<Void> closeAppender() {
     final var closeAppenderFuture = new CompletableActorFuture<Void>();
-    if (appender == null) {
+
+    LOG.info("Close appender for log stream {}", logName);
+
+    final var toCloseAppender = appender;
+    final var toCloseWriteBuffer = writeBuffer;
+    final var toCompleteExceptionallyAppenderFuture = appenderFuture;
+
+    appender = null;
+    writeBuffer = null;
+    appenderFuture = null;
+
+    if (toCompleteExceptionallyAppenderFuture != null
+        && !toCompleteExceptionallyAppenderFuture.isDone()) {
+      // while opening the appender, a close signal is received
+      toCompleteExceptionallyAppenderFuture.completeExceptionally(
+          new LogStorageAppenderClosedException());
+    }
+
+    if (toCloseAppender == null) {
       closeAppenderFuture.complete(null);
       return closeAppenderFuture;
     }
 
-    appenderFuture = null;
-    LOG.info("Close appender for log stream {}", logName);
-    final var toCloseAppender = appender;
-    final var toCloseWriteBuffer = writeBuffer;
-    appender = null;
-    writeBuffer = null;
     toCloseAppender
         .closeAsync()
         .onComplete(
@@ -252,81 +281,77 @@ public final class LogStreamImpl extends Actor
                 closeAppenderFuture.completeExceptionally(t);
               }
             });
+
     return closeAppenderFuture;
   }
 
   private ActorFuture<LogStorageAppender> openAppender() {
-    try {
-      tryOpenAppender();
-    } catch (final Exception error) {
-      onOpenAppenderFailed(error);
+    if (appenderFuture != null) {
+      return appenderFuture;
     }
+
+    appenderFuture = new CompletableActorFuture<>();
+    actor.run(
+        () -> {
+          final var initialPosition = getWriteBuffersInitialPosition();
+          writeBuffer = createAndScheduleWriteBuffer(initialPosition);
+
+          writeBuffer
+              .openSubscriptionAsync(APPENDER_SUBSCRIPTION_NAME)
+              .onComplete(
+                  (subscription, throwable) -> {
+                    if (throwable == null) {
+                      createAndScheduleLogStorageAppender(subscription)
+                          .onComplete(
+                              (v, t) -> {
+                                if (t != null) {
+                                  onFailure(t);
+                                } else {
+                                  appenderFuture.complete(appender);
+                                  appender.addFailureListener(this);
+                                }
+                              });
+                    } else {
+                      onFailure(throwable);
+                    }
+                  });
+        });
+
     return appenderFuture;
   }
 
-  private void tryOpenAppender() {
-    final long lastPosition;
-    try {
-      lastPosition = getLastPosition();
-    } catch (final UnrecoverableException error) {
-      LOG.error("Unexpected error when opening appender", error);
-      onUnrecoverableFailure();
-      appenderFuture.completeExceptionally(error);
-      return;
-    }
+  private long getWriteBuffersInitialPosition() {
+    final var lastPosition = getLastCommittedPosition();
+    long initialPosition = 1;
 
-    final long initialPosition;
     if (lastPosition > 0) {
       initialPosition = lastPosition + 1;
-    } else {
-      initialPosition = 1;
     }
 
-    writeBuffer =
-        Dispatchers.create(buildActorName(nodeId, "dispatcher", partitionId))
-            .maxFragmentLength(maxFrameLength)
-            .initialPosition(initialPosition)
-            .name(logName + "-write-buffer")
-            .actorSchedulingService(actorSchedulingService)
-            .build();
-
-    writeBuffer
-        .openSubscriptionAsync(APPENDER_SUBSCRIPTION_NAME)
-        .onComplete(
-            (subscription, throwable) -> {
-              if (throwable == null) {
-                appender =
-                    new LogStorageAppender(
-                        buildActorName(nodeId, "LogAppender", partitionId),
-                        partitionId,
-                        logStorage,
-                        subscription,
-                        maxFrameLength);
-
-                actorSchedulingService
-                    .submitActor(appender)
-                    .onComplete(
-                        (v, t) -> {
-                          if (t != null) {
-                            onOpenAppenderFailed(t);
-                          } else {
-                            appenderFuture.complete(appender);
-                            appender.addFailureListener(this);
-                          }
-                        });
-              } else {
-                onOpenAppenderFailed(throwable);
-              }
-            });
+    return initialPosition;
   }
 
-  private void onOpenAppenderFailed(final Throwable error) {
-    LOG.error("Unexpected error when opening appender", error);
-    appenderFuture.completeExceptionally(error);
-    onFailure();
+  private Dispatcher createAndScheduleWriteBuffer(final long initialPosition) {
+    return Dispatchers.create(buildActorName(nodeId, "dispatcher", partitionId))
+        .maxFragmentLength(maxFrameLength)
+        .initialPosition(initialPosition)
+        .name(logName + "-write-buffer")
+        .actorSchedulingService(actorSchedulingService)
+        .build();
   }
 
-  private long getLastPosition() {
+  private ActorFuture<Void> createAndScheduleLogStorageAppender(final Subscription subscription) {
+    appender =
+        new LogStorageAppender(
+            buildActorName(nodeId, "LogAppender", partitionId),
+            partitionId,
+            logStorage,
+            subscription,
+            maxFrameLength);
+    return actorSchedulingService.submitActor(appender);
+  }
+
+  private long getLastCommittedPosition() {
     try (final LogStorageReader storageReader = logStorage.newReader();
         final LogStreamReader logReader = new LogStreamReaderImpl(storageReader)) {
       return logReader.seekToEnd();
@@ -381,5 +406,11 @@ public final class LogStreamImpl extends Actor
   private interface WriterCreator<T extends LogStreamWriter> {
 
     T create(int partitionId, Dispatcher dispatcher);
+  }
+
+  private static final class LogStorageAppenderClosedException extends RuntimeException {
+    private LogStorageAppenderClosedException() {
+      super("LogStorageAppender was closed before opening succeeded");
+    }
   }
 }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamErrorTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamErrorTest.java
@@ -19,12 +19,25 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class LogStreamErrorTest {
+
+  @Parameterized.Parameter(0)
+  public Throwable logStorageException;
 
   @Rule public ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule();
   final LogStorage mockLogStorage = mock(LogStorage.class);
   private SyncLogStream logStream;
+
+  @Parameterized.Parameters
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {new RuntimeException("reader cannot be created")}, {new Error("reader cannot be created")}
+    };
+  }
 
   @Before
   public void setup() {
@@ -35,7 +48,7 @@ public class LogStreamErrorTest {
             .withActorSchedulingService(actorSchedulerRule.get())
             .build();
 
-    when(mockLogStorage.newReader()).thenThrow(new RuntimeException("reader cannot be created"));
+    when(mockLogStorage.newReader()).thenThrow(logStorageException);
   }
 
   @After


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

backports #8605 
relates #7992

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
