### PR TITLE
Store temporal values from expression result as variable

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityInputMappingTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityInputMappingTest.java
@@ -35,6 +35,14 @@ public final class ActivityInputMappingTest {
   @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
   private static final String PROCESS_ID = "process";
 
+  private static final String A_TIME_VALUE = "\"04:20:00@Europe/Berlin\"";
+  private static final String A_LOCAL_TIME_VALUE = "\"04:20\"";
+  private static final String A_DATE_VALUE = "\"2021-02-24\"";
+  private static final String A_LOCAL_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20\"";
+  private static final String A_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20+01:00\"";
+  private static final String A_DAY_TIME_DURATION_VALUE = "\"PT42H56M33S\"";
+  private static final String A_YEAR_MONTH_DURATION_VALUE = "\"P2Y3M\"";
+
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
@@ -76,6 +84,41 @@ public final class ActivityInputMappingTest {
         mapping(b -> b.zeebeInputExpression("x.y", "y")),
         activityVariables(variable("y", "2"))
       },
+      {
+        "{'x': %s}".formatted(A_TIME_VALUE),
+        mapping(b -> b.zeebeInputExpression("time(x)", "y")),
+        activityVariables(variable("y", A_TIME_VALUE))
+      },
+      {
+        "{'x': %s}".formatted(A_LOCAL_TIME_VALUE),
+        mapping(b -> b.zeebeInputExpression("time(x)", "y")),
+        activityVariables(variable("y", A_LOCAL_TIME_VALUE))
+      },
+      {
+        "{'x': %s}".formatted(A_DATE_VALUE),
+        mapping(b -> b.zeebeInputExpression("date(x)", "y")),
+        activityVariables(variable("y", A_DATE_VALUE))
+      },
+      {
+        "{'x': %s}".formatted(A_LOCAL_DATE_AND_TIME_VALUE),
+        mapping(b -> b.zeebeInputExpression("date and time(x)", "y")),
+        activityVariables(variable("y", A_LOCAL_DATE_AND_TIME_VALUE))
+      },
+      {
+        "{'x': %s}".formatted(A_DATE_AND_TIME_VALUE),
+        mapping(b -> b.zeebeInputExpression("date and time(x)", "y")),
+        activityVariables(variable("y", A_DATE_AND_TIME_VALUE))
+      },
+      {
+        "{'x': %s}".formatted(A_DAY_TIME_DURATION_VALUE),
+        mapping(b -> b.zeebeInputExpression("duration(x)", "y")),
+        activityVariables(variable("y", A_DAY_TIME_DURATION_VALUE))
+      },
+      {
+        "{'x': %s}".formatted(A_YEAR_MONTH_DURATION_VALUE),
+        mapping(b -> b.zeebeInputExpression("duration(x)", "y")),
+        activityVariables(variable("y", A_YEAR_MONTH_DURATION_VALUE))
+      }
     };
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityOutputMappingTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityOutputMappingTest.java
@@ -35,7 +35,16 @@ import org.junit.runners.Parameterized.Parameters;
 public final class ActivityOutputMappingTest {
 
   @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
+
   private static final String PROCESS_ID = "process";
+
+  private static final String A_TIME_VALUE = "\"04:20:00@Europe/Berlin\"";
+  private static final String A_LOCAL_TIME_VALUE = "\"04:20\"";
+  private static final String A_DATE_VALUE = "\"2021-02-24\"";
+  private static final String A_LOCAL_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20\"";
+  private static final String A_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20+01:00\"";
+  private static final String A_DAY_TIME_DURATION_VALUE = "\"PT42H56M33S\"";
+  private static final String A_YEAR_MONTH_DURATION_VALUE = "\"P2Y3M\"";
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
@@ -93,6 +102,41 @@ public final class ActivityOutputMappingTest {
         mapping(b -> b.zeebeOutputExpression("x", "z.x").zeebeOutputExpression("y", "z.y")),
         scopeVariables(variable("z", "{\"x\":1,\"y\":2}"))
       },
+      {
+        "{'x': %s}".formatted(A_TIME_VALUE),
+        mapping(b -> b.zeebeOutputExpression("time(x)", "y")),
+        scopeVariables(variable("y", A_TIME_VALUE))
+      },
+      {
+        "{'x': %s}".formatted(A_LOCAL_TIME_VALUE),
+        mapping(b -> b.zeebeOutputExpression("time(x)", "y")),
+        scopeVariables(variable("y", A_LOCAL_TIME_VALUE))
+      },
+      {
+        "{'x': %s}".formatted(A_DATE_VALUE),
+        mapping(b -> b.zeebeOutputExpression("date(x)", "y")),
+        scopeVariables(variable("y", A_DATE_VALUE))
+      },
+      {
+        "{'x': %s}".formatted(A_LOCAL_DATE_AND_TIME_VALUE),
+        mapping(b -> b.zeebeOutputExpression("date and time(x)", "y")),
+        scopeVariables(variable("y", A_LOCAL_DATE_AND_TIME_VALUE))
+      },
+      {
+        "{'x': %s}".formatted(A_DATE_AND_TIME_VALUE),
+        mapping(b -> b.zeebeOutputExpression("date and time(x)", "y")),
+        scopeVariables(variable("y", A_DATE_AND_TIME_VALUE))
+      },
+      {
+        "{'x': %s}".formatted(A_DAY_TIME_DURATION_VALUE),
+        mapping(b -> b.zeebeOutputExpression("duration(x)", "y")),
+        scopeVariables(variable("y", A_DAY_TIME_DURATION_VALUE))
+      },
+      {
+        "{'x': %s}".formatted(A_YEAR_MONTH_DURATION_VALUE),
+        mapping(b -> b.zeebeOutputExpression("duration(x)", "y")),
+        scopeVariables(variable("y", A_YEAR_MONTH_DURATION_VALUE))
+      }
     };
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableValue.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableValue.java
@@ -10,20 +10,7 @@ package io.camunda.zeebe.engine.processing.variable.mapping;
 import io.camunda.zeebe.test.util.JsonUtil;
 import java.util.Objects;
 
-public final class VariableValue {
-
-  private final String name;
-  private final String value;
-
-  private VariableValue(final String name, final String value) {
-    this.name = name;
-    this.value = value;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(name, value);
-  }
+public record VariableValue(String name, String value) {
 
   @Override
   public boolean equals(final Object o) {
@@ -35,6 +22,11 @@ public final class VariableValue {
     }
     final VariableValue that = (VariableValue) o;
     return Objects.equals(name, that.name) && JsonUtil.isEqual(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, value);
   }
 
   @Override

--- a/expression-language/src/test/java/io/camunda/zeebe/el/EvaluationResultTest.java
+++ b/expression-language/src/test/java/io/camunda/zeebe/el/EvaluationResultTest.java
@@ -187,7 +187,7 @@ public class EvaluationResultTest {
     assertThat(evaluationResult.getBoolean()).isNull();
     assertThat(evaluationResult.getNumber()).isNull();
     assertThat(evaluationResult.getList()).isNull();
-    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("null"));
+    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("\"2020-04-02\""));
   }
 
   @Test
@@ -199,7 +199,7 @@ public class EvaluationResultTest {
     assertThat(evaluationResult.getBoolean()).isNull();
     assertThat(evaluationResult.getNumber()).isNull();
     assertThat(evaluationResult.getList()).isNull();
-    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("null"));
+    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("\"14:00\""));
   }
 
   @Test
@@ -210,8 +210,8 @@ public class EvaluationResultTest {
     assertThat(evaluationResult.getString()).isNull();
     assertThat(evaluationResult.getBoolean()).isNull();
     assertThat(evaluationResult.getNumber()).isNull();
-    assertThat(evaluationResult.getList()).isEqualTo(List.of(asMsgPack("null")));
-    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("[null]"));
+    assertThat(evaluationResult.getList()).isEqualTo(List.of(asMsgPack("\"2020-04-02\"")));
+    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("[\"2020-04-02\"]"));
   }
 
   @Test
@@ -223,7 +223,7 @@ public class EvaluationResultTest {
     assertThat(evaluationResult.getBoolean()).isNull();
     assertThat(evaluationResult.getNumber()).isNull();
     assertThat(evaluationResult.getList()).isNull();
-    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("{'x':null}"));
+    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("{'x':\"2020-04-02\"}"));
   }
 
   private EvaluationResult evaluateExpression(final String expression) {

--- a/feel/src/main/scala/io/camunda/zeebe/feel/impl/FeelToMessagePackTransformer.scala
+++ b/feel/src/main/scala/io/camunda/zeebe/feel/impl/FeelToMessagePackTransformer.scala
@@ -36,10 +36,7 @@ class FeelToMessagePackTransformer {
       case ValNumber(number) if number.isWhole => writer.writeInteger(number.longValue)
       case ValNumber(number) => writer.writeFloat(number.doubleValue)
       case ValBoolean(boolean) => writer.writeBoolean(boolean)
-      case ValString(string) => {
-        stringWrapper.wrap(string.getBytes)
-        writer.writeString(stringWrapper)
-      }
+      case ValString(string) => writeStringValue(string)
       case ValList(items) => {
         writer.writeArrayHeader(items.size)
         items.foreach(writeValue)
@@ -63,13 +60,13 @@ class FeelToMessagePackTransformer {
           }
         }
       }
-      case ValTime(time) => writeValue(ValString(time.format))
-      case ValLocalTime(time) => writeValue((ValString(time.toString)))
-      case ValDate(date) => writeValue(ValString(date.toString))
-      case ValDateTime(dateTime) => writeValue(ValString(dateTime.toString))
-      case ValLocalDateTime(dateTime) => writeValue(ValString(dateTime.toString))
-      case ValDayTimeDuration(duration) => writeValue(ValString(duration.toString))
-      case ValYearMonthDuration(duration) => writeValue(ValString(duration.toString))
+      case ValTime(time) => writeStringValue(time.format)
+      case ValLocalTime(time) => writeStringValue(time.toString)
+      case ValDate(date) => writeStringValue(date.toString)
+      case ValDateTime(dateTime) => writeStringValue(dateTime.toString)
+      case ValLocalDateTime(dateTime) => writeStringValue(dateTime.toString)
+      case ValDayTimeDuration(duration) => writeStringValue(duration.toString)
+      case ValYearMonthDuration(duration) => writeStringValue(duration.toString)
       case other => {
         writer.writeNil()
         LOGGER.trace("No FEEL to MessagePack transformation for '{}'. Using 'null' instead.", other)
@@ -77,6 +74,9 @@ class FeelToMessagePackTransformer {
     }
   }
 
-
+  private def writeStringValue(string: String) = {
+    stringWrapper.wrap(string.getBytes)
+    writer.writeString(stringWrapper)
+  }
 }
 

--- a/feel/src/main/scala/io/camunda/zeebe/feel/impl/FeelToMessagePackTransformer.scala
+++ b/feel/src/main/scala/io/camunda/zeebe/feel/impl/FeelToMessagePackTransformer.scala
@@ -63,6 +63,13 @@ class FeelToMessagePackTransformer {
           }
         }
       }
+      case ValTime(time) => writeValue(ValString(time.format))
+      case ValLocalTime(time) => writeValue((ValString(time.toString)))
+      case ValDate(date) => writeValue(ValString(date.toString))
+      case ValDateTime(dateTime) => writeValue(ValString(dateTime.toString))
+      case ValLocalDateTime(dateTime) => writeValue(ValString(dateTime.toString))
+      case ValDayTimeDuration(duration) => writeValue(ValString(duration.toString))
+      case ValYearMonthDuration(duration) => writeValue(ValString(duration.toString))
       case other => {
         writer.writeNil()
         LOGGER.trace("No FEEL to MessagePack transformation for '{}'. Using 'null' instead.", other)


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
FEEL-expressions that result in a temporal value (e.g. a date, time, duration, etc) can now be used in combination with process instance variables. For example, if a [variable output mapping](https://docs.camunda.io/docs/components/concepts/variables/#inputoutput-variable-mappings) has a `source` FEEL-expression that results in a date, then this result is stored in the `target` variable of the output mapping. Previously, the value `null` would be stored in the `target` variable.

The stored value in the variable is the ISO-8601 string representation of the temporal value. Note that this concerns the FEEL's extension of the ISO-8601 representation that adds support for a Zone ID. The ISO-8601 only supports the UTC/Z and time offsets.

When consuming the variable in a subsequent expression, it will have the string type. The value is **not** automatically transformed back into a temporal type. If you want to use it again as a temporal type, please rebuild the associated temporal type ([date](https://docs.camunda.io/docs/reference/feel/language-guide/feel-data-types/#date), [time](https://docs.camunda.io/docs/reference/feel/language-guide/feel-data-types/#time), [date-time](https://docs.camunda.io/docs/reference/feel/language-guide/feel-data-types/#date-time), [day-time-duration](https://docs.camunda.io/docs/reference/feel/language-guide/feel-data-types/#day-time-duration), [year-month-duration](https://docs.camunda.io/docs/reference/feel/language-guide/feel-data-types/#year-month-duration)) from the string.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7054

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
