### PR TITLE
Fixes revapi configuration for merging

### DIFF
--- a/bpmn-model/revapi.json
+++ b/bpmn-model/revapi.json
@@ -1,9 +1,10 @@
 [
   {
     "extension": "revapi.filter",
-    "justification": "Ignore everything not included in the module itself",
+    "id": "filter",
     "configuration": {
       "archives": {
+        "justification": "Ignore everything not included in the module itself",
         "include": [
           "io\\.camunda:zeebe-bpmn-model:.*"
         ]
@@ -12,8 +13,8 @@
   },
   {
     "extension": "revapi.differences",
+    "id": "differences",
     "configuration": {
-      "ignore": true,
       "differences": [
         {
           "justification": "Ignore new methods for Zeebe extensions, as these are not meant to be implemented but simply consumed; as such, new methods are perfectly fine to add",
@@ -30,12 +31,6 @@
             "matcher": "java-package",
             "match": "io.camunda.zeebe.model.bpmn.builder"
           }
-        },
-        {
-          "justification": "No longer inherits from BaseElement",
-          "code": "java.class.noLongerInheritsFromClass",
-          "old": "class io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeUserTaskFormImpl",
-          "superClass": "io.camunda.zeebe.model.bpmn.impl.instance.BaseElementImpl"
         },
         {
           "justification": "Validators are used only internally; they should not used or referenced from outside of the module",

--- a/build-tools/src/main/resources/revapi/revapi.json
+++ b/build-tools/src/main/resources/revapi/revapi.json
@@ -1,6 +1,7 @@
 [
   {
     "extension": "revapi.java",
+    "id": "java",
     "configuration": {
       "reportUsesFor": "all-differences",
       "missing-classes": {
@@ -12,6 +13,7 @@
   },
   {
     "extension": "revapi.versions",
+    "id": "version",
     "configuration": {
       "enabled": true,
       "passThroughDifferences": [
@@ -39,5 +41,17 @@
         }
       }
     }
+  },
+  {
+    "extension": "revapi.differences",
+    "id": "differences",
+    "configuration": {
+      "ignore": true
+    }
+  },
+  {
+    "extension": "revapi.filter",
+    "id": "filter",
+    "configuration": {}
   }
 ]

--- a/clients/java/revapi.json
+++ b/clients/java/revapi.json
@@ -1,9 +1,10 @@
 [
   {
     "extension": "revapi.filter",
-    "justification": "Ignore everything not included in the module itself",
+    "id": "filter",
     "configuration": {
       "archives": {
+        "justification": "Ignore everything not included in the module itself",
         "include": [
           "io\\.camunda:zeebe-client-java:.*"
         ]
@@ -21,8 +22,8 @@
   },
   {
     "extension": "revapi.differences",
+    "id": "differences",
     "configuration": {
-      "ignore": true,
       "differences": [
         {
           "justification": "Ignore new methods on all types, as these are not meant to be implemented but simply consumed; as such, new methods are perfectly fine to add",

--- a/exporter-api/revapi.json
+++ b/exporter-api/revapi.json
@@ -1,9 +1,10 @@
 [
   {
     "extension": "revapi.filter",
-    "justification": "Ignore everything not included in the module itself",
+    "id": "filter",
     "configuration": {
       "archives": {
+        "justification": "Ignore everything not included in the module itself",
         "include": [
           "io\\.camunda:zeebe-exporter-api:.*"
         ]

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -1,17 +1,18 @@
 [
   {
     "extension": "revapi.filter",
-    "justification": "Ignore everything not included in the module itself",
+    "id": "filter",
     "configuration": {
       "archives": {
+        "justification": "Ignore everything not included in the module itself",
         "include": ["io\\.camunda:zeebe-protocol:.*"]
       }
     }
   },
   {
     "extension": "revapi.differences",
+    "id": "differences",
     "configuration": {
-      "ignore": true,
       "differences": [
         {
           "justification": "Ignore Enum order for BpmnElementType as ordinal() is not used and the elements are grouped in the enum.",


### PR DESCRIPTION
## Description

Fixes revapi configuration to allow merging configurations together. This will let us leverage the CI support for `ignored-changes.json` files, which are for temporary breaking changes which should be removed from the revapi configuration once a new version is released.

Essentially, you can split extension blocks across multiple files, but the extension within the same pipeline must have the exact same ID. When they have the same ID, they will be merged. Revapi doesn't do complex merging, the merging is purely additive: this means scalar properties (e.g. boolean, string, int, etc.) will fail when specified multiple times. Collections are merged, however, so two arrays will be concatenated.

We chose to use the extension name without the `revapi.` prefix, simply because it's shorter while remaining descriptive. This means all extensions share the same ID, and adding a new `ignored-changes.json` will also require one to do the same. I've updated [the wiki](https://github.com/camunda-cloud/zeebe/wiki/Breaking-Changes) as well to explain this.

This will be necessary for #8837 since we will want to add some "breaking" changes (though they aren't ABI breaking).

## Related issues

related to #8837

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
