### PR TITLE
Automatically add copyright header upon creating a new file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 !.idea/externalDependencies.xml
 !.idea/google-java-format.xml
 !.idea/saveactions_settings.xml
+!.idea/copyright/Apache_2_0.xml
+!.idea/copyright/profiles_settings.xml
+!.idea/copyright/Zeebe_1_1.xml
+!.idea/scopes/apache_license_scope.xml
 target
 .classpath
 .checkstyle

--- a/.idea/copyright/Apache_2_0.xml
+++ b/.idea/copyright/Apache_2_0.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="Copyright © &amp;#36;today.year camunda services GmbH (info@camunda.com)&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
+    <option name="myName" value="Apache 2.0" />
+  </copyright>
+</component>

--- a/.idea/copyright/Zeebe_1_1.xml
+++ b/.idea/copyright/Zeebe_1_1.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under&#10;one or more contributor license agreements. See the NOTICE file distributed&#10;with this work for additional information regarding copyright ownership.&#10;Licensed under the Zeebe Community License 1.1. You may not use this file&#10;except in compliance with the Zeebe Community License 1.1." />
+    <option name="myName" value="Zeebe 1.1" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,10 @@
+<component name="CopyrightManager">
+  <settings default="Zeebe 1.1">
+    <module2copyright>
+      <element module="apache-license-scope" copyright="Apache 2.0" />
+    </module2copyright>
+    <LanguageOptions name="__TEMPLATE__">
+      <option name="addBlankAfter" value="false" />
+    </LanguageOptions>
+  </settings>
+</component>

--- a/.idea/scopes/apache_license_scope.xml
+++ b/.idea/scopes/apache_license_scope.xml
@@ -1,0 +1,3 @@
+<component name="DependencyValidationManager">
+  <scope name="apache-license-scope" pattern="file[zeebe-client-java]:*/||file[zeebe-exporter-api]:*/||file[zeebe-protocol]:*/||file[zeebe-gateway-protocol-impl]:*/||file[zeebe-bpmn-model]:*/" />
+</component>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

These settings in intellij will automatically add the correct copyright header to a new file that's created. By default it will add the Zeebe 1.1 license header. There are 5 exceptions to this:

1. zeebe-java-client
2. zeebe-exporter-api
3. zeebe-protocol
4. zeebe-gateway-protocol-impl
5. zeebe-bpmn-model

For these 5 modules we will automatically add the Apache 2.0 license header.

The Go client should also be included in this list, however IntelliJ scopes only support the addition of packages. Since these packages are a Java concept we cannot include the Go files to these exceptions. No copyright header will be added automatically for new files in the go client.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
