### PR TITLE
fix: throw instead of silently overwriting timers

### DIFF
--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorTimerQueue.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorTimerQueue.java
@@ -17,17 +17,14 @@ public final class ActorTimerQueue extends DeadlineTimerWheel {
   private final Long2ObjectHashMap<TimerSubscription> timerJobMap = new Long2ObjectHashMap<>();
 
   private final TimerHandler timerHandler =
-      new TimerHandler() {
-        @Override
-        public boolean onTimerExpiry(final TimeUnit timeUnit, final long now, final long timerId) {
-          final TimerSubscription timer = timerJobMap.remove(timerId);
+      (timeUnit, now, timerId) -> {
+        final TimerSubscription timer = timerJobMap.remove(timerId);
 
-          if (timer != null) {
-            timer.onTimerExpired(timeUnit, now);
-          }
-
-          return true;
+        if (timer != null) {
+          timer.onTimerExpired(timeUnit, now);
         }
+
+        return true;
       };
 
   public ActorTimerQueue(final ActorClock clock) {
@@ -52,6 +49,13 @@ public final class ActorTimerQueue extends DeadlineTimerWheel {
 
     final long timerId = scheduleTimer(deadline);
     timer.setTimerId(timerId);
+    if (timerJobMap.containsKey(timerId)) {
+      throw new IllegalStateException(
+          "Failed scheduling, timer with id "
+              + timerId
+              + " already exists: "
+              + timerJobMap.get(timerId));
+    }
 
     timerJobMap.put(timerId, timer);
   }

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorTimerQueue.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorTimerQueue.java
@@ -7,12 +7,15 @@
  */
 package io.camunda.zeebe.util.sched;
 
+import io.camunda.zeebe.util.Loggers;
 import io.camunda.zeebe.util.sched.clock.ActorClock;
 import java.util.concurrent.TimeUnit;
 import org.agrona.DeadlineTimerWheel;
 import org.agrona.collections.Long2ObjectHashMap;
+import org.slf4j.Logger;
 
 public final class ActorTimerQueue extends DeadlineTimerWheel {
+  private static final Logger LOG = Loggers.ACTOR_LOGGER;
   private static final int DEFAULT_TICKS_PER_WHEEL = 32;
   private final Long2ObjectHashMap<TimerSubscription> timerJobMap = new Long2ObjectHashMap<>();
 
@@ -22,6 +25,8 @@ public final class ActorTimerQueue extends DeadlineTimerWheel {
 
         if (timer != null) {
           timer.onTimerExpired(timeUnit, now);
+        } else {
+          LOG.warn("Timer with id {} expired but is not known in this timer queue.", timerId);
         }
 
         return true;

--- a/util/src/main/java/io/camunda/zeebe/util/sched/TimerSubscription.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/TimerSubscription.java
@@ -100,4 +100,24 @@ public final class TimerSubscription implements ActorSubscription, ScheduledTime
   public void run() {
     thread.removeTimer(this);
   }
+
+  @Override
+  public String toString() {
+    return "TimerSubscription{"
+        + "timerId="
+        + timerId
+        + ", deadline="
+        + deadline
+        + ", timeUnit="
+        + timeUnit
+        + ", isRecurring="
+        + isRecurring
+        + ", isDone="
+        + isDone
+        + ", isCanceled="
+        + isCanceled
+        + ", thread="
+        + thread
+        + '}';
+  }
 }


### PR DESCRIPTION
## Description

Here we throw an exception when a timerId was generated that alreadyexists in the timerJobMap.
Throwing here will fail when scheduling a new timer or when resubmitting a recurring timer.

This should never happen, but we have one heapdump where it looks like it did: https://github.com/camunda-cloud/zeebe/issues/8776

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #8776

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
