### PR TITLE
test: enable precondition checks in benchmarks

### DIFF
--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -55,6 +55,8 @@ zeebe:
       value: "0.8"
     - name: ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK
       value: "0.9"
+    - name: ZEEBE_BROKER_EXPERIMENTAL_CONSISTENCYCHECKS_ENABLEPRECONDITIONS
+      value: "true"
 
   # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limitsS
   resources:


### PR DESCRIPTION
## Description

The new config  `zeebe.broker.experimental.consistencyChecks.enablePreconditions` is off by default. We want to make sure that the checks have no performance impact and are correct, so here we enable them for our benchmarks.
