### PR TITLE
Business rule task can define decisionId as expression

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -60,7 +60,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             zeebeState,
             eventTriggerBehavior,
             stateWriter,
-            zeebeState.getKeyGenerator());
+            zeebeState.getKeyGenerator(),
+            expressionBehavior);
 
     stateBehavior = new BpmnStateBehavior(zeebeState, variableBehavior);
     stateTransitionGuard = new ProcessInstanceStateTransitionGuard(stateBehavior);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -76,8 +76,9 @@ public final class BpmnDecisionBehavior {
       final ExecutableCalledDecision element, final BpmnElementContext context) {
     final var scopeKey = context.getElementInstanceKey();
 
+    final var decisionId = element.getDecisionId();
     // todo(#8571): avoid parsing drg every time
-    final var decisionOrFailure = findDecisionById(element.getDecisionId());
+    final var decisionOrFailure = findDecisionById(decisionId);
     final var resultOrFailure =
         decisionOrFailure
             .flatMap(this::findDrgByDecision)
@@ -85,11 +86,11 @@ public final class BpmnDecisionBehavior {
                 failure ->
                     new Failure(
                         "Expected to evaluate decision '%s', but %s"
-                            .formatted(element.getDecisionId(), failure.getMessage())))
+                            .formatted(decisionId, failure.getMessage())))
             .flatMap(drg -> parseDrg(drg.getResource()))
             // all the above failures have the same error type and the correct scope
             .mapLeft(f -> new Failure(f.getMessage(), ErrorType.CALLED_DECISION_ERROR, scopeKey))
-            .flatMap(drg -> evaluateDecisionInDrg(drg, element.getDecisionId(), scopeKey));
+            .flatMap(drg -> evaluateDecisionInDrg(drg, decisionId, scopeKey));
 
     resultOrFailure.ifRight(
         result -> {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -76,7 +76,7 @@ public final class BpmnDecisionBehavior {
       final ExecutableCalledDecision element, final BpmnElementContext context) {
     final var scopeKey = context.getElementInstanceKey();
 
-    final var decisionId = element.getDecisionId();
+    final var decisionId = element.getDecisionId().getExpression();
     // todo(#8571): avoid parsing drg every time
     final var decisionOrFailure = findDecisionById(decisionId);
     final var resultOrFailure =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableBusinessRuleTask.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableBusinessRuleTask.java
@@ -7,10 +7,12 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
+import io.camunda.zeebe.el.Expression;
+
 public final class ExecutableBusinessRuleTask extends ExecutableJobWorkerTask
     implements ExecutableCalledDecision {
 
-  private String decisionId;
+  private Expression decisionId;
   private String resultVariable;
 
   public ExecutableBusinessRuleTask(final String id) {
@@ -18,12 +20,12 @@ public final class ExecutableBusinessRuleTask extends ExecutableJobWorkerTask
   }
 
   @Override
-  public String getDecisionId() {
+  public Expression getDecisionId() {
     return decisionId;
   }
 
   @Override
-  public void setDecisionId(final String decisionId) {
+  public void setDecisionId(final Expression decisionId) {
     this.decisionId = decisionId;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCalledDecision.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCalledDecision.java
@@ -7,12 +7,14 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
+import io.camunda.zeebe.el.Expression;
+
 /** A representation of an element that calls a decision. For example, a business rule task. */
 public interface ExecutableCalledDecision {
 
-  String getDecisionId();
+  Expression getDecisionId();
 
-  void setDecisionId(String decisionId);
+  void setDecisionId(Expression decisionId);
 
   String getResultVariable();
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/BusinessRuleTaskTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/BusinessRuleTaskTransformer.java
@@ -47,6 +47,6 @@ public final class BusinessRuleTaskTransformer
     taskHeadersTransformer.transform(executableTask, taskHeaders, element);
 
     final var calledDecision = element.getSingleExtensionElement(ZeebeCalledDecision.class);
-    calledDecisionTransformer.transform(executableTask, calledDecision);
+    calledDecisionTransformer.transform(executableTask, context, calledDecision);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/CalledDecisionTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/CalledDecisionTransformer.java
@@ -8,19 +8,25 @@
 package io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe;
 
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCalledDecision;
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 
 public final class CalledDecisionTransformer {
 
   public void transform(
-      final ExecutableCalledDecision executableElement, final ZeebeCalledDecision calledDecision) {
+      final ExecutableCalledDecision executableElement,
+      final TransformContext context,
+      final ZeebeCalledDecision calledDecision) {
 
     if (calledDecision == null) {
       return;
     }
 
-    final var decisionId = calledDecision.getDecisionId();
-    executableElement.setDecisionId(decisionId);
+    final var expressionLanguage = context.getExpressionLanguage();
+
+    final var decisionIdExpression =
+        expressionLanguage.parseExpression(calledDecision.getDecisionId());
+    executableElement.setDecisionId(decisionIdExpression);
 
     final var resultVariable = calledDecision.getResultVariable();
     executableElement.setResultVariable(resultVariable);


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
A business rule task with a called decision needs to specify a decisionId for the decision that is called. It should be possible to refer to a decision based on the evaluation result of an expression. So, it should be possible to define the decisionId as an expression. See #8779.

This adds support to define the `decisionId` of a `zeebe:calledDecision` as an expression (i.e. prefixed with `=`; e.g. `= variableContainingDecisionId`), while maintaining the ability to define it as a static value (i.e. not prefixed by `=`; e.g. `an_actual_decision_id`). For example, if the `decisionId` is an expression `= variableContainingDecisionId`, then the value of the `variableContainingDecisionId` variable should be used as the id of the decision that is called.

The `decisionId` expression is evaluated during the activation of the business rule task, just after input mapping and just before the decision is evaluated. This means you can use the result of input mappings in the `decisionId` expression.

If the evaluation fails, an incident of type `EXTRACT_VALUE_ERROR` is raised, similar to other expression evaluation failures. Resolving the incident will re-apply input mappings, re-evaluate the `decisionId` expression and then call the decision.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8779

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
