### PR TITLE
Explicitly depend on google-java-format

### DIFF
--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -2,6 +2,6 @@
 <project version="4">
   <component name="ExternalDependencies">
     <plugin id="com.dubreuia" />
-    <plugin id="google-java-format" />
+    <plugin id="google-java-format" min-version="1.12.0.0" max-version="1.12.0.0" />
   </component>
 </project>

--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -2,6 +2,6 @@
 <project version="4">
   <component name="ExternalDependencies">
     <plugin id="com.dubreuia" />
-    <plugin id="google-java-format" min-version="1.12.0.0" max-version="1.12.0.0" />
+    <plugin id="google-java-format" min-version="1.12.0.0" />
   </component>
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1960,7 +1960,7 @@
           <plugin>
             <groupId>com.diffplug.spotless</groupId>
             <artifactId>spotless-maven-plugin</artifactId>
-            <configuration>
+            <configuration combine.children="append">
               <ratchetFrom>origin/main</ratchetFrom>
             </configuration>
             <executions>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -132,7 +132,6 @@
     <plugin.version.exec>3.0.0</plugin.version.exec>
     <plugin.version.failsafe>3.0.0-M5</plugin.version.failsafe>
     <plugin.version.flaky-tests>2.1.1</plugin.version.flaky-tests>
-    <plugin.version.google-java-format>1.12.0</plugin.version.google-java-format>
     <plugin.version.jacoco>0.8.7</plugin.version.jacoco>
     <plugin.version.license>4.1</plugin.version.license>
     <plugin.version.maven-jar>3.2.2</plugin.version.maven-jar>
@@ -149,6 +148,9 @@
     <plugin.version.spotless>2.22.0</plugin.version.spotless>
     <plugin.version.surefire>3.0.0-M5</plugin.version.surefire>
     <plugin.version.versions>2.10.0</plugin.version.versions>
+
+    <!-- when updating this version, also change it in .idea/externalDependencies.xml -->
+    <plugin.version.google-java-format>1.12.0</plugin.version.google-java-format>
 
     <!-- maven extensions -->
     <extension.version.os-maven-plugin>1.7.0</extension.version.os-maven-plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -132,6 +132,7 @@
     <plugin.version.exec>3.0.0</plugin.version.exec>
     <plugin.version.failsafe>3.0.0-M5</plugin.version.failsafe>
     <plugin.version.flaky-tests>2.1.1</plugin.version.flaky-tests>
+    <plugin.version.google-java-format>1.12.0</plugin.version.google-java-format>
     <plugin.version.jacoco>0.8.7</plugin.version.jacoco>
     <plugin.version.license>4.1</plugin.version.license>
     <plugin.version.maven-jar>3.2.2</plugin.version.maven-jar>
@@ -1428,11 +1429,18 @@
           <configuration>
             <java>
               <googleJavaFormat>
-                <version>1.12.0</version>
+                <version>${plugin.version.google-java-format}</version>
                 <style>GOOGLE</style>
               </googleJavaFormat>
             </java>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>com.google.googlejavaformat</groupId>
+              <artifactId>google-java-format</artifactId>
+              <version>${plugin.version.google-java-format}</version>
+            </dependency>
+          </dependencies>
         </plugin>
 
         <!-- protobuf generation -->


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Dependabot does not control the version of the google-java-format plugin used by spotless. By adding an explicit maven dependency on the plugin we can make Dependabot control it.

Note that adding this dependency doesn't change anything to the rest of the project. It also doesn't really interfere with this specific plugin, as it would in the worst case, simply add the same classes twice on the classpath. By using a property, we can control that the dependent version is the same as the one loaded inside spotless.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9024 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
