### PR TITLE
Handle `ZeebeDbInconsistentException` by transitioning to `INACTIVE`

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.util.exception.RecoverableException;
+import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.retry.AbortableRetryStrategy;
 import io.camunda.zeebe.util.retry.RecoverableRetryStrategy;
 import io.camunda.zeebe.util.retry.RetryStrategy;
@@ -262,6 +263,8 @@ public final class ProcessingStateMachine {
           metadata,
           recoverableException);
       actor.runDelayed(PROCESSING_RETRY_DELAY, () -> processCommand(currentRecord));
+    } catch (final UnrecoverableException unrecoverableException) {
+      throw unrecoverableException;
     } catch (final Exception e) {
       LOG.error(ERROR_MESSAGE_PROCESSING_FAILED_SKIP_EVENT, command, metadata, e);
       onError(e, this::writeRecords);

--- a/zb-db/src/main/java/io/camunda/zeebe/db/ZeebeDbInconsistentException.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/ZeebeDbInconsistentException.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.db;
 
-public class ZeebeDbInconsistentException extends IllegalStateException {
+import io.camunda.zeebe.util.exception.UnrecoverableException;
+
+public class ZeebeDbInconsistentException extends UnrecoverableException {
   public ZeebeDbInconsistentException(final String message) {
     super(message);
   }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/DefaultTransactionContext.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/DefaultTransactionContext.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.db.TransactionOperation;
 import io.camunda.zeebe.db.ZeebeDbException;
 import io.camunda.zeebe.db.ZeebeDbTransaction;
 import io.camunda.zeebe.util.exception.RecoverableException;
+import io.camunda.zeebe.util.exception.UnrecoverableException;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.Status;
 
@@ -33,8 +34,8 @@ public final class DefaultTransactionContext implements TransactionContext {
       } else {
         runInNewTransaction(operations);
       }
-    } catch (final RecoverableException recoverableException) {
-      throw recoverableException;
+    } catch (final RecoverableException | UnrecoverableException reportableException) {
+      throw reportableException;
     } catch (final RocksDBException rdbex) {
       final String errorMessage = "Unexpected error occurred during RocksDB transaction.";
       if (isRocksDbExceptionRecoverable(rdbex)) {

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
@@ -333,7 +333,6 @@ public final class ColumnFamilyTest {
     value.wrapLong(10);
     columnFamily.insert(key, value);
     assertThatThrownBy(() -> columnFamily.insert(key, value))
-        .getRootCause()
         .hasMessageContaining("already exists")
         .isInstanceOf(ZeebeDbInconsistentException.class);
   }
@@ -343,7 +342,6 @@ public final class ColumnFamilyTest {
     key.wrapLong(1);
     value.wrapLong(10);
     assertThatThrownBy(() -> columnFamily.update(key, value))
-        .getRootCause()
         .hasMessageContaining("does not exist")
         .isInstanceOf(ZeebeDbInconsistentException.class);
   }
@@ -352,7 +350,6 @@ public final class ColumnFamilyTest {
   public void shouldThrowOnDeleteExisting() {
     key.wrapLong(1);
     assertThatThrownBy(() -> columnFamily.deleteExisting(key))
-        .getRootCause()
         .hasMessageContaining("does not exist")
         .isInstanceOf(ZeebeDbInconsistentException.class);
   }
@@ -369,8 +366,8 @@ public final class ColumnFamilyTest {
 
     // then
     assertThatThrownBy(() -> columnFamilyWithForeignKey.insert(foreignKey, value))
-        .hasRootCauseInstanceOf(ZeebeDbInconsistentException.class)
-        .hasStackTraceContaining("Foreign key");
+        .isInstanceOf(ZeebeDbInconsistentException.class)
+        .hasMessageContaining("Foreign key");
   }
 
   @Test
@@ -383,8 +380,8 @@ public final class ColumnFamilyTest {
             DefaultColumnFamily.DEFAULT, zeebeDb.createContext(), key, foreignKey);
     // then
     assertThatThrownBy(() -> columnFamilyWithForeignKey.insert(key, foreignKey))
-        .hasRootCauseInstanceOf(ZeebeDbInconsistentException.class)
-        .hasStackTraceContaining("Foreign key");
+        .isInstanceOf(ZeebeDbInconsistentException.class)
+        .hasMessageContaining("Foreign key");
   }
 
   private void upsertKeyValuePair(final int key, final int value) {


### PR DESCRIPTION
## Description

Since the introduction of #8787 and #8884, operations on column families may throw `ZeebeDbInconsistentException`s. Before the changes in this PR, the exception was wrapped in a `RuntimeException` and then handled as all other exceptions, first retrying the processing and then, if retrying failed, an attempt to blacklist the instance and move on with the next record.

For `ZeebeDbInconsistentException` this behavior did not make sense since we must assume that the state is corrupted and that we can't safely continue processing for this partition. To implement this behavior, I've marked `ZeebeDbInconsistentException` as `UnrecoverableException` and ensured that `UnrecoverableException`s are properly bubbled up without any wrapping until they reach the `StreamProcessor` where `UnrecoverableException`s are already causing the necessary steps, eventually leading to the partition to transition to `INACTIVE`.