### PR TITLE
Fix duplicate test runs when using the `skip-random-tests` and `parallel-tests` profiles

### DIFF
--- a/.ci/scripts/distribution/it-java.sh
+++ b/.ci/scripts/distribution/it-java.sh
@@ -34,8 +34,8 @@ mvn -o -B --fail-never -T "${MAVEN_PARALLELISM}" -s "${MAVEN_SETTINGS_XML}" \
 status=${PIPESTATUS[0]}
 
 # delay checking the maven status after we've checked for flaky and duplicated tests
-findDuplicateTestRuns "${tempFile}" "./DuplicateTests.txt" || exit $?
 analyseFlakyTests "${tempFile}" "./FlakyTests.txt" || exit $?
+findDuplicateTestRuns "${tempFile}" "./DuplicateTests.txt" || exit $?
 
 if [[ $status != 0 ]]; then
   exit "${status}";

--- a/.ci/scripts/distribution/it-java.sh
+++ b/.ci/scripts/distribution/it-java.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -eux
 
 source "${BASH_SOURCE%/*}/../lib/flaky-tests.sh"
+source "${BASH_SOURCE%/*}/../lib/duplicate-tests.sh"
 
 # getconf is a POSIX way to get the number of processors available which works on both Linux and macOS
 LIMITS_CPU=${LIMITS_CPU:-$(getconf _NPROCESSORS_ONLN)}
@@ -32,7 +33,8 @@ mvn -o -B --fail-never -T "${MAVEN_PARALLELISM}" -s "${MAVEN_SETTINGS_XML}" \
   verify | tee "${tempFile}"
 status=${PIPESTATUS[0]}
 
-# delay checking the maven status after we've analysed flaky tests
+# delay checking the maven status after we've checked for flaky and duplicated tests
+findDuplicateTestRuns "${tempFile}" "./DuplicateTests.txt" || exit $?
 analyseFlakyTests "${tempFile}" "./FlakyTests.txt" || exit $?
 
 if [[ $status != 0 ]]; then

--- a/.ci/scripts/distribution/test-java.sh
+++ b/.ci/scripts/distribution/test-java.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -eux
 
 source "${BASH_SOURCE%/*}/../lib/flaky-tests.sh"
+source "${BASH_SOURCE%/*}/../lib/duplicate-tests.sh"
 
 # getconf is a POSIX way to get the number of processors available which works on both Linux and macOS
 LIMITS_CPU=${LIMITS_CPU:-$(getconf _NPROCESSORS_ONLN)}
@@ -31,7 +32,8 @@ mvn -o -B --fail-never -T "${MAVEN_PARALLELISM}" -s "${MAVEN_SETTINGS_XML}" \
   verify | tee "${tempFile}"
 status=${PIPESTATUS[0]}
 
-# delay checking the maven status after we've analysed flaky tests
+# delay checking the maven status after we've checked for flaky and duplicated tests
+findDuplicateTestRuns "${tempFile}" "./DuplicateTests.txt" || exit $?
 analyseFlakyTests "${tempFile}" "./FlakyTests.txt" || exit $?
 
 if [[ $status != 0 ]]; then

--- a/.ci/scripts/distribution/test-java.sh
+++ b/.ci/scripts/distribution/test-java.sh
@@ -33,8 +33,8 @@ mvn -o -B --fail-never -T "${MAVEN_PARALLELISM}" -s "${MAVEN_SETTINGS_XML}" \
 status=${PIPESTATUS[0]}
 
 # delay checking the maven status after we've checked for flaky and duplicated tests
-findDuplicateTestRuns "${tempFile}" "./DuplicateTests.txt" || exit $?
 analyseFlakyTests "${tempFile}" "./FlakyTests.txt" || exit $?
+findDuplicateTestRuns "${tempFile}" "./DuplicateTests.txt" || exit $?
 
 if [[ $status != 0 ]]; then
   exit "${status}";

--- a/.ci/scripts/distribution/test-java8.sh
+++ b/.ci/scripts/distribution/test-java8.sh
@@ -30,10 +30,9 @@ mvn -o -B --fail-never -T "${MAVEN_PARALLELISM}" -s "${MAVEN_SETTINGS_XML}" -pl 
  verify | tee "${tempFile}"
 status=${PIPESTATUS[0]}
 
-# delay checking the maven status after we've analysed flaky tests
 # delay checking the maven status after we've checked for flaky and duplicated tests
-findDuplicateTestRuns "${tempFile}" "./DuplicateTests.txt" || exit $?
 analyseFlakyTests "${tempFile}" "./FlakyTests.txt" || exit $?
+findDuplicateTestRuns "${tempFile}" "./DuplicateTests.txt" || exit $?
 
 if [[ $status != 0 ]]; then
   exit "${status}";

--- a/.ci/scripts/distribution/test-java8.sh
+++ b/.ci/scripts/distribution/test-java8.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -eux
 
 source "${BASH_SOURCE%/*}/../lib/flaky-tests.sh"
+source "${BASH_SOURCE%/*}/../lib/duplicate-tests.sh"
 
 # This is a workaround for JDK8, which does not support the --add-exports options
 rm .mvn/jvm.config
@@ -30,6 +31,8 @@ mvn -o -B --fail-never -T "${MAVEN_PARALLELISM}" -s "${MAVEN_SETTINGS_XML}" -pl 
 status=${PIPESTATUS[0]}
 
 # delay checking the maven status after we've analysed flaky tests
+# delay checking the maven status after we've checked for flaky and duplicated tests
+findDuplicateTestRuns "${tempFile}" "./DuplicateTests.txt" || exit $?
 analyseFlakyTests "${tempFile}" "./FlakyTests.txt" || exit $?
 
 if [[ $status != 0 ]]; then

--- a/.ci/scripts/lib/duplicate-tests.sh
+++ b/.ci/scripts/lib/duplicate-tests.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
-
-# Script that parses maven output to find any tests that are run more than once.
-# Returns 1 when no tests are found (likely an error, for example if the maven output changes) or
-# if any test is run more than once. Otherwise return 0.
-
-# We are using files instead of variables so that we don't spam stdout too much when tracing is enabled.
+#######################################
+# Parses Maven output to find if any tests was run more than once.
+# Globals:
+#   None
+# Arguments:
+#   1 - file containing the test outputs
+#   2 - writable file which where the duplicate tests will be written
+# Outputs:
+#   Error message on STDERR if duplicate tests were found.
+#   Error message on STDERR if no tests were found, indicating the function is broken
+# Returns:
+#   0 if no tests were run multiple times
+#   1 if at least one test was run multiple times or of no tests were found
+#######################################
 function findDuplicateTestRuns() {
   local -r testInputFile="$1"
   local -r outputFile="$2"
@@ -13,11 +21,11 @@ function findDuplicateTestRuns() {
   if [ -s "$tmpFile" ]; then  # found tests
       sort "$tmpFile" | uniq -d | tee "$outputFile"
       if [ -s "$outputFile" ]; then
-          echo "Found duplicate test runs!"
+          echo "Found duplicate test runs!" >&2
           return 1
       fi
       return 0
   fi
-  echo "Could not find any tests, duplicate detection is broken."
+  echo "Could not find any tests, duplicate detection is broken." >&2
   return 1
 }

--- a/.ci/scripts/lib/duplicate-tests.sh
+++ b/.ci/scripts/lib/duplicate-tests.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Script that parses maven output to find any tests that are run more than once.
+# Returns 1 when no tests are found (likely an error, for example if the maven output changes) or
+# if any test is run more than once. Otherwise return 0.
+
+# We are using files instead of variables so that we don't spam stdout too much when tracing is enabled.
+function findDuplicateTestRuns() {
+  local -r testInputFile="$1"
+  local -r outputFile="$2"
+  local -r tmpFile=$(mktemp)
+  grep -oP "\[INFO\] Running \K(io\.camunda\..*)$" "$testInputFile" > "$tmpFile"
+  if [ -s "$tmpFile" ]; then  # found tests
+      sort "$tmpFile" | uniq -d | tee "$outputFile"
+      if [ -s "$outputFile" ]; then
+          echo "Found duplicate test runs!"
+          return 1
+      fi
+      return 0
+  fi
+  echo "Could not find any tests, duplicate detection is broken."
+  return 1
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -176,6 +176,9 @@ pipeline {
                             junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}.xml", keepLongStdio: true, allowEmptyResults: true
                             junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}-FLAKY.xml", keepLongStdio: true, allowEmptyResults: true
                         }
+                        failure {
+                            archiveArtifacts artifacts: '**/FlakyTests.txt, **/DuplicateTests.txt', allowEmptyArchive: true
+                        }
                     }
                 }
 
@@ -198,6 +201,9 @@ pipeline {
                             junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}.xml", keepLongStdio: true, allowEmptyResults: true
                             junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}-FLAKY.xml", keepLongStdio: true, allowEmptyResults: true
                         }
+                        failure {
+                            archiveArtifacts artifacts: '**/DuplicateTests.txt', allowEmptyArchive: true
+                        }
                     }
                 }
 
@@ -216,6 +222,9 @@ pipeline {
                         always {
                             junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}.xml", keepLongStdio: true, allowEmptyResults: true
                             junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}-FLAKY.xml", keepLongStdio: true, allowEmptyResults: true
+                        }
+                        failure {
+                            archiveArtifacts artifacts: '**/FlakyTests.txt, **/DuplicateTests.txt', allowEmptyArchive: true
                         }
                     }
                 }
@@ -290,6 +299,7 @@ pipeline {
                                 failure {
                                     zip zipFile: 'test-reports-it.zip', archive: true, glob: "**/*/failsafe-reports/**"
                                     zip zipFile: 'test-errors-it.zip', archive: true, glob: "**/hs_err_*.log"
+                                    archiveArtifacts artifacts: '**/FlakyTests.txt, **/DuplicateTests.txt', allowEmptyArchive: true
                                 }
                             }
                         }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1412,6 +1412,8 @@
             <configuration>
               <excludes>
                 <exclude>**/*RandomizedPropertyTest.java</exclude>
+                <!-- Re-add the default exclude for inner classes, see https://github.com/camunda-cloud/zeebe/issues/8637 -->
+                <exclude>**/*$*.java</exclude>
               </excludes>
             </configuration>
           </plugin>


### PR DESCRIPTION
## Description

When adding custom excludes to the test discovery configuration of surefire, the default exclude for inner classes is no longer active. This caused issues as surefire will try to run nested test classes when it doesn't need to.

## Related issues

closes #8637 
