### PR TITLE
fix(inactive): drop transition request if term is not current

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -313,7 +313,7 @@ public interface RaftServer {
    *
    * @return A completable future to be completed once the server is inactive.
    */
-  CompletableFuture<Void> goInactive();
+  CompletableFuture<Void> goInactive(final long term);
 
   /**
    * Returns the current Raft context.

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -140,14 +140,18 @@ public class DefaultRaftServer implements RaftServer {
   }
 
   @Override
-  public CompletableFuture<Void> goInactive() {
+  public CompletableFuture<Void> goInactive(final long term) {
     final CompletableFuture<Void> future = new AtomixFuture<>();
     context
         .getThreadContext()
         .execute(
             () -> {
-              context.transition(Role.INACTIVE);
-              future.complete(null);
+              if (term == context.getTerm()) {
+                context.transition(Role.INACTIVE);
+                future.complete(null);
+              } else {
+                future.completeExceptionally(new RuntimeException("TODO"));
+              }
             });
     return future;
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -248,7 +248,7 @@ public class RaftPartition implements Partition, HealthMonitorable {
         && primary.get() != server.getMemberId();
   }
 
-  public CompletableFuture<Void> goInactive() {
-    return server.goInactive();
+  public CompletableFuture<Void> goInactive(final long term) {
+    return server.goInactive(term);
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -191,8 +191,8 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
         .build();
   }
 
-  public CompletableFuture<Void> goInactive() {
-    return server.goInactive();
+  public CompletableFuture<Void> goInactive(final long term) {
+    return server.goInactive(term);
   }
 
   /**

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -359,7 +359,7 @@ public final class ZeebePartition extends Actor
           context.getPartitionId(),
           context.getCurrentRole(),
           context.getCurrentTerm());
-      context.getRaftPartition().goInactive();
+      context.getRaftPartition().goInactive(context.getCurrentTerm());
     }
   }
 
@@ -368,7 +368,7 @@ public final class ZeebePartition extends Actor
     healthMetrics.setDead();
     zeebePartitionHealth.onUnrecoverableFailure(error);
     transitionToInactive();
-    context.getRaftPartition().goInactive();
+    context.getRaftPartition().goInactive(context.getCurrentTerm());
     failureListeners.forEach((l) -> l.onUnrecoverableFailure(report));
     context.notifyListenersOfBecomingInactive();
   }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -220,7 +220,7 @@ public class ZeebePartitionTest {
             });
     when(raft.getRole()).thenReturn(Role.FOLLOWER);
     when(ctx.getCurrentRole()).thenReturn(Role.FOLLOWER);
-    when(raft.goInactive())
+    when(raft.goInactive(anyLong()))
         .then(
             invocation -> {
               partition.onNewRole(Role.INACTIVE, 2);
@@ -236,7 +236,7 @@ public class ZeebePartitionTest {
     // then
     final InOrder order = inOrder(transition, raft);
     order.verify(transition).toFollower(0L);
-    order.verify(raft).goInactive();
+    order.verify(raft).goInactive(anyLong());
     order.verify(transition).toInactive(anyLong());
   }
 
@@ -266,7 +266,7 @@ public class ZeebePartitionTest {
     final InOrder order = inOrder(transition, raft);
     order.verify(transition).toLeader(0L);
     order.verify(transition).toInactive(anyLong());
-    order.verify(raft).goInactive();
+    order.verify(raft).goInactive(anyLong());
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8717 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
