### PR TITLE
fix: use correct key length when looking up foreign keys

### DIFF
--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyChecker.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyChecker.java
@@ -40,7 +40,7 @@ public final class ForeignKeyChecker {
             transactionDb.getDefaultNativeHandle(),
             transactionDb.getReadOptionsNativeHandle(),
             keyBuffer.byteArray(),
-            keyBuffer.capacity());
+            Long.BYTES + foreignKey.getLength());
     if (value == null) {
       throw new ZeebeDbInconsistentException(
           "Foreign key " + foreignKey.inner() + " does not exist in " + foreignKey.columnFamily());

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyCheckerTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyCheckerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.db.impl.rocksdb.transaction;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -18,7 +19,11 @@ import io.camunda.zeebe.db.ConsistencyChecksSettings;
 import io.camunda.zeebe.db.ZeebeDbInconsistentException;
 import io.camunda.zeebe.db.impl.DbForeignKey;
 import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.db.impl.DefaultZeebeDbFactory;
+import java.io.File;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 final class ForeignKeyCheckerTest {
 
@@ -56,6 +61,35 @@ final class ForeignKeyCheckerTest {
 
     // then -- check doesn't trow
     check.assertExists(tx, new DbForeignKey<>(key, TestColumnFamilies.TEST_COLUMN_FAMILY));
+  }
+
+  @Test
+  void shouldSucceedOnRealColumnFamily(@TempDir final File tempDir) throws Exception {
+    // given
+    final var db = DefaultZeebeDbFactory.<TestColumnFamilies>getDefaultFactory().createDb(tempDir);
+    final var txContext = db.createContext();
+
+    final var cf1 =
+        db.createColumnFamily(
+            TestColumnFamilies.TEST_COLUMN_FAMILY, txContext, new DbLong(), DbNil.INSTANCE);
+
+    final var check =
+        new ForeignKeyChecker(
+            (ZeebeTransactionDb<?>) db, new ConsistencyChecksSettings(true, true));
+
+    // when -- key 1 exists in first column family
+    final var cf1Key = new DbLong();
+    cf1Key.wrapLong(1);
+    cf1.insert(cf1Key, DbNil.INSTANCE);
+
+    // then -- referring to key 1 does not throw
+    assertDoesNotThrow(
+        () ->
+            check.assertExists(
+                (ZeebeTransaction) txContext.getCurrentTransaction(),
+                new DbForeignKey<>(cf1Key, TestColumnFamilies.TEST_COLUMN_FAMILY)));
+
+    db.close();
   }
 
   private enum TestColumnFamilies {


### PR DESCRIPTION
Previously we used the full key buffer when looking up foreign keys. This was wrong, as the capacity is not related to the actual key length.

Instead we now calculate the correct key length based on the column family prefix and the actual inner key length.

@pihme Btw, you had the right idea that the other tests were not strict enough: https://github.com/camunda-cloud/zeebe/pull/8906#discussion_r826200697