### PR TITLE
Mark gateway-protocol as compile time dependency

### DIFF
--- a/gateway-protocol-impl/pom.xml
+++ b/gateway-protocol-impl/pom.xml
@@ -27,9 +27,11 @@
   </properties>
 
   <dependencies>
+    <!-- required to guarantee the protocol is processed earlier during the build -->
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-gateway-protocol</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Description

Marks the gateway-protocol module as a compile dependency only to avoid licensing issues. The protocol is licensed under the Zeebe Community License, whereas the implementation module is licensed under Apache 2. As this is meant to be embedded into other applications, it's better to use the more permissive and understood of the two licenses.

Additionally, the protocol dependency is really only there to ensure that the implementation module always runs after during a maven build, allowing the build to pre-process or generate any resources for the protocol module before the implementation's.

I'm not backporting this as it could be considered a breaking change. For users of previous versions, what they can do is simply exclude the `gateway-protocol` dependency from their applications for now.

## Related issues

closes #8364 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
