### PR TITLE
New deploy resource RPC

### DIFF
--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -160,6 +160,37 @@ message DeployProcessResponse {
   repeated ProcessMetadata processes = 2;
 }
 
+message DeployRequest {
+  // list of resources to deploy
+  repeated Resource resources = 1;
+}
+
+message Resource {
+  // the resource name, e.g. myProcess.bpmn or myDecision.dmn
+  string name = 1;
+  // the file content as a UTF8-encoded string
+  bytes content = 2;
+}
+
+message DeployResponse {
+  // the unique key identifying the deployment
+  int64 key = 1;
+  // a list of deployed resources, e.g. processes
+  repeated Deployment deployments = 2;
+}
+
+message Deployment {
+  // each deployment has only one metadata
+  oneof Metadata {
+    // metadata of a deployed process
+    ProcessMetadata process = 1;
+    // metadata of a deployed decision
+    DecisionMetadata decision = 2;
+    // metadata of a deployed decision requirements
+    DecisionRequirementsMetadata decisionRequirements = 3;
+  }
+}
+
 message ProcessMetadata {
   // the bpmn process ID, as parsed during deployment; together with the version forms a
   // unique identifier for a specific process definition
@@ -171,6 +202,50 @@ message ProcessMetadata {
   // the resource name (see: ProcessRequestObject.name) from which this process was
   // parsed
   string resourceName = 4;
+}
+
+message DecisionMetadata {
+  // the dmn decision ID, as parsed during deployment; together with the
+  // versions forms a unique identifier for a specific decision
+  string dmnDecisionId = 1;
+  // the dmn name of the decision, as parsed during deployment
+  string dmnDecisionName = 2;
+  // the assigned decision version
+  int32 version = 3;
+  // the assigned decision key, which acts as a unique identifier for this
+  // decision
+  int64 decisionKey = 4;
+  // the dmn ID of the decision requirements graph that this decision is part
+  // of, as parsed during deployment
+  string dmnDecisionRequirementsId = 5;
+  // the assigned key of the decision requirements graph that this decision is
+  // part of
+  int64 decisionRequirementsKey = 6;
+  // whether this decision was already deployed previously
+  // todo: debate this field
+  bool isDuplicate = 7;
+}
+
+message DecisionRequirementsMetadata {
+  // the dmn decision requirements ID, as parsed during deployment; together
+  // with the versions forms a unique identifier for a specific decision
+  string dmnDecisionRequirementsId = 1;
+  // the dmn name of the decision requirements, as parsed during deployment
+  string dmnDecisionRequirementsName = 2;
+  // the assigned decision requirements version
+  int32 version = 3;
+  // the assigned decision requirements key, which acts as a unique identifier
+  // for this decision requirements
+  int64 decisionRequirementsKey = 4;
+  // the dmn namespace, as parsed during deployment
+  // todo: debate this field (e.g. http://camunda.org/schema/1.0/dmn)
+  string namespace = 5;
+  // the resource name (see: Resource.name) from which this decision
+  // requirements was parsed
+  string resourceName = 6;
+  // whether this decision requirements was already deployed previously
+  // todo: debate this field
+  bool isDuplicate = 7;
 }
 
 message FailJobRequest {
@@ -397,6 +472,13 @@ service Gateway {
    */
   rpc DeployProcess (DeployProcessRequest) returns (DeployProcessResponse) {
   }
+
+  /*
+    Deploys one or more resources (i.e. processes or decision models) to Zeebe.
+  */
+  rpc DeployResource (DeployRequest) returns (DeployResponse) {
+  }
+
 
   /*
     Marks the job as failed; if the retries argument is positive, then the job will be immediately

--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -160,7 +160,7 @@ message DeployProcessResponse {
   repeated ProcessMetadata processes = 2;
 }
 
-message DeployRequest {
+message DeployResourceRequest {
   // list of resources to deploy
   repeated Resource resources = 1;
 }
@@ -172,7 +172,7 @@ message Resource {
   bytes content = 2;
 }
 
-message DeployResponse {
+message DeployResourceResponse {
   // the unique key identifying the deployment
   int64 key = 1;
   // a list of deployed resources, e.g. processes
@@ -467,7 +467,7 @@ service Gateway {
   /*
     Deploys one or more resources (i.e. processes or decision models) to Zeebe.
   */
-  rpc DeployResource (DeployRequest) returns (DeployResponse) {
+  rpc DeployResource (DeployResourceRequest) returns (DeployResourceResponse) {
   }
 
 

--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -221,9 +221,6 @@ message DecisionMetadata {
   // the assigned key of the decision requirements graph that this decision is
   // part of
   int64 decisionRequirementsKey = 6;
-  // whether this decision was already deployed previously
-  // todo: debate this field
-  bool isDuplicate = 7;
 }
 
 message DecisionRequirementsMetadata {
@@ -237,15 +234,9 @@ message DecisionRequirementsMetadata {
   // the assigned decision requirements key, which acts as a unique identifier
   // for this decision requirements
   int64 decisionRequirementsKey = 4;
-  // the dmn namespace, as parsed during deployment
-  // todo: debate this field (e.g. http://camunda.org/schema/1.0/dmn)
-  string namespace = 5;
   // the resource name (see: Resource.name) from which this decision
   // requirements was parsed
-  string resourceName = 6;
-  // whether this decision requirements was already deployed previously
-  // todo: debate this field
-  bool isDuplicate = 7;
+  string resourceName = 5;
 }
 
 message FailJobRequest {

--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -465,7 +465,15 @@ service Gateway {
   }
 
   /*
-    Deploys one or more resources (i.e. processes or decision models) to Zeebe.
+    Deploys one or more resources (e.g. processes or decision models) to Zeebe.
+    Note that this is an atomic call, i.e. either all resources are deployed, or none of them are.
+
+    Errors:
+      INVALID_ARGUMENT:
+        - no resources given.
+        - if at least one resource is invalid. A resource is considered invalid if:
+          - the content is not deserializable (e.g. detected as BPMN, but it's broken XML)
+          - the content is invalid (e.g. an event-based gateway has an outgoing sequence flow to a task)
   */
   rpc DeployResource (DeployResourceRequest) returns (DeployResourceResponse) {
   }

--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -142,11 +142,15 @@ message CreateProcessInstanceWithResultResponse {
 }
 
 message DeployProcessRequest {
+  // since 8, replaced by DeployResourceRequest
+  option deprecated = true;
   // List of process resources to deploy
   repeated ProcessRequestObject processes = 1;
 }
 
 message ProcessRequestObject {
+  // since 8, replaced by Resource
+  option deprecated = true;
   // the resource basename, e.g. myProcess.bpmn
   string name = 1;
   // the process definition as a UTF8-encoded string
@@ -154,6 +158,8 @@ message ProcessRequestObject {
 }
 
 message DeployProcessResponse {
+  // since 8, replaced by DeployResourceResponse
+  option deprecated = true;
   // the unique key identifying the deployment
   int64 key = 1;
   // a list of deployed processes
@@ -462,6 +468,8 @@ service Gateway {
           - the process is invalid (e.g. an event-based gateway has an outgoing sequence flow to a task)
    */
   rpc DeployProcess (DeployProcessRequest) returns (DeployProcessResponse) {
+    // since 8, replaced by DeployResource
+    option deprecated = true;
   }
 
   /*

--- a/gateway-protocol/src/main/proto/proto.lock
+++ b/gateway-protocol/src/main/proto/proto.lock
@@ -296,6 +296,12 @@
                 "type": "ProcessRequestObject",
                 "is_repeated": true
               }
+            ],
+            "options": [
+              {
+                "name": "deprecated",
+                "value": "true"
+              }
             ]
           },
           {
@@ -310,6 +316,12 @@
                 "id": 2,
                 "name": "definition",
                 "type": "bytes"
+              }
+            ],
+            "options": [
+              {
+                "name": "deprecated",
+                "value": "true"
               }
             ]
           },
@@ -326,6 +338,74 @@
                 "name": "processes",
                 "type": "ProcessMetadata",
                 "is_repeated": true
+              }
+            ],
+            "options": [
+              {
+                "name": "deprecated",
+                "value": "true"
+              }
+            ]
+          },
+          {
+            "name": "DeployResourceRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "resources",
+                "type": "Resource",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "Resource",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "content",
+                "type": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "DeployResourceResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "key",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "deployments",
+                "type": "Deployment",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "Deployment",
+            "fields": [
+              {
+                "id": 1,
+                "name": "process",
+                "type": "ProcessMetadata"
+              },
+              {
+                "id": 2,
+                "name": "decision",
+                "type": "DecisionMetadata"
+              },
+              {
+                "id": 3,
+                "name": "decisionRequirements",
+                "type": "DecisionRequirementsMetadata"
               }
             ]
           },
@@ -349,6 +429,71 @@
               },
               {
                 "id": 4,
+                "name": "resourceName",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "DecisionMetadata",
+            "fields": [
+              {
+                "id": 1,
+                "name": "dmnDecisionId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "dmnDecisionName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "version",
+                "type": "int32"
+              },
+              {
+                "id": 4,
+                "name": "decisionKey",
+                "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "dmnDecisionRequirementsId",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "decisionRequirementsKey",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "DecisionRequirementsMetadata",
+            "fields": [
+              {
+                "id": 1,
+                "name": "dmnDecisionRequirementsId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "dmnDecisionRequirementsName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "version",
+                "type": "int32"
+              },
+              {
+                "id": 4,
+                "name": "decisionRequirementsKey",
+                "type": "int64"
+              },
+              {
+                "id": 5,
                 "name": "resourceName",
                 "type": "string"
               }
@@ -625,7 +770,18 @@
               {
                 "name": "DeployProcess",
                 "in_type": "DeployProcessRequest",
-                "out_type": "DeployProcessResponse"
+                "out_type": "DeployProcessResponse",
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
+              },
+              {
+                "name": "DeployResource",
+                "in_type": "DeployResourceRequest",
+                "out_type": "DeployResourceResponse"
               },
               {
                 "name": "FailJob",

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -30,6 +30,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstance
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Partition;
@@ -206,6 +208,17 @@ public final class EndpointManager {
         request,
         RequestMapper::toDeployProcessRequest,
         ResponseMapper::toDeployProcessResponse,
+        responseObserver);
+  }
+
+  public void deployResource(
+      final DeployResourceRequest request,
+      final ServerStreamObserver<DeployResourceResponse> responseObserver) {
+
+    sendRequest(
+        request,
+        RequestMapper::toDeployResourceRequest,
+        ResponseMapper::toDeployResourceResponse,
         responseObserver);
   }
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/GatewayGrpcService.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/GatewayGrpcService.java
@@ -21,6 +21,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstance
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.PublishMessageRequest;
@@ -89,6 +91,14 @@ public class GatewayGrpcService extends GatewayImplBase {
       final DeployProcessRequest request,
       final StreamObserver<DeployProcessResponse> responseObserver) {
     endpointManager.deployProcess(
+        request, ErrorMappingStreamObserver.ofStreamObserver(responseObserver));
+  }
+
+  @Override
+  public void deployResource(
+      final DeployResourceRequest request,
+      final StreamObserver<DeployResourceResponse> responseObserver) {
+    endpointManager.deployResource(
         request, ErrorMappingStreamObserver.ofStreamObserver(responseObserver));
   }
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerCancelProcessInstanceR
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCompleteJobRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceWithResultRequest;
-import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeployProcessRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeployResourceRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerFailJobRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerPublishMessageRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerResolveIncidentRequest;
@@ -28,10 +28,12 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessRequestObject;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.PublishMessageRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ResolveIncidentRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Resource;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.SetVariablesRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest;
@@ -42,12 +44,23 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 public final class RequestMapper {
 
-  public static BrokerDeployProcessRequest toDeployProcessRequest(
+  public static BrokerDeployResourceRequest toDeployProcessRequest(
       final DeployProcessRequest grpcRequest) {
-    final BrokerDeployProcessRequest brokerRequest = new BrokerDeployProcessRequest();
+    final BrokerDeployResourceRequest brokerRequest = new BrokerDeployResourceRequest();
 
     for (final ProcessRequestObject process : grpcRequest.getProcessesList()) {
       brokerRequest.addResource(process.getDefinition().toByteArray(), process.getName());
+    }
+
+    return brokerRequest;
+  }
+
+  public static BrokerDeployResourceRequest toDeployResourceRequest(
+      final DeployResourceRequest grpcRequest) {
+    final BrokerDeployResourceRequest brokerRequest = new BrokerDeployResourceRequest();
+
+    for (final Resource resource : grpcRequest.getResourcesList()) {
+      brokerRequest.addResource(resource.getContent().toByteArray(), resource.getName());
     }
 
     return brokerRequest;

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -65,50 +65,41 @@ public final class ResponseMapper {
       final long key, final DeploymentRecord brokerResponse) {
     final var responseBuilder = DeployResourceResponse.newBuilder().setKey(key);
 
-    brokerResponse
-        .processesMetadata()
-        .forEach(
+    brokerResponse.processesMetadata().stream()
+        .map(
             process ->
-                responseBuilder
-                    .addDeploymentsBuilder()
-                    .setProcess(
-                        ProcessMetadata.newBuilder()
-                            .setBpmnProcessId(process.getBpmnProcessId())
-                            .setVersion(process.getVersion())
-                            .setProcessDefinitionKey(process.getKey())
-                            .setResourceName(process.getResourceName())
-                            .build()));
+                ProcessMetadata.newBuilder()
+                    .setBpmnProcessId(process.getBpmnProcessId())
+                    .setVersion(process.getVersion())
+                    .setProcessDefinitionKey(process.getKey())
+                    .setResourceName(process.getResourceName())
+                    .build())
+        .forEach(process -> responseBuilder.addDeploymentsBuilder().setProcess(process));
 
-    brokerResponse
-        .decisionsMetadata()
-        .forEach(
+    brokerResponse.decisionsMetadata().stream()
+        .map(
             decision ->
-                responseBuilder
-                    .addDeploymentsBuilder()
-                    .setDecision(
-                        DecisionMetadata.newBuilder()
-                            .setDmnDecisionId(decision.getDecisionId())
-                            .setDmnDecisionName(decision.getDecisionName())
-                            .setVersion(decision.getVersion())
-                            .setDecisionKey(decision.getDecisionKey())
-                            .setDmnDecisionRequirementsId(decision.getDecisionRequirementsId())
-                            .setDecisionRequirementsKey(decision.getDecisionRequirementsKey())
-                            .build()));
+                DecisionMetadata.newBuilder()
+                    .setDmnDecisionId(decision.getDecisionId())
+                    .setDmnDecisionName(decision.getDecisionName())
+                    .setVersion(decision.getVersion())
+                    .setDecisionKey(decision.getDecisionKey())
+                    .setDmnDecisionRequirementsId(decision.getDecisionRequirementsId())
+                    .setDecisionRequirementsKey(decision.getDecisionRequirementsKey())
+                    .build())
+        .forEach(decision -> responseBuilder.addDeploymentsBuilder().setDecision(decision));
 
-    brokerResponse
-        .decisionRequirementsMetadata()
-        .forEach(
+    brokerResponse.decisionRequirementsMetadata().stream()
+        .map(
             drg ->
-                responseBuilder
-                    .addDeploymentsBuilder()
-                    .setDecisionRequirements(
-                        DecisionRequirementsMetadata.newBuilder()
-                            .setDmnDecisionRequirementsId(drg.getDecisionRequirementsId())
-                            .setDmnDecisionRequirementsName(drg.getDecisionRequirementsName())
-                            .setVersion(drg.getDecisionRequirementsVersion())
-                            .setDecisionRequirementsKey(drg.getDecisionRequirementsKey())
-                            .setResourceName(drg.getResourceName())
-                            .build()));
+                DecisionRequirementsMetadata.newBuilder()
+                    .setDmnDecisionRequirementsId(drg.getDecisionRequirementsId())
+                    .setDmnDecisionRequirementsName(drg.getDecisionRequirementsName())
+                    .setVersion(drg.getDecisionRequirementsVersion())
+                    .setDecisionRequirementsKey(drg.getDecisionRequirementsKey())
+                    .setResourceName(drg.getResourceName())
+                    .build())
+        .forEach(drg -> responseBuilder.addDeploymentsBuilder().setDecisionRequirements(drg));
 
     return responseBuilder.build();
   }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -16,8 +16,12 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstance
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionMetadata;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionRequirementsMetadata;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessMetadata;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.PublishMessageResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ResolveIncidentResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.SetVariablesResponse;
@@ -53,6 +57,58 @@ public final class ResponseMapper {
                     .setVersion(process.getVersion())
                     .setProcessDefinitionKey(process.getKey())
                     .setResourceName(bufferAsString(process.getResourceNameBuffer())));
+
+    return responseBuilder.build();
+  }
+
+  public static DeployResourceResponse toDeployResourceResponse(
+      final long key, final DeploymentRecord brokerResponse) {
+    final var responseBuilder = DeployResourceResponse.newBuilder().setKey(key);
+
+    brokerResponse
+        .processesMetadata()
+        .forEach(
+            process ->
+                responseBuilder
+                    .addDeploymentsBuilder()
+                    .setProcess(
+                        ProcessMetadata.newBuilder()
+                            .setBpmnProcessId(process.getBpmnProcessId())
+                            .setVersion(process.getVersion())
+                            .setProcessDefinitionKey(process.getKey())
+                            .setResourceName(process.getResourceName())
+                            .build()));
+
+    brokerResponse
+        .decisionsMetadata()
+        .forEach(
+            decision ->
+                responseBuilder
+                    .addDeploymentsBuilder()
+                    .setDecision(
+                        DecisionMetadata.newBuilder()
+                            .setDmnDecisionId(decision.getDecisionId())
+                            .setDmnDecisionName(decision.getDecisionName())
+                            .setVersion(decision.getVersion())
+                            .setDecisionKey(decision.getDecisionKey())
+                            .setDmnDecisionRequirementsId(decision.getDecisionRequirementsId())
+                            .setDecisionRequirementsKey(decision.getDecisionRequirementsKey())
+                            .build()));
+
+    brokerResponse
+        .decisionRequirementsMetadata()
+        .forEach(
+            drg ->
+                responseBuilder
+                    .addDeploymentsBuilder()
+                    .setDecisionRequirements(
+                        DecisionRequirementsMetadata.newBuilder()
+                            .setDmnDecisionRequirementsId(drg.getDecisionRequirementsId())
+                            .setDmnDecisionRequirementsName(drg.getDecisionRequirementsName())
+                            .setVersion(drg.getDecisionRequirementsVersion())
+                            .setDecisionRequirementsKey(drg.getDecisionRequirementsKey())
+                            .setResourceName(drg.getResourceName())
+                            .build()));
 
     return responseBuilder.build();
   }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerDeployResourceRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerDeployResourceRequest.java
@@ -13,16 +13,16 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import org.agrona.DirectBuffer;
 
-public final class BrokerDeployProcessRequest extends BrokerExecuteCommand<DeploymentRecord> {
+public final class BrokerDeployResourceRequest extends BrokerExecuteCommand<DeploymentRecord> {
 
   private final DeploymentRecord requestDto = new DeploymentRecord();
 
-  public BrokerDeployProcessRequest() {
+  public BrokerDeployResourceRequest() {
     super(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
     setPartitionId(Protocol.DEPLOYMENT_PARTITION);
   }
 
-  public BrokerDeployProcessRequest addResource(final byte[] resource, final String resourceName) {
+  public BrokerDeployResourceRequest addResource(final byte[] resource, final String resourceName) {
     requestDto.resources().add().setResource(resource).setResourceName(resourceName);
 
     return this;

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/deployment/DeployProcessStub.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/deployment/DeployProcessStub.java
@@ -11,13 +11,13 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
 import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
-import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeployProcessRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeployRequest;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import org.agrona.DirectBuffer;
 
 public final class DeployProcessStub
-    implements RequestStub<BrokerDeployProcessRequest, BrokerResponse<DeploymentRecord>> {
+    implements RequestStub<BrokerDeployRequest, BrokerResponse<DeploymentRecord>> {
 
   private static final long KEY = 123;
   private static final long PROCESS_KEY = 456;
@@ -26,7 +26,7 @@ public final class DeployProcessStub
 
   @Override
   public void registerWith(final StubbedBrokerClient gateway) {
-    gateway.registerHandler(BrokerDeployProcessRequest.class, this);
+    gateway.registerHandler(BrokerDeployRequest.class, this);
   }
 
   protected long getKey() {
@@ -42,7 +42,7 @@ public final class DeployProcessStub
   }
 
   @Override
-  public BrokerResponse<DeploymentRecord> handle(final BrokerDeployProcessRequest request)
+  public BrokerResponse<DeploymentRecord> handle(final BrokerDeployRequest request)
       throws Exception {
     final DeploymentRecord deploymentRecord = request.getRequestWriter();
     deploymentRecord

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/deployment/DeployProcessTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/deployment/DeployProcessTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.ByteString;
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
-import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeployProcessRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeployRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessRequest.Builder;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessResponse;
@@ -59,7 +59,7 @@ public final class DeployProcessTest extends GatewayTest {
     assertThat(process.getProcessDefinitionKey()).isEqualTo(stub.getProcessDefinitionKey());
     assertThat(process.getVersion()).isEqualTo(stub.getProcessVersion());
 
-    final BrokerDeployProcessRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+    final BrokerDeployRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getIntent()).isEqualTo(DeploymentIntent.CREATE);
     assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.DEPLOYMENT);
   }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/deployment/DeployProcessTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/deployment/DeployProcessTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.ByteString;
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
-import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeployRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeployResourceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessRequest.Builder;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessResponse;
@@ -59,7 +59,7 @@ public final class DeployProcessTest extends GatewayTest {
     assertThat(process.getProcessDefinitionKey()).isEqualTo(stub.getProcessDefinitionKey());
     assertThat(process.getVersion()).isEqualTo(stub.getProcessVersion());
 
-    final BrokerDeployRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+    final BrokerDeployResourceRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getIntent()).isEqualTo(DeploymentIntent.CREATE);
     assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.DEPLOYMENT);
   }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/deployment/DeployResourceStub.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/deployment/DeployResourceStub.java
@@ -14,14 +14,15 @@ import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeployResourceRequest;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
-public final class DeployProcessStub
+public final class DeployResourceStub
     implements RequestStub<BrokerDeployResourceRequest, BrokerResponse<DeploymentRecord>> {
 
   private static final long KEY = 123;
-  private static final long PROCESS_KEY = 456;
-  private static final int PROCESS_VERSION = 789;
+  private static final long PROCESS_KEY = 234;
+  private static final int PROCESS_VERSION = 345;
   private static final DirectBuffer CHECKSUM = wrapString("checksum");
 
   @Override
@@ -50,14 +51,36 @@ public final class DeployProcessStub
         .iterator()
         .forEachRemaining(
             r -> {
-              deploymentRecord
-                  .processesMetadata()
-                  .add()
-                  .setBpmnProcessId(r.getResourceNameBuffer())
-                  .setResourceName(r.getResourceNameBuffer())
-                  .setVersion(PROCESS_VERSION)
-                  .setKey(PROCESS_KEY)
-                  .setChecksum(CHECKSUM);
+              if (r.getResourceName().endsWith(".bpmn")) {
+                deploymentRecord
+                    .processesMetadata()
+                    .add()
+                    .setBpmnProcessId(r.getResourceNameBuffer())
+                    .setResourceName(r.getResourceNameBuffer())
+                    .setVersion(PROCESS_VERSION)
+                    .setKey(PROCESS_KEY)
+                    .setChecksum(CHECKSUM);
+              } else if (r.getResourceName().endsWith(".dmn")) {
+                deploymentRecord
+                    .decisionsMetadata()
+                    .add()
+                    .setDecisionId(r.getResourceName())
+                    .setDecisionName(r.getResourceName())
+                    .setVersion(456)
+                    .setDecisionKey(567)
+                    .setDecisionRequirementsId(r.getResourceName())
+                    .setDecisionRequirementsKey(678);
+                deploymentRecord
+                    .decisionRequirementsMetadata()
+                    .add()
+                    .setDecisionRequirementsId(r.getResourceName())
+                    .setDecisionRequirementsName(r.getResourceName())
+                    .setDecisionRequirementsVersion(456)
+                    .setDecisionRequirementsKey(678)
+                    .setNamespace(r.getResourceName())
+                    .setResourceName(r.getResourceName())
+                    .setChecksum(BufferUtil.wrapString("checksum"));
+              }
             });
     return new BrokerResponse<>(deploymentRecord, 0, KEY);
   }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/deployment/DeployResourceTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/deployment/DeployResourceTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.api.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.ByteString;
+import io.camunda.zeebe.gateway.api.util.GatewayTest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeployResourceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionMetadata;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DecisionRequirementsMetadata;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Deployment;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessMetadata;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import org.junit.Test;
+
+public final class DeployResourceTest extends GatewayTest {
+
+  @Test
+  public void shouldMapRequestAndResponse() {
+    // given
+    final var stub = new DeployResourceStub();
+    stub.registerWith(brokerClient);
+
+    final String bpmnName = "testProcess.bpmn";
+    final String dmnName = "testDecision.dmn";
+
+    final var builder = DeployResourceRequest.newBuilder();
+    builder.addResourcesBuilder().setName(bpmnName).setContent(ByteString.copyFromUtf8("<xml/>"));
+    builder.addResourcesBuilder().setName(dmnName).setContent(ByteString.copyFromUtf8("test"));
+
+    final var request = builder.build();
+
+    // when
+    final var response = client.deployResource(request);
+
+    // then
+    assertThat(response.getKey()).isEqualTo(stub.getKey());
+    assertThat(response.getDeploymentsCount()).isEqualTo(3);
+
+    final Deployment firstDeployment = response.getDeployments(0);
+    assertThat(firstDeployment.hasProcess()).isTrue();
+    assertThat(firstDeployment.hasDecision()).isFalse();
+    assertThat(firstDeployment.hasDecisionRequirements()).isFalse();
+    final ProcessMetadata process = firstDeployment.getProcess();
+    assertThat(process.getBpmnProcessId()).isEqualTo(bpmnName);
+    assertThat(process.getResourceName()).isEqualTo(bpmnName);
+    assertThat(process.getProcessDefinitionKey()).isEqualTo(stub.getProcessDefinitionKey());
+    assertThat(process.getVersion()).isEqualTo(stub.getProcessVersion());
+
+    final Deployment secondDeployment = response.getDeployments(1);
+    assertThat(secondDeployment.hasProcess()).isFalse();
+    assertThat(secondDeployment.hasDecision()).isTrue();
+    assertThat(secondDeployment.hasDecisionRequirements()).isFalse();
+    final DecisionMetadata decision = secondDeployment.getDecision();
+    assertThat(decision.getDmnDecisionId()).isEqualTo(dmnName);
+    assertThat(decision.getDmnDecisionName()).isEqualTo(dmnName);
+    assertThat(decision.getVersion()).isEqualTo(456);
+    assertThat(decision.getDecisionKey()).isEqualTo(567);
+    assertThat(decision.getDmnDecisionRequirementsId()).isEqualTo(dmnName);
+    assertThat(decision.getDecisionRequirementsKey()).isEqualTo(678);
+
+    final Deployment thirdDeployment = response.getDeployments(2);
+    assertThat(thirdDeployment.hasProcess()).isFalse();
+    assertThat(thirdDeployment.hasDecision()).isFalse();
+    assertThat(thirdDeployment.hasDecisionRequirements()).isTrue();
+    final DecisionRequirementsMetadata drg = thirdDeployment.getDecisionRequirements();
+    assertThat(drg.getDmnDecisionRequirementsId()).isEqualTo(dmnName);
+    assertThat(drg.getDmnDecisionRequirementsName()).isEqualTo(dmnName);
+    assertThat(drg.getVersion()).isEqualTo(456);
+    assertThat(drg.getDecisionRequirementsKey()).isEqualTo(678);
+    assertThat(drg.getResourceName()).isEqualTo(dmnName);
+
+    final BrokerDeployResourceRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+    assertThat(brokerRequest.getIntent()).isEqualTo(DeploymentIntent.CREATE);
+    assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.DEPLOYMENT);
+  }
+}

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ArrayProperty.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ArrayProperty.java
@@ -12,6 +12,8 @@ import io.camunda.zeebe.msgpack.value.ArrayValue;
 import io.camunda.zeebe.msgpack.value.BaseValue;
 import io.camunda.zeebe.msgpack.value.ValueArray;
 import java.util.Iterator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public final class ArrayProperty<T extends BaseValue> extends BaseProperty<ArrayValue<T>>
     implements ValueArray<T> {
@@ -38,5 +40,12 @@ public final class ArrayProperty<T extends BaseValue> extends BaseProperty<Array
     } catch (final Exception e) {
       throw new MsgpackPropertyException(getKey(), e);
     }
+  }
+
+  @Override
+  public Stream<T> stream() {
+    // ArrayValue is not a thread-safe Iterable
+    final var parallel = false;
+    return StreamSupport.stream(spliterator(), parallel);
   }
 }

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ValueArray.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ValueArray.java
@@ -7,6 +7,10 @@
  */
 package io.camunda.zeebe.msgpack.value;
 
+import java.util.stream.Stream;
+
 public interface ValueArray<T> extends Iterable<T> {
   T add();
+
+  Stream<T> stream();
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Adds new gRPC DeployResource RPC, request and response messages to support non-process deployments, including decision and decision requirements for DMN resources. It is defined in a way that can be easily expanded.

This deprecates the existing DeployProcess RPC and messages.

It also expands the gateway with a new DeployResource RPC implementation.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8065
closes #8074

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
