### PR TITLE
refactor: use foreign keys for timers

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
@@ -12,6 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import java.util.ArrayList;
 import java.util.List;
 import org.assertj.core.api.Assertions;
@@ -34,11 +36,7 @@ public final class TimerInstanceStateTest {
   @Test
   public void shouldInsertTimer() {
     // given
-    final TimerInstance timer = new TimerInstance();
-    timer.setElementInstanceKey(1L);
-    timer.setKey(2L);
-    timer.setDueDate(1000L);
-    state.store(timer);
+    createTimerInstance(1, 2, 1000L);
 
     // when
     final List<TimerInstance> timers = new ArrayList<>();
@@ -56,15 +54,8 @@ public final class TimerInstanceStateTest {
   @Test
   public void shouldRemoveTimer() {
     // given
-    final TimerInstance timer1 = new TimerInstance();
-    timer1.setElementInstanceKey(1L);
-    timer1.setDueDate(1000L);
-    state.store(timer1);
-
-    final TimerInstance timer2 = new TimerInstance();
-    timer2.setElementInstanceKey(2L);
-    timer2.setDueDate(2000L);
-    state.store(timer2);
+    createTimerInstance(1, 0, 1000L);
+    createTimerInstance(2, 0, 2000L);
 
     // when
     final TimerInstance timer = new TimerInstance();
@@ -83,6 +74,7 @@ public final class TimerInstanceStateTest {
   @Test
   public void shouldGetTimerByElementInstanceKey() {
     // given
+    createElementInstance(1L);
     final TimerInstance timer = new TimerInstance();
     timer.setElementInstanceKey(1L);
     timer.setProcessInstanceKey(1L);
@@ -107,47 +99,24 @@ public final class TimerInstanceStateTest {
   @Test
   public void shouldFindTimersWithDueDate() {
     // given
-    final TimerInstance timer1 = new TimerInstance();
-    timer1.setElementInstanceKey(1L);
-    timer1.setDueDate(1000L);
-    state.store(timer1);
-
-    final TimerInstance timer2 = new TimerInstance();
-    timer2.setElementInstanceKey(2L);
-    timer2.setDueDate(2000L);
-    state.store(timer2);
-
-    final TimerInstance timer3 = new TimerInstance();
-    timer3.setElementInstanceKey(3L);
-    timer3.setDueDate(3000L);
-    state.store(timer3);
+    createTimerInstance(1, 1, 1000L);
+    createTimerInstance(2, 2, 2000L);
+    createTimerInstance(3, 3, 3000L);
 
     // when
     final List<Long> keys = new ArrayList<>();
     state.findTimersWithDueDateBefore(2000L, t -> keys.add(t.getElementInstanceKey()));
 
     // then
-    assertThat(keys).hasSize(2);
-    assertThat(keys).containsExactly(1L, 2L);
+    assertThat(keys).hasSize(2).containsExactly(1L, 2L);
   }
 
   @Test
   public void shouldReturnNextDueDate() {
     // given
-    final TimerInstance timer1 = new TimerInstance();
-    timer1.setElementInstanceKey(1L);
-    timer1.setDueDate(1000L);
-    state.store(timer1);
-
-    final TimerInstance timer2 = new TimerInstance();
-    timer2.setElementInstanceKey(2L);
-    timer2.setDueDate(2000L);
-    state.store(timer2);
-
-    final TimerInstance timer3 = new TimerInstance();
-    timer3.setElementInstanceKey(3L);
-    timer3.setDueDate(3000L);
-    state.store(timer3);
+    createTimerInstance(1, 1, 1000L);
+    createTimerInstance(2, 2, 2000L);
+    createTimerInstance(3, 3, 3000L);
 
     // when
     final long nextDueDate = state.findTimersWithDueDateBefore(2000L, t -> true);
@@ -169,20 +138,9 @@ public final class TimerInstanceStateTest {
   @Test
   public void shouldReturnNegativeDueDateIfNoMoreTimers() {
     // given
-    final TimerInstance timer1 = new TimerInstance();
-    timer1.setElementInstanceKey(1L);
-    timer1.setDueDate(1000L);
-    state.store(timer1);
-
-    final TimerInstance timer2 = new TimerInstance();
-    timer2.setElementInstanceKey(2L);
-    timer2.setDueDate(1000L);
-    state.store(timer2);
-
-    final TimerInstance timer3 = new TimerInstance();
-    timer3.setElementInstanceKey(3L);
-    timer3.setDueDate(3000L);
-    state.store(timer3);
+    createTimerInstance(1, 1, 1000L);
+    createTimerInstance(2, 2, 2000L);
+    createTimerInstance(3, 3, 3000L);
 
     // when
     final long nextDueDate = state.findTimersWithDueDateBefore(3000L, t -> true);
@@ -194,15 +152,8 @@ public final class TimerInstanceStateTest {
   @Test
   public void shouldFindTimersWithDueDateUntilNotConsumed() {
     // given
-    final TimerInstance timer1 = new TimerInstance();
-    timer1.setElementInstanceKey(1L);
-    timer1.setDueDate(1000L);
-    state.store(timer1);
-
-    final TimerInstance timer2 = new TimerInstance();
-    timer2.setElementInstanceKey(2L);
-    timer2.setDueDate(2000L);
-    state.store(timer2);
+    final var timer1 = createTimerInstance(1, 1, 1000L);
+    createTimerInstance(2, 2, 2000L);
 
     // when
     final List<Long> keys = new ArrayList<>();
@@ -215,14 +166,15 @@ public final class TimerInstanceStateTest {
             });
 
     // then
-    assertThat(keys).hasSize(1);
-    assertThat(keys).contains(1L);
+    assertThat(keys).containsExactly(1L);
     assertThat(nextDueDate).isEqualTo(timer1.getDueDate());
   }
 
   @Test
   public void shouldListAllTimersByElementInstanceKey() {
     // given
+    createElementInstance(1);
+    createElementInstance(2);
     final TimerInstance timer1 = new TimerInstance();
     timer1.setElementInstanceKey(1L);
     timer1.setKey(1L);
@@ -246,7 +198,26 @@ public final class TimerInstanceStateTest {
     state.forEachTimerForElementInstance(1L, t -> keys.add(t.getKey()));
 
     // then
-    assertThat(keys).hasSize(2);
-    assertThat(keys).containsExactly(1L, 2L);
+    assertThat(keys).hasSize(2).containsExactly(1L, 2L);
+  }
+
+  private TimerInstance createTimerInstance(
+      final long elementInstanceKey, final long timerKey, final long dueDate) {
+    createElementInstance(elementInstanceKey);
+    final TimerInstance timer = new TimerInstance();
+    timer.setElementInstanceKey(elementInstanceKey);
+    timer.setKey(timerKey);
+    timer.setDueDate(dueDate);
+    state.store(timer);
+    return timer;
+  }
+
+  private void createElementInstance(final long key) {
+    stateRule
+        .getZeebeState()
+        .getElementInstanceState()
+        .createInstance(
+            new ElementInstance(
+                key, ProcessInstanceIntent.ELEMENT_ACTIVATED, new ProcessInstanceRecord()));
   }
 }


### PR DESCRIPTION
## Description

Timer instances refer to element instances. An exception is made in case the element instance key is `-1` because timers sometimes created before the element.

relates to #8930 