### PR TITLE
Allow static input mappings

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -98,6 +98,11 @@
       <artifactId>simpleclient</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+    </dependency>
+
     <!--    TEST DEPENDENCIES-->
 
     <dependency>

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.deployment.model.transformer;
 
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.el.impl.StaticExpression;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
+import org.apache.commons.text.StringEscapeUtils;
 
 /**
  * Transform variable mappings into an expression.
@@ -150,7 +152,17 @@ public final class VariableMappingTransformer {
     return new MappingContextVisitor<>() {
       @Override
       public String onEntry(final String targetKey, final Expression sourceExpression) {
-        return targetKey + ":" + sourceExpression.getExpression();
+        final String expression;
+
+        if (sourceExpression instanceof StaticExpression) {
+          expression =
+              String.format(
+                  "\"%s\"", StringEscapeUtils.escapeJava(sourceExpression.getExpression()));
+        } else {
+          expression = sourceExpression.getExpression();
+        }
+
+        return targetKey + ":" + expression;
       }
 
       @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -33,8 +33,7 @@ public final class ZeebeRuntimeValidators {
     return List.of(
         // ----------------------------------------
         ZeebeExpressionValidator.verifyThat(ZeebeInput.class)
-            .hasValidExpression(
-                ZeebeInput::getSource, expression -> expression.isNonStatic().isMandatory())
+            .hasValidExpression(ZeebeInput::getSource, ExpressionVerification::isMandatory)
             .hasValidPath(ZeebeInput::getTarget)
             .build(expressionLanguage),
         // ----------------------------------------

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -44,7 +44,7 @@ public final class ZeebeRuntimeValidators {
             .hasValidPath(ZeebeOutput::getTarget)
             .build(expressionLanguage),
         ZeebeExpressionValidator.verifyThat(Message.class)
-            .hasValidExpression(Message::getName, expression -> expression.isOptional())
+            .hasValidExpression(Message::getName, ExpressionVerification::isOptional)
             .build(expressionLanguage),
         // Checks message name expressions of start event messages
         new ProcessMessageStartEventMessageNameValidator(expressionLanguage),
@@ -71,15 +71,14 @@ public final class ZeebeRuntimeValidators {
             .build(expressionLanguage),
         // ----------------------------------------
         ZeebeExpressionValidator.verifyThat(ZeebeTaskDefinition.class)
+            .hasValidExpression(ZeebeTaskDefinition::getType, ExpressionVerification::isMandatory)
             .hasValidExpression(
-                ZeebeTaskDefinition::getType, expression -> expression.isMandatory())
-            .hasValidExpression(
-                ZeebeTaskDefinition::getRetries, expression -> expression.isMandatory())
+                ZeebeTaskDefinition::getRetries, ExpressionVerification::isMandatory)
             .build(expressionLanguage),
         // ----------------------------------------
         ZeebeExpressionValidator.verifyThat(ZeebeCalledElement.class)
             .hasValidExpression(
-                ZeebeCalledElement::getProcessId, expression -> expression.isMandatory())
+                ZeebeCalledElement::getProcessId, ExpressionVerification::isMandatory)
             .build(expressionLanguage),
         // ----------------------------------------
         ZeebeExpressionValidator.verifyThat(TimerEventDefinition.class)

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -105,15 +105,6 @@ public final class ZeebeRuntimeValidationTest {
         List.of(expect(ZeebeInput.class, INVALID_EXPRESSION_MESSAGE))
       },
       {
-        // static expression
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .serviceTask("task", s -> s.zeebeInput(STATIC_EXPRESSION, "bar"))
-            .endEvent()
-            .done(),
-        List.of(expect(ZeebeInput.class, STATIC_EXPRESSION_MESSAGE))
-      },
-      {
         // empty expression
         Bpmn.createExecutableProcess("process")
             .startEvent()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
@@ -132,7 +132,7 @@ public final class VariableInputMappingTransformerTest {
     return new ZeebeMapping() {
       @Override
       public String getSource() {
-        return source;
+        return "= " + source;
       }
 
       @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
@@ -56,7 +56,7 @@ public final class VariableMappingTransformerTest {
   @Test
   public void failToTransformWithInvalidSourceExpression() {
     // when
-    final var mappings = List.of(mapping("x?", "a"));
+    final var mappings = List.of(mapping("=x?", "a"));
 
     // when
     assertThatThrownBy(() -> transformer.transformInputMappings(mappings, expressionLanguage))
@@ -67,7 +67,7 @@ public final class VariableMappingTransformerTest {
   @Test
   public void failToTransformWithInvalidTargetExpression() {
     // given
-    final var mappings = List.of(mapping("x", "a?"));
+    final var mappings = List.of(mapping("=x", "a?"));
 
     // when
     assertThatThrownBy(() -> transformer.transformInputMappings(mappings, expressionLanguage))
@@ -78,7 +78,7 @@ public final class VariableMappingTransformerTest {
   @Test
   public void shouldEvaluateWithNotExistingVariable() {
     // given
-    final var mappings = List.of(mapping("x", "a"));
+    final var mappings = List.of(mapping("=x", "a"));
     final var expression = transformer.transformInputMappings(mappings, expressionLanguage);
 
     // when

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
@@ -165,7 +165,7 @@ public final class VariableOutputMappingTransformerTest {
     return new ZeebeMapping() {
       @Override
       public String getSource() {
-        return source;
+        return "= " + source;
       }
 
       @Override

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -50,6 +50,7 @@
     <version.commons-logging>1.2</version.commons-logging>
     <version.commons-math>3.6.1</version.commons-math>
     <version.commons-codec>1.15</version.commons-codec>
+    <version.commons-text>1.9</version.commons-text>
     <version.docker-java-api>3.2.13</version.docker-java-api>
     <version.elasticsearch>7.17.0</version.elasticsearch>
     <version.error-prone>2.11.0</version.error-prone>
@@ -509,6 +510,12 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-math3</artifactId>
         <version>${version.commons-math}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>${version.commons-text}</version>
       </dependency>
 
       <!-- for dependency convergence -->


### PR DESCRIPTION
## Description

Before input mappings always had to be expressions. It is not clear anymore why we enforced this, but Zeebe already supports static expressions based on the value of the field.

This change remove the validation for non static expression on input mappings to improve the user expierence we can offer in the [connectors use case](https://github.com/camunda/team-connectors/issues/85).

The static value will be escaped as a java string, and not as a JSON string as it would otherwise additionally escape `/` characters which will be used for URL parameters and additionally escaping them decreases the user experience.

The current implementation might multiple times escape characters like `"` and `\`, as they are escaped initially to be given to the FEEL engine and later when retrieving the value from the variable record.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8733 

Documentation issue: https://github.com/camunda-cloud/camunda-cloud-documentation/issues/643

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
