### PR TITLE
ci: disable maven cache for smoke tests

### DIFF
--- a/.github/workflows/os-smoke-test.yml
+++ b/.github/workflows/os-smoke-test.yml
@@ -24,38 +24,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Clear broken cache parts (windows)
-        if: matrix.os == 'windows-latest'
-        uses: JesseTG/rm@v1.0.2
-        with:
-          path: C:\Users\runneradmin\.m2\repository\org\agrona\agrona
-      - name: Clear broken cache parts (windows)
-        if: matrix.os == 'windows-latest'
-        uses: JesseTG/rm@v1.0.2
-        with:
-          path: C:\Users\runneradmin\.m2\repository\uk\co\real-logic\sbe-tool
-      - name: Clear broken cache parts (ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        uses: JesseTG/rm@v1.0.2
-        with:
-          path: /home/runner/.m2/repository/org/agrona/agrona
-      - name: Clear broken cache parts (ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        uses: JesseTG/rm@v1.0.2
-        with:
-          path: /home/runner/.m2/repository/uk/co/real-logic/sbe-tool
-      - name: Clear broken cache parts (macos)
-        if: matrix.os == 'macos-latest'
-        uses: JesseTG/rm@v1.0.2
-        with:
-          path: /Users/runner/.m2/repository/org/agrona/agrona
-      - name: Clear broken cache parts (macos)
-        if: matrix.os == 'macos-latest'
-        uses: JesseTG/rm@v1.0.2
-        with:
-          path: /Users/runner/.m2/repository/uk/co/real-logic/sbe-tool
       - name: Build relevant modules
         run: mvn -B -am -pl qa/integration-tests install -DskipTests -DskipChecks -T1C
       - name: Run smoke test


### PR DESCRIPTION
## Description
The cache tends to brake from time to time.
Here we disable the cache under the assumption that downloading
dependencies is fast enough and hopefully more reliable than the cache.