### PR TITLE
Do not generate ImmutableProcessInstanceRelated

### DIFF
--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRelated.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRelated.java
@@ -15,11 +15,6 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
-import io.camunda.zeebe.protocol.record.ImmutableProtocol;
-import org.immutables.value.Value;
-
-@Value.Immutable
-@ImmutableProtocol
 public interface ProcessInstanceRelated {
 
   /** @return the key of the corresponding process instance */

--- a/protocol/src/test/java/io/camunda/zeebe/protocol/ImmutableProtocolTest.java
+++ b/protocol/src/test/java/io/camunda/zeebe/protocol/ImmutableProtocolTest.java
@@ -45,9 +45,6 @@ final class ImmutableProtocolTest {
   @ArchTest
   void shouldAnnotateImmutableProtocolValues(final JavaClasses importedClasses) {
     // given
-    // exclude certain interfaces for which we won't be generating any immutable variants
-    final DescribedPredicate<JavaClass> excludedClasses =
-        Predicates.equivalentTo(ProcessInstanceRelated.class);
     final ArchRule rule =
         ArchRuleDefinition.classes()
             .that()
@@ -59,7 +56,7 @@ final class ImmutableProtocolTest {
             // also check the Record interface itself
             .or(Predicates.equivalentTo(Record.class))
             // exclude certain interfaces
-            .and(DescribedPredicate.not(excludedClasses))
+            .and(DescribedPredicate.not(getExcludedClasses()))
             .should()
             .beAnnotatedWith(ImmutableProtocol.class)
             .andShould()
@@ -67,5 +64,25 @@ final class ImmutableProtocolTest {
 
     // then
     rule.check(importedClasses);
+  }
+
+  @ArchTest
+  void shouldNotAnnotateExcludedClasses(final JavaClasses importedClasses) {
+    // given
+    final ArchRule rule =
+        ArchRuleDefinition.classes()
+            .that(getExcludedClasses())
+            .should()
+            .notBeAnnotatedWith(ImmutableProtocol.class)
+            .orShould()
+            .notBeAnnotatedWith(Value.Immutable.class);
+
+    // then
+    rule.check(importedClasses);
+  }
+
+  // exclude certain interfaces for which we won't be generating any immutable variants
+  private DescribedPredicate<JavaClass> getExcludedClasses() {
+    return Predicates.equivalentTo(ProcessInstanceRelated.class);
   }
 }


### PR DESCRIPTION
## Description

`ProcessInstanceRelated` was mistakenly annotated with the immutable annotation, which caused us to generate an unnecessary class. This simply removes it, and adds a regression test.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
