### PR TITLE
refactor: use foreign keys for decisions

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -27,24 +27,25 @@ import org.agrona.DirectBuffer;
 public final class DbDecisionState implements MutableDecisionState {
 
   private final DbLong dbDecisionKey;
-
   private final DbForeignKey<DbLong> fkDecision;
-  private final DbLong dbDecisionRequirementsKey;
-  private final DbForeignKey<DbLong> fkDecisionRequirements;
-  private final DbCompositeKey<DbForeignKey<DbLong>, DbForeignKey<DbLong>>
-      dbDecisionRequirementsKeyAndDecisionKey;
   private final PersistedDecision dbPersistedDecision;
   private final DbString dbDecisionId;
+
+  private final DbLong dbDecisionRequirementsKey;
+  private final DbForeignKey<DbLong> fkDecisionRequirements;
   private final PersistedDecisionRequirements dbPersistedDecisionRequirements;
   private final DbString dbDecisionRequirementsId;
+
+  private final DbCompositeKey<DbForeignKey<DbLong>, DbForeignKey<DbLong>>
+      dbDecisionRequirementsKeyAndDecisionKey;
+  private final ColumnFamily<DbCompositeKey<DbForeignKey<DbLong>, DbForeignKey<DbLong>>, DbNil>
+      decisionKeyByDecisionRequirementsKey;
+
   private final ColumnFamily<DbLong, PersistedDecision> decisionsByKey;
   private final ColumnFamily<DbString, DbForeignKey<DbLong>> latestDecisionKeysByDecisionId;
 
   private final ColumnFamily<DbLong, PersistedDecisionRequirements> decisionRequirementsByKey;
   private final ColumnFamily<DbString, DbForeignKey<DbLong>> latestDecisionRequirementsKeysById;
-
-  private final ColumnFamily<DbCompositeKey<DbForeignKey<DbLong>, DbForeignKey<DbLong>>, DbNil>
-      decisionKeyByDecisionRequirementsKey;
 
   public DbDecisionState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbForeignKey;
 import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.db.impl.DbString;
@@ -25,41 +26,48 @@ import org.agrona.DirectBuffer;
 
 public final class DbDecisionState implements MutableDecisionState {
 
-  private final DbLong dbDecisionKey = new DbLong();
-  private final PersistedDecision dbPersistedDecision = new PersistedDecision();
-  private final DbString dbDecisionId = new DbString();
+  private final DbLong dbDecisionKey;
 
-  private final DbLong dbDecisionRequirementsKey = new DbLong();
-  private final PersistedDecisionRequirements dbPersistedDecisionRequirements =
-      new PersistedDecisionRequirements();
-  private final DbString dbDecisionRequirementsId = new DbString();
-
-  private final DbCompositeKey<DbLong, DbLong> dbDecisionRequirementsKeyAndDecisionKey =
-      new DbCompositeKey<>(dbDecisionRequirementsKey, dbDecisionKey);
-
+  private final DbForeignKey<DbLong> fkDecision;
+  private final DbLong dbDecisionRequirementsKey;
+  private final DbForeignKey<DbLong> fkDecisionRequirements;
+  private final DbCompositeKey<DbForeignKey<DbLong>, DbForeignKey<DbLong>>
+      dbDecisionRequirementsKeyAndDecisionKey;
+  private final PersistedDecision dbPersistedDecision;
+  private final DbString dbDecisionId;
+  private final PersistedDecisionRequirements dbPersistedDecisionRequirements;
+  private final DbString dbDecisionRequirementsId;
   private final ColumnFamily<DbLong, PersistedDecision> decisionsByKey;
-  private final ColumnFamily<DbString, DbLong> latestDecisionKeysByDecisionId;
+  private final ColumnFamily<DbString, DbForeignKey<DbLong>> latestDecisionKeysByDecisionId;
 
   private final ColumnFamily<DbLong, PersistedDecisionRequirements> decisionRequirementsByKey;
-  private final ColumnFamily<DbString, DbLong> latestDecisionRequirementsKeysById;
+  private final ColumnFamily<DbString, DbForeignKey<DbLong>> latestDecisionRequirementsKeysById;
 
-  private final ColumnFamily<DbCompositeKey<DbLong, DbLong>, DbNil>
+  private final ColumnFamily<DbCompositeKey<DbForeignKey<DbLong>, DbForeignKey<DbLong>>, DbNil>
       decisionKeyByDecisionRequirementsKey;
 
   public DbDecisionState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    dbDecisionKey = new DbLong();
+    fkDecision = new DbForeignKey<>(dbDecisionKey, ZbColumnFamilies.DMN_DECISIONS);
 
+    dbPersistedDecision = new PersistedDecision();
     decisionsByKey =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.DMN_DECISIONS, transactionContext, dbDecisionKey, dbPersistedDecision);
 
+    dbDecisionId = new DbString();
     latestDecisionKeysByDecisionId =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.DMN_LATEST_DECISION_BY_ID,
             transactionContext,
             dbDecisionId,
-            dbDecisionKey);
+            fkDecision);
 
+    dbDecisionRequirementsKey = new DbLong();
+    fkDecisionRequirements =
+        new DbForeignKey<>(dbDecisionRequirementsKey, ZbColumnFamilies.DMN_DECISION_REQUIREMENTS);
+    dbPersistedDecisionRequirements = new PersistedDecisionRequirements();
     decisionRequirementsByKey =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.DMN_DECISION_REQUIREMENTS,
@@ -67,13 +75,16 @@ public final class DbDecisionState implements MutableDecisionState {
             dbDecisionRequirementsKey,
             dbPersistedDecisionRequirements);
 
+    dbDecisionRequirementsId = new DbString();
     latestDecisionRequirementsKeysById =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.DMN_LATEST_DECISION_REQUIREMENTS_BY_ID,
             transactionContext,
             dbDecisionRequirementsId,
-            dbDecisionRequirementsKey);
+            fkDecisionRequirements);
 
+    dbDecisionRequirementsKeyAndDecisionKey =
+        new DbCompositeKey<>(fkDecisionRequirements, fkDecision);
     decisionKeyByDecisionRequirementsKey =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.DMN_DECISION_KEY_BY_DECISION_REQUIREMENTS_KEY,
@@ -87,7 +98,7 @@ public final class DbDecisionState implements MutableDecisionState {
     dbDecisionId.wrapBuffer(decisionId);
 
     return Optional.ofNullable(latestDecisionKeysByDecisionId.get(dbDecisionId))
-        .flatMap(decisionKey -> findDecisionByKey(decisionKey.getValue()));
+        .flatMap(decisionKey -> findDecisionByKey(decisionKey.inner().getValue()));
   }
 
   @Override
@@ -96,7 +107,7 @@ public final class DbDecisionState implements MutableDecisionState {
     dbDecisionRequirementsId.wrapBuffer(decisionRequirementsId);
 
     return Optional.ofNullable(latestDecisionRequirementsKeysById.get(dbDecisionRequirementsId))
-        .map(DbLong::getValue)
+        .map((requirementsKey) -> requirementsKey.inner().getValue())
         .flatMap(this::findDecisionRequirementsByKey);
   }
 
@@ -119,7 +130,7 @@ public final class DbDecisionState implements MutableDecisionState {
         dbDecisionRequirementsKey,
         ((key, nil) -> {
           final var decisionKey = key.second();
-          findDecisionByKey(decisionKey.getValue()).ifPresent(decisions::add);
+          findDecisionByKey(decisionKey.inner().getValue()).ifPresent(decisions::add);
         }));
 
     return decisions;
@@ -167,13 +178,13 @@ public final class DbDecisionState implements MutableDecisionState {
   private void updateDecisionAsLatestVersion(final DecisionRecord record) {
     dbDecisionId.wrapBuffer(record.getDecisionIdBuffer());
     dbDecisionKey.wrapLong(record.getDecisionKey());
-    latestDecisionKeysByDecisionId.update(dbDecisionId, dbDecisionKey);
+    latestDecisionKeysByDecisionId.update(dbDecisionId, fkDecision);
   }
 
   private void insertDecisionAsLatestVersion(final DecisionRecord record) {
     dbDecisionId.wrapBuffer(record.getDecisionIdBuffer());
     dbDecisionKey.wrapLong(record.getDecisionKey());
-    latestDecisionKeysByDecisionId.insert(dbDecisionId, dbDecisionKey);
+    latestDecisionKeysByDecisionId.insert(dbDecisionId, fkDecision);
   }
 
   private void updateLatestDecisionRequirementsVersion(final DecisionRequirementsRecord record) {
@@ -191,12 +202,12 @@ public final class DbDecisionState implements MutableDecisionState {
   private void updateDecisionRequirementsAsLatestVersion(final DecisionRequirementsRecord record) {
     dbDecisionRequirementsId.wrapBuffer(record.getDecisionRequirementsIdBuffer());
     dbDecisionRequirementsKey.wrapLong(record.getDecisionRequirementsKey());
-    latestDecisionRequirementsKeysById.update(dbDecisionRequirementsId, dbDecisionRequirementsKey);
+    latestDecisionRequirementsKeysById.update(dbDecisionRequirementsId, fkDecisionRequirements);
   }
 
   private void insertDecisionRequirementsAsLatestVersion(final DecisionRequirementsRecord record) {
     dbDecisionRequirementsId.wrapBuffer(record.getDecisionRequirementsIdBuffer());
     dbDecisionRequirementsKey.wrapLong(record.getDecisionRequirementsKey());
-    latestDecisionRequirementsKeysById.insert(dbDecisionRequirementsId, dbDecisionRequirementsKey);
+    latestDecisionRequirementsKeysById.insert(dbDecisionRequirementsId, fkDecisionRequirements);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateTest.java
@@ -67,7 +67,10 @@ public final class DecisionStateTest {
   @Test
   void shouldPutDecision() {
     // given
-    final var decisionRecord = sampleDecisionRecord();
+    final var drg = sampleDecisionRequirementsRecord();
+    final var decisionRecord =
+        sampleDecisionRecord().setDecisionRequirementsKey(drg.getDecisionRequirementsKey());
+    decisionState.storeDecisionRequirements(drg);
     decisionState.storeDecisionRecord(decisionRecord);
 
     // when
@@ -96,6 +99,8 @@ public final class DecisionStateTest {
         sampleDecisionRecord().setDecisionId("decision-1").setDecisionKey(1L);
     final var decisionRecord2 =
         sampleDecisionRecord().setDecisionId("decision-2").setDecisionKey(2L);
+    final var drg = sampleDecisionRequirementsRecord();
+    decisionState.storeDecisionRequirements(drg);
 
     decisionState.storeDecisionRecord(decisionRecord1);
     decisionState.storeDecisionRecord(decisionRecord2);
@@ -120,10 +125,28 @@ public final class DecisionStateTest {
   @Test
   void shouldReturnLatestVersionOfDeployedDecisionById() {
     // given
-    final var decisionRecordV1 = sampleDecisionRecord().setDecisionKey(1L).setVersion(1);
-    final var decisionRecordV2 = sampleDecisionRecord().setDecisionKey(2L).setVersion(2);
-    final var decisionRecordV3 = sampleDecisionRecord().setDecisionKey(3L).setVersion(3);
+    final var drgV1 = sampleDecisionRequirementsRecord().setDecisionRequirementsKey(1L);
+    final var drgV2 = sampleDecisionRequirementsRecord().setDecisionRequirementsKey(2L);
+    final var drgV3 = sampleDecisionRequirementsRecord().setDecisionRequirementsKey(3L);
+    final var decisionRecordV1 =
+        sampleDecisionRecord()
+            .setDecisionKey(1L)
+            .setDecisionRequirementsKey(drgV1.getDecisionRequirementsKey())
+            .setVersion(1);
+    final var decisionRecordV2 =
+        sampleDecisionRecord()
+            .setDecisionKey(2L)
+            .setDecisionRequirementsKey(drgV2.getDecisionRequirementsKey())
+            .setVersion(2);
+    final var decisionRecordV3 =
+        sampleDecisionRecord()
+            .setDecisionKey(3L)
+            .setDecisionRequirementsKey(drgV3.getDecisionRequirementsKey())
+            .setVersion(3);
 
+    decisionState.storeDecisionRequirements(drgV1);
+    decisionState.storeDecisionRequirements(drgV2);
+    decisionState.storeDecisionRequirements(drgV3);
     decisionState.storeDecisionRecord(decisionRecordV1);
     decisionState.storeDecisionRecord(decisionRecordV3);
     decisionState.storeDecisionRecord(decisionRecordV2);
@@ -290,6 +313,9 @@ public final class DecisionStateTest {
         sampleDecisionRecord()
             .setDecisionKey(3L)
             .setDecisionRequirementsKey(drg2.getDecisionRequirementsKey());
+
+    decisionState.storeDecisionRequirements(drg1);
+    decisionState.storeDecisionRequirements(drg2);
 
     decisionState.storeDecisionRecord(decision1);
     decisionState.storeDecisionRecord(decision2);


### PR DESCRIPTION
## Description

Uses `DbForeignKey` internally to maintain referential integrity within `DbDecisionState`

relates to #8930 