### PR TITLE
Fix exporter flaky test

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorDistributionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorDistributionTest.java
@@ -150,6 +150,7 @@ public final class ExporterDirectorDistributionTest {
 
     activeExporters.getClock().addTime(DISTRIBUTION_INTERVAL);
     Awaitility.await("Active Director has distributed positions and passive has received it")
+        .conditionEvaluationListener(new ClockShifter(activeExporters.getClock()))
         .untilAsserted(
             () ->
                 assertThat(passiveExporterState.getPosition(EXPORTER_ID_2))

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorDistributionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorDistributionTest.java
@@ -167,13 +167,8 @@ public final class ExporterDirectorDistributionTest {
    * <p>This makes sure that even if we miss one export position event, we distribute the event
    * later again, which makes tests less flaky.
    */
-  private static final class ClockShifter implements ConditionEvaluationListener<Void> {
-
-    private final ControlledActorClock clock;
-
-    public ClockShifter(final ControlledActorClock clock) {
-      this.clock = clock;
-    }
+  private record ClockShifter(ControlledActorClock clock)
+      implements ConditionEvaluationListener<Void> {
 
     @Override
     public void conditionEvaluated(final EvaluatedCondition<Void> condition) {


### PR DESCRIPTION
## Description
In order to make sure that the clock is enhanced and the timers are triggered, we need to use the ClockShifter for each awaitility evaluation. This was used in all other places, but this missed it.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7924 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
