### PR TITLE
build: re-enable dependency analyzer

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -59,6 +59,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-bpmn-model</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -161,6 +161,9 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <failOnWarning>true</failOnWarning>
+          <ignoredNonTestScopedDependencies>
+            <ignoredNonTestScopedDependency>io.grpc:grpc-core</ignoredNonTestScopedDependency>
+          </ignoredNonTestScopedDependencies>
           <ignoredDependencies>
             <ignoredDependency>io.netty:netty-tcnative-boringssl-static</ignoredDependency>
           </ignoredDependencies>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -294,6 +294,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
+          <ignoredNonTestScopedDependencies>
+            <ignoredNonTestScopedDependency>org.agrona:agrona</ignoredNonTestScopedDependency>
+            <ignoredNonTestScopedDependency>io.netty:netty-handler</ignoredNonTestScopedDependency>
+          </ignoredNonTestScopedDependencies>
           <!-- dependencies only packaged but not explicitly used -->
           <usedDependencies>
             <dependency>io.camunda:zeebe-elasticsearch-exporter</dependency>

--- a/dmn/pom.xml
+++ b/dmn/pom.xml
@@ -45,6 +45,16 @@
       <artifactId>agrona</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.camunda.feel</groupId>
+      <artifactId>feel-engine</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-msgpack-core</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
 
     <dependency>

--- a/exporters/elasticsearch-exporter/pom.xml
+++ b/exporters/elasticsearch-exporter/pom.xml
@@ -182,5 +182,17 @@
     <!-- End of dependencies need for integration tests only -->
 
   </dependencies>
-
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredNonTestScopedDependencies>
+            <ignoredNonTestScopedDependency>com.fasterxml.jackson.core:jackson-core</ignoredNonTestScopedDependency>
+          </ignoredNonTestScopedDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/expression-language/pom.xml
+++ b/expression-language/pom.xml
@@ -27,11 +27,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-msgpack-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>zeebe-feel-integration</artifactId>
     </dependency>
 

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -49,6 +49,7 @@
     <dependency>
       <groupId>org.msgpack</groupId>
       <artifactId>msgpack-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -290,6 +291,9 @@
           <ignoredDependencies>
             <ignoredDependency>io.netty:netty-tcnative-boringssl-static</ignoredDependency>
           </ignoredDependencies>
+          <ignoredNonTestScopedDependencies>
+            <ignoredNonTestScopedDependency>io.grpc:grpc-core</ignoredNonTestScopedDependency>
+          </ignoredNonTestScopedDependencies>
         </configuration>
       </plugin>
     </plugins>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -475,12 +475,14 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${version.mockito}</version>
+        <scope>test</scope>
       </dependency>
 
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-junit-jupiter</artifactId>
         <version>${version.mockito-jupiter}</version>
+        <scope>test</scope>
       </dependency>
 
       <dependency>
@@ -1460,8 +1462,6 @@
               <!-- The analyze-only goal assumes that the test-compile phase has been executed -->
               <phase>verify</phase>
               <configuration>
-                <!-- Disabled due to https://issues.apache.org/jira/projects/MDEP/issues/MDEP-774 and https://issues.apache.org/jira/browse/MDEP-753 -->
-                <skip>true</skip>
                 <failOnWarning>true</failOnWarning>
                 <outputXML>true</outputXML>
                 <!-- dependencies not directly used in all projects during tests -->
@@ -1810,9 +1810,6 @@
                 </goals>
                 <phase>verify</phase>
                 <configuration>
-                  <!-- Disabled due to https://issues.apache.org/jira/projects/MDEP/issues/MDEP-774
-                  and https://issues.apache.org/jira/browse/MDEP-753 -->
-                  <skip>true</skip>
                   <ignoredUnusedDeclaredDependencies combine.children="append">
                     <dep>org.revapi:revapi-java</dep>
                     <dep>io.zeebe:flaky-test-extractor-maven-plugin</dep>

--- a/protocol-impl/pom.xml
+++ b/protocol-impl/pom.xml
@@ -73,8 +73,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/BrokerInfoTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/BrokerInfoTest.java
@@ -18,12 +18,12 @@ import java.util.HashMap;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public final class BrokerInfoTest {
+final class BrokerInfoTest {
 
   @Test
-  public void shouldEncodeDecodeBrokerInfo() {
+  void shouldEncodeDecodeBrokerInfo() {
     // given
     final int nodeId = 123;
     final int partitionsCount = 345;
@@ -67,7 +67,7 @@ public final class BrokerInfoTest {
   }
 
   @Test
-  public void shouldEncodeDecodeBrokerInfoWithEmptyMaps() {
+  void shouldEncodeDecodeBrokerInfoWithEmptyMaps() {
     // given
     final int nodeId = 123;
     final int partitionsCount = 345;
@@ -95,7 +95,7 @@ public final class BrokerInfoTest {
   }
 
   @Test
-  public void shouldEncodeDecodeNullValues() {
+  void shouldEncodeDecodeNullValues() {
     // given
     final BrokerInfo brokerInfo = new BrokerInfo();
 

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/SubscriptionUtilTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/SubscriptionUtilTest.java
@@ -14,12 +14,12 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public final class SubscriptionUtilTest {
+final class SubscriptionUtilTest {
 
   @Test
-  public void shouldGetSubscriptionHashCode() {
+  void shouldGetSubscriptionHashCode() {
     assertThat(getSubscriptionHashCode(wrapString("a"))).isEqualTo(97);
     assertThat(getSubscriptionHashCode(wrapString("b"))).isEqualTo(98);
     assertThat(getSubscriptionHashCode(wrapString("c"))).isEqualTo(99);
@@ -27,12 +27,12 @@ public final class SubscriptionUtilTest {
   }
 
   @Test
-  public void shouldGetZeroSubscriptionHashCodeIfEmpty() {
+  void shouldGetZeroSubscriptionHashCodeIfEmpty() {
     assertThat(getSubscriptionHashCode(new UnsafeBuffer())).isEqualTo(0);
   }
 
   @Test
-  public void shouldGetPartitionIdForCorrelationKey() {
+  void shouldGetPartitionIdForCorrelationKey() {
     assertThat(getSubscriptionPartitionId(wrapString("a"), 10)).isEqualTo(7 + START_PARTITION_ID);
     assertThat(getSubscriptionPartitionId(wrapString("b"), 3)).isEqualTo(2 + START_PARTITION_ID);
     assertThat(getSubscriptionPartitionId(wrapString("c"), 11)).isEqualTo(0 + START_PARTITION_ID);

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -118,12 +118,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-elasticsearch-exporter</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
       <scope>test</scope>

--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -67,11 +67,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.msgpack</groupId>
       <artifactId>jackson-dataformat-msgpack</artifactId>
     </dependency>

--- a/zb-db/pom.xml
+++ b/zb-db/pom.xml
@@ -44,6 +44,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
@@ -57,7 +63,8 @@
 
     <dependency>
       <groupId>net.jqwik</groupId>
-      <artifactId>jqwik</artifactId>
+      <artifactId>jqwik-api</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Description

Re-enables the dependency analyzer plugin and tries to fix all dependency issues. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8690
