### PR TITLE
Remove redundant version statements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ pipeline {
 
         stage('Build Distribution') {
             environment {
-                VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
+                VERSION = readMavenPom(file: 'bom/pom.xml').getVersion()
             }
             steps {
                 timeout(time: shortTimeoutMinutes, unit: 'MINUTES') {

--- a/atomix/pom.xml
+++ b/atomix/pom.xml
@@ -27,7 +27,6 @@
   </parent>
 
   <artifactId>zeebe-atomix-parent</artifactId>
-  <version>8.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Zeebe Atomix Parent Pom</name>

--- a/bpmn-model/pom.xml
+++ b/bpmn-model/pom.xml
@@ -11,7 +11,6 @@
   </parent>
 
   <artifactId>zeebe-bpmn-model</artifactId>
-  <version>8.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe BPMN model API</name>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -244,7 +244,7 @@
               <goal>assemble</goal>
             </goals>
             <phase>package</phase>
-            <configuration />
+            <configuration></configuration>
           </execution>
         </executions>
       </plugin>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -11,7 +11,6 @@
   </parent>
 
   <artifactId>zeebe-workflow-engine</artifactId>
-  <version>8.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Workflow Engine</name>

--- a/gateway-protocol-impl/pom.xml
+++ b/gateway-protocol-impl/pom.xml
@@ -107,7 +107,7 @@
                 <phase>generate-sources</phase>
                 <configuration>
                   <target>
-                    <copy failonerror="true" file="${project.build.directory}/generated-sources/protobuf/go/gateway.pb.go" tofile="${maven.multiModuleProjectDirectory}/clients/go/pkg/pb/gateway.pb.go" />
+                    <copy failonerror="true" file="${project.build.directory}/generated-sources/protobuf/go/gateway.pb.go" tofile="${maven.multiModuleProjectDirectory}/clients/go/pkg/pb/gateway.pb.go"></copy>
                   </target>
                 </configuration>
               </execution>

--- a/logstreams/pom.xml
+++ b/logstreams/pom.xml
@@ -11,7 +11,6 @@
   </parent>
 
   <artifactId>zeebe-logstreams</artifactId>
-  <version>8.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Logstreams</name>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -11,7 +11,6 @@
   </parent>
 
   <artifactId>zeebe-parent</artifactId>
-  <version>8.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Zeebe Parent</name>
@@ -1212,7 +1211,7 @@
                 <goal>check</goal>
               </goals>
               <phase>validate</phase>
-              <configuration />
+              <configuration></configuration>
             </execution>
           </executions>
         </plugin>
@@ -1395,7 +1394,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore></ignore>
                   </action>
                 </pluginExecution>
               </pluginExecutions>
@@ -1495,7 +1494,7 @@
               </goals>
               <configuration>
                 <rules>
-                  <dependencyConvergence />
+                  <dependencyConvergence></dependencyConvergence>
                 </rules>
               </configuration>
             </execution>
@@ -1506,7 +1505,7 @@
               </goals>
               <configuration>
                 <rules>
-                  <banDuplicatePomDependencyVersions />
+                  <banDuplicatePomDependencyVersions></banDuplicatePomDependencyVersions>
                 </rules>
               </configuration>
             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
               <exclude>**/target/**/*.md</exclude>
               <exclude>clients/go/vendor/**/*.md</exclude>
             </excludes>
-            <flexmark />
+            <flexmark></flexmark>
           </markdown>
         </configuration>
       </plugin>

--- a/protocol-impl/pom.xml
+++ b/protocol-impl/pom.xml
@@ -11,7 +11,6 @@
   </parent>
 
   <artifactId>zeebe-protocol-impl</artifactId>
-  <version>8.1.0-SNAPSHOT</version>
 
   <name>Zeebe Protocol Implementation</name>
 

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -11,7 +11,6 @@
   </parent>
 
   <artifactId>zeebe-protocol</artifactId>
-  <version>8.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Protocol</name>

--- a/snapshot/pom.xml
+++ b/snapshot/pom.xml
@@ -11,7 +11,6 @@
   </parent>
 
   <artifactId>zeebe-snapshots</artifactId>
-  <version>8.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Snapshots</name>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -11,7 +11,6 @@
   </parent>
 
   <artifactId>zeebe-transport</artifactId>
-  <version>8.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Zeebe Transport</name>


### PR DESCRIPTION
## Description

Removes version statements if the value is inherited

## Related issues

closes #9079

<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
