### PR TITLE
Fix slow Windows OS smoke test

### DIFF
--- a/.github/workflows/os-smoke-test.yml
+++ b/.github/workflows/os-smoke-test.yml
@@ -14,7 +14,7 @@ jobs:
     # This name is hard-referenced from bors.toml
     # Remember to update that if this name, or the matrix.os changes
     name: Run smoke tests on ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/os-smoke-test.yml
+++ b/.github/workflows/os-smoke-test.yml
@@ -57,6 +57,6 @@ jobs:
         with:
           path: /Users/runner/.m2/repository/uk/co/real-logic/sbe-tool
       - name: Build relevant modules
-        run: mvn -B -am -pl qa/integration-tests install -DskipTests -DskipChecks -T1C
+        run: mvn -B -am -pl qa/integration-tests install -DskipTests -DskipChecks "-Dmaven.javadoc.skip=true" -T1C
       - name: Run smoke test
         run: mvn -B -pl qa/integration-tests verify -P smoke-test -DskipUTs -DskipChecks

--- a/.github/workflows/os-smoke-test.yml
+++ b/.github/workflows/os-smoke-test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+
 jobs:
   smoke-test:
     # This name is hard-referenced from bors.toml

--- a/.github/workflows/os-smoke-test.yml
+++ b/.github/workflows/os-smoke-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-latest, windows-latest, ubuntu-latest ]
+        os: [ macos-latest, windows-2022, ubuntu-latest ]
 
     steps:
       - uses: actions/checkout@v2
@@ -27,12 +27,12 @@ jobs:
           cache: 'maven'
 
       - name: Clear broken cache parts (windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         uses: JesseTG/rm@v1.0.2
         with:
           path: C:\Users\runneradmin\.m2\repository\org\agrona\agrona
       - name: Clear broken cache parts (windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         uses: JesseTG/rm@v1.0.2
         with:
           path: C:\Users\runneradmin\.m2\repository\uk\co\real-logic\sbe-tool

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,7 @@
 status = [
   "continuous-integration/jenkins/branch",
   "Run smoke tests on macos-latest",
-  "Run smoke tests on windows-latest",
+  "Run smoke tests on windows-2022",
   "Run smoke tests on ubuntu-latest"
 ]
 


### PR DESCRIPTION
## Description

This PR updates the windows virtual environment to the new Windows Server 2022. It seems to make things a little bit faster, though I can't really guarantee this will remain so. At some point, I imagine windows-latest will point to windows-2022, so we could switch back.

Why I think it helps with the speed, isn't just the workflow execution time (though it now seems to be on par with the others), but one specific step: when building the relevant modules, on `main`, enable showing the log timestamps and you will see it spends up to 2 minutes (sometimes up to 3 minutes) just invoking maven. By this I mean, it's not even running the build yet - it calls maven at, say, 00:00:00, and then at 00:02:00 you see the first log output from maven. Here, when I ran this, it's still somewhat slow, but it's in the order of 30 seconds.

Additionally, I added some Java options which are specifically tuned for faster startup, at the cost of slight runtime performance. But since we only run a handful of tests, I think that's a good tradeoff. I didn't see a major difference in build times - or rather, I couldn't exactly pinpoint that this was the case, as it seems faster but it varies by how much. I would keep them out as I think they help more than they hurt, but happy to be challenged. You can read the commit that introduced them which has a bit more reasoning about the various flags.

Finally I increased the timeout of the workflow to what is currently the time it takes for us to build on Jenkins. It's a little ridiculous, I know, but the windows environment just seems so...slow...it's not worth failing builds just because of that, I think.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
