### PR TITLE
Implement `toString` for db primitives

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -118,7 +118,7 @@ public final class DbDecisionState implements MutableDecisionState {
     decisionKeyByDecisionRequirementsKey.whileEqualPrefix(
         dbDecisionRequirementsKey,
         ((key, nil) -> {
-          final var decisionKey = key.getSecond();
+          final var decisionKey = key.second();
           findDecisionByKey(decisionKey.getValue()).ifPresent(decisions::add);
         }));
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
@@ -71,6 +71,19 @@ public final class DbDeploymentState implements MutableDeploymentState {
   }
 
   @Override
+  public void storeDeploymentRecord(final long key, final DeploymentRecord value) {
+    deploymentKey.wrapLong(key);
+    deploymentRaw.setDeploymentRecord(value);
+    deploymentRawColumnFamily.put(deploymentKey, deploymentRaw);
+  }
+
+  @Override
+  public void removeDeploymentRecord(final long key) {
+    deploymentKey.wrapLong(key);
+    deploymentRawColumnFamily.delete(deploymentKey);
+  }
+
+  @Override
   public boolean hasPendingDeploymentDistribution(final long deploymentKey) {
     this.deploymentKey.wrapLong(deploymentKey);
 
@@ -86,10 +99,17 @@ public final class DbDeploymentState implements MutableDeploymentState {
   }
 
   @Override
-  public void storeDeploymentRecord(final long key, final DeploymentRecord value) {
+  public DeploymentRecord getStoredDeploymentRecord(final long key) {
     deploymentKey.wrapLong(key);
-    deploymentRaw.setDeploymentRecord(value);
-    deploymentRawColumnFamily.put(deploymentKey, deploymentRaw);
+
+    final var storedDeploymentRaw = deploymentRawColumnFamily.get(deploymentKey);
+
+    DeploymentRecord record = null;
+    if (storedDeploymentRaw != null) {
+      record = storedDeploymentRaw.getDeploymentRecord();
+    }
+
+    return record;
   }
 
   @Override
@@ -100,11 +120,11 @@ public final class DbDeploymentState implements MutableDeploymentState {
     final MutableLong lastDeploymentKey = new MutableLong(0);
     pendingDeploymentColumnFamily.forEach(
         (compositeKey, nil) -> {
-          final var deploymentKey = compositeKey.getFirst().getValue();
-          final var partitionId = compositeKey.getSecond().getValue();
+          final var deploymentKey = compositeKey.first().getValue();
+          final var partitionId = compositeKey.second().getValue();
 
           if (lastDeploymentKey.value != deploymentKey) {
-            final var deploymentRaw = deploymentRawColumnFamily.get(compositeKey.getFirst());
+            final var deploymentRaw = deploymentRawColumnFamily.get(compositeKey.first());
             if (deploymentRaw == null) {
               LOG.warn(
                   "Expected to find a deployment with key {} for a pending partition {}, but none found. The state is inconsistent.",
@@ -119,25 +139,5 @@ public final class DbDeploymentState implements MutableDeploymentState {
 
           pendingDeploymentVisitor.visit(deploymentKey, partitionId, lastDeployment.get());
         });
-  }
-
-  @Override
-  public void removeDeploymentRecord(final long key) {
-    deploymentKey.wrapLong(key);
-    deploymentRawColumnFamily.delete(deploymentKey);
-  }
-
-  @Override
-  public DeploymentRecord getStoredDeploymentRecord(final long key) {
-    deploymentKey.wrapLong(key);
-
-    final var storedDeploymentRaw = deploymentRawColumnFamily.get(deploymentKey);
-
-    DeploymentRecord record = null;
-    if (storedDeploymentRaw != null) {
-      record = storedDeploymentRaw.getDeploymentRecord();
-    }
-
-    return record;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -240,7 +240,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
       parentChildColumnFamily.whileEqualPrefix(
           this.parentKey,
           (key, value) -> {
-            final DbLong childKey = key.getSecond();
+            final DbLong childKey = key.second();
             final ElementInstance childInstance = getInstance(childKey.getValue());
 
             final ElementInstance copiedElementInstance = copyElementInstance(childInstance);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -250,10 +250,10 @@ public final class DbJobState implements JobState, MutableJobState {
       final long upperBound, final BiFunction<Long, JobRecord, Boolean> callback) {
     deadlinesColumnFamily.whileTrue(
         (key, value) -> {
-          final long deadline = key.getFirst().getValue();
+          final long deadline = key.first().getValue();
           final boolean isDue = deadline < upperBound;
           if (isDue) {
-            final long jobKey1 = key.getSecond().getValue();
+            final long jobKey1 = key.second().getValue();
             return visitJob(jobKey1, callback::apply, () -> deadlinesColumnFamily.delete(key));
           }
           return false;
@@ -292,7 +292,7 @@ public final class DbJobState implements JobState, MutableJobState {
     activatableColumnFamily.whileEqualPrefix(
         jobTypeKey,
         ((compositeKey, zbNil) -> {
-          final long jobKey = compositeKey.getSecond().getValue();
+          final long jobKey = compositeKey.second().getValue();
           // TODO #6521 reconsider race condition and whether or not the cleanup task is needed
           return visitJob(jobKey, callback::apply, () -> {});
         }));
@@ -315,10 +315,10 @@ public final class DbJobState implements JobState, MutableJobState {
     nextBackOffDueDate = -1L;
     backoffColumnFamily.whileTrue(
         (key, value) -> {
-          final long deadline = key.getFirst().getValue();
+          final long deadline = key.first().getValue();
           boolean consumed = false;
           if (deadline <= timestamp) {
-            final long jobKey = key.getSecond().getValue();
+            final long jobKey = key.second().getValue();
             consumed = visitJob(jobKey, callback, () -> backoffColumnFamily.delete(key));
           }
           if (!consumed) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
@@ -207,8 +207,7 @@ public final class DbMessageSubscriptionState
       throw new IllegalStateException(
           String.format(
               "Expected to find subscription with key %d and %s, but no subscription found",
-              elementKeyAndMessageName.getFirst().getValue(),
-              elementKeyAndMessageName.getSecond()));
+              elementKeyAndMessageName.first().getValue(), elementKeyAndMessageName.second()));
     }
     return visitor.visit(messageSubscription);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
@@ -107,10 +107,10 @@ public class DbMigrationState implements MutableMigrationState {
 
     messageSubscriptionSentTimeColumnFamily.forEach(
         (key, value) -> {
-          final var sentTime = key.getFirst().getValue();
-          final var elementKeyAndMessageName = key.getSecond();
-          final var elementInstanceKey = elementKeyAndMessageName.getFirst().getValue();
-          final var messageName = elementKeyAndMessageName.getSecond().getBuffer();
+          final var sentTime = key.first().getValue();
+          final var elementKeyAndMessageName = key.second();
+          final var elementInstanceKey = elementKeyAndMessageName.first().getValue();
+          final var messageName = elementKeyAndMessageName.second().getBuffer();
 
           final var messageSubscription =
               messageSubscriptionState.get(elementInstanceKey, messageName);
@@ -130,10 +130,10 @@ public class DbMigrationState implements MutableMigrationState {
 
     processSubscriptionSentTimeColumnFamily.forEach(
         (key, value) -> {
-          final var sentTime = key.getFirst().getValue();
-          final var elementKeyAndMessageName = key.getSecond();
-          final var elementInstanceKey = elementKeyAndMessageName.getFirst().getValue();
-          final var messageName = elementKeyAndMessageName.getSecond().getBuffer();
+          final var sentTime = key.first().getValue();
+          final var elementKeyAndMessageName = key.second();
+          final var elementInstanceKey = elementKeyAndMessageName.first().getValue();
+          final var messageName = elementKeyAndMessageName.second().getBuffer();
 
           final var processMessageSubscription =
               persistentState.getSubscription(elementInstanceKey, messageName);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/variable/DbVariableState.java
@@ -334,7 +334,7 @@ public class DbVariableState implements MutableVariableState {
     variablesColumnFamily.whileEqualPrefix(
         this.scopeKey,
         (compositeKey, variable) -> {
-          final DbString name = compositeKey.getSecond();
+          final DbString name = compositeKey.second();
 
           if (variableFilter.test(name)) {
             variableConsumer.accept(name, variable);

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbByte.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbByte.java
@@ -38,4 +38,9 @@ public final class DbByte implements DbKey, DbValue {
   public byte getValue() {
     return value;
   }
+
+  @Override
+  public String toString() {
+    return "DbByte{" + "value=" + value + '}';
+  }
 }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbCompositeKey.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbCompositeKey.java
@@ -11,42 +11,25 @@ import io.camunda.zeebe.db.DbKey;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 
-public final class DbCompositeKey<FirstKeyType extends DbKey, SecondKeyType extends DbKey>
-    implements DbKey {
-
-  private final FirstKeyType firstKeyTypePart;
-  private final SecondKeyType secondKeyTypePart;
-
-  public DbCompositeKey(
-      final FirstKeyType firstKeyTypePart, final SecondKeyType secondKeyTypePart) {
-    this.firstKeyTypePart = firstKeyTypePart;
-    this.secondKeyTypePart = secondKeyTypePart;
-  }
-
-  public FirstKeyType getFirst() {
-    return firstKeyTypePart;
-  }
-
-  public SecondKeyType getSecond() {
-    return secondKeyTypePart;
-  }
+public record DbCompositeKey<FirstKeyType extends DbKey, SecondKeyType extends DbKey>(
+    FirstKeyType first, SecondKeyType second) implements DbKey {
 
   @Override
   public void wrap(final DirectBuffer directBuffer, final int offset, final int length) {
-    firstKeyTypePart.wrap(directBuffer, offset, length);
-    final int firstKeyLength = firstKeyTypePart.getLength();
-    secondKeyTypePart.wrap(directBuffer, offset + firstKeyLength, length - firstKeyLength);
+    first.wrap(directBuffer, offset, length);
+    final int firstKeyLength = first.getLength();
+    second.wrap(directBuffer, offset + firstKeyLength, length - firstKeyLength);
   }
 
   @Override
   public int getLength() {
-    return firstKeyTypePart.getLength() + secondKeyTypePart.getLength();
+    return first.getLength() + second.getLength();
   }
 
   @Override
   public void write(final MutableDirectBuffer mutableDirectBuffer, final int offset) {
-    firstKeyTypePart.write(mutableDirectBuffer, offset);
-    final int firstKeyPartLength = firstKeyTypePart.getLength();
-    secondKeyTypePart.write(mutableDirectBuffer, offset + firstKeyPartLength);
+    first.write(mutableDirectBuffer, offset);
+    final int firstKeyPartLength = first.getLength();
+    second.write(mutableDirectBuffer, offset + firstKeyPartLength);
   }
 }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbInt.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbInt.java
@@ -40,4 +40,9 @@ public final class DbInt implements DbKey, DbValue {
   public int getValue() {
     return intValue;
   }
+
+  @Override
+  public String toString() {
+    return "DbInt{" + intValue + '}';
+  }
 }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbLong.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbLong.java
@@ -40,4 +40,9 @@ public final class DbLong implements DbKey, DbValue {
   public long getValue() {
     return longValue;
   }
+
+  @Override
+  public String toString() {
+    return "DbLong{" + longValue + '}';
+  }
 }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbNil.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbNil.java
@@ -33,4 +33,9 @@ public final class DbNil implements DbValue {
   public void write(final MutableDirectBuffer mutableDirectBuffer, final int offset) {
     mutableDirectBuffer.putByte(offset, EXISTENCE_BYTE);
   }
+
+  @Override
+  public String toString() {
+    return "DbNil{}";
+  }
 }

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbCompositeKeyColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbCompositeKeyColumnFamilyTest.java
@@ -102,10 +102,10 @@ public final class DbCompositeKeyColumnFamilyTest {
     final List<String> values = new ArrayList<>();
     columnFamily.forEach(
         (key, value) -> {
-          final DbString firstPart = key.getFirst();
+          final DbString firstPart = key.first();
           firstKeyParts.add(firstPart.toString());
 
-          final DbLong secondPart = key.getSecond();
+          final DbLong secondPart = key.second();
           secondKeyParts.add(secondPart.getValue());
 
           values.add(value.toString());
@@ -137,10 +137,10 @@ public final class DbCompositeKeyColumnFamilyTest {
 
     columnFamily.forEach(
         (key, value) -> {
-          final DbString firstPart = key.getFirst();
+          final DbString firstPart = key.first();
           firstKeyParts.add(firstPart.toString());
 
-          final DbLong secondPart = key.getSecond();
+          final DbLong secondPart = key.second();
           secondKeyParts.add(secondPart.getValue());
 
           values.add(value.toString());
@@ -168,10 +168,10 @@ public final class DbCompositeKeyColumnFamilyTest {
     final List<String> values = new ArrayList<>();
     columnFamily.whileTrue(
         (key, value) -> {
-          final DbString firstPart = key.getFirst();
+          final DbString firstPart = key.first();
           firstKeyParts.add(firstPart.toString());
 
-          final DbLong secondPart = key.getSecond();
+          final DbLong secondPart = key.second();
           secondKeyParts.add(secondPart.getValue());
 
           values.add(value.toString());
@@ -202,15 +202,15 @@ public final class DbCompositeKeyColumnFamilyTest {
     columnFamily.whileTrue(
         (key, value) -> {
           columnFamily.delete(key);
-          return key.getSecond().getValue() != 13;
+          return key.second().getValue() != 13;
         });
 
     columnFamily.forEach(
         (key, value) -> {
-          final DbString firstPart = key.getFirst();
+          final DbString firstPart = key.first();
           firstKeyParts.add(firstPart.toString());
 
-          final DbLong secondPart = key.getSecond();
+          final DbLong secondPart = key.second();
           secondKeyParts.add(secondPart.getValue());
 
           values.add(value.toString());
@@ -243,10 +243,10 @@ public final class DbCompositeKeyColumnFamilyTest {
     columnFamily.whileEqualPrefix(
         firstKey,
         (key, value) -> {
-          final DbString firstPart = key.getFirst();
+          final DbString firstPart = key.first();
           firstKeyParts.add(firstPart.toString());
 
-          final DbLong secondPart = key.getSecond();
+          final DbLong secondPart = key.second();
           secondKeyParts.add(secondPart.getValue());
 
           values.add(value.toString());
@@ -280,10 +280,10 @@ public final class DbCompositeKeyColumnFamilyTest {
     columnFamily.whileEqualPrefix(
         firstKey,
         (key, value) -> {
-          seenStringKeys.add(key.getFirst().toString());
-          seenLongKeys.add(key.getSecond().getValue());
+          seenStringKeys.add(key.first().toString());
+          seenLongKeys.add(key.second().getValue());
 
-          key.getFirst().wrapString("hello");
+          key.first().wrapString("hello");
           final DbString zbString = columnFamily.get(key);
           if (zbString != null) {
             values.add(zbString.toString());
@@ -317,10 +317,10 @@ public final class DbCompositeKeyColumnFamilyTest {
     columnFamily.whileEqualPrefix(
         firstKey,
         (key, value) -> {
-          final DbString firstPart = key.getFirst();
+          final DbString firstPart = key.first();
           firstKeyParts.add(firstPart.toString());
 
-          final DbLong secondPart = key.getSecond();
+          final DbLong secondPart = key.second();
           secondKeyParts.add(secondPart.getValue());
 
           values.add(value.toString());
@@ -350,7 +350,7 @@ public final class DbCompositeKeyColumnFamilyTest {
         firstKey,
         (key, value) -> {
           columnFamily.delete(key);
-          return key.getSecond().getValue() != 13;
+          return key.second().getValue() != 13;
         });
 
     final List<String> firstKeyParts = new ArrayList<>();
@@ -358,10 +358,10 @@ public final class DbCompositeKeyColumnFamilyTest {
     final List<String> values = new ArrayList<>();
     columnFamily.forEach(
         (key, value) -> {
-          final DbString firstPart = key.getFirst();
+          final DbString firstPart = key.first();
           firstKeyParts.add(firstPart.toString());
 
-          final DbLong secondPart = key.getSecond();
+          final DbLong secondPart = key.second();
           secondKeyParts.add(secondPart.getValue());
 
           values.add(value.toString());

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbCompositeKeyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbCompositeKeyTest.java
@@ -53,9 +53,9 @@ public final class DbCompositeKeyTest {
 
     // then
     assertThat(compositeKey.getLength()).isEqualTo(Long.BYTES * 2);
-    assertThat(compositeKey.getFirst().getValue()).isEqualTo(23);
+    assertThat(compositeKey.first().getValue()).isEqualTo(23);
     assertThat(firstLong.getValue()).isEqualTo(23);
-    assertThat(compositeKey.getSecond().getValue()).isEqualTo(121);
+    assertThat(compositeKey.second().getValue()).isEqualTo(121);
     assertThat(secondLong.getValue()).isEqualTo(121);
   }
 
@@ -104,9 +104,9 @@ public final class DbCompositeKeyTest {
 
     // then
     assertThat(compositeKey.getLength()).isEqualTo(Long.BYTES + 3 + Integer.BYTES);
-    assertThat(compositeKey.getFirst().toString()).isEqualTo("foo");
+    assertThat(compositeKey.first().toString()).isEqualTo("foo");
     assertThat(firstString.toString()).isEqualTo("foo");
-    assertThat(compositeKey.getSecond().getValue()).isEqualTo(121);
+    assertThat(compositeKey.second().getValue()).isEqualTo(121);
     assertThat(secondLong.getValue()).isEqualTo(121);
   }
 
@@ -176,14 +176,14 @@ public final class DbCompositeKeyTest {
     assertThat(nestedCompositeKey.getLength())
         .isEqualTo(Long.BYTES + 3 + Integer.BYTES + Long.BYTES);
 
-    final DbCompositeKey<DbString, DbLong> composite = nestedCompositeKey.getFirst();
-    assertThat(composite.getFirst().toString()).isEqualTo("foo");
+    final DbCompositeKey<DbString, DbLong> composite = nestedCompositeKey.first();
+    assertThat(composite.first().toString()).isEqualTo("foo");
     assertThat(firstString.toString()).isEqualTo("foo");
 
-    assertThat(composite.getSecond().getValue()).isEqualTo(121);
+    assertThat(composite.second().getValue()).isEqualTo(121);
     assertThat(secondLong.getValue()).isEqualTo(121);
 
-    assertThat(nestedCompositeKey.getSecond().getValue()).isEqualTo(100_234L);
+    assertThat(nestedCompositeKey.second().getValue()).isEqualTo(100_234L);
     assertThat(thirdLong.getValue()).isEqualTo(100_234L);
   }
 }


### PR DESCRIPTION
## Description
More changes extracted from #8793, this time to add `toString` implementations for the db primitives such as `DbLong` to improve the debugability, especially for new tests in #8793.

For `DbCompositeKey` I skipped implementing a `toString` manually by converting the class to record. 
