### PR TITLE
Wait for gateway start in StandaloneGateway

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
@@ -112,7 +112,7 @@ public class StandaloneGateway
 
     actorScheduler.start();
     atomixCluster.start();
-    gateway.start();
+    gateway.start().join(30, TimeUnit.SECONDS);
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR fixes the flaky windows test. Since we now make the gateway start asynchronous for the embedded gateway, it also caused a race condition in the tests that start the standalone gateway, as the test logic would start before the gateway was up, resulting in connection errors.

Additionally, I discovered a case where sometimes the topology request is successful but it returns an empty topology. I opened a follow up issue to align this, in the mean time the test was updated to handle both cases.

## Related issues

closes #9077 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
