### PR TITLE
Add API to probe the logstream batch writer if more bytes can be written without writing them

### DIFF
--- a/dispatcher/pom.xml
+++ b/dispatcher/pom.xml
@@ -39,6 +39,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/dispatcher/src/main/java/io/camunda/zeebe/dispatcher/Dispatcher.java
+++ b/dispatcher/src/main/java/io/camunda/zeebe/dispatcher/Dispatcher.java
@@ -169,6 +169,19 @@ public class Dispatcher extends Actor {
         LogBufferAppender.claimedBatchLength(fragmentCount, batchLength));
   }
 
+  /**
+   * Returns whether a batch of length {@code batchLength}, containing {@code fragmentCount}
+   * fragments, can be claimed by this dispatcher.
+   *
+   * @param fragmentCount the count of fragments in the batch
+   * @param batchLength the total length of the batch (all fragments included), unframed
+   * @return true if the batch can be claimed, false otherwise
+   */
+  public boolean canClaimFragmentBatch(final int fragmentCount, final int batchLength) {
+    final int framedLength = LogBufferAppender.claimedBatchLength(fragmentCount, batchLength);
+    return framedLength < maxFragmentLength;
+  }
+
   private synchronized long offer(
       final BiFunction<LogBufferPartition, Integer, Integer> claimer,
       final int fragmentCount,

--- a/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/DispatcherTest.java
+++ b/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/DispatcherTest.java
@@ -150,6 +150,19 @@ public final class DispatcherTest {
   public void cannotClaimFragmentBatch() {
     // given - a fragment of max length, unframed
     final int fragmentCount = 1;
+    final int batchLength = 2 * dispatcher.getMaxFragmentLength();
+
+    // when
+    final var canClaimFragmentBatch = dispatcher.canClaimFragmentBatch(fragmentCount, batchLength);
+
+    // then
+    assertThat(canClaimFragmentBatch).isFalse();
+  }
+
+  @Test
+  public void cannotClaimFragmentBatchOfMaxLength() {
+    // given - a fragment of max length, unframed
+    final int fragmentCount = 1;
     final int batchLength = dispatcher.getMaxFragmentLength();
 
     // when

--- a/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/DispatcherTest.java
+++ b/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/DispatcherTest.java
@@ -28,16 +28,15 @@ import io.camunda.zeebe.util.sched.ActorCondition;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public final class DispatcherTest {
+final class DispatcherTest {
 
   static final byte[] A_MSG_PAYLOAD = "some bytes".getBytes(StandardCharsets.UTF_8);
   static final int A_MSG_PAYLOAD_LENGTH = A_MSG_PAYLOAD.length;
   static final int A_FRAGMENT_LENGTH = align(A_MSG_PAYLOAD_LENGTH + HEADER_LENGTH, FRAME_ALIGNMENT);
-  static final int AN_INITIAL_PARTITION_ID = 0;
   static final int A_LOG_WINDOW_LENGTH = 128;
   static final int A_PARTITION_SIZE = 1024;
   static final int A_STREAM_ID = 20;
@@ -57,8 +56,8 @@ public final class DispatcherTest {
   ClaimedFragmentBatch claimedFragmentBatch;
   AtomicPosition subscriberPosition;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void beforeEach() {
     logBuffer = mock(LogBuffer.class);
     logBufferPartition0 = mock(LogBufferPartition.class);
     logBufferPartition1 = mock(LogBufferPartition.class);
@@ -110,7 +109,7 @@ public final class DispatcherTest {
   }
 
   @Test
-  public void shouldNotClaimBeyondPublisherLimit() {
+  void shouldNotClaimBeyondPublisherLimit() {
     // given
     // position of 0,0
     when(logBuffer.getActivePartitionIdVolatile()).thenReturn(0);
@@ -134,7 +133,7 @@ public final class DispatcherTest {
   }
 
   @Test
-  public void canClaimFragmentBatch() {
+  void canClaimFragmentBatch() {
     // given
     final int fragmentCount = 2;
     final int batchLength = dispatcher.getMaxFragmentLength() / 2;
@@ -147,7 +146,7 @@ public final class DispatcherTest {
   }
 
   @Test
-  public void cannotClaimFragmentBatch() {
+  void cannotClaimFragmentBatch() {
     // given - a fragment of max length, unframed
     final int fragmentCount = 1;
     final int batchLength = 2 * dispatcher.getMaxFragmentLength();
@@ -160,7 +159,7 @@ public final class DispatcherTest {
   }
 
   @Test
-  public void cannotClaimFragmentBatchOfMaxLength() {
+  void cannotClaimFragmentBatchOfMaxLength() {
     // given - a fragment of max length, unframed
     final int fragmentCount = 1;
     final int batchLength = dispatcher.getMaxFragmentLength();
@@ -175,7 +174,7 @@ public final class DispatcherTest {
   }
 
   @Test
-  public void shouldClaimFragment() {
+  void shouldClaimFragment() {
     // given
     // position is 0,0
     when(logBuffer.getActivePartitionIdVolatile()).thenReturn(0);
@@ -216,7 +215,7 @@ public final class DispatcherTest {
   }
 
   @Test
-  public void shouldReadFragmentsFromPartition() {
+  void shouldReadFragmentsFromPartition() {
     // given
     dispatcher.doOpenSubscription("test", mock(ActorCondition.class));
     when(subscriberPosition.get()).thenReturn(0L);
@@ -239,7 +238,7 @@ public final class DispatcherTest {
   }
 
   @Test
-  public void shouldNotReadBeyondPublisherPosition() {
+  void shouldNotReadBeyondPublisherPosition() {
     // given
     dispatcher.doOpenSubscription("test", mock(ActorCondition.class));
     when(subscriptionSpy.getPosition()).thenReturn(0L);
@@ -253,7 +252,7 @@ public final class DispatcherTest {
   }
 
   @Test
-  public void shouldUpdatePublisherLimit() {
+  void shouldUpdatePublisherLimit() {
     when(subscriberPosition.get()).thenReturn(position(10, 100));
 
     dispatcher.doOpenSubscription("test", mock(ActorCondition.class));
@@ -263,7 +262,7 @@ public final class DispatcherTest {
   }
 
   @Test
-  public void shouldUpdatePublisherLimitToNextPartition() {
+  void shouldUpdatePublisherLimitToNextPartition() {
     when(subscriberPosition.get()).thenReturn(position(10, A_PARTITION_SIZE - A_LOG_WINDOW_LENGTH));
 
     dispatcher.doOpenSubscription("test", mock(ActorCondition.class));
@@ -273,7 +272,7 @@ public final class DispatcherTest {
   }
 
   @Test
-  public void shouldReadFragmentsFromPartitionOnPeekAndConsume() {
+  void shouldReadFragmentsFromPartitionOnPeekAndConsume() {
     // given
     dispatcher.doOpenSubscription("test", mock(ActorCondition.class));
     when(subscriberPosition.get()).thenReturn(0L);
@@ -296,7 +295,7 @@ public final class DispatcherTest {
   }
 
   @Test
-  public void shouldNotOpenSubscriptionWithSameName() {
+  void shouldNotOpenSubscriptionWithSameName() {
     dispatcher.doOpenSubscription("s1", mock(ActorCondition.class));
     Assert.assertThrows(
         "subscription with name 's1' already exists",
@@ -305,7 +304,7 @@ public final class DispatcherTest {
   }
 
   @Test
-  public void shouldIncrementRecordPositionAfterClaimingFragment() {
+  void shouldIncrementRecordPositionAfterClaimingFragment() {
     // given
     when(publisherLimit.get()).thenReturn(position(0, A_FRAGMENT_LENGTH));
     when(logAppender.claim(
@@ -329,7 +328,7 @@ public final class DispatcherTest {
   }
 
   @Test
-  public void shouldIncreasePositionByFragmentCountAfterClaimingBatch() {
+  void shouldIncreasePositionByFragmentCountAfterClaimingBatch() {
     // given
     final int fragmentCount = 3;
     when(logBuffer.getActivePartitionIdVolatile()).thenReturn(0);

--- a/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/DispatcherTest.java
+++ b/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/DispatcherTest.java
@@ -134,6 +134,34 @@ public final class DispatcherTest {
   }
 
   @Test
+  public void canClaimFragmentBatch() {
+    // given
+    final int fragmentCount = 2;
+    final int batchLength = dispatcher.getMaxFragmentLength() / 2;
+
+    // when
+    final var canClaimFragmentBatch = dispatcher.canClaimFragmentBatch(fragmentCount, batchLength);
+
+    // then
+    assertThat(canClaimFragmentBatch).isTrue();
+  }
+
+  @Test
+  public void cannotClaimFragmentBatch() {
+    // given - a fragment of max length, unframed
+    final int fragmentCount = 1;
+    final int batchLength = dispatcher.getMaxFragmentLength();
+
+    // when
+    final var canClaimFragmentBatch = dispatcher.canClaimFragmentBatch(fragmentCount, batchLength);
+
+    // then
+    assertThat(canClaimFragmentBatch)
+        .as("cannot claim when the unframed, unaligned batch is the max fragment length")
+        .isFalse();
+  }
+
+  @Test
   public void shouldClaimFragment() {
     // given
     // position is 0,0

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBatchWriter.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBatchWriter.java
@@ -28,6 +28,16 @@ public interface LogStreamBatchWriter extends LogStreamWriter {
   /** Discard all non-written batch data. */
   void reset();
 
+  /**
+   * Returns whether an additional event of length {@code length} could be written to the batch or
+   * not.
+   *
+   * @param length the length of the event's value and metadata summed, i.e. {@link
+   *     LoggedEvent#getValueLength()} + {@link LoggedEvent#getMetadataLength()}
+   * @return true if the additional event could be written, false otherwise
+   */
+  boolean canWriteAdditionalEvent(final int length);
+
   /** Builder to add a log entry to the batch. */
   interface LogEntryBuilder {
     /** Use the default values as key. */

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchWriterImplTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchWriterImplTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.logstreams.impl.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.dispatcher.ClaimedFragmentBatch;
+import io.camunda.zeebe.dispatcher.Dispatcher;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+
+final class LogStreamBatchWriterImplTest {
+  private final Dispatcher dispatcher = mock(Dispatcher.class);
+  private final LogStreamBatchWriterImpl writer = new LogStreamBatchWriterImpl(1, dispatcher);
+
+  /**
+   * This test asserts that {@link LogStreamBatchWriterImpl#canWriteAdditionalEvent(int)} computes
+   * the correct batch length before passing it on to the dispatcher to check if it's acceptable. It
+   * also verifies that the same length is passed to the dispatcher when actually writing, ensuring
+   * both methods remain consistent with each other.
+   */
+  @Test
+  void canWriteAdditionalEvent() {
+    // given
+    final DirectBuffer value = BufferUtil.wrapString("foo");
+    final DirectBuffer metadata = BufferUtil.wrapString("bar");
+    final var expectedFragmentCount = 2;
+    final var expectedFramingLength =
+        expectedFragmentCount * LogEntryDescriptor.HEADER_BLOCK_LENGTH;
+    final var expectedEventsLength =
+        expectedFragmentCount * (value.capacity() + metadata.capacity());
+    final var expectedBatchLength = expectedEventsLength + expectedFramingLength;
+
+    // when
+    when(dispatcher.canClaimFragmentBatch(anyInt(), anyInt())).thenReturn(false);
+    when(dispatcher.canClaimFragmentBatch(expectedFragmentCount, expectedBatchLength))
+        .thenReturn(true);
+    when(dispatcher.claimFragmentBatch(any(), anyInt(), anyInt()))
+        .then(this::mockClaimFragmentBatch);
+    writer.event().value(value).metadata(metadata).done();
+    final boolean canWriteAdditionalEvent =
+        writer.canWriteAdditionalEvent(value.capacity() + metadata.capacity());
+    writer.event().value(value).metadata(metadata).done().tryWrite();
+
+    // then
+    verify(dispatcher, times(1)).canClaimFragmentBatch(expectedFragmentCount, expectedBatchLength);
+    verify(dispatcher, times(1))
+        .claimFragmentBatch(
+            any(ClaimedFragmentBatch.class), eq(expectedFragmentCount), eq(expectedBatchLength));
+    assertThat(canWriteAdditionalEvent).isTrue();
+    verifyNoMoreInteractions(dispatcher);
+  }
+
+  private long mockClaimFragmentBatch(final InvocationOnMock i) {
+    final var batch = i.getArgument(0, ClaimedFragmentBatch.class);
+    final var writeBuffer = new UnsafeBuffer(new ExpandableArrayBuffer(1024));
+    batch.wrap(writeBuffer, 1, 0, writeBuffer.capacity(), () -> {});
+    return 1L;
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a new API method, `LogStreamBatchWriter#canWriteAdditionalEvent(int)`. This allows users of the writer to probe if adding the given amount of bytes to the batch would cause it to become un-writable, without actually having to write anything to the batch, or even modify their DTO (e.g. the `TypedRecord<?>` in the engine).

To avoid having dispatcher details leak into the implementation, an analogous method is added to the dispatcher, `Dispatcher#canClaimFragmentBatch(int, int)`, which will compare the given size, framed and aligned, with the max fragment length. This is the main building block to eventually solve #5525, and enable other use cases (e.g. multi-instance creation) which deal with large batches until we have a more permanent solution (e.g. chunking follow up batches).

NOTE: the tests added in the dispatcher are not very good, but I couldn't come up with something else that wouldn't be too coupled to the implementation (i.e. essentially reusing `LogBufferAppender`). I would like some ideas/suggestions.

NOTE: this PR comes out of the larger one, #8491. You can check that one out to see how the new API would be used, e.g. in the `JobBatchCollector`. As such, this is marked for backporting, since we'll backport the complete fix for #5525.

## Related issues

related to #5525 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
