### PR TITLE
[Backport stable/1.2] Deny imports of shaded dependencies from testcontainers

### DIFF
--- a/build-tools/src/main/resources/check/.checkstyle.xml
+++ b/build-tools/src/main/resources/check/.checkstyle.xml
@@ -148,5 +148,9 @@
       <property name="separateLineBetweenGroups" value="true"/>
       <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
     </module>
+
+    <module name="IllegalImport">
+      <property name="illegalPkgs" value="org.testcontainers.shaded"/>
+    </module>
   </module>
 </module>

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredSnapshotTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredSnapshotTest.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,7 +39,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 @RunWith(Parameterized.class)
 public class ClusteredSnapshotTest {
@@ -223,7 +223,7 @@ public class ClusteredSnapshotTest {
         });
   }
 
-  private void awaitUntilAsserted(Consumer<Broker> consumer) {
+  private void awaitUntilAsserted(final Consumer<Broker> consumer) {
     Awaitility.await()
         .pollInterval(Duration.ofSeconds(1))
         .timeout(Duration.ofSeconds(60))
@@ -287,7 +287,7 @@ public class ClusteredSnapshotTest {
         .join();
   }
 
-  private BrokerAssert assertThat(Broker broker) {
+  private BrokerAssert assertThat(final Broker broker) {
     return new BrokerAssert(broker, clusteringRule);
   }
 
@@ -343,7 +343,7 @@ public class ClusteredSnapshotTest {
 
     private final ClusteringRule rule;
 
-    protected BrokerAssert(Broker actual, ClusteringRule rule) {
+    protected BrokerAssert(final Broker actual, final ClusteringRule rule) {
       super(actual, BrokerAssert.class);
       this.rule = rule;
     }
@@ -359,11 +359,11 @@ public class ClusteredSnapshotTest {
 
   private static class SnapshotAssert extends AbstractAssert<SnapshotAssert, SnapshotId> {
 
-    protected SnapshotAssert(SnapshotId actual) {
+    protected SnapshotAssert(final SnapshotId actual) {
       super(actual, SnapshotAssert.class);
     }
 
-    public SnapshotAssert withIndex(long expected) {
+    public SnapshotAssert withIndex(final long expected) {
       Assertions.assertThat(actual.getIndex())
           .withFailMessage(
               "Expecting snapshot index <%s> but was <%s>", expected, actual.getIndex())
@@ -371,14 +371,14 @@ public class ClusteredSnapshotTest {
       return myself;
     }
 
-    public SnapshotAssert withTerm(long expected) {
+    public SnapshotAssert withTerm(final long expected) {
       Assertions.assertThat(actual.getTerm())
           .withFailMessage("Expecting snapshot term <%s> but was <%s>", expected, actual.getTerm())
           .isEqualTo(expected);
       return myself;
     }
 
-    public SnapshotAssert withProcessedPosition(long expected) {
+    public SnapshotAssert withProcessedPosition(final long expected) {
       Assertions.assertThat(actual.getProcessedPosition())
           .withFailMessage(
               "Expecting snapshot processed position <%s> but was <%s>",
@@ -387,7 +387,7 @@ public class ClusteredSnapshotTest {
       return myself;
     }
 
-    public SnapshotAssert withExportedPosition(long expected) {
+    public SnapshotAssert withExportedPosition(final long expected) {
       Assertions.assertThat(actual.getExportedPosition())
           .withFailMessage(
               "Expecting snapshot exported position <%s> but was <%s>",
@@ -397,7 +397,7 @@ public class ClusteredSnapshotTest {
     }
 
     @Override
-    public SnapshotAssert isEqualTo(Object expected) {
+    public SnapshotAssert isEqualTo(final Object expected) {
       return super.isEqualTo(expected);
     }
   }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/BrokerMonitoringEndpointTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/BrokerMonitoringEndpointTest.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.it.health;
 
 import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import io.camunda.zeebe.test.util.testcontainers.ZeebeTestContainerDefaults;
 import io.restassured.builder.RequestSpecBuilder;


### PR DESCRIPTION
Manual backport of #8670 