### PR TITLE
Spike for 4099 fix

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.engine.processing.bpmn.task.JobWorkerTaskProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.task.ManualTaskProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.task.ReceiveTaskProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
+import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.EnumMap;
 import java.util.Map;
@@ -35,7 +36,7 @@ public final class BpmnElementProcessors {
   private final Map<BpmnElementType, BpmnElementProcessor<?>> processors =
       new EnumMap<>(BpmnElementType.class);
 
-  public BpmnElementProcessors(final BpmnBehaviors bpmnBehaviors) {
+  public BpmnElementProcessors(final BpmnBehaviors bpmnBehaviors, final ZeebeState zeebeState) {
     // tasks
     processors.put(BpmnElementType.SERVICE_TASK, new JobWorkerTaskProcessor(bpmnBehaviors));
     processors.put(
@@ -53,7 +54,7 @@ public final class BpmnElementProcessors {
         BpmnElementType.EVENT_BASED_GATEWAY, new EventBasedGatewayProcessor(bpmnBehaviors));
 
     // containers
-    processors.put(BpmnElementType.PROCESS, new ProcessProcessor(bpmnBehaviors));
+    processors.put(BpmnElementType.PROCESS, new ProcessProcessor(bpmnBehaviors, zeebeState));
     processors.put(BpmnElementType.SUB_PROCESS, new SubProcessProcessor(bpmnBehaviors));
     processors.put(BpmnElementType.EVENT_SUB_PROCESS, new EventSubProcessProcessor(bpmnBehaviors));
     processors.put(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -71,7 +71,7 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
             jobMetrics);
     rejectionWriter = writers.rejection();
     incidentBehavior = bpmnBehaviors.incidentBehavior();
-    processors = new BpmnElementProcessors(bpmnBehaviors);
+    processors = new BpmnElementProcessors(bpmnBehaviors, zeebeState);
 
     stateTransitionGuard = bpmnBehaviors.stateTransitionGuard();
     stateTransitionBehavior = bpmnBehaviors.stateTransitionBehavior();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.VariablesLookup;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventSupplier;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
@@ -63,6 +64,12 @@ public final class BpmnEventSubscriptionBehavior {
   public <T extends ExecutableCatchEventSupplier> Either<Failure, Void> subscribeToEvents(
       final T element, final BpmnElementContext context) {
     return catchEventBehavior.subscribeToEvents(context, element, sideEffects, commandWriter);
+  }
+
+  public <T extends ExecutableCatchEventSupplier> Either<Failure, Void> subscribeToEvents(
+      final T element, final BpmnElementContext context, final VariablesLookup secondaryLookup) {
+    return catchEventBehavior.subscribeToEvents(
+        context, element, sideEffects, commandWriter, secondaryLookup);
   }
 
   public void unsubscribeFromEvents(final BpmnElementContext context) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnProcessResultSenderBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.VariablesLookup;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -54,8 +55,11 @@ public final class ProcessProcessor
   public void onActivate(
       final ExecutableFlowElementContainer element, final BpmnElementContext context) {
 
+    // TODO implement
+    final VariablesLookup secondaryLookup = (key, name) -> null;
+
     eventSubscriptionBehavior
-        .subscribeToEvents(element, context)
+        .subscribeToEvents(element, context, secondaryLookup)
         .map(o -> stateTransitionBehavior.transitionToActivated(context))
         .ifRightOrLeft(
             activated -> activateStartEvent(element, activated),

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -92,7 +92,7 @@ public final class CatchEventBehavior {
     final var evaluationResults =
         supplier.getEvents().stream()
             .filter(event -> event.isTimer() || event.isMessage())
-            .map(event -> evalExpressions(event, context))
+            .map(event -> evalExpressions(expressionProcessor, event, context))
             .collect(Either.collectorFoldingLeft());
 
     evaluationResults.ifRight(
@@ -105,15 +105,24 @@ public final class CatchEventBehavior {
   }
 
   private Either<Failure, EvalResult> evalExpressions(
-      final ExecutableCatchEvent event, final BpmnElementContext context) {
+      final ExpressionProcessor expressionProcessor,
+      final ExecutableCatchEvent event,
+      final BpmnElementContext context) {
     return Either.<Failure, EvalResult>right(new EvalResult(event))
-        .flatMap(result -> evaluateMessageName(event, context).map(result::messageName))
-        .flatMap(result -> evaluateCorrelationKey(event, context).map(result::correlationKey))
-        .flatMap(result -> evaluateTimer(event, context).map(result::timer));
+        .flatMap(
+            result ->
+                evaluateMessageName(expressionProcessor, event, context).map(result::messageName))
+        .flatMap(
+            result ->
+                evaluateCorrelationKey(expressionProcessor, event, context)
+                    .map(result::correlationKey))
+        .flatMap(result -> evaluateTimer(expressionProcessor, event, context).map(result::timer));
   }
 
   private Either<Failure, DirectBuffer> evaluateMessageName(
-      final ExecutableCatchEvent event, final BpmnElementContext context) {
+      final ExpressionProcessor expressionProcessor,
+      final ExecutableCatchEvent event,
+      final BpmnElementContext context) {
     if (!event.isMessage()) {
       return Either.right(null);
     }
@@ -126,7 +135,9 @@ public final class CatchEventBehavior {
   }
 
   private Either<Failure, DirectBuffer> evaluateCorrelationKey(
-      final ExecutableCatchEvent event, final BpmnElementContext context) {
+      final ExpressionProcessor expressionProcessor,
+      final ExecutableCatchEvent event,
+      final BpmnElementContext context) {
     if (!event.isMessage()) {
       return Either.right(null);
     }
@@ -142,7 +153,9 @@ public final class CatchEventBehavior {
   }
 
   private Either<Failure, Timer> evaluateTimer(
-      final ExecutableCatchEvent event, final BpmnElementContext context) {
+      final ExpressionProcessor expressionProcessor,
+      final ExecutableCatchEvent event,
+      final BpmnElementContext context) {
     if (!event.isTimer()) {
       return Either.right(null);
     }


### PR DESCRIPTION
Relates to #4099 

@korthout Please have a look at the changes. Once you have had a look at it, I would like to talk to you again on how to make it pretty.

My first instinct is to move the extra logic into `BpmnEventSubscriptionBehavior`. Mostly, because this class has already access to `ZeebeState`. 

I am also thinking of making the second and third commit into a distinct PR as is. Please let me know what you think about that.