### PR TITLE
test: enable foreign key checks in benchmarks

### DIFF
--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -57,6 +57,8 @@ zeebe:
       value: "0.9"
     - name: ZEEBE_BROKER_EXPERIMENTAL_CONSISTENCYCHECKS_ENABLEPRECONDITIONS
       value: "true"
+    - name: ZEEBE_BROKER_EXPERIMENTAL_CONSISTENCYCHECKS_ENABLEFOREIGNKEYCHECKS
+      value: "true"
 
   # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limitsS
   resources:


### PR DESCRIPTION
## Description

Now that we use foreign keys we should enable the checks for our benchmarks so that we can catch errors and observe any performance impacts.