### PR TITLE
Use checked methods from `ColumnFamily`

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
@@ -54,7 +54,7 @@ public final class ExportersState {
 
   private void setPosition(final long position) {
     this.position.set(position);
-    exporterPositionColumnFamily.put(exporterId, this.position);
+    exporterPositionColumnFamily.upsert(exporterId, this.position);
   }
 
   public void visitPositions(final BiConsumer<String, Long> consumer) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
@@ -71,7 +71,7 @@ public final class ExportersState {
 
   public void removePosition(final String exporter) {
     exporterId.wrapString(exporter);
-    exporterPositionColumnFamily.delete(exporterId);
+    exporterPositionColumnFamily.deleteExisting(exporterId);
   }
 
   public boolean hasExporters() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
@@ -71,7 +71,7 @@ public final class ExportersState {
 
   public void removePosition(final String exporter) {
     exporterId.wrapString(exporter);
-    exporterPositionColumnFamily.deleteExisting(exporterId);
+    exporterPositionColumnFamily.deleteIfExists(exporterId);
   }
 
   public boolean hasExporters() {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RocksDBWrapper.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RocksDBWrapper.java
@@ -35,11 +35,6 @@ public final class RocksDBWrapper {
   public void putInt(final String key, final int value) {
     this.key.wrapString(key);
     this.value.wrapLong(value);
-    defaultColumnFamily.put(this.key, this.value);
-  }
-
-  public boolean mayExist(final String key) {
-    this.key.wrapString(key);
-    return defaultColumnFamily.exists(this.key);
+    defaultColumnFamily.upsert(this.key, this.value);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/NextValueManager.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/NextValueManager.java
@@ -37,7 +37,7 @@ public final class NextValueManager {
     final long previousKey = getCurrentValue(key);
     final long nextKey = previousKey + 1;
     nextValue.set(nextKey);
-    nextValueColumnFamily.put(nextValueKey, nextValue);
+    nextValueColumnFamily.upsert(nextValueKey, nextValue);
 
     return nextKey;
   }
@@ -45,7 +45,7 @@ public final class NextValueManager {
   public void setValue(final String key, final long value) {
     nextValueKey.wrapString(key);
     nextValue.set(value);
-    nextValueColumnFamily.put(nextValueKey, nextValue);
+    nextValueColumnFamily.upsert(nextValueKey, nextValue);
   }
 
   public long getCurrentValue(final String key) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DecisionCreatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DecisionCreatedApplier.java
@@ -23,6 +23,6 @@ public final class DecisionCreatedApplier
 
   @Override
   public void applyState(final long key, final DecisionRecord value) {
-    decisionState.putDecision(value);
+    decisionState.storeDecisionRecord(value);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DecisionRequirementsCreatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DecisionRequirementsCreatedApplier.java
@@ -23,6 +23,6 @@ public final class DecisionRequirementsCreatedApplier
 
   @Override
   public void applyState(final long key, final DecisionRequirementsRecord value) {
-    decisionState.putDecisionRequirements(value);
+    decisionState.storeDecisionRequirements(value);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentDistributedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentDistributedApplier.java
@@ -50,7 +50,7 @@ public class DeploymentDistributedApplier
               decisionState.putDecisionRequirements(decisionRequirementsRecord);
             });
 
-    value.decisionsMetadata().forEach(decisionState::putDecision);
+    value.decisionsMetadata().forEach(decisionState::storeDecisionRecord);
   }
 
   private DirectBuffer getResourceByName(

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentDistributedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentDistributedApplier.java
@@ -47,7 +47,7 @@ public class DeploymentDistributedApplier
               final var resource = getResourceByName(value, drg.getResourceName());
               final var decisionRequirementsRecord =
                   createDecisionRequirementsRecord(drg, resource);
-              decisionState.putDecisionRequirements(decisionRequirementsRecord);
+              decisionState.storeDecisionRequirements(decisionRequirementsRecord);
             });
 
     value.decisionsMetadata().forEach(decisionState::storeDecisionRecord);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerCreatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerCreatedApplier.java
@@ -32,6 +32,6 @@ final class TimerCreatedApplier implements TypedEventApplier<TimerIntent, TimerR
     timerInstance.setProcessDefinitionKey(value.getProcessDefinitionKey());
     timerInstance.setProcessInstanceKey(value.getProcessInstanceKey());
 
-    timerInstanceState.put(timerInstance);
+    timerInstanceState.store(timerInstance);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -134,11 +134,11 @@ public final class DbDecisionState implements MutableDecisionState {
   public void putDecision(final DecisionRecord record) {
     dbDecisionKey.wrapLong(record.getDecisionKey());
     dbPersistedDecision.wrap(record);
-    decisionsByKey.put(dbDecisionKey, dbPersistedDecision);
+    decisionsByKey.upsert(dbDecisionKey, dbPersistedDecision);
 
     dbDecisionKey.wrapLong(record.getDecisionKey());
     dbDecisionRequirementsKey.wrapLong(record.getDecisionRequirementsKey());
-    decisionKeyByDecisionRequirementsKey.put(
+    decisionKeyByDecisionRequirementsKey.upsert(
         dbDecisionRequirementsKeyAndDecisionKey, DbNil.INSTANCE);
 
     updateLatestDecisionVersion(record);
@@ -148,7 +148,7 @@ public final class DbDecisionState implements MutableDecisionState {
   public void putDecisionRequirements(final DecisionRequirementsRecord record) {
     dbDecisionRequirementsKey.wrapLong(record.getDecisionRequirementsKey());
     dbPersistedDecisionRequirements.wrap(record);
-    decisionRequirementsByKey.put(dbDecisionRequirementsKey, dbPersistedDecisionRequirements);
+    decisionRequirementsByKey.upsert(dbDecisionRequirementsKey, dbPersistedDecisionRequirements);
 
     updateLatestDecisionRequirementsVersion(record);
   }
@@ -158,16 +158,22 @@ public final class DbDecisionState implements MutableDecisionState {
         .ifPresentOrElse(
             previousVersion -> {
               if (record.getVersion() > previousVersion.getVersion()) {
-                putDecisionAsLatestVersion(record);
+                updateDecisionAsLatestVersion(record);
               }
             },
-            () -> putDecisionAsLatestVersion(record));
+            () -> insertDecisionAsLatestVersion(record));
   }
 
-  private void putDecisionAsLatestVersion(final DecisionRecord record) {
+  private void updateDecisionAsLatestVersion(final DecisionRecord record) {
     dbDecisionId.wrapBuffer(record.getDecisionIdBuffer());
     dbDecisionKey.wrapLong(record.getDecisionKey());
-    latestDecisionKeysByDecisionId.put(dbDecisionId, dbDecisionKey);
+    latestDecisionKeysByDecisionId.update(dbDecisionId, dbDecisionKey);
+  }
+
+  private void insertDecisionAsLatestVersion(final DecisionRecord record) {
+    dbDecisionId.wrapBuffer(record.getDecisionIdBuffer());
+    dbDecisionKey.wrapLong(record.getDecisionKey());
+    latestDecisionKeysByDecisionId.insert(dbDecisionId, dbDecisionKey);
   }
 
   private void updateLatestDecisionRequirementsVersion(final DecisionRequirementsRecord record) {
@@ -176,15 +182,21 @@ public final class DbDecisionState implements MutableDecisionState {
             previousVersion -> {
               if (record.getDecisionRequirementsVersion()
                   > previousVersion.getDecisionRequirementsVersion()) {
-                putDecisionRequirementsAsLatestVersion(record);
+                updateDecisionRequirementsAsLatestVersion(record);
               }
             },
-            () -> putDecisionRequirementsAsLatestVersion(record));
+            () -> insertDecisionRequirementsAsLatestVersion(record));
   }
 
-  private void putDecisionRequirementsAsLatestVersion(final DecisionRequirementsRecord record) {
+  private void updateDecisionRequirementsAsLatestVersion(final DecisionRequirementsRecord record) {
     dbDecisionRequirementsId.wrapBuffer(record.getDecisionRequirementsIdBuffer());
     dbDecisionRequirementsKey.wrapLong(record.getDecisionRequirementsKey());
-    latestDecisionRequirementsKeysById.put(dbDecisionRequirementsId, dbDecisionRequirementsKey);
+    latestDecisionRequirementsKeysById.update(dbDecisionRequirementsId, dbDecisionRequirementsKey);
+  }
+
+  private void insertDecisionRequirementsAsLatestVersion(final DecisionRequirementsRecord record) {
+    dbDecisionRequirementsId.wrapBuffer(record.getDecisionRequirementsIdBuffer());
+    dbDecisionRequirementsKey.wrapLong(record.getDecisionRequirementsKey());
+    latestDecisionRequirementsKeysById.insert(dbDecisionRequirementsId, dbDecisionRequirementsKey);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -145,10 +145,10 @@ public final class DbDecisionState implements MutableDecisionState {
   }
 
   @Override
-  public void putDecisionRequirements(final DecisionRequirementsRecord record) {
+  public void storeDecisionRequirements(final DecisionRequirementsRecord record) {
     dbDecisionRequirementsKey.wrapLong(record.getDecisionRequirementsKey());
     dbPersistedDecisionRequirements.wrap(record);
-    decisionRequirementsByKey.upsert(dbDecisionRequirementsKey, dbPersistedDecisionRequirements);
+    decisionRequirementsByKey.insert(dbDecisionRequirementsKey, dbPersistedDecisionRequirements);
 
     updateLatestDecisionRequirementsVersion(record);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -131,14 +131,14 @@ public final class DbDecisionState implements MutableDecisionState {
   }
 
   @Override
-  public void putDecision(final DecisionRecord record) {
+  public void storeDecisionRecord(final DecisionRecord record) {
     dbDecisionKey.wrapLong(record.getDecisionKey());
     dbPersistedDecision.wrap(record);
-    decisionsByKey.upsert(dbDecisionKey, dbPersistedDecision);
+    decisionsByKey.insert(dbDecisionKey, dbPersistedDecision);
 
     dbDecisionKey.wrapLong(record.getDecisionKey());
     dbDecisionRequirementsKey.wrapLong(record.getDecisionRequirementsKey());
-    decisionKeyByDecisionRequirementsKey.upsert(
+    decisionKeyByDecisionRequirementsKey.insert(
         dbDecisionRequirementsKeyAndDecisionKey, DbNil.INSTANCE);
 
     updateLatestDecisionVersion(record);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
@@ -67,7 +67,7 @@ public final class DbDeploymentState implements MutableDeploymentState {
   public void removePendingDeploymentDistribution(final long deploymentKey, final int partition) {
     this.deploymentKey.wrapLong(deploymentKey);
     partitionKey.wrapInt(partition);
-    pendingDeploymentColumnFamily.deleteIfExists(deploymentPartitionKey);
+    pendingDeploymentColumnFamily.deleteExisting(deploymentPartitionKey);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
@@ -60,7 +60,7 @@ public final class DbDeploymentState implements MutableDeploymentState {
   public void addPendingDeploymentDistribution(final long deploymentKey, final int partition) {
     this.deploymentKey.wrapLong(deploymentKey);
     partitionKey.wrapInt(partition);
-    pendingDeploymentColumnFamily.put(deploymentPartitionKey, DbNil.INSTANCE);
+    pendingDeploymentColumnFamily.insert(deploymentPartitionKey, DbNil.INSTANCE);
   }
 
   @Override
@@ -74,7 +74,7 @@ public final class DbDeploymentState implements MutableDeploymentState {
   public void storeDeploymentRecord(final long key, final DeploymentRecord value) {
     deploymentKey.wrapLong(key);
     deploymentRaw.setDeploymentRecord(value);
-    deploymentRawColumnFamily.put(deploymentKey, deploymentRaw);
+    deploymentRawColumnFamily.insert(deploymentKey, deploymentRaw);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
@@ -67,7 +67,7 @@ public final class DbDeploymentState implements MutableDeploymentState {
   public void removePendingDeploymentDistribution(final long deploymentKey, final int partition) {
     this.deploymentKey.wrapLong(deploymentKey);
     partitionKey.wrapInt(partition);
-    pendingDeploymentColumnFamily.delete(deploymentPartitionKey);
+    pendingDeploymentColumnFamily.deleteIfExists(deploymentPartitionKey);
   }
 
   @Override
@@ -80,7 +80,7 @@ public final class DbDeploymentState implements MutableDeploymentState {
   @Override
   public void removeDeploymentRecord(final long key) {
     deploymentKey.wrapLong(key);
-    deploymentRawColumnFamily.delete(deploymentKey);
+    deploymentRawColumnFamily.deleteIfExists(deploymentKey);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -119,7 +119,7 @@ public final class DbProcessState implements MutableProcessState {
     processId.wrapBuffer(processIdBuffer);
     this.digest.set(digest);
 
-    digestByIdColumnFamily.put(processId, this.digest);
+    digestByIdColumnFamily.upsert(processId, this.digest);
   }
 
   @Override
@@ -133,12 +133,12 @@ public final class DbProcessState implements MutableProcessState {
   private void persistProcess(final long processDefinitionKey, final ProcessRecord processRecord) {
     persistedProcess.wrap(processRecord, processDefinitionKey);
     this.processDefinitionKey.wrapLong(processDefinitionKey);
-    processColumnFamily.put(this.processDefinitionKey, persistedProcess);
+    processColumnFamily.upsert(this.processDefinitionKey, persistedProcess);
 
     processId.wrapBuffer(processRecord.getBpmnProcessIdBuffer());
     processVersion.wrapLong(processRecord.getVersion());
 
-    processByIdAndVersionColumnFamily.put(idAndVersionKey, persistedProcess);
+    processByIdAndVersionColumnFamily.upsert(idAndVersionKey, persistedProcess);
   }
 
   private void updateLatestVersion(final ProcessRecord processRecord) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -133,12 +133,12 @@ public final class DbElementInstanceState implements MutableElementInstanceState
       elementInstanceKey.wrapLong(key);
       parentKey.wrapLong(instance.getParentKey());
 
-      parentChildColumnFamily.delete(parentChildKey);
-      elementInstanceColumnFamily.delete(elementInstanceKey);
+      parentChildColumnFamily.deleteIfExists(parentChildKey);
+      elementInstanceColumnFamily.deleteExisting(elementInstanceKey);
 
       variableState.removeScope(key);
 
-      awaitProcessInstanceResultMetadataColumnFamily.delete(elementInstanceKey);
+      awaitProcessInstanceResultMetadataColumnFamily.deleteIfExists(elementInstanceKey);
       removeNumberOfTakenSequenceFlows(key);
 
       final long parentKey = instance.getParentKey();
@@ -221,7 +221,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
             numberOfTakenSequenceFlows.wrapInt(newValue);
             numberOfTakenSequenceFlowsColumnFamily.update(key, numberOfTakenSequenceFlows);
           } else {
-            numberOfTakenSequenceFlowsColumnFamily.delete(key);
+            numberOfTakenSequenceFlowsColumnFamily.deleteExisting(key);
           }
         });
   }
@@ -295,7 +295,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     numberOfTakenSequenceFlowsColumnFamily.whileEqualPrefix(
         this.flowScopeKey,
         (key, number) -> {
-          numberOfTakenSequenceFlowsColumnFamily.delete(key);
+          numberOfTakenSequenceFlowsColumnFamily.deleteExisting(key);
         });
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
@@ -95,7 +95,7 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
             (key, value) -> deleteTrigger(key));
 
     this.eventScopeKey.wrapLong(eventScopeKey);
-    eventScopeInstanceColumnFamily.delete(this.eventScopeKey);
+    eventScopeInstanceColumnFamily.deleteIfExists(this.eventScopeKey);
   }
 
   @Override
@@ -195,6 +195,6 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
   }
 
   private void deleteTrigger(final DbCompositeKey<DbLong, DbLong> triggerKey) {
-    eventTriggerColumnFamily.delete(triggerKey);
+    eventTriggerColumnFamily.deleteIfExists(triggerKey);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
@@ -53,7 +53,7 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
     if (instance != null) {
       this.eventScopeKey.wrapLong(eventScopeKey);
       instance.setAccepting(false);
-      eventScopeInstanceColumnFamily.put(this.eventScopeKey, instance);
+      eventScopeInstanceColumnFamily.update(this.eventScopeKey, instance);
     }
   }
 
@@ -82,7 +82,7 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
       eventScopeInstance.addInterrupting(interruptingId);
     }
 
-    eventScopeInstanceColumnFamily.put(this.eventScopeKey, eventScopeInstance);
+    eventScopeInstanceColumnFamily.insert(this.eventScopeKey, eventScopeInstance);
   }
 
   @Override
@@ -125,7 +125,7 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
     if (isAcceptingEvent(instance)) {
       if (instance.isInterrupting(elementId)) {
         instance.setAccepting(false);
-        eventScopeInstanceColumnFamily.put(this.eventScopeKey, instance);
+        eventScopeInstanceColumnFamily.update(this.eventScopeKey, instance);
       }
 
       createTrigger(eventScopeKey, eventKey, elementId, variables);
@@ -191,7 +191,7 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
 
     eventTrigger.setElementId(elementId).setVariables(variables).setEventKey(eventKey);
 
-    eventTriggerColumnFamily.put(eventTriggerKey, eventTrigger);
+    eventTriggerColumnFamily.insert(eventTriggerKey, eventTrigger);
   }
 
   private void deleteTrigger(final DbCompositeKey<DbLong, DbLong> triggerKey) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbIncidentState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbIncidentState.java
@@ -92,14 +92,14 @@ public final class DbIncidentState implements MutableIncidentState {
     final IncidentRecord incidentRecord = getIncidentRecord(key);
 
     if (incidentRecord != null) {
-      incidentColumnFamily.delete(incidentKey);
+      incidentColumnFamily.deleteExisting(incidentKey);
 
       if (isJobIncident(incidentRecord)) {
         jobKey.wrapLong(incidentRecord.getJobKey());
-        jobIncidentColumnFamily.delete(jobKey);
+        jobIncidentColumnFamily.deleteExisting(jobKey);
       } else {
         elementInstanceKey.wrapLong(incidentRecord.getElementInstanceKey());
-        processInstanceIncidentColumnFamily.delete(elementInstanceKey);
+        processInstanceIncidentColumnFamily.deleteExisting(elementInstanceKey);
       }
 
       metrics.incidentResolved();

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbIncidentState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbIncidentState.java
@@ -73,29 +73,18 @@ public final class DbIncidentState implements MutableIncidentState {
   public void createIncident(final long incidentKey, final IncidentRecord incident) {
     this.incidentKey.wrapLong(incidentKey);
     incidentWrite.setRecord(incident);
-    incidentColumnFamily.put(this.incidentKey, incidentWrite);
+    incidentColumnFamily.insert(this.incidentKey, incidentWrite);
 
     incidentKeyValue.set(incidentKey);
     if (isJobIncident(incident)) {
       jobKey.wrapLong(incident.getJobKey());
-      jobIncidentColumnFamily.put(jobKey, incidentKeyValue);
+      jobIncidentColumnFamily.insert(jobKey, incidentKeyValue);
     } else {
       elementInstanceKey.wrapLong(incident.getElementInstanceKey());
-      processInstanceIncidentColumnFamily.put(elementInstanceKey, incidentKeyValue);
+      processInstanceIncidentColumnFamily.insert(elementInstanceKey, incidentKeyValue);
     }
 
     metrics.incidentCreated();
-  }
-
-  @Override
-  public IncidentRecord getIncidentRecord(final long incidentKey) {
-    this.incidentKey.wrapLong(incidentKey);
-
-    final Incident incident = incidentColumnFamily.get(this.incidentKey);
-    if (incident != null) {
-      return incident.getRecord();
-    }
-    return null;
   }
 
   @Override
@@ -115,6 +104,17 @@ public final class DbIncidentState implements MutableIncidentState {
 
       metrics.incidentResolved();
     }
+  }
+
+  @Override
+  public IncidentRecord getIncidentRecord(final long incidentKey) {
+    this.incidentKey.wrapLong(incidentKey);
+
+    final Incident incident = incidentColumnFamily.get(this.incidentKey);
+    if (incident != null) {
+      return incident.getRecord();
+    }
+    return null;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -133,7 +133,7 @@ public final class DbJobState implements JobState, MutableJobState {
     updateJob(key, record, State.ACTIVATABLE);
     jobKey.wrapLong(key);
     backoffKey.wrapLong(record.getRecurringTime());
-    backoffColumnFamily.delete(backoffJobKey);
+    backoffColumnFamily.deleteExisting(backoffJobKey);
   }
 
   @Override
@@ -176,9 +176,9 @@ public final class DbJobState implements JobState, MutableJobState {
     final long deadline = record.getDeadline();
 
     jobKey.wrapLong(key);
-    jobsColumnFamily.delete(jobKey);
+    jobsColumnFamily.deleteExisting(jobKey);
 
-    statesJobColumnFamily.delete(jobKey);
+    statesJobColumnFamily.deleteExisting(jobKey);
 
     makeJobNotActivatable(type);
 
@@ -254,7 +254,8 @@ public final class DbJobState implements JobState, MutableJobState {
           final boolean isDue = deadline < upperBound;
           if (isDue) {
             final long jobKey1 = key.second().getValue();
-            return visitJob(jobKey1, callback::apply, () -> deadlinesColumnFamily.delete(key));
+            return visitJob(
+                jobKey1, callback::apply, () -> deadlinesColumnFamily.deleteExisting(key));
           }
           return false;
         });
@@ -319,7 +320,7 @@ public final class DbJobState implements JobState, MutableJobState {
           boolean consumed = false;
           if (deadline <= timestamp) {
             final long jobKey = key.second().getValue();
-            consumed = visitJob(jobKey, callback, () -> backoffColumnFamily.delete(key));
+            consumed = visitJob(jobKey, callback, () -> backoffColumnFamily.deleteExisting(key));
           }
           if (!consumed) {
             nextBackOffDueDate = deadline;
@@ -390,11 +391,11 @@ public final class DbJobState implements JobState, MutableJobState {
     EnsureUtil.ensureNotNullOrEmpty("type", type);
 
     jobTypeKey.wrapBuffer(type);
-    activatableColumnFamily.delete(typeJobKey);
+    activatableColumnFamily.deleteIfExists(typeJobKey);
   }
 
   private void removeJobDeadline(final long deadline) {
     deadlineKey.wrapLong(deadline);
-    deadlinesColumnFamily.delete(deadlineJobKey);
+    deadlinesColumnFamily.deleteIfExists(deadlineJobKey);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbTimerInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbTimerInstanceState.java
@@ -68,10 +68,10 @@ public final class DbTimerInstanceState implements MutableTimerInstanceState {
   public void remove(final TimerInstance timer) {
     elementInstanceKey.wrapLong(timer.getElementInstanceKey());
     timerKey.wrapLong(timer.getKey());
-    timerInstanceColumnFamily.delete(elementAndTimerKey);
+    timerInstanceColumnFamily.deleteExisting(elementAndTimerKey);
 
     dueDateKey.wrapLong(timer.getDueDate());
-    dueDateColumnFamily.delete(dueDateCompositeKey);
+    dueDateColumnFamily.deleteExisting(dueDateCompositeKey);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbTimerInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbTimerInstanceState.java
@@ -58,10 +58,10 @@ public final class DbTimerInstanceState implements MutableTimerInstanceState {
     timerKey.wrapLong(timer.getKey());
     elementInstanceKey.wrapLong(timer.getElementInstanceKey());
 
-    timerInstanceColumnFamily.put(elementAndTimerKey, timer);
+    timerInstanceColumnFamily.insert(elementAndTimerKey, timer);
 
     dueDateKey.wrapLong(timer.getDueDate());
-    dueDateColumnFamily.put(dueDateCompositeKey, DbNil.INSTANCE);
+    dueDateColumnFamily.insert(dueDateCompositeKey, DbNil.INSTANCE);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbTimerInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbTimerInstanceState.java
@@ -54,7 +54,7 @@ public final class DbTimerInstanceState implements MutableTimerInstanceState {
   }
 
   @Override
-  public void put(final TimerInstance timer) {
+  public void store(final TimerInstance timer) {
     timerKey.wrapLong(timer.getKey());
     elementInstanceKey.wrapLong(timer.getElementInstanceKey());
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartEventSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartEventSubscriptionState.java
@@ -64,9 +64,9 @@ public final class DbMessageStartEventSubscriptionState
 
     messageName.wrapBuffer(subscription.getMessageNameBuffer());
     processDefinitionKey.wrapLong(subscription.getProcessDefinitionKey());
-    subscriptionsColumnFamily.put(
+    subscriptionsColumnFamily.upsert(
         messageNameAndProcessDefinitionKey, messageStartEventSubscription);
-    subscriptionsOfProcessDefinitionKeyColumnFamily.put(
+    subscriptionsOfProcessDefinitionKeyColumnFamily.upsert(
         processDefinitionKeyAndMessageName, DbNil.INSTANCE);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartEventSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageStartEventSubscriptionState.java
@@ -75,8 +75,9 @@ public final class DbMessageStartEventSubscriptionState
     this.processDefinitionKey.wrapLong(processDefinitionKey);
     this.messageName.wrapBuffer(messageName);
 
-    subscriptionsColumnFamily.delete(messageNameAndProcessDefinitionKey);
-    subscriptionsOfProcessDefinitionKeyColumnFamily.delete(processDefinitionKeyAndMessageName);
+    subscriptionsColumnFamily.deleteExisting(messageNameAndProcessDefinitionKey);
+    subscriptionsOfProcessDefinitionKeyColumnFamily.deleteExisting(
+        processDefinitionKeyAndMessageName);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
@@ -164,19 +164,19 @@ public final class DbMessageState implements MutableMessageState {
   public void put(final long key, final MessageRecord record) {
     messageKey.wrapLong(key);
     message.setMessageKey(key).setMessage(record);
-    messageColumnFamily.put(messageKey, message);
+    messageColumnFamily.insert(messageKey, message);
 
     messageName.wrapBuffer(record.getNameBuffer());
     correlationKey.wrapBuffer(record.getCorrelationKeyBuffer());
-    nameCorrelationMessageColumnFamily.put(nameCorrelationMessageKey, DbNil.INSTANCE);
+    nameCorrelationMessageColumnFamily.insert(nameCorrelationMessageKey, DbNil.INSTANCE);
 
     deadline.wrapLong(record.getDeadline());
-    deadlineColumnFamily.put(deadlineMessageKey, DbNil.INSTANCE);
+    deadlineColumnFamily.insert(deadlineMessageKey, DbNil.INSTANCE);
 
     final DirectBuffer messageId = record.getMessageIdBuffer();
     if (messageId.capacity() > 0) {
       this.messageId.wrapBuffer(messageId);
-      messageIdColumnFamily.put(nameCorrelationMessageIdKey, DbNil.INSTANCE);
+      messageIdColumnFamily.upsert(nameCorrelationMessageIdKey, DbNil.INSTANCE);
     }
   }
 
@@ -187,7 +187,7 @@ public final class DbMessageState implements MutableMessageState {
 
     this.messageKey.wrapLong(messageKey);
     bpmnProcessIdKey.wrapBuffer(bpmnProcessId);
-    correlatedMessageColumnFamily.put(messageBpmnProcessIdKey, DbNil.INSTANCE);
+    correlatedMessageColumnFamily.insert(messageBpmnProcessIdKey, DbNil.INSTANCE);
   }
 
   @Override
@@ -209,7 +209,7 @@ public final class DbMessageState implements MutableMessageState {
 
     bpmnProcessIdKey.wrapBuffer(bpmnProcessId);
     this.correlationKey.wrapBuffer(correlationKey);
-    activeProcessInstancesByCorrelationKeyColumnFamiliy.put(
+    activeProcessInstancesByCorrelationKeyColumnFamiliy.insert(
         bpmnProcessIdCorrelationKey, DbNil.INSTANCE);
   }
 
@@ -232,7 +232,7 @@ public final class DbMessageState implements MutableMessageState {
 
     this.processInstanceKey.wrapLong(processInstanceKey);
     this.correlationKey.wrapBuffer(correlationKey);
-    processInstanceCorrelationKeyColumnFamiliy.put(this.processInstanceKey, this.correlationKey);
+    processInstanceCorrelationKeyColumnFamiliy.insert(this.processInstanceKey, this.correlationKey);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
@@ -198,7 +198,7 @@ public final class DbMessageState implements MutableMessageState {
     this.messageKey.wrapLong(messageKey);
     bpmnProcessIdKey.wrapBuffer(bpmnProcessId);
 
-    correlatedMessageColumnFamily.delete(messageBpmnProcessIdKey);
+    correlatedMessageColumnFamily.deleteExisting(messageBpmnProcessIdKey);
   }
 
   @Override
@@ -221,7 +221,7 @@ public final class DbMessageState implements MutableMessageState {
 
     bpmnProcessIdKey.wrapBuffer(bpmnProcessId);
     this.correlationKey.wrapBuffer(correlationKey);
-    activeProcessInstancesByCorrelationKeyColumnFamiliy.delete(bpmnProcessIdCorrelationKey);
+    activeProcessInstancesByCorrelationKeyColumnFamiliy.deleteExisting(bpmnProcessIdCorrelationKey);
   }
 
   @Override
@@ -240,7 +240,7 @@ public final class DbMessageState implements MutableMessageState {
     ensureGreaterThan("process instance key", processInstanceKey, 0);
 
     this.processInstanceKey.wrapLong(processInstanceKey);
-    processInstanceCorrelationKeyColumnFamiliy.delete(this.processInstanceKey);
+    processInstanceCorrelationKeyColumnFamiliy.deleteExisting(this.processInstanceKey);
   }
 
   @Override
@@ -251,26 +251,26 @@ public final class DbMessageState implements MutableMessageState {
     }
 
     messageKey.wrapLong(storedMessage.getMessageKey());
-    messageColumnFamily.delete(messageKey);
+    messageColumnFamily.deleteExisting(messageKey);
 
     messageName.wrapBuffer(storedMessage.getMessage().getNameBuffer());
     correlationKey.wrapBuffer(storedMessage.getMessage().getCorrelationKeyBuffer());
 
-    nameCorrelationMessageColumnFamily.delete(nameCorrelationMessageKey);
+    nameCorrelationMessageColumnFamily.deleteExisting(nameCorrelationMessageKey);
 
     final DirectBuffer messageId = storedMessage.getMessage().getMessageIdBuffer();
     if (messageId.capacity() > 0) {
       this.messageId.wrapBuffer(messageId);
-      messageIdColumnFamily.delete(nameCorrelationMessageIdKey);
+      messageIdColumnFamily.deleteExisting(nameCorrelationMessageIdKey);
     }
 
     deadline.wrapLong(storedMessage.getMessage().getDeadline());
-    deadlineColumnFamily.delete(deadlineMessageKey);
+    deadlineColumnFamily.deleteExisting(deadlineMessageKey);
 
     correlatedMessageColumnFamily.whileEqualPrefix(
         messageKey,
         ((compositeKey, zbNil) -> {
-          correlatedMessageColumnFamily.delete(compositeKey);
+          correlatedMessageColumnFamily.deleteExisting(compositeKey);
         }));
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
@@ -177,12 +177,12 @@ public final class DbMessageSubscriptionState
 
   @Override
   public void remove(final MessageSubscription subscription) {
-    subscriptionColumnFamily.delete(elementKeyAndMessageName);
+    subscriptionColumnFamily.deleteExisting(elementKeyAndMessageName);
 
     final var record = subscription.getRecord();
     messageName.wrapBuffer(record.getMessageNameBuffer());
     correlationKey.wrapBuffer(record.getCorrelationKeyBuffer());
-    messageNameAndCorrelationKeyColumnFamily.delete(nameCorrelationAndElementInstanceKey);
+    messageNameAndCorrelationKeyColumnFamily.deleteExisting(nameCorrelationAndElementInstanceKey);
 
     transientState.remove(subscription.getRecord());
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
@@ -122,10 +122,10 @@ public final class DbMessageSubscriptionState
 
     messageSubscription.setKey(key).setRecord(record).setCorrelating(false);
 
-    subscriptionColumnFamily.put(elementKeyAndMessageName, messageSubscription);
+    subscriptionColumnFamily.insert(elementKeyAndMessageName, messageSubscription);
 
     correlationKey.wrapBuffer(record.getCorrelationKeyBuffer());
-    messageNameAndCorrelationKeyColumnFamily.put(
+    messageNameAndCorrelationKeyColumnFamily.insert(
         nameCorrelationAndElementInstanceKey, DbNil.INSTANCE);
   }
 
@@ -194,7 +194,7 @@ public final class DbMessageSubscriptionState
     messageName.wrapBuffer(record.getMessageNameBuffer());
 
     subscription.setCorrelating(correlating);
-    subscriptionColumnFamily.put(elementKeyAndMessageName, subscription);
+    subscriptionColumnFamily.update(elementKeyAndMessageName, subscription);
   }
 
   private Boolean visitMessageSubscription(

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
@@ -173,7 +173,7 @@ public final class DbProcessMessageSubscriptionState
         subscription.getRecord().getElementInstanceKey(),
         subscription.getRecord().getMessageNameBuffer());
 
-    subscriptionColumnFamily.delete(elementKeyAndMessageName);
+    subscriptionColumnFamily.deleteExisting(elementKeyAndMessageName);
 
     transientState.remove(subscription.getRecord());
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
@@ -70,8 +70,14 @@ public final class DbProcessMessageSubscriptionState
     processMessageSubscription.reset();
     processMessageSubscription.setKey(key).setRecord(record);
 
-    subscriptionColumnFamily.put(elementKeyAndMessageName, processMessageSubscription);
+    subscriptionColumnFamily.insert(elementKeyAndMessageName, processMessageSubscription);
 
+    transientState.add(record);
+  }
+
+  @Override
+  public void updateToOpeningState(final ProcessMessageSubscriptionRecord record) {
+    update(record, s -> s.setRecord(record).setOpening());
     transientState.add(record);
   }
 
@@ -159,7 +165,7 @@ public final class DbProcessMessageSubscriptionState
     wrapSubscriptionKeys(
         subscription.getRecord().getElementInstanceKey(),
         subscription.getRecord().getMessageNameBuffer());
-    subscriptionColumnFamily.put(elementKeyAndMessageName, subscription);
+    subscriptionColumnFamily.update(elementKeyAndMessageName, subscription);
   }
 
   private void remove(final ProcessMessageSubscription subscription) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/ProcessMessageSubscription.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/ProcessMessageSubscription.java
@@ -39,6 +39,11 @@ public final class ProcessMessageSubscription extends UnpackedObject implements 
     return stateProp.getValue() == State.STATE_OPENING;
   }
 
+  public ProcessMessageSubscription setOpening() {
+    stateProp.setValue(State.STATE_OPENING);
+    return this;
+  }
+
   public ProcessMessageSubscription setOpened() {
     stateProp.setValue(State.STATE_OPENED);
     return this;

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
@@ -148,7 +148,7 @@ public class DbMigrationState implements MutableMigrationState {
             if (processMessageSubscription.isOpening()) {
               // explicit call to put(..). This has the desired side-effect that the subscription
               // is added to transient state
-              persistentState.put(elementInstanceKey, exclusiveCopy);
+              persistentState.updateToOpeningState(exclusiveCopy);
               transientState.updateSentTime(exclusiveCopy, sentTime);
             } else if (processMessageSubscription.isClosing()) {
               // explicit call to updateToClosingState(..). This has the desired side-effect that

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
@@ -119,7 +119,7 @@ public class DbMigrationState implements MutableMigrationState {
             transientState.updateCommandSentTime(messageSubscription.getRecord(), sentTime);
           }
 
-          messageSubscriptionSentTimeColumnFamily.delete(key);
+          messageSubscriptionSentTimeColumnFamily.deleteExisting(key);
         });
   }
 
@@ -158,7 +158,7 @@ public class DbMigrationState implements MutableMigrationState {
             }
           }
 
-          processSubscriptionSentTimeColumnFamily.delete(key);
+          processSubscriptionSentTimeColumnFamily.deleteExisting(key);
         });
   }
 
@@ -199,7 +199,7 @@ public class DbMigrationState implements MutableMigrationState {
                 key.getValue(), eventKey, elementIdBuffer, value.get());
           }
 
-          temporaryVariableColumnFamily.delete(key);
+          temporaryVariableColumnFamily.deleteExisting(key);
         });
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDecisionState.java
@@ -18,7 +18,7 @@ public interface MutableDecisionState extends DecisionState {
    *
    * @param record the record of the decision
    */
-  void putDecision(DecisionRecord record);
+  void storeDecisionRecord(DecisionRecord record);
 
   /**
    * Put the given decision requirements (DRG) in the state. Update the latest version of the DRG if

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDecisionState.java
@@ -26,5 +26,5 @@ public interface MutableDecisionState extends DecisionState {
    *
    * @param record the record of the DRG
    */
-  void putDecisionRequirements(DecisionRequirementsRecord record);
+  void storeDecisionRequirements(DecisionRequirementsRecord record);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableElementInstanceState.java
@@ -24,6 +24,8 @@ public interface MutableElementInstanceState extends ElementInstanceState {
 
   void removeInstance(long key);
 
+  void createInstance(ElementInstance instance);
+
   void updateInstance(ElementInstance scopeInstance);
 
   void updateInstance(long key, Consumer<ElementInstance> modifier);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessMessageSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessMessageSubscriptionState.java
@@ -15,6 +15,8 @@ public interface MutableProcessMessageSubscriptionState extends ProcessMessageSu
 
   void put(final long key, ProcessMessageSubscriptionRecord record);
 
+  void updateToOpeningState(ProcessMessageSubscriptionRecord record);
+
   void updateToOpenedState(ProcessMessageSubscriptionRecord record);
 
   void updateToClosingState(ProcessMessageSubscriptionRecord record);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableTimerInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableTimerInstanceState.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.engine.state.instance.TimerInstance;
 
 public interface MutableTimerInstanceState extends TimerInstanceState {
 
-  void put(TimerInstance timer);
+  void store(TimerInstance timer);
 
   void remove(TimerInstance timer);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBlackListState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBlackListState.java
@@ -51,7 +51,7 @@ public final class DbBlackListState implements MutableBlackListState {
       LOG.warn(BLACKLIST_INSTANCE_MESSAGE, key);
 
       processInstanceKey.wrapLong(key);
-      blackListColumnFamily.put(processInstanceKey, DbNil.INSTANCE);
+      blackListColumnFamily.insert(processInstanceKey, DbNil.INSTANCE);
       blacklistMetrics.countBlacklistedInstance();
     }
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbLastProcessedPositionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbLastProcessedPositionState.java
@@ -41,6 +41,6 @@ public final class DbLastProcessedPositionState implements MutableLastProcessedP
   @Override
   public void markAsProcessed(final long position) {
     this.position.set(position);
-    positionColumnFamily.put(positionKey, this.position);
+    positionColumnFamily.upsert(positionKey, this.position);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
@@ -123,7 +123,8 @@ public class DbVariableState implements MutableVariableState {
     removeAllVariables(scopeKey);
 
     childKey.wrapLong(scopeKey);
-    childParentColumnFamily.delete(childKey);
+    // TODO: Could be deleteExisting except for tests
+    childParentColumnFamily.deleteIfExists(childKey);
   }
 
   @Override
@@ -131,7 +132,7 @@ public class DbVariableState implements MutableVariableState {
     visitVariablesLocal(
         scopeKey,
         dbString -> true,
-        (dbString, variable1) -> variablesColumnFamily.delete(scopeKeyVariableNameKey),
+        (dbString, variable1) -> variablesColumnFamily.deleteExisting(scopeKeyVariableNameKey),
         () -> false);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
@@ -105,7 +105,7 @@ public class DbVariableState implements MutableVariableState {
     variableNameView.wrap(name, nameOffset, nameLength);
     variableName.wrapBuffer(variableNameView);
 
-    variablesColumnFamily.put(scopeKeyVariableNameKey, newVariable);
+    variablesColumnFamily.upsert(scopeKeyVariableNameKey, newVariable);
   }
 
   @Override
@@ -113,7 +113,7 @@ public class DbVariableState implements MutableVariableState {
     this.childKey.wrapLong(childKey);
     this.parentKey.set(parentKey);
 
-    childParentColumnFamily.put(this.childKey, this.parentKey);
+    childParentColumnFamily.insert(this.childKey, this.parentKey);
   }
 
   @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeoutTriggerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeoutTriggerTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.util.ZeebeStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.util.sched.ActorControl;
+import java.util.stream.IntStream;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,9 +48,13 @@ public final class JobTimeoutTriggerTest {
     processingContext.enableLogStreamWriter();
     jobTimeoutTrigger.onRecovered(processingContext);
 
-    jobState.activate(0, newJobRecord());
-    jobState.activate(1, newJobRecord());
-    jobState.activate(2, newJobRecord());
+    IntStream.range(0, 3)
+        .forEach(
+            (i) -> {
+              final var job = newJobRecord();
+              jobState.create(i, job);
+              jobState.activate(i, job);
+            });
   }
 
   private JobRecord newJobRecord() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateTest.java
@@ -68,7 +68,7 @@ public final class DecisionStateTest {
   void shouldPutDecision() {
     // given
     final var decisionRecord = sampleDecisionRecord();
-    decisionState.putDecision(decisionRecord);
+    decisionState.storeDecisionRecord(decisionRecord);
 
     // when
     final var persistedDecision =
@@ -97,8 +97,8 @@ public final class DecisionStateTest {
     final var decisionRecord2 =
         sampleDecisionRecord().setDecisionId("decision-2").setDecisionKey(2L);
 
-    decisionState.putDecision(decisionRecord1);
-    decisionState.putDecision(decisionRecord2);
+    decisionState.storeDecisionRecord(decisionRecord1);
+    decisionState.storeDecisionRecord(decisionRecord2);
 
     // when
     final var persistedDecision1 =
@@ -124,9 +124,9 @@ public final class DecisionStateTest {
     final var decisionRecordV2 = sampleDecisionRecord().setDecisionKey(2L).setVersion(2);
     final var decisionRecordV3 = sampleDecisionRecord().setDecisionKey(3L).setVersion(3);
 
-    decisionState.putDecision(decisionRecordV1);
-    decisionState.putDecision(decisionRecordV3);
-    decisionState.putDecision(decisionRecordV2);
+    decisionState.storeDecisionRecord(decisionRecordV1);
+    decisionState.storeDecisionRecord(decisionRecordV3);
+    decisionState.storeDecisionRecord(decisionRecordV2);
 
     // when
     final var persistedDecision =
@@ -291,9 +291,9 @@ public final class DecisionStateTest {
             .setDecisionKey(3L)
             .setDecisionRequirementsKey(drg2.getDecisionRequirementsKey());
 
-    decisionState.putDecision(decision1);
-    decisionState.putDecision(decision2);
-    decisionState.putDecision(decision3);
+    decisionState.storeDecisionRecord(decision1);
+    decisionState.storeDecisionRecord(decision2);
+    decisionState.storeDecisionRecord(decision3);
 
     // when
     final var decisionsOfDrg1 =

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateTest.java
@@ -142,7 +142,7 @@ public final class DecisionStateTest {
   void shouldPutDecisionRequirements() {
     // given
     final var drg = sampleDecisionRequirementsRecord();
-    decisionState.putDecisionRequirements(drg);
+    decisionState.storeDecisionRequirements(drg);
 
     // when
     final var persistedDrg =
@@ -181,8 +181,8 @@ public final class DecisionStateTest {
             .setDecisionRequirementsId("drg-2")
             .setDecisionRequirementsKey(2L);
 
-    decisionState.putDecisionRequirements(drg1);
-    decisionState.putDecisionRequirements(drg2);
+    decisionState.storeDecisionRequirements(drg1);
+    decisionState.storeDecisionRequirements(drg2);
 
     // when
     final var persistedDrg1 =
@@ -217,9 +217,9 @@ public final class DecisionStateTest {
             .setDecisionRequirementsKey(3L)
             .setDecisionRequirementsVersion(3);
 
-    decisionState.putDecisionRequirements(decisionRecordV1);
-    decisionState.putDecisionRequirements(decisionRecordV3);
-    decisionState.putDecisionRequirements(decisionRecordV2);
+    decisionState.storeDecisionRequirements(decisionRecordV1);
+    decisionState.storeDecisionRequirements(decisionRecordV3);
+    decisionState.storeDecisionRequirements(decisionRecordV2);
 
     // when
     final var persistedDrg =
@@ -239,8 +239,8 @@ public final class DecisionStateTest {
     final var drg1 = sampleDecisionRequirementsRecord().setDecisionRequirementsKey(1L);
     final var drg2 = sampleDecisionRequirementsRecord().setDecisionRequirementsKey(2L);
 
-    decisionState.putDecisionRequirements(drg1);
-    decisionState.putDecisionRequirements(drg2);
+    decisionState.storeDecisionRequirements(drg1);
+    decisionState.storeDecisionRequirements(drg2);
 
     // when
     final var persistedDrg1 =

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
@@ -89,21 +89,6 @@ public class DeploymentStateTest {
   }
 
   @Test
-  public void shouldRemovePendingDeploymentIdempotent() {
-    // given
-    final var deploymentKey = 10L;
-    final var partition = 1;
-    deploymentState.addPendingDeploymentDistribution(deploymentKey, partition);
-    deploymentState.removePendingDeploymentDistribution(deploymentKey, partition);
-
-    // when
-    deploymentState.removePendingDeploymentDistribution(deploymentKey, partition);
-
-    // then
-    assertThat(deploymentState.hasPendingDeploymentDistribution(deploymentKey)).isFalse();
-  }
-
-  @Test
   public void shouldReturnTrueForDifferentPendingDeploymentOnHasPendingCheck() {
     // given
     final var deploymentKey = 10L;

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
@@ -654,9 +654,15 @@ public final class JobStateTest {
         .hasStackTraceContaining("type must not be empty");
 
     // should not throw any exception
+    // TODO: maybe rewrite this a little bit
+    jobState.create(1L, newJobRecord());
     jobState.activate(1L, newJobRecord());
     jobState.complete(1L, jobWithoutDeadline);
+
+    jobState.create(1L, newJobRecord());
     jobState.cancel(1L, jobWithoutDeadline);
+
+    jobState.create(1L, newJobRecord());
     jobState.throwError(1L, jobWithoutDeadline);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
@@ -646,6 +646,7 @@ public final class JobStateTest {
         .hasStackTraceContaining("type must not be empty");
 
     // cancel
+    jobState.create(1L, newJobRecord());
     assertThatThrownBy(() -> jobState.cancel(1L, jobWithoutType))
         .hasStackTraceContaining("type must not be empty");
 
@@ -654,7 +655,6 @@ public final class JobStateTest {
         .hasStackTraceContaining("type must not be empty");
 
     // should not throw any exception
-    // TODO: maybe rewrite this a little bit
     jobState.create(1L, newJobRecord());
     jobState.activate(1L, newJobRecord());
     jobState.complete(1L, jobWithoutDeadline);

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
@@ -38,7 +38,7 @@ public final class TimerInstanceStateTest {
     timer.setElementInstanceKey(1L);
     timer.setKey(2L);
     timer.setDueDate(1000L);
-    state.put(timer);
+    state.store(timer);
 
     // when
     final List<TimerInstance> timers = new ArrayList<>();
@@ -59,12 +59,12 @@ public final class TimerInstanceStateTest {
     final TimerInstance timer1 = new TimerInstance();
     timer1.setElementInstanceKey(1L);
     timer1.setDueDate(1000L);
-    state.put(timer1);
+    state.store(timer1);
 
     final TimerInstance timer2 = new TimerInstance();
     timer2.setElementInstanceKey(2L);
     timer2.setDueDate(2000L);
-    state.put(timer2);
+    state.store(timer2);
 
     // when
     final TimerInstance timer = new TimerInstance();
@@ -88,7 +88,7 @@ public final class TimerInstanceStateTest {
     timer.setProcessInstanceKey(1L);
     timer.setKey(2L);
     timer.setDueDate(1000L);
-    state.put(timer);
+    state.store(timer);
 
     // when
     final TimerInstance readTimer = state.get(1L, 2L);
@@ -110,17 +110,17 @@ public final class TimerInstanceStateTest {
     final TimerInstance timer1 = new TimerInstance();
     timer1.setElementInstanceKey(1L);
     timer1.setDueDate(1000L);
-    state.put(timer1);
+    state.store(timer1);
 
     final TimerInstance timer2 = new TimerInstance();
     timer2.setElementInstanceKey(2L);
     timer2.setDueDate(2000L);
-    state.put(timer2);
+    state.store(timer2);
 
     final TimerInstance timer3 = new TimerInstance();
     timer3.setElementInstanceKey(3L);
     timer3.setDueDate(3000L);
-    state.put(timer3);
+    state.store(timer3);
 
     // when
     final List<Long> keys = new ArrayList<>();
@@ -137,17 +137,17 @@ public final class TimerInstanceStateTest {
     final TimerInstance timer1 = new TimerInstance();
     timer1.setElementInstanceKey(1L);
     timer1.setDueDate(1000L);
-    state.put(timer1);
+    state.store(timer1);
 
     final TimerInstance timer2 = new TimerInstance();
     timer2.setElementInstanceKey(2L);
     timer2.setDueDate(2000L);
-    state.put(timer2);
+    state.store(timer2);
 
     final TimerInstance timer3 = new TimerInstance();
     timer3.setElementInstanceKey(3L);
     timer3.setDueDate(3000L);
-    state.put(timer3);
+    state.store(timer3);
 
     // when
     final long nextDueDate = state.findTimersWithDueDateBefore(2000L, t -> true);
@@ -172,17 +172,17 @@ public final class TimerInstanceStateTest {
     final TimerInstance timer1 = new TimerInstance();
     timer1.setElementInstanceKey(1L);
     timer1.setDueDate(1000L);
-    state.put(timer1);
+    state.store(timer1);
 
     final TimerInstance timer2 = new TimerInstance();
     timer2.setElementInstanceKey(2L);
     timer2.setDueDate(1000L);
-    state.put(timer2);
+    state.store(timer2);
 
     final TimerInstance timer3 = new TimerInstance();
     timer3.setElementInstanceKey(3L);
     timer3.setDueDate(3000L);
-    state.put(timer3);
+    state.store(timer3);
 
     // when
     final long nextDueDate = state.findTimersWithDueDateBefore(3000L, t -> true);
@@ -197,12 +197,12 @@ public final class TimerInstanceStateTest {
     final TimerInstance timer1 = new TimerInstance();
     timer1.setElementInstanceKey(1L);
     timer1.setDueDate(1000L);
-    state.put(timer1);
+    state.store(timer1);
 
     final TimerInstance timer2 = new TimerInstance();
     timer2.setElementInstanceKey(2L);
     timer2.setDueDate(2000L);
-    state.put(timer2);
+    state.store(timer2);
 
     // when
     final List<Long> keys = new ArrayList<>();
@@ -227,19 +227,19 @@ public final class TimerInstanceStateTest {
     timer1.setElementInstanceKey(1L);
     timer1.setKey(1L);
     timer1.setDueDate(1000L);
-    state.put(timer1);
+    state.store(timer1);
 
     final TimerInstance timer2 = new TimerInstance();
     timer2.setElementInstanceKey(1L);
     timer2.setKey(2L);
     timer2.setDueDate(2000L);
-    state.put(timer2);
+    state.store(timer2);
 
     final TimerInstance timer3 = new TimerInstance();
     timer3.setElementInstanceKey(2L);
     timer3.setKey(3L);
     timer3.setDueDate(2000L);
-    state.put(timer3);
+    state.store(timer3);
 
     // when
     final List<Long> keys = new ArrayList<>();

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
@@ -175,7 +175,7 @@ public final class TimerInstanceStateTest {
     state.put(timer1);
 
     final TimerInstance timer2 = new TimerInstance();
-    timer2.setElementInstanceKey(1L);
+    timer2.setElementInstanceKey(2L);
     timer2.setDueDate(1000L);
     state.put(timer2);
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/LegacyDbMessageSubscriptionState.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/LegacyDbMessageSubscriptionState.java
@@ -94,10 +94,10 @@ final class LegacyDbMessageSubscriptionState {
 
     messageSubscription.setKey(key).setRecord(record).setCommandSentTime(0);
 
-    subscriptionColumnFamily.put(elementKeyAndMessageName, messageSubscription);
+    subscriptionColumnFamily.upsert(elementKeyAndMessageName, messageSubscription);
 
     correlationKey.wrapBuffer(record.getCorrelationKeyBuffer());
-    messageNameAndCorrelationKeyColumnFamily.put(
+    messageNameAndCorrelationKeyColumnFamily.upsert(
         nameCorrelationAndElementInstanceKey, DbNil.INSTANCE);
   }
   /*
@@ -172,11 +172,11 @@ final class LegacyDbMessageSubscriptionState {
     removeSubscriptionFromSentTimeColumnFamily(subscription);
 
     subscription.setCommandSentTime(sentTime);
-    subscriptionColumnFamily.put(elementKeyAndMessageName, subscription);
+    subscriptionColumnFamily.upsert(elementKeyAndMessageName, subscription);
 
     if (sentTime > 0) {
       this.sentTime.wrapLong(subscription.getCommandSentTime());
-      sentTimeColumnFamily.put(sentTimeCompositeKey, DbNil.INSTANCE);
+      sentTimeColumnFamily.upsert(sentTimeCompositeKey, DbNil.INSTANCE);
     }
   }
   /*

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/LegacyDbMessageSubscriptionState.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/LegacyDbMessageSubscriptionState.java
@@ -215,12 +215,12 @@ final class LegacyDbMessageSubscriptionState {
   }
 
   public void remove(final LegacyMessageSubscription subscription) {
-    subscriptionColumnFamily.delete(elementKeyAndMessageName);
+    subscriptionColumnFamily.deleteIfExists(elementKeyAndMessageName);
 
     final var record = subscription.getRecord();
     messageName.wrapBuffer(record.getMessageNameBuffer());
     correlationKey.wrapBuffer(record.getCorrelationKeyBuffer());
-    messageNameAndCorrelationKeyColumnFamily.delete(nameCorrelationAndElementInstanceKey);
+    messageNameAndCorrelationKeyColumnFamily.deleteIfExists(nameCorrelationAndElementInstanceKey);
 
     removeSubscriptionFromSentTimeColumnFamily(subscription);
   }
@@ -229,7 +229,7 @@ final class LegacyDbMessageSubscriptionState {
       final LegacyMessageSubscription subscription) {
     if (subscription.getCommandSentTime() > 0) {
       sentTime.wrapLong(subscription.getCommandSentTime());
-      sentTimeColumnFamily.delete(sentTimeCompositeKey);
+      sentTimeColumnFamily.deleteIfExists(sentTimeCompositeKey);
     }
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/LegacyDbProcessMessageSubscriptionState.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/LegacyDbProcessMessageSubscriptionState.java
@@ -69,10 +69,10 @@ public final class LegacyDbProcessMessageSubscriptionState {
     processMessageSubscription.reset();
     processMessageSubscription.setKey(key).setRecord(record).setCommandSentTime(commandSentTime);
 
-    subscriptionColumnFamily.put(elementKeyAndMessageName, processMessageSubscription);
+    subscriptionColumnFamily.upsert(elementKeyAndMessageName, processMessageSubscription);
 
     sentTime.wrapLong(commandSentTime);
-    sentTimeColumnFamily.put(sentTimeCompositeKey, DbNil.INSTANCE);
+    sentTimeColumnFamily.upsert(sentTimeCompositeKey, DbNil.INSTANCE);
   }
 
   public void updateToOpenedState(final ProcessMessageSubscriptionRecord record) {
@@ -165,7 +165,7 @@ public final class LegacyDbProcessMessageSubscriptionState {
     wrapSubscriptionKeys(
         subscription.getRecord().getElementInstanceKey(),
         subscription.getRecord().getMessageNameBuffer());
-    subscriptionColumnFamily.put(elementKeyAndMessageName, subscription);
+    subscriptionColumnFamily.upsert(elementKeyAndMessageName, subscription);
 
     final long updatedSentTime = subscription.getCommandSentTime();
     if (updatedSentTime != previousSentTime) {
@@ -176,7 +176,7 @@ public final class LegacyDbProcessMessageSubscriptionState {
 
       if (updatedSentTime > 0) {
         sentTime.wrapLong(updatedSentTime);
-        sentTimeColumnFamily.put(sentTimeCompositeKey, DbNil.INSTANCE);
+        sentTimeColumnFamily.upsert(sentTimeCompositeKey, DbNil.INSTANCE);
       }
     }
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/LegacyDbProcessMessageSubscriptionState.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/LegacyDbProcessMessageSubscriptionState.java
@@ -171,7 +171,7 @@ public final class LegacyDbProcessMessageSubscriptionState {
     if (updatedSentTime != previousSentTime) {
       if (previousSentTime > 0) {
         sentTime.wrapLong(previousSentTime);
-        sentTimeColumnFamily.delete(sentTimeCompositeKey);
+        sentTimeColumnFamily.deleteIfExists(sentTimeCompositeKey);
       }
 
       if (updatedSentTime > 0) {
@@ -186,10 +186,10 @@ public final class LegacyDbProcessMessageSubscriptionState {
         subscription.getRecord().getElementInstanceKey(),
         subscription.getRecord().getMessageNameBuffer());
 
-    subscriptionColumnFamily.delete(elementKeyAndMessageName);
+    subscriptionColumnFamily.deleteIfExists(elementKeyAndMessageName);
 
     sentTime.wrapLong(subscription.getCommandSentTime());
-    sentTimeColumnFamily.delete(sentTimeCompositeKey);
+    sentTimeColumnFamily.deleteIfExists(sentTimeCompositeKey);
   }
 
   private void wrapSubscriptionKeys(final long elementInstanceKey, final DirectBuffer messageName) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_3/LegacyDbTemporaryVariablesState.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_3/LegacyDbTemporaryVariablesState.java
@@ -38,7 +38,7 @@ public class LegacyDbTemporaryVariablesState {
     temporaryVariables.set(variables);
     temporaryVariablesKeyInstance.wrapLong(key);
 
-    temporaryVariableColumnFamily.put(temporaryVariablesKeyInstance, temporaryVariables);
+    temporaryVariableColumnFamily.upsert(temporaryVariablesKeyInstance, temporaryVariables);
   }
 
   public boolean isEmpty() {

--- a/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
@@ -102,16 +102,6 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue> 
   void whileEqualPrefix(DbKey keyPrefix, KeyValuePairVisitor<KeyType, ValueType> visitor);
 
   /**
-   * Deletes the key-value pair with the given key from the column family.
-   *
-   * @deprecated Prefer the {@link ColumnFamily#deleteExisting} which checks that the key does exist
-   *     or the unchecked {@link ColumnFamily#deleteIfExists}.
-   * @param key the key which identifies the pair
-   */
-  @Deprecated(forRemoval = true)
-  void delete(KeyType key);
-
-  /**
    * Deletes the key-value pair with the given key if it exists in the column family
    *
    * @throws IllegalStateException if the key does not exist

--- a/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
@@ -20,18 +20,6 @@ import java.util.function.Consumer;
 public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue> {
 
   /**
-   * Stores the key-value pair into the column family.
-   *
-   * @deprecated Prefer {@link ColumnFamily#insert} or {@link ColumnFamily#update} which check that
-   *     the key does not exist (insert) or does exist (update). If update and insert can't be used,
-   *     use {@link ColumnFamily#upsert} instead of this method.
-   * @param key the key
-   * @param value the value
-   */
-  @Deprecated(forRemoval = true)
-  void put(KeyType key, ValueType value);
-
-  /**
    * Inserts a new key value pair into the column family.
    *
    * @throws IllegalStateException if key already exists

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -68,11 +68,6 @@ class TransactionalColumnFamily<
   }
 
   @Override
-  public void put(final KeyType key, final ValueType value) {
-    upsert(key, value);
-  }
-
-  @Override
   public void insert(final KeyType key, final ValueType value) {
     ensureInOpenTransaction(
         transaction -> {

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -185,11 +185,6 @@ class TransactionalColumnFamily<
   }
 
   @Override
-  public void delete(final KeyType key) {
-    deleteIfExists(key);
-  }
-
-  @Override
   public void deleteExisting(final KeyType key) {
     ensureInOpenTransaction(
         transaction -> {

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyRandomizedPropertyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyRandomizedPropertyTest.java
@@ -71,7 +71,6 @@ public class ColumnFamilyRandomizedPropertyTest {
             InsertOp.class,
             UpdateOp.class,
             UpsertOp.class,
-            DeleteOp.class,
             DeleteExisting.class,
             DeleteIfExists.class);
     final var k = Arbitraries.longs().greaterOrEqual(0);
@@ -144,19 +143,6 @@ public class ColumnFamilyRandomizedPropertyTest {
     @Override
     public BiConsumer<Long, Long> modify(final Map<Long, Long> map) {
       return map::put;
-    }
-  }
-
-  record DeleteOp(long key, long value) implements TestableOperation {
-
-    @Override
-    public BiConsumer<DbLong, DbLong> modify(final ColumnFamily<DbLong, DbLong> columnFamily) {
-      return (k, v) -> columnFamily.delete(k);
-    }
-
-    @Override
-    public BiConsumer<Long, Long> modify(final Map<Long, Long> map) {
-      return (k, v) -> map.remove(k);
     }
   }
 

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyRandomizedPropertyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyRandomizedPropertyTest.java
@@ -68,7 +68,6 @@ public class ColumnFamilyRandomizedPropertyTest {
   ListArbitrary<TestableOperation> operations() {
     final var op =
         Arbitraries.of(
-            PutOp.class,
             InsertOp.class,
             UpdateOp.class,
             UpsertOp.class,
@@ -119,19 +118,6 @@ public class ColumnFamilyRandomizedPropertyTest {
     @Override
     public BiConsumer<Long, Long> modify(final Map<Long, Long> map) {
       return map::putIfAbsent;
-    }
-  }
-
-  record PutOp(long key, long value) implements TestableOperation {
-
-    @Override
-    public BiConsumer<DbLong, DbLong> modify(final ColumnFamily<DbLong, DbLong> columnFamily) {
-      return columnFamily::put;
-    }
-
-    @Override
-    public BiConsumer<Long, Long> modify(final Map<Long, Long> map) {
-      return map::put;
     }
   }
 

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
@@ -45,13 +45,13 @@ public final class ColumnFamilyTest {
   }
 
   @Test
-  public void shouldPutValue() {
+  public void shouldInsertValue() {
     // given
     key.wrapLong(1213);
     value.wrapLong(255);
 
     // when
-    columnFamily.put(key, value);
+    columnFamily.insert(key, value);
     value.wrapLong(221);
 
     // then

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
@@ -79,10 +79,10 @@ public final class ColumnFamilyTest {
   @Test
   public void shouldPutMultipleValues() {
     // given
-    putKeyValuePair(1213, 255);
+    upsertKeyValuePair(1213, 255);
 
     // when
-    putKeyValuePair(456789, 12345);
+    upsertKeyValuePair(456789, 12345);
     value.wrapLong(221);
 
     // then
@@ -102,11 +102,11 @@ public final class ColumnFamilyTest {
   @Test
   public void shouldPutAndGetMultipleValues() {
     // given
-    putKeyValuePair(1213, 255);
+    upsertKeyValuePair(1213, 255);
 
     // when
     DbLong longValue = columnFamily.get(key);
-    putKeyValuePair(456789, 12345);
+    upsertKeyValuePair(456789, 12345);
     value.wrapLong(221);
 
     // then
@@ -127,7 +127,7 @@ public final class ColumnFamilyTest {
   @Test
   public void shouldCheckForExistence() {
     // given
-    putKeyValuePair(1213, 255);
+    upsertKeyValuePair(1213, 255);
 
     // when
     final boolean exists = columnFamily.exists(key);
@@ -151,7 +151,7 @@ public final class ColumnFamilyTest {
   @Test
   public void shouldDelete() {
     // given
-    putKeyValuePair(1213, 255);
+    upsertKeyValuePair(1213, 255);
 
     // when
     columnFamily.delete(key);
@@ -167,7 +167,7 @@ public final class ColumnFamilyTest {
   @Test
   public void shouldNotDeleteDifferentKey() {
     // given
-    putKeyValuePair(1213, 255);
+    upsertKeyValuePair(1213, 255);
 
     // when
     key.wrapLong(700);
@@ -186,11 +186,11 @@ public final class ColumnFamilyTest {
   @Test
   public void shouldUseForeachValue() {
     // given
-    putKeyValuePair(4567, 123);
-    putKeyValuePair(6734, 921);
-    putKeyValuePair(1213, 255);
-    putKeyValuePair(1, Short.MAX_VALUE);
-    putKeyValuePair(Short.MAX_VALUE, 1);
+    upsertKeyValuePair(4567, 123);
+    upsertKeyValuePair(6734, 921);
+    upsertKeyValuePair(1213, 255);
+    upsertKeyValuePair(1, Short.MAX_VALUE);
+    upsertKeyValuePair(Short.MAX_VALUE, 1);
 
     // when
     final List<Long> values = new ArrayList<>();
@@ -203,11 +203,11 @@ public final class ColumnFamilyTest {
   @Test
   public void shouldUseForeachPair() {
     // given
-    putKeyValuePair(4567, 123);
-    putKeyValuePair(6734, 921);
-    putKeyValuePair(1213, 255);
-    putKeyValuePair(1, Short.MAX_VALUE);
-    putKeyValuePair(Short.MAX_VALUE, 1);
+    upsertKeyValuePair(4567, 123);
+    upsertKeyValuePair(6734, 921);
+    upsertKeyValuePair(1213, 255);
+    upsertKeyValuePair(1, Short.MAX_VALUE);
+    upsertKeyValuePair(Short.MAX_VALUE, 1);
 
     // when
     final List<Long> keys = new ArrayList<>();
@@ -226,11 +226,11 @@ public final class ColumnFamilyTest {
   @Test
   public void shouldDeleteOnForeachPair() {
     // given
-    putKeyValuePair(4567, 123);
-    putKeyValuePair(6734, 921);
-    putKeyValuePair(1213, 255);
-    putKeyValuePair(1, Short.MAX_VALUE);
-    putKeyValuePair(Short.MAX_VALUE, 1);
+    upsertKeyValuePair(4567, 123);
+    upsertKeyValuePair(6734, 921);
+    upsertKeyValuePair(1213, 255);
+    upsertKeyValuePair(1, Short.MAX_VALUE);
+    upsertKeyValuePair(Short.MAX_VALUE, 1);
 
     // when
     columnFamily.forEach(
@@ -268,11 +268,11 @@ public final class ColumnFamilyTest {
   @Test
   public void shouldUseWhileTrue() {
     // given
-    putKeyValuePair(4567, 123);
-    putKeyValuePair(6734, 921);
-    putKeyValuePair(1213, 255);
-    putKeyValuePair(1, Short.MAX_VALUE);
-    putKeyValuePair(Short.MAX_VALUE, 1);
+    upsertKeyValuePair(4567, 123);
+    upsertKeyValuePair(6734, 921);
+    upsertKeyValuePair(1213, 255);
+    upsertKeyValuePair(1, Short.MAX_VALUE);
+    upsertKeyValuePair(Short.MAX_VALUE, 1);
 
     // when
     final List<Long> keys = new ArrayList<>();
@@ -293,11 +293,11 @@ public final class ColumnFamilyTest {
   @Test
   public void shouldDeleteWhileTrue() {
     // given
-    putKeyValuePair(4567, 123);
-    putKeyValuePair(6734, 921);
-    putKeyValuePair(1213, 255);
-    putKeyValuePair(1, Short.MAX_VALUE);
-    putKeyValuePair(Short.MAX_VALUE, 1);
+    upsertKeyValuePair(4567, 123);
+    upsertKeyValuePair(6734, 921);
+    upsertKeyValuePair(1213, 255);
+    upsertKeyValuePair(1, Short.MAX_VALUE);
+    upsertKeyValuePair(Short.MAX_VALUE, 1);
 
     // when
     columnFamily.whileTrue(
@@ -323,7 +323,7 @@ public final class ColumnFamilyTest {
   public void shouldCheckIfEmpty() {
     assertThat(columnFamily.isEmpty()).isTrue();
 
-    putKeyValuePair(1, 10);
+    upsertKeyValuePair(1, 10);
     assertThat(columnFamily.isEmpty()).isFalse();
 
     columnFamily.delete(key);
@@ -360,9 +360,9 @@ public final class ColumnFamilyTest {
         .isInstanceOf(ZeebeDbInconsistentException.class);
   }
 
-  private void putKeyValuePair(final int key, final int value) {
+  private void upsertKeyValuePair(final int key, final int value) {
     this.key.wrapLong(key);
     this.value.wrapLong(value);
-    columnFamily.put(this.key, this.value);
+    columnFamily.upsert(this.key, this.value);
   }
 }

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
@@ -154,7 +154,7 @@ public final class ColumnFamilyTest {
     upsertKeyValuePair(1213, 255);
 
     // when
-    columnFamily.delete(key);
+    columnFamily.deleteExisting(key);
 
     // then
     final boolean exists = columnFamily.exists(key);
@@ -171,7 +171,7 @@ public final class ColumnFamilyTest {
 
     // when
     key.wrapLong(700);
-    columnFamily.delete(key);
+    columnFamily.deleteIfExists(key);
 
     // then
     key.wrapLong(1213);
@@ -235,7 +235,7 @@ public final class ColumnFamilyTest {
     // when
     columnFamily.forEach(
         (key, value) -> {
-          columnFamily.delete(key);
+          columnFamily.deleteExisting(key);
         });
 
     final List<Long> keys = new ArrayList<>();
@@ -302,7 +302,7 @@ public final class ColumnFamilyTest {
     // when
     columnFamily.whileTrue(
         (key, value) -> {
-          columnFamily.delete(key);
+          columnFamily.deleteExisting(key);
           return key.getValue() != 4567;
         });
 
@@ -326,7 +326,7 @@ public final class ColumnFamilyTest {
     upsertKeyValuePair(1, 10);
     assertThat(columnFamily.isEmpty()).isFalse();
 
-    columnFamily.delete(key);
+    columnFamily.deleteExisting(key);
     assertThat(columnFamily.isEmpty()).isTrue();
   }
 

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbCompositeKeyColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbCompositeKeyColumnFamilyTest.java
@@ -47,14 +47,14 @@ public final class DbCompositeKeyColumnFamilyTest {
   }
 
   @Test
-  public void shouldPutValue() {
+  public void shouldUpsertValue() {
     // given
     firstKey.wrapString("foo");
     secondKey.wrapLong(2);
     value.wrapString("baring");
 
     // when
-    columnFamily.put(compositeKey, value);
+    columnFamily.upsert(compositeKey, value);
     value.wrapString("yes");
 
     // then
@@ -70,12 +70,12 @@ public final class DbCompositeKeyColumnFamilyTest {
   @Test
   public void shouldUseForeachValue() {
     // given
-    putKeyValuePair("foo", 12, "baring");
-    putKeyValuePair("foo", 13, "different value");
-    putKeyValuePair("this is the one", 255, "as you know");
-    putKeyValuePair("hello", 34, "world");
-    putKeyValuePair("another", 923113, "string");
-    putKeyValuePair("might", 37426, "be good");
+    upsertKeyValuePair("foo", 12, "baring");
+    upsertKeyValuePair("foo", 13, "different value");
+    upsertKeyValuePair("this is the one", 255, "as you know");
+    upsertKeyValuePair("hello", 34, "world");
+    upsertKeyValuePair("another", 923113, "string");
+    upsertKeyValuePair("might", 37426, "be good");
 
     // when
     final List<String> values = new ArrayList<>();
@@ -89,12 +89,12 @@ public final class DbCompositeKeyColumnFamilyTest {
   @Test
   public void shouldUseForeachPair() {
     // given
-    putKeyValuePair("foo", 12, "baring");
-    putKeyValuePair("foo", 13, "different value");
-    putKeyValuePair("this is the one", 255, "as you know");
-    putKeyValuePair("hello", 34, "world");
-    putKeyValuePair("another", 923113, "string");
-    putKeyValuePair("might", 37426, "be good");
+    upsertKeyValuePair("foo", 12, "baring");
+    upsertKeyValuePair("foo", 13, "different value");
+    upsertKeyValuePair("this is the one", 255, "as you know");
+    upsertKeyValuePair("hello", 34, "world");
+    upsertKeyValuePair("another", 923113, "string");
+    upsertKeyValuePair("might", 37426, "be good");
 
     // when
     final List<String> firstKeyParts = new ArrayList<>();
@@ -122,12 +122,12 @@ public final class DbCompositeKeyColumnFamilyTest {
   @Test
   public void shouldUseForeachToDelete() {
     // given
-    putKeyValuePair("foo", 12, "baring");
-    putKeyValuePair("foo", 13, "different value");
-    putKeyValuePair("this is the one", 255, "as you know");
-    putKeyValuePair("hello", 34, "world");
-    putKeyValuePair("another", 923113, "string");
-    putKeyValuePair("might", 37426, "be good");
+    upsertKeyValuePair("foo", 12, "baring");
+    upsertKeyValuePair("foo", 13, "different value");
+    upsertKeyValuePair("this is the one", 255, "as you know");
+    upsertKeyValuePair("hello", 34, "world");
+    upsertKeyValuePair("another", 923113, "string");
+    upsertKeyValuePair("might", 37426, "be good");
 
     // when
     final List<String> firstKeyParts = new ArrayList<>();
@@ -155,12 +155,12 @@ public final class DbCompositeKeyColumnFamilyTest {
   @Test
   public void shouldUseWhileTrue() {
     // given
-    putKeyValuePair("foo", 12, "baring");
-    putKeyValuePair("foo", 13, "different value");
-    putKeyValuePair("this is the one", 255, "as you know");
-    putKeyValuePair("hello", 34, "world");
-    putKeyValuePair("another", 923113, "string");
-    putKeyValuePair("might", 37426, "be good");
+    upsertKeyValuePair("foo", 12, "baring");
+    upsertKeyValuePair("foo", 13, "different value");
+    upsertKeyValuePair("this is the one", 255, "as you know");
+    upsertKeyValuePair("hello", 34, "world");
+    upsertKeyValuePair("another", 923113, "string");
+    upsertKeyValuePair("might", 37426, "be good");
 
     // when
     final List<String> firstKeyParts = new ArrayList<>();
@@ -188,12 +188,12 @@ public final class DbCompositeKeyColumnFamilyTest {
   @Test
   public void shouldUseWhileTrueToDelete() {
     // given
-    putKeyValuePair("foo", 12, "baring");
-    putKeyValuePair("foo", 13, "different value");
-    putKeyValuePair("this is the one", 255, "as you know");
-    putKeyValuePair("hello", 34, "world");
-    putKeyValuePair("another", 923113, "string");
-    putKeyValuePair("might", 37426, "be good");
+    upsertKeyValuePair("foo", 12, "baring");
+    upsertKeyValuePair("foo", 13, "different value");
+    upsertKeyValuePair("this is the one", 255, "as you know");
+    upsertKeyValuePair("hello", 34, "world");
+    upsertKeyValuePair("another", 923113, "string");
+    upsertKeyValuePair("might", 37426, "be good");
 
     // when
     final List<String> firstKeyParts = new ArrayList<>();
@@ -225,15 +225,15 @@ public final class DbCompositeKeyColumnFamilyTest {
   @Test
   public void shouldUseWhileEqualPrefix() {
     // given
-    putKeyValuePair("foo", 12, "baring");
-    putKeyValuePair("foobar", 53, "expected value");
-    putKeyValuePair("foo", 13, "different value");
-    putKeyValuePair("foo", 213, "oh wow");
-    putKeyValuePair("foo", 53, "expected value");
-    putKeyValuePair("this is the one", 255, "as you know");
-    putKeyValuePair("hello", 34, "world");
-    putKeyValuePair("another", 923113, "string");
-    putKeyValuePair("might", 37426, "be good");
+    upsertKeyValuePair("foo", 12, "baring");
+    upsertKeyValuePair("foobar", 53, "expected value");
+    upsertKeyValuePair("foo", 13, "different value");
+    upsertKeyValuePair("foo", 213, "oh wow");
+    upsertKeyValuePair("foo", 53, "expected value");
+    upsertKeyValuePair("this is the one", 255, "as you know");
+    upsertKeyValuePair("hello", 34, "world");
+    upsertKeyValuePair("another", 923113, "string");
+    upsertKeyValuePair("might", 37426, "be good");
 
     // when
     firstKey.wrapString("foo");
@@ -261,16 +261,16 @@ public final class DbCompositeKeyColumnFamilyTest {
   @Test
   public void shouldUseGetWhileIterating() {
     // given
-    putKeyValuePair("foo", 12, "baring");
-    putKeyValuePair("foobar", 53, "expected value");
-    putKeyValuePair("foo", 13, "different value");
-    putKeyValuePair("foo", 213, "oh wow");
-    putKeyValuePair("foo", 53, "expected value");
-    putKeyValuePair("this is the one", 255, "as you know");
-    putKeyValuePair("hello", 213, "world");
-    putKeyValuePair("another", 923113, "string");
-    putKeyValuePair("hello", 13, "foo");
-    putKeyValuePair("might", 37426, "be good");
+    upsertKeyValuePair("foo", 12, "baring");
+    upsertKeyValuePair("foobar", 53, "expected value");
+    upsertKeyValuePair("foo", 13, "different value");
+    upsertKeyValuePair("foo", 213, "oh wow");
+    upsertKeyValuePair("foo", 53, "expected value");
+    upsertKeyValuePair("this is the one", 255, "as you know");
+    upsertKeyValuePair("hello", 213, "world");
+    upsertKeyValuePair("another", 923113, "string");
+    upsertKeyValuePair("hello", 13, "foo");
+    upsertKeyValuePair("might", 37426, "be good");
 
     // when
     firstKey.wrapString("foo");
@@ -299,15 +299,15 @@ public final class DbCompositeKeyColumnFamilyTest {
   @Test
   public void shouldUseWhileEqualPrefixAndTrue() {
     // given
-    putKeyValuePair("foo", 12, "baring");
-    putKeyValuePair("foobar", 53, "expected value");
-    putKeyValuePair("foo", 13, "different value");
-    putKeyValuePair("foo", 213, "oh wow");
-    putKeyValuePair("foo", 53, "expected value");
-    putKeyValuePair("this is the one", 255, "as you know");
-    putKeyValuePair("hello", 34, "world");
-    putKeyValuePair("another", 923113, "string");
-    putKeyValuePair("might", 37426, "be good");
+    upsertKeyValuePair("foo", 12, "baring");
+    upsertKeyValuePair("foobar", 53, "expected value");
+    upsertKeyValuePair("foo", 13, "different value");
+    upsertKeyValuePair("foo", 213, "oh wow");
+    upsertKeyValuePair("foo", 53, "expected value");
+    upsertKeyValuePair("this is the one", 255, "as you know");
+    upsertKeyValuePair("hello", 34, "world");
+    upsertKeyValuePair("another", 923113, "string");
+    upsertKeyValuePair("might", 37426, "be good");
 
     // when
     firstKey.wrapString("foo");
@@ -337,12 +337,12 @@ public final class DbCompositeKeyColumnFamilyTest {
   @Test
   public void shouldUseWhileEqualPrefixToDelete() {
     // given
-    putKeyValuePair("foo", 12, "baring");
-    putKeyValuePair("foo", 13, "different value");
-    putKeyValuePair("this is the one", 255, "as you know");
-    putKeyValuePair("hello", 34, "world");
-    putKeyValuePair("another", 923113, "string");
-    putKeyValuePair("might", 37426, "be good");
+    upsertKeyValuePair("foo", 12, "baring");
+    upsertKeyValuePair("foo", 13, "different value");
+    upsertKeyValuePair("this is the one", 255, "as you know");
+    upsertKeyValuePair("hello", 34, "world");
+    upsertKeyValuePair("another", 923113, "string");
+    upsertKeyValuePair("might", 37426, "be good");
 
     // when
     firstKey.wrapString("foo");
@@ -373,11 +373,11 @@ public final class DbCompositeKeyColumnFamilyTest {
     assertThat(secondKeyParts).containsExactly(34L, 37426L, 923113L, 255L);
   }
 
-  private void putKeyValuePair(final String firstKey, final long secondKey, final String value) {
+  private void upsertKeyValuePair(final String firstKey, final long secondKey, final String value) {
     this.firstKey.wrapString(firstKey);
     this.secondKey.wrapLong(secondKey);
 
     this.value.wrapString(value);
-    columnFamily.put(compositeKey, this.value);
+    columnFamily.upsert(compositeKey, this.value);
   }
 }

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbCompositeKeyColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbCompositeKeyColumnFamilyTest.java
@@ -133,7 +133,7 @@ public final class DbCompositeKeyColumnFamilyTest {
     final List<String> firstKeyParts = new ArrayList<>();
     final List<Long> secondKeyParts = new ArrayList<>();
     final List<String> values = new ArrayList<>();
-    columnFamily.forEach((key, value) -> columnFamily.delete(key));
+    columnFamily.forEach((key, value) -> columnFamily.deleteExisting(key));
 
     columnFamily.forEach(
         (key, value) -> {
@@ -201,7 +201,7 @@ public final class DbCompositeKeyColumnFamilyTest {
     final List<String> values = new ArrayList<>();
     columnFamily.whileTrue(
         (key, value) -> {
-          columnFamily.delete(key);
+          columnFamily.deleteExisting(key);
           return key.second().getValue() != 13;
         });
 
@@ -349,7 +349,7 @@ public final class DbCompositeKeyColumnFamilyTest {
     columnFamily.whileEqualPrefix(
         firstKey,
         (key, value) -> {
-          columnFamily.delete(key);
+          columnFamily.deleteExisting(key);
           return key.second().getValue() != 13;
         });
 

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbStringColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbStringColumnFamilyTest.java
@@ -44,13 +44,13 @@ public final class DbStringColumnFamilyTest {
   }
 
   @Test
-  public void shouldPutValue() {
+  public void shouldUpsertValue() {
     // given
     key.wrapString("foo");
     value.wrapString("baring");
 
     // when
-    columnFamily.put(key, value);
+    columnFamily.upsert(key, value);
     value.wrapString("yes");
 
     // then
@@ -66,11 +66,11 @@ public final class DbStringColumnFamilyTest {
   @Test
   public void shouldUseForeachValue() {
     // given
-    putKeyValuePair("foo", "baring");
-    putKeyValuePair("this is the one", "as you know");
-    putKeyValuePair("hello", "world");
-    putKeyValuePair("another", "string");
-    putKeyValuePair("might", "be good");
+    upsertKeyValuePair("foo", "baring");
+    upsertKeyValuePair("this is the one", "as you know");
+    upsertKeyValuePair("hello", "world");
+    upsertKeyValuePair("another", "string");
+    upsertKeyValuePair("might", "be good");
 
     // when
     final List<String> values = new ArrayList<>();
@@ -83,11 +83,11 @@ public final class DbStringColumnFamilyTest {
   @Test
   public void shouldUseForeachPair() {
     // given
-    putKeyValuePair("foo", "baring");
-    putKeyValuePair("this is the one", "as you know");
-    putKeyValuePair("hello", "world");
-    putKeyValuePair("another", "string");
-    putKeyValuePair("might", "be good");
+    upsertKeyValuePair("foo", "baring");
+    upsertKeyValuePair("this is the one", "as you know");
+    upsertKeyValuePair("hello", "world");
+    upsertKeyValuePair("another", "string");
+    upsertKeyValuePair("might", "be good");
 
     // when
     final List<String> keys = new ArrayList<>();
@@ -106,11 +106,11 @@ public final class DbStringColumnFamilyTest {
   @Test
   public void shouldUseWhileTrue() {
     // given
-    putKeyValuePair("foo", "baring");
-    putKeyValuePair("this is the one", "as you know");
-    putKeyValuePair("hello", "world");
-    putKeyValuePair("another", "string");
-    putKeyValuePair("might", "be good");
+    upsertKeyValuePair("foo", "baring");
+    upsertKeyValuePair("this is the one", "as you know");
+    upsertKeyValuePair("hello", "world");
+    upsertKeyValuePair("another", "string");
+    upsertKeyValuePair("might", "be good");
 
     // when
     final List<String> keys = new ArrayList<>();
@@ -131,11 +131,11 @@ public final class DbStringColumnFamilyTest {
   @Test
   public void shouldUseWhileEqualPrefix() {
     // given
-    putKeyValuePair("foo", "baring");
-    putKeyValuePair("this is the one", "as you know");
-    putKeyValuePair("hello", "world");
-    putKeyValuePair("another", "string");
-    putKeyValuePair("and", "be good");
+    upsertKeyValuePair("foo", "baring");
+    upsertKeyValuePair("this is the one", "as you know");
+    upsertKeyValuePair("hello", "world");
+    upsertKeyValuePair("another", "string");
+    upsertKeyValuePair("and", "be good");
 
     // when
     key.wrapString("an");
@@ -161,11 +161,11 @@ public final class DbStringColumnFamilyTest {
   @Test
   public void shouldUseWhileEqualPrefixLikeGet() {
     // given
-    putKeyValuePair("foo", "baring");
-    putKeyValuePair("this is the one", "as you know");
-    putKeyValuePair("hello", "world");
-    putKeyValuePair("another", "string");
-    putKeyValuePair("and", "be good");
+    upsertKeyValuePair("foo", "baring");
+    upsertKeyValuePair("this is the one", "as you know");
+    upsertKeyValuePair("hello", "world");
+    upsertKeyValuePair("another", "string");
+    upsertKeyValuePair("and", "be good");
 
     // when
     key.wrapString("and");
@@ -188,7 +188,7 @@ public final class DbStringColumnFamilyTest {
   @Test
   public void shouldAllowSingleNestedWhileEqualPrefix() {
     // given
-    putKeyValuePair("and", "be good");
+    upsertKeyValuePair("and", "be good");
     key.wrapString("and");
 
     // when
@@ -204,7 +204,7 @@ public final class DbStringColumnFamilyTest {
   @Test
   public void shouldThrowExceptionOnMultipleNestedWhileEqualPrefix() {
     // given
-    putKeyValuePair("and", "be good");
+    upsertKeyValuePair("and", "be good");
     key.wrapString("and");
 
     // when
@@ -225,9 +225,9 @@ public final class DbStringColumnFamilyTest {
             "Currently nested prefix iterations are not supported! This will cause unexpected behavior.");
   }
 
-  private void putKeyValuePair(final String key, final String value) {
+  private void upsertKeyValuePair(final String key, final String value) {
     this.key.wrapString(key);
     this.value.wrapString(value);
-    columnFamily.put(this.key, this.value);
+    columnFamily.upsert(this.key, this.value);
   }
 }

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTransactionTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTransactionTest.java
@@ -79,9 +79,9 @@ public final class DbTransactionTest {
     // when
     transactionContext.runInTransaction(
         () -> {
-          oneColumnFamily.put(oneKey, oneValue);
-          twoColumnFamily.put(twoKey, twoValue);
-          threeColumnFamily.put(threeKey, threeValue);
+          oneColumnFamily.insert(oneKey, oneValue);
+          twoColumnFamily.insert(twoKey, twoValue);
+          threeColumnFamily.insert(threeKey, threeValue);
         });
 
     // then
@@ -105,9 +105,9 @@ public final class DbTransactionTest {
     final ZeebeDbTransaction transaction = transactionContext.getCurrentTransaction();
     transaction.run(
         () -> {
-          oneColumnFamily.put(oneKey, oneValue);
-          twoColumnFamily.put(twoKey, twoValue);
-          threeColumnFamily.put(threeKey, threeValue);
+          oneColumnFamily.insert(oneKey, oneValue);
+          twoColumnFamily.insert(twoKey, twoValue);
+          threeColumnFamily.insert(threeKey, threeValue);
         });
 
     // when
@@ -134,9 +134,9 @@ public final class DbTransactionTest {
     final ZeebeDbTransaction transaction = transactionContext.getCurrentTransaction();
     transaction.run(
         () -> {
-          oneColumnFamily.put(oneKey, oneValue);
-          twoColumnFamily.put(twoKey, twoValue);
-          threeColumnFamily.put(threeKey, threeValue);
+          oneColumnFamily.insert(oneKey, oneValue);
+          twoColumnFamily.insert(twoKey, twoValue);
+          threeColumnFamily.insert(threeKey, threeValue);
         });
 
     // when
@@ -184,9 +184,9 @@ public final class DbTransactionTest {
           final ZeebeDbTransaction sameTransaction = transactionContext.getCurrentTransaction();
           sameTransaction.run(
               () -> {
-                oneColumnFamily.put(oneKey, oneValue);
-                twoColumnFamily.put(twoKey, twoValue);
-                threeColumnFamily.put(threeKey, threeValue);
+                oneColumnFamily.insert(oneKey, oneValue);
+                twoColumnFamily.insert(twoKey, twoValue);
+                threeColumnFamily.insert(threeKey, threeValue);
               });
           sameTransaction.commit();
 
@@ -219,9 +219,9 @@ public final class DbTransactionTest {
     final ZeebeDbTransaction transaction = transactionContext.getCurrentTransaction();
     transaction.run(
         () -> {
-          oneColumnFamily.put(oneKey, oneValue);
-          twoColumnFamily.put(twoKey, twoValue);
-          threeColumnFamily.put(threeKey, threeValue);
+          oneColumnFamily.insert(oneKey, oneValue);
+          twoColumnFamily.insert(twoKey, twoValue);
+          threeColumnFamily.insert(threeKey, threeValue);
         });
 
     // when
@@ -243,7 +243,7 @@ public final class DbTransactionTest {
     // when
     transactionContext.runInTransaction(
         () -> {
-          oneColumnFamily.put(oneKey, oneValue);
+          oneColumnFamily.insert(oneKey, oneValue);
           final DbLong value = oneColumnFamily.get(oneKey);
           actualValue.set(value.getValue());
         });
@@ -259,7 +259,7 @@ public final class DbTransactionTest {
     final Map<Long, Long> actualValues = new HashMap<>();
     oneKey.wrapLong(1);
     oneValue.wrapLong(-1);
-    oneColumnFamily.put(oneKey, oneValue);
+    oneColumnFamily.insert(oneKey, oneValue);
 
     // when
     transactionContext.runInTransaction(
@@ -267,12 +267,12 @@ public final class DbTransactionTest {
           // update value
           oneKey.wrapLong(1);
           oneValue.wrapLong(-2);
-          oneColumnFamily.put(oneKey, oneValue);
+          oneColumnFamily.update(oneKey, oneValue);
 
           // create new key-value pair
           oneKey.wrapLong(2);
           oneValue.wrapLong(-3);
-          oneColumnFamily.put(oneKey, oneValue);
+          oneColumnFamily.insert(oneKey, oneValue);
 
           actualValues.put(oneKey.getValue(), oneColumnFamily.get(oneKey).getValue());
           oneKey.wrapLong(1);
@@ -293,11 +293,11 @@ public final class DbTransactionTest {
 
     oneKey.wrapLong(1);
     oneValue.wrapLong(-1);
-    oneColumnFamily.put(oneKey, oneValue);
+    oneColumnFamily.insert(oneKey, oneValue);
 
     oneKey.wrapLong(2);
     oneValue.wrapLong(-2);
-    oneColumnFamily.put(oneKey, oneValue);
+    oneColumnFamily.insert(oneKey, oneValue);
 
     // when
     transactionContext.runInTransaction(
@@ -305,12 +305,12 @@ public final class DbTransactionTest {
           // update old value
           oneKey.wrapLong(2);
           oneValue.wrapLong(-5);
-          oneColumnFamily.put(oneKey, oneValue);
+          oneColumnFamily.update(oneKey, oneValue);
 
           // create new key-value pair
           oneKey.wrapLong(3);
           oneValue.wrapLong(-3);
-          oneColumnFamily.put(oneKey, oneValue);
+          oneColumnFamily.insert(oneKey, oneValue);
 
           oneColumnFamily.forEach((k, v) -> actualValues.put(k.getValue(), v.getValue()));
         });
@@ -328,15 +328,15 @@ public final class DbTransactionTest {
     // given
     oneKey.wrapLong(1);
     oneValue.wrapLong(-1);
-    oneColumnFamily.put(oneKey, oneValue);
+    oneColumnFamily.insert(oneKey, oneValue);
 
     oneKey.wrapLong(2);
     oneValue.wrapLong(-2);
-    oneColumnFamily.put(oneKey, oneValue);
+    oneColumnFamily.insert(oneKey, oneValue);
 
     // when
     transactionContext.runInTransaction(
-        () -> oneColumnFamily.forEach((k, v) -> oneColumnFamily.delete(k)));
+        () -> oneColumnFamily.forEach((k, v) -> oneColumnFamily.deleteExisting(k)));
 
     // then
     assertThat(oneColumnFamily.exists(oneKey)).isFalse();
@@ -350,15 +350,14 @@ public final class DbTransactionTest {
     final AtomicLong actualValue = new AtomicLong(0);
     oneKey.wrapLong(1);
     oneValue.wrapLong(-1);
-    oneColumnFamily.put(oneKey, oneValue);
+    oneColumnFamily.insert(oneKey, oneValue);
 
     twoValue.wrapLong(192313);
 
     // when
-    oneColumnFamily.put(oneKey, oneValue);
     transactionContext.runInTransaction(
         () -> {
-          transactionContext.runInTransaction(() -> oneColumnFamily.put(oneKey, twoValue));
+          transactionContext.runInTransaction(() -> oneColumnFamily.update(oneKey, twoValue));
           final DbLong value = oneColumnFamily.get(oneKey);
           actualValue.set(value.getValue());
         });
@@ -376,24 +375,24 @@ public final class DbTransactionTest {
 
     twoKey.wrapLong(52000);
     twoValue.wrapLong(192313);
-    twoColumnFamily.put(twoKey, twoValue);
+    twoColumnFamily.insert(twoKey, twoValue);
 
     threeKey.wrapLong(Short.MAX_VALUE);
     threeValue.wrapLong(Integer.MAX_VALUE);
-    threeColumnFamily.put(threeKey, threeValue);
+    threeColumnFamily.insert(threeKey, threeValue);
 
     // when
     transactionContext.runInTransaction(
         () -> {
           // create
-          oneColumnFamily.put(oneKey, oneValue);
+          oneColumnFamily.insert(oneKey, oneValue);
 
           // delete
-          twoColumnFamily.delete(twoKey);
+          twoColumnFamily.deleteExisting(twoKey);
 
           // update
           threeValue.wrapLong(Integer.MIN_VALUE);
-          threeColumnFamily.put(threeKey, threeValue);
+          threeColumnFamily.update(threeKey, threeValue);
         });
 
     // then
@@ -416,10 +415,10 @@ public final class DbTransactionTest {
     transactionContext.runInTransaction(
         () -> {
           // create
-          oneColumnFamily.put(oneKey, oneValue);
+          oneColumnFamily.insert(oneKey, oneValue);
 
           // delete
-          oneColumnFamily.delete(oneKey);
+          oneColumnFamily.deleteExisting(oneKey);
         });
 
     // then
@@ -434,7 +433,7 @@ public final class DbTransactionTest {
 
     twoKey.wrapLong(52000);
     twoValue.wrapLong(192313);
-    twoColumnFamily.put(twoKey, twoValue);
+    twoColumnFamily.insert(twoKey, twoValue);
 
     threeKey.wrapLong(Short.MAX_VALUE);
     threeValue.wrapLong(Integer.MAX_VALUE);
@@ -444,9 +443,9 @@ public final class DbTransactionTest {
     try {
       transactionContext.runInTransaction(
           () -> {
-            oneColumnFamily.put(oneKey, oneValue);
+            oneColumnFamily.insert(oneKey, oneValue);
             twoColumnFamily.delete(twoKey);
-            threeColumnFamily.put(threeKey, threeValue);
+            threeColumnFamily.insert(threeKey, threeValue);
             throw new RuntimeException();
           });
     } catch (final Exception e) {

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTransactionTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbTransactionTest.java
@@ -192,7 +192,7 @@ public final class DbTransactionTest {
 
           // then it is committed but available in this transaction
           assertThat(oneColumnFamily.exists(oneKey)).isTrue();
-          oneColumnFamily.delete(oneKey);
+          oneColumnFamily.deleteExisting(oneKey);
 
           assertThat(twoColumnFamily.exists(twoKey)).isTrue();
           assertThat(threeColumnFamily.exists(threeKey)).isTrue();
@@ -444,7 +444,7 @@ public final class DbTransactionTest {
       transactionContext.runInTransaction(
           () -> {
             oneColumnFamily.insert(oneKey, oneValue);
-            twoColumnFamily.delete(twoKey);
+            twoColumnFamily.deleteExisting(twoKey);
             threeColumnFamily.insert(threeKey, threeValue);
             throw new RuntimeException();
           });

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbTest.java
@@ -38,7 +38,7 @@ public final class ZeebeRocksDbTest {
     value.wrapString("bar");
     final ColumnFamily<DbString, DbString> columnFamily =
         db.createColumnFamily(DefaultColumnFamily.DEFAULT, db.createContext(), key, value);
-    columnFamily.put(key, value);
+    columnFamily.insert(key, value);
 
     // when
     final File snapshotDir = new File(temporaryFolder.newFolder(), "snapshot");
@@ -62,7 +62,7 @@ public final class ZeebeRocksDbTest {
     value.wrapString("bar");
     ColumnFamily<DbString, DbString> columnFamily =
         db.createColumnFamily(DefaultColumnFamily.DEFAULT, db.createContext(), key, value);
-    columnFamily.put(key, value);
+    columnFamily.insert(key, value);
     db.close();
 
     // when
@@ -91,15 +91,15 @@ public final class ZeebeRocksDbTest {
     value.wrapString("bar");
     ColumnFamily<DbString, DbString> columnFamily =
         db.createColumnFamily(DefaultColumnFamily.DEFAULT, db.createContext(), key, value);
-    columnFamily.put(key, value);
+    columnFamily.insert(key, value);
 
     final File snapshotDir = new File(temporaryFolder.newFolder(), "snapshot");
     db.createSnapshot(snapshotDir);
     value.wrapString("otherString");
-    columnFamily.put(key, value);
+    columnFamily.update(key, value);
 
     // when
-    assertThat(pathName.listFiles()).isNotEmpty();
+    assertThat(pathName).isNotEmptyDirectory();
     db.close();
     db = dbFactory.createDb(snapshotDir);
     columnFamily =
@@ -108,7 +108,6 @@ public final class ZeebeRocksDbTest {
     // then
     final DbString dbString = columnFamily.get(key);
 
-    assertThat(dbString).isNotNull();
-    assertThat(dbString.toString()).isEqualTo("bar");
+    assertThat(dbString).hasToString("bar");
   }
 }

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbIterationTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbIterationTest.java
@@ -74,7 +74,7 @@ public final class ZeebeRocksDbIterationTest {
       firstKey.wrapLong(prefix);
       for (long suffix = 0; suffix < suffixes; suffix++) {
         secondKey.wrapLong(suffix);
-        columnFamily.put(compositeKey, DbNil.INSTANCE);
+        columnFamily.upsert(compositeKey, DbNil.INSTANCE);
       }
     }
 


### PR DESCRIPTION
## Description

Replaces all usages of `ColumnFamily#put` with `insert`, `update` or `upsert`  and  `delete` with `deleteExisting` or `deleteIfExists`

I've tried to not use `upsert` where possible because this method doesn't check anything and is essentially just a renamed `put`.  To get rid of all of them would require more refactoring than I'd like in this PR

## Related issues

closes #8787 

