### PR TITLE
ci: temporarily disable macos smoke tests for bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [
   "continuous-integration/jenkins/branch",
-  "Run smoke tests on macos-latest",
+  # "Run smoke tests on macos-latest",
   "Run smoke tests on windows-2022",
   "Run smoke tests on ubuntu-latest"
 ]


### PR DESCRIPTION
## Description

Temporarily disable the macOS smoke tests because there are a lot of failed bors runs due to a broken cache.