### PR TITLE
Downgrade zeebe-protocol-jackson to java 8

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,7 @@ run the command: `mvn clean install -DskipTests` in the root folder.
 
 > NOTE: All Java modules in Zeebe are built and tested with JDK 17. Most modules use language level
 > 17, exceptions are: zeebe-bpmn-model, zeebe-client-java, zeebe-gateway-protocol,
-> zeebe-gateway-protocol-impl and zeebe-protocol which use language level 8 and
-> zeebe-protocol-jackson which uses language level 11.
+> zeebe-gateway-protocol-impl, zeebe-protocol and zeebe-protocol-jackson which use language level 8
 >
 > NOTE: The Go client and zbctl are built and tested with Go 1.15
 >

--- a/protocol-jackson/pom.xml
+++ b/protocol-jackson/pom.xml
@@ -16,7 +16,7 @@
   <name>Zeebe Protocol Jackson</name>
 
   <properties>
-    <version.java>11</version.java>
+    <version.java>8</version.java>
   </properties>
 
   <dependencies>

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/DefaultJsonSerializable.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/DefaultJsonSerializable.java
@@ -18,12 +18,11 @@ import java.io.UncheckedIOException;
  */
 interface DefaultJsonSerializable extends JsonSerializable {
   /** @deprecated use your own {@link ObjectMapper} instead of relying on this one */
-  @Deprecated(since = "1.2.0")
-  ObjectMapper JSON_WRITER = new ObjectMapper();
+  @Deprecated ObjectMapper JSON_WRITER = new ObjectMapper();
 
   /** @deprecated use a {@link ObjectMapper} directly instead of calling this method */
   @Override
-  @Deprecated(since = "1.2.0")
+  @Deprecated
   default String toJson() {
     try {
       return JSON_WRITER.writeValueAsString(this);

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/IntentTypeIdResolver.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/IntentTypeIdResolver.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.databind.DatabindContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 
@@ -37,13 +38,13 @@ final class IntentTypeIdResolver extends TypeIdResolverBase {
 
   @Override
   public JavaType typeFromId(final DatabindContext context, final String id) {
-    final var valueType = ValueType.valueOf(id);
-    final var typeFactory = context.getTypeFactory();
+    final ValueType valueType = ValueType.valueOf(id);
+    final TypeFactory typeFactory = context.getTypeFactory();
     return typeFactory.constructType(mapValueTypeToIntentClass(valueType));
   }
 
   private Class<? extends Intent> mapValueTypeToIntentClass(final ValueType valueType) {
-    final var typeInfo = ValueTypes.getTypeInfoOrNull(valueType);
+    final ValueTypeInfo<?> typeInfo = ValueTypes.getTypeInfoOrNull(valueType);
     if (typeInfo == null) {
       return Intent.UNKNOWN.getClass();
     }

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/ValueTypeIdResolver.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/ValueTypeIdResolver.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.databind.DatabindContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 
@@ -38,8 +39,8 @@ final class ValueTypeIdResolver extends TypeIdResolverBase {
 
   @Override
   public JavaType typeFromId(final DatabindContext context, final String id) {
-    final var valueType = ValueType.valueOf(id);
-    final var typeFactory = context.getTypeFactory();
+    final ValueType valueType = ValueType.valueOf(id);
+    final TypeFactory typeFactory = context.getTypeFactory();
     return typeFactory.constructType(mapValueTypeToRecordValue(valueType));
   }
 

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/ValueTypes.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/ValueTypes.java
@@ -137,7 +137,7 @@ final class ValueTypes {
   private ValueTypes() {}
 
   static ValueTypeInfo<?> getTypeInfo(final ValueType valueType) {
-    final var typeInfo = TYPES.get(valueType);
+    final ValueTypeInfo<?> typeInfo = TYPES.get(valueType);
     if (typeInfo == null) {
       throw new IllegalArgumentException(
           String.format(

--- a/protocol-jackson/src/test/java/io/camunda/zeebe/protocol/jackson/record/IntentTypeIdResolverTest.java
+++ b/protocol-jackson/src/test/java/io/camunda/zeebe/protocol/jackson/record/IntentTypeIdResolverTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.jackson.record;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.BeanDeserializerFactory;
 import com.fasterxml.jackson.databind.deser.DefaultDeserializationContext;
@@ -35,16 +36,16 @@ final class IntentTypeIdResolverTest {
   @ParameterizedTest
   void shouldHandleEveryKnownValueType(final ValueType type) throws IOException {
     // given
-    final var mapper = new ObjectMapper();
-    final var baseContext =
+    final ObjectMapper mapper = new ObjectMapper();
+    final DefaultDeserializationContext.Impl baseContext =
         new DefaultDeserializationContext.Impl(BeanDeserializerFactory.instance);
-    final var context =
+    final DefaultDeserializationContext context =
         baseContext.createInstance(
             mapper.getDeserializationConfig(),
             mapper.createParser("{}"),
             mapper.getInjectableValues());
-    final var resolver = new IntentTypeIdResolver();
-    final var resolvedType = resolver.typeFromId(context, resolver.idFromValue(type));
+    final IntentTypeIdResolver resolver = new IntentTypeIdResolver();
+    final JavaType resolvedType = resolver.typeFromId(context, resolver.idFromValue(type));
 
     assertThat(Intent.class).isAssignableFrom(resolvedType.getRawClass());
   }

--- a/protocol-jackson/src/test/java/io/camunda/zeebe/protocol/jackson/record/ValueTypeIdResolveTest.java
+++ b/protocol-jackson/src/test/java/io/camunda/zeebe/protocol/jackson/record/ValueTypeIdResolveTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.jackson.record;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.BeanDeserializerFactory;
 import com.fasterxml.jackson.databind.deser.DefaultDeserializationContext;
@@ -32,16 +33,16 @@ final class ValueTypeIdResolveTest {
   @ParameterizedTest
   void shouldHandleEveryKnownValueType(final ValueType type) throws IOException {
     // given
-    final var mapper = new ObjectMapper();
-    final var baseContext =
+    final ObjectMapper mapper = new ObjectMapper();
+    final DefaultDeserializationContext.Impl baseContext =
         new DefaultDeserializationContext.Impl(BeanDeserializerFactory.instance);
-    final var context =
+    final DefaultDeserializationContext context =
         baseContext.createInstance(
             mapper.getDeserializationConfig(),
             mapper.createParser("{}"),
             mapper.getInjectableValues());
-    final var resolver = new ValueTypeIdResolver();
-    final var resolvedType = resolver.typeFromId(context, resolver.idFromValue(type));
+    final ValueTypeIdResolver resolver = new ValueTypeIdResolver();
+    final JavaType resolvedType = resolver.typeFromId(context, resolver.idFromValue(type));
 
     assertThat(RecordValue.class).isAssignableFrom(resolvedType.getRawClass());
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
It makes sense to keep zeebe-protocol-jackson the same version as zeebe-protocol. The module will still be built using jdk17, but the language level will be targeting Java 8.

Two small changes had to be made to make the module Java 8 compatible:
1. Remove the `since` attribute from the `@Deprecated` annotations
2. Replace `var` with actual types.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
