### PR TITLE
Include bpmnProcessId as part of exported variable records

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -156,6 +156,7 @@ public final class BpmnStateBehavior {
         context.getElementInstanceKey(),
         context.getProcessDefinitionKey(),
         context.getProcessInstanceKey(),
+        context.getBpmnProcessId(),
         variableName,
         variableValue,
         valueOffset,
@@ -174,6 +175,7 @@ public final class BpmnStateBehavior {
         targetScope,
         context.getProcessDefinitionKey(),
         context.getProcessInstanceKey(),
+        context.getBpmnProcessId(),
         variablesAsDocument);
   }
 
@@ -183,7 +185,11 @@ public final class BpmnStateBehavior {
       final DeployedProcess targetProcess) {
     final var variables = variablesState.getVariablesAsDocument(sourceScopeKey);
     variableBehavior.mergeDocument(
-        targetProcessInstanceKey, targetProcess.getKey(), targetProcessInstanceKey, variables);
+        targetProcessInstanceKey,
+        targetProcess.getKey(),
+        targetProcessInstanceKey,
+        targetProcess.getBpmnProcessId(),
+        variables);
   }
 
   public boolean isInterrupted(final BpmnElementContext flowScopeContext) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -55,6 +55,7 @@ public final class BpmnVariableMappingBehavior {
     final long scopeKey = context.getElementInstanceKey();
     final long processDefinitionKey = context.getProcessDefinitionKey();
     final long processInstanceKey = context.getProcessInstanceKey();
+    final DirectBuffer bpmnProcessId = context.getBpmnProcessId();
     final Optional<Expression> inputMappingExpression = element.getInputMappings();
 
     if (inputMappingExpression.isPresent()) {
@@ -63,7 +64,7 @@ public final class BpmnVariableMappingBehavior {
           .map(
               result -> {
                 variableBehavior.mergeLocalDocument(
-                    scopeKey, processDefinitionKey, processInstanceKey, result);
+                    scopeKey, processDefinitionKey, processInstanceKey, bpmnProcessId, result);
                 return null;
               });
     }
@@ -83,6 +84,7 @@ public final class BpmnVariableMappingBehavior {
     final long elementInstanceKey = context.getElementInstanceKey();
     final long processDefinitionKey = record.getProcessDefinitionKey();
     final long processInstanceKey = record.getProcessInstanceKey();
+    final DirectBuffer bpmnProcessId = context.getBpmnProcessId();
     final long scopeKey = getVariableScopeKey(context);
     final Optional<Expression> outputMappingExpression = element.getOutputMappings();
 
@@ -99,7 +101,7 @@ public final class BpmnVariableMappingBehavior {
       // set as local variables
       if (hasVariables) {
         variableBehavior.mergeLocalDocument(
-            elementInstanceKey, processDefinitionKey, processInstanceKey, variables);
+            elementInstanceKey, processDefinitionKey, processInstanceKey, bpmnProcessId, variables);
       }
 
       // apply the output mappings
@@ -108,21 +110,21 @@ public final class BpmnVariableMappingBehavior {
           .map(
               result -> {
                 variableBehavior.mergeDocument(
-                    scopeKey, processDefinitionKey, processInstanceKey, result);
+                    scopeKey, processDefinitionKey, processInstanceKey, bpmnProcessId, result);
                 return null;
               });
 
     } else if (hasVariables) {
       // merge/propagate the event variables by default
       variableBehavior.mergeDocument(
-          elementInstanceKey, processDefinitionKey, processInstanceKey, variables);
+          elementInstanceKey, processDefinitionKey, processInstanceKey, bpmnProcessId, variables);
     } else if (isConnectedToEventBasedGateway(element)
         || element.getElementType() == BpmnElementType.BOUNDARY_EVENT
         || element.getElementType() == BpmnElementType.START_EVENT) {
       // event variables are set local variables instead of temporary variables
       final var localVariables = variablesState.getVariablesLocalAsDocument(elementInstanceKey);
       variableBehavior.mergeDocument(
-          scopeKey, processDefinitionKey, processInstanceKey, localVariables);
+          scopeKey, processDefinitionKey, processInstanceKey, bpmnProcessId, localVariables);
     }
 
     return Either.right(null);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
@@ -250,6 +250,7 @@ public class EventTriggerBehavior {
           eventInstanceKey,
           elementRecord.getProcessDefinitionKey(),
           elementRecord.getProcessInstanceKey(),
+          elementRecord.getBpmnProcessIdBuffer(),
           variables);
     }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -73,7 +73,8 @@ public final class CreateProcessInstanceProcessor
     }
 
     final long processInstanceKey = keyGenerator.nextKey();
-    if (!setVariablesFromDocument(controller, record, process.getKey(), processInstanceKey)) {
+    if (!setVariablesFromDocument(
+        controller, record, process.getKey(), processInstanceKey, process.getBpmnProcessId())) {
       return true;
     }
 
@@ -105,12 +106,14 @@ public final class CreateProcessInstanceProcessor
       final CommandControl<ProcessInstanceCreationRecord> controller,
       final ProcessInstanceCreationRecord record,
       final long processDefinitionKey,
-      final long processInstanceKey) {
+      final long processInstanceKey,
+      final DirectBuffer bpmnProcessId) {
     try {
       variableBehavior.mergeLocalDocument(
           processInstanceKey,
           processDefinitionKey,
           processInstanceKey,
+          bpmnProcessId,
           record.getVariablesBuffer());
     } catch (final MsgpackReaderException e) {
       Loggers.PROCESS_PROCESSOR_LOGGER.error(ERROR_INVALID_VARIABLES_LOGGED_MESSAGE, e);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/UpdateVariableDocumentProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/UpdateVariableDocumentProcessor.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentReco
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentUpdateSemantic;
+import org.agrona.DirectBuffer;
 
 public final class UpdateVariableDocumentProcessor
     implements TypedRecordProcessor<VariableDocumentRecord> {
@@ -60,13 +61,22 @@ public final class UpdateVariableDocumentProcessor
 
     final long processDefinitionKey = scope.getValue().getProcessDefinitionKey();
     final long processInstanceKey = scope.getValue().getProcessInstanceKey();
+    final DirectBuffer bpmnProcessId = scope.getValue().getBpmnProcessIdBuffer();
     try {
       if (value.getUpdateSemantics() == VariableDocumentUpdateSemantic.LOCAL) {
         variableBehavior.mergeLocalDocument(
-            scope.getKey(), processDefinitionKey, processInstanceKey, value.getVariablesBuffer());
+            scope.getKey(),
+            processDefinitionKey,
+            processInstanceKey,
+            bpmnProcessId,
+            value.getVariablesBuffer());
       } else {
         variableBehavior.mergeDocument(
-            scope.getKey(), processDefinitionKey, processInstanceKey, value.getVariablesBuffer());
+            scope.getKey(),
+            processDefinitionKey,
+            processInstanceKey,
+            bpmnProcessId,
+            value.getVariablesBuffer());
       }
     } catch (final MsgpackReaderException e) {
       final String reason =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableBehavior.java
@@ -61,6 +61,7 @@ public final class VariableBehavior {
       final long scopeKey,
       final long processDefinitionKey,
       final long processInstanceKey,
+      final DirectBuffer bpmnProcessId,
       final DirectBuffer document) {
     indexedDocument.index(document);
     if (indexedDocument.isEmpty()) {
@@ -70,7 +71,8 @@ public final class VariableBehavior {
     variableRecord
         .setScopeKey(scopeKey)
         .setProcessDefinitionKey(processDefinitionKey)
-        .setProcessInstanceKey(processInstanceKey);
+        .setProcessInstanceKey(processInstanceKey)
+        .setBpmnProcessId(bpmnProcessId);
     for (final DocumentEntry entry : indexedDocument) {
       applyEntryToRecord(entry);
       setLocalVariable(variableRecord);
@@ -102,6 +104,7 @@ public final class VariableBehavior {
       final long scopeKey,
       final long processDefinitionKey,
       final long processInstanceKey,
+      final DirectBuffer bpmnProcessId,
       final DirectBuffer document) {
     indexedDocument.index(document);
     if (indexedDocument.isEmpty()) {
@@ -113,7 +116,8 @@ public final class VariableBehavior {
 
     variableRecord
         .setProcessDefinitionKey(processDefinitionKey)
-        .setProcessInstanceKey(processInstanceKey);
+        .setProcessInstanceKey(processInstanceKey)
+        .setBpmnProcessId(bpmnProcessId);
     while ((parentScope = variableState.getParentScopeKey(currentScope)) > 0) {
       final Iterator<DocumentEntry> entryIterator = indexedDocument.iterator();
 
@@ -161,6 +165,7 @@ public final class VariableBehavior {
       final long scopeKey,
       final long processDefinitionKey,
       final long processInstanceKey,
+      final DirectBuffer bpmnProcessId,
       final DirectBuffer name,
       final DirectBuffer value,
       final int valueOffset,
@@ -170,6 +175,7 @@ public final class VariableBehavior {
         .setScopeKey(scopeKey)
         .setProcessDefinitionKey(processDefinitionKey)
         .setProcessInstanceKey(processInstanceKey)
+        .setBpmnProcessId(bpmnProcessId)
         .setName(name)
         .setValue(value, valueOffset, valueLength);
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableBehaviorTest.java
@@ -68,6 +68,7 @@ final class VariableBehaviorTest {
     final long parentScopeKey = 1;
     final long childScopeKey = 2;
     final long childFooKey = 3;
+    final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final Map<String, Object> document = Map.of("foo", "bar", "baz", "buz");
     state.createScope(parentScopeKey, VariableState.NO_PARENT);
     state.createScope(childScopeKey, parentScopeKey);
@@ -75,7 +76,11 @@ final class VariableBehaviorTest {
 
     // when
     behavior.mergeLocalDocument(
-        childScopeKey, processDefinitionKey, parentScopeKey, MsgPackUtil.asMsgPack(document));
+        childScopeKey,
+        processDefinitionKey,
+        parentScopeKey,
+        bpmnProcessId,
+        MsgPackUtil.asMsgPack(document));
 
     // then
     final List<RecordedEvent<VariableRecordValue>> events = getFollowUpEvents();
@@ -88,7 +93,8 @@ final class VariableBehaviorTest {
                   .hasValue("\"buz\"")
                   .hasScopeKey(childScopeKey)
                   .hasProcessDefinitionKey(processDefinitionKey)
-                  .hasProcessInstanceKey(parentScopeKey);
+                  .hasProcessInstanceKey(parentScopeKey)
+                  .hasBpmnProcessId("process");
             },
             event -> {
               assertThat(event.intent).isEqualTo(VariableIntent.UPDATED);
@@ -98,7 +104,8 @@ final class VariableBehaviorTest {
                   .hasValue("\"bar\"")
                   .hasScopeKey(childScopeKey)
                   .hasProcessDefinitionKey(processDefinitionKey)
-                  .hasProcessInstanceKey(parentScopeKey);
+                  .hasProcessInstanceKey(parentScopeKey)
+                  .hasBpmnProcessId("process");
             });
   }
 
@@ -107,12 +114,13 @@ final class VariableBehaviorTest {
     // given
     final long processDefinitionKey = 1;
     final long scopeKey = 1;
+    final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final Map<String, Object> document = Map.of();
     setVariable(2, scopeKey, processDefinitionKey, "foo", "qux");
 
     // when
     behavior.mergeLocalDocument(
-        scopeKey, processDefinitionKey, scopeKey, MsgPackUtil.asMsgPack(document));
+        scopeKey, processDefinitionKey, scopeKey, bpmnProcessId, MsgPackUtil.asMsgPack(document));
 
     // then
     assertThat(getFollowUpEvents()).isEmpty();
@@ -126,6 +134,7 @@ final class VariableBehaviorTest {
     final long parentScopeKey = 2;
     final long childScopeKey = 3;
     final long parentFooKey = 4;
+    final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final Map<String, Object> document = Map.of("foo", "bar");
     state.createScope(rootScopeKey, VariableState.NO_PARENT);
     state.createScope(parentScopeKey, rootScopeKey);
@@ -135,7 +144,11 @@ final class VariableBehaviorTest {
 
     // when
     behavior.mergeDocument(
-        childScopeKey, processDefinitionKey, rootScopeKey, MsgPackUtil.asMsgPack(document));
+        childScopeKey,
+        processDefinitionKey,
+        rootScopeKey,
+        bpmnProcessId,
+        MsgPackUtil.asMsgPack(document));
 
     // then
     final List<RecordedEvent<VariableRecordValue>> events = getFollowUpEvents();
@@ -149,7 +162,8 @@ final class VariableBehaviorTest {
                   .hasValue("\"bar\"")
                   .hasScopeKey(parentScopeKey)
                   .hasProcessDefinitionKey(processDefinitionKey)
-                  .hasProcessInstanceKey(rootScopeKey);
+                  .hasProcessInstanceKey(rootScopeKey)
+                  .hasBpmnProcessId("process");
             });
   }
 
@@ -160,6 +174,7 @@ final class VariableBehaviorTest {
     final long rootScopeKey = 1;
     final long parentScopeKey = 2;
     final long childScopeKey = 3;
+    final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final Map<String, Object> document = Map.of("foo", "bar", "buz", "baz");
     state.createScope(rootScopeKey, VariableState.NO_PARENT);
     state.createScope(parentScopeKey, rootScopeKey);
@@ -167,7 +182,11 @@ final class VariableBehaviorTest {
 
     // when
     behavior.mergeDocument(
-        childScopeKey, processDefinitionKey, rootScopeKey, MsgPackUtil.asMsgPack(document));
+        childScopeKey,
+        processDefinitionKey,
+        rootScopeKey,
+        bpmnProcessId,
+        MsgPackUtil.asMsgPack(document));
 
     // then
     final List<RecordedEvent<VariableRecordValue>> events = getFollowUpEvents();
@@ -180,7 +199,8 @@ final class VariableBehaviorTest {
                   .hasValue("\"bar\"")
                   .hasScopeKey(rootScopeKey)
                   .hasProcessDefinitionKey(processDefinitionKey)
-                  .hasProcessInstanceKey(rootScopeKey);
+                  .hasProcessInstanceKey(rootScopeKey)
+                  .hasBpmnProcessId("process");
             },
             event -> {
               assertThat(event.intent).isEqualTo(VariableIntent.CREATED);
@@ -189,7 +209,8 @@ final class VariableBehaviorTest {
                   .hasValue("\"baz\"")
                   .hasScopeKey(rootScopeKey)
                   .hasProcessDefinitionKey(processDefinitionKey)
-                  .hasProcessInstanceKey(rootScopeKey);
+                  .hasProcessInstanceKey(rootScopeKey)
+                  .hasBpmnProcessId("process");
             });
   }
 
@@ -200,6 +221,7 @@ final class VariableBehaviorTest {
     final long rootScopeKey = 1;
     final long parentScopeKey = 2;
     final long childScopeKey = 3;
+    final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final Map<String, Object> document = Map.of("foo", "bar", "buz", "baz");
     state.createScope(rootScopeKey, VariableState.NO_PARENT);
     state.createScope(parentScopeKey, rootScopeKey);
@@ -208,7 +230,11 @@ final class VariableBehaviorTest {
 
     // when
     behavior.mergeDocument(
-        childScopeKey, processDefinitionKey, rootScopeKey, MsgPackUtil.asMsgPack(document));
+        childScopeKey,
+        processDefinitionKey,
+        rootScopeKey,
+        bpmnProcessId,
+        MsgPackUtil.asMsgPack(document));
 
     // then
     final List<RecordedEvent<VariableRecordValue>> events = getFollowUpEvents();
@@ -221,7 +247,8 @@ final class VariableBehaviorTest {
                   .hasValue("\"baz\"")
                   .hasScopeKey(rootScopeKey)
                   .hasProcessDefinitionKey(processDefinitionKey)
-                  .hasProcessInstanceKey(rootScopeKey);
+                  .hasProcessInstanceKey(rootScopeKey)
+                  .hasBpmnProcessId("process");
             });
   }
 
@@ -232,6 +259,7 @@ final class VariableBehaviorTest {
     final long parentScopeKey = 1;
     final long childScopeKey = 2;
     final long childFooKey = 3;
+    final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final Map<String, Object> document = Map.of("foo", "bar");
     state.createScope(parentScopeKey, VariableState.NO_PARENT);
     state.createScope(childScopeKey, parentScopeKey);
@@ -240,7 +268,11 @@ final class VariableBehaviorTest {
 
     // when
     behavior.mergeDocument(
-        childScopeKey, processDefinitionKey, parentScopeKey, MsgPackUtil.asMsgPack(document));
+        childScopeKey,
+        processDefinitionKey,
+        parentScopeKey,
+        bpmnProcessId,
+        MsgPackUtil.asMsgPack(document));
 
     // then
     final List<RecordedEvent<VariableRecordValue>> events = getFollowUpEvents();
@@ -254,7 +286,8 @@ final class VariableBehaviorTest {
                   .hasValue("\"bar\"")
                   .hasScopeKey(childScopeKey)
                   .hasProcessDefinitionKey(processDefinitionKey)
-                  .hasProcessInstanceKey(parentScopeKey);
+                  .hasProcessInstanceKey(parentScopeKey)
+                  .hasBpmnProcessId("process");
             });
   }
 
@@ -264,6 +297,7 @@ final class VariableBehaviorTest {
     final int processDefinitionKey = 1;
     final int parentScopeKey = 1;
     final int childScopeKey = 2;
+    final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final Map<String, Object> document = Map.of();
     state.createScope(parentScopeKey, VariableState.NO_PARENT);
     state.createScope(childScopeKey, parentScopeKey);
@@ -272,7 +306,11 @@ final class VariableBehaviorTest {
 
     // when
     behavior.mergeDocument(
-        childScopeKey, processDefinitionKey, parentScopeKey, MsgPackUtil.asMsgPack(document));
+        childScopeKey,
+        processDefinitionKey,
+        parentScopeKey,
+        bpmnProcessId,
+        MsgPackUtil.asMsgPack(document));
 
     // then
     final List<RecordedEvent<VariableRecordValue>> events = getFollowUpEvents();
@@ -285,6 +323,7 @@ final class VariableBehaviorTest {
     final int processDefinitionKey = 1;
     final int parentScopeKey = 1;
     final int childScopeKey = 2;
+    final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final DirectBuffer variableName = BufferUtil.wrapString("foo");
     final DirectBuffer variableValue = packString("bar");
     state.createScope(parentScopeKey, VariableState.NO_PARENT);
@@ -295,6 +334,7 @@ final class VariableBehaviorTest {
         childScopeKey,
         processDefinitionKey,
         parentScopeKey,
+        bpmnProcessId,
         variableName,
         variableValue,
         0,
@@ -311,7 +351,8 @@ final class VariableBehaviorTest {
                   .hasValue("\"bar\"")
                   .hasScopeKey(childScopeKey)
                   .hasProcessDefinitionKey(processDefinitionKey)
-                  .hasProcessInstanceKey(parentScopeKey);
+                  .hasProcessInstanceKey(parentScopeKey)
+                  .hasBpmnProcessId("process");
             });
   }
 
@@ -322,6 +363,7 @@ final class VariableBehaviorTest {
     final long parentScopeKey = 1;
     final long childScopeKey = 2;
     final long parentFooKey = 3;
+    final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final DirectBuffer variableName = BufferUtil.wrapString("foo");
     final DirectBuffer variableValue = packString("bar");
     state.createScope(parentScopeKey, VariableState.NO_PARENT);
@@ -333,6 +375,7 @@ final class VariableBehaviorTest {
         parentScopeKey,
         processDefinitionKey,
         parentScopeKey,
+        bpmnProcessId,
         variableName,
         variableValue,
         0,
@@ -350,7 +393,8 @@ final class VariableBehaviorTest {
                   .hasValue("\"bar\"")
                   .hasScopeKey(parentScopeKey)
                   .hasProcessDefinitionKey(processDefinitionKey)
-                  .hasProcessInstanceKey(parentScopeKey);
+                  .hasProcessInstanceKey(parentScopeKey)
+                  .hasBpmnProcessId("process");
             });
   }
 
@@ -361,6 +405,7 @@ final class VariableBehaviorTest {
     final long parentScopeKey = 1;
     final long childScopeKey = 2;
     final long parentFooKey = 3;
+    final DirectBuffer bpmnProcessId = BufferUtil.wrapString("process");
     final DirectBuffer variableName = BufferUtil.wrapString("foo");
     final DirectBuffer variableValue = packString("bar");
     state.createScope(parentScopeKey, VariableState.NO_PARENT);
@@ -372,6 +417,7 @@ final class VariableBehaviorTest {
         parentScopeKey,
         processDefinitionKey,
         parentScopeKey,
+        bpmnProcessId,
         variableName,
         variableValue,
         0,

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
@@ -34,6 +34,9 @@
             },
             "processDefinitionKey": {
               "type": "long"
+            },
+            "bpmnProcessId": {
+              "type": "keyword"
             }
           }
         }

--- a/protocol-impl/pom.xml
+++ b/protocol-impl/pom.xml
@@ -79,6 +79,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
@@ -45,10 +45,22 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
     return MsgPackConverter.convertToJson(valueProp.getValue());
   }
 
+  @Override
   public long getScopeKey() {
     return scopeKeyProp.getValue();
   }
 
+  public VariableRecord setScopeKey(final long scopeKey) {
+    scopeKeyProp.setValue(scopeKey);
+    return this;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
+  }
+
+  @Override
   public long getProcessDefinitionKey() {
     return processDefinitionKeyProp.getValue();
   }
@@ -58,8 +70,18 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
     return this;
   }
 
-  public VariableRecord setScopeKey(final long scopeKey) {
-    scopeKeyProp.setValue(scopeKey);
+  @Override
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  public VariableRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  public VariableRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProp.setValue(processInstanceKey);
     return this;
   }
 
@@ -68,13 +90,13 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
     return this;
   }
 
-  public VariableRecord setValue(final DirectBuffer value, final int offset, final int length) {
-    valueProp.setValue(value, offset, length);
+  public VariableRecord setName(final DirectBuffer name) {
+    nameProp.setValue(name);
     return this;
   }
 
-  public VariableRecord setName(final DirectBuffer name) {
-    nameProp.setValue(name);
+  public VariableRecord setValue(final DirectBuffer value, final int offset, final int length) {
+    valueProp.setValue(value, offset, length);
     return this;
   }
 
@@ -88,27 +110,8 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
     return valueProp.getValue();
   }
 
-  public long getProcessInstanceKey() {
-    return processInstanceKeyProp.getValue();
-  }
-
-  public VariableRecord setProcessInstanceKey(final long processInstanceKey) {
-    processInstanceKeyProp.setValue(processInstanceKey);
-    return this;
-  }
-
   @JsonIgnore
   public DirectBuffer getBpmnProcessIdBuffer() {
     return bpmnProcessIdProp.getValue();
-  }
-
-  @Override
-  public String getBpmnProcessId() {
-    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
-  }
-
-  public VariableRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
-    bpmnProcessIdProp.setValue(bpmnProcessId);
-    return this;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
@@ -24,13 +24,15 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   private final LongProperty scopeKeyProp = new LongProperty("scopeKey");
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey");
   private final LongProperty processDefinitionKeyProp = new LongProperty("processDefinitionKey");
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
 
   public VariableRecord() {
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeKeyProp)
         .declareProperty(processInstanceKeyProp)
-        .declareProperty(processDefinitionKeyProp);
+        .declareProperty(processDefinitionKeyProp)
+        .declareProperty(bpmnProcessIdProp);
   }
 
   @Override
@@ -92,6 +94,21 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
 
   public VariableRecord setProcessInstanceKey(final long processInstanceKey) {
     processInstanceKeyProp.setValue(processInstanceKey);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBpmnProcessIdBuffer() {
+    return bpmnProcessIdProp.getValue();
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  public VariableRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
     return this;
   }
 }

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -643,15 +643,17 @@ public final class JsonSerializableToJsonTest {
               final long scopeKey = 3;
               final long processInstanceKey = 2;
               final long processDefinitionKey = 4;
+              final String bpmnProcessId = "process";
 
               return new VariableRecord()
                   .setName(wrapString(name))
                   .setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(value)))
                   .setScopeKey(scopeKey)
                   .setProcessInstanceKey(processInstanceKey)
-                  .setProcessDefinitionKey(processDefinitionKey);
+                  .setProcessDefinitionKey(processDefinitionKey)
+                  .setBpmnProcessId(wrapString(bpmnProcessId));
             },
-        "{'scopeKey':3,'processInstanceKey':2,'processDefinitionKey':4,'name':'x','value':'1'}"
+        "{'scopeKey':3,'processInstanceKey':2,'processDefinitionKey':4,'bpmnProcessId':'process','name':'x','value':'1'}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableRecordValue.java
@@ -39,4 +39,7 @@ public interface VariableRecordValue extends RecordValue, ProcessInstanceRelated
 
   /** @return the key of the process the variable belongs to */
   long getProcessDefinitionKey();
+
+  /** @return the BPMN process id this process instance belongs to. */
+  String getBpmnProcessId();
 }


### PR DESCRIPTION
## Description

This PR adds a new `bpmnProcessId` property to all `VariableRecordValue` instances. This property is set during processing before the record is written in all cases. However, it is not stored in the state, but only persisted in the log, much like the `VariableRecordValue#getProcessInstanceKey` property.

Doing this allows consumers of the exported record stream to index variables over a process' ID. This use case  is mostly for users who want to aggregate variables over a specific process without having to care about its version (and thus the unique keys for each process/version pair). See the linked issue for more.

NOTE: a small thing jumped out, which is that variables now have a few properties which are really only used for the consumers of the exported stream. I don't expect we add more of these, but if we do, at some point we might want to revise our approach instead of just tacking on the property over each record.

NOTE: the `bpmnProcessId` has an empty string as default value. While we should ensure it's always set in newer versions, I assumed for backwards compatibility this is necessary. Let me know if that's not the case, maybe I forgot how the message pack decoding works.

## Related issues

closes #8181 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
