### PR TITLE
Introduce new protocol-util module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <module>exporters/elasticsearch-exporter</module>
     <module>protocol-impl</module>
     <module>protocol-jackson</module>
+    <module>protocol-util</module>
     <module>zb-db</module>
     <module>expression-language</module>
     <module>feel</module>

--- a/protocol-util/README.md
+++ b/protocol-util/README.md
@@ -1,0 +1,16 @@
+# Zeebe Protocol Utilities
+
+This module consists of shared utilities to manipulate and work with the Zeebe binary protocol.
+
+## Type mappings
+
+Included here are some type mapping utilities. They express the implicit mappings between certain
+protocol properties in a more explicit way.
+
+For one, by convention, every `ValueType` (outside of `SBE_UNKNOWN` and `NULL_VAL`) always has a
+corresponding value type (i.e. an interface type extending `RecordValue`) and an intent type (i.e.
+an enum extending `Intent`). This relationship is now encoded in `ValueTypeMapping`.
+
+Second, every protocol value type (e.g. `Record`, `RecordValue` subtypes, etc.) has a concrete,
+generated, immutable variant. This is expressed in `ProtocolTypeMapping`, and can be used, for
+example, to simplify deserialization or copying of the interface types.

--- a/protocol-util/pom.xml
+++ b/protocol-util/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>zeebe-parent</artifactId>
+    <version>1.4.0-SNAPSHOT</version>
+    <relativePath>../parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>zeebe-protocol-util</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Zeebe Protocol Utilities</name>
+
+  <properties>
+    <version.java>8</version.java>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
+
+    <!-- Used to discover the mappings between the protocol's abstract and concrete types -->
+    <dependency>
+      <groupId>io.github.classgraph</groupId>
+      <artifactId>classgraph</artifactId>
+    </dependency>
+
+    <!-- Utilities -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/protocol-util/src/main/java/io/camunda/zeebe/protocol/util/ProtocolTypeMapping.java
+++ b/protocol-util/src/main/java/io/camunda/zeebe/protocol/util/ProtocolTypeMapping.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.util;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.Record;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ClassInfoList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A utility class to lazy load and cache the mappings between the protocol abstract classes, e.g.
+ * {@link Record}, {@link io.camunda.zeebe.protocol.record.value.ErrorRecordValue}, and their
+ * concrete immutable implementations, e.g. {@link
+ * io.camunda.zeebe.protocol.record.ImmutableRecord}.
+ *
+ * <p>This class is thread-safe, including static initialization by multiple concurrent class
+ * loaders.
+ *
+ * <p>Expected usage is via {@link #forEach(Consumer)}.
+ */
+public final class ProtocolTypeMapping {
+  private static final String PROTOCOL_PACKAGE_NAME = Record.class.getPackage().getName() + "*";
+  private static final Logger LOGGER = LoggerFactory.getLogger(ProtocolTypeMapping.class);
+  private final Map<Class<?>, Mapping<?>> concreteMappings;
+  private final Map<Class<?>, Mapping<?>> abstractMappings;
+
+  private ProtocolTypeMapping() {
+    concreteMappings = new HashMap<>();
+    abstractMappings = new HashMap<>();
+
+    loadTypeMappings();
+  }
+
+  /**
+   * Iterates over all known protocol type mappings.
+   *
+   * @param consumer called for each known protocol type mapping
+   */
+  public static void forEach(final Consumer<Mapping<?>> consumer) {
+    Singleton.INSTANCE.concreteMappings.values().forEach(consumer);
+  }
+
+  /**
+   * Returns a type mapping for the given concrete type, or null if none found.
+   *
+   * @param concreteType the concrete type to look for
+   * @return a mapping of this concrete type to an abstract type and builder type
+   */
+  @SuppressWarnings("java:S1452") // the expected usage is to pass it as is with the wildcard type
+  public static Mapping<?> getForConcreteType(final Class<?> concreteType) {
+    return Singleton.INSTANCE.concreteMappings.get(concreteType);
+  }
+
+  /**
+   * Returns a type mapping for the given abstract type, or null if none found.
+   *
+   * @param abstractType the abstract type to look for
+   * @return a mapping of this abstract type to an concrete type and builder type
+   */
+  @SuppressWarnings("java:S1452") // the expected usage is to pass it as is with the wildcard type
+  public static Mapping<?> getForAbstractType(final Class<?> abstractType) {
+    return Singleton.INSTANCE.abstractMappings.get(abstractType);
+  }
+
+  private void loadTypeMappings() {
+    final ClassInfoList abstractTypes = findProtocolTypes();
+    for (final ClassInfo abstractType : abstractTypes) {
+      LOGGER.trace("Found abstract protocol type {}", abstractType);
+      loadTypeMappingsFor(abstractType, abstractType.loadClass());
+    }
+
+    if (abstractTypes.isEmpty()) {
+      LOGGER.warn(
+          "Found no abstract protocol types in package {}; deserialization will most likely not work",
+          PROTOCOL_PACKAGE_NAME);
+    }
+  }
+
+  private <T> void loadTypeMappingsFor(final ClassInfo abstractType, final Class<T> abstractClass) {
+    Objects.requireNonNull(abstractType, "must specify an abstract type");
+    Objects.requireNonNull(abstractClass, "must specify the abstract class");
+
+    // a few of the abstract types actually extend each other, so we need to lookup only the direct
+    // concrete types, as otherwise we won't be able to tell which implementation is the right one
+    final ClassInfoList concreteTypes =
+        abstractType
+            .getClassesImplementing()
+            .filter(ClassInfo::isStandardClass)
+            .filter(info -> !info.isAbstract())
+            .directOnly();
+
+    for (final ClassInfo concreteType : concreteTypes) {
+      final Class<T> concreteClass = concreteType.loadClass(abstractClass);
+      LOGGER.trace(
+          "Found concrete type mapping for protocol class {} => {}", abstractClass, concreteClass);
+      loadTypeMappingsFor(concreteType, abstractClass, concreteClass);
+    }
+
+    if (concreteTypes.isEmpty()) {
+      LOGGER.warn(
+          "Found no concrete type mapping for protocol type {}; deserialization may not always work",
+          abstractClass);
+    }
+  }
+
+  private <T> void loadTypeMappingsFor(
+      final ClassInfo concreteType, final Class<T> abstractClass, final Class<T> concreteClass) {
+    Objects.requireNonNull(concreteType, "must specify a concrete type");
+    Objects.requireNonNull(abstractClass, "must specify an abstract class");
+    Objects.requireNonNull(concreteClass, "must specify a concrete class");
+
+    final ClassInfoList builderTypes =
+        concreteType.getInnerClasses().filter(info -> "Builder".equals(info.getSimpleName()));
+    for (final ClassInfo builder : builderTypes) {
+      final Mapping<T> mapping = new Mapping<>(abstractClass, concreteClass, builder.loadClass());
+      concreteMappings.put(concreteClass, mapping);
+      abstractMappings.put(abstractClass, mapping);
+    }
+
+    if (builderTypes.isEmpty()) {
+      LOGGER.warn(
+          "Found no inner builder type for concrete type {} of protocol type {}; deserialization "
+              + "may not work",
+          concreteClass,
+          abstractClass);
+    }
+  }
+
+  // visible for testing
+  static ClassInfoList findProtocolTypes() {
+    return new ClassGraph()
+        .acceptPackages(PROTOCOL_PACKAGE_NAME)
+        .enableAnnotationInfo()
+        .scan()
+        .getAllInterfaces()
+        .filter(info -> info.hasAnnotation(ImmutableProtocol.class))
+        .directOnly();
+  }
+
+  /**
+   * A mapping between an abstract protocol type (i.e. annotated via {@link ImmutableProtocol}, its
+   * concrete type, and its builder type.
+   *
+   * @param <T> the abstract type of the mapping
+   */
+  public static final class Mapping<T> {
+    final Class<T> abstractClass;
+    final Class<? extends T> concreteClass;
+    final Class<?> builderClass;
+
+    private Mapping(
+        final Class<T> abstractClass,
+        final Class<? extends T> concreteClass,
+        final Class<?> builderClass) {
+      this.abstractClass = Objects.requireNonNull(abstractClass, "must specify an abstract class");
+      this.concreteClass = Objects.requireNonNull(concreteClass, "must specify a concrete class");
+      this.builderClass = Objects.requireNonNull(builderClass, "must specify a builder class");
+    }
+
+    public Class<T> getAbstractClass() {
+      return abstractClass;
+    }
+
+    public Class<? extends T> getConcreteClass() {
+      return concreteClass;
+    }
+
+    public Class<?> getBuilderClass() {
+      return builderClass;
+    }
+  }
+
+  private static final class Singleton {
+    private static final ProtocolTypeMapping INSTANCE = new ProtocolTypeMapping();
+  }
+}

--- a/protocol-util/src/main/java/io/camunda/zeebe/protocol/util/ValueTypeMapping.java
+++ b/protocol-util/src/main/java/io/camunda/zeebe/protocol/util/ValueTypeMapping.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.util;
+
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
+import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import io.camunda.zeebe.protocol.record.value.DeploymentDistributionRecordValue;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessEventRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.Process;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Provides a mapping of all {@link ValueType} to their concrete implementations. It should be an
+ * exhaustive map of all possible {@link ValueType}, so if you add one, make sure to update the
+ * mapping here as well.
+ */
+@SuppressWarnings("java:S1452")
+public final class ValueTypeMapping {
+  private final Map<ValueType, Mapping<?, ?>> types;
+  private final Set<ValueType> acceptedValueTypes;
+
+  private ValueTypeMapping() {
+    types = Collections.unmodifiableMap(loadValueTypes());
+    acceptedValueTypes =
+        EnumSet.complementOf(EnumSet.of(ValueType.SBE_UNKNOWN, ValueType.NULL_VAL));
+  }
+
+  /**
+   * Returns the mapping for the given value type.
+   *
+   * @param valueType the value type of the mapping
+   * @return a mapping from this type to a {@link RecordValue} and {@link Intent}
+   * @throws IllegalArgumentException if no such mapping exists
+   */
+  public static Mapping<?, ?> get(final ValueType valueType) {
+    final Mapping<?, ?> typeInfo = Singleton.INSTANCE.types.get(valueType);
+    if (typeInfo == null) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected value type to be one of %s, but was %s",
+              Singleton.INSTANCE.types.keySet(), valueType));
+    }
+
+    return typeInfo;
+  }
+
+  /** @return the set of mappable value types */
+  public static Set<ValueType> getAcceptedValueTypes() {
+    return Singleton.INSTANCE.acceptedValueTypes;
+  }
+
+  // suppressed warning about method length; this is simply populating a map, which while tedious,
+  // isn't incredibly complex
+  @SuppressWarnings("java:S138")
+  private Map<ValueType, Mapping<?, ?>> loadValueTypes() {
+    final Map<ValueType, Mapping<?, ?>> mapping = new EnumMap<>(ValueType.class);
+
+    mapping.put(ValueType.DECISION, new Mapping<>(DecisionRecordValue.class, DecisionIntent.class));
+    mapping.put(
+        ValueType.DECISION_EVALUATION,
+        new Mapping<>(DecisionEvaluationRecordValue.class, DecisionEvaluationIntent.class));
+    mapping.put(
+        ValueType.DECISION_REQUIREMENTS,
+        new Mapping<>(DecisionRequirementsRecordValue.class, DecisionRequirementsIntent.class));
+    mapping.put(
+        ValueType.DEPLOYMENT, new Mapping<>(DeploymentRecordValue.class, DeploymentIntent.class));
+    mapping.put(
+        ValueType.DEPLOYMENT_DISTRIBUTION,
+        new Mapping<>(DeploymentDistributionRecordValue.class, DeploymentDistributionIntent.class));
+    mapping.put(ValueType.ERROR, new Mapping<>(ErrorRecordValue.class, ErrorIntent.class));
+    mapping.put(ValueType.INCIDENT, new Mapping<>(IncidentRecordValue.class, IncidentIntent.class));
+    mapping.put(ValueType.JOB, new Mapping<>(JobRecordValue.class, JobIntent.class));
+    mapping.put(
+        ValueType.JOB_BATCH, new Mapping<>(JobBatchRecordValue.class, JobBatchIntent.class));
+    mapping.put(ValueType.MESSAGE, new Mapping<>(MessageRecordValue.class, MessageIntent.class));
+    mapping.put(
+        ValueType.MESSAGE_START_EVENT_SUBSCRIPTION,
+        new Mapping<>(
+            MessageStartEventSubscriptionRecordValue.class,
+            MessageStartEventSubscriptionIntent.class));
+    mapping.put(
+        ValueType.MESSAGE_SUBSCRIPTION,
+        new Mapping<>(MessageSubscriptionRecordValue.class, MessageSubscriptionIntent.class));
+    mapping.put(ValueType.PROCESS, new Mapping<>(Process.class, ProcessIntent.class));
+    mapping.put(
+        ValueType.PROCESS_EVENT,
+        new Mapping<>(ProcessEventRecordValue.class, ProcessEventIntent.class));
+    mapping.put(
+        ValueType.PROCESS_INSTANCE,
+        new Mapping<>(ProcessInstanceRecordValue.class, ProcessInstanceIntent.class));
+    mapping.put(
+        ValueType.PROCESS_INSTANCE_CREATION,
+        new Mapping<>(
+            ProcessInstanceCreationRecordValue.class, ProcessInstanceCreationIntent.class));
+    mapping.put(
+        ValueType.PROCESS_INSTANCE_RESULT,
+        new Mapping<>(ProcessInstanceResultRecordValue.class, ProcessInstanceResultIntent.class));
+    mapping.put(
+        ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
+        new Mapping<>(
+            ProcessMessageSubscriptionRecordValue.class, ProcessMessageSubscriptionIntent.class));
+    mapping.put(ValueType.TIMER, new Mapping<>(TimerRecordValue.class, TimerIntent.class));
+    mapping.put(ValueType.VARIABLE, new Mapping<>(VariableRecordValue.class, VariableIntent.class));
+    mapping.put(
+        ValueType.VARIABLE_DOCUMENT,
+        new Mapping<>(VariableDocumentRecordValue.class, VariableDocumentIntent.class));
+
+    return mapping;
+  }
+
+  /**
+   * A mapping between value type, an abstract protocol type extending {@link RecordValue}, and the
+   * equivalent intent.
+   *
+   * @param <T> the value type
+   * @param <I> the intent type
+   */
+  public static final class Mapping<T extends RecordValue, I extends Enum<I> & Intent> {
+    private final Class<T> valueClass;
+    private final Class<I> intentClass;
+
+    private Mapping(final Class<T> valueClass, final Class<I> intentClass) {
+      this.valueClass = Objects.requireNonNull(valueClass, "must specify a value class");
+      this.intentClass = Objects.requireNonNull(intentClass, "must specify an intent");
+    }
+
+    public Class<? extends T> getValueClass() {
+      return valueClass;
+    }
+
+    public Class<I> getIntentClass() {
+      return intentClass;
+    }
+  }
+
+  private static final class Singleton {
+    private static final ValueTypeMapping INSTANCE = new ValueTypeMapping();
+  }
+}

--- a/protocol-util/src/test/java/io/camunda/zeebe/protocol/util/ProtocolTypeMappingTest.java
+++ b/protocol-util/src/test/java/io/camunda/zeebe/protocol/util/ProtocolTypeMappingTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.util.ProtocolTypeMapping.Mapping;
+import io.github.classgraph.ClassInfoList;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Execution(ExecutionMode.CONCURRENT)
+final class ProtocolTypeMappingTest {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("protocolClassProvider")
+  void shouldMapProtocolClass(
+      @SuppressWarnings("unused") final String testName, final Class<?> protocolClass)
+      throws NoSuchMethodException {
+    assertTypeMapping(protocolClass);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("valueClassProvider")
+  void shouldMapEveryKnownValueClass(
+      @SuppressWarnings("unused") final String testName, final Class<?> valueClass)
+      throws NoSuchMethodException {
+    assertTypeMapping(valueClass);
+  }
+
+  @Test
+  void shouldIterateOverAllKnownMappings() {
+    // given
+    final ClassInfoList protocolTypes = ProtocolTypeMapping.findProtocolTypes();
+    final List<Mapping<?>> mappings = new ArrayList<>();
+
+    // when
+    ProtocolTypeMapping.forEach(mappings::add);
+
+    // then
+    assertThat(mappings).hasSameSizeAs(protocolTypes);
+  }
+
+  /**
+   * Asserts that there is a type mapping for the given protocol class, that its abstract class is
+   * the given protocol class, its concrete class a concrete implementation of the protocol class,
+   * and that it has a builder which is an inner class of the concrete type.
+   */
+  private void assertTypeMapping(final Class<?> abstractType) throws NoSuchMethodException {
+    final Mapping<?> mapping = ProtocolTypeMapping.getForAbstractType(abstractType);
+    assertThat(mapping)
+        .as(
+            "protocol abstract type '%s' should have a concrete immutable type"
+                + " mapping; verify that an equivalent Immutable* class was generated for"
+                + " it, and if so, that the ProtocolTypeMapping can correctly find it",
+            abstractType)
+        .isNotNull();
+
+    assertAbstractTypeMapping(abstractType, mapping);
+    assertTypeMappingBuilder(mapping);
+    assertThat(ProtocolTypeMapping.getForConcreteType(mapping.getConcreteClass()))
+        .isSameAs(mapping);
+  }
+
+  private void assertAbstractTypeMapping(final Class<?> abstractType, final Mapping<?> mapping) {
+    assertThat(abstractType)
+        .as(
+            "type mapping for the protocol class should map itself as an abstract "
+                + "type to a concrete implementation")
+        .isEqualTo(mapping.getAbstractClass())
+        .isAssignableFrom(mapping.getConcreteClass());
+  }
+
+  private void assertTypeMappingBuilder(final Mapping<?> mapping) throws NoSuchMethodException {
+    assertThat(mapping.getBuilderClass())
+        .as(
+            "a builder class should have been assigned to the type mapping for '%s'",
+            mapping.getAbstractClass())
+        .isNotNull();
+
+    final Method buildMethod = mapping.getBuilderClass().getMethod("build");
+    assertThat(buildMethod)
+        .as("there should be a no-args build method on the builder class")
+        .isNotNull()
+        .asInstanceOf(InstanceOfAssertFactories.type(Method.class))
+        .extracting(Method::getReturnType)
+        .as("the build method should return a value of the concrete type")
+        .isEqualTo(mapping.getConcreteClass());
+  }
+
+  private static Stream<Arguments> protocolClassProvider() {
+    return ProtocolTypeMapping.findProtocolTypes().loadClasses().stream()
+        .map(protocolClass -> Arguments.of(protocolClass.getName(), protocolClass));
+  }
+
+  private static Stream<Arguments> valueClassProvider() {
+    return ValueTypeMapping.getAcceptedValueTypes().stream()
+        .map(
+            valueType ->
+                Arguments.of(valueType.name(), ValueTypeMapping.get(valueType).getValueClass()));
+  }
+}

--- a/protocol-util/src/test/java/io/camunda/zeebe/protocol/util/ValueTypeMappingTest.java
+++ b/protocol-util/src/test/java/io/camunda/zeebe/protocol/util/ValueTypeMappingTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.util.ValueTypeMapping.Mapping;
+import java.util.EnumSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+final class ValueTypeMappingTest {
+  @Test
+  void shouldNotAcceptSBESyntheticValues() {
+    // given values automatically added by SBE, i.e. "synthetic"
+    final EnumSet<ValueType> syntheticValues =
+        EnumSet.of(ValueType.NULL_VAL, ValueType.SBE_UNKNOWN);
+    final Set<ValueType> nonSyntheticValueTypes = EnumSet.complementOf(syntheticValues);
+
+    // when
+    final Set<ValueType> acceptedValueTypes = ValueTypeMapping.getAcceptedValueTypes();
+
+    // then
+    assertThat(acceptedValueTypes)
+        .doesNotContainAnyElementsOf(syntheticValues)
+        .containsExactlyElementsOf(nonSyntheticValueTypes);
+  }
+
+  @Test
+  void shouldMapAllValueTypes() {
+    // given
+    final Set<ValueType> acceptedValueTypes = ValueTypeMapping.getAcceptedValueTypes();
+
+    // when
+    assertThat(acceptedValueTypes)
+        .allSatisfy(
+            valueType -> {
+              final Mapping<?, ?> typeInfo = ValueTypeMapping.get(valueType);
+              assertThat(RecordValue.class)
+                  .as(
+                      "value type '%s' should have a value class which implements RecordValue",
+                      valueType)
+                  .isAssignableFrom(typeInfo.getValueClass());
+              assertThat(Intent.class)
+                  .as(
+                      "value type '%s' should have an intent class which implements Intent",
+                      valueType)
+                  .isAssignableFrom(typeInfo.getIntentClass());
+            });
+  }
+
+  @Test
+  void shouldThrowOnUnmappedValueType() {
+    // given
+    final ValueType unmappedType = ValueType.NULL_VAL;
+
+    // then
+    assertThatCode(() -> ValueTypeMapping.get(unmappedType))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}


### PR DESCRIPTION
## Description

Adds a new module for protocol utilities, which for now provides a centralized way to discover type mappings, e.g. mapping value type to values or intents, or abstract protocol types to concrete protocol types.

These will be used in `protocol-jackson` in the next step, and later on in other modules, e.g. to generate random records.

## Related issues

related to #8837 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
