### PR TITLE
[Backport stable/1.3] fix: avoid transition to inactive when log storage installation fails

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.monitoring.HealthMetrics;
+import io.camunda.zeebe.broker.system.partitions.impl.RecoverablePartitionTransitionException;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
@@ -333,6 +334,11 @@ public final class ZeebePartition extends Actor
           context.getCurrentTerm(),
           error);
       handleUnrecoverableFailure(error);
+    } else if (error instanceof RecoverablePartitionTransitionException) {
+      LOG.info(
+          "Aborted installation of partition {}, cause: {}",
+          context.getPartitionId(),
+          error.getMessage());
     } else {
       handleRecoverableFailure();
     }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/RecoverablePartitionTransitionException.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/RecoverablePartitionTransitionException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl;
+
+/**
+ * This exception should be used to indicate that the transition was aborted intentionally and
+ * should not be treated as a failure.
+ */
+public class RecoverablePartitionTransitionException extends RuntimeException {
+
+  public RecoverablePartitionTransitionException(final String message) {
+    super(message);
+  }
+}


### PR DESCRIPTION
## Description

When the installation of the `LogStorage` fails because the targeted
term does not match Raft's term, then throw a specific exception. This
is an expected state because while installing the partition a leadership
change happened causing a new term in Raft.

That specific exception is treated differently, meaning, no Raft
transition is requested by Zeebe, because for sure a new Zeebe
transition was scheduled that will (re-)install the services.


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

backports #8767, relates to #8717

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
