### PR TITLE
Deploy flattened POMs and reduce BOM to "public" modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ work/
 public/
 tngp-data
 
+.flattened-pom.xml
+
 hs_err*.log
 /data/
 /metrics/

--- a/bom/README.md
+++ b/bom/README.md
@@ -1,8 +1,17 @@
 # Zeebe BOM
 
-Contains versions for all Zeebe modules. It can be imported using maven by
-adding the following dependency to the `dependencyManagement` section of your
-pom.
+The Bill of Materials (BOM) is the recommended way for third-party projects to import Zeebe
+dependencies. It bundles dependencies that we consider consumable.
+
+These dependencies receive special attention from the team when it comes to backwards compatibility.
+The team will try to maintain backwards compatibility for these libraries, but this does not mean
+that we guarantee it. For our official backwards compatibility guarantees, please refer to the
+[Public API documentation](https://docs.camunda.io/docs/apis-clients/public-api/).
+
+## Usage
+
+The BOM can be imported using maven by adding the following dependency to the `dependencyManagement`
+section of your pom.
 
 ```xml
 <dependencyManagement>
@@ -16,5 +25,19 @@ pom.
       </dependency>
     </dependencies>
 </dependencyManagement>
+```
+
+Once imported, you can easily add the dependencies you need to the `dependencies` section of your pom.
+
+For example, you can use it to import the
+[Zeebe Java Client](https://docs.camunda.io/docs/apis-clients/java-client/).
+
+```xml
+<dependencies>
+  <dependency>
+    <groupId>io.camunda</groupId>
+    <artifactId>zeebe-client-java</artifactId>
+  </dependency>
+</dependencies>
 ```
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -31,6 +31,7 @@
     <nexus.release.repository>https://app.camunda.com/nexus/content/repositories/zeebe-io/</nexus.release.repository>
     <nexus.sonatype.url>https://s01.oss.sonatype.org</nexus.sonatype.url>
 
+    <plugin.version.flatten>1.2.2</plugin.version.flatten>
     <plugin.version.javadoc>3.3.2</plugin.version.javadoc>
   </properties>
 
@@ -257,6 +258,30 @@
       <url>https://app.camunda.com/nexus/content/repositories/zeebe-io-snapshots/</url>
     </repository>
   </repositories>
+
+  <build>
+
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>${plugin.version.flatten}</version>
+        <configuration combine.children="append">
+          <flattenMode>bom</flattenMode>
+          <outputDirectory>${project.build.directory}</outputDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
   <profiles>
     <profile>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -39,7 +39,7 @@
     <dependencies>
       <dependency>
         <groupId>io.camunda</groupId>
-        <artifactId>zeebe-broker</artifactId>
+        <artifactId>zeebe-bpmn-model</artifactId>
         <version>${project.version}</version>
       </dependency>
 
@@ -51,97 +51,7 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
-        <artifactId>zeebe-protocol-test-util</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-bpmn-model</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-dispatcher</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-logstreams</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-workflow-engine</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-msgpack-core</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-msgpack-value</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-protocol</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-protocol-impl</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-protocol-jackson</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-transport</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-test-util</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-util</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-db</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-build-tools</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-gateway-protocol</artifactId>
+        <artifactId>zeebe-exporter-api</artifactId>
         <version>${project.version}</version>
       </dependency>
 
@@ -153,83 +63,9 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
-        <artifactId>zeebe-gateway</artifactId>
+        <artifactId>zeebe-protocol</artifactId>
         <version>${project.version}</version>
       </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-exporter-api</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-elasticsearch-exporter</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-protocol-asserts</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-expression-language</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-feel-integration</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-snapshots</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-journal</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-dmn</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <!-- ATOMIX -->
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-atomix-cluster</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-atomix-storage</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-atomix-utils</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-atomix</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -104,7 +104,15 @@
         <version>${plugin.version.flatten}</version>
         <configuration combine.children="append">
           <flattenMode>bom</flattenMode>
-          <outputDirectory>${project.build.directory}</outputDirectory>
+          <!--
+            do not change the outputDirectory; it must remain the same one as the relative project
+            directory, as many plugins expect to resolve the project directory from the current POM
+            file's parent, and any plugin which would run post flatten would resolve the project
+            directory to the wrong one. For example, if you configure it to
+            ${project.build.directory}, then any plugin after will think that the project's
+            directory is not /parent/ but /parent/target, which may affect the execution of plugins
+            (e.g. resource file resolution)
+            -->
         </configuration>
         <executions>
           <execution>
@@ -112,6 +120,13 @@
             <phase>process-resources</phase>
             <goals>
               <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
             </goals>
           </execution>
         </executions>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -10,20 +10,28 @@
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath />
   </parent>
+
   <groupId>io.camunda</groupId>
   <artifactId>zeebe-bom</artifactId>
   <version>1.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
+
   <name>Zeebe BOM</name>
+  <description/>
   <url>http://zeebe.io/</url>
   <inceptionYear>2017</inceptionYear>
 
   <scm>
-    <connection>scm:git:git@github.com:zeebe-io/zeebe.git</connection>
-    <developerConnection>scm:git:git@github.com:zeebe-io/zeebe.git</developerConnection>
+    <connection>scm:git:git@github.com:camunda-cloud/zeebe.git</connection>
+    <developerConnection>scm:git:git@github.com:camunda-cloud/zeebe.git</developerConnection>
     <tag>HEAD</tag>
-    <url>https://github.com/zeebe-io/zeebe</url>
+    <url>https://github.com/camunda-cloud/zeebe</url>
   </scm>
+
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/camunda-cloud/zeebe/issues</url>
+  </issueManagement>
 
   <properties>
     <!-- release parent settings -->

--- a/expression-language/pom.xml
+++ b/expression-language/pom.xml
@@ -16,10 +16,6 @@
   <properties>
     <!-- do we still need to skip JavaDoc generation? -->
     <maven.javadoc.skip>true</maven.javadoc.skip>
-
-    <!-- ignore Spotbugs failures related to Scala classes -->
-    <spotbugs.exclude>${basedir}/spotbugs/spotbugs-exclude.xml</spotbugs.exclude>
-
   </properties>
 
   <dependencies>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1394,6 +1394,14 @@
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <configuration>
+          <flattenMode>ossrh</flattenMode>
+        </configuration>
+      </plugin>
     </plugins>
     <extensions>
       <extension>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -179,6 +179,171 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Internal Zeebe modules -->
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-broker</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-protocol-test-util</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-dispatcher</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-logstreams</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-workflow-engine</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-msgpack-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-msgpack-value</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-protocol-impl</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-protocol-jackson</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-transport</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-test-util</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-util</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-db</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-build-tools</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-gateway-protocol</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-gateway</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-elasticsearch-exporter</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-protocol-asserts</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-expression-language</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-feel-integration</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-snapshots</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-journal</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-dmn</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <!-- ATOMIX -->
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-atomix-cluster</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-atomix-storage</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-atomix-utils</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-atomix</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <!-- Third party dependencies -->
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>


### PR DESCRIPTION
## Description

This PR introduces the `flatten-maven-plugin`, which will flatten any hierarchy in a module's POM before it's deployed somewhere. The original POM will remain intact. The goal here is to simplify the integration of the modules in other people's projects, by making it more explicit which dependencies are pulled by the module, and which version they should be.

Additionally, the BOM is now reduced to only including these modules which were tailor explicitly to be consumed by third party projects. The goal with that is to make it explicit to users which modules they can safely rely on in their projects, and all the rest, so called internal modules, which may be renamed, changed, dropped, etc., and are only expected to be used in Zeebe. Note that they can still be imported in third party projects, but that is then at the user's risks.

## Related issues

closes #8716 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
