### PR TITLE
Let `WorkloadGenerator` wait longer for created incident

### DIFF
--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -139,6 +139,12 @@
       <artifactId>netty-common</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/WorkloadGenerator.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/WorkloadGenerator.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.test.util;
 
-import static io.camunda.zeebe.test.util.record.RecordingExporter.processInstanceRecords;
-
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.worker.JobWorker;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -93,6 +91,12 @@ public final class WorkloadGenerator {
         .join();
 
     // wait for incident and resolve it
+    TestUtil.waitUntil(
+        () ->
+            RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("task")
+                .exists());
     final Record<IncidentRecordValue> incident =
         RecordingExporter.incidentRecords(IncidentIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
@@ -104,7 +108,7 @@ public final class WorkloadGenerator {
     // wrap up
     TestUtil.waitUntil(
         () ->
-            processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
                 .filter(r -> r.getKey() == processInstanceKey)
                 .exists());
     worker.close();


### PR DESCRIPTION
## Description

The `WorkloadGenerator` should be easy to use and reliable. Currently, it often fails because it's waiting for an incident record to be exported. Because `WorkloadGenerator` is not really supposed to test whether creating incidents works, I think it's fine to increase the timeout here significantly because we can assume that not finding an incident is just a temporary problem.

Should close #8620
