### PR TITLE
[Backport stable/1.2] Release fixes

### DIFF
--- a/.ci/pipelines/release_zeebe.groovy
+++ b/.ci/pipelines/release_zeebe.groovy
@@ -141,7 +141,7 @@ spec:
                 }
 
                 container('golang') {
-                    sh '.ci/scripts/release/post-github.sh'
+                    sh '.ci/scripts/release/post-release-go.sh'
                 }
             }
         }

--- a/.ci/pipelines/release_zeebe_java8.groovy
+++ b/.ci/pipelines/release_zeebe_java8.groovy
@@ -122,6 +122,10 @@ spec:
                 container('maven') {
                     sh '.ci/scripts/release/github-release.sh'
                 }
+
+                container('golang') {
+                    sh '.ci/scripts/release/post-release-go.sh'
+                }
             }
         }
 

--- a/.ci/scripts/release/post-release-go.sh
+++ b/.ci/scripts/release/post-release-go.sh
@@ -3,7 +3,7 @@
 cd "clients/go/internal/embedded"
 
 echo "${DEVELOPMENT_VERSION}" > data/VERSION
-"${GOPATH}/go-bindata" -pkg embedded -o embedded.go -prefix data/ data/
+go-bindata -pkg embedded -o embedded.go -prefix data/ data/
 
 git commit -am "build(project): prepare next development version (Go client)"
 git push origin "${RELEASE_BRANCH}"

--- a/.ci/scripts/release/prepare-go.sh
+++ b/.ci/scripts/release/prepare-go.sh
@@ -11,3 +11,14 @@ export CGO_ENABLED=0
 export GO111MODULE=on
 go get -u "github.com/smola/gocompat/...@v0.3.0"
 go get -u "github.com/go-bindata/go-bindata/...@v3"
+
+# Verify binary is available under $GOPATH/bin
+if ! command -v go-bindata > /dev/null 2>&1; then
+  echo "Failed to install go-bindata, go-bindata is not available on the path"
+  exit 1
+fi
+
+if ! command -v gocompat > /dev/null 2>&1; then
+  echo "Failed to install gocopmat, gocompat is not available on the path"
+  exit 1
+fi


### PR DESCRIPTION
## Description

This PR backports some release script fixes/improvements made in #8714 to stable/1.2.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
