### PR TITLE
ci: a failing smoke test doesn't cancel other smoke tests

### DIFF
--- a/.github/workflows/os-smoke-test.yml
+++ b/.github/workflows/os-smoke-test.yml
@@ -17,6 +17,7 @@ jobs:
     timeout-minutes: 20
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ macos-latest, windows-2022, ubuntu-latest ]
 


### PR DESCRIPTION
Whenever a smoke test failed, it cancelled other smoke tests. This
prevented us from easily disabling one smoke test in the bors conditions

Now we always run all smoke tests and don't cancel others on failure.

relates to #8920 