### PR TITLE
Assign versions for deployed decisions and DRGs

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -67,7 +67,8 @@ public final class DeploymentTransformer {
             zeebeState.getProcessState(),
             expressionProcessor);
     final var dmnResourceTransformer =
-        new DmnResourceTransformer(keyGenerator, stateWriter, this::getChecksum);
+        new DmnResourceTransformer(
+            keyGenerator, stateWriter, this::getChecksum, zeebeState.getDecisionState());
 
     resourceTransformers =
         Map.ofEntries(
@@ -141,7 +142,7 @@ public final class DeploymentTransformer {
     return rejectionReason;
   }
 
-  private DeploymentResourceTransformer getResourceTransformer(String resourceName) {
+  private DeploymentResourceTransformer getResourceTransformer(final String resourceName) {
     return resourceTransformers.entrySet().stream()
         .filter(entry -> resourceName.endsWith(entry.getKey()))
         .map(Entry::getValue)

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -102,8 +102,8 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
             duplicatedDrg -> {
               final var failureMessage =
                   String.format(
-                      "The decision requirements ids must be unique within a deployment."
-                          + " Found a duplicated id '%s' in the resources '%s' and '%s'.",
+                      "Expected the decision requirements ids to be unique within a deployment"
+                          + " but found a duplicated id '%s' in the resources '%s' and '%s'.",
                       decisionRequirementsId,
                       duplicatedDrg.getResourceName(),
                       resource.getResourceName());
@@ -127,8 +127,8 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
             duplicatedDecision -> {
               final var failureMessage =
                   String.format(
-                      "The decision ids must be unique within a deployment."
-                          + " Found a duplicated id '%s' in the resources '%s' and '%s'.",
+                      "Expected the decision ids to be unique within a deployment"
+                          + " but found a duplicated id '%s' in the resources '%s' and '%s'.",
                       duplicatedDecision.getDecisionId(),
                       findResourceName(
                           deploymentEvent, duplicatedDecision.getDecisionRequirementsKey()),

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentDmnTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentDmnTest.java
@@ -393,8 +393,8 @@ public final class DeploymentDmnTest {
     assertThat(deploymentEvent.getRejectionReason())
         .contains(
             String.format(
-                "The decision requirements ids must be unique within a deployment. "
-                    + "Found a duplicated id 'force-users' in the resources '%s' and '%s'",
+                "Expected the decision requirements ids to be unique within a deployment "
+                    + "but found a duplicated id 'force-users' in the resources '%s' and '%s'",
                 DMN_DECISION_TABLE, DMN_DECISION_TABLE_V2));
   }
 
@@ -418,8 +418,8 @@ public final class DeploymentDmnTest {
     assertThat(deploymentEvent.getRejectionReason())
         .contains(
             String.format(
-                "The decision ids must be unique within a deployment. "
-                    + "Found a duplicated id 'jedi-or-sith' in the resources '%s' and '%s'",
+                "Expected the decision ids to be unique within a deployment "
+                    + "but found a duplicated id 'jedi-or-sith' in the resources '%s' and '%s'",
                 DMN_DECISION_TABLE, DMN_DECISION_TABLE_RENAMED_DRG));
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentDmnTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentDmnTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.io.IOException;
@@ -32,6 +33,10 @@ import org.junit.Test;
 public final class DeploymentDmnTest {
 
   private static final String DMN_DECISION_TABLE = "/dmn/decision-table.dmn";
+  private static final String DMN_DECISION_TABLE_V2 = "/dmn/decision-table_v2.dmn";
+  private static final String DMN_DECISION_TABLE_RENAMED_DRG =
+      "/dmn/decision-table-with-renamed-drg.dmn";
+
   private static final String DMN_INVALID_EXPRESSION =
       "/dmn/decision-table-with-invalid-expression.dmn";
   private static final String DMN_WITH_TWO_DECISIONS = "/dmn/drg-force-user.dmn";
@@ -193,6 +198,179 @@ public final class DeploymentDmnTest {
     assertThat(decisionRecords.get(0).getKey())
         .describedAs("Expect that the decision records have different keys")
         .isNotEqualTo(decisionRecords.get(1).getKey());
+  }
+
+  @Test
+  public void shouldDeployNewVersion() {
+    // given
+    engine.deployment().withXmlClasspathResource(DMN_DECISION_TABLE).deploy();
+
+    // when
+    final var deploymentEvent =
+        engine.deployment().withXmlClasspathResource(DMN_DECISION_TABLE_V2).deploy();
+
+    // then
+    assertThat(deploymentEvent.getValue().getDecisionRequirementsMetadata())
+        .extracting(DecisionRequirementsMetadataValue::getDecisionRequirementsVersion)
+        .describedAs("Expect that the DRG version is increased")
+        .containsExactly(2);
+
+    assertThat(deploymentEvent.getValue().getDecisionsMetadata())
+        .extracting(DecisionRecordValue::getVersion)
+        .describedAs("Expect that the decision version is increased")
+        .containsExactly(2);
+
+    assertThat(RecordingExporter.decisionRequirementsRecords().limit(2))
+        .hasSize(2)
+        .extracting(Record::getValue)
+        .extracting(
+            DecisionRequirementsMetadataValue::getDecisionRequirementsId,
+            DecisionRequirementsMetadataValue::getDecisionRequirementsVersion)
+        .contains(tuple("force-users", 1), tuple("force-users", 2));
+
+    assertThat(RecordingExporter.decisionRecords().limit(2))
+        .hasSize(2)
+        .extracting(Record::getValue)
+        .extracting(DecisionRecordValue::getDecisionId, DecisionRecordValue::getVersion)
+        .contains(tuple("jedi-or-sith", 1), tuple("jedi-or-sith", 2));
+  }
+
+  @Test
+  public void shouldDeployDuplicate() {
+    // given
+    final var firstDeployment =
+        engine.deployment().withXmlClasspathResource(DMN_DECISION_TABLE).deploy();
+
+    final var drgV1 = firstDeployment.getValue().getDecisionRequirementsMetadata().get(0);
+    final var decisionV1 = firstDeployment.getValue().getDecisionsMetadata().get(0);
+
+    // when
+    final var secondDeployment =
+        engine.deployment().withXmlClasspathResource(DMN_DECISION_TABLE).deploy();
+
+    // then
+    assertThat(secondDeployment.getValue().getDecisionRequirementsMetadata()).hasSize(1);
+
+    final var drgMetadata = secondDeployment.getValue().getDecisionRequirementsMetadata().get(0);
+    Assertions.assertThat(drgMetadata)
+        .hasDecisionRequirementsVersion(1)
+        .hasDecisionRequirementsKey(drgV1.getDecisionRequirementsKey())
+        .isDuplicate();
+
+    assertThat(secondDeployment.getValue().getDecisionsMetadata()).hasSize(1);
+
+    final var decisionMetadata = secondDeployment.getValue().getDecisionsMetadata().get(0);
+    Assertions.assertThat(decisionMetadata)
+        .hasVersion(1)
+        .hasDecisionKey(decisionV1.getDecisionKey())
+        .hasDecisionRequirementsKey(drgV1.getDecisionRequirementsKey())
+        .isDuplicate();
+  }
+
+  @Test
+  public void shouldOmitRecordsForDuplicate() {
+    // given
+    engine.deployment().withXmlClasspathResource(DMN_DECISION_TABLE).deploy();
+
+    // when
+    engine.deployment().withXmlClasspathResource(DMN_DECISION_TABLE).deploy();
+
+    engine.deployment().withXmlClasspathResource(DMN_DECISION_TABLE_V2).deploy();
+
+    // then
+    assertThat(RecordingExporter.decisionRequirementsRecords().limit(2))
+        .extracting(Record::getValue)
+        .extracting(DecisionRequirementsMetadataValue::getDecisionRequirementsVersion)
+        .describedAs("Expect to omit decision requirements record for duplicate")
+        .containsExactly(1, 2);
+
+    assertThat(RecordingExporter.decisionRecords().limit(2))
+        .extracting(Record::getValue)
+        .extracting(DecisionRecordValue::getVersion)
+        .describedAs("Expect to omit decision record for duplicate")
+        .containsExactly(1, 2);
+  }
+
+  @Test
+  public void shouldDeployNewVersionIfResourceNameDiffers() {
+    // given
+    final var dmnResource = readResource(DMN_DECISION_TABLE);
+    engine.deployment().withXmlResource(dmnResource, "decision-table.dmn").deploy();
+
+    // when
+    final var deploymentEvent =
+        engine.deployment().withXmlResource(dmnResource, "renamed-decision-table.dmn").deploy();
+
+    // then
+    assertThat(deploymentEvent.getValue().getDecisionRequirementsMetadata())
+        .extracting(DecisionRequirementsMetadataValue::getDecisionRequirementsVersion)
+        .describedAs("Expect that the DRG version is increased")
+        .containsExactly(2);
+
+    assertThat(deploymentEvent.getValue().getDecisionsMetadata())
+        .extracting(DecisionRecordValue::getVersion)
+        .describedAs("Expect that the decision version is increased")
+        .containsExactly(2);
+  }
+
+  @Test
+  public void shouldDeployNewVersionIfDrgIdDiffers() {
+    // given
+    engine.deployment().withXmlClasspathResource(DMN_DECISION_TABLE).deploy();
+
+    // when
+    engine.deployment().withXmlClasspathResource(DMN_DECISION_TABLE_RENAMED_DRG).deploy();
+
+    // then
+    assertThat(RecordingExporter.decisionRequirementsRecords().limit(2))
+        .hasSize(2)
+        .extracting(Record::getValue)
+        .extracting(
+            DecisionRequirementsMetadataValue::getDecisionRequirementsId,
+            DecisionRequirementsMetadataValue::getDecisionRequirementsVersion)
+        .contains(tuple("force-users", 1), tuple("star-wars", 1));
+
+    assertThat(RecordingExporter.decisionRecords().limit(2))
+        .hasSize(2)
+        .extracting(Record::getValue)
+        .extracting(DecisionRecordValue::getDecisionId, DecisionRecordValue::getVersion)
+        .contains(tuple("jedi-or-sith", 1), tuple("jedi-or-sith", 2));
+  }
+
+  @Test
+  public void shouldDeployDecisionWithTwoDrg() {
+    // given
+    engine.deployment().withXmlClasspathResource(DMN_DECISION_TABLE).deploy();
+    engine.deployment().withXmlClasspathResource(DMN_DECISION_TABLE_RENAMED_DRG).deploy();
+
+    // when
+    final var deploymentEvent =
+        engine.deployment().withXmlClasspathResource(DMN_DECISION_TABLE).deploy();
+
+    // then
+    assertThat(deploymentEvent.getValue().getDecisionRequirementsMetadata())
+        .extracting(
+            DecisionRequirementsMetadataValue::getDecisionRequirementsVersion,
+            DecisionRequirementsMetadataValue::isDuplicate)
+        .describedAs("Expect that the DRG is a duplicate")
+        .containsOnly(tuple(1, true));
+
+    assertThat(deploymentEvent.getValue().getDecisionsMetadata())
+        .extracting(DecisionRecordValue::getVersion, DecisionRecordValue::isDuplicate)
+        .describedAs("Expect that the decision version is increased")
+        .containsExactly(tuple(3, false));
+
+    assertThat(RecordingExporter.decisionRecords().limit(3))
+        .hasSize(3)
+        .extracting(Record::getValue)
+        .extracting(
+            DecisionRecordValue::getDecisionId,
+            DecisionRecordValue::getVersion,
+            DecisionRecordValue::getDecisionRequirementsId)
+        .contains(
+            tuple("jedi-or-sith", 1, "force-users"),
+            tuple("jedi-or-sith", 2, "star-wars"),
+            tuple("jedi-or-sith", 3, "force-users"));
   }
 
   private byte[] getChecksum(final String resourceName) {

--- a/engine/src/test/resources/dmn/decision-table-with-renamed-drg.dmn
+++ b/engine/src/test/resources/dmn/decision-table-with-renamed-drg.dmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="star-wars" name="Star Wars" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+  <decision id="jedi-or-sith" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="faction" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utwb1e">
+        <inputEntry id="UnaryTests_1v3sd4m">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tgh8k1">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1bwgcym">
+        <inputEntry id="UnaryTests_0n1ewm3">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19xnlkw">
+          <text>"Sith"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi-or-sith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/engine/src/test/resources/dmn/decision-table_v2.dmn
+++ b/engine/src/test/resources/dmn/decision-table_v2.dmn
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force-users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+  <decision id="jedi-or-sith" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="faction" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utwb1e">
+        <inputEntry id="UnaryTests_1v3sd4m">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tgh8k1">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_082pgko">
+        <inputEntry id="UnaryTests_1c5d2fm">
+          <text>"yellow"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_147e97v">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0ew7pm8">
+        <inputEntry id="UnaryTests_00n1gw3">
+          <text>"purple"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_13mttsk">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1bwgcym">
+        <inputEntry id="UnaryTests_0n1ewm3">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19xnlkw">
+          <text>"Sith"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi-or-sith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>


### PR DESCRIPTION
## Description

* check the DMN resources of a deployment if the DRGs/decisions were deployed before
  * a DRG/decision is a duplicate if the latest DRG/decision in the state has the same resource name and the same checksum (similar to the check of BPMN processes)
  * mark duplicated DRG/decisions and assign the latest versions from the state
  * increase the version if the DRG/decision is different from the latest DRG/decision in the state
* reject deploy command if two DRGs or decisions have the same ID (similar to the check of BPMN process ids)

## Related issues

closes #8174

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
