### PR TITLE
Support to override authority in TLS handshake

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -49,8 +49,11 @@ public final class ClientProperties {
   /** @see ZeebeClientBuilder#caCertificatePath(String) */
   public static final String CA_CERTIFICATE_PATH = "zeebe.client.security.certpath";
 
-  /** @see io.camunda.zeebe.client.ZeebeClientBuilder#keepAlive(Duration) */
+  /** @see ZeebeClientBuilder#keepAlive(Duration) */
   public static final String KEEP_ALIVE = "zeebe.client.keepalive";
+
+  /** @see ZeebeClientBuilder#overrideAuthority(String) */
+  public static final String OVERRIDE_AUTHORITY = "zeebe.client.overrideauthority";
 
   /** @see ZeebeClientCloudBuilderStep1#withClusterId(java.lang.String) */
   public static final String CLOUD_CLUSTER_ID = "zeebe.client.cloud.clusterId";

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -92,6 +92,19 @@ public interface ZeebeClientBuilder {
 
   ZeebeClientBuilder withJsonMapper(JsonMapper jsonMapper);
 
+  /**
+   * Overrides the authority used with TLS virtual hosting. Specifically, to override hostname
+   * verification in the TLS handshake. It does not change what host is actually connected to.
+   *
+   * <p>This method is intended for testing, but may safely be used outside of tests as an
+   * alternative to DNS overrides.
+   *
+   * <p>This setting does nothing if a {@link #usePlaintext() plaintext} connection is used.
+   *
+   * @param authority The alternative authority to use, commonly in the form <code>host:port</code>.
+   */
+  ZeebeClientBuilder overrideAuthority(String authority);
+
   /** @return a new {@link ZeebeClient} with the provided configuration options. */
   ZeebeClient build();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -101,7 +101,10 @@ public interface ZeebeClientBuilder {
    *
    * <p>This setting does nothing if a {@link #usePlaintext() plaintext} connection is used.
    *
-   * @param authority The alternative authority to use, commonly in the form <code>host:port</code>.
+   * @param authority The alternative authority to use, commonly in the form <code>host</code> or
+   *     <code>host:port</code>
+   * @apiNote For the full definition of authority see [RFC 2396: Uniform Resource Identifiers
+   *     (URI): Generic Syntax](http://www.ietf.org/rfc/rfc2396.txt)
    */
   ZeebeClientBuilder overrideAuthority(String authority);
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -61,4 +61,7 @@ public interface ZeebeClientConfiguration {
 
   /** @see ZeebeClientBuilder#withJsonMapper(io.camunda.zeebe.client.api.JsonMapper) */
   JsonMapper getJsonMapper();
+
+  /** @see ZeebeClientBuilder#overrideAuthority(String) */
+  String getAuthority();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -63,5 +63,5 @@ public interface ZeebeClientConfiguration {
   JsonMapper getJsonMapper();
 
   /** @see ZeebeClientBuilder#overrideAuthority(String) */
-  String getAuthority();
+  String getOverrideAuthority();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -59,7 +59,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private CredentialsProvider credentialsProvider;
   private Duration keepAlive = Duration.ofSeconds(45);
   private JsonMapper jsonMapper = new ZeebeObjectMapper();
-  private String authority;
+  private String overrideAuthority;
 
   @Override
   public String getGatewayAddress() {
@@ -132,8 +132,8 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   }
 
   @Override
-  public String getAuthority() {
-    return authority;
+  public String getOverrideAuthority() {
+    return overrideAuthority;
   }
 
   @Override
@@ -288,7 +288,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
   @Override
   public ZeebeClientBuilder overrideAuthority(final String authority) {
-    this.authority = authority;
+    overrideAuthority = authority;
     return this;
   }
 
@@ -334,7 +334,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     appendProperty(sb, "defaultJobPollInterval", defaultJobPollInterval);
     appendProperty(sb, "defaultMessageTimeToLive", defaultMessageTimeToLive);
     appendProperty(sb, "defaultRequestTimeout", defaultRequestTimeout);
-    appendProperty(sb, "overriddenAuthority", authority);
+    appendProperty(sb, "overrideAuthority", overrideAuthority);
 
     return sb.toString();
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -123,6 +123,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     return interceptors;
   }
 
+  @Override
   public JsonMapper getJsonMapper() {
     return jsonMapper;
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -19,6 +19,7 @@ import static io.camunda.zeebe.client.ClientProperties.CA_CERTIFICATE_PATH;
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_MESSAGE_TIME_TO_LIVE;
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT;
 import static io.camunda.zeebe.client.ClientProperties.KEEP_ALIVE;
+import static io.camunda.zeebe.client.ClientProperties.OVERRIDE_AUTHORITY;
 import static io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
 import static io.camunda.zeebe.client.impl.BuilderUtils.appendProperty;
 
@@ -41,6 +42,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   public static final String PLAINTEXT_CONNECTION_VAR = "ZEEBE_INSECURE_CONNECTION";
   public static final String CA_CERTIFICATE_VAR = "ZEEBE_CA_CERTIFICATE_PATH";
   public static final String KEEP_ALIVE_VAR = "ZEEBE_KEEP_ALIVE";
+  public static final String OVERRIDE_AUTHORITY_VAR = "ZEEBE_OVERRIDE_AUTHORITY";
   public static final String DEFAULT_GATEWAY_ADDRESS = "0.0.0.0:26500";
 
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
@@ -57,6 +59,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private CredentialsProvider credentialsProvider;
   private Duration keepAlive = Duration.ofSeconds(45);
   private JsonMapper jsonMapper = new ZeebeObjectMapper();
+  private String authority;
 
   @Override
   public String getGatewayAddress() {
@@ -129,6 +132,11 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   }
 
   @Override
+  public String getAuthority() {
+    return authority;
+  }
+
+  @Override
   public ZeebeClientBuilder withProperties(final Properties properties) {
 
     if (properties.containsKey(ClientProperties.GATEWAY_ADDRESS)) {
@@ -183,6 +191,9 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     }
     if (properties.containsKey(KEEP_ALIVE)) {
       keepAlive(properties.getProperty(KEEP_ALIVE));
+    }
+    if (properties.containsKey(OVERRIDE_AUTHORITY)) {
+      overrideAuthority(properties.getProperty(OVERRIDE_AUTHORITY));
     }
     return this;
   }
@@ -276,6 +287,12 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   }
 
   @Override
+  public ZeebeClientBuilder overrideAuthority(final String authority) {
+    this.authority = authority;
+    return this;
+  }
+
+  @Override
   public ZeebeClient build() {
     applyOverrides();
     applyDefaults();
@@ -299,6 +316,10 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     if (Environment.system().isDefined(KEEP_ALIVE_VAR)) {
       keepAlive(Environment.system().get(KEEP_ALIVE_VAR));
     }
+
+    if (Environment.system().isDefined(OVERRIDE_AUTHORITY_VAR)) {
+      overrideAuthority(Environment.system().get(OVERRIDE_AUTHORITY_VAR));
+    }
   }
 
   @Override
@@ -313,6 +334,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     appendProperty(sb, "defaultJobPollInterval", defaultJobPollInterval);
     appendProperty(sb, "defaultMessageTimeToLive", defaultMessageTimeToLive);
     appendProperty(sb, "defaultRequestTimeout", defaultRequestTimeout);
+    appendProperty(sb, "overriddenAuthority", authority);
 
     return sb.toString();
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -75,25 +75,6 @@ public class ZeebeClientCloudBuilderImpl
   }
 
   @Override
-  public ZeebeClientCloudBuilderStep4 gatewayAddress(final String gatewayAddress) {
-    innerBuilder.gatewayAddress(gatewayAddress);
-    return this;
-  }
-
-  @Override
-  public ZeebeClientCloudBuilderStep4 usePlaintext() {
-    innerBuilder.usePlaintext();
-    return this;
-  }
-
-  @Override
-  public ZeebeClientCloudBuilderStep4 credentialsProvider(
-      final CredentialsProvider credentialsProvider) {
-    innerBuilder.credentialsProvider(credentialsProvider);
-    return this;
-  }
-
-  @Override
   public ZeebeClientCloudBuilderStep4 withProperties(final Properties properties) {
     if (properties.containsKey(ClientProperties.CLOUD_CLUSTER_ID)) {
       withClusterId(properties.getProperty(ClientProperties.CLOUD_CLUSTER_ID));
@@ -105,6 +86,12 @@ public class ZeebeClientCloudBuilderImpl
       withClientSecret(properties.getProperty(ClientProperties.CLOUD_CLIENT_SECRET));
     }
     innerBuilder.withProperties(properties);
+    return this;
+  }
+
+  @Override
+  public ZeebeClientCloudBuilderStep4 gatewayAddress(final String gatewayAddress) {
+    innerBuilder.gatewayAddress(gatewayAddress);
     return this;
   }
 
@@ -151,8 +138,21 @@ public class ZeebeClientCloudBuilderImpl
   }
 
   @Override
+  public ZeebeClientCloudBuilderStep4 usePlaintext() {
+    innerBuilder.usePlaintext();
+    return this;
+  }
+
+  @Override
   public ZeebeClientCloudBuilderStep4 caCertificatePath(final String certificatePath) {
     innerBuilder.caCertificatePath(certificatePath);
+    return this;
+  }
+
+  @Override
+  public ZeebeClientCloudBuilderStep4 credentialsProvider(
+      final CredentialsProvider credentialsProvider) {
+    innerBuilder.credentialsProvider(credentialsProvider);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -21,6 +21,7 @@ import static io.camunda.zeebe.client.impl.command.ArgumentUtil.ensureNotNull;
 import io.camunda.zeebe.client.ClientProperties;
 import io.camunda.zeebe.client.CredentialsProvider;
 import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1;
 import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2;
 import io.camunda.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3;
@@ -171,6 +172,12 @@ public class ZeebeClientCloudBuilderImpl
   @Override
   public ZeebeClientCloudBuilderStep4 withJsonMapper(final JsonMapper jsonMapper) {
     innerBuilder.withJsonMapper(jsonMapper);
+    return this;
+  }
+
+  @Override
+  public ZeebeClientBuilder overrideAuthority(final String authority) {
+    innerBuilder.overrideAuthority(authority);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -99,7 +99,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
       final GatewayStub gatewayStub,
       final ScheduledExecutorService executorService) {
     this.config = config;
-    this.jsonMapper = config.getJsonMapper();
+    jsonMapper = config.getJsonMapper();
     this.channel = channel;
     asyncStub = gatewayStub;
     this.executorService = executorService;
@@ -289,7 +289,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
   }
 
   @Override
-  public UpdateRetriesJobCommandStep1 newUpdateRetriesCommand(ActivatedJob job) {
+  public UpdateRetriesJobCommandStep1 newUpdateRetriesCommand(final ActivatedJob job) {
     return newUpdateRetriesCommand(job.getKey());
   }
 
@@ -322,7 +322,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
   }
 
   @Override
-  public CompleteJobCommandStep1 newCompleteCommand(ActivatedJob job) {
+  public CompleteJobCommandStep1 newCompleteCommand(final ActivatedJob job) {
     return newCompleteCommand(job.getKey());
   }
 
@@ -332,17 +332,17 @@ public final class ZeebeClientImpl implements ZeebeClient {
   }
 
   @Override
-  public FailJobCommandStep1 newFailCommand(ActivatedJob job) {
+  public FailJobCommandStep1 newFailCommand(final ActivatedJob job) {
     return newFailCommand(job.getKey());
   }
 
   @Override
-  public ThrowErrorCommandStep1 newThrowErrorCommand(long jobKey) {
+  public ThrowErrorCommandStep1 newThrowErrorCommand(final long jobKey) {
     return jobClient.newThrowErrorCommand(jobKey);
   }
 
   @Override
-  public ThrowErrorCommandStep1 newThrowErrorCommand(ActivatedJob job) {
+  public ThrowErrorCommandStep1 newThrowErrorCommand(final ActivatedJob job) {
     return newThrowErrorCommand(job.getKey());
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -161,8 +161,8 @@ public final class ZeebeClientImpl implements ZeebeClient {
       }
 
       channelBuilder.useTransportSecurity().sslContext(sslContext);
-      if (config.getAuthority() != null) {
-        channelBuilder.overrideAuthority(config.getAuthority());
+      if (config.getOverrideAuthority() != null) {
+        channelBuilder.overrideAuthority(config.getOverrideAuthority());
       }
     } else {
       channelBuilder.usePlaintext();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -161,6 +161,9 @@ public final class ZeebeClientImpl implements ZeebeClient {
       }
 
       channelBuilder.useTransportSecurity().sslContext(sslContext);
+      if (config.getAuthority() != null) {
+        channelBuilder.overrideAuthority(config.getAuthority());
+      }
     } else {
       channelBuilder.usePlaintext();
     }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -62,7 +62,7 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(configuration.getDefaultJobPollInterval()).isEqualTo(Duration.ofMillis(100));
       assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(Duration.ofHours(1));
       assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
-      assertThat(configuration.getAuthority()).isNull();
+      assertThat(configuration.getOverrideAuthority()).isNull();
     }
   }
 
@@ -164,7 +164,7 @@ public final class ZeebeClientTest extends ClientTest {
     builder.build();
 
     // then
-    assertThat(builder.getAuthority()).isEqualTo("virtualhost");
+    assertThat(builder.getOverrideAuthority()).isEqualTo("virtualhost");
   }
 
   @Test
@@ -178,7 +178,7 @@ public final class ZeebeClientTest extends ClientTest {
     builder.build();
 
     // then
-    assertThat(builder.getAuthority()).isEqualTo("virtualhost");
+    assertThat(builder.getOverrideAuthority()).isEqualTo("virtualhost");
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.client;
 import static io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.CA_CERTIFICATE_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.KEEP_ALIVE_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.OVERRIDE_AUTHORITY_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.PLAINTEXT_CONNECTION_VAR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -61,6 +62,7 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(configuration.getDefaultJobPollInterval()).isEqualTo(Duration.ofMillis(100));
       assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(Duration.ofHours(1));
       assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
+      assertThat(configuration.getAuthority()).isNull();
     }
   }
 
@@ -150,6 +152,33 @@ public final class ZeebeClientTest extends ClientTest {
 
     // then
     assertThat(builder.getKeepAlive()).isEqualTo(Duration.ofSeconds(15));
+  }
+
+  @Test
+  public void shouldSetAuthority() {
+    // given
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    builder.overrideAuthority("virtualhost");
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getAuthority()).isEqualTo("virtualhost");
+  }
+
+  @Test
+  public void shouldOverrideAuthorityWithEnvVar() {
+    // given
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    builder.overrideAuthority("localhost");
+    Environment.system().put(OVERRIDE_AUTHORITY_VAR, "virtualhost");
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getAuthority()).isEqualTo("virtualhost");
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/SecurityTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/SecurityTest.java
@@ -9,14 +9,16 @@ package io.camunda.zeebe.it.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.client.api.response.Topology;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.it.clustering.ClusteringRule;
-import io.camunda.zeebe.it.clustering.DeploymentClusteredTest;
-import io.camunda.zeebe.it.util.GrpcClientRule;
 import io.netty.util.NetUtil;
 import java.io.File;
+import java.net.URL;
+import java.security.cert.CertificateException;
+import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -29,44 +31,62 @@ public final class SecurityTest {
       new ClusteringRule(
           1, 1, 1, brokerCfg -> {}, this::configureGatewayForTls, this::configureClientForTls);
 
-  public final GrpcClientRule clientRule =
-      new GrpcClientRule(
-          cfg ->
-              configureClientForTls(
-                  cfg.gatewayAddress(
-                      NetUtil.toSocketAddressString(clusteringRule.getGatewayAddress()))));
-
-  @Rule
-  public RuleChain ruleChain =
-      RuleChain.outerRule(testTimeout).around(clusteringRule).around(clientRule);
+  @Rule public RuleChain ruleChain = RuleChain.outerRule(testTimeout).around(clusteringRule);
 
   @Test
   public void shouldEstablishSecureConnection() {
+    final var client = newSecureClient().build();
+
     // when
-    final Topology topology = clientRule.getClient().newTopologyRequest().send().join();
+    final Topology topology = client.newTopologyRequest().send().join();
 
     // then
     assertThat(topology.getBrokers().size()).isEqualTo(1);
   }
 
+  @Test
+  public void shouldAllowToOverrideAuthority() {
+    final var client = newSecureClient().overrideAuthority("localhost").build();
+
+    // when
+    final Topology topology = client.newTopologyRequest().send().join();
+
+    // then
+    assertThat(topology.getBrokers().size()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldRejectDifferentAuthority() {
+    // given
+    final var client = newSecureClient().overrideAuthority("virtualhost").build();
+
+    // when, then
+    Assertions.assertThatThrownBy(() -> client.newTopologyRequest().send().join())
+        .hasRootCauseInstanceOf(CertificateException.class)
+        .hasRootCauseMessage("No name matching virtualhost found");
+  }
+
+  private ZeebeClientBuilder newSecureClient() {
+    return configureClientForTls(ZeebeClient.newClientBuilder())
+        .gatewayAddress(NetUtil.toSocketAddressString(clusteringRule.getGatewayAddress()));
+  }
+
   private ZeebeClientBuilder configureClientForTls(final ZeebeClientBuilder clientBuilder) {
-    return clientBuilder.caCertificatePath(
-        DeploymentClusteredTest.class
-            .getClassLoader()
-            .getResource("security/test-chain.cert.pem")
-            .getPath());
+    return clientBuilder.caCertificatePath(getResource("security/test-chain.cert.pem").getPath());
   }
 
   private void configureGatewayForTls(final GatewayCfg gatewayCfg) {
-    final String certificatePath =
-        getClass().getClassLoader().getResource("security/test-chain.cert.pem").getFile();
-    final String privateKeyPath =
-        getClass().getClassLoader().getResource("security/test-server.key.pem").getFile();
+    final String certificatePath = getResource("security/test-chain.cert.pem").getFile();
+    final String privateKeyPath = getResource("security/test-server.key.pem").getFile();
 
     gatewayCfg
         .getSecurity()
         .setEnabled(true)
         .setCertificateChainPath(new File(certificatePath))
         .setPrivateKeyPath(new File(privateKeyPath));
+  }
+
+  private URL getResource(final String name) {
+    return getClass().getClassLoader().getResource(name);
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Adds support to override the authority used in the TLS handshake. Specifically, to override the hostname used in the hostname verification.

It can be set using the `.overrideAuthority` on the `ZeebeClientBuilder` API, using the `ZEEBE_OVERRIDE_AUTHORITY` environment variable, or using the `zeebe.client.overrideauthority` configuration property.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8707 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
