### PR TITLE
[Backport stable/1.2] Let `WorkloadGenerator` wait longer for created incident

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -112,6 +112,12 @@
       <artifactId>agrona</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/test/src/main/java/io/camunda/zeebe/test/exporter/ExporterIntegrationRule.java
+++ b/test/src/main/java/io/camunda/zeebe/test/exporter/ExporterIntegrationRule.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.test.exporter;
 
 import static io.camunda.zeebe.test.EmbeddedBrokerRule.TEST_RECORD_EXPORTER_ID;
-import static io.camunda.zeebe.test.util.record.RecordingExporter.processInstanceRecords;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,7 +26,6 @@ import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.test.ClientRule;
 import io.camunda.zeebe.test.EmbeddedBrokerRule;
 import io.camunda.zeebe.test.util.TestConfigurationFactory;
-import io.camunda.zeebe.test.util.TestUtil;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.netty.util.NetUtil;
@@ -43,6 +41,7 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
 import org.junit.rules.ExternalResource;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -294,10 +293,16 @@ public class ExporterIntegrationRule extends ExternalResource {
 
     // wait for incident and resolve it
     final Record<IncidentRecordValue> incident =
-        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withElementId("task")
-            .getFirst();
+        Awaitility.await("the incident was created")
+            .timeout(Duration.ofMinutes(1))
+            .until(
+                () ->
+                    RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .withElementId("task")
+                        .findFirst(),
+                Optional::isPresent)
+            .orElseThrow();
     clientRule
         .getClient()
         .newUpdateRetriesCommand(incident.getValue().getJobKey())
@@ -385,11 +390,12 @@ public class ExporterIntegrationRule extends ExternalResource {
    * @param processInstanceKey ID of the process
    */
   public void awaitProcessCompletion(final long processInstanceKey) {
-    TestUtil.waitUntil(
-        () ->
-            processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
-                .filter(r -> r.getKey() == processInstanceKey)
-                .exists());
+    Awaitility.await("the process instance was completed")
+        .until(
+            () ->
+                RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                    .filter(r -> r.getKey() == processInstanceKey)
+                    .exists());
   }
 
   private Properties newClientProperties() {


### PR DESCRIPTION
Manual backport of #8650 