### PR TITLE
feat: introduce foreign keys

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ConsistencyCheckCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ConsistencyCheckCfg.java
@@ -11,7 +11,9 @@ import io.camunda.zeebe.db.ConsistencyChecksSettings;
 
 public class ConsistencyCheckCfg {
   private static final boolean DEFAULT_ENABLE_PRECONDITIONS = false;
+  private static final boolean DEFAULT_ENABLE_FOREIGN_KEY_CHECKS = false;
   private boolean enablePreconditions = DEFAULT_ENABLE_PRECONDITIONS;
+  private boolean enableForeignKeyChecks = DEFAULT_ENABLE_FOREIGN_KEY_CHECKS;
 
   public boolean isEnablePreconditions() {
     return enablePreconditions;
@@ -21,8 +23,16 @@ public class ConsistencyCheckCfg {
     this.enablePreconditions = enablePreconditions;
   }
 
+  public boolean isEnableForeignKeyChecks() {
+    return enableForeignKeyChecks;
+  }
+
+  public void setEnableForeignKeyChecks(final boolean enableForeignKeyChecks) {
+    this.enableForeignKeyChecks = enableForeignKeyChecks;
+  }
+
   public ConsistencyChecksSettings getSettings() {
-    return new ConsistencyChecksSettings(enablePreconditions);
+    return new ConsistencyChecksSettings(enablePreconditions, enableForeignKeyChecks);
   }
 
   @Override

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfgTest.java
@@ -123,13 +123,36 @@ public class ExperimentalCfgTest {
   @Test
   public void shouldSetEnablePreconditionsFromEnv() {
     // given
-    environment.put("zeebe.broker.experimental.consistencyChecks.enablePreconditions", "true");
+    environment.put("zeebe.broker.experimental.consistencyChecks.enablePreconditions", "false");
 
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
     final var consistencyChecks = cfg.getExperimental().getConsistencyChecks();
 
     // then
-    assertThat(consistencyChecks.isEnablePreconditions()).isTrue();
+    assertThat(consistencyChecks.isEnablePreconditions()).isFalse();
+  }
+
+  @Test
+  public void shouldSetEnableForeignKeyChecksFromConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
+    final var consistencyChecks = cfg.getExperimental().getConsistencyChecks();
+
+    // then
+    assertThat(consistencyChecks.isEnableForeignKeyChecks()).isTrue();
+  }
+
+  @Test
+  public void shouldSetEnableForeignKeyChecksFromEnv() {
+    // given
+    environment.put("zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks", "false");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
+    final var consistencyChecks = cfg.getExperimental().getConsistencyChecks();
+
+    // then
+    assertThat(consistencyChecks.isEnableForeignKeyChecks()).isFalse();
   }
 }

--- a/broker/src/test/resources/system/experimental-cfg.yaml
+++ b/broker/src/test/resources/system/experimental-cfg.yaml
@@ -11,3 +11,4 @@ zeebe:
         enabled: true
       consistencyChecks:
         enablePreconditions: true
+        enableForeignKeyChecks: true

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -694,6 +694,10 @@
         # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_CONSISTENCYCHECKS_ENABLEPRECONDITIONS
         # enablePreconditions: false
 
+        # Configures if inserting or updating key-value pairs on RocksDB should check that foreign keys exist.
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_CONSISTENCYCHECKS_ENABLEFOREIGNKEYCHECKS
+        # enableForeignKeyChecks: false
+
       # Allows to configure the query API. By default, the broker only offers a command API, which
       # is used by the gateway to pass commands it received along to the broker. Commands can then
       # be processed. Zeebe does not directly support querying of brokers, instead it provides a way

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -631,6 +631,10 @@
         # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_CONSISTENCYCHECKS_ENABLEPRECONDITIONS
         # enablePreconditions: false
 
+        # Configures if inserting or updating key-value pairs on RocksDB should check that foreign keys exist.
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_CONSISTENCYCHECKS_ENABLEFOREIGNKEYCHECKS
+        # enableForeignKeyChecks: false
+
       # Allows to configure the query API. By default, the broker only offers a command API, which
       # is used by the gateway to pass commands it received along to the broker. Commands can then
       # be processed. Zeebe does not directly support querying of brokers, instead it provides a way

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/DefaultZeebeDbFactory.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/DefaultZeebeDbFactory.java
@@ -16,7 +16,7 @@ public final class DefaultZeebeDbFactory {
 
   public static ZeebeDbFactory<ZbColumnFamilies> defaultFactory() {
     // enable consistency checks for tests
-    final var consistencyChecks = new ConsistencyChecksSettings(true);
+    final var consistencyChecks = new ConsistencyChecksSettings(true, true);
     return new ZeebeRocksDbFactory<>(new RocksDbConfiguration(), consistencyChecks);
   }
 }

--- a/zb-db/pom.xml
+++ b/zb-db/pom.xml
@@ -44,8 +44,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/zb-db/src/main/java/io/camunda/zeebe/db/ConsistencyChecksSettings.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/ConsistencyChecksSettings.java
@@ -7,11 +7,13 @@
  */
 package io.camunda.zeebe.db;
 
-public record ConsistencyChecksSettings(boolean enablePreconditions) {
+public record ConsistencyChecksSettings(
+    boolean enablePreconditions, boolean enableForeignKeyChecks) {
   private static final boolean DEFAULT_ENABLE_PRECONDITIONS = false;
+  private static final boolean DEFAULT_ENABLE_FOREIGN_KEY_CHECKS = false;
 
   /** Intended for tests, uses the default settings for all consistency checks. */
   public ConsistencyChecksSettings() {
-    this(DEFAULT_ENABLE_PRECONDITIONS);
+    this(DEFAULT_ENABLE_PRECONDITIONS, DEFAULT_ENABLE_FOREIGN_KEY_CHECKS);
   }
 }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/ContainsForeignKeys.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/ContainsForeignKeys.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.db;
+
+import io.camunda.zeebe.db.impl.DbForeignKey;
+import java.util.Collection;
+
+public interface ContainsForeignKeys {
+  Collection<DbForeignKey<?>> containedForeignKeys();
+}

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbForeignKey.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbForeignKey.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.db.impl;
+
+import io.camunda.zeebe.db.ContainsForeignKeys;
+import io.camunda.zeebe.db.DbKey;
+import io.camunda.zeebe.db.DbValue;
+import java.util.Collection;
+import java.util.Collections;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+/**
+ * Wraps a key from a given column family. When serialized via {@link
+ * io.camunda.zeebe.util.buffer.BufferWriter}, this behaves exactly as the inner key.
+ *
+ * @param inner
+ * @param columnFamily
+ * @param <K>
+ */
+public record DbForeignKey<K extends DbKey>(K inner, Enum<?> columnFamily)
+    implements DbKey, DbValue, ContainsForeignKeys {
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    inner.wrap(buffer, offset, length);
+  }
+
+  @Override
+  public int getLength() {
+    return inner.getLength();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    inner.write(buffer, offset);
+  }
+
+  @Override
+  public Collection<DbForeignKey<?>> containedForeignKeys() {
+    return Collections.singletonList(this);
+  }
+}

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyChecker.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyChecker.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.db.impl.rocksdb.transaction;
+
+import io.camunda.zeebe.db.ConsistencyChecksSettings;
+import io.camunda.zeebe.db.ContainsForeignKeys;
+import io.camunda.zeebe.db.DbKey;
+import io.camunda.zeebe.db.ZeebeDbInconsistentException;
+import io.camunda.zeebe.db.impl.DbForeignKey;
+import io.camunda.zeebe.db.impl.ZeebeDbConstants;
+import org.agrona.ExpandableArrayBuffer;
+
+/**
+ * Similar to {@link TransactionalColumnFamily} but supports lookups on arbitrary column families.
+ * Can be used to check that a foreign key is valid.
+ */
+public final class ForeignKeyChecker {
+  private final ZeebeTransactionDb<?> transactionDb;
+  private final ExpandableArrayBuffer keyBuffer = new ExpandableArrayBuffer();
+  private final boolean enabled;
+
+  public ForeignKeyChecker(
+      final ZeebeTransactionDb<?> transactionDb, final ConsistencyChecksSettings settings) {
+    this.transactionDb = transactionDb;
+    enabled = settings.enableForeignKeyChecks();
+  }
+
+  private void assertExists(
+      final ZeebeTransaction transaction, final DbForeignKey<? extends DbKey> foreignKey)
+      throws Exception {
+    keyBuffer.putLong(0, foreignKey.columnFamily().ordinal(), ZeebeDbConstants.ZB_DB_BYTE_ORDER);
+    foreignKey.write(keyBuffer, Long.BYTES);
+    final var value =
+        transaction.get(
+            transactionDb.getDefaultNativeHandle(),
+            transactionDb.getReadOptionsNativeHandle(),
+            keyBuffer.byteArray(),
+            keyBuffer.capacity());
+    if (value == null) {
+      throw new ZeebeDbInconsistentException(
+          "Foreign key " + foreignKey.inner() + " does not exist in " + foreignKey.columnFamily());
+    }
+  }
+
+  public void assertExists(
+      final ZeebeTransaction transaction, final ContainsForeignKeys containsForeignKey)
+      throws Exception {
+    if (!enabled) {
+      return;
+    }
+    for (final var fk : containsForeignKey.containedForeignKeys()) {
+      assertExists(transaction, fk);
+    }
+  }
+}

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DefaultZeebeDbFactory.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DefaultZeebeDbFactory.java
@@ -17,7 +17,7 @@ public final class DefaultZeebeDbFactory {
   public static <ColumnFamilyType extends Enum<ColumnFamilyType>>
       ZeebeDbFactory<ColumnFamilyType> getDefaultFactory() {
     // enable consistency checks for tests
-    final var consistencyChecks = new ConsistencyChecksSettings(true);
+    final var consistencyChecks = new ConsistencyChecksSettings(true, true);
     return new ZeebeRocksDbFactory<>(new RocksDbConfiguration(), consistencyChecks);
   }
 }

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/ForeignKeyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/ForeignKeyTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.db.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.zeebe.db.DbKey;
+import org.junit.jupiter.api.Test;
+
+final class ForeignKeyTest {
+
+  @Test
+  void shouldCollectSingleForeignKey() {
+    // given
+    final var key = new DbForeignKey<>(mock(DbKey.class), TestColumnFamilies.TEST_COLUMN_FAMILY);
+
+    // then
+    assertThat(key.containedForeignKeys()).singleElement().isEqualTo(key);
+  }
+
+  @Test
+  void shouldCollectForeignKeysFromSingleComposite() {
+    // given
+    final var key = new DbForeignKey<>(mock(DbKey.class), TestColumnFamilies.TEST_COLUMN_FAMILY);
+    final var composite = new DbCompositeKey<>(key, mock(DbKey.class));
+
+    // then
+    assertThat(composite.containedForeignKeys()).singleElement().isEqualTo(key);
+  }
+
+  @Test
+  void shouldCollectForeignKeysFromNestedComposite() {
+    // given
+    final var key1 = new DbForeignKey<>(mock(DbKey.class), TestColumnFamilies.TEST_COLUMN_FAMILY);
+    final var key2 = new DbForeignKey<>(mock(DbKey.class), TestColumnFamilies.TEST_COLUMN_FAMILY);
+    final var key3 = new DbForeignKey<>(mock(DbKey.class), TestColumnFamilies.TEST_COLUMN_FAMILY);
+    final var composite = new DbCompositeKey<>(new DbCompositeKey<>(key1, key2), key3);
+
+    // then
+    assertThat(composite.containedForeignKeys()).containsExactly(key1, key2, key3);
+  }
+
+  private enum TestColumnFamilies {
+    TEST_COLUMN_FAMILY
+  }
+}

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyCheckerTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyCheckerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.db.impl.rocksdb.transaction;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.db.ConsistencyChecksSettings;
+import io.camunda.zeebe.db.ZeebeDbInconsistentException;
+import io.camunda.zeebe.db.impl.DbForeignKey;
+import io.camunda.zeebe.db.impl.DbLong;
+import org.junit.jupiter.api.Test;
+
+final class ForeignKeyCheckerTest {
+
+  @Test
+  void shouldFailOnMissingForeignKey() throws Exception {
+    // given
+    final var db = mock(ZeebeTransactionDb.class);
+    final var tx = mock(ZeebeTransaction.class);
+    final var check = new ForeignKeyChecker(db, new ConsistencyChecksSettings(true, true));
+    final var key = new DbLong();
+    key.wrapLong(1);
+
+    // when
+    when(tx.get(anyLong(), anyLong(), any(), anyInt())).thenReturn(null);
+
+    // then
+    assertThatThrownBy(
+            () ->
+                check.assertExists(
+                    tx, new DbForeignKey<>(key, TestColumnFamilies.TEST_COLUMN_FAMILY)))
+        .isInstanceOf(ZeebeDbInconsistentException.class);
+  }
+
+  @Test
+  void shouldSucceedOnExistingForeignKey() throws Exception {
+    // given
+    final var db = mock(ZeebeTransactionDb.class);
+    final var tx = mock(ZeebeTransaction.class);
+    final var check = new ForeignKeyChecker(db, new ConsistencyChecksSettings(true, true));
+    final var key = new DbLong();
+    key.wrapLong(1);
+
+    // when -- tx says every key exists
+    when(tx.get(anyLong(), anyLong(), any(), anyInt())).thenReturn(new byte[] {});
+
+    // then -- check doesn't trow
+    check.assertExists(tx, new DbForeignKey<>(key, TestColumnFamilies.TEST_COLUMN_FAMILY));
+  }
+
+  private enum TestColumnFamilies {
+    TEST_COLUMN_FAMILY
+  }
+}


### PR DESCRIPTION
## Description

This introduces a new type `DbForeignKey` that wraps an inner key and contains the name of the column family that the inner key belongs to. When used in place of regular keys or values, this allows `TransactionalColumnFamily` to check during insert/update/upsert, that the foreign key does exist in the specified column family. The lookup is implemented in `ForeignKeyChecker` which can be thought of as a flexible version of `TransactionalColumnFamily` that supports lookups over arbitrary column families.

To avoid the cost of recursively unwrapping composite keys to search for foreign keys that should be checked, constructing a composite key pre-collects a list of contained foreign keys.

The checking of foreign keys can be controlled by the feature flag `zeebe.broker.experimental.consistencyChecks.enableForeignKeys` which is off by default except for tests.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #8884 
