### PR TITLE
[Backport stable/8.0] Relax timeout for instance completion

### DIFF
--- a/test-util/src/main/java/io/camunda/zeebe/test/util/WorkloadGenerator.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/WorkloadGenerator.java
@@ -42,6 +42,8 @@ public final class WorkloadGenerator {
           .endEvent()
           .done();
 
+  private WorkloadGenerator() {}
+
   /**
    * Given a client, deploy a process, start instances, work on service tasks, create and resolve
    * incidents and finish the instance.
@@ -115,6 +117,7 @@ public final class WorkloadGenerator {
 
     // wrap up
     Awaitility.await("the process instance was completed")
+        .timeout(Duration.ofMinutes(1))
         .until(
             () ->
                 RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)


### PR DESCRIPTION
## Description

It's likely the job worker has to wait until the job is timing out, which may cause at times the test to take more than 10 seconds to wait for the process instance to be completed.

Let's relax the timeout generously to avoid having to do this again.

(cherry picked from commit cbf3d03a1d04311a59fc067624eda38c00315700)

## Related issues

backports #9058 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
