### PR TITLE
Fix flaky exporter distribute test

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorDistributionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorDistributionTest.java
@@ -93,12 +93,13 @@ public final class ExporterDirectorDistributionTest {
     final long position =
         activeExporters.writeEvent(DeploymentIntent.CREATED, new DeploymentRecord());
 
-    Awaitility.await("director has read all records until now")
-        .untilAsserted(() -> assertThat(exporter.getExportedRecords()).hasSize(1));
-
     final var activeExporterState = activeExporters.getExportersState();
-    assertThat(activeExporterState.getPosition(EXPORTER_ID_1)).isEqualTo(position);
-    assertThat(activeExporterState.getPosition(EXPORTER_ID_2)).isEqualTo(position);
+    Awaitility.await("Director has read all records and update the positions.")
+        .untilAsserted(
+            () -> {
+              assertThat(activeExporterState.getPosition(EXPORTER_ID_1)).isEqualTo(position);
+              assertThat(activeExporterState.getPosition(EXPORTER_ID_2)).isEqualTo(position);
+            });
 
     final var passiveExporterState = passiveExporters.getExportersState();
     assertThat(passiveExporterState.getPosition(EXPORTER_ID_1)).isEqualTo(-1);

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorDistributionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorDistributionTest.java
@@ -86,7 +86,6 @@ public final class ExporterDirectorDistributionTest {
   @Test
   public void shouldDistributeExporterPositions() {
     // given
-    final ControlledTestExporter exporter = exporters.get(1);
     exporters.forEach(e -> e.shouldAutoUpdatePosition(true));
     startExporters(exporterDescriptors);
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/util/ControlledTestExporter.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/util/ControlledTestExporter.java
@@ -11,12 +11,12 @@ import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.record.Record;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
 public class ControlledTestExporter implements Exporter {
-  private final List<Record<?>> exportedRecords = new ArrayList<>();
+  private final List<Record<?>> exportedRecords = new CopyOnWriteArrayList<>();
 
   private boolean shouldAutoUpdatePosition;
   private Consumer<Context> onConfigure;


### PR DESCRIPTION
## Description

  * One issue in our current exporter tests was that the tests (within the main thread) are accessing a non-thread safe collection, while the exporter actor is updating the collection.
  * Previously we awaited that the exporter has seen all records and expected that the position is already updated. This can't be guaranteed. The position was updated after the collection, which lead to race conditions. Furthermore the collection was previously not thread safe. In general it is not necessary to await that the record is read, it is enough to await the position update. 

 This PR fixes both above described issues.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8644 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
