### PR TITLE
feat(benchmark): fail make on error

### DIFF
--- a/benchmarks/setup/default/Makefile
+++ b/benchmarks/setup/default/Makefile
@@ -5,17 +5,17 @@ all: zeebe starter timer simpleStarter worker
 
 .PHONY: zeebe
 zeebe:
-	-helm install --namespace $(namespace) $(namespace) camunda-cloud/ccsm-helm -f zeebe-values.yaml --skip-crds
+	helm install --namespace $(namespace) $(namespace) camunda-cloud/ccsm-helm -f zeebe-values.yaml --skip-crds
 
 # Generates templates from the zeebe helm charts, useful to make some more specific changes which are not doable by the values file.
 # To apply the templates use k apply -f ccsm-helm/templates/
 .PHONY: template
 template:
-	-helm template $(namespace) camunda-cloud/ccsm-helm -f zeebe-values.yaml --skip-crds --output-dir .
+	helm template $(namespace) camunda-cloud/ccsm-helm -f zeebe-values.yaml --skip-crds --output-dir .
 
 .PHONY: update
 update:
-	-helm upgrade --namespace $(namespace) $(namespace) camunda-cloud/ccsm-helm -f zeebe-values.yaml
+	helm upgrade --namespace $(namespace) $(namespace) camunda-cloud/ccsm-helm -f zeebe-values.yaml
 
 .PHONY: starter
 starter:


### PR DESCRIPTION
## Description

Remove suppression of errors from benchmark Makefile for installation tasks. For cleanup tasks they are necessary.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [x] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
