### PR TITLE
Write an event if a decision evaluation failed

### DIFF
--- a/dmn/src/main/java/io/camunda/zeebe/dmn/DecisionEvaluationResult.java
+++ b/dmn/src/main/java/io/camunda/zeebe/dmn/DecisionEvaluationResult.java
@@ -22,7 +22,7 @@ public interface DecisionEvaluationResult {
   boolean isFailure();
 
   /**
-   * Returns the reason why the evaluation failed. Use {@link #isFailure()} ()} to check if the
+   * Returns the reason why the evaluation failed. Use {@link #isFailure()} to check if the
    * evaluation was successful or not.
    *
    * @return the failure message if the evaluation was not successful, or {@code null} if the

--- a/dmn/src/main/java/io/camunda/zeebe/dmn/DecisionEvaluationResult.java
+++ b/dmn/src/main/java/io/camunda/zeebe/dmn/DecisionEvaluationResult.java
@@ -30,6 +30,15 @@ public interface DecisionEvaluationResult {
    */
   String getFailureMessage();
 
+  /**
+   * Returns the id of the decision where the evaluation failed. Use {@link #isFailure()} to check
+   * if the evaluation was successful or not.
+   *
+   * @return the id of the decision where the evaluation failed, or {@code null} if the evaluation
+   *     was successful
+   */
+  String getFailedDecisionId();
+
   /** @return the output of the decision if it was made successfully, otherwise {@code null} */
   DirectBuffer getOutput();
 

--- a/dmn/src/main/java/io/camunda/zeebe/dmn/impl/DmnScalaDecisionEngine.java
+++ b/dmn/src/main/java/io/camunda/zeebe/dmn/impl/DmnScalaDecisionEngine.java
@@ -106,8 +106,15 @@ public final class DmnScalaDecisionEngine implements DecisionEngine {
 
     if (result.isLeft()) {
       final var reason = result.left().get().failure().message();
+
+      String failedDecisionId = null;
+      if (!evaluatedDecisions.isEmpty()) {
+        failedDecisionId = evaluatedDecisions.get(evaluatedDecisions.size() - 1).decisionId();
+      }
+
       return new EvaluationFailure(
           String.format("Expected to evaluate decision '%s', but %s", decisionId, reason),
+          failedDecisionId,
           evaluatedDecisions);
     }
 

--- a/dmn/src/main/java/io/camunda/zeebe/dmn/impl/EvaluationFailure.java
+++ b/dmn/src/main/java/io/camunda/zeebe/dmn/impl/EvaluationFailure.java
@@ -16,14 +16,19 @@ import org.agrona.DirectBuffer;
 public final class EvaluationFailure implements DecisionEvaluationResult {
 
   private final String message;
+  private final String failedDecisionId;
   private final List<EvaluatedDecision> evaluatedDecisions;
 
   public EvaluationFailure(final String message) {
-    this(message, List.of());
+    this(message, null, List.of());
   }
 
-  public EvaluationFailure(final String message, final List<EvaluatedDecision> evaluatedDecisions) {
+  public EvaluationFailure(
+      final String message,
+      final String failedDecisionId,
+      final List<EvaluatedDecision> evaluatedDecisions) {
     this.message = message;
+    this.failedDecisionId = failedDecisionId;
     this.evaluatedDecisions = evaluatedDecisions;
   }
 
@@ -35,6 +40,11 @@ public final class EvaluationFailure implements DecisionEvaluationResult {
   @Override
   public String getFailureMessage() {
     return message;
+  }
+
+  @Override
+  public String getFailedDecisionId() {
+    return failedDecisionId;
   }
 
   @Override

--- a/dmn/src/main/java/io/camunda/zeebe/dmn/impl/EvaluationResult.java
+++ b/dmn/src/main/java/io/camunda/zeebe/dmn/impl/EvaluationResult.java
@@ -35,6 +35,11 @@ public final class EvaluationResult implements DecisionEvaluationResult {
   }
 
   @Override
+  public String getFailedDecisionId() {
+    return null;
+  }
+
+  @Override
   public DirectBuffer getOutput() {
     return output;
   }

--- a/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluatedDecisionsTest.java
+++ b/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluatedDecisionsTest.java
@@ -170,8 +170,11 @@ class DmnEvaluatedDecisionsTest {
 
     assertThat(result.getFailureMessage())
         .isEqualTo(
-            "Expected to evaluate decision 'force_user', but failed to evaluate expression 'lightsaberColor': "
-                + "no variable found for name 'lightsaberColor'");
+            """
+            Expected to evaluate decision 'force_user', \
+            but failed to evaluate expression 'lightsaberColor': \
+            no variable found for name 'lightsaberColor'\
+            """);
 
     assertThat(result.getFailedDecisionId()).isEqualTo("jedi_or_sith");
 

--- a/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluatedDecisionsTest.java
+++ b/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluatedDecisionsTest.java
@@ -119,8 +119,8 @@ class DmnEvaluatedDecisionsTest {
   }
 
   @Test
-  @DisplayName("Should return partial output if evaluation fails")
-  void shouldReturnPartialResultIfEvaluationFails() {
+  @DisplayName("Should return output of required decision if evaluation fails on root decision")
+  void shouldReturnOutputOfRequiredDecisionIfEvaluationFailsOnRootDecision() {
     // given
     final var inputStream = getClass().getResourceAsStream(VALID_DRG);
     final var parsedDrg = decisionEngine.parse(inputStream);
@@ -140,6 +140,8 @@ class DmnEvaluatedDecisionsTest {
             "Expected to evaluate decision 'force_user', but failed to evaluate expression 'height': "
                 + "no variable found for name 'height'");
 
+    assertThat(result.getFailedDecisionId()).isEqualTo("force_user");
+
     assertThat(result.getEvaluatedDecisions())
         .hasSize(2)
         .extracting(EvaluatedDecision::decisionId, EvaluatedDecision::decisionName)
@@ -149,6 +151,37 @@ class DmnEvaluatedDecisionsTest {
     final var evaluatedDecisions = result.getEvaluatedDecisions();
     assertEquality(evaluatedDecisions.get(0).decisionOutput(), "'Jedi'");
     assertEquality(evaluatedDecisions.get(1).decisionOutput(), "null");
+  }
+
+  @Test
+  @DisplayName("Should return partial output if evaluation fails on required decision")
+  void shouldReturnPartialOutputIfEvaluationFailsOnRequiredDecision() {
+    // given
+    final var inputStream = getClass().getResourceAsStream(VALID_DRG);
+    final var parsedDrg = decisionEngine.parse(inputStream);
+
+    // when
+    final var result = decisionEngine.evaluateDecisionById(parsedDrg, "force_user", null);
+
+    // then
+    assertThat(result.isFailure())
+        .describedAs("Expect that the result is not evaluated successfully")
+        .isTrue();
+
+    assertThat(result.getFailureMessage())
+        .isEqualTo(
+            "Expected to evaluate decision 'force_user', but failed to evaluate expression 'lightsaberColor': "
+                + "no variable found for name 'lightsaberColor'");
+
+    assertThat(result.getFailedDecisionId()).isEqualTo("jedi_or_sith");
+
+    assertThat(result.getEvaluatedDecisions()).hasSize(1);
+
+    final var evaluatedDecision = result.getEvaluatedDecisions().get(0);
+    assertThat(evaluatedDecision.decisionId()).isEqualTo("jedi_or_sith");
+    assertEquality(evaluatedDecision.decisionOutput(), "null");
+    assertThat(evaluatedDecision.evaluatedInputs()).hasSize(0);
+    assertThat(evaluatedDecision.matchedRules()).hasSize(0);
   }
 
   @Nested

--- a/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluationTest.java
+++ b/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluationTest.java
@@ -52,6 +52,11 @@ class DmnEvaluationTest {
             "Expect that the evaluation failed because the DRG does not contain the referred decision")
         .contains("no decision found for 'not_in_drg'");
 
+    assertThat(result.getFailedDecisionId())
+        .describedAs(
+            "Expect that the failed decision id is 'null' if the decision was not evaluated")
+        .isNull();
+
     assertThat(result.getOutput())
         .describedAs("Expect that a failed evaluation has no output")
         .isNull();
@@ -76,6 +81,8 @@ class DmnEvaluationTest {
         .isNotNull()
         .describedAs("Expect that the evaluation failed because of a missing variable")
         .contains("no variable found for");
+
+    assertThat(result.getFailedDecisionId()).isEqualTo("jedi_or_sith");
 
     assertThat(result.getOutput())
         .describedAs("Expect that a failed evaluation has no output")
@@ -105,6 +112,10 @@ class DmnEvaluationTest {
         .describedAs("Expect that the evaluation failed because the DRG is invalid")
         .contains("the decision requirements graph is invalid");
 
+    assertThat(result.getFailedDecisionId())
+        .describedAs("Expect that the failed decision id is 'null' if the DRG is invalid")
+        .isNull();
+
     assertThat(result.getOutput())
         .describedAs("Expect that a successful result has no output")
         .isNull();
@@ -131,6 +142,10 @@ class DmnEvaluationTest {
 
     assertThat(result.getFailureMessage())
         .describedAs("Expect that a successful result has no failure message")
+        .isNull();
+
+    assertThat(result.getFailedDecisionId())
+        .describedAs("Expect that a successful result has no failed decision")
         .isNull();
 
     assertThat(result.getOutput())

--- a/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluationTest.java
+++ b/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluationTest.java
@@ -96,7 +96,6 @@ class DmnEvaluationTest {
             new VariablesContext(Map.of("lightsaberColor", asMsgPack("\"blue\""))));
 
     // then
-    // then
     assertThat(result.isFailure())
         .describedAs("Expect that the result is not evaluated successfully")
         .isTrue();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
@@ -264,7 +264,9 @@ public final class BusinessRuleTaskTest {
         .hasDecisionVersion(calledDecision.getVersion())
         .hasDecisionRequirementsKey(calledDecision.getDecisionRequirementsKey())
         .hasDecisionRequirementsId(calledDecision.getDecisionRequirementsId())
-        .hasDecisionOutput("\"Obi-Wan Kenobi\"");
+        .hasDecisionOutput("\"Obi-Wan Kenobi\"")
+        .hasFailedDecisionId("")
+        .hasEvaluationFailureMessage("");
 
     assertThat(decisionEvaluationValue)
         .hasProcessDefinitionKey(businessRuleTaskActivated.getValue().getProcessDefinitionKey())
@@ -367,5 +369,87 @@ public final class BusinessRuleTaskTest {
                 .exists())
         .as("Decision is evaluated successfully")
         .isTrue();
+  }
+
+  @Test
+  public void shouldWriteDecisionEvaluationEventIfEvaluationFailed() {
+    // given
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlClasspathResource(DMN_RESOURCE)
+            .withXmlResource(
+                processWithBusinessRuleTask(
+                    t ->
+                        t.zeebeCalledDecisionId("force_user").zeebeResultVariable(RESULT_VARIABLE)))
+            .deploy();
+
+    final var calledDecision =
+        deployment.getValue().getDecisionsMetadata().stream()
+            .filter(decision -> decision.getDecisionId().equals("force_user"))
+            .findFirst()
+            .orElseThrow();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var businessRuleTaskActivating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.BUSINESS_RULE_TASK)
+            .getFirst();
+
+    // then
+    final var decisionEvaluationRecord =
+        RecordingExporter.decisionEvaluationRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    assertThat(decisionEvaluationRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasValueType(ValueType.DECISION_EVALUATION)
+        .hasIntent(DecisionEvaluationIntent.FAILED)
+        .hasSourceRecordPosition(businessRuleTaskActivating.getSourceRecordPosition());
+    assertThat(decisionEvaluationRecord.getKey())
+        .describedAs("Expect that the decision evaluation event has a key")
+        .isPositive();
+
+    final var decisionEvaluationValue = decisionEvaluationRecord.getValue();
+    assertThat(decisionEvaluationValue)
+        .hasDecisionKey(calledDecision.getDecisionKey())
+        .hasDecisionId(calledDecision.getDecisionId())
+        .hasDecisionName(calledDecision.getDecisionName())
+        .hasDecisionVersion(calledDecision.getVersion())
+        .hasDecisionRequirementsKey(calledDecision.getDecisionRequirementsKey())
+        .hasDecisionRequirementsId(calledDecision.getDecisionRequirementsId())
+        .hasDecisionOutput("null")
+        .hasFailedDecisionId("jedi_or_sith")
+        .hasEvaluationFailureMessage(
+            """
+            Expected to evaluate decision 'force_user', \
+            but failed to evaluate expression 'lightsaberColor': \
+            no variable found for name 'lightsaberColor'\
+            """);
+
+    assertThat(decisionEvaluationValue)
+        .hasProcessDefinitionKey(businessRuleTaskActivating.getValue().getProcessDefinitionKey())
+        .hasBpmnProcessId(businessRuleTaskActivating.getValue().getBpmnProcessId())
+        .hasProcessInstanceKey(businessRuleTaskActivating.getValue().getProcessInstanceKey())
+        .hasElementInstanceKey(businessRuleTaskActivating.getKey())
+        .hasElementId(businessRuleTaskActivating.getValue().getElementId());
+
+    final var evaluatedDecisions = decisionEvaluationValue.getEvaluatedDecisions();
+    assertThat(evaluatedDecisions).hasSize(1);
+
+    assertThat(evaluatedDecisions.get(0))
+        .hasDecisionId("jedi_or_sith")
+        .hasDecisionName("Jedi or Sith")
+        .hasDecisionType("DECISION_TABLE")
+        .hasDecisionOutput("null")
+        .satisfies(
+            evaluatedDecision -> {
+              assertThat(evaluatedDecision.getEvaluatedInputs()).hasSize(0);
+              assertThat(evaluatedDecision.getMatchedRules()).hasSize(0);
+            });
   }
 }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
@@ -57,6 +57,12 @@
             "elementInstanceKey": {
               "type": "long"
             },
+            "evaluationFailureMessage": {
+              "type": "keyword"
+            },
+            "failedDecisionId": {
+              "type": "keyword"
+            },
             "evaluatedDecisions": {
               "properties": {
                 "decisionId": {

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -820,7 +820,9 @@ final class JsonSerializableToJsonTest {
                       .setDecisionVersion(1)
                       .setProcessInstanceKey(4L)
                       .setElementInstanceKey(5L)
-                      .setElementId("element-id");
+                      .setElementId("element-id")
+                      .setEvaluationFailureMessage("evaluation-failure-message")
+                      .setFailedDecisionId("failed-decision-id");
 
               final var evaluatedDecisionRecord = record.evaluatedDecisions().add();
               evaluatedDecisionRecord
@@ -848,7 +850,30 @@ final class JsonSerializableToJsonTest {
 
               return record;
             },
-        "{'decisionKey':1,'decisionId':'decision-id','decisionName':'decision-name','decisionVersion':1,'decisionRequirementsKey':2,'decisionRequirementsId':'decision-requirements-id','decisionOutput':'\"decision-output\"','processDefinitionKey':3,'bpmnProcessId':'bpmn-process-id','processInstanceKey':4,'elementInstanceKey':5,'elementId':'element-id','evaluatedDecisions':[{'decisionId':'decision-id','decisionName':'decision-name','decisionOutput':'\"decision-output\"','decisionType':'DECISION_TABLE','evaluatedInputs':[{'inputId':'input-id','inputName':'input-name','inputValue':'\"input-value\"'}],'matchedRules':[{'ruleId':'rule-id','ruleIndex':1,'evaluatedOutputs':[{'outputId':'output-id','outputName':'output-name','outputValue':'\"output-value\"'}]}]}]}"
+        "{'decisionKey':1,'decisionId':'decision-id','decisionName':'decision-name','decisionVersion':1,'decisionRequirementsKey':2,'decisionRequirementsId':'decision-requirements-id','decisionOutput':'\"decision-output\"','processDefinitionKey':3,'bpmnProcessId':'bpmn-process-id','processInstanceKey':4,'elementInstanceKey':5,'elementId':'element-id','evaluatedDecisions':[{'decisionId':'decision-id','decisionName':'decision-name','decisionOutput':'\"decision-output\"','decisionType':'DECISION_TABLE','evaluatedInputs':[{'inputId':'input-id','inputName':'input-name','inputValue':'\"input-value\"'}],'matchedRules':[{'ruleId':'rule-id','ruleIndex':1,'evaluatedOutputs':[{'outputId':'output-id','outputName':'output-name','outputValue':'\"output-value\"'}]}]}],'evaluationFailureMessage':'evaluation-failure-message','failedDecisionId':'failed-decision-id'}"
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// Empty DecisionEvaluationRecord ////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty DecisionEvaluationRecord",
+        (Supplier<UnifiedRecordValue>)
+            () ->
+                new DecisionEvaluationRecord()
+                    .setDecisionKey(1L)
+                    .setDecisionId("decision-id")
+                    .setDecisionName("decision-name")
+                    .setDecisionVersion(1)
+                    .setDecisionRequirementsKey(2L)
+                    .setDecisionRequirementsId("decision-requirements-id")
+                    .setProcessDefinitionKey(3L)
+                    .setBpmnProcessId("bpmn-process-id")
+                    .setDecisionVersion(1)
+                    .setProcessInstanceKey(4L)
+                    .setElementInstanceKey(5L)
+                    .setElementId("element-id"),
+        "{'decisionKey':1,'decisionId':'decision-id','decisionName':'decision-name','decisionVersion':1,'decisionRequirementsKey':2,'decisionRequirementsId':'decision-requirements-id','decisionOutput':'null','processDefinitionKey':3,'bpmnProcessId':'bpmn-process-id','processInstanceKey':4,'elementInstanceKey':5,'elementId':'element-id','evaluatedDecisions':[],'evaluationFailureMessage':'','failedDecisionId':''}"
       },
     };
   }

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -932,8 +932,7 @@ final class JsonSerializableToJsonTest {
               "processInstanceKey":4,
               "elementInstanceKey":5,
               "elementId":"element-id",
-              "evaluatedDecisions":[
-              ],
+              "evaluatedDecisions":[],
               "evaluationFailureMessage":"",
               "failedDecisionId":""
           }

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -850,7 +850,52 @@ final class JsonSerializableToJsonTest {
 
               return record;
             },
-        "{'decisionKey':1,'decisionId':'decision-id','decisionName':'decision-name','decisionVersion':1,'decisionRequirementsKey':2,'decisionRequirementsId':'decision-requirements-id','decisionOutput':'\"decision-output\"','processDefinitionKey':3,'bpmnProcessId':'bpmn-process-id','processInstanceKey':4,'elementInstanceKey':5,'elementId':'element-id','evaluatedDecisions':[{'decisionId':'decision-id','decisionName':'decision-name','decisionOutput':'\"decision-output\"','decisionType':'DECISION_TABLE','evaluatedInputs':[{'inputId':'input-id','inputName':'input-name','inputValue':'\"input-value\"'}],'matchedRules':[{'ruleId':'rule-id','ruleIndex':1,'evaluatedOutputs':[{'outputId':'output-id','outputName':'output-name','outputValue':'\"output-value\"'}]}]}],'evaluationFailureMessage':'evaluation-failure-message','failedDecisionId':'failed-decision-id'}"
+        """
+          {
+              "decisionKey":1,
+              "decisionId":"decision-id",
+              "decisionName":"decision-name",
+              "decisionVersion":1,
+              "decisionRequirementsKey":2,
+              "decisionRequirementsId":"decision-requirements-id",
+              "decisionOutput":'"decision-output"',
+              "processDefinitionKey":3,
+              "bpmnProcessId":"bpmn-process-id",
+              "processInstanceKey":4,
+              "elementInstanceKey":5,
+              "elementId":"element-id",
+              "evaluatedDecisions":[
+                  {
+                      "decisionId":"decision-id",
+                      "decisionName":"decision-name",
+                      "decisionOutput":'"decision-output"',
+                      "decisionType":"DECISION_TABLE",
+                      "evaluatedInputs":[
+                          {
+                              "inputId":"input-id",
+                              "inputName":"input-name",
+                              "inputValue":'"input-value"'
+                          }
+                      ],
+                      "matchedRules":[
+                          {
+                              "ruleId":"rule-id",
+                              "ruleIndex":1,
+                              "evaluatedOutputs":[
+                                  {
+                                      "outputId":"output-id",
+                                      "outputName":"output-name",
+                                      "outputValue":'"output-value"'
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              ],
+              "evaluationFailureMessage":"evaluation-failure-message",
+              "failedDecisionId":"failed-decision-id"
+          }
+          """
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -873,7 +918,26 @@ final class JsonSerializableToJsonTest {
                     .setProcessInstanceKey(4L)
                     .setElementInstanceKey(5L)
                     .setElementId("element-id"),
-        "{'decisionKey':1,'decisionId':'decision-id','decisionName':'decision-name','decisionVersion':1,'decisionRequirementsKey':2,'decisionRequirementsId':'decision-requirements-id','decisionOutput':'null','processDefinitionKey':3,'bpmnProcessId':'bpmn-process-id','processInstanceKey':4,'elementInstanceKey':5,'elementId':'element-id','evaluatedDecisions':[],'evaluationFailureMessage':'','failedDecisionId':''}"
+        """
+          {
+              "decisionKey":1,
+              "decisionId":"decision-id",
+              "decisionName":"decision-name",
+              "decisionVersion":1,
+              "decisionRequirementsKey":2,
+              "decisionRequirementsId":"decision-requirements-id",
+              "decisionOutput":"null",
+              "processDefinitionKey":3,
+              "bpmnProcessId":"bpmn-process-id",
+              "processInstanceKey":4,
+              "elementInstanceKey":5,
+              "elementId":"element-id",
+              "evaluatedDecisions":[
+              ],
+              "evaluationFailureMessage":"",
+              "failedDecisionId":""
+          }
+          """
       },
     };
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionEvaluationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionEvaluationIntent.java
@@ -16,7 +16,8 @@
 package io.camunda.zeebe.protocol.record.intent;
 
 public enum DecisionEvaluationIntent implements Intent {
-  EVALUATED(0);
+  EVALUATED(0),
+  FAILED(1);
 
   private final short value;
 
@@ -32,6 +33,8 @@ public enum DecisionEvaluationIntent implements Intent {
     switch (value) {
       case 0:
         return EVALUATED;
+      case 1:
+        return FAILED;
       default:
         return UNKNOWN;
     }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DecisionEvaluationRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DecisionEvaluationRecordValue.java
@@ -64,4 +64,25 @@ public interface DecisionEvaluationRecordValue extends RecordValue {
    * @return details of the evaluated decisions
    */
   List<EvaluatedDecisionValue> getEvaluatedDecisions();
+
+  /**
+   * If the evaluation of the decision failed then it returns the reason why the evaluation of the
+   * {@link #getFailedDecisionId() failed decision} was not successful. The failure message is not
+   * available if the decision was evaluated successfully.
+   *
+   * @return the failure message why the evaluation failed, or an empty string if the evaluation was
+   *     successful
+   */
+  String getEvaluationFailureMessage();
+
+  /**
+   * If the evaluation of the decision failed then it returns the id of the decision where the
+   * evaluation failed. It can be the called/root decision or any of its required decisions. The
+   * reason of the failure can be retrieved as {@link #getEvaluationFailureMessage() evaluation
+   * failure message}. The decision id is not available if the decision was evaluated successfully.
+   *
+   * @return the id of the decision in the DMN where the evaluation failed, or an empty string if
+   *     the evaluation was successful
+   */
+  String getFailedDecisionId();
 }


### PR DESCRIPTION
## Description

* add new intent `FAILED` for decision evaluations that are not successful
* extend the decision evaluation record to expose `evaluationFailure` and `failedDecisionId` for failed decisions 
* write a decision evaluation event if the evaluation of the decision failed
* adjust the ES template

## Related issues

closes #8235 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
