### PR TITLE
Add javadoc to toJson() method

### DIFF
--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ArrayValue.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ArrayValue.java
@@ -111,6 +111,13 @@ public final class ArrayValue<T extends BaseValue> extends BaseValue
     return MsgPackWriter.getEncodedArrayHeaderLenght(elementCount) + bufferLength;
   }
 
+  /**
+   * Please be aware that iterating over an {@link ArrayValue} is not thread-safe. Iterating over
+   * this will modify the buffer. Multiple threads iterating over the same object will result in
+   * exceptions!
+   *
+   * @return an iterator for this object
+   */
   @Override
   public Iterator<T> iterator() {
     flushAndResetInnerValue();
@@ -126,6 +133,13 @@ public final class ArrayValue<T extends BaseValue> extends BaseValue
     return cursorIndex < elementCount;
   }
 
+  /**
+   * Please be aware that iterating over an {@link ArrayValue} is not thread-safe. Iterating over
+   * this will modify the buffer. Multiple threads iterating over the same object will result in
+   * exceptions!
+   *
+   * @return the next element
+   */
   @Override
   public T next() {
     if (!hasNext()) {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
@@ -170,6 +170,13 @@ public final class MsgPackConverter {
     }
   }
 
+  /**
+   * Please be aware that this method may not thread-safe depending on the object that gets
+   * serialized.
+   *
+   * @param recordValue the object to be serialized
+   * @return a JSON marshaled representation
+   */
   public static String convertJsonSerializableObjectToJson(final JsonSerializable recordValue) {
     try {
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
@@ -146,6 +146,14 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     return recordValue;
   }
 
+  /**
+   * Please be aware that this method is not thread-safe. Some records contain properties that will
+   * get modified when iterating over it (eg. Records containing an
+   * {@link io.camunda.zeebe.msgpack.property.ArrayProperty).
+   * Multiple threads serializing the same Record at a time will result in exceptions.
+   *
+   * @return a JSON marshaled representation
+   */
   @Override
   public String toJson() {
     return MsgPackConverter.convertJsonSerializableObjectToJson(this);


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The toJson() method of CopiedRecord is not thread-safe. This is unexpected behaviour which is not documented properly. To warn others and hopefully save some time debugging in the future I have added some javadoc to this method.

## Related issues

<!-- Which issues are closed by this PR or are related -->

N/A

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
