### PR TITLE
Rename Record#clone to Record#copyOf

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/util/ControlledTestExporter.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/util/ControlledTestExporter.java
@@ -99,7 +99,7 @@ public class ControlledTestExporter implements Exporter {
 
   @Override
   public void export(final Record<?> record) {
-    final Record<?> copiedRecord = record.clone();
+    final Record<?> copiedRecord = record.copyOf();
     if (onExport != null) {
       onExport.accept(copiedRecord);
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentRecordWrapper.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentRecordWrapper.java
@@ -85,6 +85,11 @@ final class IncidentRecordWrapper implements TypedRecord<ProcessInstanceRecord> 
   }
 
   @Override
+  public Record<ProcessInstanceRecord> copyOf() {
+    return this;
+  }
+
+  @Override
   public long getKey() {
     return key;
   }
@@ -107,10 +112,5 @@ final class IncidentRecordWrapper implements TypedRecord<ProcessInstanceRecord> 
   @Override
   public int getLength() {
     return 0;
-  }
-
-  @Override
-  public Record<ProcessInstanceRecord> clone() {
-    return this;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CopiedRecords.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CopiedRecords.java
@@ -19,6 +19,8 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 public final class CopiedRecords {
 
+  private CopiedRecords() {}
+
   public static CopiedRecord createCopiedRecord(final int partitionId, final LoggedEvent rawEvent) {
     // we have to access the underlying buffer and copy the metadata and value bytes
     // otherwise next event will overwrite the event before, since UnpackedObject

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedEventImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedEventImpl.java
@@ -87,6 +87,11 @@ public final class TypedEventImpl implements TypedRecord {
   }
 
   @Override
+  public Record copyOf() {
+    return CopiedRecords.createCopiedRecord(getPartitionId(), rawEvent);
+  }
+
+  @Override
   public long getKey() {
     return rawEvent.getKey();
   }
@@ -117,11 +122,6 @@ public final class TypedEventImpl implements TypedRecord {
   @Override
   public String toJson() {
     return MsgPackConverter.convertJsonSerializableObjectToJson(this);
-  }
-
-  @Override
-  public Record clone() {
-    return CopiedRecords.createCopiedRecord(getPartitionId(), rawEvent);
   }
 
   @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
@@ -119,12 +119,12 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
   }
 
   @Override
-  public String toJson() {
+  public Record<T> copyOf() {
     throw new UnsupportedOperationException("not yet implemented");
   }
 
   @Override
-  public Record<T> clone() {
+  public String toJson() {
     throw new UnsupportedOperationException("not yet implemented");
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
@@ -146,6 +146,11 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     return recordValue;
   }
 
+  @Override
+  public Record<T> copyOf() {
+    return new CopiedRecord<>(this);
+  }
+
   /**
    * Please be aware that this method is not thread-safe. Some records contain properties that will
    * get modified when iterating over it (eg. Records containing an
@@ -157,11 +162,6 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   @Override
   public String toJson() {
     return MsgPackConverter.convertJsonSerializableObjectToJson(this);
-  }
-
-  @Override
-  public Record<T> clone() {
-    return new CopiedRecord<>(this);
   }
 
   @Override

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractRecord.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractRecord.java
@@ -51,9 +51,8 @@ public abstract class AbstractRecord<T extends RecordValue>
   public abstract T getValue();
 
   /** @return itself as the object is immutable and can be used as is */
-  @SuppressWarnings({"MethodDoesntCallSuperMethod", "squid:S2975", "squid:S1182"})
   @Override
-  public Record<T> clone() {
+  public Record<T> copyOf() {
     return this;
   }
 }

--- a/protocol/ignored-changes.json
+++ b/protocol/ignored-changes.json
@@ -1,0 +1,34 @@
+[
+  {
+    "extension": "revapi.differences",
+    "id": "differences",
+    "configuration": {
+      "differences": [
+        {
+          "code": "java.class.noLongerImplementsInterface",
+          "classSimpleName": "Record",
+          "interface": "java.lang.Cloneable",
+          "justification": "Cloneable was not properly implemented on the Record interface, as it was doing a deep copy instead of the expected shallow copy"
+        },
+        {
+          "code": "java.method.exception.checkedAdded",
+          "classQualifiedName": "io.camunda.zeebe.protocol.record.Record",
+          "methodName": "clone",
+          "justification": "Revert implementing Cloneable, which means we now default back to the implementation in Object"
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method io.camunda.zeebe.protocol.record.Record<T> io.camunda.zeebe.protocol.record.Record<T extends io.camunda.zeebe.protocol.record.RecordValue>::clone()",
+          "new": "method java.lang.Object java.lang.Object::clone() throws java.lang.CloneNotSupportedException @ io.camunda.zeebe.protocol.record.Record<T extends io.camunda.zeebe.protocol.record.RecordValue>",
+          "justification": "Revert implementing Cloneable, which means we now default back to the implementation in Object"
+        },
+        {
+          "code": "java.method.visibilityReduced",
+          "old": "method io.camunda.zeebe.protocol.record.Record<T> io.camunda.zeebe.protocol.record.Record<T extends io.camunda.zeebe.protocol.record.RecordValue>::clone()",
+          "new": "method java.lang.Object java.lang.Object::clone() throws java.lang.CloneNotSupportedException @ io.camunda.zeebe.protocol.record.Record<T extends io.camunda.zeebe.protocol.record.RecordValue>",
+          "justification": "Revert implementing Cloneable, which means we now default back to the implementation in Object"
+        }
+      ]
+    }
+  }
+]

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -20,11 +20,11 @@
           "classQualifiedName": "io.camunda.zeebe.protocol.record.value.BpmnElementType"
         },
         {
-          "justification": "Ignore new methods for Protocol Record Value interfaces, as these are not meant to be implemented but simply consumed; as such, new methods are perfectly fine to add",
+          "justification": "Ignore new methods for Protocol Record interfaces, as these are not meant to be implemented but simply consumed; as such, new methods are perfectly fine to add",
           "code": "java.method.addedToInterface",
           "new": {
             "matcher": "java-package",
-            "match": "/io\\.camunda\\.zeebe\\.protocol\\.record\\.value(\\..*)?/"
+            "match": "/io\\.camunda\\.zeebe\\.protocol\\.record(\\..*)?/"
           }
         },
         {

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.protocol.record;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 
 /** Represents a record published to the log stream. */
-public interface Record<T extends RecordValue> extends JsonSerializable, Cloneable {
+public interface Record<T extends RecordValue> extends JsonSerializable {
   /**
    * Retrieves the position of the record. Positions are locally unique to the partition, and
    * monotonically increasing. Records are then ordered on the partition by their positions, i.e.
@@ -93,5 +93,5 @@ public interface Record<T extends RecordValue> extends JsonSerializable, Cloneab
    *
    * @return a deep copy of this record
    */
-  Record<T> clone();
+  Record<T> copyOf();
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -80,7 +80,7 @@ public final class RecordingExporter implements Exporter {
   public void export(final Record<?> record) {
     LOCK.lock();
     try {
-      RECORDS.add(record.clone());
+      RECORDS.add(record.copyOf());
       IS_EMPTY.signal();
       if (controller != null) { // the engine tests do not open the exporter
         controller.updateLastExportedRecordPosition(record.getPosition());

--- a/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
+++ b/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
@@ -115,13 +115,13 @@ public final class RecordingExporterTest {
     }
 
     @Override
-    public String toJson() {
-      return null;
+    public Record<TestValue> copyOf() {
+      return this;
     }
 
     @Override
-    public Record<TestValue> clone() {
-      return this;
+    public String toJson() {
+      return null;
     }
   }
 


### PR DESCRIPTION
## Description

Renames the `clone` method to `copyOf`. This was flagged as warning as the clone method is a special method in Java, with specific semantics, and the `Cloneable` interface is simply a marker interface to reuse the built-in cloning facitilities. As we were always implementing the method and changing the semantics, it's more accurate to use a copy method instead.

Marks the changes of renaming `Record#clone` to `Record#copyOf` as non-ABI breaking. This isn't technically correct, however:

- The interfaces in the protocol are meant purely for consumption and not for implementation
- The impact of renaming `clone` to `copyOf` is fairly minimal, and the upgrade path is very simple
- Most users of the method would be exporters, which already receive a copied record, and thus usually don't need to use this method
- Cloneable is a marker interface which was useless, as we were re-implementing the clone method, and changing its semantics. Removing it is expected to have very little impact

## Related issues

related to #8837 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
