### PR TITLE
Add missing protocol-jackson types for DMN records

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -111,6 +111,7 @@
     <version.commons-io>2.11.0</version.commons-io>
     <version.immutables>2.9.0</version.immutables>
     <version.jsr305>3.0.2</version.jsr305>
+    <version.classgraph>4.8.139</version.classgraph>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.0.0</plugin.version.antrun>
@@ -911,6 +912,12 @@
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
         <version>${version.byte-buddy}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.github.classgraph</groupId>
+        <artifactId>classgraph</artifactId>
+        <version>${version.classgraph}</version>
       </dependency>
 
       <dependency>

--- a/protocol-jackson/pom.xml
+++ b/protocol-jackson/pom.xml
@@ -62,6 +62,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.github.classgraph</groupId>
+      <artifactId>classgraph</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/protocol-jackson/pom.xml
+++ b/protocol-jackson/pom.xml
@@ -52,6 +52,12 @@
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractEvaluatedDecisionValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractEvaluatedDecisionValue.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.EvaluatedDecisionValueBuilder.ImmutableEvaluatedDecisionValue;
+import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableEvaluatedDecisionValue.class)
+public abstract class AbstractEvaluatedDecisionValue implements EvaluatedDecisionValue {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractEvaluatedInputValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractEvaluatedInputValue.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.EvaluatedInputValueBuilder.ImmutableEvaluatedInputValue;
+import io.camunda.zeebe.protocol.record.value.EvaluatedInputValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableEvaluatedInputValue.class)
+public abstract class AbstractEvaluatedInputValue implements EvaluatedInputValue {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractEvaluatedOutputValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractEvaluatedOutputValue.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.EvaluatedOutputValueBuilder.ImmutableEvaluatedOutputValue;
+import io.camunda.zeebe.protocol.record.value.EvaluatedOutputValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableEvaluatedOutputValue.class)
+public abstract class AbstractEvaluatedOutputValue implements EvaluatedOutputValue {}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractMatchedRuleValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractMatchedRuleValue.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.camunda.zeebe.protocol.jackson.record.MatchedRuleValueBuilder.ImmutableMatchedRuleValue;
+import io.camunda.zeebe.protocol.record.value.MatchedRuleValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ZeebeStyle
+@JsonDeserialize(as = ImmutableMatchedRuleValue.class)
+public abstract class AbstractMatchedRuleValue implements MatchedRuleValue {}

--- a/protocol-jackson/src/test/java/io/camunda/zeebe/protocol/jackson/record/CompletenessTest.java
+++ b/protocol-jackson/src/test/java/io/camunda/zeebe/protocol/jackson/record/CompletenessTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ClassInfoList;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * This test ensures that there is an immutable variant of {@link Record} generated, and one for
+ * each interface found in {@link io.camunda.zeebe.protocol.record.value} (and its subpackages).
+ *
+ * <p>This assumes that all interfaces in there are meant to be protocol types.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+final class CompletenessTest {
+  private static final ClassInfoList ABSTRACT_TYPES =
+      new ClassGraph()
+          .acceptPackages("io.camunda.zeebe.protocol.jackson.record")
+          .scan()
+          .getAllStandardClasses()
+          .filter(ClassInfo::isAbstract)
+          .filter(info -> !info.isInnerClass());
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("provideProtocolTypes")
+  void shouldGenerateImmutableRecord(
+      @SuppressWarnings("unused") final String className, final Class<?> protocolClass) {
+    // given
+    final ClassInfoList abstractClass =
+        ABSTRACT_TYPES.filter(info -> info.implementsInterface(protocolClass)).directOnly();
+
+    // then
+    assertThat(abstractClass)
+        .as(
+            "there should be exactly one abstract variant '%s' in this module; "
+                + "if the interface in question is actually a meta interface, like '%s', "
+                + "please add it to the rejectClasses(...) call below",
+            protocolClass, ProcessInstanceRelated.class)
+        .isNotEmpty();
+  }
+
+  private static Stream<Arguments> provideProtocolTypes() {
+    return findProtocolTypes().stream()
+        .map(info -> Arguments.of(info.getSimpleName(), info.loadClass()));
+  }
+
+  private static ClassInfoList findProtocolTypes() {
+    return new ClassGraph()
+        .acceptClasses(Record.class.getName())
+        .acceptPackages(
+            "io.camunda.zeebe.protocol.record.value", "io.camunda.zeebe.protocol.record.value.*")
+        .rejectClasses(ProcessInstanceRelated.class.getName())
+        .scan()
+        .getAllInterfaces();
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the missing protocol types for DMN records, and a test which will fail if a new interface is added under `io.camunda.protocol.record.value` (or a sub-package) which has no corresponding abstract type (with the exception of `ProcessInstanceRelated`).

This isn't the ideal solution, and I would still push for #8837, but as I don't know when that will happen, this should help things fo r now.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
