### PR TITLE
fix: notify new `SnapshotReplicationListener`s about missed replications

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/SnapshotReplicationListenerTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/SnapshotReplicationListenerTest.java
@@ -17,7 +17,6 @@ package io.atomix.raft;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
@@ -68,8 +67,7 @@ public class SnapshotReplicationListenerTest {
     final var follower = raftRule.getFollower().orElseThrow();
     // then
     follower.getContext().notifySnapshotReplicationStarted();
-    verify(snapshotReplicationListener, never()).onSnapshotReplicationStarted();
     follower.getContext().addSnapshotReplicationListener(snapshotReplicationListener);
-    verify(snapshotReplicationListener).onSnapshotReplicationStarted();
+    verify(snapshotReplicationListener, timeout(1_000).times(1)).onSnapshotReplicationStarted();
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/SnapshotReplicationListenerTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/SnapshotReplicationListenerTest.java
@@ -17,6 +17,7 @@ package io.atomix.raft;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
@@ -58,5 +59,17 @@ public class SnapshotReplicationListenerTest {
     verify(snapshotReplicationListener, timeout(1_000).times(1)).onSnapshotReplicationStarted();
     verify(snapshotReplicationListener, timeout(1_000).times(1))
         .onSnapshotReplicationCompleted(follower.getTerm());
+  }
+
+  @Test
+  public void shouldNotifyOnRegisteringListener() {
+    // given
+    final var snapshotReplicationListener = mock(SnapshotReplicationListener.class);
+    final var follower = raftRule.getFollower().orElseThrow();
+    // then
+    follower.getContext().notifySnapshotReplicationStarted();
+    verify(snapshotReplicationListener, never()).onSnapshotReplicationStarted();
+    follower.getContext().addSnapshotReplicationListener(snapshotReplicationListener);
+    verify(snapshotReplicationListener).onSnapshotReplicationStarted();
   }
 }


### PR DESCRIPTION
## Description
We are using `SnapshotReplicationListener`s to transition to inactive when a snapshot replication starts. Snapshot replication can start before any listeners have registered, which means that the listener will only be notified about snapshot replication finishing, triggering a transition to follower without first transitioning to inactive.

This PR introduces a new flag in the `RaftContext` to keep track of ongoing snapshot replications so that newly registered listeners can be notified about immediately. 

## Related issues

closes #8830