### PR TITLE
fix(client/java): Reduced log level of job activations

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java
@@ -151,7 +151,7 @@ public final class JobPoller implements StreamObserver<ActivateJobsResponse> {
 
   private void pollingDone() {
     if (activatedJobs > 0) {
-      LOG.trace(
+      LOG.debug(
           "Activated {} jobs for worker {} and job type {}",
           activatedJobs,
           requestBuilder.getWorker(),

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobPoller.java
@@ -151,7 +151,7 @@ public final class JobPoller implements StreamObserver<ActivateJobsResponse> {
 
   private void pollingDone() {
     if (activatedJobs > 0) {
-      LOG.info(
+      LOG.trace(
           "Activated {} jobs for worker {} and job type {}",
           activatedJobs,
           requestBuilder.getWorker(),


### PR DESCRIPTION
## Description

When you have a busy system you get a lot of log entries in the default system telling you that jobs are activated:

```
2022-02-02 08:35:11.397  INFO 20508 --- [ault-executor-2] io.camunda.zeebe.client.job.poller       : Activated 22 jobs for worker default and job type camunda-platform-to-cloud-migration
```

This is very noisy and I wonder if we should switch this log statement to trace.

The potential downside is that this is less visible when getting started - but I think that is OK as a developer quite easily recognizes when his job handler is called (or does its own logging).

WDYT? @falko? 