### PR TITLE
Export the evaluated decision result to ES

### DIFF
--- a/dmn/src/test/java/io/camunda/zeebe/dmn/DmnParsingTest.java
+++ b/dmn/src/test/java/io/camunda/zeebe/dmn/DmnParsingTest.java
@@ -64,7 +64,7 @@ class DmnParsingTest {
         .describedAs("Expect that the DMN is parsed successfully")
         .isTrue();
 
-    assertThat(parsedDrg.getId()).isEqualTo("force-users");
+    assertThat(parsedDrg.getId()).isEqualTo("force_users");
     assertThat(parsedDrg.getName()).isEqualTo("Force Users");
     assertThat(parsedDrg.getNamespace()).isEqualTo("http://camunda.org/schema/1.0/dmn");
 

--- a/dmn/src/test/resources/decision-table-with-invalid-expression.dmn
+++ b/dmn/src/test/resources/decision-table-with-invalid-expression.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force-users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
   <decision id="jediOrSith" name="Jedi or Sith">
     <decisionTable id="DecisionTable_14n3bxx">
       <input id="Input_1" label="Lightsaber color" biodi:width="192">

--- a/dmn/src/test/resources/decision-table.dmn
+++ b/dmn/src/test/resources/decision-table.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force-users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="jedi_or_sith" name="Jedi or Sith">
     <decisionTable id="DecisionTable_14n3bxx">
       <input id="Input_1" label="Lightsaber color" biodi:width="192">

--- a/dmn/src/test/resources/drg-decision-types.dmn
+++ b/dmn/src/test/resources/drg-decision-types.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force-users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="decision_table" name="Decision Table">
     <decisionTable id="DecisionTable_14n3bxx">
       <input id="Input_1" label="Input" biodi:width="192">

--- a/dmn/src/test/resources/drg-force-user.dmn
+++ b/dmn/src/test/resources/drg-force-user.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="force-users" name="force-users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="force_users" name="force_users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.0.0-alpha.1">
   <decision id="jedi_or_sith" name="Jedi or Sith">
     <decisionTable id="DecisionTable_14n3bxx">
       <input id="Input_1" label="Lightsaber color" biodi:width="192">

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentDmnTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentDmnTest.java
@@ -63,7 +63,7 @@ public final class DeploymentDmnTest {
 
     final var drgMetadata = deploymentEvent.getValue().getDecisionRequirementsMetadata().get(0);
     Assertions.assertThat(drgMetadata)
-        .hasDecisionRequirementsId("force-users")
+        .hasDecisionRequirementsId("force_users")
         .hasDecisionRequirementsName("Force Users")
         .hasDecisionRequirementsVersion(1)
         .hasNamespace("http://camunda.org/schema/1.0/dmn")
@@ -77,11 +77,11 @@ public final class DeploymentDmnTest {
 
     final var decisionMetadata = deploymentEvent.getValue().getDecisionsMetadata().get(0);
     Assertions.assertThat(decisionMetadata)
-        .hasDecisionId("jedi-or-sith")
+        .hasDecisionId("jedi_or_sith")
         .hasDecisionName("Jedi or Sith")
-        .hasDecisionRequirementsId("force-users")
+        .hasDecisionRequirementsId("force_users")
         .hasVersion(1)
-        .hasDecisionRequirementsId("force-users")
+        .hasDecisionRequirementsId("force_users")
         .hasDecisionRequirementsKey(drgMetadata.getDecisionRequirementsKey());
     assertThat(decisionMetadata.getDecisionKey()).isPositive();
   }
@@ -122,7 +122,7 @@ public final class DeploymentDmnTest {
     assertThat(record.getKey()).isPositive();
 
     final var decisionRequirementsRecord = record.getValue();
-    assertThat(decisionRequirementsRecord.getDecisionRequirementsId()).isEqualTo("force-users");
+    assertThat(decisionRequirementsRecord.getDecisionRequirementsId()).isEqualTo("force_users");
     assertThat(decisionRequirementsRecord.getDecisionRequirementsName()).isEqualTo("Force Users");
     assertThat(decisionRequirementsRecord.getDecisionRequirementsKey()).isPositive();
     assertThat(decisionRequirementsRecord.getDecisionRequirementsVersion()).isEqualTo(1);
@@ -156,9 +156,9 @@ public final class DeploymentDmnTest {
 
     final var decisionRecord = record.getValue();
     Assertions.assertThat(decisionRecord)
-        .hasDecisionId("jedi-or-sith")
+        .hasDecisionId("jedi_or_sith")
         .hasDecisionName("Jedi or Sith")
-        .hasDecisionRequirementsId("force-users")
+        .hasDecisionRequirementsId("force_users")
         .hasVersion(1);
 
     assertThat(decisionRecord.getDecisionKey()).isPositive();
@@ -226,13 +226,13 @@ public final class DeploymentDmnTest {
         .extracting(
             DecisionRequirementsMetadataValue::getDecisionRequirementsId,
             DecisionRequirementsMetadataValue::getDecisionRequirementsVersion)
-        .contains(tuple("force-users", 1), tuple("force-users", 2));
+        .contains(tuple("force_users", 1), tuple("force_users", 2));
 
     assertThat(RecordingExporter.decisionRecords().limit(2))
         .hasSize(2)
         .extracting(Record::getValue)
         .extracting(DecisionRecordValue::getDecisionId, DecisionRecordValue::getVersion)
-        .contains(tuple("jedi-or-sith", 1), tuple("jedi-or-sith", 2));
+        .contains(tuple("jedi_or_sith", 1), tuple("jedi_or_sith", 2));
   }
 
   @Test
@@ -328,13 +328,13 @@ public final class DeploymentDmnTest {
         .extracting(
             DecisionRequirementsMetadataValue::getDecisionRequirementsId,
             DecisionRequirementsMetadataValue::getDecisionRequirementsVersion)
-        .contains(tuple("force-users", 1), tuple("star-wars", 1));
+        .contains(tuple("force_users", 1), tuple("star-wars", 1));
 
     assertThat(RecordingExporter.decisionRecords().limit(2))
         .hasSize(2)
         .extracting(Record::getValue)
         .extracting(DecisionRecordValue::getDecisionId, DecisionRecordValue::getVersion)
-        .contains(tuple("jedi-or-sith", 1), tuple("jedi-or-sith", 2));
+        .contains(tuple("jedi_or_sith", 1), tuple("jedi_or_sith", 2));
   }
 
   @Test
@@ -368,9 +368,9 @@ public final class DeploymentDmnTest {
             DecisionRecordValue::getVersion,
             DecisionRecordValue::getDecisionRequirementsId)
         .contains(
-            tuple("jedi-or-sith", 1, "force-users"),
-            tuple("jedi-or-sith", 2, "star-wars"),
-            tuple("jedi-or-sith", 3, "force-users"));
+            tuple("jedi_or_sith", 1, "force_users"),
+            tuple("jedi_or_sith", 2, "star-wars"),
+            tuple("jedi_or_sith", 3, "force_users"));
   }
 
   @Test
@@ -394,7 +394,7 @@ public final class DeploymentDmnTest {
         .contains(
             String.format(
                 "Expected the decision requirements ids to be unique within a deployment "
-                    + "but found a duplicated id 'force-users' in the resources '%s' and '%s'",
+                    + "but found a duplicated id 'force_users' in the resources '%s' and '%s'",
                 DMN_DECISION_TABLE, DMN_DECISION_TABLE_V2));
   }
 
@@ -419,7 +419,7 @@ public final class DeploymentDmnTest {
         .contains(
             String.format(
                 "Expected the decision ids to be unique within a deployment "
-                    + "but found a duplicated id 'jedi-or-sith' in the resources '%s' and '%s'",
+                    + "but found a duplicated id 'jedi_or_sith' in the resources '%s' and '%s'",
                 DMN_DECISION_TABLE, DMN_DECISION_TABLE_RENAMED_DRG));
   }
 

--- a/engine/src/test/resources/dmn/decision-table-with-invalid-expression.dmn
+++ b/engine/src/test/resources/dmn/decision-table-with-invalid-expression.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force-users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
   <decision id="jediOrSith" name="Jedi or Sith">
     <decisionTable id="DecisionTable_14n3bxx">
       <input id="Input_1" label="Lightsaber color" biodi:width="192">

--- a/engine/src/test/resources/dmn/decision-table-with-renamed-drg.dmn
+++ b/engine/src/test/resources/dmn/decision-table-with-renamed-drg.dmn
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="star-wars" name="Star Wars" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
-  <decision id="jedi-or-sith" name="Jedi or Sith">
+  <decision id="jedi_or_sith" name="Jedi or Sith">
     <decisionTable id="DecisionTable_14n3bxx">
       <input id="Input_1" label="Lightsaber color" biodi:width="192">
         <inputExpression id="InputExpression_1" typeRef="string">
           <text>lightsaberColor</text>
         </inputExpression>
       </input>
-      <output id="Output_1" label="Jedi or Sith" name="faction" typeRef="string" biodi:width="192">
+      <output id="Output_1" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
         <outputValues id="UnaryTests_0hj346a">
           <text>"Jedi","Sith"</text>
         </outputValues>
@@ -40,7 +40,7 @@
   </decision>
   <dmndi:DMNDI>
     <dmndi:DMNDiagram>
-      <dmndi:DMNShape dmnElementRef="jedi-or-sith">
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
         <dc:Bounds height="80" width="180" x="160" y="100" />
       </dmndi:DMNShape>
     </dmndi:DMNDiagram>

--- a/engine/src/test/resources/dmn/decision-table.dmn
+++ b/engine/src/test/resources/dmn/decision-table.dmn
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force-users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
-  <decision id="jedi-or-sith" name="Jedi or Sith">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <decision id="jedi_or_sith" name="Jedi or Sith">
     <decisionTable id="DecisionTable_14n3bxx">
       <input id="Input_1" label="Lightsaber color" biodi:width="192">
         <inputExpression id="InputExpression_1" typeRef="string">
           <text>lightsaberColor</text>
         </inputExpression>
       </input>
-      <output id="Output_1" label="Jedi or Sith" name="faction" typeRef="string" biodi:width="192">
+      <output id="Output_1" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
         <outputValues id="UnaryTests_0hj346a">
           <text>"Jedi","Sith"</text>
         </outputValues>
@@ -40,7 +40,7 @@
   </decision>
   <dmndi:DMNDI>
     <dmndi:DMNDiagram>
-      <dmndi:DMNShape dmnElementRef="jedi-or-sith">
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
         <dc:Bounds height="80" width="180" x="160" y="100" />
       </dmndi:DMNShape>
     </dmndi:DMNDiagram>

--- a/engine/src/test/resources/dmn/decision-table_v2.dmn
+++ b/engine/src/test/resources/dmn/decision-table_v2.dmn
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force-users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
-  <decision id="jedi-or-sith" name="Jedi or Sith">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+  <decision id="jedi_or_sith" name="Jedi or Sith">
     <decisionTable id="DecisionTable_14n3bxx">
       <input id="Input_1" label="Lightsaber color" biodi:width="192">
         <inputExpression id="InputExpression_1" typeRef="string">
           <text>lightsaberColor</text>
         </inputExpression>
       </input>
-      <output id="Output_1" label="Jedi or Sith" name="faction" typeRef="string" biodi:width="192">
+      <output id="Output_1" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
         <outputValues id="UnaryTests_0hj346a">
           <text>"Jedi","Sith"</text>
         </outputValues>
@@ -56,7 +56,7 @@
   </decision>
   <dmndi:DMNDI>
     <dmndi:DMNDiagram>
-      <dmndi:DMNShape dmnElementRef="jedi-or-sith">
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
         <dc:Bounds height="80" width="180" x="160" y="100" />
       </dmndi:DMNShape>
     </dmndi:DMNDiagram>

--- a/engine/src/test/resources/dmn/drg-force-user.dmn
+++ b/engine/src/test/resources/dmn/drg-force-user.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="force-users" name="force-users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="force_users" name="force_users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="jedi_or_sith" name="Jedi or Sith">
     <decisionTable id="DecisionTable_14n3bxx">
       <input id="Input_1" label="Lightsaber color" biodi:width="192">

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -192,6 +192,9 @@ public class ElasticsearchExporter implements Exporter {
       if (index.decision) {
         createValueIndexTemplate(ValueType.DECISION);
       }
+      if (index.decisionEvaluation) {
+        createValueIndexTemplate(ValueType.DECISION_EVALUATION);
+      }
     }
 
     indexTemplatesCreated = true;

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -83,6 +83,8 @@ public class ElasticsearchExporterConfiguration {
         return index.decisionRequirements;
       case DECISION:
         return index.decision;
+      case DECISION_EVALUATION:
+        return index.decisionEvaluation;
       default:
         return false;
     }
@@ -129,6 +131,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean processMessageSubscription = false;
     public boolean decisionRequirements = true;
     public boolean decision = true;
+    public boolean decisionEvaluation = true;
 
     // index settings
     private Integer numberOfShards = null;
@@ -138,7 +141,7 @@ public class ElasticsearchExporterConfiguration {
       return numberOfShards;
     }
 
-    public void setNumberOfShards(Integer numberOfShards) {
+    public void setNumberOfShards(final Integer numberOfShards) {
       this.numberOfShards = numberOfShards;
     }
 
@@ -146,7 +149,7 @@ public class ElasticsearchExporterConfiguration {
       return numberOfReplicas;
     }
 
-    public void setNumberOfReplicas(Integer numberOfReplicas) {
+    public void setNumberOfReplicas(final Integer numberOfReplicas) {
       this.numberOfReplicas = numberOfReplicas;
     }
 
@@ -192,6 +195,8 @@ public class ElasticsearchExporterConfiguration {
           + decisionRequirements
           + ", decision="
           + decision
+          + ", decisionEvaluation="
+          + decisionEvaluation
           + '}';
     }
   }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
@@ -1,0 +1,117 @@
+{
+  "index_patterns": [
+    "zeebe-record_decision_evaluation_*"
+  ],
+  "composed_of": [
+    "zeebe-record"
+  ],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-decision-evaluation": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "decisionId": {
+              "type": "keyword"
+            },
+            "decisionName": {
+              "type": "keyword"
+            },
+            "decisionVersion": {
+              "type": "long"
+            },
+            "decisionKey": {
+              "type": "long"
+            },
+            "decisionRequirementsId": {
+              "type": "keyword"
+            },
+            "decisionRequirementsKey": {
+              "type": "long"
+            },
+            "decisionOutput": {
+              "enabled": false
+            },
+            "bpmnProcessId": {
+              "type": "keyword"
+            },
+            "processDefinitionKey": {
+              "type": "long"
+            },
+            "processInstanceKey": {
+              "type": "long"
+            },
+            "elementId": {
+              "type": "keyword"
+            },
+            "elementInstanceKey": {
+              "type": "long"
+            },
+            "evaluatedDecisions": {
+              "properties": {
+                "decisionId": {
+                  "type": "keyword"
+                },
+                "decisionName": {
+                  "type": "keyword"
+                },
+                "decisionType": {
+                  "type": "keyword"
+                },
+                "decisionOutput": {
+                  "enabled": false
+                },
+                "evaluatedInputs": {
+                  "properties": {
+                    "inputId": {
+                      "type": "keyword"
+                    },
+                    "inputName": {
+                      "type": "keyword"
+                    },
+                    "inputValue": {
+                      "enabled": false
+                    }
+                  }
+                },
+                "matchedRules": {
+                  "properties": {
+                    "ruleId": {
+                      "type": "keyword"
+                    },
+                    "ruleIndex": {
+                      "type": "long"
+                    },
+                    "evaluatedOutputs": {
+                      "properties": {
+                        "outputId": {
+                          "type": "keyword"
+                        },
+                        "outputName": {
+                          "type": "keyword"
+                        },
+                        "outputValue": {
+                          "enabled": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -22,6 +23,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Map;
 import org.awaitility.Awaitility;
 import org.elasticsearch.client.Request;
@@ -89,6 +91,10 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
   }
 
   protected void assertRecordExported(final Record<?> record) {
+    await("index templates need to be created")
+        .atMost(Duration.ofMinutes(1))
+        .untilAsserted(this::assertIndexSettings);
+
     Awaitility.await("Expected the record to be exported: " + record.toJson())
         .ignoreExceptionsInstanceOf(ElasticsearchExporterException.class)
         .untilAsserted(

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterAuthenticationIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterAuthenticationIT.java
@@ -64,7 +64,6 @@ public class ElasticsearchExporterAuthenticationIT
 
     // assert index settings for all created indices
     esClient = createElasticsearchClient(configuration);
-    assertIndexSettings();
 
     // assert all records which where recorded during the tests where exported
     exporterBrokerRule.visitExportedRecords(

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/records/ElasticsearchExporterDmnRecordIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/records/ElasticsearchExporterDmnRecordIT.java
@@ -8,14 +8,12 @@
 package io.camunda.zeebe.exporter.records;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 import io.camunda.zeebe.exporter.AbstractElasticsearchExporterIntegrationTestCase;
 import io.camunda.zeebe.exporter.ElasticsearchExporter;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
-import java.time.Duration;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,10 +42,6 @@ public final class ElasticsearchExporterDmnRecordIT
     exporterBrokerRule.deployResourceFromClasspath(DMN_RESOURCE);
 
     // then
-    await("index templates need to be created")
-        .atMost(Duration.ofMinutes(1))
-        .untilAsserted(this::assertIndexSettings);
-
     final var deploymentRecord =
         RecordingExporter.deploymentRecords().withIntent(DeploymentIntent.CREATED).getFirst();
 
@@ -63,10 +57,6 @@ public final class ElasticsearchExporterDmnRecordIT
     exporterBrokerRule.deployResourceFromClasspath(DMN_RESOURCE);
 
     // then
-    await("index templates need to be created")
-        .atMost(Duration.ofMinutes(1))
-        .untilAsserted(this::assertIndexSettings);
-
     final var decisionRecord = RecordingExporter.decisionRecords().getFirst();
 
     assertRecordExported(decisionRecord);
@@ -78,10 +68,6 @@ public final class ElasticsearchExporterDmnRecordIT
     exporterBrokerRule.deployResourceFromClasspath(DMN_RESOURCE);
 
     // then
-    await("index templates need to be created")
-        .atMost(Duration.ofMinutes(1))
-        .untilAsserted(this::assertIndexSettings);
-
     final var decisionRequirementsRecord =
         RecordingExporter.decisionRequirementsRecords().getFirst();
 
@@ -106,10 +92,6 @@ public final class ElasticsearchExporterDmnRecordIT
         exporterBrokerRule.createProcessInstance("process", Map.of("lightsaberColor", "blue"));
 
     // then
-    await("index templates need to be created")
-        .atMost(Duration.ofMinutes(1))
-        .untilAsserted(this::assertIndexSettings);
-
     final var decisionEvaluationRecord =
         RecordingExporter.decisionEvaluationRecords()
             .withProcessInstanceKey(processInstanceKey)

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/records/ElasticsearchExporterJobRecordIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/records/ElasticsearchExporterJobRecordIT.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.exporter.records;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 import io.camunda.zeebe.client.api.worker.JobWorker;
 import io.camunda.zeebe.exporter.AbstractElasticsearchExporterIntegrationTestCase;
@@ -61,7 +60,6 @@ public class ElasticsearchExporterJobRecordIT
     final var processInstanceKey = exporterBrokerRule.createProcessInstance("process", Map.of());
 
     // then
-    await("index templates need to be created").untilAsserted(this::assertIndexSettings);
     final var jobCreated =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
@@ -86,7 +84,6 @@ public class ElasticsearchExporterJobRecordIT
     final var processInstanceKey = exporterBrokerRule.createProcessInstance("process", Map.of());
 
     // then
-    await("index templates need to be created").untilAsserted(this::assertIndexSettings);
     final var jobCreated =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
@@ -110,7 +107,6 @@ public class ElasticsearchExporterJobRecordIT
 
     final var processInstanceKey = exporterBrokerRule.createProcessInstance("process", Map.of());
 
-    await("index templates need to be created").untilAsserted(this::assertIndexSettings);
     final var jobCreated =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)

--- a/exporters/elasticsearch-exporter/src/test/resources/dmn/decision-table.dmn
+++ b/exporters/elasticsearch-exporter/src/test/resources/dmn/decision-table.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force-users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="jedi_or_sith" name="Jedi or Sith">
     <decisionTable id="DecisionTable_14n3bxx">
       <input id="Input_1" label="Lightsaber color" biodi:width="192">

--- a/exporters/elasticsearch-exporter/src/test/resources/dmn/decision-table.dmn
+++ b/exporters/elasticsearch-exporter/src/test/resources/dmn/decision-table.dmn
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force-users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
-  <decision id="jedi-or-sith" name="Jedi or Sith">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force-users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+  <decision id="jedi_or_sith" name="Jedi or Sith">
     <decisionTable id="DecisionTable_14n3bxx">
       <input id="Input_1" label="Lightsaber color" biodi:width="192">
         <inputExpression id="InputExpression_1" typeRef="string">
           <text>lightsaberColor</text>
         </inputExpression>
       </input>
-      <output id="Output_1" label="Jedi or Sith" name="faction" typeRef="string" biodi:width="192">
+      <output id="Output_1" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
         <outputValues id="UnaryTests_0hj346a">
           <text>"Jedi","Sith"</text>
         </outputValues>
@@ -40,7 +40,7 @@
   </decision>
   <dmndi:DMNDI>
     <dmndi:DMNDiagram>
-      <dmndi:DMNShape dmnElementRef="jedi-or-sith">
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
         <dc:Bounds height="80" width="180" x="160" y="100" />
       </dmndi:DMNShape>
     </dmndi:DMNDiagram>


### PR DESCRIPTION
## Description

* add new ES template for DMN decision evaluation records
* export DMN decision evaluation records by default

## Related issues

closes #8116

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
