### PR TITLE
test(protocol): add consistency test for intent classes

### DIFF
--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -109,6 +109,12 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.github.classgraph</groupId>
+      <artifactId>classgraph</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -40,7 +40,9 @@ public interface Intent {
           ProcessEventIntent.class,
           DecisionIntent.class,
           DecisionRequirementsIntent.class,
-          DecisionEvaluationIntent.class);
+          DecisionEvaluationIntent.class,
+          MessageStartEventSubscriptionIntent.class,
+          ProcessInstanceResultIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN =
       new Intent() {

--- a/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentConsistencyTest.java
+++ b/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentConsistencyTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ScanResult;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
+public class IntentConsistencyTest {
+
+  private static final Collection<String> IGNORED =
+      Arrays.asList(Intent.UNKNOWN.getClass().getName());
+
+  @Test
+  void listOfIntentClassesIsComplete() {
+    // given
+    final Collection<String> expectedIntentClasses =
+        Intent.INTENT_CLASSES.stream().map(Class::getName).collect(Collectors.toSet());
+
+    // when + then
+    final SoftAssertions softly = new SoftAssertions();
+    try (final ScanResult scanResult =
+        new ClassGraph().enableClassInfo().acceptPackages("io.camunda.zeebe").scan()) {
+
+      final Set<ClassInfo> intentClasses =
+          scanResult.getClassesImplementing(Intent.class).stream()
+              .filter(ClassInfo::isStandardClass)
+              .collect(Collectors.toSet());
+
+      for (final ClassInfo intentClassInfo : intentClasses) {
+
+        final boolean removed = expectedIntentClasses.remove(intentClassInfo.getName());
+
+        if (!removed && !IGNORED.contains(intentClassInfo.getName())) {
+          /* if this fails, add the failing class either to Intent.INTENT_CLASSES
+           * or to IGNORED
+           */
+          softly.fail(
+              "Class " + intentClassInfo.getName() + " is not part of Intent.INTENT_CLASSES");
+        }
+      }
+
+      softly.assertAll();
+    }
+  }
+}


### PR DESCRIPTION
## Description

* Adds test to find intent classes that are not added to `Intent.INTENT_CLASSES`
* Adds missing intent classes

## Related issues

closes #9012

<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done
Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
