### PR TITLE
refactor: enable waiting for manual snapshot

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.broker.system.partitions.StateController;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorMode;
 import io.camunda.zeebe.logstreams.impl.Loggers;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotException;
 import io.camunda.zeebe.snapshots.SnapshotException.SnapshotNotFoundException;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
@@ -26,6 +27,7 @@ import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 import org.slf4j.Logger;
@@ -56,7 +58,7 @@ public final class AsyncSnapshotDirector extends Actor
   private Long lastWrittenPosition;
   private TransientSnapshot pendingSnapshot;
   private long lowerBoundSnapshotPosition;
-  private boolean takingSnapshot;
+  private CompletableActorFuture<Optional<PersistedSnapshot>> snapshotFuture;
   private boolean persistingSnapshot;
 
   @SuppressWarnings("java:S3077") // allow volatile here, health is immutable
@@ -124,7 +126,7 @@ public final class AsyncSnapshotDirector extends Actor
         snapshotRate,
         failure);
 
-    resetStateOnFailure();
+    resetStateOnFailure(failure);
     healthReport = HealthReport.unhealthy(this).withIssue(failure);
 
     for (final var listener : listeners) {
@@ -133,7 +135,7 @@ public final class AsyncSnapshotDirector extends Actor
   }
 
   /**
-   * Create an AsyncSnapshotDirector that can take snapshot when the Streamprocessor is in
+   * Create an AsyncSnapshotDirector that can take snapshot when the StreamProcessor is in
    * continuous replay mode.
    *
    * @param nodeId id of this broker
@@ -185,12 +187,20 @@ public final class AsyncSnapshotDirector extends Actor
   }
 
   private void scheduleSnapshotOnRate() {
-    actor.runAtFixedRate(snapshotRate, this::prepareTakingSnapshot);
-    prepareTakingSnapshot();
+    actor.runAtFixedRate(snapshotRate, () -> prepareTakingSnapshot(new CompletableActorFuture<>()));
+    prepareTakingSnapshot(new CompletableActorFuture<>());
   }
 
-  public void forceSnapshot() {
-    actor.call(this::prepareTakingSnapshot);
+  /**
+   * Directly take a snapshot, independently of the scheduled snapshots.
+   *
+   * @return A future that is completed successfully when the snapshot was taken or if the snapshot
+   *     was skipped.
+   */
+  public CompletableActorFuture<Optional<PersistedSnapshot>> forceSnapshot() {
+    final var newSnapshotFuture = new CompletableActorFuture<Optional<PersistedSnapshot>>();
+    actor.call(() -> prepareTakingSnapshot(newSnapshotFuture));
+    return newSnapshotFuture;
   }
 
   @Override
@@ -208,12 +218,15 @@ public final class AsyncSnapshotDirector extends Actor
     actor.run(() -> listeners.remove(failureListener));
   }
 
-  private void prepareTakingSnapshot() {
-    if (takingSnapshot) {
+  private void prepareTakingSnapshot(
+      final CompletableActorFuture<Optional<PersistedSnapshot>> newSnapshotFuture) {
+    if (snapshotFuture != null) {
+      LOG.debug("Already taking snapshot, skipping this request for a new snapshot");
+      newSnapshotFuture.complete(Optional.empty());
       return;
     }
 
-    takingSnapshot = true;
+    snapshotFuture = newSnapshotFuture;
     final var futureLastProcessedPosition = streamProcessor.getLastProcessedPositionAsync();
     actor.runOnCompletion(
         futureLastProcessedPosition,
@@ -222,7 +235,8 @@ public final class AsyncSnapshotDirector extends Actor
             if (lastProcessedPosition == StreamProcessor.UNSET_POSITION) {
               LOG.debug(
                   "We will skip taking this snapshot, because we haven't processed something yet.");
-              takingSnapshot = false;
+              snapshotFuture.complete(Optional.empty());
+              snapshotFuture = null;
               return;
             }
 
@@ -231,7 +245,8 @@ public final class AsyncSnapshotDirector extends Actor
 
           } else {
             LOG.error(ERROR_MSG_ON_RESOLVE_PROCESSED_POS, error);
-            takingSnapshot = false;
+            snapshotFuture.completeExceptionally(error);
+            snapshotFuture = null;
           }
         });
   }
@@ -247,7 +262,7 @@ public final class AsyncSnapshotDirector extends Actor
             } else {
               LOG.error("Failed to take a snapshot for {}", processorName, snapshotTakenError);
             }
-            resetStateOnFailure();
+            resetStateOnFailure(snapshotTakenError);
             return;
           }
 
@@ -271,7 +286,7 @@ public final class AsyncSnapshotDirector extends Actor
       persistingSnapshot = false;
       persistSnapshotIfLastWrittenPositionCommitted();
     } else {
-      resetStateOnFailure();
+      resetStateOnFailure(error);
       LOG.error(ERROR_MSG_ON_RESOLVE_WRITTEN_POS, error);
     }
   }
@@ -318,6 +333,7 @@ public final class AsyncSnapshotDirector extends Actor
       snapshotPersistFuture.onComplete(
           (snapshot, persistError) -> {
             if (persistError != null) {
+              snapshotFuture.completeExceptionally(persistError);
               if (persistError instanceof SnapshotNotFoundException) {
                 LOG.warn(
                     "Failed to persist transient snapshot {}. Nothing to worry if a newer snapshot exists.",
@@ -326,18 +342,24 @@ public final class AsyncSnapshotDirector extends Actor
               } else {
                 LOG.error(ERROR_MSG_MOVE_SNAPSHOT, persistError);
               }
+            } else {
+              snapshotFuture.complete(Optional.of(snapshot));
             }
             lastWrittenPosition = null;
-            takingSnapshot = false;
+            snapshotFuture = null;
             pendingSnapshot = null;
             persistingSnapshot = false;
           });
     }
   }
 
-  private void resetStateOnFailure() {
+  private void resetStateOnFailure(final Throwable failure) {
+    if (snapshotFuture != null && !snapshotFuture.isDone()) {
+      snapshotFuture.completeExceptionally(failure);
+    }
+
     lastWrittenPosition = null;
-    takingSnapshot = false;
+    snapshotFuture = null;
     if (pendingSnapshot != null) {
       pendingSnapshot.abort();
       pendingSnapshot = null;

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
@@ -133,8 +133,8 @@ public final class AsyncSnapshottingTest {
     createAsyncSnapshotDirectorOfProcessingMode();
     final var firstSnapshot = asyncSnapshotDirector.forceSnapshot();
     setCommitPosition(99L);
-    assertThat(firstSnapshot.join()).isPresent();
-    final var firstSnapshotIndex = firstSnapshot.join().orElseThrow().getIndex();
+    assertThat(firstSnapshot.join()).isNotNull();
+    final var firstSnapshotIndex = firstSnapshot.join().getIndex();
 
     // when
     final var secondSnapshot = asyncSnapshotDirector.forceSnapshot();
@@ -143,10 +143,9 @@ public final class AsyncSnapshottingTest {
     // then
     assertThat(secondSnapshot.join())
         .describedAs("Second snapshot is taken")
-        .isPresent()
-        .get()
-        .extracting(PersistedSnapshot::getIndex, as(InstanceOfAssertFactories.LONG))
+        .isNotNull()
         .describedAs("Second snapshot has a higher index")
+        .extracting(PersistedSnapshot::getIndex, as(InstanceOfAssertFactories.LONG))
         .isGreaterThan(firstSnapshotIndex);
     assertThat(persistedSnapshotStore.getLatestSnapshot()).isPresent();
   }
@@ -202,7 +201,7 @@ public final class AsyncSnapshottingTest {
     setCommitPosition(commitPosition);
 
     // then
-    assertThat(secondSnapshot.join()).isPresent();
+    assertThat(secondSnapshot.join()).isNotNull();
     assertThat(persistedSnapshotStore.getLatestSnapshot()).isPresent();
   }
 
@@ -213,7 +212,7 @@ public final class AsyncSnapshottingTest {
     final var snapshot = asyncSnapshotDirector.forceSnapshot();
 
     // then
-    assertThat(snapshot.join()).isPresent();
+    assertThat(snapshot.join()).isNotNull();
     assertThat(persistedSnapshotStore.getLatestSnapshot()).isPresent();
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
@@ -30,14 +32,14 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Optional;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.awaitility.Awaitility;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 
-public final class AsyncSnapshotingTest {
+public final class AsyncSnapshottingTest {
 
   private final TemporaryFolder tempFolderRule = new TemporaryFolder();
   private final AutoCloseableRule autoCloseableRule = new AutoCloseableRule();
@@ -93,7 +95,8 @@ public final class AsyncSnapshotingTest {
         .thenReturn(CompletableActorFuture.completed(32L));
 
     when(mockStreamProcessor.getLastWrittenPositionAsync())
-        .thenReturn(CompletableActorFuture.completed(99L), CompletableActorFuture.completed(100L));
+        .thenReturn(CompletableActorFuture.completed(99L))
+        .thenReturn(CompletableActorFuture.completed(100L));
   }
 
   private void createAsyncSnapshotDirectorOfProcessingMode() {
@@ -114,37 +117,38 @@ public final class AsyncSnapshotingTest {
   public void shouldValidSnapshotWhenCommitPositionGreaterEquals() {
     // given
     createAsyncSnapshotDirectorOfProcessingMode();
-    asyncSnapshotDirector.forceSnapshot();
+    final var snapshot = asyncSnapshotDirector.forceSnapshot();
 
     // when
     setCommitPosition(100L);
 
     // then
-    Awaitility.await()
-        .untilAsserted(() -> assertThat(persistedSnapshotStore.getLatestSnapshot()).isPresent());
+    assertThat(snapshot.join()).isNotNull();
+    assertThat(persistedSnapshotStore.getLatestSnapshot()).isPresent();
   }
 
   @Test
   public void shouldTakeSnapshotsOneByOne() {
     // given
     createAsyncSnapshotDirectorOfProcessingMode();
-    asyncSnapshotDirector.forceSnapshot();
+    final var firstSnapshot = asyncSnapshotDirector.forceSnapshot();
     setCommitPosition(99L);
-    Awaitility.await()
-        .untilAsserted(() -> assertThat(persistedSnapshotStore.getLatestSnapshot()).isPresent());
-    final PersistedSnapshot oldSnapshot = persistedSnapshotStore.getLatestSnapshot().orElseThrow();
+    assertThat(firstSnapshot.join()).isPresent();
+    final var firstSnapshotIndex = firstSnapshot.join().orElseThrow().getIndex();
 
     // when
-    asyncSnapshotDirector.forceSnapshot();
+    final var secondSnapshot = asyncSnapshotDirector.forceSnapshot();
     setCommitPosition(100L);
 
     // then
-    Awaitility.await()
-        .untilAsserted(
-            () ->
-                assertThat(persistedSnapshotStore.getCurrentSnapshotIndex())
-                    .describedAs("New snapshot is taken")
-                    .isGreaterThan(oldSnapshot.getIndex()));
+    assertThat(secondSnapshot.join())
+        .describedAs("Second snapshot is taken")
+        .isPresent()
+        .get()
+        .extracting(PersistedSnapshot::getIndex, as(InstanceOfAssertFactories.LONG))
+        .describedAs("Second snapshot has a higher index")
+        .isGreaterThan(firstSnapshotIndex);
+    assertThat(persistedSnapshotStore.getLatestSnapshot()).isPresent();
   }
 
   @Test
@@ -157,22 +161,21 @@ public final class AsyncSnapshotingTest {
 
     when(mockStreamProcessor.getLastProcessedPositionAsync())
         .thenReturn(CompletableActorFuture.completed(lastProcessedPosition));
+    final var initialFailure = new RuntimeException("getLastWrittenPositionAsync fails");
     when(mockStreamProcessor.getLastWrittenPositionAsync())
-        .thenReturn(
-            CompletableActorFuture.completedExceptionally(
-                new RuntimeException("getLastWrittenPositionAsync fails")));
+        .thenReturn(CompletableActorFuture.completedExceptionally(initialFailure));
     setCommitPosition(commitPosition);
-    asyncSnapshotDirector.forceSnapshot();
-    verify(mockStreamProcessor, timeout(5000).times(1)).getLastWrittenPositionAsync();
+    assertThatThrownBy(() -> asyncSnapshotDirector.forceSnapshot().join()).hasCause(initialFailure);
+    verify(mockStreamProcessor, timeout(10000).times(1)).getLastWrittenPositionAsync();
 
     // when
     when(mockStreamProcessor.getLastWrittenPositionAsync())
         .thenReturn(CompletableActorFuture.completed(lastWrittenPosition));
-    asyncSnapshotDirector.forceSnapshot();
 
     // then
-    Awaitility.await()
-        .untilAsserted(() -> assertThat(persistedSnapshotStore.getLatestSnapshot()).isPresent());
+    assertThat(asyncSnapshotDirector.forceSnapshot().join()).isNotNull();
+    assertThat(persistedSnapshotStore.getLatestSnapshot()).isPresent();
+    verify(mockStreamProcessor, timeout(10000).times(2)).getLastWrittenPositionAsync();
   }
 
   @Test
@@ -183,34 +186,34 @@ public final class AsyncSnapshotingTest {
     final long lastWrittenPosition = 26L;
     final long commitPosition = 100L;
 
+    final var initialFailure = new RuntimeException("getLastProcessedPositionAsync fails");
     when(mockStreamProcessor.getLastProcessedPositionAsync())
-        .thenReturn(
-            CompletableActorFuture.completedExceptionally(
-                new RuntimeException("getLastProcessedPositionAsync fails")));
+        .thenReturn(CompletableActorFuture.completedExceptionally(initialFailure));
     when(mockStreamProcessor.getLastWrittenPositionAsync())
         .thenReturn(CompletableActorFuture.completed(lastWrittenPosition));
-    asyncSnapshotDirector.forceSnapshot();
+
+    assertThatThrownBy(() -> asyncSnapshotDirector.forceSnapshot().join()).hasCause(initialFailure);
     verify(mockStreamProcessor, timeout(5000).times(1)).getLastProcessedPositionAsync();
 
     // when
     when(mockStreamProcessor.getLastProcessedPositionAsync())
         .thenReturn(CompletableActorFuture.completed(lastProcessedPosition));
-    asyncSnapshotDirector.forceSnapshot();
+    final var secondSnapshot = asyncSnapshotDirector.forceSnapshot();
     setCommitPosition(commitPosition);
 
     // then
-    Awaitility.await()
-        .untilAsserted(() -> assertThat(persistedSnapshotStore.getLatestSnapshot()).isPresent());
+    assertThat(secondSnapshot.join()).isPresent();
+    assertThat(persistedSnapshotStore.getLatestSnapshot()).isPresent();
   }
 
   @Test
   public void shouldPersistSnapshotWithoutWaitingForCommitWhenInReplayMode() {
     // when
     createAsyncSnapshotDirectorOfReplayMode();
-    asyncSnapshotDirector.forceSnapshot();
+    final var snapshot = asyncSnapshotDirector.forceSnapshot();
 
     // then
-    Awaitility.await()
-        .untilAsserted(() -> assertThat(persistedSnapshotStore.getLatestSnapshot()).isPresent());
+    assertThat(snapshot.join()).isPresent();
+    assertThat(persistedSnapshotStore.getLatestSnapshot()).isPresent();
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
@@ -124,7 +124,7 @@ public final class AsyncSnapshottingTest {
 
     // then
     assertThat(snapshot.join()).isNotNull();
-    assertThat(persistedSnapshotStore.getLatestSnapshot()).isPresent();
+    assertThat(persistedSnapshotStore.getLatestSnapshot()).hasValue(snapshot.join());
   }
 
   @Test
@@ -147,7 +147,7 @@ public final class AsyncSnapshottingTest {
         .describedAs("Second snapshot has a higher index")
         .extracting(PersistedSnapshot::getIndex, as(InstanceOfAssertFactories.LONG))
         .isGreaterThan(firstSnapshotIndex);
-    assertThat(persistedSnapshotStore.getLatestSnapshot()).isPresent();
+    assertThat(persistedSnapshotStore.getLatestSnapshot()).hasValue(secondSnapshot.join());
   }
 
   @Test
@@ -202,7 +202,7 @@ public final class AsyncSnapshottingTest {
 
     // then
     assertThat(secondSnapshot.join()).isNotNull();
-    assertThat(persistedSnapshotStore.getLatestSnapshot()).isPresent();
+    assertThat(persistedSnapshotStore.getLatestSnapshot()).hasValue(secondSnapshot.join());
   }
 
   @Test
@@ -213,6 +213,6 @@ public final class AsyncSnapshottingTest {
 
     // then
     assertThat(snapshot.join()).isNotNull();
-    assertThat(persistedSnapshotStore.getLatestSnapshot()).isPresent();
+    assertThat(persistedSnapshotStore.getLatestSnapshot()).hasValue(snapshot.join());
   }
 }


### PR DESCRIPTION
## Description
Taking a manual snapshot with `AsyncSnapshotDirector.forceSnapshot` used to be completely async.
Because this has made some tests flaky, we now return a future that is completed when the snapshot was taken (or skipped).
This allows us to wait for snapshots in tests.

I realize this is a bit of a maximalist solution to a flaky test issue so I'm also okay with closing this PR and just fixing it by increasing some timeouts.

## Related issues

closes #8686 

