### PR TITLE
Fix 4099 by opening event subscriptions after start event's output mappings were applied

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -53,13 +53,8 @@ public final class ProcessProcessor
   @Override
   public void onActivate(
       final ExecutableFlowElementContainer element, final BpmnElementContext context) {
-
-    eventSubscriptionBehavior
-        .subscribeToEvents(element, context)
-        .map(o -> stateTransitionBehavior.transitionToActivated(context))
-        .ifRightOrLeft(
-            activated -> activateStartEvent(element, activated),
-            failure -> incidentBehavior.createIncident(failure, context));
+    final var activatedContext = stateTransitionBehavior.transitionToActivated(context);
+    activateStartEvent(element, activatedContext);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -51,7 +51,6 @@ public final class SubProcessProcessor
 
     variableMappingBehavior
         .applyInputMappings(activating, element)
-        .flatMap(ok -> eventSubscriptionBehavior.subscribeToEvents(element, activating))
         .ifRightOrLeft(
             ok -> {
               final var activated = stateTransitionBehavior.transitionToActivated(activating);


### PR DESCRIPTION
## Description

This moves the step when event subscriptions are opened from `ProcessProcessor` and `SubprocessProcessor` to `StartEventProcessor`. This way, subscriptions and the values used for them will only be evaluated after output mappings of the start event have been applied.

This fits better to user expectations and fixes #4099 

## Related issues

closes #4099

<!-- Cut-off marker

## Definition of Ready
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done
Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
