### PR TITLE
Business rule task can evaluate a DMN decision

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.processing.bpmn.event.StartEventProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.gateway.EventBasedGatewayProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.gateway.ExclusiveGatewayProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.gateway.ParallelGatewayProcessor;
+import io.camunda.zeebe.engine.processing.bpmn.task.BusinessRuleTaskProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.task.JobWorkerTaskProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.task.ManualTaskProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.task.ReceiveTaskProcessor;
@@ -37,7 +38,8 @@ public final class BpmnElementProcessors {
   public BpmnElementProcessors(final BpmnBehaviors bpmnBehaviors) {
     // tasks
     processors.put(BpmnElementType.SERVICE_TASK, new JobWorkerTaskProcessor(bpmnBehaviors));
-    processors.put(BpmnElementType.BUSINESS_RULE_TASK, new JobWorkerTaskProcessor(bpmnBehaviors));
+    processors.put(
+        BpmnElementType.BUSINESS_RULE_TASK, new BusinessRuleTaskProcessor(bpmnBehaviors));
     processors.put(BpmnElementType.SCRIPT_TASK, new JobWorkerTaskProcessor(bpmnBehaviors));
     processors.put(BpmnElementType.SEND_TASK, new JobWorkerTaskProcessor(bpmnBehaviors));
     processors.put(BpmnElementType.USER_TASK, new JobWorkerTaskProcessor(bpmnBehaviors));

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
@@ -14,6 +14,8 @@ public interface BpmnBehaviors {
 
   ExpressionProcessor expressionBehavior();
 
+  BpmnDecisionBehavior decisionBehavior();
+
   BpmnVariableMappingBehavior variableMappingBehavior();
 
   BpmnEventPublicationBehavior eventPublicationBehavior();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
+import io.camunda.zeebe.dmn.DecisionEngineFactory;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContainerProcessor;
@@ -26,6 +27,7 @@ import java.util.function.Function;
 public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
   private final ExpressionProcessor expressionBehavior;
+  private final BpmnDecisionBehavior decisionBehavior;
   private final BpmnVariableMappingBehavior variableMappingBehavior;
   private final BpmnEventPublicationBehavior eventPublicationBehavior;
   private final BpmnEventSubscriptionBehavior eventSubscriptionBehavior;
@@ -52,6 +54,9 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
     final StateWriter stateWriter = writers.state();
     final var commandWriter = writers.command();
     this.expressionBehavior = expressionBehavior;
+    decisionBehavior =
+        new BpmnDecisionBehavior(
+            DecisionEngineFactory.createDecisionEngine(), zeebeState, eventTriggerBehavior);
 
     stateBehavior = new BpmnStateBehavior(zeebeState, variableBehavior);
     stateTransitionGuard = new ProcessInstanceStateTransitionGuard(stateBehavior);
@@ -97,6 +102,11 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   @Override
   public ExpressionProcessor expressionBehavior() {
     return expressionBehavior;
+  }
+
+  @Override
+  public BpmnDecisionBehavior decisionBehavior() {
+    return decisionBehavior;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.behavior;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.camunda.zeebe.dmn.DecisionEngine;
+import io.camunda.zeebe.dmn.DecisionEvaluationResult;
+import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
+import io.camunda.zeebe.dmn.impl.VariablesContext;
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCalledDecision;
+import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
+import io.camunda.zeebe.engine.state.deployment.PersistedDecisionRequirements;
+import io.camunda.zeebe.engine.state.immutable.DecisionState;
+import io.camunda.zeebe.engine.state.immutable.VariableState;
+import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.io.ByteArrayInputStream;
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+
+/** Provides decision behavior to the BPMN processors */
+public final class BpmnDecisionBehavior {
+
+  private final DecisionEngine decisionEngine;
+  private final DecisionState decisionState;
+  private final EventTriggerBehavior eventTriggerBehavior;
+  private final VariableState variableState;
+
+  public BpmnDecisionBehavior(
+      final DecisionEngine decisionEngine,
+      final ZeebeState zeebeState,
+      final EventTriggerBehavior eventTriggerBehavior) {
+    this.decisionEngine = decisionEngine;
+    decisionState = zeebeState.getDecisionState();
+    variableState = zeebeState.getVariableState();
+    this.eventTriggerBehavior = eventTriggerBehavior;
+  }
+
+  /**
+   * Evaluate a decision during the processing of a bpmn element.
+   *
+   * @param element the called decision of the current bpmn element
+   * @param context process instance-related data of the element that is executed
+   * @return either an evaluated decision's result or a failure
+   */
+  public Either<Failure, DecisionEvaluationResult> evaluateDecision(
+      final ExecutableCalledDecision element, final BpmnElementContext context) {
+    final var scopeKey = context.getElementInstanceKey();
+
+    final var resultOrFailure =
+        findDrgInState(element)
+            .flatMap(drg -> evaluateDecisionInDrg(drg, element.getDecisionId(), scopeKey));
+
+    // The output mapping behavior determines what to do with the decision result. Since the output
+    // mapping may fail and raise an incident, we need to write the variable to a record. This is
+    // because we want to evaluate the decision on element activation, while the output mapping
+    // happens on element completion. We don't want to re-evaluate the decision for output mapping
+    // related incidents.
+    resultOrFailure.ifRight(
+        result ->
+            triggerProcessEventWithResultVariable(context, element.getResultVariable(), result));
+
+    // the failure must have the correct error type and scope, and we only want to declare this once
+    return resultOrFailure.mapLeft(
+        failure -> new Failure(failure.getMessage(), ErrorType.CALLED_ELEMENT_ERROR, scopeKey));
+  }
+
+  // todo(#8571): avoid parsing drg every time
+  private Either<Failure, ParsedDecisionRequirementsGraph> findDrgInState(
+      final ExecutableCalledDecision element) {
+    return findDecisionById(element.getDecisionId())
+        .flatMap(this::findDrgByDecision)
+        .mapLeft(
+            failure ->
+                new Failure(
+                    "Expected to evaluate decision id '%s', but %s"
+                        .formatted(element.getDecisionId(), failure.getMessage())))
+        .flatMap(drg -> parseDrg(drg.getResource()));
+  }
+
+  private Either<Failure, PersistedDecision> findDecisionById(final String decisionId) {
+    return Either.ofOptional(
+            decisionState.findLatestDecisionById(BufferUtil.wrapString(decisionId)))
+        .orElse(new Failure("no decision found for id '%s'".formatted(decisionId)));
+  }
+
+  private Either<Failure, PersistedDecisionRequirements> findDrgByDecision(
+      final PersistedDecision decision) {
+    final var key = decision.getDecisionRequirementsKey();
+    final var id = decision.getDecisionRequirementsId();
+    return Either.ofOptional(decisionState.findDecisionRequirementsByKey(key))
+        .orElse(new Failure("no drg found for id '%s'".formatted(bufferAsString(id))));
+  }
+
+  private Either<Failure, ParsedDecisionRequirementsGraph> parseDrg(final DirectBuffer resource) {
+    return Either.<Failure, DirectBuffer>right(resource)
+        .map(BufferUtil::bufferAsArray)
+        .map(ByteArrayInputStream::new)
+        .map(decisionEngine::parse)
+        .flatMap(
+            parseResult -> {
+              if (parseResult.isValid()) {
+                return Either.right(parseResult);
+              } else {
+                return Either.left(new Failure(parseResult.getFailureMessage()));
+              }
+            });
+  }
+
+  private Either<Failure, DecisionEvaluationResult> evaluateDecisionInDrg(
+      final ParsedDecisionRequirementsGraph drg, final String decisionId, final long scopeKey) {
+    final var variables = variableState.getVariablesAsDocument(scopeKey);
+    final var evaluationContext = new VariablesContext(MsgPackConverter.convertToMap(variables));
+    final var result = decisionEngine.evaluateDecisionById(drg, decisionId, evaluationContext);
+    if (result.isFailure()) {
+      return Either.left(new Failure(result.getFailureMessage()));
+    } else {
+      return Either.right(result);
+    }
+  }
+
+  private void triggerProcessEventWithResultVariable(
+      final BpmnElementContext context,
+      final String resultVariableName,
+      final DecisionEvaluationResult result) {
+    final DirectBuffer resultVariable =
+        serializeToNamedVariable(resultVariableName, result.getOutput());
+    eventTriggerBehavior.triggeringProcessEvent(
+        context.getProcessDefinitionKey(),
+        context.getProcessInstanceKey(),
+        context.getElementInstanceKey(),
+        context.getElementId(),
+        resultVariable);
+  }
+
+  private static DirectBuffer serializeToNamedVariable(
+      final String name, final DirectBuffer value) {
+    final var resultBuffer = new ExpandableArrayBuffer();
+    final var writer = new MsgPackWriter();
+    writer.wrap(resultBuffer, 0);
+    writer.writeMapHeader(1);
+    writer.writeString(BufferUtil.wrapString(name));
+    writer.writeRaw(value);
+    return resultBuffer;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/BusinessRuleTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/BusinessRuleTaskProcessor.java
@@ -157,7 +157,7 @@ public final class BusinessRuleTaskProcessor
     }
   }
 
-  /** Extract different behaviors depending on the type of event. */
+  /** Extract different behaviors depending on the type of task. */
   private interface BusinessRuleTaskBehavior {
     void onActivate(ExecutableBusinessRuleTask element, BpmnElementContext activating);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/BusinessRuleTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/BusinessRuleTaskProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.bpmn.task;
 
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementProcessor;
+import io.camunda.zeebe.engine.processing.bpmn.BpmnProcessingException;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnDecisionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventSubscriptionBehavior;
@@ -36,28 +37,30 @@ public final class BusinessRuleTaskProcessor
   @Override
   public void onActivate(
       final ExecutableBusinessRuleTask element, final BpmnElementContext context) {
-    eventBehaviorOf(element).onActivate(element, context);
+    eventBehaviorOf(element, context).onActivate(element, context);
   }
 
   @Override
   public void onComplete(
       final ExecutableBusinessRuleTask element, final BpmnElementContext context) {
-    eventBehaviorOf(element).onComplete(element, context);
+    eventBehaviorOf(element, context).onComplete(element, context);
   }
 
   @Override
   public void onTerminate(
       final ExecutableBusinessRuleTask element, final BpmnElementContext context) {
-    eventBehaviorOf(element).onTerminate(element, context);
+    eventBehaviorOf(element, context).onTerminate(element, context);
   }
 
-  private BusinessRuleTaskBehavior eventBehaviorOf(final ExecutableBusinessRuleTask element) {
+  private BusinessRuleTaskBehavior eventBehaviorOf(
+      final ExecutableBusinessRuleTask element, final BpmnElementContext context) {
     if (element.getDecisionId() != null) {
       return calledDecisionBehavior;
     } else if (element.getJobWorkerProperties() != null) {
       return jobWorkerTaskBehavior;
     } else {
-      throw new IllegalArgumentException(
+      throw new BpmnProcessingException(
+          context,
           "Expected to process business rule task, but could not determine processing behavior");
     }
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/BusinessRuleTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/BusinessRuleTaskProcessor.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.task;
+
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementProcessor;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableBusinessRuleTask;
+
+public final class BusinessRuleTaskProcessor
+    implements BpmnElementProcessor<ExecutableBusinessRuleTask> {
+
+  private final BusinessRuleTaskBehavior calledDecisionBehavior;
+  private final BusinessRuleTaskBehavior jobWorkerTaskBehavior;
+
+  public BusinessRuleTaskProcessor(final BpmnBehaviors bpmnBehaviors) {
+    calledDecisionBehavior = new CalledDecisionBehavior();
+    jobWorkerTaskBehavior = new JobWorkerTaskBehavior(bpmnBehaviors);
+  }
+
+  @Override
+  public Class<ExecutableBusinessRuleTask> getType() {
+    return ExecutableBusinessRuleTask.class;
+  }
+
+  @Override
+  public void onActivate(
+      final ExecutableBusinessRuleTask element, final BpmnElementContext context) {
+    eventBehaviorOf(element).onActivate(element, context);
+  }
+
+  @Override
+  public void onComplete(
+      final ExecutableBusinessRuleTask element, final BpmnElementContext context) {
+    eventBehaviorOf(element).onComplete(element, context);
+  }
+
+  @Override
+  public void onTerminate(
+      final ExecutableBusinessRuleTask element, final BpmnElementContext context) {
+    eventBehaviorOf(element).onTerminate(element, context);
+  }
+
+  private BusinessRuleTaskBehavior eventBehaviorOf(final ExecutableBusinessRuleTask element) {
+    if (element.getDecisionId() != null) {
+      return calledDecisionBehavior;
+    } else if (element.getJobWorkerProperties() != null) {
+      return jobWorkerTaskBehavior;
+    } else {
+      throw new IllegalArgumentException(
+          "Expected to process business rule task, but could not determine processing behavior");
+    }
+  }
+
+  private static final class CalledDecisionBehavior implements BusinessRuleTaskBehavior {
+
+    @Override
+    public void onActivate(
+        final ExecutableBusinessRuleTask element, final BpmnElementContext activating) {
+      // todo: implement
+    }
+
+    @Override
+    public void onComplete(
+        final ExecutableBusinessRuleTask element, final BpmnElementContext completing) {
+      // todo: implement
+    }
+
+    @Override
+    public void onTerminate(
+        final ExecutableBusinessRuleTask element, final BpmnElementContext terminating) {
+      // todo: implement
+    }
+  }
+
+  private static final class JobWorkerTaskBehavior implements BusinessRuleTaskBehavior {
+
+    private final JobWorkerTaskProcessor delegate;
+
+    public JobWorkerTaskBehavior(final BpmnBehaviors bpmnBehaviors) {
+      delegate = new JobWorkerTaskProcessor(bpmnBehaviors);
+    }
+
+    @Override
+    public void onActivate(
+        final ExecutableBusinessRuleTask element, final BpmnElementContext activating) {
+      delegate.onActivate(element, activating);
+    }
+
+    @Override
+    public void onComplete(
+        final ExecutableBusinessRuleTask element, final BpmnElementContext completing) {
+      delegate.onComplete(element, completing);
+    }
+
+    @Override
+    public void onTerminate(
+        final ExecutableBusinessRuleTask element, final BpmnElementContext terminating) {
+      delegate.onTerminate(element, terminating);
+    }
+  }
+
+  /** Extract different behaviors depending on the type of event. */
+  private interface BusinessRuleTaskBehavior {
+    void onActivate(ExecutableBusinessRuleTask element, BpmnElementContext activating);
+
+    void onComplete(ExecutableBusinessRuleTask element, BpmnElementContext completing);
+
+    void onTerminate(ExecutableBusinessRuleTask element, BpmnElementContext terminating);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableBusinessRuleTask.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableBusinessRuleTask.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.element;
+
+public final class ExecutableBusinessRuleTask extends ExecutableJobWorkerTask {
+
+  private String decisionId;
+  private String resultVariable;
+
+  public ExecutableBusinessRuleTask(final String id) {
+    super(id);
+  }
+
+  public String getDecisionId() {
+    return decisionId;
+  }
+
+  public void setDecisionId(final String decisionId) {
+    this.decisionId = decisionId;
+  }
+
+  public String getResultVariable() {
+    return resultVariable;
+  }
+
+  public void setResultVariable(final String resultVariable) {
+    this.resultVariable = resultVariable;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableBusinessRuleTask.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableBusinessRuleTask.java
@@ -7,7 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
-public final class ExecutableBusinessRuleTask extends ExecutableJobWorkerTask {
+public final class ExecutableBusinessRuleTask extends ExecutableJobWorkerTask
+    implements ExecutableCalledDecision {
 
   private String decisionId;
   private String resultVariable;
@@ -16,18 +17,22 @@ public final class ExecutableBusinessRuleTask extends ExecutableJobWorkerTask {
     super(id);
   }
 
+  @Override
   public String getDecisionId() {
     return decisionId;
   }
 
+  @Override
   public void setDecisionId(final String decisionId) {
     this.decisionId = decisionId;
   }
 
+  @Override
   public String getResultVariable() {
     return resultVariable;
   }
 
+  @Override
   public void setResultVariable(final String resultVariable) {
     this.resultVariable = resultVariable;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCalledDecision.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCalledDecision.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.element;
+
+/** A representation of an element that calls a decision. For example, a business rule task. */
+public interface ExecutableCalledDecision {
+
+  String getDecisionId();
+
+  void setDecisionId(String decisionId);
+
+  String getResultVariable();
+
+  void setResultVariable(String resultVariable);
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.deployment.model.transformation;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.BoundaryEventTransformer;
+import io.camunda.zeebe.engine.processing.deployment.model.transformer.BusinessRuleTaskTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.CallActivityTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.CatchEventTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.ContextProcessTransformer;
@@ -31,7 +32,6 @@ import io.camunda.zeebe.engine.processing.deployment.model.transformer.StartEven
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.SubProcessTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.UserTaskTransformer;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
 import io.camunda.zeebe.model.bpmn.instance.ScriptTask;
 import io.camunda.zeebe.model.bpmn.instance.SendTask;
 import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
@@ -73,6 +73,7 @@ public final class BpmnTransformer {
 
     step2Visitor = new TransformationVisitor();
     step2Visitor.registerHandler(new BoundaryEventTransformer());
+    step2Visitor.registerHandler(new BusinessRuleTaskTransformer());
     step2Visitor.registerHandler(new CallActivityTransformer());
     step2Visitor.registerHandler(new CatchEventTransformer());
     step2Visitor.registerHandler(new ContextProcessTransformer());
@@ -80,7 +81,6 @@ public final class BpmnTransformer {
     step2Visitor.registerHandler(new FlowNodeTransformer());
     step2Visitor.registerHandler(new IntermediateThrowEventTransformer());
     step2Visitor.registerHandler(new JobWorkerElementTransformer<>(ServiceTask.class));
-    step2Visitor.registerHandler(new JobWorkerElementTransformer<>(BusinessRuleTask.class));
     step2Visitor.registerHandler(new JobWorkerElementTransformer<>(ScriptTask.class));
     step2Visitor.registerHandler(new JobWorkerElementTransformer<>(SendTask.class));
     step2Visitor.registerHandler(new ReceiveTaskTransformer());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/BusinessRuleTaskTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/BusinessRuleTaskTransformer.java
@@ -7,13 +7,15 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.transformer;
 
-import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableBusinessRuleTask;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
+import io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe.CalledDecisionTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe.TaskDefinitionTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe.TaskHeadersTransformer;
 import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
 
@@ -23,6 +25,8 @@ public final class BusinessRuleTaskTransformer
   private final TaskDefinitionTransformer taskDefinitionTransformer =
       new TaskDefinitionTransformer();
   private final TaskHeadersTransformer taskHeadersTransformer = new TaskHeadersTransformer();
+  private final CalledDecisionTransformer calledDecisionTransformer =
+      new CalledDecisionTransformer();
 
   @Override
   public Class<BusinessRuleTask> getType() {
@@ -34,12 +38,15 @@ public final class BusinessRuleTaskTransformer
 
     final ExecutableProcess process = context.getCurrentProcess();
     final var executableTask =
-        process.getElementById(element.getId(), ExecutableJobWorkerElement.class);
+        process.getElementById(element.getId(), ExecutableBusinessRuleTask.class);
 
     final var taskDefinition = element.getSingleExtensionElement(ZeebeTaskDefinition.class);
     taskDefinitionTransformer.transform(executableTask, context, taskDefinition);
 
     final var taskHeaders = element.getSingleExtensionElement(ZeebeTaskHeaders.class);
     taskHeadersTransformer.transform(executableTask, taskHeaders, element);
+
+    final var calledDecision = element.getSingleExtensionElement(ZeebeCalledDecision.class);
+    calledDecisionTransformer.transform(executableTask, calledDecision);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/BusinessRuleTaskTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/BusinessRuleTaskTransformer.java
@@ -9,12 +9,13 @@ package io.camunda.zeebe.engine.processing.deployment.model.transformer;
 
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
-import io.camunda.zeebe.engine.processing.deployment.model.element.JobWorkerProperties;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe.TaskDefinitionTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe.TaskHeadersTransformer;
 import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
 
 public final class BusinessRuleTaskTransformer
     implements ModelElementTransformer<BusinessRuleTask> {
@@ -32,13 +33,13 @@ public final class BusinessRuleTaskTransformer
   public void transform(final BusinessRuleTask element, final TransformContext context) {
 
     final ExecutableProcess process = context.getCurrentProcess();
-    final ExecutableJobWorkerElement jobWorkerElement =
+    final var executableTask =
         process.getElementById(element.getId(), ExecutableJobWorkerElement.class);
 
-    final var jobWorkerProperties = new JobWorkerProperties();
-    jobWorkerElement.setJobWorkerProperties(jobWorkerProperties);
+    final var taskDefinition = element.getSingleExtensionElement(ZeebeTaskDefinition.class);
+    taskDefinitionTransformer.transform(executableTask, context, taskDefinition);
 
-    taskDefinitionTransformer.transform(element, jobWorkerProperties, context);
-    taskHeadersTransformer.transform(element, jobWorkerProperties);
+    final var taskHeaders = element.getSingleExtensionElement(ZeebeTaskHeaders.class);
+    taskHeadersTransformer.transform(executableTask, taskHeaders, element);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/BusinessRuleTaskTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/BusinessRuleTaskTransformer.java
@@ -14,27 +14,22 @@ import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelE
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe.TaskDefinitionTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe.TaskHeadersTransformer;
-import io.camunda.zeebe.model.bpmn.instance.FlowElement;
+import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
 
-public final class JobWorkerElementTransformer<T extends FlowElement>
-    implements ModelElementTransformer<T> {
+public final class BusinessRuleTaskTransformer
+    implements ModelElementTransformer<BusinessRuleTask> {
 
-  private final Class<T> type;
   private final TaskDefinitionTransformer taskDefinitionTransformer =
       new TaskDefinitionTransformer();
   private final TaskHeadersTransformer taskHeadersTransformer = new TaskHeadersTransformer();
 
-  public JobWorkerElementTransformer(final Class<T> type) {
-    this.type = type;
+  @Override
+  public Class<BusinessRuleTask> getType() {
+    return BusinessRuleTask.class;
   }
 
   @Override
-  public Class<T> getType() {
-    return type;
-  }
-
-  @Override
-  public void transform(final T element, final TransformContext context) {
+  public void transform(final BusinessRuleTask element, final TransformContext context) {
 
     final ExecutableProcess process = context.getCurrentProcess();
     final ExecutableJobWorkerElement jobWorkerElement =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowElementInstantiationTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowElementInstantiationTransformer.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.deployment.model.transformer;
 import io.camunda.zeebe.engine.processing.deployment.model.element.AbstractFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableActivity;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableBoundaryEvent;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableBusinessRuleTask;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCallActivity;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEndEvent;
@@ -59,7 +60,7 @@ public final class FlowElementInstantiationTransformer
     ELEMENT_FACTORIES = new HashMap<>();
 
     ELEMENT_FACTORIES.put(Activity.class, ExecutableActivity::new);
-    ELEMENT_FACTORIES.put(BusinessRuleTask.class, ExecutableJobWorkerTask::new);
+    ELEMENT_FACTORIES.put(BusinessRuleTask.class, ExecutableBusinessRuleTask::new);
     ELEMENT_FACTORIES.put(BoundaryEvent.class, ExecutableBoundaryEvent::new);
     ELEMENT_FACTORIES.put(CallActivity.class, ExecutableCallActivity::new);
     ELEMENT_FACTORIES.put(EndEvent.class, ExecutableEndEvent::new);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/JobWorkerElementTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/JobWorkerElementTransformer.java
@@ -9,12 +9,13 @@ package io.camunda.zeebe.engine.processing.deployment.model.transformer;
 
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
-import io.camunda.zeebe.engine.processing.deployment.model.element.JobWorkerProperties;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe.TaskDefinitionTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe.TaskHeadersTransformer;
 import io.camunda.zeebe.model.bpmn.instance.FlowElement;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
 
 public final class JobWorkerElementTransformer<T extends FlowElement>
     implements ModelElementTransformer<T> {
@@ -40,10 +41,10 @@ public final class JobWorkerElementTransformer<T extends FlowElement>
     final ExecutableJobWorkerElement jobWorkerElement =
         process.getElementById(element.getId(), ExecutableJobWorkerElement.class);
 
-    final var jobWorkerProperties = new JobWorkerProperties();
-    jobWorkerElement.setJobWorkerProperties(jobWorkerProperties);
+    final var taskDefinition = element.getSingleExtensionElement(ZeebeTaskDefinition.class);
+    taskDefinitionTransformer.transform(jobWorkerElement, context, taskDefinition);
 
-    taskDefinitionTransformer.transform(element, jobWorkerProperties, context);
-    taskHeadersTransformer.transform(element, jobWorkerProperties);
+    final var taskHeaders = element.getSingleExtensionElement(ZeebeTaskHeaders.class);
+    taskHeadersTransformer.transform(jobWorkerElement, taskHeaders, element);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/CalledDecisionTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/CalledDecisionTransformer.java
@@ -7,22 +7,22 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe;
 
-import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableBusinessRuleTask;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 
 public final class CalledDecisionTransformer {
 
   public void transform(
-      final ExecutableBusinessRuleTask businessRuleTask, final ZeebeCalledDecision calledDecision) {
+      final ExecutableCalledDecision executableElement, final ZeebeCalledDecision calledDecision) {
 
     if (calledDecision == null) {
       return;
     }
 
     final var decisionId = calledDecision.getDecisionId();
-    businessRuleTask.setDecisionId(decisionId);
+    executableElement.setDecisionId(decisionId);
 
     final var resultVariable = calledDecision.getResultVariable();
-    businessRuleTask.setResultVariable(resultVariable);
+    executableElement.setResultVariable(resultVariable);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/CalledDecisionTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/CalledDecisionTransformer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableBusinessRuleTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
+
+public final class CalledDecisionTransformer {
+
+  public void transform(
+      final ExecutableBusinessRuleTask businessRuleTask, final ZeebeCalledDecision calledDecision) {
+
+    if (calledDecision == null) {
+      return;
+    }
+
+    final var decisionId = calledDecision.getDecisionId();
+    businessRuleTask.setDecisionId(decisionId);
+
+    final var resultVariable = calledDecision.getResultVariable();
+    businessRuleTask.setResultVariable(resultVariable);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/TaskDefinitionTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/TaskDefinitionTransformer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe;
+
+import io.camunda.zeebe.el.Expression;
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.engine.processing.deployment.model.element.JobWorkerProperties;
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
+import io.camunda.zeebe.model.bpmn.instance.FlowElement;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
+
+public final class TaskDefinitionTransformer {
+
+  public void transform(
+      final FlowElement element,
+      final JobWorkerProperties jobWorkerProperties,
+      final TransformContext context) {
+    final ZeebeTaskDefinition taskDefinition =
+        element.getSingleExtensionElement(ZeebeTaskDefinition.class);
+
+    final ExpressionLanguage expressionLanguage = context.getExpressionLanguage();
+    final Expression jobTypeExpression =
+        expressionLanguage.parseExpression(taskDefinition.getType());
+
+    jobWorkerProperties.setType(jobTypeExpression);
+
+    final Expression retriesExpression =
+        expressionLanguage.parseExpression(taskDefinition.getRetries());
+
+    jobWorkerProperties.setRetries(retriesExpression);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/TaskDefinitionTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/TaskDefinitionTransformer.java
@@ -9,19 +9,26 @@ package io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe;
 
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.JobWorkerProperties;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
-import io.camunda.zeebe.model.bpmn.instance.FlowElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
+import java.util.Optional;
 
 public final class TaskDefinitionTransformer {
 
   public void transform(
-      final FlowElement element,
-      final JobWorkerProperties jobWorkerProperties,
-      final TransformContext context) {
-    final ZeebeTaskDefinition taskDefinition =
-        element.getSingleExtensionElement(ZeebeTaskDefinition.class);
+      final ExecutableJobWorkerElement element,
+      final TransformContext context,
+      final ZeebeTaskDefinition taskDefinition) {
+
+    if (taskDefinition == null) {
+      return;
+    }
+
+    final var jobWorkerProperties =
+        Optional.ofNullable(element.getJobWorkerProperties()).orElse(new JobWorkerProperties());
+    element.setJobWorkerProperties(jobWorkerProperties);
 
     final ExpressionLanguage expressionLanguage = context.getExpressionLanguage();
     final Expression jobTypeExpression =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/TaskHeadersTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/TaskHeadersTransformer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe;
+
+import io.camunda.zeebe.engine.Loggers;
+import io.camunda.zeebe.engine.processing.deployment.model.element.JobWorkerProperties;
+import io.camunda.zeebe.model.bpmn.instance.FlowElement;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+
+public final class TaskHeadersTransformer {
+
+  private static final Logger LOG = Loggers.STREAM_PROCESSING;
+
+  public void transform(final FlowElement element, final JobWorkerProperties jobWorkerProperties) {
+    final ZeebeTaskHeaders taskHeaders = element.getSingleExtensionElement(ZeebeTaskHeaders.class);
+
+    if (taskHeaders != null) {
+      final Map<String, String> validHeaders =
+          taskHeaders.getHeaders().stream()
+              .filter(this::isValidHeader)
+              .collect(Collectors.toMap(ZeebeHeader::getKey, ZeebeHeader::getValue));
+
+      if (validHeaders.size() < taskHeaders.getHeaders().size()) {
+        LOG.warn(
+            "Ignoring invalid headers for task '{}'. Must have non-empty key and value.",
+            element.getName());
+      }
+
+      if (!validHeaders.isEmpty()) {
+        jobWorkerProperties.setTaskHeaders(validHeaders);
+      }
+    }
+  }
+
+  public boolean isValidHeader(final ZeebeHeader header) {
+    return header != null
+        && header.getValue() != null
+        && !header.getValue().isEmpty()
+        && header.getKey() != null
+        && !header.getKey().isEmpty();
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
@@ -157,7 +157,7 @@ public final class BusinessRuleTaskTest {
   }
 
   @Test
-  public void shouldWriteResultAsLocalVariableWhenOutputMappingsDefined() {
+  public void shouldUseResultInOutputMappings() {
     // given
     ENGINE
         .deployment()
@@ -194,31 +194,7 @@ public final class BusinessRuleTaskTest {
         .extracting(Record::getValue)
         .extracting(VariableRecordValue::getScopeKey, VariableRecordValue::getValue)
         .containsExactly(taskInstanceKey, "\"Jedi\"");
-  }
 
-  @Test
-  public void shouldUseResultInOutputMappings() {
-    // given
-    ENGINE
-        .deployment()
-        .withXmlClasspathResource("/dmn/drg-force-user.dmn")
-        .withXmlResource(
-            processWithBusinessRuleTask(
-                t ->
-                    t.zeebeCalledDecisionId("jedi-or-sith")
-                        .zeebeResultVariable(RESULT_VARIABLE)
-                        .zeebeOutputExpression(RESULT_VARIABLE, OUTPUT_TARGET)))
-        .deploy();
-
-    // when
-    final long processInstanceKey =
-        ENGINE
-            .processInstance()
-            .ofBpmnProcessId(PROCESS_ID)
-            .withVariable("lightsaberColor", "blue")
-            .create();
-
-    // then
     Assertions.assertThat(
             RecordingExporter.variableRecords(VariableIntent.CREATED)
                 .withProcessInstanceKey(processInstanceKey)

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
@@ -34,6 +34,7 @@ public final class BusinessRuleTaskTest {
 
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
+  private static final String DMN_RESOURCE = "/dmn/drg-force-user.dmn";
   private static final String PROCESS_ID = "process";
   private static final String TASK_ID = "task";
   private static final String RESULT_VARIABLE = "result";
@@ -54,7 +55,7 @@ public final class BusinessRuleTaskTest {
     // given
     ENGINE
         .deployment()
-        .withXmlClasspathResource("/dmn/drg-force-user.dmn")
+        .withXmlClasspathResource(DMN_RESOURCE)
         .withXmlResource(
             processWithBusinessRuleTask(
                 t -> t.zeebeCalledDecisionId("jedi-or-sith").zeebeResultVariable(RESULT_VARIABLE)))
@@ -100,7 +101,7 @@ public final class BusinessRuleTaskTest {
     // given
     ENGINE
         .deployment()
-        .withXmlClasspathResource("/dmn/drg-force-user.dmn")
+        .withXmlClasspathResource(DMN_RESOURCE)
         .withXmlResource(
             processWithBusinessRuleTask(
                 t -> t.zeebeCalledDecisionId("jedi-or-sith").zeebeResultVariable(RESULT_VARIABLE)))
@@ -131,7 +132,7 @@ public final class BusinessRuleTaskTest {
     // given
     ENGINE
         .deployment()
-        .withXmlClasspathResource("/dmn/drg-force-user.dmn")
+        .withXmlClasspathResource(DMN_RESOURCE)
         .withXmlResource(
             processWithBusinessRuleTask(
                 t -> t.zeebeCalledDecisionId("jedi-or-sith").zeebeResultVariable(RESULT_VARIABLE)))
@@ -161,7 +162,7 @@ public final class BusinessRuleTaskTest {
     // given
     ENGINE
         .deployment()
-        .withXmlClasspathResource("/dmn/drg-force-user.dmn")
+        .withXmlClasspathResource(DMN_RESOURCE)
         .withXmlResource(
             processWithBusinessRuleTask(
                 t ->

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.activity;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.BusinessRuleTaskBuilder;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.function.Consumer;
+import org.assertj.core.api.Assertions;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class BusinessRuleTaskTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String TASK_ID = "task";
+  private static final String RESULT_VARIABLE = "result";
+  private static final String OUTPUT_TARGET = "output";
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  private static BpmnModelInstance processWithBusinessRuleTask(
+      final Consumer<BusinessRuleTaskBuilder> modifier) {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .businessRuleTask(TASK_ID, modifier)
+        .done();
+  }
+
+  @Test
+  public void shouldActivateTask() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlClasspathResource("/dmn/drg-force-user.dmn")
+        .withXmlResource(
+            processWithBusinessRuleTask(
+                t -> t.zeebeCalledDecisionId("jedi-or-sith").zeebeResultVariable(RESULT_VARIABLE)))
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("lightsaberColor", "blue")
+            .create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.BUSINESS_RULE_TASK)
+                .limit(3))
+        .extracting(Record::getRecordType, Record::getIntent)
+        .containsSequence(
+            tuple(RecordType.COMMAND, ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple(RecordType.EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(RecordType.EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED));
+
+    final Record<ProcessInstanceRecordValue> taskActivating =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementType(BpmnElementType.BUSINESS_RULE_TASK)
+            .getFirst();
+
+    assertThat(taskActivating.getValue())
+        .hasElementId(TASK_ID)
+        .hasBpmnElementType(BpmnElementType.BUSINESS_RULE_TASK)
+        .hasFlowScopeKey(processInstanceKey)
+        .hasBpmnProcessId(PROCESS_ID)
+        .hasProcessInstanceKey(processInstanceKey);
+  }
+
+  @Test
+  public void shouldCompleteTask() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlClasspathResource("/dmn/drg-force-user.dmn")
+        .withXmlResource(
+            processWithBusinessRuleTask(
+                t -> t.zeebeCalledDecisionId("jedi-or-sith").zeebeResultVariable(RESULT_VARIABLE)))
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("lightsaberColor", "blue")
+            .create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.BUSINESS_RULE_TASK, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.BUSINESS_RULE_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldWriteResultAsProcessInstanceVariable() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlClasspathResource("/dmn/drg-force-user.dmn")
+        .withXmlResource(
+            processWithBusinessRuleTask(
+                t -> t.zeebeCalledDecisionId("jedi-or-sith").zeebeResultVariable(RESULT_VARIABLE)))
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("lightsaberColor", "blue")
+            .create();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.variableRecords(VariableIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withName(RESULT_VARIABLE)
+                .getFirst())
+        .extracting(Record::getValue)
+        .extracting(VariableRecordValue::getScopeKey, VariableRecordValue::getValue)
+        .containsExactly(processInstanceKey, "\"Jedi\"");
+  }
+
+  @Test
+  public void shouldWriteResultAsLocalVariableWhenOutputMappingsDefined() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlClasspathResource("/dmn/drg-force-user.dmn")
+        .withXmlResource(
+            processWithBusinessRuleTask(
+                t ->
+                    t.zeebeCalledDecisionId("jedi-or-sith")
+                        .zeebeResultVariable(RESULT_VARIABLE)
+                        .zeebeOutputExpression(RESULT_VARIABLE, OUTPUT_TARGET)))
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("lightsaberColor", "blue")
+            .create();
+
+    final long taskInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.BUSINESS_RULE_TASK)
+            .getFirst()
+            .getKey();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.variableRecords(VariableIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withName(RESULT_VARIABLE)
+                .getFirst())
+        .extracting(Record::getValue)
+        .extracting(VariableRecordValue::getScopeKey, VariableRecordValue::getValue)
+        .containsExactly(taskInstanceKey, "\"Jedi\"");
+  }
+
+  @Test
+  public void shouldUseResultInOutputMappings() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlClasspathResource("/dmn/drg-force-user.dmn")
+        .withXmlResource(
+            processWithBusinessRuleTask(
+                t ->
+                    t.zeebeCalledDecisionId("jedi-or-sith")
+                        .zeebeResultVariable(RESULT_VARIABLE)
+                        .zeebeOutputExpression(RESULT_VARIABLE, OUTPUT_TARGET)))
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("lightsaberColor", "blue")
+            .create();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.variableRecords(VariableIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withName(OUTPUT_TARGET)
+                .getFirst())
+        .extracting(Record::getValue)
+        .extracting(VariableRecordValue::getScopeKey, VariableRecordValue::getValue)
+        .containsExactly(processInstanceKey, "\"Jedi\"");
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/BusinessRuleTaskIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/BusinessRuleTaskIncidentTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.BusinessRuleTaskBuilder;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValueAssert;
+import io.camunda.zeebe.test.util.collection.Maps;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.function.Consumer;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/** Tests for incidents specific for business-rule-tasks. */
+public class BusinessRuleTaskIncidentTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String TASK_ELEMENT_ID = "business-rule-task";
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  private BpmnModelInstance processWithBusinessRuleTask(
+      final Consumer<BusinessRuleTaskBuilder> modifier) {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .businessRuleTask(TASK_ELEMENT_ID, modifier)
+        .endEvent()
+        .done();
+  }
+
+  private IncidentRecordValueAssert assertIncidentCreated(
+      final long processInstanceKey, final long elementInstanceKey) {
+    final var incidentRecord =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    return Assertions.assertThat(incidentRecord.getValue())
+        .hasElementId(TASK_ELEMENT_ID)
+        .hasElementInstanceKey(elementInstanceKey)
+        .hasJobKey(-1L)
+        .hasVariableScopeKey(elementInstanceKey);
+  }
+
+  // --------------------------------------------------------------------------
+  // ----- CalledDecision related tests
+
+  @Test
+  public void shouldCreateIncidentIfDecisionEvaluationFailed() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlClasspathResource("/dmn/drg-force-user.dmn")
+        .withXmlResource(
+            processWithBusinessRuleTask(
+                b -> b.zeebeCalledDecisionId("jedi-or-sith").zeebeResultVariable("result")))
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var taskActivating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(TASK_ELEMENT_ID)
+            .withElementType(BpmnElementType.BUSINESS_RULE_TASK)
+            .getFirst();
+
+    // then
+    assertIncidentCreated(processInstanceKey, taskActivating.getKey())
+        .hasErrorType(ErrorType.CALLED_ELEMENT_ERROR)
+        .hasErrorMessage(
+            """
+            Expected to evaluate decision 'jedi-or-sith', \
+            but failed to evaluate expression 'lightsaberColor': \
+            no variable found for name 'lightsaberColor'\
+            """);
+  }
+
+  @Test
+  public void shouldResolveIncidentAndCreateNewIncidentWhenContinuationFails() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlClasspathResource("/dmn/drg-force-user.dmn")
+        .withXmlResource(
+            processWithBusinessRuleTask(
+                b -> b.zeebeCalledDecisionId("jedi-or-sith").zeebeResultVariable("result")))
+        .deploy();
+
+    // and an instance of that process is created without the required variables for the decision
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // and an incident created
+    final var incidentCreated =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // when we try to resolve the incident
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incidentCreated.getKey()).resolve();
+
+    // then
+    assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.RESOLVED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withRecordKey(incidentCreated.getKey())
+                .exists())
+        .describedAs("original incident is resolved")
+        .isTrue();
+
+    assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .filter(i -> i.getKey() != incidentCreated.getKey())
+                .exists())
+        .describedAs("a new incident is created")
+        .isTrue();
+  }
+
+  @Test
+  public void shouldResolveIncidentAfterDecisionEvaluationFailed() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlClasspathResource("/dmn/drg-force-user.dmn")
+        .withXmlResource(
+            processWithBusinessRuleTask(
+                b -> b.zeebeCalledDecisionId("jedi-or-sith").zeebeResultVariable("result")))
+        .deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var incidentCreated =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // when
+
+    // ... update state to resolve issue
+    ENGINE
+        .variables()
+        .ofScope(incidentCreated.getValue().getElementInstanceKey())
+        .withDocument(Maps.of(entry("lightsaberColor", "blue")))
+        .update();
+
+    // ... resolve incident
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incidentCreated.getKey()).resolve();
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .incidentRecords()
+                .onlyEvents())
+        .extracting(Record::getKey, Record::getIntent)
+        .describedAs("created incident is resolved and no new incident is created")
+        .containsExactly(
+            tuple(incidentCreated.getKey(), IncidentIntent.CREATED),
+            tuple(incidentCreated.getKey(), IncidentIntent.RESOLVED));
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId(TASK_ELEMENT_ID)
+                .exists())
+        .describedAs("business rule task is successfully completed")
+        .isTrue();
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/OutputMappingIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/OutputMappingIncidentTest.java
@@ -53,9 +53,6 @@ public class OutputMappingIncidentTest {
   @Parameter(3)
   public boolean createsJob;
 
-  @Parameter(4)
-  public Map<String, Object> variables;
-
   @Parameters(name = "{index}: {0}")
   public static Collection<Object[]> parameters() {
     return Arrays.asList(
@@ -73,8 +70,7 @@ public class OutputMappingIncidentTest {
                         .endEvent()
                         .done()),
             "serviceTaskId",
-            true,
-            Map.of()
+            true
           },
           {
             "Intermediate throw event",
@@ -88,8 +84,7 @@ public class OutputMappingIncidentTest {
                         .endEvent()
                         .done()),
             "intermediateThrowEventId",
-            false,
-            Map.of()
+            false
           },
           {
             "Business rule task",
@@ -104,12 +99,12 @@ public class OutputMappingIncidentTest {
                             b ->
                                 b.zeebeCalledDecisionId("jedi-or-sith")
                                     .zeebeResultVariable("result")
+                                    .zeebeInputExpression("\"blue\"", "lightsaberColor")
                                     .zeebeOutputExpression("foo", "bar"))
                         .endEvent()
                         .done()),
             "businessRuleTaskId",
-            false,
-            Map.of("lightsaberColor", "blue")
+            false
           }
         });
   }
@@ -120,8 +115,7 @@ public class OutputMappingIncidentTest {
     deployment.deploy();
 
     // when
-    final long processInstanceKey =
-        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariables(variables).create();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     if (createsJob) {
       ENGINE.job().withType("type").ofInstance(processInstanceKey).complete();
@@ -161,8 +155,7 @@ public class OutputMappingIncidentTest {
     // given
     deployment.deploy();
 
-    final long processInstanceKey =
-        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariables(variables).create();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     if (createsJob) {
       ENGINE.job().withType("type").ofInstance(processInstanceKey).complete();
@@ -203,8 +196,7 @@ public class OutputMappingIncidentTest {
   public void shouldResolveIncidentIfProcessCancelled() {
     deployment.deploy();
 
-    final long processInstanceKey =
-        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariables(variables).create();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     if (createsJob) {
       ENGINE.job().withType("type").ofInstance(processInstanceKey).complete();

--- a/util/src/main/java/io/camunda/zeebe/util/Either.java
+++ b/util/src/main/java/io/camunda/zeebe/util/Either.java
@@ -86,6 +86,30 @@ public interface Either<L, R> {
   }
 
   /**
+   * Convenience method to convert an {@link Optional<R>} of R to an {@code Either<?, R>}, using an
+   * intermediary representation of the Optional in the form of {@link EitherOptional}.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * Either.ofOptional(Optional.of(1))
+   *   .orElse("left value")
+   *   .ifRightOrLeft(
+   *     right -> System.out.println("If Optional is present, right is the contained value"),
+   *     left -> System.out.println("If Optional is empty, left is the value provided by orElse")
+   *   );
+   * }</pre>
+   *
+   * @param right The optional that may contain the right value
+   * @param <R> the type of the right value
+   * @return An intermediary representation {@link EitherOptional}
+   */
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  static <R> EitherOptional<R> ofOptional(final Optional<R> right) {
+    return new EitherOptional<>(right);
+  }
+
+  /**
    * Returns a collector for {@code Either<L,R>} that collects them into {@code
    * Either<List<L>,List<R>} and favors {@link Left} over {@link Right}.
    *
@@ -454,6 +478,20 @@ public interface Either<L, R> {
     @Override
     public String toString() {
       return "Left[" + value + ']';
+    }
+  }
+
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  final class EitherOptional<R> {
+
+    private final Optional<R> right;
+
+    public EitherOptional(final Optional<R> right) {
+      this.right = right;
+    }
+
+    public <L> Either<L, R> orElse(final L left) {
+      return right.<Either<L, R>>map(Either::right).orElse(Either.left(left));
     }
   }
 }

--- a/util/src/main/java/io/camunda/zeebe/util/Either.java
+++ b/util/src/main/java/io/camunda/zeebe/util/Either.java
@@ -486,7 +486,7 @@ public interface Either<L, R> {
 
     private final Optional<R> right;
 
-    public EitherOptional(final Optional<R> right) {
+    private EitherOptional(final Optional<R> right) {
       this.right = right;
     }
 

--- a/util/src/test/java/io/camunda/zeebe/util/EitherTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/EitherTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.Collection;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -165,6 +166,14 @@ class EitherTest {
     final var leftConsumer = new VerifiableConsumer();
     Either.left(value).ifRightOrLeft(new FailConsumer(), leftConsumer);
     assertThat(leftConsumer.hasBeenExecuted).isTrue();
+  }
+
+  @DisplayName("Only an Either of Optional with a value present is a Right")
+  @ParameterizedTest
+  @MethodSource("parameters")
+  void onlyAnEitherOfPresentOptionalIsRight(final Object value) {
+    assertThat(Either.ofOptional(Optional.of(value)).orElse(null)).isEqualTo(Either.right(value));
+    assertThat(Either.ofOptional(Optional.empty()).orElse(value)).isEqualTo(Either.left(value));
   }
 
   /** Simple Consumer that knows whether it's been executed. */


### PR DESCRIPTION
## Description

This adds the ability to process business rule tasks that refer to a called decision (see #8060). Business rule tasks that refer to a [task definition](https://docs.camunda.io/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks/#defining-a-task) instead of a called decision work like they did before, i.e. by creating a job for job workers.

On activation of a business rule task with called decision, the decision specified by `decisionId` is retrieved from the deployed decisions state. If present, the engine uses the `dmn` module to evaluate the decision. If that is successful, the decision result's output is stored in a result variable (defined by `resultVariable`).

The result variable stores the decision result's output according to the following rules:
- if the business rule task defines no output mappings, the result variable is [propagated](https://docs.camunda.io/docs/components/concepts/variables/#variable-propagation)
- if there are [output mappings](https://docs.camunda.io/docs/components/concepts/variables/#output-mappings) defined on the business rule task, the result variable is set as a [local variable](https://docs.camunda.io/docs/components/concepts/variables/#local-variables) of the business rule task

If any of this fails, Zeebe raises an incident on the business rule task. For example, if the decision was not deployed yet, then an incident is raised. This allows you to:
1. deploy the decision to fix the problem
2. retry activating the business rule task by resolving the incident

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8080

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
