### PR TITLE
[Backport stable/1.2] Remove references to master

### DIFF
--- a/.ci/scripts/distribution/analyse-java.sh
+++ b/.ci/scripts/distribution/analyse-java.sh
@@ -22,7 +22,7 @@ else
     PROPERTIES+=("-Dsonar.branch.name=${GIT_BRANCH}")
   fi
 
-  if [ "${GIT_BRANCH}" == "master" ] || [ "${GIT_BRANCH}" == "develop" ]; then
+  if [ "${GIT_BRANCH}" == "develop" ]; then
     TARGET_BRANCH="${GIT_BRANCH}"
   else
     TARGET_BRANCH="develop"

--- a/.ci/seed.dsl
+++ b/.ci/seed.dsl
@@ -22,7 +22,7 @@ def seedJob = job('seed-job-zeebe') {
       }
       branch 'develop'
       extensions {
-        localBranch 'master'
+        localBranch 'develop'
         pathRestriction {
           includedRegions(dslScriptPathToMonitor)
           excludedRegions('')
@@ -37,7 +37,7 @@ def seedJob = job('seed-job-zeebe') {
     }
   }
 
-  label 'master'
+  label 'develop'
   jdk '(Default)'
 
   steps {

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,7 +4,6 @@ on:
     tags:
       - v*
     branches:
-      - master
       - develop
   pull_request:
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,11 +70,8 @@ describes:
 
 ## Create a Pull Request
 
-Zeebe follows a
-[gitflow](https://nvie.com/posts/a-successful-git-branching-model/) process.
-The `develop` branch contains the current in-development state of the project. The `master` branch contains the latest stable release.
-
-To work on an issue, follow the following steps:
+The `develop` branch contains the current in-development state of the project. To work on an issue,
+follow the following steps:
 
 1. Check that a [GitHub issue][issues] exists for the task you want to work on.
    If one does not, create one. Refer to the [issue guidelines](#github-issue-guidelines).

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,8 +6,6 @@
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
 def buildName = "${env.JOB_BASE_NAME.replaceAll("%2F", "-").replaceAll("\\.", "-").take(20)}-${env.BUILD_ID}"
 
-def masterBranchName = 'master'
-def isMasterBranch = env.BRANCH_NAME == masterBranchName
 def developBranchName = 'develop'
 def isDevelopBranch = env.BRANCH_NAME == developBranchName
 def latestStableBranchName = 'stable/1.2'
@@ -391,7 +389,7 @@ pipeline {
                                 build job: 'zeebe-docker', parameters: [
                                     string(name: 'BRANCH', value: env.BRANCH_NAME),
                                     string(name: 'VERSION', value: env.VERSION),
-                                    booleanParam(name: 'IS_LATEST', value: isMasterBranch),
+                                    booleanParam(name: 'IS_LATEST', value: false),
                                     booleanParam(name: 'PUSH', value: isDevelopBranch)
                                 ]
                             }

--- a/licenses/Clarification-on-gRPC-code-generation.txt
+++ b/licenses/Clarification-on-gRPC-code-generation.txt
@@ -1,6 +1,6 @@
 Clarification on gRPC Code Generation
 
-The Zeebe Gateway Protocol (API) as published https://github.com/zeebe-io/zeebe/blob/master/gateway-protocol/src/main/proto/gateway.proto
+The Zeebe Gateway Protocol (API) as published https://github.com/zeebe-io/zeebe/blob/develop/gateway-protocol/src/main/proto/gateway.proto
 is licensed under the Zeebe Community License 1.1. Using gRPC tooling to
 generate stubs for the protocol does not constitute creating a derivative work
 under the Zeebe Community License 1.1 and no licensing restrictions are imposed


### PR DESCRIPTION
## Description

Backports removing references to master to stable/1.2.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
