### PR TITLE
Rename distribution artifact from camunda-cloud-zeebe to camunda-zeebe

### DIFF
--- a/.ci/scripts/docker/build.sh
+++ b/.ci/scripts/docker/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -eux
 
 echo "Building Zeebe Docker image ${IMAGE}:${TAG}"
-docker build --no-cache --build-arg DISTBALL=camunda-cloud-zeebe.tar.gz -t ${IMAGE}:${TAG} --target app .
+docker build --no-cache --build-arg DISTBALL=camunda-zeebe.tar.gz -t ${IMAGE}:${TAG} --target app .

--- a/.ci/scripts/docker/prepare.sh
+++ b/.ci/scripts/docker/prepare.sh
@@ -2,10 +2,10 @@
 
 mvn dependency:get -B \
     -DremoteRepositories="camunda-nexus::::https://app.camunda.com/nexus/content/repositories/public" \
-    -DgroupId="io.camunda" -DartifactId="camunda-cloud-zeebe" \
+    -DgroupId="io.camunda" -DartifactId="camunda-zeebe" \
     -Dversion="${VERSION}" -Dpackaging="tar.gz" -Dtransitive=false
 
 mvn dependency:copy -B \
-    -Dartifact="io.camunda:camunda-cloud-zeebe:${VERSION}:tar.gz" \
+    -Dartifact="io.camunda:camunda-zeebe:${VERSION}:tar.gz" \
     -DoutputDirectory=${WORKSPACE} \
     -Dmdep.stripVersion=true

--- a/.ci/scripts/release/github-release.sh
+++ b/.ci/scripts/release/github-release.sh
@@ -15,8 +15,8 @@ declare -a GH_OPTIONS=()
 # compute their sha1 sum and upload those as well, but no need to list that here. If there are new
 # binaries to ship with a Zeebe release, add them here.
 declare -a ARTIFACTS=( \
-  "dist/target/camunda-cloud-zeebe-${RELEASE_VERSION}.tar.gz" \
-  "dist/target/camunda-cloud-zeebe-${RELEASE_VERSION}.zip" \
+  "dist/target/camunda-zeebe-${RELEASE_VERSION}.tar.gz" \
+  "dist/target/camunda-zeebe-${RELEASE_VERSION}.zip" \
   "clients/go/cmd/zbctl/dist/zbctl" \
   "clients/go/cmd/zbctl/dist/zbctl.exe" \
   "clients/go/cmd/zbctl/dist/zbctl.darwin" \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@ run the command: `mvn clean install -DskipTests` in the root folder.
 The resulting Zeebe distribution can be found in the folder `dist/target`, i.e.
 
 ```
-dist/target/camunda-cloud-zeebe-X.Y.Z-SNAPSHOT.tar.gz
-dist/target/camunda-cloud-zeebe-X.Y.Z-SNAPSHOT.zip
+dist/target/camunda-zeebe-X.Y.Z-SNAPSHOT.tar.gz
+dist/target/camunda-zeebe-X.Y.Z-SNAPSHOT.zip
 ```
 
 This is a small overview of the contents of the different modules:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,7 @@ pipeline {
             }
             steps {
                 timeout(time: shortTimeoutMinutes, unit: 'MINUTES') {
-                    // since zbctl is included in camunda-cloud-zeebe.tar.gz, which is produced by
+                    // since zbctl is included in camunda-zeebe.tar.gz, which is produced by
                     // maven, we have to build the go artifacts first
                     container('golang') {
                         sh '.ci/scripts/distribution/build-go.sh'
@@ -102,10 +102,10 @@ pipeline {
 
                     // to simplify building the Docker image, we copy the distribution to a fixed
                     // filename that doesn't include the version
-                    runMavenContainerCommand('cp dist/target/camunda-cloud-zeebe-*.tar.gz camunda-cloud-zeebe.tar.gz')
+                    runMavenContainerCommand('cp dist/target/camunda-zeebe-*.tar.gz camunda-zeebe.tar.gz')
 
                     container('python') {
-                        camundaGCloudSaveTmpFile('zeebe-distro', ['camunda-cloud-zeebe.tar.gz'])
+                        camundaGCloudSaveTmpFile('zeebe-distro', ['camunda-zeebe.tar.gz'])
 
                         sh "tar -cf zeebe-build.tar ./m2-repository/io/camunda/*/${VERSION}/*"
                         camundaGCloudSaveTmpFile('zeebe-build', ['zeebe-build.tar'])
@@ -274,7 +274,7 @@ pipeline {
                             steps {
                                 timeout(time: shortTimeoutMinutes, unit: 'MINUTES') {
                                     container('python') {
-                                        camundaGCloudRestoreTmpFile('zeebe-distro', ['camunda-cloud-zeebe.tar.gz'])
+                                        camundaGCloudRestoreTmpFile('zeebe-distro', ['camunda-zeebe.tar.gz'])
                                     }
                                     container('docker') {
                                         sh '.ci/scripts/docker/build.sh'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zeebe - Workflow Engine for Microservices Orchestration
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.camunda.zeebe/camunda-cloud-zeebe/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.camunda.zeebe/camunda-cloud-zeebe)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.camunda.zeebe/camunda-zeebe/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.camunda.zeebe/camunda-zeebe)
 
 Zeebe provides visibility into and control over business processes that span multiple microservices. It is the engine that powers [Camunda Cloud](https://camunda.com/products/cloud/workflow-engine/).
 

--- a/benchmarks/setup/README.md
+++ b/benchmarks/setup/README.md
@@ -46,7 +46,7 @@ If you want to use your own or a different Zeebe snapshot then you could do the 
 # builds the dist with zbctl packed
 clients/go/cmd/zbctl/build.sh && mvn clean install -T1C -DskipTests -pl dist -am
 # builds the a new zeebe docker image
-docker build --build-arg DISTBALL=dist/target/camunda-cloud-zeebe-*.tar.gz -t gcr.io/zeebe-io/zeebe:SNAPSHOT-$(date +%Y-%m-%d)-$(git rev-parse --short=8 HEAD) --target app .
+docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz -t gcr.io/zeebe-io/zeebe:SNAPSHOT-$(date +%Y-%m-%d)-$(git rev-parse --short=8 HEAD) --target app .
 # pushes the image to our docker registry
 docker push gcr.io/zeebe-io/zeebe:SNAPSHOT-$(date +%Y-%m-%d)-$(git rev-parse --short=8 HEAD)
 ```

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -26,7 +26,7 @@ GO111MODULE=off mockgen -source $GOPATH/src/github.com/camunda-cloud/zeebe/clien
 To run the integration tests, a Docker image for Zeebe must be built with the tag 'current-test'. To do that you can run (in the camunda-cloud/zeebe dir):
 
 ```
-docker build --build-arg DISTBALL=dist/target/camunda-cloud-zeebe*.tar.gz -t camunda/zeebe:current-test --target app .
+docker build --build-arg DISTBALL=dist/target/camunda-zeebe*.tar.gz -t camunda/zeebe:current-test --target app .
 ```
 
 To add new zbctl tests, you must generate a golden file with the expected output of the command you are testing. The tests ignore numbers so you can leave any keys or timestamps in your golden file, even though these will most likely be different from test command's output. However, non-numeric variables are not ignored. For instance, the help menu contains:

--- a/createBenchmark.sh
+++ b/createBenchmark.sh
@@ -44,7 +44,7 @@ set -x
 
 mvn clean install -DskipTests -DskipChecks -T1C
 
-docker build --build-arg DISTBALL=dist/target/camunda-cloud-zeebe-*.tar.gz --build-arg APP_ENV=dev -t "gcr.io/zeebe-io/zeebe:$benchmark" .
+docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t "gcr.io/zeebe-io/zeebe:$benchmark" .
 docker push "gcr.io/zeebe-io/zeebe:$benchmark"
 
 cd benchmarks/project

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -9,7 +9,7 @@
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>camunda-cloud-zeebe</artifactId>
+  <artifactId>camunda-zeebe</artifactId>
 
   <packaging>jar</packaging>
 
@@ -206,13 +206,13 @@
   </dependencies>
 
   <build>
-    <finalName>camunda-cloud-zeebe-${project.version}</finalName>
+    <finalName>camunda-zeebe-${project.version}</finalName>
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>appassembler-maven-plugin</artifactId>
         <configuration>
-          <assembleDirectory>${project.build.directory}/camunda-cloud-zeebe</assembleDirectory>
+          <assembleDirectory>${project.build.directory}/camunda-zeebe</assembleDirectory>
           <configurationDirectory>config</configurationDirectory>
           <copyConfigurationDirectory>true</copyConfigurationDirectory>
           <extraJvmArguments>-Xms128m
@@ -260,10 +260,10 @@
             <configuration>
               <target>
                 <?SORTPOM IGNORE?> <!-- ordering is important here, chmod needs to run after copying -->
-                <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.exe" tofile="${project.build.directory}/camunda-cloud-zeebe/bin/zbctl.exe" />
-                <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.darwin" tofile="${project.build.directory}/camunda-cloud-zeebe/bin/zbctl.darwin" />
-                <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl" tofile="${project.build.directory}/camunda-cloud-zeebe/bin/zbctl" />
-                <chmod dir="${project.build.directory}/camunda-cloud-zeebe/bin" failonerror="${zbctl.force}" includes="zbctl*" perm="ugo+rx" />
+                <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.exe" tofile="${project.build.directory}/camunda-zeebe/bin/zbctl.exe" />
+                <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.darwin" tofile="${project.build.directory}/camunda-zeebe/bin/zbctl.darwin" />
+                <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl" tofile="${project.build.directory}/camunda-zeebe/bin/zbctl" />
+                <chmod dir="${project.build.directory}/camunda-zeebe/bin" failonerror="${zbctl.force}" includes="zbctl*" perm="ugo+rx" />
                 <?SORTPOM RESUME?>
               </target>
             </configuration>

--- a/dist/src/main/assembly.xml
+++ b/dist/src/main/assembly.xml
@@ -5,7 +5,7 @@
   <id>distro</id>
 
   <includeBaseDirectory>true</includeBaseDirectory>
-  <baseDirectory>camunda-cloud-zeebe-${project.version}/</baseDirectory>
+  <baseDirectory>camunda-zeebe-${project.version}/</baseDirectory>
 
   <formats>
     <format>zip</format>
@@ -14,7 +14,7 @@
 
   <fileSets>
     <fileSet>
-      <directory>${project.build.directory}/camunda-cloud-zeebe</directory>
+      <directory>${project.build.directory}/camunda-zeebe</directory>
       <outputDirectory>/</outputDirectory>
     </fileSet>
     <fileSet>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -301,7 +301,7 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>camunda-cloud-zeebe</artifactId>
+      <artifactId>camunda-zeebe</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/qa/update-tests/README.md
+++ b/qa/update-tests/README.md
@@ -3,7 +3,7 @@
 To run the upgradability tests, a Docker image for Zeebe must be built with the tag 'current-test'. To do that you can run (in the zeebe-io/zeebe dir):
 
 ```
-docker build --build-arg DISTBALL=dist/target/camunda-cloud-zeebe*.tar.gz -t camunda/zeebe:current-test --target app .
+docker build --build-arg DISTBALL=dist/target/camunda-zeebe*.tar.gz -t camunda/zeebe:current-test --target app .
 ```
 
 ## Debugging

--- a/recreateBenchmark.sh
+++ b/recreateBenchmark.sh
@@ -51,7 +51,7 @@ set -x
 
 mvn clean install -DskipTests -DskipChecks -T1C
 
-docker build --build-arg DISTBALL=dist/target/camunda-cloud-zeebe-*.tar.gz --build-arg APP_ENV=dev -t "gcr.io/zeebe-io/zeebe:$benchmark" .
+docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t "gcr.io/zeebe-io/zeebe:$benchmark" .
 docker push "gcr.io/zeebe-io/zeebe:$benchmark"
 
 cd "$pwd/benchmarks/project"


### PR DESCRIPTION
## Description

This PR renames the distribution artifact produced by `dist` to `camunda-zeebe`. This aligns the artifact names with other Camunda 8 artifacts in order to avoid confusion between Camunda and Camunda Cloud.

NOTE: I haven't tested the release since our release job picks up the scripts from `main`. I will test it once it's merged, but before the release. I anyway need to test the repo move before the release in April, so I would test them both then.

## Related issues

closes #8911

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
