### PR TITLE
fix: don't wait for actor being submitted

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
@@ -16,8 +16,7 @@ import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.util.sched.ActorScheduler;
-import java.io.IOException;
-import java.io.UncheckedIOException;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
 import java.util.function.Function;
 
 public final class EmbeddedGatewayService implements AutoCloseable {
@@ -34,7 +33,6 @@ public final class EmbeddedGatewayService implements AutoCloseable {
             new BrokerClientImpl(
                 cfg, messagingService, membershipService, eventService, actorScheduler, false);
     gateway = new Gateway(configuration.getGateway(), brokerClientFactory, actorScheduler);
-    startGateway();
   }
 
   @Override
@@ -48,11 +46,7 @@ public final class EmbeddedGatewayService implements AutoCloseable {
     return gateway;
   }
 
-  private void startGateway() {
-    try {
-      gateway.start();
-    } catch (final IOException e) {
-      throw new UncheckedIOException("Gateway was not able to start", e);
-    }
+  public ActorFuture<Gateway> start() {
+    return gateway.start();
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStepTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.util.sched.Actor;
 import io.camunda.zeebe.util.sched.ActorScheduler;
 import io.camunda.zeebe.util.sched.TestConcurrencyControl;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
@@ -58,6 +59,7 @@ class EmbeddedGatewayServiceStepTest {
 
     private ActorFuture<BrokerStartupContext> startupFuture;
     private ActorScheduler actorScheduler;
+    private Actor actor;
 
     @BeforeEach
     void setUp() {
@@ -81,6 +83,9 @@ class EmbeddedGatewayServiceStepTest {
       final var port = SocketUtil.getNextAddress().getPort();
       final var commandApiCfg = TEST_BROKER_CONFIG.getGateway().getNetwork();
       commandApiCfg.setPort(port);
+
+      actor = Actor.newActor().build();
+      actorScheduler.submitActor(actor);
     }
 
     @AfterEach
@@ -95,7 +100,10 @@ class EmbeddedGatewayServiceStepTest {
     @Test
     void shouldCompleteFuture() {
       // when
-      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+      actor.run(
+          () -> {
+            sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+          });
 
       // then
       assertThat(startupFuture).succeedsWithin(TIME_OUT);
@@ -105,7 +113,10 @@ class EmbeddedGatewayServiceStepTest {
     @Test
     void shouldStartAndInstallEmbeddedGatewayService() {
       // when
-      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+      actor.run(
+          () -> {
+            sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+          });
       await().until(startupFuture::isDone);
 
       // then

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -25,9 +25,11 @@ import io.camunda.zeebe.gateway.interceptors.impl.ContextInjectingInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.DecoratedInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.InterceptorRepository;
 import io.camunda.zeebe.gateway.query.impl.QueryApiImpl;
+import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.sched.Actor;
-import io.camunda.zeebe.util.sched.ActorControl;
 import io.camunda.zeebe.util.sched.ActorSchedulingService;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import io.grpc.BindableService;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -35,14 +37,12 @@ import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.netty.NettyServerBuilder;
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import me.dinowernli.grpc.prometheus.Configuration;
@@ -110,31 +110,65 @@ public final class Gateway {
     return brokerClient;
   }
 
-  public void start() throws IOException {
+  public ActorFuture<Gateway> start() {
+    final var resultFuture = new CompletableActorFuture<Gateway>();
+
     healthManager.setStatus(Status.STARTING);
     brokerClient = buildBrokerClient();
 
-    final var activateJobsHandler = buildActivateJobsHandler(brokerClient);
-    submitActorToActivateJobs((Consumer<ActorControl>) activateJobsHandler);
+    createAndStartActivateJobsHandler(brokerClient)
+        .whenComplete(
+            (activateJobsHandler, error) -> {
+              if (error != null) {
+                resultFuture.completeExceptionally(error);
+                return;
+              }
 
+              final var serverResult = createAndStartServer(activateJobsHandler);
+              if (serverResult.isLeft()) {
+                final var exception = serverResult.getLeft();
+                resultFuture.completeExceptionally(exception);
+              } else {
+                server = serverResult.get();
+                healthManager.setStatus(Status.RUNNING);
+                resultFuture.complete(this);
+              }
+            });
+
+    return resultFuture;
+  }
+
+  private Either<Exception, Server> createAndStartServer(
+      final ActivateJobsHandler activateJobsHandler) {
     final EndpointManager endpointManager = new EndpointManager(brokerClient, activateJobsHandler);
     final GatewayGrpcService gatewayGrpcService = new GatewayGrpcService(endpointManager);
-    final ServerBuilder<?> serverBuilder = serverBuilderFactory.apply(gatewayCfg);
 
+    try {
+      final var serverBuilder = serverBuilderFactory.apply(gatewayCfg);
+      applySecurityConfigurationIfEnabled(serverBuilder);
+      final var server = buildServer(serverBuilder, gatewayGrpcService);
+      server.start();
+      return Either.right(server);
+    } catch (Exception e) {
+      return Either.left(e);
+    }
+  }
+
+  private void applySecurityConfigurationIfEnabled(final ServerBuilder<?> serverBuilder) {
     final SecurityCfg securityCfg = gatewayCfg.getSecurity();
     if (securityCfg.isEnabled()) {
       setSecurityConfig(serverBuilder, securityCfg);
     }
+  }
 
-    server =
-        serverBuilder
-            .addService(applyInterceptors(gatewayGrpcService))
-            .addService(
-                ServerInterceptors.intercept(
-                    healthManager.getHealthService(), MONITORING_SERVER_INTERCEPTOR))
-            .build();
-    server.start();
-    healthManager.setStatus(Status.RUNNING);
+  private Server buildServer(
+      final ServerBuilder<?> serverBuilder, final BindableService interceptorService) {
+    return serverBuilder
+        .addService(applyInterceptors(interceptorService))
+        .addService(
+            ServerInterceptors.intercept(
+                healthManager.getHealthService(), MONITORING_SERVER_INTERCEPTOR))
+        .build();
   }
 
   private static NettyServerBuilder setNetworkConfig(final NetworkCfg cfg) {
@@ -186,15 +220,22 @@ public final class Gateway {
     return brokerClientFactory.apply(gatewayCfg);
   }
 
-  private void submitActorToActivateJobs(final Consumer<ActorControl> consumer) {
-    final var actorStartedFuture = new CompletableFuture<ActorControl>();
+  private CompletableFuture<ActivateJobsHandler> createAndStartActivateJobsHandler(
+      final BrokerClient brokerClient) {
+    final var handler = buildActivateJobsHandler(brokerClient);
+    return submitActorToActivateJobs(handler);
+  }
+
+  private CompletableFuture<ActivateJobsHandler> submitActorToActivateJobs(
+      final ActivateJobsHandler handler) {
+    final var future = new CompletableFuture<ActivateJobsHandler>();
     final var actor =
         Actor.newActor()
             .name("ActivateJobsHandler")
-            .actorStartedHandler(consumer.andThen(actorStartedFuture::complete))
+            .actorStartedHandler(handler.andThen(t -> future.complete(handler)))
             .build();
     actorSchedulingService.submitActor(actor);
-    actorStartedFuture.join();
+    return future;
   }
 
   private ActivateJobsHandler buildActivateJobsHandler(final BrokerClient brokerClient) {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/ActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/ActivateJobsHandler.java
@@ -10,10 +10,12 @@ package io.camunda.zeebe.gateway.impl.job;
 import io.camunda.zeebe.gateway.grpc.ServerStreamObserver;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
+import io.camunda.zeebe.util.sched.ActorControl;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 
 /** Can handle an 'activate jobs' request from a client. */
-public interface ActivateJobsHandler {
+public interface ActivateJobsHandler extends Consumer<ActorControl> {
 
   static final AtomicLong ACTIVATE_JOBS_REQUEST_ID_GENERATOR = new AtomicLong(1);
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -27,15 +27,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Consumer;
 import org.slf4j.Logger;
 
 /**
  * Adds long polling to the handling of activate job requests. When there are no jobs available to
  * activate, the response will be kept open.
  */
-public final class LongPollingActivateJobsHandler
-    implements ActivateJobsHandler, Consumer<ActorControl> {
+public final class LongPollingActivateJobsHandler implements ActivateJobsHandler {
 
   private static final String JOBS_AVAILABLE_TOPIC = "jobsAvailable";
   private static final Logger LOG = Loggers.GATEWAY_LOGGER;

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
@@ -41,8 +41,7 @@ import java.util.function.Consumer;
  * Iterates in round-robin fashion over partitions to activate jobs. Uses a map from job type to
  * partition-IDs to determine the next partition to use.
  */
-public final class RoundRobinActivateJobsHandler
-    implements ActivateJobsHandler, Consumer<ActorControl> {
+public final class RoundRobinActivateJobsHandler implements ActivateJobsHandler {
 
   private static final String ACTIVATE_JOB_NOT_SENT_MSG = "Failed to send activated jobs to client";
   private static final String ACTIVATE_JOB_NOT_SENT_MSG_WITH_REASON =

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
@@ -61,7 +61,7 @@ class UnavailableBrokersTest {
             cluster.getMembershipService(),
             cluster.getEventService(),
             actorScheduler);
-    gateway.start();
+    gateway.start().join();
 
     final String gatewayAddress = NetUtil.toSocketAddressString(networkCfg.toSocketAddress());
     client = ZeebeClient.newClientBuilder().gatewayAddress(gatewayAddress).usePlaintext().build();

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/LongPollingActivateJobsTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/LongPollingActivateJobsTest.java
@@ -41,7 +41,6 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.sched.Actor;
-import io.camunda.zeebe.util.sched.ActorControl;
 import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
 import io.camunda.zeebe.util.sched.testing.ActorSchedulerRule;
 import io.grpc.Status.Code;
@@ -991,13 +990,13 @@ public final class LongPollingActivateJobsTest {
   }
 
   private void submitActorToActivateJobs(final LongPollingActivateJobsHandler handler) {
-    final var actorStartedFuture = new CompletableFuture<ActorControl>();
+    final var future = new CompletableFuture<>();
     final var actor =
         Actor.newActor()
             .name("LongPollingHandler-Test")
-            .actorStartedHandler(handler.andThen(actorStartedFuture::complete))
+            .actorStartedHandler(handler.andThen(future::complete))
             .build();
     actorSchedulerRule.submitActor(actor);
-    actorStartedFuture.join();
+    future.join();
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -77,14 +77,14 @@ public final class StubbedGateway {
   }
 
   private void submitActorToActivateJobs(final Consumer<ActorControl> consumer) {
-    final var actorStartedFuture = new CompletableFuture<ActorControl>();
+    final var future = new CompletableFuture<>();
     final var actor =
         Actor.newActor()
             .name("ActivateJobsHandler")
-            .actorStartedHandler(consumer.andThen(actorStartedFuture::complete))
+            .actorStartedHandler(consumer.andThen(future::complete))
             .build();
     actorScheduler.submitActor(actor);
-    actorStartedFuture.join();
+    future.join();
   }
 
   private ActivateJobsHandler buildActivateJobsHandler(final BrokerClient brokerClient) {

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
@@ -83,7 +83,7 @@ final class InterceptorIT {
     config.getInterceptors().add(interceptorCfg);
 
     // when
-    gateway.start();
+    gateway.start().join();
     try (final var client = createZeebeClient()) {
       final Future<DeploymentEvent> result =
           client
@@ -110,7 +110,7 @@ final class InterceptorIT {
     config.getInterceptors().add(interceptorCfg);
 
     // when
-    gateway.start();
+    gateway.start().join();
     try (final var client = createZeebeClient()) {
       try {
         client.newTopologyRequest().send().join();

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.gateway.security;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.utils.net.Address;
@@ -49,7 +49,7 @@ final class SecurityTest {
 
     // when
     gateway = buildGateway(cfg);
-    gateway.start();
+    gateway.start().join();
 
     // then
     SslAssert.assertThat(cfg.getNetwork().toSocketAddress()).isSecuredBy(certificate);
@@ -65,9 +65,9 @@ final class SecurityTest {
     gateway = buildGateway(cfg);
 
     // then
-    assertThatCode(() -> gateway.start())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(
+    assertThatThrownBy(() -> gateway.start().join())
+        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseMessage(
             "Expected to find a certificate chain file at the provided location '%s' but none was found.",
             cfg.getSecurity().getCertificateChainPath());
   }
@@ -82,9 +82,9 @@ final class SecurityTest {
     gateway = buildGateway(cfg);
 
     // then
-    assertThatCode(() -> gateway.start())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(
+    assertThatThrownBy(() -> gateway.start().join())
+        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseMessage(
             "Expected to find a private key file at the provided location '%s' but none was found.",
             cfg.getSecurity().getPrivateKeyPath());
   }
@@ -99,9 +99,9 @@ final class SecurityTest {
     gateway = buildGateway(cfg);
 
     // then
-    assertThatCode(() -> gateway.start())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(
+    assertThatThrownBy(() -> gateway.start().join())
+        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseMessage(
             "Expected to find a valid path to a private key but none was found. "
                 + "Edit the gateway configuration file to provide one or to disable TLS.");
   }
@@ -116,9 +116,9 @@ final class SecurityTest {
     gateway = buildGateway(cfg);
 
     // then
-    assertThatCode(() -> gateway.start())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(
+    assertThatThrownBy(() -> gateway.start().join())
+        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseMessage(
             "Expected to find a valid path to a certificate chain but none was found. "
                 + "Edit the gateway configuration file to provide one or to disable TLS.");
   }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -230,7 +230,7 @@ public final class ClusteringRule extends ExternalResource {
 
     // create gateway
     gateway = createGateway();
-    gateway.start();
+    gateway.start().join();
 
     // create client
     client = createClient();

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/EmbeddedGatewayWithOneCpuThreadIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/EmbeddedGatewayWithOneCpuThreadIT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.Broker;
+import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class EmbeddedGatewayWithOneCpuThreadIT {
+
+  @Rule
+  public EmbeddedBrokerRule brokerRule =
+      new EmbeddedBrokerRule(brokerCfg -> brokerCfg.getThreads().setCpuThreadCount(1));
+
+  private Broker broker;
+  private ZeebeClient client;
+
+  @Before
+  public void setup() {
+    broker = brokerRule.getBroker();
+    client = createClient();
+  }
+
+  private ZeebeClient createClient() {
+    final var config = broker.getConfig();
+    final var gtwConfig = config.getGateway();
+    final var port = gtwConfig.getNetwork().getPort();
+
+    return ZeebeClient.newClientBuilder()
+        .usePlaintext()
+        .gatewayAddress("localhost:" + port)
+        .build();
+  }
+
+  @After
+  public void tearDown() {
+    client.close();
+  }
+
+  @Test
+  public void shouldStartEmbeddedGateway() {
+    // given
+    final var context = broker.getBrokerContext();
+    final var embeddedGatewayService = context.getEmbeddedGatewayService();
+
+    // when
+    // already started by EmbeddedBrokerRule
+
+    // then
+    assertThat(embeddedGatewayService).isNotNull();
+    assertThat(embeddedGatewayService.get()).isNotNull();
+  }
+
+  @Test
+  public void shouldDeployProcess() throws InterruptedException {
+    // given
+    final var process = Bpmn.createExecutableProcess().startEvent().endEvent().done();
+
+    // when
+    final var result = client.newDeployCommand().addProcessModel(process, "foo.bpmn").send().join();
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getProcesses()).hasSize(1);
+  }
+}


### PR DESCRIPTION
## Description

* Ensures that the activate jobs handler actor is submitted to the actor scheduler without blocking the actor thread
* This requires the usage of `CompletableFuture` to get notified when the handler has been scheduled successfully
* That way, the implementation works in case of an embedded and standalone gateway
* Adjust test cases to avoid potential race conditions

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8992

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
