### PR TITLE
build: replace usage of deprecated maven expression `name`

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -17,7 +17,7 @@
   <packaging>pom</packaging>
 
   <name>Zeebe BOM</name>
-  <description>${name}</description>
+  <description>${project.name}</description>
   <url>http://zeebe.io/</url>
   <inceptionYear>2017</inceptionYear>
 


### PR DESCRIPTION
## Description

I missed this warning in #8860
> The expression ${name} is deprecated. Please use ${project.name} instead.
