### PR TITLE
POC for using `gcloudSaveTmpFile` as alternative to Jenkins stash

### DIFF
--- a/.ci/podSpecs/distribution-template.yml
+++ b/.ci/podSpecs/distribution-template.yml
@@ -93,6 +93,10 @@ spec:
         requests:
           cpu: 4
           memory: 8Gi
+    - name: python
+      image: python:3.10
+      command: [ "cat" ]
+      tty: true
   volumes:
     - name: docker-storage
       emptyDir: { }

--- a/.ci/podSpecs/integration-test-template.yml
+++ b/.ci/podSpecs/integration-test-template.yml
@@ -63,6 +63,10 @@ spec:
         requests:
           cpu: 18
           memory: 60Gi
+    - name: python
+      image: python:3.10
+      command: [ "cat" ]
+      tty: true
   volumes:
     - name: docker-storage
       emptyDir: { }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,8 +103,13 @@ pipeline {
                     // to simplify building the Docker image, we copy the distribution to a fixed
                     // filename that doesn't include the version
                     runMavenContainerCommand('cp dist/target/camunda-cloud-zeebe-*.tar.gz camunda-cloud-zeebe.tar.gz')
-                    stash name: "zeebe-build", includes: "m2-repository/io/camunda/*/${VERSION}/*"
-                    stash name: "zeebe-distro", includes: "camunda-cloud-zeebe.tar.gz"
+
+                    container('maven') {
+                        gcloudSaveTmpFile('zeebe-distro', ['camunda-cloud-zeebe.tar.gz'])
+
+                        sh "tar -cf zeebe-build.tar ./m2-repository/io/camunda/*/${VERSION}/*"
+                        gcloudSaveTmpFile('zeebe-build', ['zeebe-build.tar'])
+                    }
                 }
             }
         }
@@ -250,7 +255,10 @@ pipeline {
                                 timeout(time: shortTimeoutMinutes, unit: 'MINUTES') {
                                     prepareMavenContainer()
 
-                                    unstash name: "zeebe-build"
+                                    container('maven') {
+                                        gcloudRestoreTmpFile('zeebe-build', ['zeebe-build.tar'])
+                                        sh "tar -xf zeebe-build.tar"
+                                    }
                                     runMavenContainerCommand('.ci/scripts/distribution/it-prepare.sh')
                                 }
                             }
@@ -265,7 +273,9 @@ pipeline {
 
                             steps {
                                 timeout(time: shortTimeoutMinutes, unit: 'MINUTES') {
-                                    unstash name: "zeebe-distro"
+                                    container('maven') {
+                                        gcloudRestoreTmpFile('zeebe-distro', ['camunda-cloud-zeebe.tar.gz'])
+                                    }
                                     container('docker') {
                                         sh '.ci/scripts/docker/build.sh'
                                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,7 +104,7 @@ pipeline {
                     // filename that doesn't include the version
                     runMavenContainerCommand('cp dist/target/camunda-cloud-zeebe-*.tar.gz camunda-cloud-zeebe.tar.gz')
 
-                    container('maven') {
+                    container('python') {
                         gcloudSaveTmpFile('zeebe-distro', ['camunda-cloud-zeebe.tar.gz'])
 
                         sh "tar -cf zeebe-build.tar ./m2-repository/io/camunda/*/${VERSION}/*"
@@ -255,7 +255,7 @@ pipeline {
                                 timeout(time: shortTimeoutMinutes, unit: 'MINUTES') {
                                     prepareMavenContainer()
 
-                                    container('maven') {
+                                    container('python') {
                                         gcloudRestoreTmpFile('zeebe-build', ['zeebe-build.tar'])
                                         sh "tar -xf zeebe-build.tar"
                                     }
@@ -273,7 +273,7 @@ pipeline {
 
                             steps {
                                 timeout(time: shortTimeoutMinutes, unit: 'MINUTES') {
-                                    container('maven') {
+                                    container('python') {
                                         gcloudRestoreTmpFile('zeebe-distro', ['camunda-cloud-zeebe.tar.gz'])
                                     }
                                     container('docker') {


### PR DESCRIPTION
## Description

As part of https://jira.camunda.com/browse/INFRA-3024 I'm working on providing an alternative to Jenkins [stash/unstash](https://www.jenkins.io/doc/pipeline/steps/workflow-basic-steps/#stash-stash-some-files-to-be-used-later-in-the-build) that:
- performs with a more consistent and hopefully shorter execution time
  - Nicolas told me that `stash` can take 30-60s and more depending on how busy the Jenkins master is with activity, as all stashed files get sent there and stored it is a single point of access
- does that for singular large files (100 MiB and more)
  - no direct support of archiving multiple files with exclude expressions due to implementation + maintenance effort for Infra team, usually a `tar` command in the pipeline can achieve the same

This PR is a POC showing how to adapt the main Zeebe pipeline to use the new API of `gcloudSaveTmpFile` and `gcloudRestoreTmpFile` successfully in `dev` environment: https://dev.ci.zeebe.camunda.cloud/job/camunda-cloud/job/zeebe/job/INFRA-3024/ (builds fail at a later stage due to missing secrets in `dev` env)

### But is it faster?

Yes, comparing the `main` branch with [this POC](https://dev.ci.zeebe.camunda.cloud/job/camunda-cloud/job/zeebe/job/INFRA-3024/28/):
- the [zeebe-distro stashing](https://github.com/camunda-cloud/zeebe/blob/b6ed008bb252ccb5a1ec995bf0245bc2a51f7b67/Jenkinsfile#L107) takes around 8 seconds on `main` and 8s in POC (incl one-time overhead)
- the [zeebe-build stashing](https://github.com/camunda-cloud/zeebe/blob/b6ed008bb252ccb5a1ec995bf0245bc2a51f7b67/Jenkinsfile#L106) takes around 17 seconds on `main` and 4s in POC
- the [zeebe-build un-stashing](https://github.com/camunda-cloud/zeebe/blob/b6ed008bb252ccb5a1ec995bf0245bc2a51f7b67/Jenkinsfile#L253) takes around 10 seconds on `main` and 10s in POC (incl one-time overhead)
- the [zeebe-distro un-stashing](https://github.com/camunda-cloud/zeebe/blob/b6ed008bb252ccb5a1ec995bf0245bc2a51f7b67/Jenkinsfile#L268) takes around 5 seconds on `main` and 3s in POC

What does `(incl one-time overhead)` mean and why are the gains sometimes smaller than other times?
On the first usage of `gcloudSaveTmpFile` or `gcloudRestoreTmpFile` in a new agent we need to download the GCloud SDK which takes 6s. This could be optimized further by using a Docker image/podTemplate that already includes the SDK, but was too much effort for a POC which is _still faster_ than `main` already!

Another benefit will probably manifest when more than one branch use `gcloudSaveTmpFile` as Google Cloud Storage will scale better than all agents accessing the Jenkins master thus leading to more _consistent_ execution times.

## Related issues

Related to INFRA-3024