### PR TITLE
[Backport stable/1.3] Fix notification of snapshot replication listeners about missed events

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -476,18 +476,20 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
           snapshotReplicationListeners.add(snapshotReplicationListener);
           // Notify listener immediately if it registered during an ongoing replication.
           // This is to prevent missing necessary state transitions.
-          switch (missedSnapshotReplicationEvents) {
-            case STARTED:
-              snapshotReplicationListener.onSnapshotReplicationStarted();
-              break;
-            case COMPLETED:
-              {
+          if (role.role() == Role.FOLLOWER) {
+            switch (missedSnapshotReplicationEvents) {
+              case STARTED:
                 snapshotReplicationListener.onSnapshotReplicationStarted();
-                snapshotReplicationListener.onSnapshotReplicationCompleted(term);
                 break;
-              }
-            default:
-              break;
+              case COMPLETED:
+                {
+                  snapshotReplicationListener.onSnapshotReplicationStarted();
+                  snapshotReplicationListener.onSnapshotReplicationCompleted(term);
+                  break;
+                }
+              default:
+                break;
+            }
           }
         });
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -681,6 +681,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   private void completeTransition() {
+    missedSnapshotReplicationEvents = MissedSnapshotReplicationEvents.NONE;
     ongoingTransition = false;
   }
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/SnapshotReplicationListenerTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/SnapshotReplicationListenerTest.java
@@ -100,4 +100,18 @@ public class SnapshotReplicationListenerTest {
     verify(snapshotReplicationListener, times(0))
         .onSnapshotReplicationCompleted(follower.getTerm());
   }
+
+  @Test
+  public void shouldNotCallListenerOnRegisterIfLeader() {
+    // given
+    final var snapshotReplicationListener = mock(SnapshotReplicationListener.class);
+    final var leader = raftRule.getLeader().orElseThrow();
+    // when
+    leader.getContext().notifySnapshotReplicationStarted();
+    leader.getContext().notifySnapshotReplicationCompleted();
+    leader.getContext().addSnapshotReplicationListener(snapshotReplicationListener);
+    // then
+    verify(snapshotReplicationListener, times(0)).onSnapshotReplicationStarted();
+    verify(snapshotReplicationListener, times(0)).onSnapshotReplicationCompleted(leader.getTerm());
+  }
 }


### PR DESCRIPTION
## Description

Manual backport of #8994 for `1.3`
