### PR TITLE
Mark DeployProcessCommand as deprecated for Go client

### DIFF
--- a/clients/go/cmd/zbctl/internal/commands/deploy.go
+++ b/clients/go/cmd/zbctl/internal/commands/deploy.go
@@ -25,6 +25,7 @@ import (
 var deployCmd = &cobra.Command{
 	Use:     "deploy <processPath>...",
 	Short:   "Deploys new resources for each file provided",
+	Long:    "Deploys new resources for each file provided. The `deploy <processPath>...` usage is deprecated. Please use the `deploy resource` subcommand.",
 	Args:    cobra.MinimumNArgs(1),
 	PreRunE: initClient,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/clients/go/cmd/zbctl/internal/commands/deploy.go
+++ b/clients/go/cmd/zbctl/internal/commands/deploy.go
@@ -25,7 +25,7 @@ import (
 var deployCmd = &cobra.Command{
 	Use:     "deploy <processPath>...",
 	Short:   "Deploys new resources for each file provided",
-	Long:    "Deploys new resources for each file provided. The `deploy <processPath>...` usage is deprecated. Please use the `deploy resource` subcommand.",
+	Long:    "Deploys new resources for each file provided. The `deploy <processPath>...` usage is deprecated, to be removed in 8.1. Please use the `deploy resource` subcommand.",
 	Args:    cobra.MinimumNArgs(1),
 	PreRunE: initClient,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/clients/go/cmd/zbctl/internal/commands/root.go
+++ b/clients/go/cmd/zbctl/internal/commands/root.go
@@ -50,7 +50,7 @@ var rootCmd = &cobra.Command{
 	Short: "zeebe command line interface",
 	Long: `zbctl is a command line interface designed to create and read resources inside zeebe broker.
 It is designed for regular maintenance jobs such as:
-	* deploying processes,
+	* deploying resources,
 	* creating jobs and process instances
 	* activating, completing or failing jobs
 	* update variables and retries

--- a/clients/go/cmd/zbctl/testdata/help.golden
+++ b/clients/go/cmd/zbctl/testdata/help.golden
@@ -1,6 +1,6 @@
 zbctl is a command line interface designed to create and read resources inside zeebe broker.
 It is designed for regular maintenance jobs such as:
-	* deploying processes,
+	* deploying resources,
 	* creating jobs and process instances
 	* activating, completing or failing jobs
 	* update variables and retries

--- a/clients/go/pkg/commands/deploy.go
+++ b/clients/go/pkg/commands/deploy.go
@@ -49,6 +49,7 @@ func (cmd *DeployCommand) Send(ctx context.Context) (*pb.DeployProcessResponse, 
 	return response, err
 }
 
+// Deprecated: Use NewDeployResourceCommand instead. To be removed in 8.1.0.
 func NewDeployCommand(gateway pb.GatewayClient, pred retryPredicate) *DeployCommand {
 	return &DeployCommand{
 		Command: Command{

--- a/clients/go/pkg/zbc/api.go
+++ b/clients/go/pkg/zbc/api.go
@@ -22,6 +22,7 @@ import (
 
 type Client interface {
 	NewTopologyCommand() *commands.TopologyCommand
+	// Deprecated: Use NewDeployResourceCommand instead. To be removed in 8.1.0.
 	NewDeployProcessCommand() *commands.DeployCommand
 	NewDeployResourceCommand() *commands.DeployResourceCommand
 

--- a/clients/go/pkg/zbc/client.go
+++ b/clients/go/pkg/zbc/client.go
@@ -82,7 +82,7 @@ func (c *ClientImpl) NewTopologyCommand() *commands.TopologyCommand {
 }
 
 func (c *ClientImpl) NewDeployProcessCommand() *commands.DeployCommand {
-	return commands.NewDeployCommand(c.gateway, c.credentialsProvider.ShouldRetryRequest)
+	return commands.NewDeployCommand(c.gateway, c.credentialsProvider.ShouldRetryRequest) // nolint
 }
 
 func (c *ClientImpl) NewDeployResourceCommand() *commands.DeployResourceCommand {


### PR DESCRIPTION
## Description

This PR marks `DeployProcessCommand` as a deprecated method in the Go client, and also the `zbctl deploy <processPath>...` usage (to be replaced by `zbctl deploy resource <resourcePath>...`).

Using the deprecated API in Go will trigger a warning (as you can see by our need to add `//nolint` in places :smile:)

## Related issues

related to #8995

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
