### PR TITLE
Add decision element metrics

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
@@ -13,13 +13,27 @@ import io.prometheus.client.Counter;
 
 public final class ProcessEngineMetrics {
 
+  static final Counter EXECUTED_INSTANCES =
+      Counter.build()
+          .namespace("zeebe")
+          .name("executed_instances_total")
+          .help("Number of executed instances")
+          .labelNames("organizationId", "type", "action", "partition")
+          .register();
+  static final Counter EVALUATED_DMN_ELEMENTS =
+      Counter.build()
+          .namespace("zeebe")
+          .name("evaluated_dmn_elements_total")
+          .help("Number of evaluated DMN elements including required decisions")
+          .labelNames("organizationId", "action", "partition")
+          .register();
   private static final String ORGANIZATION_ID =
       System.getenv().getOrDefault("CAMUNDA_CLOUD_ORGANIZATION_ID", "null");
-
   private static final String ACTION_ACTIVATED = "activated";
   private static final String ACTION_COMPLETED = "completed";
   private static final String ACTION_TERMINATED = "terminated";
-
+  private static final String ACTION_EVALUATED_SUCCESSFULLY = "evaluated_successfully";
+  private static final String ACTION_EVALUATED_FAILED = "evaluated_failed";
   private static final Counter ELEMENT_INSTANCE_EVENTS =
       Counter.build()
           .namespace("zeebe")
@@ -27,15 +41,6 @@ public final class ProcessEngineMetrics {
           .help("Number of process element instance events")
           .labelNames("action", "type", "partition")
           .register();
-
-  private static final Counter EXECUTED_INSTANCES =
-      Counter.build()
-          .namespace("zeebe")
-          .name("executed_instances_total")
-          .help("Number of executed instances")
-          .labelNames("organizationId", "type", "action", "partition")
-          .register();
-
   private final String partitionIdLabel;
 
   public ProcessEngineMetrics(final int partitionId) {
@@ -86,5 +91,17 @@ public final class ProcessEngineMetrics {
   private boolean isRootProcessInstance(
       final BpmnElementType elementType, final long parentProcessInstanceKey) {
     return isProcessInstance(elementType) && parentProcessInstanceKey == -1;
+  }
+
+  public void increaseSuccessfullyEvaluatedDmnElements(final int amount) {
+    increaseEvaluatedDmnElements(ACTION_EVALUATED_SUCCESSFULLY, amount);
+  }
+
+  public void increaseFailedEvaluatedDmnElements(final int amount) {
+    increaseEvaluatedDmnElements(ACTION_EVALUATED_FAILED, amount);
+  }
+
+  private void increaseEvaluatedDmnElements(final String action, final int amount) {
+    EVALUATED_DMN_ELEMENTS.labels(ORGANIZATION_ID, action, partitionIdLabel).inc(amount);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -54,6 +54,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
     final StateWriter stateWriter = writers.state();
     final var commandWriter = writers.command();
     this.expressionBehavior = expressionBehavior;
+    final var metrics = new ProcessEngineMetrics(zeebeState.getPartitionId());
+
     decisionBehavior =
         new BpmnDecisionBehavior(
             DecisionEngineFactory.createDecisionEngine(),
@@ -61,7 +63,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             eventTriggerBehavior,
             stateWriter,
             zeebeState.getKeyGenerator(),
-            expressionBehavior);
+            expressionBehavior,
+            metrics);
 
     stateBehavior = new BpmnStateBehavior(zeebeState, variableBehavior);
     stateTransitionGuard = new ProcessInstanceStateTransitionGuard(stateBehavior);
@@ -71,7 +74,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
         new BpmnStateTransitionBehavior(
             zeebeState.getKeyGenerator(),
             stateBehavior,
-            new ProcessEngineMetrics(zeebeState.getPartitionId()),
+            metrics,
             processorLookup,
             writers,
             zeebeState.getElementInstanceState());

--- a/engine/src/test/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetricsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetricsTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.prometheus.client.CollectorRegistry;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class ProcessEngineMetricsTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String DMN_RESOURCE = "/dmn/drg-force-user.dmn";
+  private static final String PROCESS_ID = "process";
+  private static final String TASK_ID = "task";
+
+  @Before
+  public void resetMetrics() {
+    ProcessEngineMetrics.EVALUATED_DMN_ELEMENTS.clear();
+    ProcessEngineMetrics.EXECUTED_INSTANCES.clear();
+  }
+
+  @Test
+  public void shouldIncreaseSuccessfullyEvaluatedDmnElements() {
+    ENGINE
+        .deployment()
+        .withXmlClasspathResource(DMN_RESOURCE)
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .businessRuleTask(
+                    TASK_ID,
+                    t -> t.zeebeCalledDecisionId("force_user").zeebeResultVariable("result"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariables(Map.of("lightsaberColor", "blue", "height", 175))
+            .create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    assertThat(activatedProcessInstanceMetric()).isNotNull().isEqualTo(1);
+
+    assertThat(completedProcessInstanceMetric()).isNotNull().isEqualTo(1);
+
+    assertThat(succeededEvaluatedDmnElementsMetric())
+        .isNotNull()
+        .describedAs(
+            "Expected two decision where executed, i.e. the root decision and one required decision")
+        .isEqualTo(2);
+  }
+
+  @Test
+  public void shouldIncreaseFailedEvaluatedDmnElements() {
+    ENGINE
+        .deployment()
+        .withXmlClasspathResource(DMN_RESOURCE)
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .businessRuleTask(
+                    TASK_ID,
+                    t -> t.zeebeCalledDecisionId("force_user").zeebeResultVariable("result"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("lightsaberColor", "blue")
+            .create();
+
+    RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    assertThat(activatedProcessInstanceMetric()).isNotNull().isEqualTo(1);
+
+    assertThat(terminatedProcessInstanceMetric()).isNotNull().isEqualTo(1);
+
+    assertThat(failedEvaluatedDmnElementsMetric())
+        .isNotNull()
+        .describedAs(
+            "Expected two decision where executed as the required decision succeeded but the root decision failed")
+        .isEqualTo(2);
+  }
+
+  @Test
+  public void shouldIncreaseFailedEvaluatedDmnElementsIfRequiredDecisionFailed() {
+    ENGINE
+        .deployment()
+        .withXmlClasspathResource(DMN_RESOURCE)
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .businessRuleTask(
+                    TASK_ID,
+                    t -> t.zeebeCalledDecisionId("force_user").zeebeResultVariable("result"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    assertThat(failedEvaluatedDmnElementsMetric())
+        .isNotNull()
+        .describedAs("Expected only one decision was executed as the required decision failed")
+        .isEqualTo(1);
+  }
+
+  private Double activatedProcessInstanceMetric() {
+    return executedProcessInstanceMetric("activated");
+  }
+
+  private Double completedProcessInstanceMetric() {
+    return executedProcessInstanceMetric("completed");
+  }
+
+  private Double terminatedProcessInstanceMetric() {
+    return executedProcessInstanceMetric("terminated");
+  }
+
+  private Double executedProcessInstanceMetric(final String action) {
+    return metricValue(
+        "zeebe_executed_instances_total",
+        entry("organizationId", "null"),
+        entry("type", "ROOT_PROCESS_INSTANCE"),
+        entry("action", action),
+        entry("partition", "1"));
+  }
+
+  private Double succeededEvaluatedDmnElementsMetric() {
+    return evaluatedDmnElementsMetric("evaluated_successfully");
+  }
+
+  private Double failedEvaluatedDmnElementsMetric() {
+    return evaluatedDmnElementsMetric("evaluated_failed");
+  }
+
+  private Double evaluatedDmnElementsMetric(final String action) {
+    return metricValue(
+        "zeebe_evaluated_dmn_elements_total",
+        entry("organizationId", "null"),
+        entry("action", action),
+        entry("partition", "1"));
+  }
+
+  @SafeVarargs
+  private Double metricValue(final String name, final Entry<String, String>... labels) {
+    final List<String> labelNames = Arrays.stream(labels).map(Entry::getKey).toList();
+    final List<String> labelValues = Arrays.stream(labels).map(Entry::getValue).toList();
+    return CollectorRegistry.defaultRegistry.getSampleValue(
+        name, labelNames.toArray(new String[] {}), labelValues.toArray(new String[] {}));
+  }
+}


### PR DESCRIPTION
## Description

Adds new Prometheus metric to track successfully and failed evaluated DMN element.

Metric Name: `zeebe_evaluated_dmn_elements_total`
Metric Labels:
- `organizationId`
- `action`: `evaluated_successfully` or `evaluated_failed`
- `partition`
 
The metric tracks all evaluated decision including the required decisions.
This is aligned with Camunda 7 value metric EDE.

If a decision evaluation failed all required decision are also counted as failed for the metric.

## Related issues

closes #8805

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
