### PR TITLE
[Backports stable/1.2] Remove temporary cache cleaning

### DIFF
--- a/.github/workflows/os-smoke-test.yml
+++ b/.github/workflows/os-smoke-test.yml
@@ -27,36 +27,6 @@ jobs:
           distribution: 'adopt'
           cache: 'maven'
 
-      - name: Clear broken cache parts (windows)
-        if: matrix.os == 'windows-2022'
-        uses: JesseTG/rm@v1.0.2
-        with:
-          path: C:\Users\runneradmin\.m2\repository\org\agrona\agrona
-      - name: Clear broken cache parts (windows)
-        if: matrix.os == 'windows-2022'
-        uses: JesseTG/rm@v1.0.2
-        with:
-          path: C:\Users\runneradmin\.m2\repository\uk\co\real-logic\sbe-tool
-      - name: Clear broken cache parts (ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        uses: JesseTG/rm@v1.0.2
-        with:
-          path: /home/runner/.m2/repository/org/agrona/agrona
-      - name: Clear broken cache parts (ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        uses: JesseTG/rm@v1.0.2
-        with:
-          path: /home/runner/.m2/repository/uk/co/real-logic/sbe-tool
-      - name: Clear broken cache parts (macos)
-        if: matrix.os == 'macos-latest'
-        uses: JesseTG/rm@v1.0.2
-        with:
-          path: /Users/runner/.m2/repository/org/agrona/agrona
-      - name: Clear broken cache parts (macos)
-        if: matrix.os == 'macos-latest'
-        uses: JesseTG/rm@v1.0.2
-        with:
-          path: /Users/runner/.m2/repository/uk/co/real-logic/sbe-tool
       - name: Build relevant modules
         run: mvn -B -am -pl qa/integration-tests install -DskipTests -DskipChecks "-Dmaven.javadoc.skip=true" -T1C
       - name: Run smoke test


### PR DESCRIPTION
## Description

This PR backports #8943 to stable/1.2.

## Related issues

backports #8943

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
