### PR TITLE
docs(license): link added to license text #8800

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Available under the [Apache License, Version 2.0](/licenses/APACHE-2.0.txt):
 
 The Zeebe Gateway Protocol (API) as published in the
 [gateway-protocol](/gateway-protocol/src/main/proto/gateway.proto) is licensed
-under the Zeebe Community License 1.1. Using gRPC tooling to generate stubs for
-the protocol does not constitute creating a derivative work under the Zeebe
-Community License 1.1 and no licensing restrictions are imposed on the
-resulting stub code by the Zeebe Community License 1.1.
+under the [Zeebe Community License 1.1](https://github.com/camunda-cloud/zeebe/blob/main/licenses/ZEEBE-COMMUNITY-LICENSE-1.1.txt). Using gRPC tooling to generate stubs for
+the protocol does not constitute creating a derivative work under the [Zeebe Community License 1.1](https://github.com/camunda-cloud/zeebe/blob/main/licenses/ZEEBE-COMMUNITY-LICENSE-1.1.txt) and no licensing restrictions are imposed on the
+resulting stub code by the [Zeebe Community License 1.1](https://github.com/camunda-cloud/zeebe/blob/main/licenses/ZEEBE-COMMUNITY-LICENSE-1.1.txt).

--- a/README.md
+++ b/README.md
@@ -82,5 +82,5 @@ Available under the [Apache License, Version 2.0](/licenses/APACHE-2.0.txt):
 The Zeebe Gateway Protocol (API) as published in the
 [gateway-protocol](/gateway-protocol/src/main/proto/gateway.proto) is licensed
 under the [Zeebe Community License 1.1](/licenses/ZEEBE-COMMUNITY-LICENSE-1.1.txt). Using gRPC tooling to generate stubs for
-the protocol does not constitute creating a derivative work under the [Zeebe Community License 1.1](https://github.com/camunda-cloud/zeebe/blob/main/licenses/ZEEBE-COMMUNITY-LICENSE-1.1.txt) and no licensing restrictions are imposed on the
+the protocol does not constitute creating a derivative work under the Zeebe Community License 1.1 and no licensing restrictions are imposed on the
 resulting stub code by the [Zeebe Community License 1.1](https://github.com/camunda-cloud/zeebe/blob/main/licenses/ZEEBE-COMMUNITY-LICENSE-1.1.txt).

--- a/README.md
+++ b/README.md
@@ -81,6 +81,6 @@ Available under the [Apache License, Version 2.0](/licenses/APACHE-2.0.txt):
 
 The Zeebe Gateway Protocol (API) as published in the
 [gateway-protocol](/gateway-protocol/src/main/proto/gateway.proto) is licensed
-under the [Zeebe Community License 1.1](https://github.com/camunda-cloud/zeebe/blob/main/licenses/ZEEBE-COMMUNITY-LICENSE-1.1.txt). Using gRPC tooling to generate stubs for
+under the [Zeebe Community License 1.1](/licenses/ZEEBE-COMMUNITY-LICENSE-1.1.txt). Using gRPC tooling to generate stubs for
 the protocol does not constitute creating a derivative work under the [Zeebe Community License 1.1](https://github.com/camunda-cloud/zeebe/blob/main/licenses/ZEEBE-COMMUNITY-LICENSE-1.1.txt) and no licensing restrictions are imposed on the
 resulting stub code by the [Zeebe Community License 1.1](https://github.com/camunda-cloud/zeebe/blob/main/licenses/ZEEBE-COMMUNITY-LICENSE-1.1.txt).

--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ The Zeebe Gateway Protocol (API) as published in the
 [gateway-protocol](/gateway-protocol/src/main/proto/gateway.proto) is licensed
 under the [Zeebe Community License 1.1](/licenses/ZEEBE-COMMUNITY-LICENSE-1.1.txt). Using gRPC tooling to generate stubs for
 the protocol does not constitute creating a derivative work under the Zeebe Community License 1.1 and no licensing restrictions are imposed on the
-resulting stub code by the [Zeebe Community License 1.1](https://github.com/camunda-cloud/zeebe/blob/main/licenses/ZEEBE-COMMUNITY-LICENSE-1.1.txt).
+resulting stub code by the Zeebe Community License 1.1.


### PR DESCRIPTION
## Description

Links were enabled to the license page from readme file 

## Related issues

<!-- Resolves #8800  -->

closes #8800 

Documentation:
* [X] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [X] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [X] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
