### PR TITLE
Extend evaluated decision event with decisionVersion for evaluted decisions

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/BusinessRuleTaskTest.java
@@ -286,6 +286,7 @@ public final class BusinessRuleTaskTest {
         .hasDecisionId("jedi_or_sith")
         .hasDecisionName("Jedi or Sith")
         .hasDecisionKey(requiredDecision.getDecisionKey())
+        .hasDecisionVersion(requiredDecision.getVersion())
         .hasDecisionType("DECISION_TABLE")
         .hasDecisionOutput("\"Jedi\"")
         .satisfies(
@@ -314,6 +315,7 @@ public final class BusinessRuleTaskTest {
         .hasDecisionId("force_user")
         .hasDecisionName("Which force user?")
         .hasDecisionKey(calledDecision.getDecisionKey())
+        .hasDecisionVersion(calledDecision.getVersion())
         .hasDecisionType("DECISION_TABLE")
         .hasDecisionOutput("\"Obi-Wan Kenobi\"")
         .satisfies(
@@ -452,6 +454,7 @@ public final class BusinessRuleTaskTest {
         .hasDecisionId("jedi_or_sith")
         .hasDecisionName("Jedi or Sith")
         .hasDecisionKey(requiredDecision.getDecisionKey())
+        .hasDecisionVersion(requiredDecision.getVersion())
         .hasDecisionType("DECISION_TABLE")
         .hasDecisionOutput("null")
         .satisfies(

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
@@ -74,6 +74,9 @@
                 "decisionKey": {
                   "type": "long"
                 },
+                "decisionVersion": {
+                  "type": "long"
+                },
                 "decisionType": {
                   "type": "keyword"
                 },

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedDecisionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedDecisionRecord.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ValueArray;
@@ -31,6 +32,7 @@ public final class EvaluatedDecisionRecord extends UnifiedRecordValue
   private final StringProperty decisionIdProp = new StringProperty("decisionId");
   private final StringProperty decisionNameProp = new StringProperty("decisionName");
   private final LongProperty decisionKeyProp = new LongProperty("decisionKey");
+  private final IntegerProperty decisionVersionProp = new IntegerProperty("decisionVersion");
   private final StringProperty decisionTypeProp = new StringProperty("decisionType");
   private final BinaryProperty decisionOutputProp = new BinaryProperty("decisionOutput");
 
@@ -44,6 +46,7 @@ public final class EvaluatedDecisionRecord extends UnifiedRecordValue
     declareProperty(decisionIdProp)
         .declareProperty(decisionNameProp)
         .declareProperty(decisionKeyProp)
+        .declareProperty(decisionVersionProp)
         .declareProperty(decisionTypeProp)
         .declareProperty(decisionOutputProp)
         .declareProperty(evaluatedInputsProp)
@@ -77,6 +80,16 @@ public final class EvaluatedDecisionRecord extends UnifiedRecordValue
 
   public EvaluatedDecisionRecord setDecisionKey(final long decisionKey) {
     decisionKeyProp.setValue(decisionKey);
+    return this;
+  }
+
+  @Override
+  public long getDecisionVersion() {
+    return decisionVersionProp.getValue();
+  }
+
+  public EvaluatedDecisionRecord setDecisionVersion(final int decisionVersion) {
+    decisionVersionProp.setValue(decisionVersion);
     return this;
   }
 

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -829,6 +829,7 @@ final class JsonSerializableToJsonTest {
                   .setDecisionId("decision-id")
                   .setDecisionName("decision-name")
                   .setDecisionKey(6L)
+                  .setDecisionVersion(7)
                   .setDecisionType("DECISION_TABLE")
                   .setDecisionOutput(toMessagePack("'decision-output'"));
 
@@ -870,6 +871,7 @@ final class JsonSerializableToJsonTest {
                       "decisionId":"decision-id",
                       "decisionName":"decision-name",
                       "decisionKey":6,
+                      "decisionVersion":7,
                       "decisionOutput":'"decision-output"',
                       "decisionType":"DECISION_TABLE",
                       "evaluatedInputs":[

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EvaluatedDecisionValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EvaluatedDecisionValue.java
@@ -32,6 +32,9 @@ public interface EvaluatedDecisionValue extends RecordValue {
   /** @return the key of the evaluated decision */
   long getDecisionKey();
 
+  /** @return the version of the evaluated decision */
+  long getDecisionVersion();
+
   /** @return the type of the evaluated decision */
   String getDecisionType();
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This extends the EvaluatedDecision event by adding the `decisionVersion` to each of the `evaluatedDecisions`.

It also adds this to the Elasticsearch template so the ES exporter can export this property.

This PR is greatly inspired by https://github.com/camunda-cloud/zeebe/pull/8829, which did the same for the `decisionKey` of the `evaluatedDecisions`. Each commit describes which specific commit it was inspired by. This should help make the review easier.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8867

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
