### PR TITLE
Writing to log from `StreamProcessorRule` is executed on an actor thread

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorInconsistentPositionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorInconsistentPositionTest.java
@@ -60,9 +60,11 @@ public final class StreamProcessorInconsistentPositionTest {
     testStreams.createLogStream(getLogName(2), 2, listLogStorage);
 
     firstStreamProcessorComposite =
-        new StreamProcessingComposite(testStreams, 1, DefaultZeebeDbFactory.defaultFactory());
+        new StreamProcessingComposite(
+            testStreams, 1, DefaultZeebeDbFactory.defaultFactory(), actorSchedulerRule.get());
     secondStreamProcessorComposite =
-        new StreamProcessingComposite(testStreams, 2, DefaultZeebeDbFactory.defaultFactory());
+        new StreamProcessingComposite(
+            testStreams, 2, DefaultZeebeDbFactory.defaultFactory(), actorSchedulerRule.get());
   }
 
   @After

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRuleTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRuleTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class EngineRuleTest {
+  @Rule public EngineRule engineRule = EngineRule.singlePartition();
+
+  /**
+   * Previously, commands were written with timestamps that weren't controlled by the actor clock in
+   * {@link EngineRule}.
+   *
+   * @see <a href="https://github.com/camunda-cloud/zeebe/issues/8891">Issue 8891</a>
+   */
+  @Test
+  public void commandTimestampIsControllable() {
+    // given
+    final var expectedTimestamp = Instant.now().minus(Duration.ofDays(1));
+    engineRule.getClock().setCurrentTime(expectedTimestamp);
+
+    // when
+    final var message = engineRule.message().withName("test").withCorrelationKey("test").publish();
+    engineRule.awaitProcessingOf(message);
+
+    // then
+    final var records = RecordingExporter.getRecords();
+    assertThat(records).allMatch(r -> r.getTimestamp() == expectedTimestamp.toEpochMilli());
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -326,7 +326,8 @@ public final class StreamProcessorRule implements TestRule {
       }
 
       streamProcessingComposite =
-          new StreamProcessingComposite(streams, startPartitionId, zeebeDbFactory);
+          new StreamProcessingComposite(
+              streams, startPartitionId, zeebeDbFactory, actorSchedulerRule.get());
     }
 
     @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -322,10 +322,10 @@ public final class TestStreams {
             () -> new NoSuchElementException("No stream processor found with name: " + streamName));
   }
 
-  public long writeBatch(final String logName, final RecordToWrite[] recordToWrites) {
+  public LogStreamBatchWriter setupBatchWriter(
+      final String logName, final RecordToWrite[] recordToWrites) {
     final SynchronousLogStream logStream = getLogStream(logName);
     final LogStreamBatchWriter logStreamBatchWriter = logStream.newLogStreamBatchWriter();
-
     for (final RecordToWrite recordToWrite : recordToWrites) {
       logStreamBatchWriter
           .event()
@@ -335,7 +335,7 @@ public final class TestStreams {
           .valueWriter(recordToWrite.getUnifiedRecordValue())
           .done();
     }
-    return logStreamBatchWriter.tryWrite();
+    return logStreamBatchWriter;
   }
 
   public static class FluentLogWriter {


### PR DESCRIPTION
## Description

Since writing records sets timestamps and we want these timestamps to be controlled by the actor clock of the `StreamProcessorRule`, writing itself must happen within an actor thread.

Here we submit a helper actor from the `StreamProcessingComposite` which is only used to execute the `write`s on an actor thread, while building the record and `LogStreamRecordWriter` happens outside the actor.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8891 

