### PR TITLE
docs(zbctl): improve help text and add docs link

### DIFF
--- a/clients/go/cmd/zbctl/internal/commands/root.go
+++ b/clients/go/cmd/zbctl/internal/commands/root.go
@@ -46,7 +46,7 @@ var clientCacheFlag string
 var rootCmd = &cobra.Command{
 	Use:   "zbctl",
 	Short: "zeebe command line interface",
-	Long: `zbctl is a command line interface for Camunda Cloud designed to create and read resources inside a Zeebe broker.
+	Long: `zbctl is a command line interface designed to create and read resources inside a Zeebe cluster.
 It can be used for regular development and maintenance tasks such as:
 	* deploying processes,
 	* creating process instances and job workers

--- a/clients/go/cmd/zbctl/internal/commands/root.go
+++ b/clients/go/cmd/zbctl/internal/commands/root.go
@@ -46,13 +46,15 @@ var clientCacheFlag string
 var rootCmd = &cobra.Command{
 	Use:   "zbctl",
 	Short: "zeebe command line interface",
-	Long: `zbctl is a command line interface designed to create and read resources inside zeebe broker.
-It is designed for regular maintenance jobs such as:
+	Long: `zbctl is a command line interface for Camunda Cloud designed to create and read resources inside a Zeebe broker.
+It can be used for regular development and maintenance tasks such as:
 	* deploying processes,
-	* creating jobs and process instances
+	* creating process instances and job workers
 	* activating, completing or failing jobs
-	* update variables and retries
-	* view cluster status`,
+	* updating variables and job retries
+	* viewing cluster status
+
+Documentation: https://docs.camunda.io/docs/apis-clients/cli-client/index/`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		// silence help here instead of as a parameter because we only want to suppress it on a 'Zeebe' error and not if
 		// parsing args fails


### PR DESCRIPTION
## Description

Improve content and gramar of `zbctl` help text and add link to online documentation.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
