### PR TITLE
Correctly truncate a job activation batch if it will not fit in the dispatcher

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -65,7 +65,6 @@ public final class EngineProcessors {
 
     final LogStream stream = processingContext.getLogStream();
     final int partitionId = stream.getPartitionId();
-    final int maxFragmentSize = processingContext.getMaxFragmentSize();
 
     final var variablesState = zeebeState.getVariableState();
     final var expressionProcessor =
@@ -128,7 +127,6 @@ public final class EngineProcessors {
         zeebeState,
         onJobsAvailableCallback,
         eventPublicationBehavior,
-        maxFragmentSize,
         writers,
         jobMetrics,
         eventTriggerBehavior);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/TypedStreamWriterProxy.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/TypedStreamWriterProxy.java
@@ -40,6 +40,16 @@ public final class TypedStreamWriterProxy implements TypedStreamWriter {
   }
 
   @Override
+  public boolean canWriteEventOfLength(final int eventLength) {
+    return writer.canWriteEventOfLength(eventLength);
+  }
+
+  @Override
+  public int getMaxEventLength() {
+    return writer.getMaxEventLength();
+  }
+
+  @Override
   public void appendNewCommand(final Intent intent, final RecordValue value) {
     writer.appendNewCommand(intent, value);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentRecordWrapper.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentRecordWrapper.java
@@ -105,7 +105,7 @@ final class IncidentRecordWrapper implements TypedRecord<ProcessInstanceRecord> 
   }
 
   @Override
-  public long getLength() {
+  public int getLength() {
     return 0;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.processing.job;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.camunda.zeebe.engine.metrics.JobMetrics;
-import io.camunda.zeebe.engine.processing.job.JobBatchCollector.LargeJob;
+import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -80,7 +80,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     final JobBatchRecord value = record.getValue();
     final long jobBatchKey = keyGenerator.nextKey();
 
-    final Either<LargeJob, Integer> result = jobBatchCollector.collectJobs(record);
+    final Either<TooLargeJob, Integer> result = jobBatchCollector.collectJobs(record);
     final var activatedJobCount = result.getOrElse(0);
     result.ifLeft(
         largeJob -> raiseIncidentJobTooLargeForMessageSize(largeJob.key(), largeJob.record()));

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
+import io.camunda.zeebe.engine.state.immutable.JobState;
+import io.camunda.zeebe.engine.state.immutable.VariableState;
+import io.camunda.zeebe.msgpack.value.DocumentValue;
+import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.msgpack.value.ValueArray;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Collection;
+import java.util.function.Predicate;
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.collections.MutableInteger;
+import org.agrona.collections.MutableReference;
+import org.agrona.collections.ObjectHashSet;
+
+/**
+ * Collects jobs to be activated as part of a {@link JobBatchRecord}. Activate-able jobs are read
+ * from the {@link JobState}, resolving and setting their variables from the {@link VariableState},
+ * and added to the given batch record.
+ */
+final class JobBatchCollector {
+  private final ObjectHashSet<DirectBuffer> variableNames = new ObjectHashSet<>();
+
+  private final JobState jobState;
+  private final VariableState variableState;
+  private final Predicate<Integer> canWriteEventOfLength;
+
+  /**
+   * @param jobState the state from which jobs are collected
+   * @param variableState the state from which variables are resolved and collected
+   * @param canWriteEventOfLength a predicate which should return whether the resulting {@link
+   *     TypedRecord} containing the {@link JobBatchRecord} will be writable or not. The predicate
+   *     takes in the size of the record, and should return true if it can write such a record, and
+   *     false otherwise
+   */
+  JobBatchCollector(
+      final JobState jobState,
+      final VariableState variableState,
+      final Predicate<Integer> canWriteEventOfLength) {
+    this.jobState = jobState;
+    this.variableState = variableState;
+    this.canWriteEventOfLength = canWriteEventOfLength;
+  }
+
+  /**
+   * Collects jobs to be added to the given {@code record}. The jobs and their keys are added
+   * directly to the given record.
+   *
+   * <p>This method will fail only if it could not activate anything because the batch would be too
+   * large, but there was at least one job to activate. On failure, it will return that job and its
+   * key. On success, it will return the amount of jobs activated.
+   *
+   * @param record the batch activate command; jobs and their keys will be added directly into it
+   * @return the amount of activated jobs on success, or a job which was too large to activate
+   */
+  Either<LargeJob, Integer> collectJobs(final TypedRecord<JobBatchRecord> record) {
+    final JobBatchRecord value = record.getValue();
+    final ValueArray<JobRecord> jobIterator = value.jobs();
+    final ValueArray<LongValue> jobKeyIterator = value.jobKeys();
+    final Collection<DirectBuffer> requestedVariables = collectVariableNames(value);
+    final var maxActivatedCount = value.getMaxJobsToActivate();
+    final var activatedCount = new MutableInteger(0);
+    final var jobCopyBuffer = new ExpandableArrayBuffer();
+    final var unwritableJob = new MutableReference<LargeJob>();
+
+    jobState.forEachActivatableJobs(
+        value.getTypeBuffer(),
+        (key, jobRecord) -> {
+          // fill in the job record properties first in order to accurately estimate its size before
+          // adding it to the batch
+          final var deadline = record.getTimestamp() + value.getTimeout();
+          jobRecord.setDeadline(deadline).setWorker(value.getWorkerBuffer());
+          setJobVariables(requestedVariables, jobRecord, jobRecord.getElementInstanceKey());
+
+          // the expected length is based on the current record's length plus the length of the job
+          // record we would add to the batch, the number of bytes taken by the additional job key,
+          // as well as one byte required per job key for its type header. if we ever add more, this
+          // should be updated accordingly.
+          final var jobRecordLength = jobRecord.getLength();
+          final var expectedEventLength = record.getLength() + jobRecordLength + Long.BYTES + 1;
+          if (activatedCount.value <= maxActivatedCount
+              && canWriteEventOfLength.test(expectedEventLength)) {
+            appendJobToBatch(jobIterator, jobKeyIterator, jobCopyBuffer, key, jobRecord);
+            activatedCount.increment();
+          } else {
+            // if no jobs were activated, then the current job is simply too large, and we cannot
+            // activate it
+            if (activatedCount.value == 0) {
+              unwritableJob.set(new LargeJob(key, jobRecord));
+            }
+
+            value.setTruncated(true);
+            return false;
+          }
+
+          return activatedCount.value < maxActivatedCount;
+        });
+
+    if (unwritableJob.ref != null) {
+      return Either.left(unwritableJob.ref);
+    }
+
+    return Either.right(activatedCount.value);
+  }
+
+  private void setJobVariables(
+      final Collection<DirectBuffer> requestedVariables,
+      final JobRecord jobRecord,
+      final long elementInstanceKey) {
+    if (elementInstanceKey >= 0) {
+      final DirectBuffer variables = collectVariables(requestedVariables, elementInstanceKey);
+      jobRecord.setVariables(variables);
+    } else {
+      jobRecord.setVariables(DocumentValue.EMPTY_DOCUMENT);
+    }
+  }
+
+  private void appendJobToBatch(
+      final ValueArray<JobRecord> jobIterator,
+      final ValueArray<LongValue> jobKeyIterator,
+      final ExpandableArrayBuffer jobCopyBuffer,
+      final Long key,
+      final JobRecord jobRecord) {
+    jobKeyIterator.add().setValue(key);
+    final JobRecord arrayValueJob = jobIterator.add();
+
+    // clone job record since buffer is reused during iteration
+    jobRecord.write(jobCopyBuffer, 0);
+    arrayValueJob.wrap(jobCopyBuffer, 0, jobRecord.getLength());
+  }
+
+  private Collection<DirectBuffer> collectVariableNames(final JobBatchRecord batchRecord) {
+    final ValueArray<StringValue> requestedVariables = batchRecord.variables();
+
+    variableNames.clear();
+    requestedVariables.forEach(
+        variable -> variableNames.add(BufferUtil.cloneBuffer(variable.getValue())));
+
+    return variableNames;
+  }
+
+  private DirectBuffer collectVariables(
+      final Collection<DirectBuffer> variableNames, final long elementInstanceKey) {
+    final DirectBuffer variables;
+
+    if (variableNames.isEmpty()) {
+      variables = variableState.getVariablesAsDocument(elementInstanceKey);
+    } else {
+      variables = variableState.getVariablesAsDocument(elementInstanceKey, variableNames);
+    }
+
+    return variables;
+  }
+
+  record LargeJob(long key, JobRecord record) {}
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -66,7 +66,7 @@ final class JobBatchCollector {
    * @param record the batch activate command; jobs and their keys will be added directly into it
    * @return the amount of activated jobs on success, or a job which was too large to activate
    */
-  Either<LargeJob, Integer> collectJobs(final TypedRecord<JobBatchRecord> record) {
+  Either<TooLargeJob, Integer> collectJobs(final TypedRecord<JobBatchRecord> record) {
     final JobBatchRecord value = record.getValue();
     final ValueArray<JobRecord> jobIterator = value.jobs();
     final ValueArray<LongValue> jobKeyIterator = value.jobKeys();
@@ -74,7 +74,7 @@ final class JobBatchCollector {
     final var maxActivatedCount = value.getMaxJobsToActivate();
     final var activatedCount = new MutableInteger(0);
     final var jobCopyBuffer = new ExpandableArrayBuffer();
-    final var unwritableJob = new MutableReference<LargeJob>();
+    final var unwritableJob = new MutableReference<TooLargeJob>();
 
     jobState.forEachActivatableJobs(
         value.getTypeBuffer(),
@@ -99,7 +99,7 @@ final class JobBatchCollector {
             // if no jobs were activated, then the current job is simply too large, and we cannot
             // activate it
             if (activatedCount.value == 0) {
-              unwritableJob.set(new LargeJob(key, jobRecord));
+              unwritableJob.set(new TooLargeJob(key, jobRecord));
             }
 
             value.setTruncated(true);
@@ -165,5 +165,5 @@ final class JobBatchCollector {
     return variables;
   }
 
-  record LargeJob(long key, JobRecord record) {}
+  record TooLargeJob(long key, JobRecord record) {}
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -28,7 +28,6 @@ public final class JobEventProcessors {
       final MutableZeebeState zeebeState,
       final Consumer<String> onJobsAvailableCallback,
       final BpmnEventPublicationBehavior eventPublicationBehavior,
-      final int maxRecordSize,
       final Writers writers,
       final JobMetrics jobMetrics,
       final EventTriggerBehavior eventTriggerBehavior) {
@@ -70,7 +69,7 @@ public final class JobEventProcessors {
             ValueType.JOB_BATCH,
             JobBatchIntent.ACTIVATE,
             new JobBatchActivateProcessor(
-                writers, zeebeState, zeebeState.getKeyGenerator(), maxRecordSize, jobMetrics))
+                writers, zeebeState, zeebeState.getKeyGenerator(), jobMetrics))
         .withListener(new JobTimeoutTrigger(jobState))
         .withListener(jobBackoffChecker)
         .withListener(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedEventImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedEventImpl.java
@@ -110,8 +110,8 @@ public final class TypedEventImpl implements TypedRecord {
 
   @Override
   @JsonIgnore
-  public long getLength() {
-    return (long) metadata.getLength() + value.getLength();
+  public int getLength() {
+    return metadata.getLength() + value.getLength();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecord.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecord.java
@@ -13,15 +13,17 @@ import io.camunda.zeebe.protocol.record.RecordMetadataEncoder;
 
 public interface TypedRecord<T extends UnifiedRecordValue> extends Record<T> {
 
+  @Override
   long getKey();
 
+  @Override
   T getValue();
 
   int getRequestStreamId();
 
   long getRequestId();
 
-  long getLength();
+  int getLength();
 
   default boolean hasRequestMetadata() {
     return getRequestId() != RecordMetadataEncoder.requestIdNullValue()

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/EventApplyingStateWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/EventApplyingStateWriter.java
@@ -35,4 +35,14 @@ public final class EventApplyingStateWriter implements StateWriter {
     eventWriter.appendFollowUpEvent(key, intent, value);
     eventApplier.applyState(key, intent, value);
   }
+
+  @Override
+  public boolean canWriteEventOfLength(final int eventLength) {
+    return eventWriter.canWriteEventOfLength(eventLength);
+  }
+
+  @Override
+  public int getMaxEventLength() {
+    return eventWriter.getMaxEventLength();
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/NoopTypedStreamWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/NoopTypedStreamWriter.java
@@ -33,6 +33,11 @@ public final class NoopTypedStreamWriter implements TypedStreamWriter {
   }
 
   @Override
+  public int getMaxEventLength() {
+    return Integer.MAX_VALUE;
+  }
+
+  @Override
   public void appendNewCommand(final Intent intent, final RecordValue value) {
     // no op implementation
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
@@ -13,4 +13,30 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 public interface TypedEventWriter {
 
   void appendFollowUpEvent(long key, Intent intent, RecordValue value);
+
+  /**
+   * Use this to know whether you can write an event of this length.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * final TypedEventWriter writer;
+   * // ... assign the writer
+   * final TypedRecord<?> record;
+   * // ... assign record
+   * if (!writer.canWriteEventOfLength(record.getLength())) {
+   *   // raise an incident or some such
+   *   return;
+   * }
+   * }</pre>
+   *
+   * @param eventLength the length of the event that will be written
+   * @return true if an event of length {@code eventLength} can be written
+   */
+  default boolean canWriteEventOfLength(final int eventLength) {
+    return eventLength <= getMaxEventLength();
+  }
+
+  /** @return the maximum event length */
+  int getMaxEventLength();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedStreamWriterImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedStreamWriterImpl.java
@@ -129,4 +129,29 @@ public class TypedStreamWriterImpl implements TypedStreamWriter {
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
     appendRecord(key, RecordType.EVENT, intent, value);
   }
+
+  /**
+   * Use this to know whether you can add an event of the given length to the underlying batch
+   * writer.
+   *
+   * @param eventLength the length of the event that will be added to the batch
+   * @return true if an event of length {@code eventLength} can be added to this batch such that it
+   *     can later be written
+   */
+  @Override
+  public boolean canWriteEventOfLength(final int eventLength) {
+    return batchWriter.canWriteAdditionalEvent(eventLength);
+  }
+
+  /**
+   * This is not actually accurate, as the frame length needs to also be aligned by the same amount
+   * of bytes as the batch. However, this would break concerns here, i.e. the writer here would have
+   * to become Dispatcher aware.
+   *
+   * @return an approximate value of the max fragment length
+   */
+  @Override
+  public int getMaxEventLength() {
+    return batchWriter.getMaxFragmentLength();
+  }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.processing.job.JobBatchCollector.LargeJob;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
+import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.util.MockTypedRecord;
+import io.camunda.zeebe.engine.util.ZeebeStateExtension;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValueWithVariablesAssert;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValueAssert;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValueAssert;
+import io.camunda.zeebe.test.util.MsgPackUtil;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+import org.agrona.DirectBuffer;
+import org.agrona.collections.MutableReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ZeebeStateExtension.class)
+final class JobBatchCollectorTest {
+  private static final String JOB_TYPE = "job";
+
+  private final RecordLengthEvaluator lengthEvaluator = new RecordLengthEvaluator();
+
+  @SuppressWarnings("unused") // injected by the extension
+  private MutableZeebeState state;
+
+  private JobBatchCollector collector;
+
+  @BeforeEach
+  void beforeEach() {
+    collector =
+        new JobBatchCollector(state.getJobState(), state.getVariableState(), lengthEvaluator);
+  }
+
+  @Test
+  void shouldTruncateBatchIfNoMoreCanBeWritten() {
+    // given
+    final long variableScopeKey = state.getKeyGenerator().nextKey();
+    final TypedRecord<JobBatchRecord> record = createRecord();
+    final List<Job> jobs = Arrays.asList(createJob(variableScopeKey), createJob(variableScopeKey));
+    final var toggle = new AtomicBoolean(true);
+
+    // when - set up the evaluator to only accept the first job
+    lengthEvaluator.canWriteEventOfLength = (length) -> toggle.getAndSet(false);
+    final Either<LargeJob, Integer> result = collector.collectJobs(record);
+
+    // then
+    final JobBatchRecord batchRecord = record.getValue();
+    EitherAssert.assertThat(result)
+        .as("should have activated only one job successfully")
+        .right()
+        .isEqualTo(1);
+    JobBatchRecordValueAssert.assertThat(batchRecord).hasOnlyJobKeys(jobs.get(0).key).isTruncated();
+  }
+
+  @Test
+  void shouldReturnLargeJobIfFirstJobCannotBeWritten() {
+    // given
+    final long variableScopeKey = state.getKeyGenerator().nextKey();
+    final TypedRecord<JobBatchRecord> record = createRecord();
+    final List<Job> jobs = Arrays.asList(createJob(variableScopeKey), createJob(variableScopeKey));
+
+    // when - set up the evaluator to accept no jobs
+    lengthEvaluator.canWriteEventOfLength = (length) -> false;
+    final Either<LargeJob, Integer> result = collector.collectJobs(record);
+
+    // then
+    final JobBatchRecord batchRecord = record.getValue();
+    EitherAssert.assertThat(result)
+        .as("should return excessively large job")
+        .left()
+        .hasFieldOrPropertyWithValue("key", jobs.get(0).key);
+    JobBatchRecordValueAssert.assertThat(batchRecord).hasNoJobKeys().hasNoJobs().isTruncated();
+  }
+
+  @Test
+  void shouldCollectJobsWithVariables() {
+    // given - multiple jobs to ensure variables are collected based on the scope
+    final TypedRecord<JobBatchRecord> record = createRecord();
+    final long firstScopeKey = state.getKeyGenerator().nextKey();
+    final long secondScopeKey = state.getKeyGenerator().nextKey();
+    final Map<String, String> firstJobVariables = Map.of("foo", "bar", "baz", "buz");
+    final Map<String, String> secondJobVariables = Map.of("fizz", "buzz");
+    createJobWithVariables(firstScopeKey, firstJobVariables);
+    createJobWithVariables(secondScopeKey, secondJobVariables);
+
+    // when
+    collector.collectJobs(record);
+
+    // then
+    final JobBatchRecord batchRecord = record.getValue();
+    JobBatchRecordValueAssert.assertThat(batchRecord)
+        .satisfies(
+            batch -> {
+              final List<JobRecordValue> activatedJobs = batch.getJobs();
+              RecordValueWithVariablesAssert.assertThat(activatedJobs.get(0))
+                  .hasVariables(firstJobVariables);
+              RecordValueWithVariablesAssert.assertThat(activatedJobs.get(1))
+                  .hasVariables(secondJobVariables);
+            });
+  }
+
+  @Test
+  void shouldAppendJobKeyToBatchRecord() {
+    // given - multiple jobs to ensure variables are collected based on the scope
+    final TypedRecord<JobBatchRecord> record = createRecord();
+    final long scopeKey = state.getKeyGenerator().nextKey();
+    final List<Job> jobs = Arrays.asList(createJob(scopeKey), createJob(scopeKey));
+
+    // when
+    collector.collectJobs(record);
+
+    // then
+    final JobBatchRecord batchRecord = record.getValue();
+    JobBatchRecordValueAssert.assertThat(batchRecord).hasJobKeys(jobs.get(0).key, jobs.get(1).key);
+  }
+
+  @Test
+  void shouldActivateUpToMaxJobs() {
+    // given
+    final TypedRecord<JobBatchRecord> record = createRecord();
+    final long scopeKey = state.getKeyGenerator().nextKey();
+    final List<Job> jobs = Arrays.asList(createJob(scopeKey), createJob(scopeKey));
+    record.getValue().setMaxJobsToActivate(1);
+
+    // when
+    final Either<LargeJob, Integer> result = collector.collectJobs(record);
+
+    // then
+    final JobBatchRecord batchRecord = record.getValue();
+    EitherAssert.assertThat(result).as("should collect only the first job").right().isEqualTo(1);
+    JobBatchRecordValueAssert.assertThat(batchRecord).hasJobKeys(jobs.get(0).key).isNotTruncated();
+  }
+
+  @Test
+  void shouldSetDeadlineOnActivation() {
+    // given
+    final TypedRecord<JobBatchRecord> record = createRecord();
+    final long scopeKey = state.getKeyGenerator().nextKey();
+    final long expectedDeadline = record.getTimestamp() + record.getValue().getTimeout();
+    createJob(scopeKey);
+    createJob(scopeKey);
+
+    // when
+    collector.collectJobs(record);
+
+    // then
+    final JobBatchRecord batchRecord = record.getValue();
+    JobBatchRecordValueAssert.assertThat(batchRecord)
+        .satisfies(
+            batch -> {
+              final List<JobRecordValue> activatedJobs = batch.getJobs();
+              JobRecordValueAssert.assertThat(activatedJobs.get(0))
+                  .as("first activated job has the expected deadline")
+                  .hasDeadline(expectedDeadline);
+              JobRecordValueAssert.assertThat(activatedJobs.get(1))
+                  .as("second activated job has the expected deadline")
+                  .hasDeadline(expectedDeadline);
+            });
+  }
+
+  @Test
+  void shouldSetWorkerOnActivation() {
+    // given
+    final TypedRecord<JobBatchRecord> record = createRecord();
+    final long scopeKey = state.getKeyGenerator().nextKey();
+    final String expectedWorker = "foo";
+    createJob(scopeKey);
+    createJob(scopeKey);
+    record.getValue().setWorker(expectedWorker);
+
+    // when
+    collector.collectJobs(record);
+
+    // then
+    final JobBatchRecord batchRecord = record.getValue();
+    JobBatchRecordValueAssert.assertThat(batchRecord)
+        .satisfies(
+            batch -> {
+              final List<JobRecordValue> activatedJobs = batch.getJobs();
+              JobRecordValueAssert.assertThat(activatedJobs.get(0))
+                  .as("first activated job has the expected worker")
+                  .hasWorker(expectedWorker);
+              JobRecordValueAssert.assertThat(activatedJobs.get(1))
+                  .as("second activated job has the expected worker")
+                  .hasWorker(expectedWorker);
+            });
+  }
+
+  @Test
+  void shouldFetchOnlyRequestedVariables() {
+    // given
+    final TypedRecord<JobBatchRecord> record = createRecord();
+    final long firstScopeKey = state.getKeyGenerator().nextKey();
+    final long secondScopeKey = state.getKeyGenerator().nextKey();
+    final Map<String, String> firstJobVariables = Map.of("foo", "bar", "baz", "buz");
+    final Map<String, String> secondJobVariables = Map.of("fizz", "buzz");
+    createJobWithVariables(firstScopeKey, firstJobVariables);
+    createJobWithVariables(secondScopeKey, secondJobVariables);
+    record.getValue().variables().add().wrap(BufferUtil.wrapString("foo"));
+
+    // when
+    collector.collectJobs(record);
+
+    // then
+    final JobBatchRecord batchRecord = record.getValue();
+    JobBatchRecordValueAssert.assertThat(batchRecord)
+        .satisfies(
+            batch -> {
+              final List<JobRecordValue> activatedJobs = batch.getJobs();
+              RecordValueWithVariablesAssert.assertThat(activatedJobs.get(0))
+                  .hasVariables(Map.of("foo", "bar"));
+              RecordValueWithVariablesAssert.assertThat(activatedJobs.get(1))
+                  .hasVariables(Collections.emptyMap());
+            });
+  }
+
+  /**
+   * This is specifically a regression test for #5525. It's possible for this test to become
+   * outdated if we ever change how records are serialized, variables packed, etc. But it's a
+   * best-effort solution to make sure that if we do, we are forced to double-check and ensure we're
+   * correctly estimating the size of the record before writing it.
+   *
+   * <p>Long term, the writer should be able to cope with arbitrarily large batches, but until then
+   * we're stuck with this workaround for a better UX.
+   */
+  @Test
+  void shouldEstimateLengthCorrectly() {
+    // given - multiple jobs to ensure variables are collected based on the scope
+    final TypedRecord<JobBatchRecord> record = createRecord();
+    final long scopeKey = state.getKeyGenerator().nextKey();
+    final Map<String, String> variables = Map.of("foo", "bar");
+    final MutableReference<Integer> estimatedLength = new MutableReference<>();
+    final int initialLength = record.getLength();
+    createJobWithVariables(scopeKey, variables);
+
+    // when
+    lengthEvaluator.canWriteEventOfLength =
+        length -> {
+          estimatedLength.set(length);
+          return true;
+        };
+    collector.collectJobs(record);
+
+    // then
+    // the expected length is then the length of the initial record + the length of the activated
+    // job + the length of a key (long) and one byte for its list header
+    final var activatedJob = (JobRecord) record.getValue().getJobs().get(0);
+    final int expectedLength = initialLength + activatedJob.getLength() + 9;
+    assertThat(estimatedLength.ref).isEqualTo(expectedLength);
+  }
+
+  private TypedRecord<JobBatchRecord> createRecord() {
+    final RecordMetadata metadata =
+        new RecordMetadata()
+            .recordType(RecordType.COMMAND)
+            .intent(JobBatchIntent.ACTIVATE)
+            .valueType(ValueType.JOB_BATCH);
+    final var batchRecord =
+        new JobBatchRecord()
+            .setTimeout(Duration.ofSeconds(10).toMillis())
+            .setMaxJobsToActivate(10)
+            .setType(JOB_TYPE)
+            .setWorker("test");
+
+    return new MockTypedRecord<>(state.getKeyGenerator().nextKey(), metadata, batchRecord);
+  }
+
+  private Job createJob(final long variableScopeKey) {
+    final var jobRecord =
+        new JobRecord()
+            .setBpmnProcessId("process")
+            .setElementId("element")
+            .setElementInstanceKey(variableScopeKey)
+            .setType(JOB_TYPE);
+    final long jobKey = state.getKeyGenerator().nextKey();
+
+    state.getJobState().create(jobKey, jobRecord);
+    return new Job(jobKey, jobRecord);
+  }
+
+  private void createJobWithVariables(
+      final long variableScopeKey, final Map<String, String> variables) {
+    setVariables(variableScopeKey, variables);
+    createJob(variableScopeKey);
+  }
+
+  private void setVariables(final long variableScopeKey, final Map<String, String> variables) {
+    final var variableState = state.getVariableState();
+    variables.forEach(
+        (key, value) ->
+            variableState.setVariableLocal(
+                variableScopeKey,
+                variableScopeKey,
+                variableScopeKey,
+                BufferUtil.wrapString(key),
+                packString(value)));
+  }
+
+  private DirectBuffer packString(final String value) {
+    return MsgPackUtil.encodeMsgPack(b -> b.packString(value));
+  }
+
+  private static final class RecordLengthEvaluator implements Predicate<Integer> {
+    private Predicate<Integer> canWriteEventOfLength = length -> true;
+
+    @Override
+    public boolean test(final Integer length) {
+      return canWriteEventOfLength.test(length);
+    }
+  }
+
+  private record Job(long key, JobRecord job) {}
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.processing.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.engine.processing.job.JobBatchCollector.LargeJob;
+import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.engine.util.MockTypedRecord;
@@ -68,7 +68,7 @@ final class JobBatchCollectorTest {
 
     // when - set up the evaluator to only accept the first job
     lengthEvaluator.canWriteEventOfLength = (length) -> toggle.getAndSet(false);
-    final Either<LargeJob, Integer> result = collector.collectJobs(record);
+    final Either<TooLargeJob, Integer> result = collector.collectJobs(record);
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -88,7 +88,7 @@ final class JobBatchCollectorTest {
 
     // when - set up the evaluator to accept no jobs
     lengthEvaluator.canWriteEventOfLength = (length) -> false;
-    final Either<LargeJob, Integer> result = collector.collectJobs(record);
+    final Either<TooLargeJob, Integer> result = collector.collectJobs(record);
 
     // then
     final JobBatchRecord batchRecord = record.getValue();
@@ -150,7 +150,7 @@ final class JobBatchCollectorTest {
     record.getValue().setMaxJobsToActivate(1);
 
     // when
-    final Either<LargeJob, Integer> result = collector.collectJobs(record);
+    final Either<TooLargeJob, Integer> result = collector.collectJobs(record);
 
     // then
     final JobBatchRecord batchRecord = record.getValue();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
@@ -219,6 +219,11 @@ public class StreamProcessorHealthTest {
     }
 
     @Override
+    public int getMaxEventLength() {
+      return Integer.MAX_VALUE;
+    }
+
+    @Override
     public void appendNewCommand(final Intent intent, final RecordValue value) {}
 
     @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
@@ -56,7 +56,7 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
   }
 
   @Override
-  public long getLength() {
+  public int getLength() {
     return metadata.getLength() + value.getLength();
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingTypedEventWriter.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingTypedEventWriter.java
@@ -31,6 +31,11 @@ public final class RecordingTypedEventWriter implements TypedEventWriter {
     events.add(new RecordedEvent<>(key, intent, value));
   }
 
+  @Override
+  public int getMaxEventLength() {
+    return Integer.MAX_VALUE;
+  }
+
   public static final class RecordedEvent<T extends RecordValue> {
 
     public final long key;


### PR DESCRIPTION
## Description

This PR fixes a bug where at times, we would try to activate a job batch which was too big and could not be written into the dispatcher, as when it was framed and aligned, its size would exceed the `maxFragmentLength`. The fix itself is simple, and it was to delegate, all the way down to the dispatcher (with layers adding their own framing in between), the responsibility to decide whether more jobs can be added to the batch or not. To simplify the code and testing, the responsibility of collecting jobs into a batch was extracted into a specific class.

The new API, `TypedEventWriter#canWriteEventOfLength(int)` could potentially be reused in other places where we want to prevent writing batches that are too large. However, this is a bit brittle, since it requires the code in the engine to properly compute beforehand how the record will grow when you modify it. For example, in the `JobBatchCollector`, to calculate the length of the `TypedRecord<JobBatchRecordValue> record` when adding a given `JobRecordValue` to it, we need the following:

```java
// the expected length is based on the current record's length plus the length of the job
// record we would add to the batch, the number of bytes taken by the additional job key,
// as well as one byte required per job key for its type header. if we ever add more, 
// should be updated accordingly.
final var jobRecordLength = jobRecord.getLength();
final var expectedEventLength = record.getLength() + jobRecordLength + Long.BYTES + 1;
```

Not extremely complicated, but could be error prone. A better solution, chunking the follow up events, is not something we can sanely do in between KRs, unfortunately, and would most likely carry a high risk, so wouldn't be anything we can backport. For now, I think this is an OK compromise.

NOTE: this PR depends on #8797 and #8798. Wait for these to be merged before reviewing!

## Related issues

closes #5525

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
