### PR TITLE
Introduce new immutable protocol

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -116,6 +116,7 @@
     <version.servlet-api>2.5</version.servlet-api>
     <version.osgi>6.0.0</version.osgi>
     <version.findbugs-annotations>3.0.1u2</version.findbugs-annotations>
+    <version.spotbugs>4.5.3</version.spotbugs>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.0.0</plugin.version.antrun>
@@ -688,6 +689,12 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
         <version>${version.commons-text}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-annotations</artifactId>
+        <version>${version.spotbugs}</version>
       </dependency>
 
       <!-- for dependency convergence -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -117,6 +117,7 @@
     <version.osgi>6.0.0</version.osgi>
     <version.findbugs-annotations>3.0.1u2</version.findbugs-annotations>
     <version.spotbugs>4.5.3</version.spotbugs>
+    <version.archunit>0.23.0</version.archunit>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.0.0</plugin.version.antrun>
@@ -475,6 +476,24 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${version.junit4}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.tngtech.archunit</groupId>
+        <artifactId>archunit</artifactId>
+        <version>${version.archunit}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.tngtech.archunit</groupId>
+        <artifactId>archunit-junit5-engine</artifactId>
+        <version>${version.archunit}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.tngtech.archunit</groupId>
+        <artifactId>archunit-junit5-api</artifactId>
+        <version>${version.archunit}</version>
       </dependency>
 
       <dependency>

--- a/protocol-asserts/pom.xml
+++ b/protocol-asserts/pom.xml
@@ -46,12 +46,23 @@
           <packages>
             <param>io.camunda.zeebe.protocol.record</param>
           </packages>
+          <excludes>
+            <!--
+              exclude immutable values from the assertions, I don't see much value since we already
+              generated asserts for their interface types
+              -->
+            <exclude>^.*\.Immutable.*$</exclude>
+          </excludes>
           <generatedSourcesScope>compile</generatedSourcesScope>
-          <targetDir>${project.build.directory}/generated-sources/assertj-assertions</targetDir>
           <generateAssertions>true</generateAssertions>
           <generateBddAssertions>false</generateBddAssertions>
-          <generateSoftAssertions>false</generateSoftAssertions>
+          <generateSoftAssertions>true</generateSoftAssertions>
           <generateJUnitSoftAssertions>false</generateJUnitSoftAssertions>
+          <!-- do not generate hierarchical assertions, as otherwise for things like
+              RecordValueWithVariables, your JobRecordValue has no variables assertion and must be
+              converted first to a RecordValueWithVariables, which is unnecessarily tedious -->
+          <hierarchical>false</hierarchical>
+          <targetDir>${project.build.directory}/generated-sources/assertj-assertions</targetDir>
         </configuration>
         <executions>
           <execution>
@@ -69,7 +80,7 @@
         <groupId>com.google.code.maven-replacer-plugin</groupId>
         <artifactId>replacer</artifactId>
         <configuration>
-          <file>${project.build.directory}/generated-sources/assertj-assertions/io/camunda/zeebe/protocol/record/AbstractRecordAssert.java</file>
+          <file>${project.build.directory}/generated-sources/assertj-assertions/io/camunda/zeebe/protocol/record/RecordAssert.java</file>
           <replacements>
             <replacement>
               <token>T value</token>

--- a/protocol-jackson/pom.xml
+++ b/protocol-jackson/pom.xml
@@ -30,6 +30,22 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- these two dependencies are temporarily required, as they're now picked up transitively by
+      immutables from the protocol module, which means they're now annotating the code generated
+      here, and thus are "hard" dependencies; this will be removed once we stop generating code in
+      this module -->
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <version>4.5.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+    </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>

--- a/protocol/ignored-changes.json
+++ b/protocol/ignored-changes.json
@@ -27,6 +27,26 @@
           "old": "method io.camunda.zeebe.protocol.record.Record<T> io.camunda.zeebe.protocol.record.Record<T extends io.camunda.zeebe.protocol.record.RecordValue>::clone()",
           "new": "method java.lang.Object java.lang.Object::clone() throws java.lang.CloneNotSupportedException @ io.camunda.zeebe.protocol.record.Record<T extends io.camunda.zeebe.protocol.record.RecordValue>",
           "justification": "Revert implementing Cloneable, which means we now default back to the implementation in Object"
+        },
+        {
+          "code": "java.annotation.added",
+          "annotationType": "org.immutables.value.Value.Immutable",
+          "justification": "Immutable annotations do not change the compatibility of the interface they annotate"
+        },
+        {
+          "code": "java.annotation.added",
+          "annotationType": "org.immutables.value.Value.Default",
+          "justification": "Immutable annotations do not change the compatibility of the interface they annotate"
+        },
+        {
+          "code": "java.annotation.added",
+          "annotationType": "org.immutables.value.Value.NonAttribute",
+          "justification": "Immutable annotations do not change the compatibility of the interface they annotate"
+        },
+        {
+          "code": "java.annotation.added",
+          "annotationType": "io.camunda.zeebe.protocol.record.ImmutableProtocol",
+          "justification": "Immutable annotations do not change the compatibility of the interface they annotate"
         }
       ]
     }

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -60,8 +60,14 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -35,6 +35,30 @@
       <artifactId>agrona</artifactId>
     </dependency>
 
+    <!--
+      scoped as provided since the annotations are not retained at runtime, and therefore it can be
+      omitted entirely
+      -->
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!--
+      adding SpotBugs annotations to the classpath will cause Immutables to generate the proper
+      annotations and suppress false positives
+    -->
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -57,6 +81,18 @@
     </resources>
 
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs combine.children="append">
+            <!-- required by javac detection logic in immutables -->
+            <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+          </compilerArgs>
+          <fork>true</fork>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -72,6 +72,32 @@
     </dependency>
 
     <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit-junit5-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- required to run both arch unit and junit 5 engines together -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit-junit5-engine</artifactId>
+      <version>${version.archunit}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
@@ -164,6 +190,18 @@
       <plugin>
         <groupId>org.revapi</groupId>
         <artifactId>revapi-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+            <ignoredUnusedDeclaredDependencies>
+              <!-- both engines need to be specify to run them side by side, but aren't explicitly used anywhere in the code -->
+              <ignoredUnusedDeclaredDependency>com.tngtech.archunit:archunit-junit5-engine</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>org.junit.jupiter:junit-jupiter-engine</ignoredUnusedDeclaredDependency>
+            </ignoredUnusedDeclaredDependencies>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/ImmutableProtocol.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/ImmutableProtocol.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.immutables.value.Value;
+import org.immutables.value.Value.Style.ValidationMethod;
+
+/**
+ * Types annotated with this are considered concrete types of the protocol (e.g. {@link Record}, and
+ * not simply behavioral types (e.g. {@link JsonSerializable}.
+ *
+ * <p>For every abstract type annotated with this, an immutable, concrete type will be generated.
+ * For example, given {@link Record}, then {@link ImmutableRecord} will be generated. Every leaf
+ * type of the protocol - that is, any type which may end up in {@link Record} or nested in one of
+ * its properties - should be annotated with this.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.CLASS)
+@Value.Style(
+    // standardize to mimic Java beans
+    get = {"is*", "get*"},
+    // do not generate code which relies on Guava or other libraries
+    jdkOnly = true,
+    // do not pre-compute the hash, instead compute it once the first time it's required and memoize
+    // it
+    defaults = @Value.Immutable(lazyhash = true),
+    // allow null values to be passed; this allows for partial deserialization
+    validationMethod = ValidationMethod.NONE,
+    clearBuilder = true,
+    // enables passing other immutable builders as arguments, allowing you to chain multiple
+    // builders together which may help reduce the amount of allocations
+    attributeBuilderDetection = true,
+    // enables detecting the presence of types that also have immutable counterparts; while this
+    // slows down compilation, it enables us to do a deep copy of objects
+    deepImmutablesDetection = true,
+    // disable the Jackson integration to avoid bringing this in with the protocol; this is later
+    // bridged in the protocol-jackson module
+    jacksonIntegration = false,
+    // converts methods for attributes such as `jobs` from `addJobs(JobRecordValue)` to
+    // `addJob(JobRecordValue)` for the variants with only one argument
+    depluralize = true,
+    // prefix builder methods with `with` to distinguish them from other, non attribute methods
+    // present in the builder; this will be useful to integrate with Jackson in protocol-jackson,
+    // for example
+    init = "with*")
+public @interface ImmutableProtocol {}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/JsonSerializable.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/JsonSerializable.java
@@ -15,8 +15,19 @@
  */
 package io.camunda.zeebe.protocol.record;
 
+import org.immutables.value.Value;
+
 public interface JsonSerializable {
 
-  /** @return a JSON marshaled representation */
-  String toJson();
+  /**
+   * @return a JSON marshaled representation
+   * @throws UnsupportedOperationException if the implementation does not support it; in that case,
+   *     you may try using a library like Jackson with our {@code protocol-jackson} module.
+   */
+  @Value.NonAttribute
+  default String toJson() {
+    throw new UnsupportedOperationException(
+        "Failed to serialize value to JSON; this implementation does not support it out of the box. "
+            + " You may want to try with the protocol-jackson module.");
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
@@ -16,8 +16,11 @@
 package io.camunda.zeebe.protocol.record;
 
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import org.immutables.value.Value;
 
 /** Represents a record published to the log stream. */
+@Value.Immutable
+@ImmutableProtocol
 public interface Record<T extends RecordValue> extends JsonSerializable {
   /**
    * Retrieves the position of the record. Positions are locally unique to the partition, and
@@ -79,7 +82,7 @@ public interface Record<T extends RecordValue> extends JsonSerializable {
 
   /**
    * Returns the raw value of the record, which should implement one of the interfaces in the {@link
-   * io.camunda.zeebe.exporter.record.value} package.
+   * io.camunda.zeebe.protocol.record.value} package.
    *
    * <p>The record value is essentially the record specific data, e.g. for a process instance
    * creation event, it would contain information relevant to the process instance being created.
@@ -93,5 +96,10 @@ public interface Record<T extends RecordValue> extends JsonSerializable {
    *
    * @return a deep copy of this record
    */
-  Record<T> copyOf();
+  @Value.NonAttribute
+  default Record<T> copyOf() {
+    throw new UnsupportedOperationException(
+        "Failed to create a deep copy of this record; this implementation does not support this out"
+            + " of the box");
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DecisionEvaluationRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DecisionEvaluationRecordValue.java
@@ -15,10 +15,14 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import java.util.List;
+import org.immutables.value.Value;
 
 /** Represents the evaluation of a DMN decision. */
+@Value.Immutable
+@ImmutableProtocol
 public interface DecisionEvaluationRecordValue extends RecordValue {
 
   /** @return the key of the evaluated decision */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DeploymentDistributionRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DeploymentDistributionRecordValue.java
@@ -15,8 +15,12 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
 
+@Value.Immutable
+@ImmutableProtocol
 public interface DeploymentDistributionRecordValue extends RecordValue {
 
   /** @return the partition where the deployment should be distributed */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DeploymentRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DeploymentRecordValue.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
@@ -22,12 +23,15 @@ import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMet
 import io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import java.util.List;
+import org.immutables.value.Value;
 
 /**
  * Represents a single deployment event or command.
  *
  * <p>See {@link DeploymentIntent} for intents.
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface DeploymentRecordValue extends RecordValue {
   /** @return the resources to deploy */
   List<DeploymentResource> getResources();

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ErrorRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ErrorRecordValue.java
@@ -15,9 +15,13 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
 
 /** Error records are written on unexpected errors during the processing phase. */
+@Value.Immutable
+@ImmutableProtocol
 public interface ErrorRecordValue extends RecordValue {
 
   /** @return the exception message, which causes this error record. */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EvaluatedDecisionValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EvaluatedDecisionValue.java
@@ -15,12 +15,16 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import java.util.List;
+import org.immutables.value.Value;
 
 /**
  * An evaluated DMN decision. It contains details of the evaluation depending on the decision type.
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface EvaluatedDecisionValue extends RecordValue {
 
   /** @return the id of the evaluated decision */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EvaluatedInputValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EvaluatedInputValue.java
@@ -15,12 +15,16 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
 
 /**
  * An evaluated input of a decision table. It contains details of the input and the value of the
  * evaluated input expression.
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface EvaluatedInputValue extends RecordValue {
 
   /** @return the id of the evaluated input */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EvaluatedOutputValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EvaluatedOutputValue.java
@@ -15,12 +15,16 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
 
 /**
  * An evaluated output of a decision table that belongs to a {@link MatchedRuleValue matched rule}.
  * It contains details of the output and the value of the evaluated output expression.
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface EvaluatedOutputValue extends RecordValue {
 
   /** @return the id of the evaluated output */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IncidentRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IncidentRecordValue.java
@@ -15,14 +15,18 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import org.immutables.value.Value;
 
 /**
  * Represents a process incident.
  *
  * <p>See {@link IncidentIntent} for intents.
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface IncidentRecordValue extends RecordValue, ProcessInstanceRelated {
   /**
    * @return the type of error this incident is caused by. Can be <code>UNKNOWN</code> if the
@@ -52,6 +56,7 @@ public interface IncidentRecordValue extends RecordValue, ProcessInstanceRelated
    * @return the key of the process instance this incident belongs to. Can be <code>-1</code> if the
    *     incident record is part of a {@link IncidentIntent#RESOLVE} command.
    */
+  @Override
   long getProcessInstanceKey();
 
   /**

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobBatchRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobBatchRecordValue.java
@@ -15,15 +15,19 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import java.util.List;
+import org.immutables.value.Value;
 
 /**
  * Represents a job batch related event or command.
  *
  * <p>See {@link JobBatchIntent} for intents.
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface JobBatchRecordValue extends RecordValue {
   /** @return the type of the job */
   String getType();

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -15,15 +15,19 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import java.util.Map;
+import org.immutables.value.Value;
 
 /**
  * Represents a job related event or command.
  *
  * <p>See {@link JobIntent} for intents.
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface JobRecordValue extends RecordValueWithVariables, ProcessInstanceRelated {
 
   /** @return the type of the job */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MatchedRuleValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MatchedRuleValue.java
@@ -15,13 +15,17 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import java.util.List;
+import org.immutables.value.Value;
 
 /**
  * A matched rule of a decision table. It contains details of the rule and its {@link
  * EvaluatedOutputValue outputs}.
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface MatchedRuleValue extends RecordValue {
 
   /** @return the id of the matched rule */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageRecordValue.java
@@ -15,14 +15,18 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import org.immutables.value.Value;
 
 /**
  * Represents a message event or command.
  *
  * <p>See {@link MessageIntent} for intents.
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface MessageRecordValue extends RecordValueWithVariables {
   /** @return the name of the message */
   String getName();

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageStartEventSubscriptionRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageStartEventSubscriptionRecordValue.java
@@ -15,14 +15,18 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import org.immutables.value.Value;
 
 /**
  * Represents message start event subscription commands and events
  *
  * <p>See {@link MessageStartEventSubscriptionIntent} for intents.
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface MessageStartEventSubscriptionRecordValue extends RecordValueWithVariables {
 
   /** @return the process key tied to the subscription */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
@@ -15,14 +15,18 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import org.immutables.value.Value;
 
 /**
  * Represents a message correlation subscription event or command.
  *
  * <p>See {@link MessageSubscriptionIntent} for intents.
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface MessageSubscriptionRecordValue
     extends RecordValueWithVariables, ProcessInstanceRelated {
 

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessEventRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessEventRecordValue.java
@@ -15,7 +15,9 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
+import org.immutables.value.Value;
 
 /**
  * Represents a signal that an event was triggered in a process instance, within a given scope, and
@@ -34,6 +36,8 @@ import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
  * from the emitter (e.g. error throw end event, escalation), and there is no special purpose entity
  * associated with the emitter (e.g. timer, message).
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface ProcessEventRecordValue extends RecordValueWithVariables, ProcessInstanceRelated {
 
   /** @return the key identifying the event's scope */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
@@ -15,8 +15,12 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
+import org.immutables.value.Value;
 
+@Value.Immutable
+@ImmutableProtocol
 public interface ProcessInstanceCreationRecordValue
     extends RecordValueWithVariables, ProcessInstanceRelated {
   /** @return the BPMN process id to create a process from */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
@@ -15,14 +15,18 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import org.immutables.value.Value;
 
 /**
  * Represents a process instance related command or event.
  *
  * <p>See {@link ProcessInstanceIntent} for intents.
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface ProcessInstanceRecordValue extends RecordValue, ProcessInstanceRelated {
   /** @return the BPMN process id this process instance belongs to. */
   String getBpmnProcessId();
@@ -34,6 +38,7 @@ public interface ProcessInstanceRecordValue extends RecordValue, ProcessInstance
   long getProcessDefinitionKey();
 
   /** @return the key of the process instance */
+  @Override
   long getProcessInstanceKey();
 
   /** @return the id of the current process element, or empty if the id is not specified. */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRelated.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRelated.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutableProtocol
 public interface ProcessInstanceRelated {
 
   /** @return the key of the corresponding process instance */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceResultRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceResultRecordValue.java
@@ -15,14 +15,18 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent;
+import org.immutables.value.Value;
 
 /**
  * Represents a process instance related command or event.
  *
  * <p>See {@link ProcessInstanceResultIntent} for intents.
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface ProcessInstanceResultRecordValue
     extends RecordValueWithVariables, ProcessInstanceRelated {
   /** @return the BPMN process id this process instance belongs to. */
@@ -35,5 +39,6 @@ public interface ProcessInstanceResultRecordValue
   long getProcessDefinitionKey();
 
   /** @return the key of the process instance */
+  @Override
   long getProcessInstanceKey();
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessMessageSubscriptionRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessMessageSubscriptionRecordValue.java
@@ -15,14 +15,18 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import org.immutables.value.Value;
 
 /**
  * Represents a process message subscription command or event.
  *
  * <p>See {@link ProcessMessageSubscriptionIntent} for intents.
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface ProcessMessageSubscriptionRecordValue
     extends RecordValueWithVariables, ProcessInstanceRelated {
   /** @return the process instance key */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/TimerRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/TimerRecordValue.java
@@ -15,14 +15,18 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import org.immutables.value.Value;
 
 /**
  * Represents a timer event or command.
  *
  * <p>See {@link TimerIntent} for intents.
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface TimerRecordValue extends RecordValue, ProcessInstanceRelated {
 
   /** @return the key of the process in which this timer was created */
@@ -32,6 +36,7 @@ public interface TimerRecordValue extends RecordValue, ProcessInstanceRelated {
   long getElementInstanceKey();
 
   /** @return the key of the related process instance */
+  @Override
   long getProcessInstanceKey();
 
   /** @return the due date of the timer as Unix timestamp in millis. */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableDocumentRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableDocumentRecordValue.java
@@ -15,8 +15,12 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
+import org.immutables.value.Value;
 
+@Value.Immutable
+@ImmutableProtocol
 public interface VariableDocumentRecordValue extends RecordValueWithVariables {
 
   /** @return the scope key associated with the variable document */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/VariableRecordValue.java
@@ -15,14 +15,18 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import org.immutables.value.Value;
 
 /**
  * Represents a variable related event.
  *
  * <p>See {@link VariableIntent} for intents.
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface VariableRecordValue extends RecordValue, ProcessInstanceRelated {
 
   /** @return the name of the variable. */
@@ -35,6 +39,7 @@ public interface VariableRecordValue extends RecordValue, ProcessInstanceRelated
   long getScopeKey();
 
   /** @return the key of the process instance the variable belongs to */
+  @Override
   long getProcessInstanceKey();
 
   /** @return the key of the process the variable belongs to */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/DecisionRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/DecisionRecordValue.java
@@ -15,13 +15,17 @@
  */
 package io.camunda.zeebe.protocol.record.value.deployment;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
 
 /**
  * Represents a deployed decision. A decision belongs to a decision requirements graph (DRG/DRD)
  * that represents the DMN resource. The DMN resource itself is stored as part of the DRG (see
  * {@link DecisionRequirementsRecordValue}).
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface DecisionRecordValue extends RecordValue {
 
   /** @return the ID of the decision in the DMN */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/DecisionRequirementsMetadataValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/DecisionRequirementsMetadataValue.java
@@ -15,11 +15,16 @@
  */
 package io.camunda.zeebe.protocol.record.value.deployment;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import org.immutables.value.Value;
+
 /**
  * The metadata of a deployed decision requirements graph (DRG/DRD). A DRG represents the DMN
  * resource and all decisions of the DMN belongs to it. The metadata contains relevant properties of
  * the DMN resource, except the binary DMN resource itself.
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface DecisionRequirementsMetadataValue {
 
   /** @return the ID of the DRG in the DMN */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/DecisionRequirementsRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/DecisionRequirementsRecordValue.java
@@ -15,12 +15,16 @@
  */
 package io.camunda.zeebe.protocol.record.value.deployment;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
 
 /**
  * Represents a deployed decision requirements graph (DRG/DRD) for a DMN resource. The decisions of
  * the DMN resource belongs to this DRG. The DMN resource itself is stored only in the DRG.
  */
+@Value.Immutable
+@ImmutableProtocol
 public interface DecisionRequirementsRecordValue
     extends RecordValue, DecisionRequirementsMetadataValue {
 

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/DeploymentResource.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/DeploymentResource.java
@@ -15,7 +15,12 @@
  */
 package io.camunda.zeebe.protocol.record.value.deployment;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import org.immutables.value.Value;
+
 /** Represents a single deployment resource. */
+@Value.Immutable
+@ImmutableProtocol
 public interface DeploymentResource {
 
   /** @return the resource contents */

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/Process.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/Process.java
@@ -15,7 +15,12 @@
  */
 package io.camunda.zeebe.protocol.record.value.deployment;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import org.immutables.value.Value;
+
 /** Represents a deployed process, which extends the meta data with the acutal resources */
+@Value.Immutable
+@ImmutableProtocol
 public interface Process extends ProcessMetadataValue {
   /** @return returns the corresponding binary resource */
   byte[] getResource();

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/ProcessMetadataValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/ProcessMetadataValue.java
@@ -15,9 +15,13 @@
  */
 package io.camunda.zeebe.protocol.record.value.deployment;
 
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
 
 /** Represents deployed process meta data, so all important properties of an deployed process. */
+@Value.Immutable
+@ImmutableProtocol
 public interface ProcessMetadataValue extends RecordValue {
   /** @return the bpmn process ID of this process */
   String getBpmnProcessId();

--- a/protocol/src/test/java/io/camunda/zeebe/protocol/EnumDecodingTest.java
+++ b/protocol/src/test/java/io/camunda/zeebe/protocol/EnumDecodingTest.java
@@ -23,14 +23,14 @@ import io.camunda.zeebe.protocol.record.ErrorResponseEncoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public final class EnumDecodingTest {
+final class EnumDecodingTest {
 
-  protected final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
-  protected final ErrorResponseEncoder bodyEncoder = new ErrorResponseEncoder();
-  protected final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
-  protected final ErrorResponseDecoder bodyDecoder = new ErrorResponseDecoder();
+  private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final ErrorResponseEncoder bodyEncoder = new ErrorResponseEncoder();
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+  private final ErrorResponseDecoder bodyDecoder = new ErrorResponseDecoder();
 
   /**
    * This case is important for forward compatibility. Assume client in version X, broker in version
@@ -39,7 +39,7 @@ public final class EnumDecodingTest {
    * This should not result in an exception.
    */
   @Test
-  public void shouldHandleUnknownEnumValue() {
+  void shouldHandleUnknownEnumValue() {
     // given
     final UnsafeBuffer buffer = new UnsafeBuffer(new byte[1024]);
     headerEncoder

--- a/protocol/src/test/java/io/camunda/zeebe/protocol/ImmutableProtocolTest.java
+++ b/protocol/src/test/java/io/camunda/zeebe/protocol/ImmutableProtocolTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClass.Predicates;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
+import org.immutables.value.Value;
+
+/**
+ * This test ensures that we always generate immutable variants of every protocol type, namely:
+ *
+ * <ul>
+ *   <li>{@link Record}
+ *   <li>all types extending {@link io.camunda.zeebe.protocol.record.RecordValue}, except certain
+ *       meta types, such as {@link ProcessInstanceRelated} or {@link
+ *       io.camunda.zeebe.protocol.record.RecordValueWithVariables}
+ *   <li>all other types referenced in the above values, such as {@link
+ *       io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource}
+ * </ul>
+ */
+@AnalyzeClasses(packages = "io.camunda.zeebe.protocol.record..")
+final class ImmutableProtocolTest {
+  @ArchTest
+  void shouldAnnotateImmutableProtocolValues(final JavaClasses importedClasses) {
+    // given
+    // exclude certain interfaces for which we won't be generating any immutable variants
+    final DescribedPredicate<JavaClass> excludedClasses =
+        Predicates.equivalentTo(ProcessInstanceRelated.class);
+    final ArchRule rule =
+        ArchRuleDefinition.classes()
+            .that()
+            // lookup only interface types, ignore enums or concrete classes
+            .areInterfaces()
+            .and()
+            // check only all the types under the record.value and subpackages
+            .resideInAnyPackage("io.camunda.zeebe.protocol.record.value..")
+            // also check the Record interface itself
+            .or(Predicates.equivalentTo(Record.class))
+            // exclude certain interfaces
+            .and(DescribedPredicate.not(excludedClasses))
+            .should()
+            .beAnnotatedWith(ImmutableProtocol.class)
+            .andShould()
+            .beAnnotatedWith(Value.Immutable.class);
+
+    // then
+    rule.check(importedClasses);
+  }
+}

--- a/protocol/src/test/java/io/camunda/zeebe/protocol/ProtocolTest.java
+++ b/protocol/src/test/java/io/camunda/zeebe/protocol/ProtocolTest.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.protocol;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteOrder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class ProtocolTest {
 

--- a/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
+++ b/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
@@ -18,22 +18,17 @@ package io.camunda.zeebe.protocol.record.intent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
-public class IntentEncodingDecodingTest {
+final class IntentEncodingDecodingTest {
 
-  @Parameter public ParameterSet parameterSet;
-
-  @Test
-  public void shouldEncodeAndDecodeTimerIntent() {
+  @ParameterizedTest
+  @MethodSource("parameters")
+  void shouldEncodeAndDecodeTimerIntent(final ParameterSet parameterSet) {
     final short value = parameterSet.intent.value();
 
     final Intent decoded = parameterSet.decoder.apply(value);
@@ -41,8 +36,7 @@ public class IntentEncodingDecodingTest {
     assertThat(decoded).isSameAs(parameterSet.intent);
   }
 
-  @Parameters(name = "{0}")
-  public static Collection<ParameterSet> parameters() {
+  private static Stream<ParameterSet> parameters() {
     final List<ParameterSet> result = new ArrayList<>();
     result.addAll(
         buildParameterSets(DecisionEvaluationIntent.class, DecisionEvaluationIntent::from));
@@ -77,7 +71,7 @@ public class IntentEncodingDecodingTest {
     result.addAll(buildParameterSets(VariableDocumentIntent.class, VariableDocumentIntent::from));
     result.addAll(buildParameterSets(VariableIntent.class, VariableIntent::from));
 
-    return result;
+    return result.stream();
   }
 
   private static List<ParameterSet> buildParameterSets(


### PR DESCRIPTION
## Description

Introduces a new immutable protocol directly under `protocol`, which annotates the types directly. This has several advantages:

- We can now easily recursively copy the types (except for `Record`, which is a special case due to its generic typing)
- It's less error prone thanks to an ArchUnit test guaranteeing we don't forget to annotate the types
- It's less overhead for developers when adding new types
- It allows us to easily collect metadata about the types via reflection using annotations

This is the first step for #8837 - the next step will remove the immutable variants in `protocol-jackson` and replace them with this.

## Related issues

related to #8837 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
