### PR TITLE
Improve stability of StreamProcessorReplayModeTest#shouldNotSetLastProcessedPositionIfLessThanSnapshotPosition

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -66,7 +66,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private ProcessingStateMachine processingStateMachine;
   private ReplayStateMachine replayStateMachine;
 
-  private volatile Phase phase = Phase.REPLAY;
+  private volatile Phase phase = Phase.INITIAL;
 
   private CompletableActorFuture<Void> openFuture;
   private CompletableActorFuture<Void> closeFuture = CompletableActorFuture.completed(null);
@@ -139,6 +139,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
       if (!shouldProcess) {
         setStateToPausedAndNotifyListeners();
+      } else {
+        phase = Phase.REPLAY;
       }
 
       if (isInReplayOnlyMode()) {
@@ -464,6 +466,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   }
 
   public enum Phase {
+    INITIAL,
     REPLAY,
     PROCESSING,
     FAILED,

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorReplayModeTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorReplayModeTest.java
@@ -311,6 +311,10 @@ public final class StreamProcessorReplayModeTest {
     // when
     startStreamProcessor(replayContinuously);
 
+    Awaitility.await()
+        .untilAsserted(
+            () -> assertThat(getCurrentPhase(replayContinuously)).isEqualTo(Phase.REPLAY));
+
     final var eventPosition =
         replayContinuously.writeEvent(
             ELEMENT_ACTIVATING,


### PR DESCRIPTION
## Description

The test case is flaky because the event is written before the stream processor starts the replay. As a result, the event is skipped and the listener is not invoked as expected.

* define a new stream processor phase: `INITIAL`
* the stream processor is created with the phase `INITIAL` instead of `REPLAY`
* use the new phase to determine when the stream processor starts to replay events
* improve the test case by waiting until the stream processing starts the replay

## Related issues

closes #8558 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
