### PR TITLE
build: set the description of all projects to fix releasing

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -17,7 +17,7 @@
   <packaging>pom</packaging>
 
   <name>Zeebe BOM</name>
-  <description/>
+  <description>${name}</description>
   <url>http://zeebe.io/</url>
   <inceptionYear>2017</inceptionYear>
 


### PR DESCRIPTION
## Description

Previously, the description was inherited from camunda-release-parent.
Since that description was not accurate, [we overwrote this to be empty instead](https://github.com/camunda-cloud/zeebe/pull/8833/commits/764a19c420965e11940e24a64fa75c9b255ed20e). This is not valid and can't be published on maven central, as per the requirements:  https://central.sonatype.org/publish/requirements/#project-name-description-and-url. See also the failed release pipeline for `1.4.0-alpha2`: https://ci.zeebe.camunda.cloud/blue/organizations/jenkins/zeebe-release/detail/zeebe-release/240/pipeline/

Instead of coming up with a sensible description for each project, here we just set the description to be the name of the artifact.