### PR TITLE
Unflake ReplayStateRandomizedPropertyTest

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
-import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -42,17 +41,17 @@ import org.slf4j.Logger;
  *
  * <pre>
  *
- * +-----------------+             +--------------------+
- * |                 |             |                    |      exception
- * | readNextEvent() |------------>|   processEvent()   |------------------+
- * |                 |             |                    |                  v
- * +-----------------+             +--------------------+            +---------------+
+ * +------------------+            +--------------------+
+ * |                  |            |                    |      exception
+ * | readNextRecord() |----------->|  processCommand()  |------------------+
+ * |                  |            |                    |                  v
+ * +------------------+            +--------------------+            +---------------+
  *           ^                             |                         |               |------+
  *           |                             |         +-------------->|   onError()   |      | exception
  *           |                             |         |  exception    |               |<-----+
  *           |                     +-------v-------------+           +---------------+
  *           |                     |                     |                 |
- *           |                     |    writeEvent()     |                 |
+ *           |                     |   writeRecords()    |                 |
  *           |                     |                     |<----------------+
  * +----------------------+        +---------------------+
  * |                      |                 |
@@ -79,7 +78,7 @@ import org.slf4j.Logger;
 public final class ProcessingStateMachine {
 
   private static final Logger LOG = Loggers.PROCESSOR_LOGGER;
-  private static final String ERROR_MESSAGE_WRITE_EVENT_ABORTED =
+  private static final String ERROR_MESSAGE_WRITE_RECORD_ABORTED =
       "Expected to write one or more follow up events for event '{} {}' without errors, but exception was thrown.";
   private static final String ERROR_MESSAGE_ROLLBACK_ABORTED =
       "Expected to roll back the current transaction for event '{} {}' successfully, but exception was thrown.";
@@ -129,17 +128,17 @@ public final class ProcessingStateMachine {
   private final ErrorRecord errorRecord = new ErrorRecord();
   private final RecordValues recordValues;
   private final RecordProcessorMap recordProcessorMap;
-  private final TypedEventImpl typedEvent;
+  private final TypedEventImpl typedCommand;
   private final StreamProcessorMetrics metrics;
   private final StreamProcessorListener streamProcessorListener;
 
   // current iteration
   private SideEffectProducer sideEffectProducer;
-  private LoggedEvent currentEvent;
+  private LoggedEvent currentRecord;
   private TypedRecordProcessor<?> currentProcessor;
   private ZeebeDbTransaction zeebeDbTransaction;
   private long writtenPosition = StreamProcessor.UNSET_POSITION;
-  private long lastSuccessfulProcessedEventPosition = StreamProcessor.UNSET_POSITION;
+  private long lastSuccessfulProcessedRecordPosition = StreamProcessor.UNSET_POSITION;
   private long lastWrittenPosition = StreamProcessor.UNSET_POSITION;
   private volatile boolean onErrorHandlingLoop;
   private int onErrorRetries;
@@ -167,7 +166,7 @@ public final class ProcessingStateMachine {
     this.shouldProcessNext = shouldProcessNext;
 
     final int partitionId = logStream.getPartitionId();
-    typedEvent = new TypedEventImpl(partitionId);
+    typedCommand = new TypedEventImpl(partitionId);
     responseWriter = context.getWriters().response();
 
     metrics = new StreamProcessorMetrics(partitionId);
@@ -175,37 +174,37 @@ public final class ProcessingStateMachine {
   }
 
   private void skipRecord() {
-    notifySkippedListener(currentEvent);
-    actor.submit(this::readNextEvent);
+    notifySkippedListener(currentRecord);
+    actor.submit(this::readNextRecord);
     metrics.eventSkipped();
   }
 
-  void readNextEvent() {
+  void readNextRecord() {
     if (onErrorRetries > 0) {
       onErrorHandlingLoop = false;
       onErrorRetries = 0;
     }
 
-    tryToReadNextEvent();
+    tryToReadNextRecord();
   }
 
-  private void tryToReadNextEvent() {
+  private void tryToReadNextRecord() {
     final var hasNext = logStreamReader.hasNext();
 
-    if (currentEvent != null) {
+    if (currentRecord != null) {
       // All commands cause a follow-up event or rejection, which means the processor
       // reached the end of the log if:
       //  * the last record was an event or rejection
       //  * and there is no next record on the log
-      final var previousEvent = currentEvent;
-      reachedEnd = commandFilter.applies(previousEvent) && !hasNext;
+      final var previousRecord = currentRecord;
+      reachedEnd = commandFilter.applies(previousRecord) && !hasNext;
     }
 
     if (shouldProcessNext.getAsBoolean() && hasNext && currentProcessor == null) {
-      currentEvent = logStreamReader.next();
+      currentRecord = logStreamReader.next();
 
-      if (eventFilter.applies(currentEvent)) {
-        processEvent(currentEvent);
+      if (eventFilter.applies(currentRecord)) {
+        processCommand(currentRecord);
       } else {
         skipRecord();
       }
@@ -223,11 +222,11 @@ public final class ProcessingStateMachine {
     return reachedEnd;
   }
 
-  private void processEvent(final LoggedEvent event) {
+  private void processCommand(final LoggedEvent command) {
     metadata.reset();
-    event.readMetadata(metadata);
+    command.readMetadata(metadata);
 
-    currentProcessor = chooseNextProcessor(event);
+    currentProcessor = chooseNextProcessor(command);
     if (currentProcessor == null) {
       skipRecord();
       return;
@@ -240,28 +239,31 @@ public final class ProcessingStateMachine {
     processingTimer = metrics.startProcessingDurationTimer(metadata.getRecordType());
 
     try {
-      final UnifiedRecordValue value = recordValues.readRecordValue(event, metadata.getValueType());
-      typedEvent.wrap(event, metadata, value);
+      final var value = recordValues.readRecordValue(command, metadata.getValueType());
+      typedCommand.wrap(command, metadata, value);
 
-      metrics.processingLatency(event.getTimestamp(), processingStartTime);
+      metrics.processingLatency(command.getTimestamp(), processingStartTime);
 
-      processInTransaction(typedEvent);
+      processInTransaction(typedCommand);
 
       metrics.commandsProcessed();
 
-      writeEvent();
+      writeRecords();
     } catch (final RecoverableException recoverableException) {
       // recoverable
       LOG.error(
-          ERROR_MESSAGE_PROCESSING_FAILED_RETRY_PROCESSING, event, metadata, recoverableException);
-      actor.runDelayed(PROCESSING_RETRY_DELAY, () -> processEvent(currentEvent));
+          ERROR_MESSAGE_PROCESSING_FAILED_RETRY_PROCESSING,
+          command,
+          metadata,
+          recoverableException);
+      actor.runDelayed(PROCESSING_RETRY_DELAY, () -> processCommand(currentRecord));
     } catch (final Exception e) {
-      LOG.error(ERROR_MESSAGE_PROCESSING_FAILED_SKIP_EVENT, event, metadata, e);
-      onError(e, this::writeEvent);
+      LOG.error(ERROR_MESSAGE_PROCESSING_FAILED_SKIP_EVENT, command, metadata, e);
+      onError(e, this::writeRecords);
     }
   }
 
-  private TypedRecordProcessor<?> chooseNextProcessor(final LoggedEvent event) {
+  private TypedRecordProcessor<?> chooseNextProcessor(final LoggedEvent command) {
     TypedRecordProcessor<?> typedRecordProcessor = null;
 
     try {
@@ -269,7 +271,7 @@ public final class ProcessingStateMachine {
           recordProcessorMap.get(
               metadata.getRecordType(), metadata.getValueType(), metadata.getIntent().value());
     } catch (final Exception e) {
-      LOG.error(ERROR_MESSAGE_ON_EVENT_FAILED_SKIP_EVENT, event, metadata, e);
+      LOG.error(ERROR_MESSAGE_ON_EVENT_FAILED_SKIP_EVENT, command, metadata, e);
     }
 
     return typedRecordProcessor;
@@ -326,7 +328,7 @@ public final class ProcessingStateMachine {
         retryFuture,
         (bool, throwable) -> {
           if (throwable != null) {
-            LOG.error(ERROR_MESSAGE_ROLLBACK_ABORTED, currentEvent, metadata, throwable);
+            LOG.error(ERROR_MESSAGE_ROLLBACK_ABORTED, currentRecord, metadata, throwable);
           }
           try {
             errorHandlingInTransaction(processingException);
@@ -342,7 +344,7 @@ public final class ProcessingStateMachine {
     zeebeDbTransaction = transactionContext.getCurrentTransaction();
     zeebeDbTransaction.run(
         () -> {
-          final long position = typedEvent.getPosition();
+          final long position = typedCommand.getPosition();
           resetOutput(position);
 
           writeRejectionOnCommand(processingException);
@@ -350,30 +352,30 @@ public final class ProcessingStateMachine {
 
           zeebeState
               .getBlackListState()
-              .tryToBlacklist(typedEvent, errorRecord::setProcessInstanceKey);
+              .tryToBlacklist(typedCommand, errorRecord::setProcessInstanceKey);
 
           logStreamWriter.appendFollowUpEvent(
-              typedEvent.getKey(), ErrorIntent.CREATED, errorRecord);
+              typedCommand.getKey(), ErrorIntent.CREATED, errorRecord);
         });
   }
 
   private void writeRejectionOnCommand(final Throwable exception) {
     final String errorMessage =
-        String.format(PROCESSING_ERROR_MESSAGE, typedEvent, exception.getMessage());
+        String.format(PROCESSING_ERROR_MESSAGE, typedCommand, exception.getMessage());
     LOG.error(errorMessage, exception);
 
-    logStreamWriter.appendRejection(typedEvent, RejectionType.PROCESSING_ERROR, errorMessage);
+    logStreamWriter.appendRejection(typedCommand, RejectionType.PROCESSING_ERROR, errorMessage);
     responseWriter.writeRejectionOnCommand(
-        typedEvent, RejectionType.PROCESSING_ERROR, errorMessage);
+        typedCommand, RejectionType.PROCESSING_ERROR, errorMessage);
   }
 
-  private void writeEvent() {
+  private void writeRecords() {
     final ActorFuture<Boolean> retryFuture =
         writeRetryStrategy.runWithRetry(
             () -> {
               final long position = logStreamWriter.flush();
 
-              // only overwrite position if events were flushed
+              // only overwrite position if records were flushed
               if (position > 0) {
                 writtenPosition = position;
               }
@@ -386,12 +388,12 @@ public final class ProcessingStateMachine {
         retryFuture,
         (bool, t) -> {
           if (t != null) {
-            LOG.error(ERROR_MESSAGE_WRITE_EVENT_ABORTED, currentEvent, metadata, t);
-            onError(t, this::writeEvent);
+            LOG.error(ERROR_MESSAGE_WRITE_RECORD_ABORTED, currentRecord, metadata, t);
+            onError(t, this::writeRecords);
           } else {
             // We write various type of records. The positions are always increasing and
             // incremented by 1 for one record (even in a batch), so we can count the amount
-            // of written events via the lastWritten and now written position.
+            // of written records via the lastWritten and now written position.
             final var amount = writtenPosition - lastWrittenPosition;
             metrics.recordsWritten(amount);
             updateState();
@@ -404,8 +406,8 @@ public final class ProcessingStateMachine {
         updateStateRetryStrategy.runWithRetry(
             () -> {
               zeebeDbTransaction.commit();
-              lastSuccessfulProcessedEventPosition = currentEvent.getPosition();
-              metrics.setLastProcessedPosition(lastSuccessfulProcessedEventPosition);
+              lastSuccessfulProcessedRecordPosition = currentRecord.getPosition();
+              metrics.setLastProcessedPosition(lastSuccessfulProcessedRecordPosition);
               lastWrittenPosition = writtenPosition;
               return true;
             },
@@ -415,7 +417,7 @@ public final class ProcessingStateMachine {
         retryFuture,
         (bool, throwable) -> {
           if (throwable != null) {
-            LOG.error(ERROR_MESSAGE_UPDATE_STATE_FAILED, currentEvent, metadata, throwable);
+            LOG.error(ERROR_MESSAGE_UPDATE_STATE_FAILED, currentRecord, metadata, throwable);
             onError(throwable, this::updateState);
           } else {
             executeSideEffects();
@@ -431,17 +433,18 @@ public final class ProcessingStateMachine {
         retryFuture,
         (bool, throwable) -> {
           if (throwable != null) {
-            LOG.error(ERROR_MESSAGE_EXECUTE_SIDE_EFFECT_ABORTED, currentEvent, metadata, throwable);
+            LOG.error(
+                ERROR_MESSAGE_EXECUTE_SIDE_EFFECT_ABORTED, currentRecord, metadata, throwable);
           }
 
-          notifyProcessedListener(typedEvent);
+          notifyProcessedListener(typedCommand);
 
           // observe the processing duration
           processingTimer.close();
 
-          // continue with next event
+          // continue with next record
           currentProcessor = null;
-          actor.submit(this::readNextEvent);
+          actor.submit(this::readNextRecord);
         });
   }
 
@@ -461,8 +464,8 @@ public final class ProcessingStateMachine {
     }
   }
 
-  public long getLastSuccessfulProcessedEventPosition() {
-    return lastSuccessfulProcessedEventPosition;
+  public long getLastSuccessfulProcessedRecordPosition() {
+    return lastSuccessfulProcessedRecordPosition;
   }
 
   public long getLastWrittenPosition() {
@@ -474,20 +477,20 @@ public final class ProcessingStateMachine {
   }
 
   public void startProcessing(final LastProcessingPositions lastProcessingPositions) {
-    // Replay ends at the end of the log and returns the lastSourceEventPosition
+    // Replay ends at the end of the log and returns the lastSourceRecordPosition
     // which is equal to the last processed position
     // we need to seek to the next record after that position where the processing should start
     // Be aware on processing we ignore events, so we will process the next command
     final var lastProcessedPosition = lastProcessingPositions.getLastProcessedPosition();
     logStreamReader.seekToNextEvent(lastProcessedPosition);
-    if (lastSuccessfulProcessedEventPosition == StreamProcessor.UNSET_POSITION) {
-      lastSuccessfulProcessedEventPosition = lastProcessedPosition;
+    if (lastSuccessfulProcessedRecordPosition == StreamProcessor.UNSET_POSITION) {
+      lastSuccessfulProcessedRecordPosition = lastProcessedPosition;
     }
 
     if (lastWrittenPosition == StreamProcessor.UNSET_POSITION) {
       lastWrittenPosition = lastProcessingPositions.getLastWrittenPosition();
     }
 
-    actor.submit(this::readNextEvent);
+    actor.submit(this::readNextRecord);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -79,21 +79,21 @@ public final class ProcessingStateMachine {
 
   private static final Logger LOG = Loggers.PROCESSOR_LOGGER;
   private static final String ERROR_MESSAGE_WRITE_RECORD_ABORTED =
-      "Expected to write one or more follow up events for event '{} {}' without errors, but exception was thrown.";
+      "Expected to write one or more follow-up records for record '{} {}' without errors, but exception was thrown.";
   private static final String ERROR_MESSAGE_ROLLBACK_ABORTED =
-      "Expected to roll back the current transaction for event '{} {}' successfully, but exception was thrown.";
+      "Expected to roll back the current transaction for record '{} {}' successfully, but exception was thrown.";
   private static final String ERROR_MESSAGE_EXECUTE_SIDE_EFFECT_ABORTED =
-      "Expected to execute side effects for event '{} {}' successfully, but exception was thrown.";
+      "Expected to execute side effects for record '{} {}' successfully, but exception was thrown.";
   private static final String ERROR_MESSAGE_UPDATE_STATE_FAILED =
-      "Expected to successfully update state for event '{} {}', but caught an exception. Retry.";
+      "Expected to successfully update state for record '{} {}', but caught an exception. Retry.";
   private static final String ERROR_MESSAGE_ON_EVENT_FAILED_SKIP_EVENT =
-      "Expected to find event processor for event '{} {}', but caught an exception. Skip this event.";
+      "Expected to find processor for record '{} {}', but caught an exception. Skip this record.";
   private static final String ERROR_MESSAGE_PROCESSING_FAILED_SKIP_EVENT =
-      "Expected to successfully process event '{} {}' with processor, but caught an exception. Skip this event.";
+      "Expected to successfully process record '{} {}' with processor, but caught an exception. Skip this record.";
   private static final String ERROR_MESSAGE_PROCESSING_FAILED_RETRY_PROCESSING =
-      "Expected to process event '{} {}' successfully on stream processor, but caught recoverable exception. Retry processing.";
+      "Expected to process record '{} {}' successfully on stream processor, but caught recoverable exception. Retry processing.";
   private static final String PROCESSING_ERROR_MESSAGE =
-      "Expected to process event '%s' without errors, but exception occurred with message '%s'.";
+      "Expected to process record '%s' without errors, but exception occurred with message '%s'.";
   private static final String NOTIFY_PROCESSED_LISTENER_ERROR_MESSAGE =
       "Expected to invoke processed listener for record {} successfully, but exception was thrown.";
   private static final String NOTIFY_SKIPPED_LISTENER_ERROR_MESSAGE =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -202,7 +202,7 @@ public final class ProcessingStateMachine {
       reachedEnd =
           commandFilter.applies(previousRecord)
               && !hasNext
-              && lastWrittenPosition == previousRecord.getPosition();
+              && lastWrittenPosition <= previousRecord.getPosition();
     }
 
     if (shouldProcessNext.getAsBoolean() && hasNext && currentProcessor == null) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -355,7 +355,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
           if (isInReplayOnlyMode()) {
             return replayStateMachine.getLastSourceEventPosition();
           } else {
-            return processingStateMachine.getLastSuccessfulProcessedEventPosition();
+            return processingStateMachine.getLastSuccessfulProcessedRecordPosition();
           }
         });
   }
@@ -453,7 +453,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
               // since the listeners are not recovered yet
               lifecycleAwareListeners.forEach(StreamProcessorLifecycleAware::onResumed);
               phase = Phase.PROCESSING;
-              actor.submit(processingStateMachine::readNextEvent);
+              actor.submit(processingStateMachine::readNextRecord);
               LOG.debug("Resumed processing for partition {}", partitionId);
             }
           }
@@ -462,7 +462,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   @Override
   public void onRecordAvailable() {
-    actor.run(processingStateMachine::readNextEvent);
+    actor.run(processingStateMachine::readNextRecord);
   }
 
   public enum Phase {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -295,7 +295,7 @@ public final class TestStreams {
   }
 
   public void pauseProcessing(final String streamName) {
-    streamContextMap.get(streamName).streamProcessor.pauseProcessing();
+    streamContextMap.get(streamName).streamProcessor.pauseProcessing().join();
     LOG.info("Paused processing for stream {}", streamName);
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

So far, I was unable to reproduce the ReplayStateRandomizedPropertyTest as flaky, but we can still try to stabilize the test.

This tries to unflake the `ReplayStateRandomizedPropertyTest` in 2 ways:

- by waiting for the stream processor to be paused using a simple join on the ActorFuture of `pauseProcessing()`
  -  we now know that the stream processor will actually be paused in the test
- by taking the dispatcher into account when determining whether the stream processor has reached the end
  - reaching the end means that the stream processor is really done with its processing until a non-follow-up command is written. This is an assumption/requirement of the test.
  - the stream processor can write follow-up records to the log stream using the dispatcher
  - the dispatcher writes the records to the log stream asynchronously
  - so follow-up records that keep the engine processing may have been written, but they might not yet be on the log stream
  - we can check this in the stream processor using the `lastWrittenPosition` and comparing it with the position of this last record on the log stream

I've tagged along a few improvements to the stream processor while I was trying to understand it. Specifically, it changes the terminology used in the processing state machine to align with our strict event sourcing.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7778 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
