### PR TITLE
Add dmn properties to protocol-jackson DeploymentRecord

### DIFF
--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractDeploymentRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractDeploymentRecordValue.java
@@ -8,10 +8,14 @@
 package io.camunda.zeebe.protocol.jackson.record;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.DecisionRecordValueBuilder.ImmutableDecisionRecordValue;
+import io.camunda.zeebe.protocol.jackson.record.DecisionRequirementsRecordValueBuilder.ImmutableDecisionRequirementsRecordValue;
 import io.camunda.zeebe.protocol.jackson.record.DeploymentRecordValueBuilder.ImmutableDeploymentRecordValue;
 import io.camunda.zeebe.protocol.jackson.record.DeploymentResourceBuilder.ImmutableDeploymentResource;
 import io.camunda.zeebe.protocol.jackson.record.ProcessMetadataValueBuilder.ImmutableProcessMetadataValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import java.util.List;
@@ -29,4 +33,12 @@ public abstract class AbstractDeploymentRecordValue
   @JsonDeserialize(contentAs = ImmutableProcessMetadataValue.class)
   @Override
   public abstract List<ProcessMetadataValue> getProcessesMetadata();
+
+  @JsonDeserialize(contentAs = ImmutableDecisionRecordValue.class)
+  @Override
+  public abstract List<DecisionRecordValue> getDecisionsMetadata();
+
+  @JsonDeserialize(contentAs = ImmutableDecisionRequirementsRecordValue.class)
+  @Override
+  public abstract List<DecisionRequirementsMetadataValue> getDecisionRequirementsMetadata();
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
With the addition of DMN properties to DeploymentRecords, these properties should also be added to the AbstractDeploymentRecordValue of protocol-jackson. Without this the mapping will break, as it does not know what to do when mapping DeploymentRecords.

## Related issues

<!-- Which issues are closed by this PR or are related -->

N/A

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
