### PR TITLE
[Backport stable/1.3] Let `WorkloadGenerator` wait longer for created incident

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -106,6 +106,12 @@
       <artifactId>agrona</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
Manual backport of #8650 