### PR TITLE
chore(maven): migrate to new artifacts.camunda.com

### DIFF
--- a/.ci/scripts/docker/prepare.sh
+++ b/.ci/scripts/docker/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -eux
 
 mvn dependency:get -B \
-    -DremoteRepositories="camunda-nexus::::https://app.camunda.com/nexus/content/repositories/public" \
+    -DremoteRepositories="camunda-nexus::::https://artifacts.camunda.com/artifactory/public" \
     -DgroupId="io.camunda" -DartifactId="camunda-zeebe" \
     -Dversion="${VERSION}" -Dpackaging="tar.gz" -Dtransitive=false
 

--- a/benchmarks/project/pom.xml
+++ b/benchmarks/project/pom.xml
@@ -101,7 +101,7 @@
       </snapshots>
       <id>zeebe</id>
       <name>Zeebe Repository</name>
-      <url>https://app.camunda.com/nexus/content/repositories/zeebe-io/</url>
+      <url>https://artifacts.camunda.com/artifactory/zeebe-io</url>
     </repository>
 
     <repository>
@@ -113,7 +113,7 @@
       </snapshots>
       <id>zeebe-snapshots</id>
       <name>Zeebe Snapshot Repository</name>
-      <url>https://app.camunda.com/nexus/content/repositories/zeebe-io-snapshots/</url>
+      <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots</url>
     </repository>
   </repositories>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -35,8 +35,8 @@
 
   <properties>
     <!-- release parent settings -->
-    <nexus.snapshot.repository>https://app.camunda.com/nexus/content/repositories/zeebe-io-snapshots/</nexus.snapshot.repository>
-    <nexus.release.repository>https://app.camunda.com/nexus/content/repositories/zeebe-io/</nexus.release.repository>
+    <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots</nexus.snapshot.repository>
+    <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io</nexus.release.repository>
     <nexus.sonatype.url>https://s01.oss.sonatype.org</nexus.sonatype.url>
 
     <plugin.version.flatten>1.2.7</plugin.version.flatten>
@@ -87,7 +87,7 @@
       </snapshots>
       <id>zeebe</id>
       <name>Zeebe Repository</name>
-      <url>https://app.camunda.com/nexus/content/repositories/zeebe-io/</url>
+      <url>https://artifacts.camunda.com/artifactory/zeebe-io</url>
     </repository>
 
     <repository>
@@ -99,7 +99,7 @@
       </snapshots>
       <id>zeebe-snapshots</id>
       <name>Zeebe Snapshot Repository</name>
-      <url>https://app.camunda.com/nexus/content/repositories/zeebe-io-snapshots/</url>
+      <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
## Description

As announced, we need to switch to the new URL for Artifactory.

## Related issues

Related to INFRA-3107
