### PR TITLE
feat: additional foreign key types

### DIFF
--- a/zb-db/src/main/java/io/camunda/zeebe/db/ContainsForeignKeys.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/ContainsForeignKeys.java
@@ -11,5 +11,5 @@ import io.camunda.zeebe.db.impl.DbForeignKey;
 import java.util.Collection;
 
 public interface ContainsForeignKeys {
-  Collection<DbForeignKey<?>> containedForeignKeys();
+  Collection<DbForeignKey<DbKey>> containedForeignKeys();
 }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbCompositeKey.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbCompositeKey.java
@@ -19,7 +19,7 @@ public final class DbCompositeKey<FirstKeyType extends DbKey, SecondKeyType exte
     implements DbKey, ContainsForeignKeys {
   final FirstKeyType first;
   final SecondKeyType second;
-  final Collection<DbForeignKey<?>> containedForeignKeys;
+  final Collection<DbForeignKey<DbKey>> containedForeignKeys;
 
   public DbCompositeKey(final FirstKeyType first, final SecondKeyType second) {
     this.first = first;
@@ -36,7 +36,7 @@ public final class DbCompositeKey<FirstKeyType extends DbKey, SecondKeyType exte
   }
 
   @Override
-  public Collection<DbForeignKey<?>> containedForeignKeys() {
+  public Collection<DbForeignKey<DbKey>> containedForeignKeys() {
     return containedForeignKeys;
   }
 
@@ -59,9 +59,9 @@ public final class DbCompositeKey<FirstKeyType extends DbKey, SecondKeyType exte
     second.write(mutableDirectBuffer, offset + firstKeyPartLength);
   }
 
-  private static Collection<DbForeignKey<?>> collectContainedForeignKeys(
+  private static Collection<DbForeignKey<DbKey>> collectContainedForeignKeys(
       final DbKey first, final DbKey second) {
-    final var result = new ArrayList<DbForeignKey<?>>();
+    final var result = new ArrayList<DbForeignKey<DbKey>>();
     if (first instanceof ContainsForeignKeys firstForeignKeyProvider) {
       result.addAll(firstForeignKeyProvider.containedForeignKeys());
     }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbForeignKey.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbForeignKey.java
@@ -56,6 +56,10 @@ public record DbForeignKey<K extends DbKey>(
     return Collections.singletonList((DbForeignKey<DbKey>) this);
   }
 
+  public boolean shouldSkipCheck() {
+    return skip.test(inner);
+  }
+
   public enum MatchType {
     Full,
     Prefix,

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbForeignKey.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbForeignKey.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.db.DbKey;
 import io.camunda.zeebe.db.DbValue;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 
@@ -23,8 +24,17 @@ import org.agrona.MutableDirectBuffer;
  * @param columnFamily
  * @param <K>
  */
-public record DbForeignKey<K extends DbKey>(K inner, Enum<?> columnFamily)
+public record DbForeignKey<K extends DbKey>(
+    K inner, Enum<?> columnFamily, MatchType match, Predicate<K> skip)
     implements DbKey, DbValue, ContainsForeignKeys {
+
+  public DbForeignKey(final K inner, final Enum<?> columnFamily) {
+    this(inner, columnFamily, MatchType.Full);
+  }
+
+  public DbForeignKey(final K inner, final Enum<?> columnFamily, final MatchType match) {
+    this(inner, columnFamily, match, (k) -> false);
+  }
 
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
@@ -42,7 +52,12 @@ public record DbForeignKey<K extends DbKey>(K inner, Enum<?> columnFamily)
   }
 
   @Override
-  public Collection<DbForeignKey<?>> containedForeignKeys() {
-    return Collections.singletonList(this);
+  public Collection<DbForeignKey<DbKey>> containedForeignKeys() {
+    return Collections.singletonList((DbForeignKey<DbKey>) this);
+  }
+
+  public enum MatchType {
+    Full,
+    Prefix,
   }
 }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyChecker.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyChecker.java
@@ -44,49 +44,65 @@ public final class ForeignKeyChecker {
 
   private void assertForeignKeyExists(
       final ZeebeTransaction transaction, final DbForeignKey<DbKey> foreignKey) throws Exception {
-    if (foreignKey.skip().test(foreignKey.inner())) {
+    if (foreignKey.shouldSkipCheck()) {
       return;
     }
 
     keyBuffer.putLong(0, foreignKey.columnFamily().ordinal(), ZeebeDbConstants.ZB_DB_BYTE_ORDER);
     foreignKey.write(keyBuffer, Long.BYTES);
+    final var keyBufferLength = Long.BYTES + foreignKey.getLength();
+
+    switch (foreignKey.match()) {
+      case Full -> assertKeyExists(transaction, foreignKey, keyBuffer.byteArray(), keyBufferLength);
+      case Prefix -> assertPrefixExists(
+          transaction, foreignKey, keyBuffer.byteArray(), keyBufferLength);
+      default -> throw new IllegalStateException(
+          "Unknown foreign key match type: " + foreignKey.match());
+    }
+  }
+
+  private void assertKeyExists(
+      final ZeebeTransaction transaction,
+      final DbForeignKey<? extends DbKey> foreignKey,
+      final byte[] key,
+      final int keyLength)
+      throws Exception {
     final var exists =
-        switch (foreignKey.match()) {
-          case Full -> keyExists(transaction, foreignKey);
-          case Prefix -> prefixExists(transaction, foreignKey);
-        };
+        transaction.get(
+                transactionDb.getDefaultNativeHandle(),
+                transactionDb.getReadOptionsNativeHandle(),
+                key,
+                keyLength)
+            != null;
     if (!exists) {
       throw new ZeebeDbInconsistentException(
           "Foreign key " + foreignKey.inner() + " does not exist in " + foreignKey.columnFamily());
     }
   }
 
-  private boolean keyExists(
-      final ZeebeTransaction transaction, final DbForeignKey<? extends DbKey> foreignKey)
-      throws Exception {
-    return transaction.get(
-            transactionDb.getDefaultNativeHandle(),
-            transactionDb.getReadOptionsNativeHandle(),
-            keyBuffer.byteArray(),
-            Long.BYTES + foreignKey.getLength())
-        != null;
-  }
-
-  private boolean prefixExists(
-      final ZeebeTransaction transaction, final DbForeignKey<? extends DbKey> foreignKey) {
+  private void assertPrefixExists(
+      final ZeebeTransaction transaction,
+      final DbForeignKey<? extends DbKey> foreignKey,
+      final byte[] prefix,
+      final int prefixLength) {
     try (final var iterator =
         transaction.newIterator(
             transactionDb.getPrefixReadOptions(), transactionDb.getDefaultHandle())) {
-      final var prefixKey = keyBuffer.byteArray();
-      final var prefixLength = Long.BYTES + foreignKey.getLength();
 
       RocksDbInternal.seek(
-          iterator, ZeebeTransactionDb.getNativeHandle(iterator), prefixKey, prefixLength);
+          iterator, ZeebeTransactionDb.getNativeHandle(iterator), prefix, prefixLength);
+      boolean exists = false;
       if (iterator.isValid()) {
         final byte[] keyBytes = iterator.key();
-        return BufferUtil.startsWith(prefixKey, 0, prefixLength, keyBytes, 0, keyBytes.length);
+        exists = BufferUtil.startsWith(prefix, 0, prefixLength, keyBytes, 0, keyBytes.length);
       }
-      return false;
+      if (!exists) {
+        throw new ZeebeDbInconsistentException(
+            "Foreign key "
+                + foreignKey.inner()
+                + " does not exist as prefix in "
+                + foreignKey.columnFamily());
+      }
     }
   }
 }

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyCheckerTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyCheckerTest.java
@@ -79,27 +79,17 @@ final class ForeignKeyCheckerTest {
 
     // then
     assertDoesNotThrow(
-        () -> {
-          key.wrapLong(-1);
-          check.assertExists(
-              tx,
-              new DbForeignKey<>(
-                  key,
-                  TestColumnFamilies.TEST_COLUMN_FAMILY,
-                  MatchType.Full,
-                  (k) -> k.getValue() == -1));
-        });
+        () ->
+            check.assertExists(
+                tx,
+                new DbForeignKey<>(
+                    key, TestColumnFamilies.TEST_COLUMN_FAMILY, MatchType.Full, (k) -> true)));
     assertThatThrownBy(
-            () -> {
-              key.wrapLong(5);
-              check.assertExists(
-                  tx,
-                  new DbForeignKey<>(
-                      key,
-                      TestColumnFamilies.TEST_COLUMN_FAMILY,
-                      MatchType.Full,
-                      (k) -> k.getValue() == -1));
-            })
+            () ->
+                check.assertExists(
+                    tx,
+                    new DbForeignKey<>(
+                        key, TestColumnFamilies.TEST_COLUMN_FAMILY, MatchType.Full, (k) -> false)))
         .isInstanceOf(ZeebeDbInconsistentException.class)
         .hasMessageContaining("Foreign key");
   }

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyCheckerTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyCheckerTest.java
@@ -17,9 +17,12 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.db.ConsistencyChecksSettings;
 import io.camunda.zeebe.db.ZeebeDbInconsistentException;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
 import io.camunda.zeebe.db.impl.DbForeignKey;
+import io.camunda.zeebe.db.impl.DbForeignKey.MatchType;
 import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.db.impl.DefaultZeebeDbFactory;
 import java.io.File;
 import org.junit.jupiter.api.Test;
@@ -64,6 +67,71 @@ final class ForeignKeyCheckerTest {
   }
 
   @Test
+  void shouldRespectSkipCondition() throws Exception {
+    // given
+    final var db = mock(ZeebeTransactionDb.class);
+    final var tx = mock(ZeebeTransaction.class);
+    final var check = new ForeignKeyChecker(db, new ConsistencyChecksSettings(true, true));
+    final var key = new DbLong();
+
+    // when -- tx says no key exists
+    when(tx.get(anyLong(), anyLong(), any(), anyInt())).thenReturn(null);
+
+    // then
+    assertDoesNotThrow(
+        () -> {
+          key.wrapLong(-1);
+          check.assertExists(
+              tx,
+              new DbForeignKey<>(
+                  key,
+                  TestColumnFamilies.TEST_COLUMN_FAMILY,
+                  MatchType.Full,
+                  (k) -> k.getValue() == -1));
+        });
+    assertThatThrownBy(
+            () -> {
+              key.wrapLong(5);
+              check.assertExists(
+                  tx,
+                  new DbForeignKey<>(
+                      key,
+                      TestColumnFamilies.TEST_COLUMN_FAMILY,
+                      MatchType.Full,
+                      (k) -> k.getValue() == -1));
+            })
+        .isInstanceOf(ZeebeDbInconsistentException.class)
+        .hasMessageContaining("Foreign key");
+  }
+
+  @Test
+  void shouldCheckIfKeyIsNotSkipped() throws Exception {
+    // given
+    final var db = mock(ZeebeTransactionDb.class);
+    final var tx = mock(ZeebeTransaction.class);
+    final var check = new ForeignKeyChecker(db, new ConsistencyChecksSettings(true, true));
+    final var key = new DbLong();
+
+    // when -- tx says no key exists
+    when(tx.get(anyLong(), anyLong(), any(), anyInt())).thenReturn(null);
+
+    // then
+    assertThatThrownBy(
+            () -> {
+              key.wrapLong(5);
+              check.assertExists(
+                  tx,
+                  new DbForeignKey<>(
+                      key,
+                      TestColumnFamilies.TEST_COLUMN_FAMILY,
+                      MatchType.Full,
+                      (k) -> k.getValue() == -1));
+            })
+        .isInstanceOf(ZeebeDbInconsistentException.class)
+        .hasMessageContaining("Foreign key");
+  }
+
+  @Test
   void shouldSucceedOnRealColumnFamily(@TempDir final File tempDir) throws Exception {
     // given
     final var db = DefaultZeebeDbFactory.<TestColumnFamilies>getDefaultFactory().createDb(tempDir);
@@ -88,6 +156,70 @@ final class ForeignKeyCheckerTest {
             check.assertExists(
                 (ZeebeTransaction) txContext.getCurrentTransaction(),
                 new DbForeignKey<>(cf1Key, TestColumnFamilies.TEST_COLUMN_FAMILY)));
+
+    db.close();
+  }
+
+  @Test
+  void shouldFindByPrefix(@TempDir final File tempDir) throws Exception {
+    // given
+    final var db = DefaultZeebeDbFactory.<TestColumnFamilies>getDefaultFactory().createDb(tempDir);
+    final var txContext = db.createContext();
+
+    final var cf1Key = new DbCompositeKey<>(new DbLong(), new DbString());
+    cf1Key.first().wrapLong(1);
+    cf1Key.second().wrapString("suffix");
+    final var cf1 =
+        db.createColumnFamily(
+            TestColumnFamilies.TEST_COLUMN_FAMILY, txContext, cf1Key, DbNil.INSTANCE);
+
+    final var check =
+        new ForeignKeyChecker(
+            (ZeebeTransactionDb<?>) db, new ConsistencyChecksSettings(true, true));
+
+    // when -- key 1 exists in first column family
+    cf1.insert(cf1Key, DbNil.INSTANCE);
+
+    // then -- referring to key 1 by prefix does not throw
+    final var fk =
+        new DbForeignKey<>(
+            new DbLong(), TestColumnFamilies.TEST_COLUMN_FAMILY, MatchType.Prefix, (any) -> false);
+    fk.inner().wrapLong(cf1Key.first().getValue());
+    assertDoesNotThrow(
+        () -> check.assertExists((ZeebeTransaction) txContext.getCurrentTransaction(), fk));
+
+    db.close();
+  }
+
+  @Test
+  void shouldThrowWhenPrefixIsNotFound(@TempDir final File tempDir) throws Exception {
+    // given
+    final var db = DefaultZeebeDbFactory.<TestColumnFamilies>getDefaultFactory().createDb(tempDir);
+    final var txContext = db.createContext();
+
+    final var cf1Key = new DbCompositeKey<>(new DbLong(), new DbString());
+    cf1Key.first().wrapLong(1);
+    cf1Key.second().wrapString("suffix");
+    final var cf1 =
+        db.createColumnFamily(
+            TestColumnFamilies.TEST_COLUMN_FAMILY, txContext, cf1Key, DbNil.INSTANCE);
+
+    final var check =
+        new ForeignKeyChecker(
+            (ZeebeTransactionDb<?>) db, new ConsistencyChecksSettings(true, true));
+
+    // when -- key 1 exists in first column family
+    cf1.insert(cf1Key, DbNil.INSTANCE);
+
+    // then -- referring to a non-existing key prefix fails
+    final var fk =
+        new DbForeignKey<>(
+            new DbLong(), TestColumnFamilies.TEST_COLUMN_FAMILY, MatchType.Prefix, (any) -> false);
+    fk.inner().wrapLong(cf1Key.first().getValue() + 1);
+    assertThatThrownBy(
+            () -> check.assertExists((ZeebeTransaction) txContext.getCurrentTransaction(), fk))
+        .isInstanceOf(ZeebeDbInconsistentException.class)
+        .hasMessageContaining("Foreign key");
 
     db.close();
   }


### PR DESCRIPTION
## Description
This adds two extensions to `DbForeignKey`:

1. The ability to check that the inner key is a prefix of another key in the referred column family.
2. The ability to skip the check in certain circumstances to support cases where foreign keys are created with a placeholder value that is later updated.

closes #8944 