### PR TITLE
#3631: Re-activate jobs

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -115,7 +115,7 @@ public final class Gateway {
     brokerClient = buildBrokerClient();
 
     final var activateJobsHandler = buildActivateJobsHandler(brokerClient);
-    submitActivateJobsActor((Consumer<ActorControl>) activateJobsHandler);
+    submitActorToActivateJobs((Consumer<ActorControl>) activateJobsHandler);
 
     final EndpointManager endpointManager = new EndpointManager(brokerClient, activateJobsHandler);
     final GatewayGrpcService gatewayGrpcService = new GatewayGrpcService(endpointManager);
@@ -186,7 +186,7 @@ public final class Gateway {
     return brokerClientFactory.apply(gatewayCfg);
   }
 
-  private void submitActivateJobsActor(final Consumer<ActorControl> consumer) {
+  private void submitActorToActivateJobs(final Consumer<ActorControl> consumer) {
     final var actorStartedFuture = new CompletableFuture<ActorControl>();
     final var actor =
         Actor.newActor()

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import me.dinowernli.grpc.prometheus.Configuration;
@@ -113,15 +114,8 @@ public final class Gateway {
     healthManager.setStatus(Status.STARTING);
     brokerClient = buildBrokerClient();
 
-    final ActivateJobsHandler activateJobsHandler;
-    if (gatewayCfg.getLongPolling().isEnabled()) {
-      final LongPollingActivateJobsHandler longPollingHandler =
-          buildLongPollingHandler(brokerClient);
-      submitLongPollingActor(longPollingHandler);
-      activateJobsHandler = longPollingHandler;
-    } else {
-      activateJobsHandler = new RoundRobinActivateJobsHandler(brokerClient);
-    }
+    final var activateJobsHandler = buildActivateJobsHandler(brokerClient);
+    submitActivateJobsActor((Consumer<ActorControl>) activateJobsHandler);
 
     final EndpointManager endpointManager = new EndpointManager(brokerClient, activateJobsHandler);
     final GatewayGrpcService gatewayGrpcService = new GatewayGrpcService(endpointManager);
@@ -153,17 +147,6 @@ public final class Gateway {
     return NettyServerBuilder.forAddress(new InetSocketAddress(cfg.getHost(), cfg.getPort()))
         .permitKeepAliveTime(minKeepAliveInterval.toMillis(), TimeUnit.MILLISECONDS)
         .permitKeepAliveWithoutCalls(false);
-  }
-
-  private void submitLongPollingActor(final LongPollingActivateJobsHandler handler) {
-    final var actorStartedFuture = new CompletableFuture<ActorControl>();
-    final var actor =
-        Actor.newActor()
-            .name(handler.getName())
-            .actorStartedHandler(handler.andThen(actorStartedFuture::complete))
-            .build();
-    actorSchedulingService.submitActor(actor);
-    actorStartedFuture.join();
   }
 
   private void setSecurityConfig(final ServerBuilder<?> serverBuilder, final SecurityCfg security) {
@@ -201,6 +184,25 @@ public final class Gateway {
 
   private BrokerClient buildBrokerClient() {
     return brokerClientFactory.apply(gatewayCfg);
+  }
+
+  private void submitActivateJobsActor(final Consumer<ActorControl> consumer) {
+    final var actorStartedFuture = new CompletableFuture<ActorControl>();
+    final var actor =
+        Actor.newActor()
+            .name("ActivateJobsHandler")
+            .actorStartedHandler(consumer.andThen(actorStartedFuture::complete))
+            .build();
+    actorSchedulingService.submitActor(actor);
+    actorStartedFuture.join();
+  }
+
+  private ActivateJobsHandler buildActivateJobsHandler(final BrokerClient brokerClient) {
+    if (gatewayCfg.getLongPolling().isEnabled()) {
+      return buildLongPollingHandler(brokerClient);
+    } else {
+      return new RoundRobinActivateJobsHandler(brokerClient);
+    }
   }
 
   private LongPollingActivateJobsHandler buildLongPollingHandler(final BrokerClient brokerClient) {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/ActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/ActivateJobsHandler.java
@@ -10,9 +10,12 @@ package io.camunda.zeebe.gateway.impl.job;
 import io.camunda.zeebe.gateway.grpc.ServerStreamObserver;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
+import java.util.concurrent.atomic.AtomicLong;
 
 /** Can handle an 'activate jobs' request from a client. */
 public interface ActivateJobsHandler {
+
+  static final AtomicLong ACTIVATE_JOBS_REQUEST_ID_GENERATOR = new AtomicLong(1);
 
   /**
    * Handle activate jobs request from a client
@@ -22,4 +25,11 @@ public interface ActivateJobsHandler {
    */
   void activateJobs(
       ActivateJobsRequest request, ServerStreamObserver<ActivateJobsResponse> responseObserver);
+
+  public static InflightActivateJobsRequest toInflightActivateJobsRequest(
+      final ActivateJobsRequest request,
+      final ServerStreamObserver<ActivateJobsResponse> responseObserver) {
+    return new InflightActivateJobsRequest(
+        ACTIVATE_JOBS_REQUEST_ID_GENERATOR.getAndIncrement(), request, responseObserver);
+  }
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
@@ -80,7 +80,10 @@ public final class InFlightLongPollingActivateJobsRequestsState {
   }
 
   private boolean isObsolete(final InflightActivateJobsRequest request) {
-    return request.isTimedOut() || request.isCanceled() || request.isCompleted();
+    return request.isTimedOut()
+        || request.isCanceled()
+        || request.isCompleted()
+        || request.isAborted();
   }
 
   public void removeRequest(final InflightActivateJobsRequest request) {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InFlightLongPollingActivateJobsRequestsState.java
@@ -18,9 +18,9 @@ public final class InFlightLongPollingActivateJobsRequestsState {
 
   private final String jobType;
   private final LongPollingMetrics metrics;
-  private final Queue<LongPollingActivateJobsRequest> activeRequests = new LinkedList<>();
-  private final Queue<LongPollingActivateJobsRequest> pendingRequests = new LinkedList<>();
-  private final Set<LongPollingActivateJobsRequest> activeRequestsToBeRepeated = new HashSet<>();
+  private final Queue<InflightActivateJobsRequest> activeRequests = new LinkedList<>();
+  private final Queue<InflightActivateJobsRequest> pendingRequests = new LinkedList<>();
+  private final Set<InflightActivateJobsRequest> activeRequestsToBeRepeated = new HashSet<>();
   private int failedAttempts;
   private long lastUpdatedTime;
 
@@ -60,14 +60,14 @@ public final class InFlightLongPollingActivateJobsRequestsState {
     return lastUpdatedTime;
   }
 
-  public void enqueueRequest(final LongPollingActivateJobsRequest request) {
+  public void enqueueRequest(final InflightActivateJobsRequest request) {
     if (!pendingRequests.contains(request)) {
       pendingRequests.offer(request);
     }
     removeObsoleteRequestsAndUpdateMetrics();
   }
 
-  public Queue<LongPollingActivateJobsRequest> getPendingRequests() {
+  public Queue<InflightActivateJobsRequest> getPendingRequests() {
     removeObsoleteRequestsAndUpdateMetrics();
     return pendingRequests;
   }
@@ -79,29 +79,29 @@ public final class InFlightLongPollingActivateJobsRequestsState {
     metrics.setBlockedRequestsCount(jobType, pendingRequests.size());
   }
 
-  private boolean isObsolete(final LongPollingActivateJobsRequest request) {
+  private boolean isObsolete(final InflightActivateJobsRequest request) {
     return request.isTimedOut() || request.isCanceled() || request.isCompleted();
   }
 
-  public void removeRequest(final LongPollingActivateJobsRequest request) {
+  public void removeRequest(final InflightActivateJobsRequest request) {
     pendingRequests.remove(request);
     removeObsoleteRequestsAndUpdateMetrics();
   }
 
-  public LongPollingActivateJobsRequest getNextPendingRequest() {
+  public InflightActivateJobsRequest getNextPendingRequest() {
     removeObsoleteRequestsAndUpdateMetrics();
-    final LongPollingActivateJobsRequest request = pendingRequests.poll();
+    final InflightActivateJobsRequest request = pendingRequests.poll();
     metrics.setBlockedRequestsCount(jobType, pendingRequests.size());
     return request;
   }
 
-  public void addActiveRequest(final LongPollingActivateJobsRequest request) {
+  public void addActiveRequest(final InflightActivateJobsRequest request) {
     activeRequests.offer(request);
     pendingRequests.remove(request);
     activeRequestsToBeRepeated.remove(request);
   }
 
-  public void removeActiveRequest(final LongPollingActivateJobsRequest request) {
+  public void removeActiveRequest(final InflightActivateJobsRequest request) {
     activeRequests.remove(request);
     activeRequestsToBeRepeated.remove(request);
   }
@@ -116,7 +116,7 @@ public final class InFlightLongPollingActivateJobsRequestsState {
    * attempts were reset to 0 (because new jobs became available) whilst the request was running,
    * and if the request's long polling is enabled.
    */
-  public boolean shouldBeRepeated(final LongPollingActivateJobsRequest request) {
+  public boolean shouldBeRepeated(final InflightActivateJobsRequest request) {
     return activeRequestsToBeRepeated.contains(request) && !request.isLongPollingDisabled();
   }
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InflightActivateJobsRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InflightActivateJobsRequest.java
@@ -18,7 +18,7 @@ import java.time.Duration;
 import java.util.Objects;
 import org.slf4j.Logger;
 
-public final class LongPollingActivateJobsRequest {
+public final class InflightActivateJobsRequest {
 
   private static final Logger LOG = Loggers.GATEWAY_LOGGER;
   private final long requestId;
@@ -33,7 +33,7 @@ public final class LongPollingActivateJobsRequest {
   private boolean isTimedOut;
   private boolean isCompleted;
 
-  public LongPollingActivateJobsRequest(
+  public InflightActivateJobsRequest(
       final long requestId,
       final ActivateJobsRequest request,
       final ServerStreamObserver<ActivateJobsResponse> responseObserver) {
@@ -47,7 +47,7 @@ public final class LongPollingActivateJobsRequest {
         request.getRequestTimeout());
   }
 
-  private LongPollingActivateJobsRequest(
+  private InflightActivateJobsRequest(
       final long requestId,
       final BrokerActivateJobsRequest request,
       final ServerStreamObserver<ActivateJobsResponse> responseObserver,
@@ -179,7 +179,7 @@ public final class LongPollingActivateJobsRequest {
     if (getClass() != obj.getClass()) {
       return false;
     }
-    final var other = (LongPollingActivateJobsRequest) obj;
+    final var other = (InflightActivateJobsRequest) obj;
     return Objects.equals(jobType, other.jobType)
         && maxJobsToActivate == other.maxJobsToActivate
         && requestId == other.requestId

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InflightActivateJobsRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InflightActivateJobsRequest.java
@@ -19,7 +19,7 @@ import java.time.Duration;
 import java.util.Objects;
 import org.slf4j.Logger;
 
-public final class InflightActivateJobsRequest {
+public class InflightActivateJobsRequest {
 
   private static final Logger LOG = Loggers.GATEWAY_LOGGER;
   private final long requestId;
@@ -84,11 +84,24 @@ public final class InflightActivateJobsRequest {
     return isCompleted;
   }
 
+  /**
+   * Sends activated jobs to the respective client.
+   *
+   * @param activatedJobs to send back to the client
+   * @return an instance of {@link Either} indicating the following:
+   *     <ul>
+   *       <li>{@link Either#get() == true}: if the activated jobs have been sent back to the client
+   *       <li>{@link Either#get() == false}: if the activated jobs couldn't be sent back to the
+   *           client
+   *       <li>{@link Either#getLeft() != null}: if sending back the activated jobs failed with an
+   *           exception (note: in this case {@link Either#isRight() == false})
+   *     </ul>
+   */
   public Either<Exception, Boolean> tryToSendActivatedJobs(
-      final ActivateJobsResponse grpcResponse) {
+      final ActivateJobsResponse activatedJobs) {
     if (isOpen()) {
       try {
-        responseObserver.onNext(grpcResponse);
+        responseObserver.onNext(activatedJobs);
         return Either.right(true);
       } catch (final Exception e) {
         LOG.warn("Failed to send response to client.", e);

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InflightActivateJobsRequestState.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InflightActivateJobsRequestState.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.impl.job;
+
+import io.camunda.zeebe.gateway.impl.broker.PartitionIdIterator;
+
+public class InflightActivateJobsRequestState {
+
+  private final PartitionIdIterator iterator;
+  private int remainingAmount;
+  private boolean pollPrevPartition;
+  private boolean resourceExhaustedWasPresent;
+
+  public InflightActivateJobsRequestState(
+      final PartitionIdIterator iterator, final int remainingAmount) {
+    this.iterator = iterator;
+    this.remainingAmount = remainingAmount;
+  }
+
+  private boolean hasNextPartition() {
+    return iterator.hasNext();
+  }
+
+  public int getCurrentPartition() {
+    return iterator.getCurrentPartitionId();
+  }
+
+  public int getNextPartition() {
+    return pollPrevPartition ? iterator.getCurrentPartitionId() : iterator.next();
+  }
+
+  public int getRemainingAmount() {
+    return remainingAmount;
+  }
+
+  public void setRemainingAmount(int remainingAmount) {
+    this.remainingAmount = remainingAmount;
+  }
+
+  public boolean wasResourceExhaustedPresent() {
+    return resourceExhaustedWasPresent;
+  }
+
+  public void setResourceExhaustedWasPresent(final boolean resourceExhaustedWasPresent) {
+    this.resourceExhaustedWasPresent = resourceExhaustedWasPresent;
+  }
+
+  public void setPollPrevPartition(boolean pollPrevPartition) {
+    this.pollPrevPartition = pollPrevPartition;
+  }
+
+  public boolean shouldActivateJobs() {
+    return remainingAmount > 0 && (pollPrevPartition || hasNextPartition());
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -152,9 +152,7 @@ public final class LongPollingActivateJobsHandler
       final int partitionsCount = topology.getPartitionsCount();
       activateJobsHandler.activateJobs(
           partitionsCount,
-          request.getRequest(),
-          request.getMaxJobsToActivate(),
-          request.getType(),
+          request,
           response -> onResponse(request, response),
           error -> onError(state, request, error),
           (remainingAmount, containedResourceExhaustedResponse) ->

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -69,13 +69,10 @@ public final class LongPollingActivateJobsHandler
     metrics = new LongPollingMetrics();
   }
 
-  public String getName() {
-    return "GatewayLongPollingJobHandler";
-  }
-
   @Override
   public void accept(ActorControl actor) {
     this.actor = actor;
+    activateJobsHandler.accept(actor);
     onActorStarted();
   }
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -224,8 +224,8 @@ public final class LongPollingActivateJobsHandler
       final Throwable error) {
     actor.submit(
         () -> {
-          state.removeActiveRequest(request);
           request.onError(error);
+          state.removeActiveRequest(request);
         });
   }
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -153,7 +153,6 @@ public final class LongPollingActivateJobsHandler
       activateJobsHandler.activateJobs(
           partitionsCount,
           request,
-          response -> onResponse(request, response),
           error -> onError(state, request, error),
           (remainingAmount, containedResourceExhaustedResponse) ->
               onCompleted(state, request, remainingAmount, containedResourceExhaustedResponse));
@@ -217,11 +216,6 @@ public final class LongPollingActivateJobsHandler
             resetFailedAttemptsAndHandlePendingRequests(request.getType());
           });
     }
-  }
-
-  private void onResponse(
-      final InflightActivateJobsRequest request, final ActivateJobsResponse activateJobsResponse) {
-    actor.submit(() -> request.onResponse(activateJobsResponse));
   }
 
   private void onError(

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
@@ -21,14 +21,17 @@ import io.camunda.zeebe.gateway.impl.broker.PartitionIdIterator;
 import io.camunda.zeebe.gateway.impl.broker.RequestDispatchStrategy;
 import io.camunda.zeebe.gateway.impl.broker.RoundRobinDispatchStrategy;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerFailJobRequest;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.sched.ActorControl;
 import io.grpc.protobuf.StatusProto;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
@@ -148,19 +151,21 @@ public final class RoundRobinActivateJobsHandler
           final var response = brokerResponse.getResponse();
           final ActivateJobsResponse grpcResponse =
               ResponseMapper.toActivateJobsResponse(brokerResponse.getKey(), response);
-
           final var jobsCount = grpcResponse.getJobsCount();
           final var jobsActivated = jobsCount > 0;
 
           if (jobsActivated) {
             final var result = request.tryToSendActivatedJobs(grpcResponse);
-            final var responseWasSent = result.isRight() && result.get();
+            final var responseWasSent = result.getOrElse(false);
 
             if (!responseWasSent) {
-              final var reason = createReasonMessage(result);
+              final var activatedJobsToReactivate = grpcResponse.getJobsList();
+              final var jobKeys = response.getJobKeys();
               final var jobType = request.getType();
+              final var reason = createReasonMessage(result);
 
-              logResponseNotSent(jobType, reason);
+              logResponseNotSent(jobType, jobKeys, reason);
+              reactivateJobs(activatedJobsToReactivate, reason);
               cancelActivateJobsRequest(reason, delegate);
               return;
             }
@@ -184,6 +189,30 @@ public final class RoundRobinActivateJobsHandler
       errorMessage = ACTIVATE_JOB_NOT_SENT_MSG;
     }
     return errorMessage;
+  }
+
+  private void reactivateJobs(final List<ActivatedJob> activateJobs, final String message) {
+    if (activateJobs != null) {
+      activateJobs.forEach(j -> tryToReactivateJob(j, message));
+    }
+  }
+
+  private void tryToReactivateJob(final ActivatedJob job, final String message) {
+    final var request = toFailJobRequest(job, message);
+    brokerClient
+        .sendRequestWithRetry(request)
+        .whenComplete(
+            (response, error) -> {
+              if (error != null) {
+                Loggers.GATEWAY_LOGGER.info(
+                    "Failed to reactivate job {} due to {}", job.getKey(), error.getMessage());
+              }
+            });
+  }
+
+  private BrokerFailJobRequest toFailJobRequest(final ActivatedJob job, final String errorMessage) {
+    return new BrokerFailJobRequest(job.getKey(), job.getRetries(), 0)
+        .setErrorMessage(errorMessage);
   }
 
   private void cancelActivateJobsRequest(
@@ -231,9 +260,14 @@ public final class RoundRobinActivateJobsHandler
         "Failed to activate jobs for type {} from partition {}", jobType, partition, error);
   }
 
-  private void logResponseNotSent(final String jobType, final String reason) {
+  private void logResponseNotSent(
+      final String jobType, final List<Long> jobKeys, final String reason) {
     Loggers.GATEWAY_LOGGER.debug(
-        "Failed to send back activated jobs for type {}, because: {}", jobType, reason);
+        "Failed to send {} activated jobs for type {} (with job keys: {}) to client, because: {}",
+        jobKeys.size(),
+        jobType,
+        jobKeys,
+        reason);
   }
 
   private PartitionIdIterator partitionIdIteratorForType(

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
@@ -93,6 +93,10 @@ public final class RoundRobinActivateJobsHandler
       final ResponseObserverDelegate delegate) {
     actor.run(
         () -> {
+          if (!request.isOpen()) {
+            return;
+          }
+
           if (requestState.shouldActivateJobs()) {
             final var brokerRequest = request.getRequest();
             final var partitionId = requestState.getNextPartition();

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/LongPollingActivateJobsTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/LongPollingActivateJobsTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient.RequestHandler;
 import io.camunda.zeebe.gateway.cmd.BrokerRejectionException;
 import io.camunda.zeebe.gateway.grpc.ServerStreamObserver;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerFailJobRequest;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerError;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerErrorResponse;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerRejection;
@@ -33,6 +34,7 @@ import io.camunda.zeebe.gateway.impl.job.InflightActivateJobsRequest;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -52,6 +54,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -72,7 +75,8 @@ public final class LongPollingActivateJobsTest {
   private final ControlledActorClock actorClock = new ControlledActorClock();
   @Rule public final ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule(actorClock);
   private LongPollingActivateJobsHandler handler;
-  private ActivateJobsStub stub;
+  private ActivateJobsStub activateJobsStub;
+  private FailJobStub failJobStub;
   private int partitionsCount;
   private final StubbedBrokerClient brokerClient = new StubbedBrokerClient();
   private final AtomicLong requestIdGenerator = new AtomicLong(1);
@@ -86,10 +90,15 @@ public final class LongPollingActivateJobsTest {
             .setProbeTimeoutMillis(PROBE_TIMEOUT)
             .setMinEmptyResponses(FAILED_RESPONSE_THRESHOLD)
             .build();
-    submitLongPollingActor(handler);
-    stub = spy(new ActivateJobsStub());
-    stub.registerWith(brokerClient);
-    stub.addAvailableJobs(TYPE, 0);
+    submitActorToActivateJobs(handler);
+
+    activateJobsStub = spy(new ActivateJobsStub());
+    activateJobsStub.registerWith(brokerClient);
+    activateJobsStub.addAvailableJobs(TYPE, 0);
+
+    failJobStub = spy(new FailJobStub());
+    failJobStub.registerWith(brokerClient);
+
     partitionsCount = brokerClient.getTopologyManager().getTopology().getPartitionsCount();
   }
 
@@ -116,7 +125,7 @@ public final class LongPollingActivateJobsTest {
 
     // when
     waitUntil(request::hasScheduledTimer);
-    stub.addAvailableJobs(TYPE, 1);
+    activateJobsStub.addAvailableJobs(TYPE, 1);
     verify(responseSpy, times(0)).onCompleted();
     brokerClient.notifyJobsAvailable(TYPE);
 
@@ -132,7 +141,7 @@ public final class LongPollingActivateJobsTest {
     activateJobsAndWaitUntilBlocked(amount);
 
     // then
-    verify(stub, times(amount * partitionsCount)).handle(any());
+    verify(activateJobsStub, times(amount * partitionsCount)).handle(any());
   }
 
   @Test
@@ -147,7 +156,7 @@ public final class LongPollingActivateJobsTest {
     waitUntil(request::hasScheduledTimer);
 
     // then
-    verify(stub, times(amount * partitionsCount)).handle(any());
+    verify(activateJobsStub, times(amount * partitionsCount)).handle(any());
   }
 
   @Test
@@ -157,10 +166,10 @@ public final class LongPollingActivateJobsTest {
     activateJobsAndWaitUntilBlocked(amount);
     final int firstRound = amount * partitionsCount;
 
-    verify(stub, times(firstRound)).handle(any());
+    verify(activateJobsStub, times(firstRound)).handle(any());
 
     // when
-    stub.addAvailableJobs(TYPE, 1);
+    activateJobsStub.addAvailableJobs(TYPE, 1);
     brokerClient.notifyJobsAvailable(TYPE);
 
     // then
@@ -170,7 +179,7 @@ public final class LongPollingActivateJobsTest {
     // the one request which has a result, re-triggers the remaining requests
     final int invTriggeredBySuccessfulRequest = (amount - 1) * partitionsCount;
     verify(
-            stub,
+            activateJobsStub,
             timeout(2000)
                 .times(firstRound + invTriggeredByNotification + invTriggeredBySuccessfulRequest))
         .handle(any());
@@ -201,7 +210,7 @@ public final class LongPollingActivateJobsTest {
 
     // when
     final InflightActivateJobsRequest successRequest = getLongPollingActivateJobsRequest();
-    stub.addAvailableJobs(TYPE, 1);
+    activateJobsStub.addAvailableJobs(TYPE, 1);
     brokerClient.notifyJobsAvailable(TYPE);
     handler.activateJobs(successRequest);
 
@@ -214,7 +223,7 @@ public final class LongPollingActivateJobsTest {
   public void shouldNotBlockOtherJobTypes() {
     // given
     final String otherType = "other-type";
-    stub.addAvailableJobs(otherType, 2);
+    activateJobsStub.addAvailableJobs(otherType, 2);
     final int threshold = FAILED_RESPONSE_THRESHOLD;
     activateJobsAndWaitUntilBlocked(threshold);
 
@@ -236,7 +245,7 @@ public final class LongPollingActivateJobsTest {
             .setLongPollingTimeout(20000)
             .setProbeTimeoutMillis(probeTimeout)
             .build();
-    submitLongPollingActor(handler);
+    submitActorToActivateJobs(handler);
 
     final InflightActivateJobsRequest request = getLongPollingActivateJobsRequest();
     handler.activateJobs(request);
@@ -246,7 +255,7 @@ public final class LongPollingActivateJobsTest {
     actorClock.addTime(Duration.ofMillis(probeTimeout));
 
     // then
-    verify(stub, timeout(2000).times(2 * partitionsCount)).handle(any());
+    verify(activateJobsStub, timeout(2000).times(2 * partitionsCount)).handle(any());
   }
 
   @Test
@@ -260,7 +269,7 @@ public final class LongPollingActivateJobsTest {
             .setLongPollingTimeout(longPollingTimeout)
             .setProbeTimeoutMillis(probeTimeout)
             .build();
-    submitLongPollingActor(handler);
+    submitActorToActivateJobs(handler);
 
     final int threshold = FAILED_RESPONSE_THRESHOLD;
     final List<InflightActivateJobsRequest> requests = activateJobsAndWaitUntilBlocked(threshold);
@@ -276,7 +285,7 @@ public final class LongPollingActivateJobsTest {
 
     // then
     final int totalRequests = threshold + 1;
-    verify(stub, timeout(1000).times(totalRequests * partitionsCount)).handle(any());
+    verify(activateJobsStub, timeout(1000).times(totalRequests * partitionsCount)).handle(any());
   }
 
   @Test
@@ -335,7 +344,7 @@ public final class LongPollingActivateJobsTest {
     // when
     actorClock.addTime(Duration.ofMillis(requestTimeout));
     waitUntil(shortRequest::isTimedOut);
-    stub.addAvailableJobs(TYPE, 2);
+    activateJobsStub.addAvailableJobs(TYPE, 2);
     brokerClient.notifyJobsAvailable(TYPE);
 
     // then
@@ -553,7 +562,7 @@ public final class LongPollingActivateJobsTest {
           }
         });
 
-    stub.addAvailableJobs(TYPE, 3 * MAX_JOBS_TO_ACTIVATE);
+    activateJobsStub.addAvailableJobs(TYPE, 3 * MAX_JOBS_TO_ACTIVATE);
 
     // when
     handler.activateJobs(firstRequest);
@@ -571,10 +580,10 @@ public final class LongPollingActivateJobsTest {
     assertThat(secondRequest.isCompleted()).isTrue();
     assertThat(thirdRequest.isCompleted()).isTrue();
 
-    verify(stub, times(1)).handle(firstRequest.getRequest());
-    verify(stub, times(1)).handle(secondRequest.getRequest());
-    verify(stub, times(1)).handle(thirdRequest.getRequest());
-    verify(stub, times(partitionsCount * 2)).handle(fourthRequest.getRequest());
+    verify(activateJobsStub, times(1)).handle(firstRequest.getRequest());
+    verify(activateJobsStub, times(1)).handle(secondRequest.getRequest());
+    verify(activateJobsStub, times(1)).handle(thirdRequest.getRequest());
+    verify(activateJobsStub, times(partitionsCount * 2)).handle(fourthRequest.getRequest());
   }
 
   @Test
@@ -600,7 +609,7 @@ public final class LongPollingActivateJobsTest {
                   new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "backpressure"));
             }
             count += 1;
-            return stub.handle(request);
+            return activateJobsStub.handle(request);
           }
         });
     // when
@@ -641,7 +650,7 @@ public final class LongPollingActivateJobsTest {
                       Intent.UNKNOWN, 1, RejectionType.INVALID_ARGUMENT, "expected"));
             }
             count += 1;
-            return stub.handle(request);
+            return activateJobsStub.handle(request);
           }
         });
     // when
@@ -684,7 +693,7 @@ public final class LongPollingActivateJobsTest {
 
     // then
     waitUntil(request::isCompleted);
-    verify(stub, times(partitionsCount)).handle(any());
+    verify(activateJobsStub, times(partitionsCount)).handle(any());
   }
 
   @Test
@@ -707,7 +716,7 @@ public final class LongPollingActivateJobsTest {
     waitUntil(request::isTimedOut);
 
     // then
-    verify(stub, atLeast(partitionsCount)).handle(any());
+    verify(activateJobsStub, atLeast(partitionsCount)).handle(any());
   }
 
   @Test
@@ -724,15 +733,17 @@ public final class LongPollingActivateJobsTest {
                     .build(),
                 spy(ServerStreamObserver.class)));
 
-    stub.addAvailableJobs(TYPE, MAX_JOBS_TO_ACTIVATE);
-    doReturn(Either.right(false)).when(request).tryToSendActivatedJobs(any());
+    activateJobsStub.addAvailableJobs(TYPE, MAX_JOBS_TO_ACTIVATE);
+
+    final var responseNotSent = Either.right(false);
+    doReturn(responseNotSent).when(request).tryToSendActivatedJobs(any());
 
     // when
     handler.activateJobs(request);
     waitUntil(request::isAborted);
 
     // then
-    verify(stub, times(1)).handle(request.getRequest());
+    verify(activateJobsStub, times(1)).handle(any());
   }
 
   @Test
@@ -748,16 +759,187 @@ public final class LongPollingActivateJobsTest {
                 .build(),
             spy(ServerStreamObserver.class));
 
-    stub.addAvailableJobs(TYPE, MAX_JOBS_TO_ACTIVATE);
+    activateJobsStub.addAvailableJobs(TYPE, MAX_JOBS_TO_ACTIVATE);
+
+    final var sendResponseException = new RuntimeException("foo");
     final var responseObserver = request.getResponseObserver();
-    doThrow(new RuntimeException("foo")).when(responseObserver).onNext(any());
+    doThrow(sendResponseException).when(responseObserver).onNext(any());
 
     // when
     handler.activateJobs(request);
     waitUntil(request::isAborted);
 
     // then
-    verify(stub, times(1)).handle(request.getRequest());
+    verify(activateJobsStub, times(1)).handle(any());
+  }
+
+  @Test
+  public void shouldMakeAllActivatedJobReactivatableWhenJobsAreNotSend() throws Exception {
+    // given
+    activateJobsStub.addAvailableJobs(TYPE, MAX_JOBS_TO_ACTIVATE);
+    final var request = spy(getLongPollingActivateJobsRequest());
+
+    final var responseNotSent = Either.right(false);
+    doReturn(responseNotSent).when(request).tryToSendActivatedJobs(any());
+
+    // when
+    handler.activateJobs(request);
+    waitUntil(request::isAborted);
+
+    // then
+    verify(request.getResponseObserver(), times(1)).onError(any());
+    verify(failJobStub, times(MAX_JOBS_TO_ACTIVATE)).handle(any());
+  }
+
+  @Test
+  public void shouldMakeAllActivatedJobReactivatableWhenJobsAreNotSendDueException()
+      throws Exception {
+    // given
+    activateJobsStub.addAvailableJobs(TYPE, MAX_JOBS_TO_ACTIVATE);
+    final var request = getLongPollingActivateJobsRequest();
+
+    final var sendResponseException = new RuntimeException("foo");
+    final var responseObserver = request.getResponseObserver();
+    doThrow(sendResponseException).when(responseObserver).onNext(any());
+
+    // when
+    handler.activateJobs(request);
+    waitUntil(request::isAborted);
+
+    // then
+    verify(responseObserver, times(1)).onError(any());
+    verify(failJobStub, times(MAX_JOBS_TO_ACTIVATE)).handle(any());
+  }
+
+  @Test
+  public void shouldOnlyMakeJobsReactivatableInCurrentIterationWhenJobsAreNotReturned()
+      throws Exception {
+    // given
+    final var responseNotSent = Either.right(false);
+
+    final var request =
+        spy(
+            new InflightActivateJobsRequest(
+                getNextRequestId(),
+                ActivateJobsRequest.newBuilder()
+                    .setType(TYPE)
+                    .setMaxJobsToActivate(3 * MAX_JOBS_TO_ACTIVATE)
+                    .setRequestTimeout(500)
+                    .build(),
+                spy(ServerStreamObserver.class)));
+    final var responseObserver = request.getResponseObserver();
+
+    registerCustomHandlerWithNotification(
+        (r) -> {
+          final var partitionId = r.getPartitionId();
+          if (partitionId == 1) {
+            activateJobsStub.addAvailableJobs(TYPE, MAX_JOBS_TO_ACTIVATE);
+          } else if (partitionId == 2) {
+            activateJobsStub.addAvailableJobs(TYPE, MAX_JOBS_TO_ACTIVATE);
+            doReturn(responseNotSent).when(request).tryToSendActivatedJobs(any());
+          }
+        });
+
+    // when
+    handler.activateJobs(request);
+    waitUntil(request::isAborted);
+
+    // then
+    verify(responseObserver, times(1)).onNext(any());
+    verify(activateJobsStub, times(2)).handle(request.getRequest());
+
+    verify(responseObserver, times(1)).onError(any());
+    verify(failJobStub, times(MAX_JOBS_TO_ACTIVATE)).handle(any());
+  }
+
+  @Test
+  public void shouldOnlyMakeJobsReactivatableInCurrentIterationWhenJobsAreNotReturnedDueException()
+      throws Exception {
+    // given
+    final var request =
+        new InflightActivateJobsRequest(
+            getNextRequestId(),
+            ActivateJobsRequest.newBuilder()
+                .setType(TYPE)
+                .setMaxJobsToActivate(3 * MAX_JOBS_TO_ACTIVATE)
+                .setRequestTimeout(500)
+                .build(),
+            spy(ServerStreamObserver.class));
+
+    final var responseObserver = request.getResponseObserver();
+    final var sendResponseException = new RuntimeException("foo");
+
+    registerCustomHandlerWithNotification(
+        (r) -> {
+          final var partitionId = r.getPartitionId();
+          if (partitionId == 1) {
+            activateJobsStub.addAvailableJobs(TYPE, MAX_JOBS_TO_ACTIVATE);
+          } else if (partitionId == 2) {
+            activateJobsStub.addAvailableJobs(TYPE, MAX_JOBS_TO_ACTIVATE);
+            doThrow(sendResponseException).when(responseObserver).onNext(any());
+          }
+        });
+
+    // when
+    handler.activateJobs(request);
+    waitUntil(request::isAborted);
+
+    // then
+    verify(responseObserver, times(2)).onNext(any());
+    verify(activateJobsStub, times(2)).handle(request.getRequest());
+
+    verify(responseObserver, times(1)).onError(any());
+    verify(failJobStub, times(MAX_JOBS_TO_ACTIVATE)).handle(any());
+  }
+
+  @Test
+  public void shouldSetCurrentRetriesAndNoBackoff() throws Exception {
+    // given
+    final var activatedJobRef = new AtomicReference<ActivatedJob>();
+    activateJobsStub.addAvailableJobs(TYPE, 1);
+    final var request =
+        new InflightActivateJobsRequest(
+            getNextRequestId(),
+            ActivateJobsRequest.newBuilder()
+                .setType(TYPE)
+                .setMaxJobsToActivate(MAX_JOBS_TO_ACTIVATE)
+                .setRequestTimeout(500)
+                .build(),
+            spy(ServerStreamObserver.class)) {
+
+          @Override
+          public Either<Exception, Boolean> tryToSendActivatedJobs(
+              ActivateJobsResponse grpcResponse) {
+            activatedJobRef.set(grpcResponse.getJobs(0));
+            super.tryToSendActivatedJobs(grpcResponse);
+            return Either.right(false);
+          }
+        };
+
+    // when
+    handler.activateJobs(request);
+    waitUntil(request::isAborted);
+
+    // then
+    final var brokerRequests = brokerClient.getBrokerRequests();
+    assertThat(brokerRequests)
+        .describedAs("Expected 2 requests: 1 to activate jobs and 1 to fail a job")
+        .hasSize(2);
+
+    final var firstBrokerRequest = brokerRequests.get(0);
+    assertThat(firstBrokerRequest).isInstanceOf(BrokerActivateJobsRequest.class);
+
+    final var secondBrokerRequest = brokerRequests.get(1);
+    assertThat(secondBrokerRequest).isInstanceOf(BrokerFailJobRequest.class);
+
+    final var failRequest = (BrokerFailJobRequest) secondBrokerRequest;
+    final var brokerRequestValue = failRequest.getRequestWriter();
+    final var activatedJob = activatedJobRef.get();
+
+    assertThat(failRequest.getKey()).isEqualTo(activatedJob.getKey());
+    assertThat(brokerRequestValue.getRetries()).isEqualTo(activatedJob.getRetries());
+    assertThat(brokerRequestValue.getRetryBackoff()).isEqualTo(0);
+    assertThat(brokerRequestValue.getErrorMessageBuffer()).isNotNull();
   }
 
   private List<InflightActivateJobsRequest> activateJobsAndWaitUntilBlocked(final int amount) {
@@ -803,12 +985,12 @@ public final class LongPollingActivateJobsTest {
           public BrokerResponse<?> handle(final BrokerActivateJobsRequest request)
               throws Exception {
             notification.accept(request);
-            return stub.handle(request);
+            return activateJobsStub.handle(request);
           }
         });
   }
 
-  private void submitLongPollingActor(final LongPollingActivateJobsHandler handler) {
+  private void submitActorToActivateJobs(final LongPollingActivateJobsHandler handler) {
     final var actorStartedFuture = new CompletableFuture<ActorControl>();
     final var actor =
         Actor.newActor()

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
@@ -134,6 +134,10 @@ public final class StubbedBrokerClient implements BrokerClient {
     return (T) brokerRequests.get(0);
   }
 
+  public List<BrokerRequest> getBrokerRequests() {
+    return brokerRequests;
+  }
+
   public interface RequestStub<
           RequestT extends BrokerRequest<?>, ResponseT extends BrokerResponse<?>>
       extends RequestHandler<RequestT, ResponseT> {

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -9,8 +9,11 @@ package io.camunda.zeebe.gateway.api.util;
 
 import io.camunda.zeebe.gateway.EndpointManager;
 import io.camunda.zeebe.gateway.GatewayGrpcService;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
+import io.camunda.zeebe.gateway.impl.job.RoundRobinActivateJobsHandler;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayBlockingStub;
 import io.camunda.zeebe.util.sched.Actor;
@@ -22,30 +25,30 @@ import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
-@SuppressWarnings({"rawtypes", "unchecked"})
+@SuppressWarnings({"unchecked"})
 public final class StubbedGateway {
 
   private static final String SERVER_NAME = "server";
 
   private final StubbedBrokerClient brokerClient;
-  private final ActivateJobsHandler activateJobsHandler;
   private final ActorScheduler actorScheduler;
+  private final GatewayCfg config;
   private Server server;
 
   public StubbedGateway(
       final ActorScheduler actorScheduler,
       final StubbedBrokerClient brokerClient,
-      final ActivateJobsHandler activateJobsHandler) {
+      final GatewayCfg config) {
     this.actorScheduler = actorScheduler;
     this.brokerClient = brokerClient;
-    this.activateJobsHandler = activateJobsHandler;
+    this.config = config;
   }
 
   public void start() throws IOException {
-    if (activateJobsHandler instanceof LongPollingActivateJobsHandler handler) {
-      submitLongPollingActor(handler);
-    }
+    final var activateJobsHandler = buildActivateJobsHandler(brokerClient);
+    submitActivateJobsActor((Consumer<ActorControl>) activateJobsHandler);
 
     final EndpointManager endpointManager = new EndpointManager(brokerClient, activateJobsHandler);
     final GatewayGrpcService gatewayGrpcService = new GatewayGrpcService(endpointManager);
@@ -54,17 +57,6 @@ public final class StubbedGateway {
         InProcessServerBuilder.forName(SERVER_NAME).addService(gatewayGrpcService);
     server = serverBuilder.build();
     server.start();
-  }
-
-  private void submitLongPollingActor(final LongPollingActivateJobsHandler handler) {
-    final var actorStartedFuture = new CompletableFuture<ActorControl>();
-    final var actor =
-        Actor.newActor()
-            .name(handler.getName())
-            .actorStartedHandler(handler.andThen(actorStartedFuture::complete))
-            .build();
-    actorScheduler.submitActor(actor);
-    actorStartedFuture.join();
   }
 
   public void stop() {
@@ -82,5 +74,28 @@ public final class StubbedGateway {
     final ManagedChannel channel =
         InProcessChannelBuilder.forName(SERVER_NAME).directExecutor().build();
     return GatewayGrpc.newBlockingStub(channel);
+  }
+
+  private void submitActivateJobsActor(final Consumer<ActorControl> consumer) {
+    final var actorStartedFuture = new CompletableFuture<ActorControl>();
+    final var actor =
+        Actor.newActor()
+            .name("ActivateJobsHandler")
+            .actorStartedHandler(consumer.andThen(actorStartedFuture::complete))
+            .build();
+    actorScheduler.submitActor(actor);
+    actorStartedFuture.join();
+  }
+
+  private ActivateJobsHandler buildActivateJobsHandler(final BrokerClient brokerClient) {
+    if (config.getLongPolling().isEnabled()) {
+      return buildLongPollingHandler(brokerClient);
+    } else {
+      return new RoundRobinActivateJobsHandler(brokerClient);
+    }
+  }
+
+  private LongPollingActivateJobsHandler buildLongPollingHandler(final BrokerClient brokerClient) {
+    return LongPollingActivateJobsHandler.newBuilder().setBrokerClient(brokerClient).build();
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -48,7 +48,7 @@ public final class StubbedGateway {
 
   public void start() throws IOException {
     final var activateJobsHandler = buildActivateJobsHandler(brokerClient);
-    submitActivateJobsActor((Consumer<ActorControl>) activateJobsHandler);
+    submitActorToActivateJobs((Consumer<ActorControl>) activateJobsHandler);
 
     final EndpointManager endpointManager = new EndpointManager(brokerClient, activateJobsHandler);
     final GatewayGrpcService gatewayGrpcService = new GatewayGrpcService(endpointManager);
@@ -76,7 +76,7 @@ public final class StubbedGateway {
     return GatewayGrpc.newBlockingStub(channel);
   }
 
-  private void submitActivateJobsActor(final Consumer<ActorControl> consumer) {
+  private void submitActorToActivateJobs(final Consumer<ActorControl> consumer) {
     final var actorStartedFuture = new CompletableFuture<ActorControl>();
     final var actor =
         Actor.newActor()

--- a/util/src/main/java/io/camunda/zeebe/util/sched/Actor.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/Actor.java
@@ -132,4 +132,50 @@ public abstract class Actor implements CloseableSilently, AsyncClosable, Concurr
   public void run(final Runnable action) {
     actor.run(action);
   }
+
+  public static ActorBuilder newActor() {
+    return new ActorBuilder();
+  }
+
+  public static class ActorBuilder {
+
+    private String name;
+    private Consumer<ActorControl> actorStartedHandler;
+
+    public ActorBuilder name(final String name) {
+      this.name = name;
+      return this;
+    }
+
+    public ActorBuilder actorStartedHandler(final Consumer<ActorControl> actorStartedHandler) {
+      this.actorStartedHandler = actorStartedHandler;
+      return this;
+    }
+
+    public Actor build() {
+      final var wrapper =
+          new Consumer<ActorControl>() {
+
+            @Override
+            public String toString() {
+              if (name != null) {
+                return name;
+              } else if (actorStartedHandler != null) {
+                return actorStartedHandler.getClass().getName();
+              } else {
+                return super.toString();
+              }
+            }
+
+            @Override
+            public void accept(ActorControl t) {
+              if (actorStartedHandler != null) {
+                actorStartedHandler.accept(t);
+              }
+            }
+          };
+
+      return wrap(wrapper);
+    }
+  }
 }

--- a/util/src/test/java/io/camunda/zeebe/util/sched/ActorBuilderTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/sched/ActorBuilderTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util.sched;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+public class ActorBuilderTest {
+
+  @Test
+  void shouldBuildActor() {
+    // when
+    final var actor = Actor.newActor().build();
+
+    // then
+    assertThat(actor).isNotNull().isInstanceOf(Actor.class);
+  }
+
+  @Test
+  void shouldSetActorName() {
+    // given
+    final var actorName = "foo";
+
+    // when
+    final var actor = Actor.newActor().name(actorName).build();
+
+    // then
+    assertThat(actor.getName()).isEqualTo(actorName);
+  }
+
+  @Test
+  void shouldCallOnActorStartedHandler() throws Exception {
+    // given
+    final var latch = new CountDownLatch(1);
+    final var actorControlRef = new AtomicReference<>();
+
+    final var scheduler = ActorScheduler.newActorScheduler().build();
+    scheduler.start();
+
+    // when
+    final var actor =
+        Actor.newActor()
+            .actorStartedHandler(
+                (c) -> {
+                  actorControlRef.set(c);
+                  latch.countDown();
+                })
+            .build();
+    scheduler.submitActor(actor);
+
+    // then
+    assertThat(latch.await(5, TimeUnit.SECONDS));
+    assertThat(actorControlRef.get()).isNotNull();
+
+    // cleanup
+    final var stopFuture = scheduler.stop();
+    await().until(stopFuture::isDone);
+  }
+}


### PR DESCRIPTION
## Description

* Introduces a builder to construct a "standalone" actor
* Refactors that the LongPollingHandler delegates to the actor instead
of inheriting from an actor
* Now, RoundRobinHandler also uses an actor to submit actor jobs
* RoundRobinHandler and LongPollingHandler shares the same actor to
avoid concurrent access on inflight activate jobs requests
* When the activated jobs could not be sent to the client, the activated
jobs will be made re-activatable by submitting a fail command for each
job
* Also, the round-robin handler will stop activating jobs for that given
client request
* Includes also some class name changes

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3631

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [x] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
