### PR TITLE
Write an event for a decision evaluation

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -56,7 +56,11 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
     this.expressionBehavior = expressionBehavior;
     decisionBehavior =
         new BpmnDecisionBehavior(
-            DecisionEngineFactory.createDecisionEngine(), zeebeState, eventTriggerBehavior);
+            DecisionEngineFactory.createDecisionEngine(),
+            zeebeState,
+            eventTriggerBehavior,
+            stateWriter,
+            zeebeState.getKeyGenerator());
 
     stateBehavior = new BpmnStateBehavior(zeebeState, variableBehavior);
     stateTransitionGuard = new ProcessInstanceStateTransitionGuard(stateBehavior);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -181,17 +181,17 @@ public final class BpmnDecisionBehavior {
     final var decisionEvaluationEvent =
         new DecisionEvaluationRecord()
             .setDecisionKey(decision.getDecisionKey())
-            .setDecisionId(bufferAsString(decision.getDecisionId()))
-            .setDecisionName(bufferAsString(decision.getDecisionName()))
+            .setDecisionId(decision.getDecisionId())
+            .setDecisionName(decision.getDecisionName())
             .setDecisionVersion(decision.getVersion())
             .setDecisionRequirementsKey(decision.getDecisionRequirementsKey())
-            .setDecisionRequirementsId(bufferAsString(decision.getDecisionRequirementsId()))
+            .setDecisionRequirementsId(decision.getDecisionRequirementsId())
             .setDecisionOutput(decisionResult.getOutput())
             .setProcessDefinitionKey(context.getProcessDefinitionKey())
-            .setBpmnProcessId(bufferAsString(context.getBpmnProcessId()))
+            .setBpmnProcessId(context.getBpmnProcessId())
             .setProcessInstanceKey(context.getProcessInstanceKey())
             .setElementInstanceKey(context.getElementInstanceKey())
-            .setElementId(bufferAsString(context.getElementId()));
+            .setElementId(context.getElementId());
 
     decisionResult
         .getEvaluatedDecisions()

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -89,13 +89,13 @@ public final class BpmnDecisionBehavior {
             .flatMap(drg -> parseDrg(drg.getResource()))
             .flatMap(drg -> evaluateDecisionInDrg(drg, element.getDecisionId(), scopeKey));
 
-    // The output mapping behavior determines what to do with the decision result. Since the output
-    // mapping may fail and raise an incident, we need to write the variable to a record. This is
-    // because we want to evaluate the decision on element activation, while the output mapping
-    // happens on element completion. We don't want to re-evaluate the decision for output mapping
-    // related incidents.
     resultOrFailure.ifRight(
         result -> {
+          // The output mapping behavior determines what to do with the decision result. Since the
+          // output mapping may fail and raise an incident, we need to write the variable to a
+          // record. This is because we want to evaluate the decision on element activation, while
+          // the output mapping happens on element completion. We don't want to re-evaluate the
+          // decision for output mapping related incidents.
           triggerProcessEventWithResultVariable(context, element.getResultVariable(), result);
 
           final var decision = decisionOrFailure.get();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedEventRegistry.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedEventRegistry.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentDistributionRecord;
@@ -61,6 +62,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.PROCESS_EVENT, ProcessEventRecord.class);
     registry.put(ValueType.DECISION, DecisionRecord.class);
     registry.put(ValueType.DECISION_REQUIREMENTS, DecisionRequirementsRecord.class);
+    registry.put(ValueType.DECISION_EVALUATION, DecisionEvaluationRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
@@ -58,7 +58,7 @@ public final class BusinessRuleTaskTest {
         .withXmlClasspathResource(DMN_RESOURCE)
         .withXmlResource(
             processWithBusinessRuleTask(
-                t -> t.zeebeCalledDecisionId("jedi-or-sith").zeebeResultVariable(RESULT_VARIABLE)))
+                t -> t.zeebeCalledDecisionId("jedi_or_sith").zeebeResultVariable(RESULT_VARIABLE)))
         .deploy();
 
     // when
@@ -104,7 +104,7 @@ public final class BusinessRuleTaskTest {
         .withXmlClasspathResource(DMN_RESOURCE)
         .withXmlResource(
             processWithBusinessRuleTask(
-                t -> t.zeebeCalledDecisionId("jedi-or-sith").zeebeResultVariable(RESULT_VARIABLE)))
+                t -> t.zeebeCalledDecisionId("jedi_or_sith").zeebeResultVariable(RESULT_VARIABLE)))
         .deploy();
 
     // when
@@ -135,7 +135,7 @@ public final class BusinessRuleTaskTest {
         .withXmlClasspathResource(DMN_RESOURCE)
         .withXmlResource(
             processWithBusinessRuleTask(
-                t -> t.zeebeCalledDecisionId("jedi-or-sith").zeebeResultVariable(RESULT_VARIABLE)))
+                t -> t.zeebeCalledDecisionId("jedi_or_sith").zeebeResultVariable(RESULT_VARIABLE)))
         .deploy();
 
     // when
@@ -166,7 +166,7 @@ public final class BusinessRuleTaskTest {
         .withXmlResource(
             processWithBusinessRuleTask(
                 t ->
-                    t.zeebeCalledDecisionId("jedi-or-sith")
+                    t.zeebeCalledDecisionId("jedi_or_sith")
                         .zeebeResultVariable(RESULT_VARIABLE)
                         .zeebeOutputExpression(RESULT_VARIABLE, OUTPUT_TARGET)))
         .deploy();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentDmnTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentDmnTest.java
@@ -185,7 +185,7 @@ public final class DeploymentDmnTest {
         .hasSize(2)
         .extracting(Record::getValue)
         .extracting(DecisionRecordValue::getDecisionId, DecisionRecordValue::getDecisionName)
-        .contains(tuple("jedi-or-sith", "Jedi or Sith"), tuple("force-user", "Which force user?"));
+        .contains(tuple("jedi_or_sith", "Jedi or Sith"), tuple("force_user", "Which force user?"));
 
     assertThat(decisionRecords)
         .extracting(Record::getValue)

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/BusinessRuleTaskIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/BusinessRuleTaskIncidentTest.java
@@ -73,7 +73,7 @@ public class BusinessRuleTaskIncidentTest {
         .withXmlClasspathResource("/dmn/drg-force-user.dmn")
         .withXmlResource(
             processWithBusinessRuleTask(
-                b -> b.zeebeCalledDecisionId("jedi-or-sith").zeebeResultVariable("result")))
+                b -> b.zeebeCalledDecisionId("jedi_or_sith").zeebeResultVariable("result")))
         .deploy();
 
     // when
@@ -91,7 +91,7 @@ public class BusinessRuleTaskIncidentTest {
         .hasErrorType(ErrorType.CALLED_ELEMENT_ERROR)
         .hasErrorMessage(
             """
-            Expected to evaluate decision 'jedi-or-sith', \
+            Expected to evaluate decision 'jedi_or_sith', \
             but failed to evaluate expression 'lightsaberColor': \
             no variable found for name 'lightsaberColor'\
             """);
@@ -105,7 +105,7 @@ public class BusinessRuleTaskIncidentTest {
         .withXmlClasspathResource("/dmn/drg-force-user.dmn")
         .withXmlResource(
             processWithBusinessRuleTask(
-                b -> b.zeebeCalledDecisionId("jedi-or-sith").zeebeResultVariable("result")))
+                b -> b.zeebeCalledDecisionId("jedi_or_sith").zeebeResultVariable("result")))
         .deploy();
 
     // and an instance of that process is created without the required variables for the decision
@@ -146,7 +146,7 @@ public class BusinessRuleTaskIncidentTest {
         .withXmlClasspathResource("/dmn/drg-force-user.dmn")
         .withXmlResource(
             processWithBusinessRuleTask(
-                b -> b.zeebeCalledDecisionId("jedi-or-sith").zeebeResultVariable("result")))
+                b -> b.zeebeCalledDecisionId("jedi_or_sith").zeebeResultVariable("result")))
         .deploy();
 
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/OutputMappingIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/OutputMappingIncidentTest.java
@@ -97,7 +97,7 @@ public class OutputMappingIncidentTest {
                         .businessRuleTask(
                             "businessRuleTaskId",
                             b ->
-                                b.zeebeCalledDecisionId("jedi-or-sith")
+                                b.zeebeCalledDecisionId("jedi_or_sith")
                                     .zeebeResultVariable("result")
                                     .zeebeInputExpression("\"blue\"", "lightsaberColor")
                                     .zeebeOutputExpression("foo", "bar"))

--- a/engine/src/test/resources/dmn/drg-force-user.dmn
+++ b/engine/src/test/resources/dmn/drg-force-user.dmn
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="force-users" name="force-users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
-  <decision id="jedi-or-sith" name="Jedi or Sith">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="force-users" name="force-users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+  <decision id="jedi_or_sith" name="Jedi or Sith">
     <decisionTable id="DecisionTable_14n3bxx">
       <input id="Input_1" label="Lightsaber color" biodi:width="192">
         <inputExpression id="InputExpression_1" typeRef="string">
           <text>lightsaberColor</text>
         </inputExpression>
       </input>
-      <output id="Output_1" label="Jedi or Sith" name="faction" typeRef="string" biodi:width="192">
+      <output id="Output_1" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
         <outputValues id="UnaryTests_0hj346a">
           <text>"Jedi","Sith"</text>
         </outputValues>
@@ -38,14 +38,14 @@
       </rule>
     </decisionTable>
   </decision>
-  <decision id="force-user" name="Which force user?">
+  <decision id="force_user" name="Which force user?">
     <informationRequirement id="InformationRequirement_1o8esai">
-      <requiredDecision href="#jedi-or-sith" />
+      <requiredDecision href="#jedi_or_sith" />
     </informationRequirement>
     <decisionTable id="DecisionTable_07g94t1" hitPolicy="FIRST">
       <input id="InputClause_0qnqj25" label="Jedi or Sith">
         <inputExpression id="LiteralExpression_00lcyt5" typeRef="string">
-          <text>faction</text>
+          <text>jedi_or_sith</text>
         </inputExpression>
         <inputValues id="UnaryTests_1xjidd8">
           <text>"Jedi","Sith"</text>
@@ -56,7 +56,7 @@
           <text>height</text>
         </inputExpression>
       </input>
-      <output id="OutputClause_0hhe1yo" label="Force user" name="force-user" typeRef="string" />
+      <output id="OutputClause_0hhe1yo" label="Force user" name="force_user" typeRef="string" />
       <rule id="DecisionRule_13zidc5">
         <inputEntry id="UnaryTests_056skcq">
           <text>"Jedi"</text>
@@ -128,10 +128,10 @@
   </decision>
   <dmndi:DMNDI>
     <dmndi:DMNDiagram>
-      <dmndi:DMNShape dmnElementRef="jedi-or-sith">
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
         <dc:Bounds height="80" width="180" x="160" y="280" />
       </dmndi:DMNShape>
-      <dmndi:DMNShape id="DMNShape_1sb3tre" dmnElementRef="force-user">
+      <dmndi:DMNShape id="DMNShape_1sb3tre" dmnElementRef="force_user">
         <dc:Bounds height="80" width="180" x="280" y="80" />
       </dmndi:DMNShape>
       <dmndi:DMNEdge id="DMNEdge_0gt1p1u" dmnElementRef="InformationRequirement_1o8esai">

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.decision;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ValueArray;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayList;
+import java.util.List;
+import org.agrona.DirectBuffer;
+
+public final class DecisionEvaluationRecord extends UnifiedRecordValue
+    implements DecisionEvaluationRecordValue {
+
+  private final LongProperty decisionKeyProp = new LongProperty("decisionKey");
+  private final StringProperty decisionIdProp = new StringProperty("decisionId");
+  private final StringProperty decisionNameProp = new StringProperty("decisionName");
+  private final IntegerProperty decisionVersionProp = new IntegerProperty("decisionVersion");
+  private final StringProperty decisionRequirementsIdProp =
+      new StringProperty("decisionRequirementsId");
+  private final LongProperty decisionRequirementsKeyProp =
+      new LongProperty("decisionRequirementsKey");
+  private final BinaryProperty decisionOutputProp = new BinaryProperty("decisionOutput");
+
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId");
+  private final LongProperty processDefinitionKeyProp = new LongProperty("processDefinitionKey");
+  private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey");
+  private final StringProperty elementIdProp = new StringProperty("elementId");
+  private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey");
+
+  private final ArrayProperty<EvaluatedDecisionRecord> evaluatedDecisionsProp =
+      new ArrayProperty<>("evaluatedDecisions", new EvaluatedDecisionRecord());
+
+  public DecisionEvaluationRecord() {
+    declareProperty(decisionKeyProp)
+        .declareProperty(decisionIdProp)
+        .declareProperty(decisionNameProp)
+        .declareProperty(decisionVersionProp)
+        .declareProperty(decisionRequirementsIdProp)
+        .declareProperty(decisionRequirementsKeyProp)
+        .declareProperty(decisionOutputProp)
+        .declareProperty(bpmnProcessIdProp)
+        .declareProperty(processDefinitionKeyProp)
+        .declareProperty(processInstanceKeyProp)
+        .declareProperty(elementIdProp)
+        .declareProperty(elementInstanceKeyProp)
+        .declareProperty(evaluatedDecisionsProp);
+  }
+
+  @Override
+  public long getDecisionKey() {
+    return decisionKeyProp.getValue();
+  }
+
+  public DecisionEvaluationRecord setDecisionKey(final long decisionKey) {
+    decisionKeyProp.setValue(decisionKey);
+    return this;
+  }
+
+  @Override
+  public String getDecisionId() {
+    return bufferAsString(decisionIdProp.getValue());
+  }
+
+  public DecisionEvaluationRecord setDecisionId(final String decisionId) {
+    decisionIdProp.setValue(decisionId);
+    return this;
+  }
+
+  @Override
+  public String getDecisionName() {
+    return bufferAsString(decisionNameProp.getValue());
+  }
+
+  public DecisionEvaluationRecord setDecisionName(final String decisionName) {
+    decisionNameProp.setValue(decisionName);
+    return this;
+  }
+
+  @Override
+  public int getDecisionVersion() {
+    return decisionVersionProp.getValue();
+  }
+
+  public DecisionEvaluationRecord setDecisionVersion(final int decisionVersion) {
+    decisionVersionProp.setValue(decisionVersion);
+    return this;
+  }
+
+  @Override
+  public String getDecisionRequirementsId() {
+    return bufferAsString(decisionRequirementsIdProp.getValue());
+  }
+
+  public DecisionEvaluationRecord setDecisionRequirementsId(final String decisionRequirementsId) {
+    decisionRequirementsIdProp.setValue(decisionRequirementsId);
+    return this;
+  }
+
+  @Override
+  public long getDecisionRequirementsKey() {
+    return decisionRequirementsKeyProp.getValue();
+  }
+
+  public DecisionEvaluationRecord setDecisionRequirementsKey(final long decisionRequirementsKey) {
+    decisionRequirementsKeyProp.setValue(decisionRequirementsKey);
+    return this;
+  }
+
+  @Override
+  public String getDecisionOutput() {
+    return MsgPackConverter.convertToJson(decisionOutputProp.getValue());
+  }
+
+  public DecisionEvaluationRecord setDecisionOutput(final DirectBuffer decisionOutput) {
+    decisionOutputProp.setValue(decisionOutput);
+    return this;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  public DecisionEvaluationRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKeyProp.getValue();
+  }
+
+  public DecisionEvaluationRecord setProcessDefinitionKey(final long processDefinitionKey) {
+    processDefinitionKeyProp.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
+  }
+
+  public DecisionEvaluationRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProp.setValue(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public String getElementId() {
+    return bufferAsString(elementIdProp.getValue());
+  }
+
+  public DecisionEvaluationRecord setElementId(final String elementId) {
+    elementIdProp.setValue(elementId);
+    return this;
+  }
+
+  @Override
+  public long getElementInstanceKey() {
+    return elementInstanceKeyProp.getValue();
+  }
+
+  public DecisionEvaluationRecord setElementInstanceKey(final long elementInstanceKey) {
+    elementInstanceKeyProp.setValue(elementInstanceKey);
+    return this;
+  }
+
+  @Override
+  public List<EvaluatedDecisionValue> getEvaluatedDecisions() {
+    final List<EvaluatedDecisionValue> evaluatedDecisions = new ArrayList<>();
+
+    for (final EvaluatedDecisionRecord evaluatedDecision : evaluatedDecisionsProp) {
+      final var copyRecord = new EvaluatedDecisionRecord();
+      final var copyBuffer = BufferUtil.createCopy(evaluatedDecision);
+      copyRecord.wrap(copyBuffer);
+      evaluatedDecisions.add(copyRecord);
+    }
+
+    return evaluatedDecisions;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getDecisionOutputBuffer() {
+    return decisionOutputProp.getValue();
+  }
+
+  @JsonIgnore
+  public ValueArray<EvaluatedDecisionRecord> evaluatedDecisions() {
+    return evaluatedDecisionsProp;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getDecisionRequirementsIdBuffer() {
+    return decisionRequirementsIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBpmnProcessIdBuffer() {
+    return bpmnProcessIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getElementIdBuffer() {
+    return elementIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getDecisionIdBuffer() {
+    return decisionIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getDecisionNameBuffer() {
+    return decisionNameProp.getValue();
+  }
+}

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
@@ -83,12 +83,22 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
     return this;
   }
 
+  public DecisionEvaluationRecord setDecisionId(final DirectBuffer decisionId) {
+    decisionIdProp.setValue(decisionId);
+    return this;
+  }
+
   @Override
   public String getDecisionName() {
     return bufferAsString(decisionNameProp.getValue());
   }
 
   public DecisionEvaluationRecord setDecisionName(final String decisionName) {
+    decisionNameProp.setValue(decisionName);
+    return this;
+  }
+
+  public DecisionEvaluationRecord setDecisionName(final DirectBuffer decisionName) {
     decisionNameProp.setValue(decisionName);
     return this;
   }
@@ -109,6 +119,12 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
   }
 
   public DecisionEvaluationRecord setDecisionRequirementsId(final String decisionRequirementsId) {
+    decisionRequirementsIdProp.setValue(decisionRequirementsId);
+    return this;
+  }
+
+  public DecisionEvaluationRecord setDecisionRequirementsId(
+      final DirectBuffer decisionRequirementsId) {
     decisionRequirementsIdProp.setValue(decisionRequirementsId);
     return this;
   }
@@ -143,6 +159,11 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
     return this;
   }
 
+  public DecisionEvaluationRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
   @Override
   public long getProcessDefinitionKey() {
     return processDefinitionKeyProp.getValue();
@@ -169,6 +190,11 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
   }
 
   public DecisionEvaluationRecord setElementId(final String elementId) {
+    elementIdProp.setValue(elementId);
+    return this;
+  }
+
+  public DecisionEvaluationRecord setElementId(final DirectBuffer elementId) {
     elementIdProp.setValue(elementId);
     return this;
   }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedDecisionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedDecisionRecord.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.decision;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ValueArray;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import io.camunda.zeebe.protocol.record.value.EvaluatedInputValue;
+import io.camunda.zeebe.protocol.record.value.MatchedRuleValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayList;
+import java.util.List;
+import org.agrona.DirectBuffer;
+
+public final class EvaluatedDecisionRecord extends UnifiedRecordValue
+    implements EvaluatedDecisionValue {
+
+  private final StringProperty decisionIdProp = new StringProperty("decisionId");
+  private final StringProperty decisionNameProp = new StringProperty("decisionName");
+  private final StringProperty decisionTypeProp = new StringProperty("decisionType");
+  private final BinaryProperty decisionOutputProp = new BinaryProperty("decisionOutput");
+
+  private final ArrayProperty<EvaluatedInputRecord> evaluatedInputsProp =
+      new ArrayProperty<>("evaluatedInputs", new EvaluatedInputRecord());
+
+  private final ArrayProperty<MatchedRuleRecord> matchedRulesProp =
+      new ArrayProperty<>("matchedRules", new MatchedRuleRecord());
+
+  public EvaluatedDecisionRecord() {
+    declareProperty(decisionIdProp)
+        .declareProperty(decisionNameProp)
+        .declareProperty(decisionTypeProp)
+        .declareProperty(decisionOutputProp)
+        .declareProperty(evaluatedInputsProp)
+        .declareProperty(matchedRulesProp);
+  }
+
+  @Override
+  public String getDecisionId() {
+    return bufferAsString(decisionIdProp.getValue());
+  }
+
+  public EvaluatedDecisionRecord setDecisionId(final String decisionId) {
+    decisionIdProp.setValue(decisionId);
+    return this;
+  }
+
+  @Override
+  public String getDecisionName() {
+    return bufferAsString(decisionNameProp.getValue());
+  }
+
+  public EvaluatedDecisionRecord setDecisionName(final String decisionName) {
+    decisionNameProp.setValue(decisionName);
+    return this;
+  }
+
+  @Override
+  public String getDecisionType() {
+    return bufferAsString(decisionTypeProp.getValue());
+  }
+
+  public EvaluatedDecisionRecord setDecisionType(final String decisionType) {
+    decisionTypeProp.setValue(decisionType);
+    return this;
+  }
+
+  @Override
+  public String getDecisionOutput() {
+    return MsgPackConverter.convertToJson(decisionOutputProp.getValue());
+  }
+
+  public EvaluatedDecisionRecord setDecisionOutput(final DirectBuffer decisionOutput) {
+    decisionOutputProp.setValue(decisionOutput);
+    return this;
+  }
+
+  @Override
+  public List<EvaluatedInputValue> getEvaluatedInputs() {
+    final List<EvaluatedInputValue> evaluatedInputs = new ArrayList<>();
+
+    for (final EvaluatedInputRecord evaluatedInput : evaluatedInputsProp) {
+      final var copyRecord = new EvaluatedInputRecord();
+      final var copyBuffer = BufferUtil.createCopy(evaluatedInput);
+      copyRecord.wrap(copyBuffer);
+      evaluatedInputs.add(copyRecord);
+    }
+
+    return evaluatedInputs;
+  }
+
+  @Override
+  public List<MatchedRuleValue> getMatchedRules() {
+    final List<MatchedRuleValue> matchedRules = new ArrayList<>();
+
+    for (final MatchedRuleRecord matchedRule : matchedRulesProp) {
+      final var copyRecord = new MatchedRuleRecord();
+      final var copyBuffer = BufferUtil.createCopy(matchedRule);
+      copyRecord.wrap(copyBuffer);
+      matchedRules.add(copyRecord);
+    }
+
+    return matchedRules;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getDecisionOutputBuffer() {
+    return decisionOutputProp.getValue();
+  }
+
+  @JsonIgnore
+  public ValueArray<MatchedRuleRecord> matchedRules() {
+    return matchedRulesProp;
+  }
+
+  @JsonIgnore
+  public ValueArray<EvaluatedInputRecord> evaluatedInputs() {
+    return evaluatedInputsProp;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getDecisionIdBuffer() {
+    return decisionIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getDecisionNameBuffer() {
+    return decisionNameProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getDecisionTypeBuffer() {
+    return decisionTypeProp.getValue();
+  }
+}

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedInputRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedInputRecord.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.decision;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.EvaluatedInputValue;
+import org.agrona.DirectBuffer;
+
+public final class EvaluatedInputRecord extends UnifiedRecordValue implements EvaluatedInputValue {
+
+  private final StringProperty inputIdProp = new StringProperty("inputId");
+  private final StringProperty inputNameProp = new StringProperty("inputName");
+  private final BinaryProperty inputValueProp = new BinaryProperty("inputValue");
+
+  public EvaluatedInputRecord() {
+    declareProperty(inputIdProp).declareProperty(inputNameProp).declareProperty(inputValueProp);
+  }
+
+  @Override
+  public String getInputId() {
+    return bufferAsString(inputIdProp.getValue());
+  }
+
+  public EvaluatedInputRecord setInputId(final String inputId) {
+    inputIdProp.setValue(inputId);
+    return this;
+  }
+
+  @Override
+  public String getInputName() {
+    return bufferAsString(inputNameProp.getValue());
+  }
+
+  public EvaluatedInputRecord setInputName(final String inputName) {
+    inputNameProp.setValue(inputName);
+    return this;
+  }
+
+  @Override
+  public String getInputValue() {
+    return MsgPackConverter.convertToJson(inputValueProp.getValue());
+  }
+
+  public EvaluatedInputRecord setInputValue(final DirectBuffer inputValue) {
+    inputValueProp.setValue(inputValue);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getInputValueBuffer() {
+    return inputValueProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getInputIdBuffer() {
+    return inputIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getInputNameBuffer() {
+    return inputNameProp.getValue();
+  }
+}

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedOutputRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedOutputRecord.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.decision;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.EvaluatedOutputValue;
+import org.agrona.DirectBuffer;
+
+public final class EvaluatedOutputRecord extends UnifiedRecordValue
+    implements EvaluatedOutputValue {
+
+  private final StringProperty outputIdProp = new StringProperty("outputId");
+  private final StringProperty outputNameProp = new StringProperty("outputName");
+  private final BinaryProperty outputValueProp = new BinaryProperty("outputValue");
+
+  public EvaluatedOutputRecord() {
+    declareProperty(outputIdProp).declareProperty(outputNameProp).declareProperty(outputValueProp);
+  }
+
+  @Override
+  public String getOutputId() {
+    return bufferAsString(outputIdProp.getValue());
+  }
+
+  public EvaluatedOutputRecord setOutputId(final String outputId) {
+    outputIdProp.setValue(outputId);
+    return this;
+  }
+
+  @Override
+  public String getOutputName() {
+    return bufferAsString(outputNameProp.getValue());
+  }
+
+  public EvaluatedOutputRecord setOutputName(final String outputName) {
+    outputNameProp.setValue(outputName);
+    return this;
+  }
+
+  @Override
+  public String getOutputValue() {
+    return MsgPackConverter.convertToJson(outputValueProp.getValue());
+  }
+
+  public EvaluatedOutputRecord setOutputValue(final DirectBuffer outputValue) {
+    outputValueProp.setValue(outputValue);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getOutputValueBuffer() {
+    return outputValueProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getOutputIdBuffer() {
+    return outputIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getOutputNameBuffer() {
+    return outputNameProp.getValue();
+  }
+}

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/MatchedRuleRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/MatchedRuleRecord.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.decision;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ValueArray;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.EvaluatedOutputValue;
+import io.camunda.zeebe.protocol.record.value.MatchedRuleValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayList;
+import java.util.List;
+import org.agrona.DirectBuffer;
+
+public final class MatchedRuleRecord extends UnifiedRecordValue implements MatchedRuleValue {
+
+  private final StringProperty ruleIdProp = new StringProperty("ruleId");
+  private final IntegerProperty ruleIndexProp = new IntegerProperty("ruleIndex");
+
+  private final ArrayProperty<EvaluatedOutputRecord> evaluatedOutputsProp =
+      new ArrayProperty<>("evaluatedOutputs", new EvaluatedOutputRecord());
+
+  public MatchedRuleRecord() {
+    declareProperty(ruleIdProp)
+        .declareProperty(ruleIndexProp)
+        .declareProperty(evaluatedOutputsProp);
+  }
+
+  @Override
+  public String getRuleId() {
+    return bufferAsString(ruleIdProp.getValue());
+  }
+
+  public MatchedRuleRecord setRuleId(final String ruleId) {
+    ruleIdProp.setValue(ruleId);
+    return this;
+  }
+
+  @Override
+  public int getRuleIndex() {
+    return ruleIndexProp.getValue();
+  }
+
+  public MatchedRuleRecord setRuleIndex(final int ruleIndex) {
+    ruleIndexProp.setValue(ruleIndex);
+    return this;
+  }
+
+  @Override
+  public List<EvaluatedOutputValue> getEvaluatedOutputs() {
+    final List<EvaluatedOutputValue> evaluatedOutputs = new ArrayList<>();
+
+    for (final EvaluatedOutputRecord evaluatedOutput : evaluatedOutputsProp) {
+      final var copyRecord = new EvaluatedOutputRecord();
+      final var copyBuffer = BufferUtil.createCopy(evaluatedOutput);
+      copyRecord.wrap(copyBuffer);
+      evaluatedOutputs.add(copyRecord);
+    }
+
+    return evaluatedOutputs;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getRuleIdBuffer() {
+    return ruleIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public ValueArray<EvaluatedOutputRecord> evaluatedOutputs() {
+    return evaluatedOutputsProp;
+  }
+}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractDecisionEvaluationRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractDecisionEvaluationRecordValue.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.DecisionEvaluationRecordValueBuilder.ImmutableDecisionEvaluationRecordValue;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableDecisionEvaluationRecordValue.class)
+public abstract class AbstractDecisionEvaluationRecordValue
+    implements DecisionEvaluationRecordValue, DefaultJsonSerializable {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/ValueTypes.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/ValueTypes.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.jackson.record;
 
+import io.camunda.zeebe.protocol.jackson.record.DecisionEvaluationRecordValueBuilder.ImmutableDecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.jackson.record.DecisionRecordValueBuilder.ImmutableDecisionRecordValue;
 import io.camunda.zeebe.protocol.jackson.record.DecisionRequirementsRecordValueBuilder.ImmutableDecisionRequirementsRecordValue;
 import io.camunda.zeebe.protocol.jackson.record.DeploymentDistributionRecordValueBuilder.ImmutableDeploymentDistributionRecordValue;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.protocol.jackson.record.TimerRecordValueBuilder.Immutabl
 import io.camunda.zeebe.protocol.jackson.record.VariableDocumentRecordValueBuilder.ImmutableVariableDocumentRecordValue;
 import io.camunda.zeebe.protocol.jackson.record.VariableRecordValueBuilder.ImmutableVariableRecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
@@ -66,6 +68,10 @@ final class ValueTypes {
     mapping.put(
         ValueType.DECISION,
         new ValueTypeInfo<>(ImmutableDecisionRecordValue.class, DecisionIntent.class));
+    mapping.put(
+        ValueType.DECISION_EVALUATION,
+        new ValueTypeInfo<>(
+            ImmutableDecisionEvaluationRecordValue.class, DecisionEvaluationIntent.class));
     mapping.put(
         ValueType.DECISION_REQUIREMENTS,
         new ValueTypeInfo<>(

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionEvaluationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionEvaluationIntent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum DecisionEvaluationIntent implements Intent {
+  EVALUATED(0);
+
+  private final short value;
+
+  DecisionEvaluationIntent(final int value) {
+    this.value = (short) value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return EVALUATED;
+      default:
+        return UNKNOWN;
+    }
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -39,7 +39,8 @@ public interface Intent {
           DeploymentDistributionIntent.class,
           ProcessEventIntent.class,
           DecisionIntent.class,
-          DecisionRequirementsIntent.class);
+          DecisionRequirementsIntent.class,
+          DecisionEvaluationIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN =
       new Intent() {
@@ -100,6 +101,8 @@ public interface Intent {
         return DecisionIntent.from(intent);
       case DECISION_REQUIREMENTS:
         return DecisionRequirementsIntent.from(intent);
+      case DECISION_EVALUATION:
+        return DecisionEvaluationIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -153,6 +156,8 @@ public interface Intent {
         return DecisionIntent.valueOf(intent);
       case DECISION_REQUIREMENTS:
         return DecisionRequirementsIntent.valueOf(intent);
+      case DECISION_EVALUATION:
+        return DecisionEvaluationIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DecisionEvaluationRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DecisionEvaluationRecordValue.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.RecordValue;
+import java.util.List;
+
+/** Represents the evaluation of a DMN decision. */
+public interface DecisionEvaluationRecordValue extends RecordValue {
+
+  /** @return the key of the evaluated decision */
+  long getDecisionKey();
+
+  /** @return the id of the evaluated decision in the DMN */
+  String getDecisionId();
+
+  /** @return the name of the evaluated decision in the DMN */
+  String getDecisionName();
+
+  /** @return the version of the evaluated decision */
+  int getDecisionVersion();
+
+  /** @return the id of the DRG in the DMN the evaluated decision belongs to */
+  String getDecisionRequirementsId();
+
+  /** @return the key of the deployed DRG the evaluated decision belongs to */
+  long getDecisionRequirementsKey();
+
+  /** @return the output of the evaluated decision as JSON string */
+  String getDecisionOutput();
+
+  /** @return the BPMN process id in which context the decision was evaluated */
+  String getBpmnProcessId();
+
+  /** @return the key of the process in which context the decision was evaluated */
+  long getProcessDefinitionKey();
+
+  /** @return the key of the process instance in which context the decision was evaluated */
+  long getProcessInstanceKey();
+
+  /** @return the id of the element in the BPMN in which context the decision was evaluated */
+  String getElementId();
+
+  /** @return the key of the element instance in which context the decision was evaluated */
+  long getElementInstanceKey();
+
+  /**
+   * Returns the {@link EvaluatedDecisionValue details} of the evaluated decision and its required
+   * decisions. The order depends on the evaluation order, starting from the required decisions.
+   *
+   * @return details of the evaluated decisions
+   */
+  List<EvaluatedDecisionValue> getEvaluatedDecisions();
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EvaluatedDecisionValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EvaluatedDecisionValue.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.RecordValue;
+import java.util.List;
+
+/**
+ * An evaluated DMN decision. It contains details of the evaluation depending on the decision type.
+ */
+public interface EvaluatedDecisionValue extends RecordValue {
+
+  /** @return the id of the evaluated decision */
+  String getDecisionId();
+
+  /** @return the name of the evaluated decision */
+  String getDecisionName();
+
+  /** @return the type of the evaluated decision */
+  String getDecisionType();
+
+  /** @return the output of the evaluated decision as JSON string */
+  String getDecisionOutput();
+
+  /**
+   * If the decision is a decision table then it returns the {@link EvaluatedInputValue evaluated
+   * inputs}. The inputs are not available for other types of decision.
+   *
+   * @return the evaluated inputs, or an empty list if the decision is not a decision table
+   */
+  List<EvaluatedInputValue> getEvaluatedInputs();
+
+  /**
+   * If the decision is a decision table then it returns the matched rules. The {@link
+   * MatchedRuleValue matched rules} are not available for other types of decision.
+   *
+   * @return the matched rules, or an empty list if the decision is not a decision table
+   */
+  List<MatchedRuleValue> getMatchedRules();
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EvaluatedInputValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EvaluatedInputValue.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.RecordValue;
+
+/**
+ * An evaluated input of a decision table. It contains details of the input and the value of the
+ * evaluated input expression.
+ */
+public interface EvaluatedInputValue extends RecordValue {
+
+  /** @return the id of the evaluated input */
+  String getInputId();
+
+  /** @return the name of the evaluated input */
+  String getInputName();
+
+  /** @return the value of the evaluated input expression as JSON string */
+  String getInputValue();
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EvaluatedOutputValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EvaluatedOutputValue.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.RecordValue;
+
+/**
+ * An evaluated output of a decision table that belongs to a {@link MatchedRuleValue matched rule}.
+ * It contains details of the output and the value of the evaluated output expression.
+ */
+public interface EvaluatedOutputValue extends RecordValue {
+
+  /** @return the id of the evaluated output */
+  String getOutputId();
+
+  /** @return the name of the evaluated output */
+  String getOutputName();
+
+  /** @return the value of the evaluated output expression as JSON string */
+  String getOutputValue();
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MatchedRuleValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MatchedRuleValue.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.RecordValue;
+import java.util.List;
+
+/**
+ * A matched rule of a decision table. It contains details of the rule and its {@link
+ * EvaluatedOutputValue outputs}.
+ */
+public interface MatchedRuleValue extends RecordValue {
+
+  /** @return the id of the matched rule */
+  String getRuleId();
+
+  /**
+   * Returns the index of the matched rule in the decision table, starting with 1.
+   *
+   * @return the index of the matched rule
+   */
+  int getRuleIndex();
+
+  /** @return the evaluated outputs of the rule */
+  List<EvaluatedOutputValue> getEvaluatedOutputs();
+}

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -41,6 +41,7 @@
       <validValue name="PROCESS_EVENT">24</validValue>
       <validValue name="DECISION">25</validValue>
       <validValue name="DECISION_REQUIREMENTS">26</validValue>
+      <validValue name="DECISION_EVALUATION">27</validValue>
     </enum>
 
     <enum name="RecordType" encodingType="uint8">

--- a/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
+++ b/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
@@ -44,6 +44,8 @@ public class IntentEncodingDecodingTest {
   @Parameters(name = "{0}")
   public static Collection<ParameterSet> parameters() {
     final List<ParameterSet> result = new ArrayList<>();
+    result.addAll(
+        buildParameterSets(DecisionEvaluationIntent.class, DecisionEvaluationIntent::from));
     result.addAll(buildParameterSets(DecisionIntent.class, DecisionIntent::from));
     result.addAll(
         buildParameterSets(DecisionRequirementsIntent.class, DecisionRequirementsIntent::from));

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/DecisionEvaluationRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/DecisionEvaluationRecordStream.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import java.util.stream.Stream;
+
+public final class DecisionEvaluationRecordStream
+    extends ExporterRecordStream<DecisionEvaluationRecordValue, DecisionEvaluationRecordStream> {
+
+  public DecisionEvaluationRecordStream(
+      final Stream<Record<DecisionEvaluationRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected DecisionEvaluationRecordStream supply(
+      final Stream<Record<DecisionEvaluationRecordValue>> wrappedStream) {
+    return new DecisionEvaluationRecordStream(wrappedStream);
+  }
+
+  public DecisionEvaluationRecordStream withProcessInstanceKey(final long processInstanceKey) {
+    return valueFilter(v -> v.getProcessInstanceKey() == processInstanceKey);
+  }
+
+  public DecisionEvaluationRecordStream withElementInstanceKey(final long elementInstanceKey) {
+    return valueFilter(v -> v.getElementInstanceKey() == elementInstanceKey);
+  }
+
+  public DecisionEvaluationRecordStream withElementId(final String elementId) {
+    return valueFilter(v -> v.getElementId().equals(elementId));
+  }
+
+  public DecisionEvaluationRecordStream withDecisionKey(final long decisionKey) {
+    return valueFilter(v -> v.getDecisionKey() == decisionKey);
+  }
+
+  public DecisionEvaluationRecordStream withDecisionId(final String decisionId) {
+    return valueFilter(v -> v.getDecisionId().equals(decisionId));
+  }
+
+  public DecisionEvaluationRecordStream withDecisionName(final String decisionName) {
+    return valueFilter(v -> v.getDecisionName().equals(decisionName));
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/DecisionRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/DecisionRecordStream.java
@@ -22,4 +22,16 @@ public class DecisionRecordStream
   protected DecisionRecordStream supply(final Stream<Record<DecisionRecordValue>> wrappedStream) {
     return new DecisionRecordStream(wrappedStream);
   }
+
+  public DecisionRecordStream withDecisionId(final String decisionId) {
+    return valueFilter(v -> v.getDecisionId().equals(decisionId));
+  }
+
+  public DecisionRecordStream withDecisionName(final String decisionName) {
+    return valueFilter(v -> v.getDecisionName().equals(decisionName));
+  }
+
+  public DecisionRecordStream withDecisionKey(final long decisionKey) {
+    return valueFilter(v -> v.getDecisionKey() == decisionKey);
+  }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/DecisionRequirementsRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/DecisionRequirementsRecordStream.java
@@ -16,7 +16,7 @@ public class DecisionRequirementsRecordStream
         DecisionRequirementsRecordValue, DecisionRequirementsRecordStream> {
 
   public DecisionRequirementsRecordStream(
-      Stream<Record<DecisionRequirementsRecordValue>> wrappedStream) {
+      final Stream<Record<DecisionRequirementsRecordValue>> wrappedStream) {
     super(wrappedStream);
   }
 
@@ -24,5 +24,24 @@ public class DecisionRequirementsRecordStream
   protected DecisionRequirementsRecordStream supply(
       final Stream<Record<DecisionRequirementsRecordValue>> wrappedStream) {
     return new DecisionRequirementsRecordStream(wrappedStream);
+  }
+
+  public DecisionRequirementsRecordStream withDecisionRequirementsKey(
+      final long decisionRequirementsKey) {
+    return valueFilter(v -> v.getDecisionRequirementsKey() == decisionRequirementsKey);
+  }
+
+  public DecisionRequirementsRecordStream withDecisionRequirementsId(
+      final String decisionRequirementsId) {
+    return valueFilter(v -> v.getDecisionRequirementsId().equals(decisionRequirementsId));
+  }
+
+  public DecisionRequirementsRecordStream withDecisionRequirementsName(
+      final String decisionRequirementsName) {
+    return valueFilter(v -> v.getDecisionRequirementsName().equals(decisionRequirementsName));
+  }
+
+  public DecisionRequirementsRecordStream withResourceName(final String resourceName) {
+    return valueFilter(v -> v.getResourceName().equals(resourceName));
   }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
@@ -254,6 +255,11 @@ public final class RecordingExporter implements Exporter {
   public static DecisionRequirementsRecordStream decisionRequirementsRecords() {
     return new DecisionRequirementsRecordStream(
         records(ValueType.DECISION_REQUIREMENTS, DecisionRequirementsRecordValue.class));
+  }
+
+  public static DecisionEvaluationRecordStream decisionEvaluationRecords() {
+    return new DecisionEvaluationRecordStream(
+        records(ValueType.DECISION_EVALUATION, DecisionEvaluationRecordValue.class));
   }
 
   public static class RecordIterator implements Iterator<Record<?>> {


### PR DESCRIPTION
## Description

* add new value type `DECISION_EVALUATION`
* add a new record for a decision evaluation
* write the new record when a decision is evaluated

## Related issues

closes #8115 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
