### PR TITLE
Add checked methods to `ColumnFamily`

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/SkipFailingEventsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/SkipFailingEventsTest.java
@@ -59,7 +59,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -254,8 +253,7 @@ public final class SkipFailingEventsTest {
   }
 
   @Test
-  @Ignore("will be fixed by #7429")
-  public void shouldBacklistInstanceOnReplay() throws Exception {
+  public void shouldBlacklistInstanceOnReplay() throws Exception {
     // given
     when(commandResponseWriter.tryWriteResponse(anyInt(), anyLong())).thenReturn(true);
 

--- a/zb-db/pom.xml
+++ b/zb-db/pom.xml
@@ -56,6 +56,11 @@
     </dependency>
 
     <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
     </dependency>

--- a/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
@@ -71,7 +71,7 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue> 
    * Visits the key-value pairs, which are stored in the column family. The ordering depends on the
    * key.
    *
-   * <p>Similar to {@link #forEach(BiConsumer)}.
+   * <p>Similar to {@link #forEach(Consumer)}.
    *
    * @param consumer the consumer which accepts the key-value pairs
    */

--- a/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
@@ -116,9 +116,25 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue> 
   /**
    * Deletes the key-value pair with the given key from the column family.
    *
+   * @deprecated Prefer the {@link ColumnFamily#deleteExisting} which checks that the key does exist
+   *     or the unchecked {@link ColumnFamily#deleteIfExists}.
    * @param key the key which identifies the pair
    */
+  @Deprecated(forRemoval = true)
   void delete(KeyType key);
+
+  /**
+   * Deletes the key-value pair with the given key if it exists in the column family
+   *
+   * @throws IllegalStateException if the key does not exist
+   */
+  void deleteExisting(KeyType key);
+
+  /**
+   * Deletes the key-value pair if the key does exist in the column family. No-op if the key does
+   * not exist.
+   */
+  void deleteIfExists(KeyType key);
 
   /**
    * Checks for key existence in the column family.

--- a/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
@@ -22,10 +22,31 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue> 
   /**
    * Stores the key-value pair into the column family.
    *
+   * @deprecated Prefer {@link ColumnFamily#insert} or {@link ColumnFamily#update} which check that
+   *     the key does not exist (insert) or does exist (update). If update and insert can't be used,
+   *     use {@link ColumnFamily#upsert} instead of this method.
    * @param key the key
    * @param value the value
    */
+  @Deprecated(forRemoval = true)
   void put(KeyType key, ValueType value);
+
+  /**
+   * Inserts a new key value pair into the column family.
+   *
+   * @throws IllegalStateException if key already exists
+   */
+  void insert(KeyType key, ValueType value);
+
+  /**
+   * Updates the value of an existing key in the column family.
+   *
+   * @throws IllegalStateException if key does not exist
+   */
+  void update(KeyType key, ValueType value);
+
+  /** Inserts or updates a key value pair in the column family. */
+  void upsert(KeyType key, ValueType value);
 
   /**
    * The corresponding stored value in the column family to the given key.

--- a/zb-db/src/main/java/io/camunda/zeebe/db/ZeebeDbInconsistentException.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/ZeebeDbInconsistentException.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.db;
+
+public class ZeebeDbInconsistentException extends IllegalStateException {
+  public ZeebeDbInconsistentException(final String message) {
+    super(message);
+  }
+}

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.db.DbKey;
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.db.KeyValuePairVisitor;
 import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDbInconsistentException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -41,6 +42,7 @@ class TransactionalColumnFamily<
     implements ColumnFamily<KeyType, ValueType> {
 
   private final ZeebeTransactionDb<ColumnFamilyNames> transactionDb;
+  private final ColumnFamilyNames columnFamily;
   private final TransactionContext context;
 
   private final ValueType valueInstance;
@@ -54,6 +56,7 @@ class TransactionalColumnFamily<
       final KeyType keyInstance,
       final ValueType valueInstance) {
     this.transactionDb = transactionDb;
+    this.columnFamily = columnFamily;
     this.context = context;
     this.keyInstance = keyInstance;
     this.valueInstance = valueInstance;
@@ -251,7 +254,8 @@ class TransactionalColumnFamily<
             columnFamilyContext.getKeyBufferArray(),
             columnFamilyContext.getKeyLength());
     if (value != null) {
-      throw new IllegalStateException("Key already exists");
+      throw new ZeebeDbInconsistentException(
+          "Key " + keyInstance + " in ColumnFamily " + columnFamily + " already exists");
     }
   }
 
@@ -263,7 +267,8 @@ class TransactionalColumnFamily<
             columnFamilyContext.getKeyBufferArray(),
             columnFamilyContext.getKeyLength());
     if (value == null) {
-      throw new IllegalStateException("Key does not exist");
+      throw new ZeebeDbInconsistentException(
+          "Key " + keyInstance + " in ColumnFamily " + columnFamily + " does not exist");
     }
   }
 

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -75,7 +75,7 @@ class TransactionalColumnFamily<
           columnFamilyContext.writeKey(key);
           columnFamilyContext.writeValue(value);
 
-          assertDoesNotExist(transaction);
+          assertKeyDoesNotExist(transaction);
           transaction.put(
               transactionDb.getDefaultNativeHandle(),
               columnFamilyContext.getKeyBufferArray(),
@@ -91,7 +91,7 @@ class TransactionalColumnFamily<
         transaction -> {
           columnFamilyContext.writeKey(key);
           columnFamilyContext.writeValue(value);
-          assertExists(transaction);
+          assertKeyExists(transaction);
           transaction.put(
               transactionDb.getDefaultNativeHandle(),
               columnFamilyContext.getKeyBufferArray(),
@@ -195,7 +195,7 @@ class TransactionalColumnFamily<
     ensureInOpenTransaction(
         transaction -> {
           columnFamilyContext.writeKey(key);
-          assertExists(transaction);
+          assertKeyExists(transaction);
           transaction.delete(
               transactionDb.getDefaultNativeHandle(),
               columnFamilyContext.getKeyBufferArray(),
@@ -246,7 +246,7 @@ class TransactionalColumnFamily<
     return isEmpty.get();
   }
 
-  private void assertDoesNotExist(final ZeebeTransaction transaction) throws Exception {
+  private void assertKeyDoesNotExist(final ZeebeTransaction transaction) throws Exception {
     final var value =
         transaction.get(
             transactionDb.getDefaultNativeHandle(),
@@ -259,7 +259,7 @@ class TransactionalColumnFamily<
     }
   }
 
-  private void assertExists(final ZeebeTransaction transaction) throws Exception {
+  private void assertKeyExists(final ZeebeTransaction transaction) throws Exception {
     final var value =
         transaction.get(
             transactionDb.getDefaultNativeHandle(),

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -184,6 +184,24 @@ class TransactionalColumnFamily<
 
   @Override
   public void delete(final KeyType key) {
+    deleteIfExists(key);
+  }
+
+  @Override
+  public void deleteExisting(final KeyType key) {
+    ensureInOpenTransaction(
+        transaction -> {
+          columnFamilyContext.writeKey(key);
+          assertExists(transaction);
+          transaction.delete(
+              transactionDb.getDefaultNativeHandle(),
+              columnFamilyContext.getKeyBufferArray(),
+              columnFamilyContext.getKeyLength());
+        });
+  }
+
+  @Override
+  public void deleteIfExists(final KeyType key) {
     ensureInOpenTransaction(
         transaction -> {
           columnFamilyContext.writeKey(key);

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyRandomizedPropertyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyRandomizedPropertyTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.db.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.ZeebeDbFactory;
+import io.camunda.zeebe.db.ZeebeDbInconsistentException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.arbitraries.ListArbitrary;
+import net.jqwik.api.lifecycle.AfterProperty;
+import net.jqwik.api.lifecycle.AfterTry;
+import net.jqwik.api.lifecycle.BeforeProperty;
+import org.assertj.core.util.Files;
+
+public class ColumnFamilyRandomizedPropertyTest {
+
+  private Map<Long, Long> map;
+  private ColumnFamily<DbLong, DbLong> columnFamily;
+  private ZeebeDb<DefaultColumnFamily> zeebeDb;
+
+  @BeforeProperty
+  private void setup() {
+    final var pathName = Files.newTemporaryFolder();
+    final ZeebeDbFactory<DefaultColumnFamily> dbFactory = DefaultZeebeDbFactory.getDefaultFactory();
+    zeebeDb = dbFactory.createDb(pathName);
+
+    columnFamily =
+        zeebeDb.createColumnFamily(
+            DefaultColumnFamily.DEFAULT, zeebeDb.createContext(), new DbLong(), new DbLong());
+    map = new HashMap<>();
+  }
+
+  @Property
+  void columnFamilyHasSameEntriesAsMapAfterModifying(
+      @ForAll("operations") final Iterable<TestableOperation> operations) {
+    operations.forEach(op -> op.apply(map));
+    operations.forEach(op -> op.apply(columnFamily));
+    assertEqualEntries(columnFamily, map);
+  }
+
+  @AfterTry
+  private void cleanup() {
+    columnFamily.forEach((k, v) -> columnFamily.deleteExisting(k));
+    map.clear();
+  }
+
+  @AfterProperty
+  private void teardown() throws Exception {
+    zeebeDb.close();
+  }
+
+  @Provide
+  ListArbitrary<TestableOperation> operations() {
+    final var op =
+        Arbitraries.of(
+            PutOp.class,
+            InsertOp.class,
+            UpdateOp.class,
+            UpsertOp.class,
+            DeleteOp.class,
+            DeleteExisting.class,
+            DeleteIfExists.class);
+    final var k = Arbitraries.longs().greaterOrEqual(0);
+    final var v = Arbitraries.longs();
+    return Combinators.combine(op, k, v)
+        .as(
+            (arbitraryOp, arbitraryK, arbitraryV) -> {
+              try {
+                return (TestableOperation)
+                    arbitraryOp
+                        .getDeclaredConstructor(long.class, long.class)
+                        .newInstance(arbitraryK, arbitraryV);
+              } catch (final Exception e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .list();
+  }
+
+  private void assertEqualEntries(
+      final ColumnFamily<DbLong, DbLong> columnFamily, final Map<Long, Long> map) {
+    map.forEach(
+        (key, value) -> {
+          final var dbKey = new DbLong();
+          dbKey.wrapLong(key);
+          assertThat(columnFamily.get(dbKey))
+              .as("Key " + dbKey.getValue() + " should exist ")
+              .isNotNull()
+              .as("Key " + dbKey.getValue() + " should have value " + value)
+              .extracting(DbLong::getValue)
+              .isEqualTo(value);
+        });
+    columnFamily.forEach(
+        (key, value) -> assertThat(map).containsEntry(key.getValue(), value.getValue()));
+  }
+
+  record InsertOp(long key, long value) implements TestableOperation {
+
+    @Override
+    public BiConsumer<DbLong, DbLong> modify(final ColumnFamily<DbLong, DbLong> columnFamily) {
+      return columnFamily::insert;
+    }
+
+    @Override
+    public BiConsumer<Long, Long> modify(final Map<Long, Long> map) {
+      return map::putIfAbsent;
+    }
+  }
+
+  record PutOp(long key, long value) implements TestableOperation {
+
+    @Override
+    public BiConsumer<DbLong, DbLong> modify(final ColumnFamily<DbLong, DbLong> columnFamily) {
+      return columnFamily::put;
+    }
+
+    @Override
+    public BiConsumer<Long, Long> modify(final Map<Long, Long> map) {
+      return map::put;
+    }
+  }
+
+  record UpdateOp(long key, long value) implements TestableOperation {
+
+    @Override
+    public BiConsumer<DbLong, DbLong> modify(final ColumnFamily<DbLong, DbLong> columnFamily) {
+      return columnFamily::update;
+    }
+
+    @Override
+    public BiConsumer<Long, Long> modify(final Map<Long, Long> map) {
+      return (k, newValue) -> map.computeIfPresent(k, (k1, oldValue) -> newValue);
+    }
+  }
+
+  record UpsertOp(long key, long value) implements TestableOperation {
+
+    @Override
+    public BiConsumer<DbLong, DbLong> modify(final ColumnFamily<DbLong, DbLong> columnFamily) {
+      return columnFamily::upsert;
+    }
+
+    @Override
+    public BiConsumer<Long, Long> modify(final Map<Long, Long> map) {
+      return map::put;
+    }
+  }
+
+  record DeleteOp(long key, long value) implements TestableOperation {
+
+    @Override
+    public BiConsumer<DbLong, DbLong> modify(final ColumnFamily<DbLong, DbLong> columnFamily) {
+      return (k, v) -> columnFamily.delete(k);
+    }
+
+    @Override
+    public BiConsumer<Long, Long> modify(final Map<Long, Long> map) {
+      return (k, v) -> map.remove(k);
+    }
+  }
+
+  record DeleteIfExists(long key, long value) implements TestableOperation {
+
+    @Override
+    public BiConsumer<DbLong, DbLong> modify(final ColumnFamily<DbLong, DbLong> columnFamily) {
+      return (k, v) -> columnFamily.deleteIfExists(k);
+    }
+
+    @Override
+    public BiConsumer<Long, Long> modify(final Map<Long, Long> map) {
+      return (k, v) -> map.remove(k);
+    }
+  }
+
+  record DeleteExisting(long key, long value) implements TestableOperation {
+
+    @Override
+    public BiConsumer<DbLong, DbLong> modify(final ColumnFamily<DbLong, DbLong> columnFamily) {
+      return (k, v) -> columnFamily.deleteExisting(k);
+    }
+
+    @Override
+    public BiConsumer<Long, Long> modify(final Map<Long, Long> map) {
+      return (k, v) -> map.remove(k);
+    }
+  }
+
+  interface TestableOperation {
+    long key();
+
+    long value();
+
+    BiConsumer<DbLong, DbLong> modify(ColumnFamily<DbLong, DbLong> columnFamily);
+
+    BiConsumer<Long, Long> modify(Map<Long, Long> map);
+
+    default void apply(final ColumnFamily<DbLong, DbLong> columnFamily) {
+      final var dbKey = new DbLong();
+      final var dbValue = new DbLong();
+      dbKey.wrapLong(key());
+      dbValue.wrapLong(value());
+      try {
+        modify(columnFamily).accept(dbKey, dbValue);
+      } catch (final RuntimeException e) {
+        assertThat(e).hasRootCauseInstanceOf(ZeebeDbInconsistentException.class);
+      }
+    }
+
+    default void apply(final Map<Long, Long> map) {
+      modify(map).accept(key(), value());
+    }
+  }
+}

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbFactory;
+import io.camunda.zeebe.db.ZeebeDbInconsistentException;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.db.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -327,6 +328,36 @@ public final class ColumnFamilyTest {
 
     columnFamily.delete(key);
     assertThat(columnFamily.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void shouldThrowOnInsert() {
+    key.wrapLong(1);
+    value.wrapLong(10);
+    columnFamily.insert(key, value);
+    assertThatThrownBy(() -> columnFamily.insert(key, value))
+        .getRootCause()
+        .hasMessageContaining("already exists")
+        .isInstanceOf(ZeebeDbInconsistentException.class);
+  }
+
+  @Test
+  public void shouldThrowOnUpdate() {
+    key.wrapLong(1);
+    value.wrapLong(10);
+    assertThatThrownBy(() -> columnFamily.update(key, value))
+        .getRootCause()
+        .hasMessageContaining("does not exist")
+        .isInstanceOf(ZeebeDbInconsistentException.class);
+  }
+
+  @Test
+  public void shouldThrowOnDeleteExisting() {
+    key.wrapLong(1);
+    assertThatThrownBy(() -> columnFamily.deleteExisting(key))
+        .getRootCause()
+        .hasMessageContaining("does not exist")
+        .isInstanceOf(ZeebeDbInconsistentException.class);
   }
 
   private void putKeyValuePair(final int key, final int value) {


### PR DESCRIPTION
## Description

Here we are mainly adding methods to `ColumnFamily`: `deleteExisting`, `insert`, `update` and `upsert`. They aren't used anywhere yet, that'll come in a separate PR.

Also included in this PR are two smaller fixes and one larger refactoring/cleanup of `TransactionalColumnFamily`.

## Related issues

relates to #8787