### PR TITLE
Fix benchmark image setting

### DIFF
--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -1,11 +1,13 @@
 global:
   image:
-    repository: camunda/zeebe
     tag: SNAPSHOT
     pullPolicy: Always
 
 zeebe:
-
+  # Image configuration to configure the zeebe image specifics
+  image:
+    # Image.repository defines which image repository to use
+    repository: camunda/zeebe
   # ClusterSize defines the amount of brokers (=replicas), which are deployed via helm
   clusterSize: "3"
   # PartitionCount defines how many zeebe partitions are set up in the cluster
@@ -78,6 +80,10 @@ zeebe:
 zeebe-gateway:
   # Replicas defines how many standalone gateways are deployed
   replicas: 3
+  # Image configuration to configure the zeebe-gateway image specifics
+  image:
+    # Image.repository defines which image repository to use
+    repository: camunda/zeebe
   # LogLevel defines the log level which is used by the gateway
   logLevel: debug
 

--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -117,9 +117,6 @@ zeebe-gateway:
 
 operate:
   enabled: false
-  global:
-    image:
-      repository: camunda/operate
 
 tasklist:
   enabled: false

--- a/createBenchmark.sh
+++ b/createBenchmark.sh
@@ -62,8 +62,8 @@ cd ../setup/
 cd "$benchmark"
 
 # calls OS specific sed inplace function
-sed_inplace 's/camunda\/zeebe/gcr.io\/zeebe-io\/zeebe/' zeebe-values.yaml
-sed_inplace "s/SNAPSHOT/$benchmark/" zeebe-values.yaml
+sed_inplace 's/camunda\/zeebe/gcr.io\/zeebe-io\/zeebe/g' zeebe-values.yaml
+sed_inplace "s/SNAPSHOT/$benchmark/g" zeebe-values.yaml
 sed_inplace "s/starter:SNAPSHOT/starter:$benchmark/" starter.yaml
 sed_inplace "s/starter:SNAPSHOT/starter:$benchmark/" simpleStarter.yaml
 sed_inplace "s/starter:SNAPSHOT/starter:$benchmark/" timer.yaml


### PR DESCRIPTION
## Description

Uses the new functionality from https://github.com/camunda-community-hub/camunda-cloud-helm/pull/162 to set the images per chart. Adjust the createBenchmark script such that it replaces all occurrences.
<!-- Please explain the changes you made here. -->


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
