### PR TITLE
Chained variable lookup

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
+import io.camunda.zeebe.engine.processing.variable.VariableStateEvaluationContextLookup;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.migration.DbMigrationController;
@@ -69,7 +70,8 @@ public final class EngineProcessors {
     final var variablesState = zeebeState.getVariableState();
     final var expressionProcessor =
         new ExpressionProcessor(
-            ExpressionLanguageFactory.createExpressionLanguage(), variablesState::getVariable);
+            ExpressionLanguageFactory.createExpressionLanguage(),
+            new VariableStateEvaluationContextLookup(variablesState));
 
     final DueDateTimerChecker timerChecker = new DueDateTimerChecker(zeebeState.getTimerState());
     final CatchEventBehavior catchEventBehavior =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -94,7 +94,7 @@ public final class CatchEventBehavior {
     final var evaluationResults =
         supplier.getEvents().stream()
             .filter(event -> event.isTimer() || event.isMessage())
-            .map(event -> evalExpressions(event, context))
+            .map(event -> evalExpressions(expressionProcessor, event, context))
             .collect(Either.collectorFoldingLeft());
 
     evaluationResults.ifRight(
@@ -107,15 +107,19 @@ public final class CatchEventBehavior {
   }
 
   private Either<Failure, EvalResult> evalExpressions(
-      final ExecutableCatchEvent event, final BpmnElementContext context) {
+      final ExpressionProcessor ep,
+      final ExecutableCatchEvent event,
+      final BpmnElementContext context) {
     return Either.<Failure, EvalResult>right(new EvalResult(event))
-        .flatMap(result -> evaluateMessageName(event, context).map(result::messageName))
-        .flatMap(result -> evaluateCorrelationKey(event, context).map(result::correlationKey))
-        .flatMap(result -> evaluateTimer(event, context).map(result::timer));
+        .flatMap(result -> evaluateMessageName(ep, event, context).map(result::messageName))
+        .flatMap(result -> evaluateCorrelationKey(ep, event, context).map(result::correlationKey))
+        .flatMap(result -> evaluateTimer(ep, event, context).map(result::timer));
   }
 
   private Either<Failure, DirectBuffer> evaluateMessageName(
-      final ExecutableCatchEvent event, final BpmnElementContext context) {
+      final ExpressionProcessor expressionProcessor,
+      final ExecutableCatchEvent event,
+      final BpmnElementContext context) {
     if (!event.isMessage()) {
       return Either.right(null);
     }
@@ -128,7 +132,9 @@ public final class CatchEventBehavior {
   }
 
   private Either<Failure, DirectBuffer> evaluateCorrelationKey(
-      final ExecutableCatchEvent event, final BpmnElementContext context) {
+      final ExpressionProcessor expressionProcessor,
+      final ExecutableCatchEvent event,
+      final BpmnElementContext context) {
     if (!event.isMessage()) {
       return Either.right(null);
     }
@@ -144,7 +150,9 @@ public final class CatchEventBehavior {
   }
 
   private Either<Failure, Timer> evaluateTimer(
-      final ExecutableCatchEvent event, final BpmnElementContext context) {
+      final ExpressionProcessor expressionProcessor,
+      final ExecutableCatchEvent event,
+      final BpmnElementContext context) {
     if (!event.isTimer()) {
       return Either.right(null);
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -136,6 +136,7 @@ public final class CatchEventBehavior {
 
   private Either<Failure, OngoingEvaluation> evaluateCorrelationKey(
       final OngoingEvaluation evaluation) {
+
     final var event = evaluation.event();
     final var context = evaluation.context();
     if (!event.isMessage()) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -111,9 +111,10 @@ public final class CatchEventBehavior {
       final ExecutableCatchEvent event,
       final BpmnElementContext context) {
     return Either.<Failure, EvalResult>right(new EvalResult(event))
-        .flatMap(result -> evaluateMessageName(ep, event, context).map(result::messageName))
-        .flatMap(result -> evaluateCorrelationKey(ep, event, context).map(result::correlationKey))
-        .flatMap(result -> evaluateTimer(ep, event, context).map(result::timer));
+        .flatMap(result -> evaluateMessageName(ep, event, context).map(result::withMessageName))
+        .flatMap(
+            result -> evaluateCorrelationKey(ep, event, context).map(result::withCorrelationKey))
+        .flatMap(result -> evaluateTimer(ep, event, context).map(result::withTimer));
   }
 
   private Either<Failure, DirectBuffer> evaluateMessageName(
@@ -340,17 +341,17 @@ public final class CatchEventBehavior {
       this.event = event;
     }
 
-    public EvalResult messageName(final DirectBuffer messageName) {
+    public EvalResult withMessageName(final DirectBuffer messageName) {
       this.messageName = messageName;
       return this;
     }
 
-    public EvalResult correlationKey(final DirectBuffer correlationKey) {
+    public EvalResult withCorrelationKey(final DirectBuffer correlationKey) {
       this.correlationKey = correlationKey;
       return this;
     }
 
-    public EvalResult timer(final Timer timer) {
+    public EvalResult withTimer(final Timer timer) {
       this.timer = timer;
       return this;
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -131,7 +131,7 @@ public final class CatchEventBehavior {
         .expressionProcessor()
         .evaluateStringExpression(messageNameExpression, scopeKey)
         .map(BufferUtil::wrapString)
-        .map(evaluation::withMessageName);
+        .map(evaluation::recordMessageName);
   }
 
   private Either<Failure, OngoingEvaluation> evaluateCorrelationKey(
@@ -150,7 +150,7 @@ public final class CatchEventBehavior {
         .expressionProcessor()
         .evaluateMessageCorrelationKeyExpression(expression, scopeKey)
         .map(BufferUtil::wrapString)
-        .map(evaluation::withCorrelationKey)
+        .map(evaluation::recordCorrelationKey)
         .mapLeft(f -> new Failure(f.getMessage(), f.getErrorType(), scopeKey));
   }
 
@@ -164,7 +164,7 @@ public final class CatchEventBehavior {
     return event
         .getTimerFactory()
         .apply(evaluation.expressionProcessor(), scopeKey)
-        .map(evaluation::withTimer);
+        .map(evaluation::recordTimer);
   }
 
   private void subscribeToMessageEvents(
@@ -370,17 +370,17 @@ public final class CatchEventBehavior {
       return context;
     }
 
-    public OngoingEvaluation withMessageName(final DirectBuffer messageName) {
+    public OngoingEvaluation recordMessageName(final DirectBuffer messageName) {
       this.messageName = messageName;
       return this;
     }
 
-    public OngoingEvaluation withCorrelationKey(final DirectBuffer correlationKey) {
+    public OngoingEvaluation recordCorrelationKey(final DirectBuffer correlationKey) {
       this.correlationKey = correlationKey;
       return this;
     }
 
-    public OngoingEvaluation withTimer(final Timer timer) {
+    public OngoingEvaluation recordTimer(final Timer timer) {
       this.timer = timer;
       return this;
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.common;
 
-import static io.camunda.zeebe.util.EnsureUtil.ensureGreaterThan;
-
 import io.camunda.zeebe.el.EvaluationContext;
 import io.camunda.zeebe.el.EvaluationResult;
 import io.camunda.zeebe.el.Expression;
@@ -17,7 +15,6 @@ import io.camunda.zeebe.el.ResultType;
 import io.camunda.zeebe.model.bpmn.util.time.Interval;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.util.Either;
-import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Collection;
@@ -36,12 +33,6 @@ public final class ExpressionProcessor {
   private final EvaluationContextLookup evaluationContextLookup;
 
   public ExpressionProcessor(
-      final ExpressionLanguage expressionLanguage, final VariablesLookup lookup) {
-
-    this(expressionLanguage, new VariableStateEvaluationContextLookup(lookup));
-  }
-
-  private ExpressionProcessor(
       final ExpressionLanguage expressionLanguage, final EvaluationContextLookup lookup) {
     this.expressionLanguage = expressionLanguage;
     evaluationContextLookup = lookup;
@@ -408,22 +399,6 @@ public final class ExpressionProcessor {
     public EvaluationException(final String message) {
       super(message);
     }
-  }
-
-  private record VariableStateEvaluationContextLookup(VariablesLookup lookup)
-      implements EvaluationContextLookup {
-
-    @Override
-    public EvaluationContext getContext(final long scopeKey) {
-      ensureGreaterThan("variable scope key", scopeKey, 0);
-
-      return (name) -> lookup.getVariable(scopeKey, BufferUtil.wrapString(name));
-    }
-  }
-
-  @FunctionalInterface
-  public interface VariablesLookup {
-    DirectBuffer getVariable(final long scopeKey, final DirectBuffer name);
   }
 
   @FunctionalInterface

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
@@ -33,7 +33,7 @@ public final class ExpressionProcessor {
   private final DirectBuffer resultView = new UnsafeBuffer();
 
   private final ExpressionLanguage expressionLanguage;
-  private final ContextLookup contextLookup;
+  private final EvaluationContextLookup evaluationContextLookup;
 
   public ExpressionProcessor(
       final ExpressionLanguage expressionLanguage, final VariablesLookup lookup) {
@@ -42,9 +42,9 @@ public final class ExpressionProcessor {
   }
 
   private ExpressionProcessor(
-      final ExpressionLanguage expressionLanguage, final ContextLookup lookup) {
+      final ExpressionLanguage expressionLanguage, final EvaluationContextLookup lookup) {
     this.expressionLanguage = expressionLanguage;
-    contextLookup = lookup;
+    evaluationContextLookup = lookup;
   }
 
   /**
@@ -56,8 +56,8 @@ public final class ExpressionProcessor {
    * @return new instance which uses {@code primaryContext} as new top level evaluation context
    */
   public ExpressionProcessor withPrimaryContext(final EvaluationContext primaryContext) {
-    final ContextLookup combinedLookup =
-        scopeKey -> primaryContext.combine(contextLookup.getContext(scopeKey));
+    final EvaluationContextLookup combinedLookup =
+        scopeKey -> primaryContext.combine(evaluationContextLookup.getContext(scopeKey));
     return new ExpressionProcessor(expressionLanguage, combinedLookup);
   }
 
@@ -69,8 +69,8 @@ public final class ExpressionProcessor {
    * @return new instance which uses {@code secondaryContext} as fallback
    */
   public ExpressionProcessor withSecondaryContext(final EvaluationContext secondaryContext) {
-    final ContextLookup combinedLookup =
-        scopeKey -> contextLookup.getContext(scopeKey).combine(secondaryContext);
+    final EvaluationContextLookup combinedLookup =
+        scopeKey -> evaluationContextLookup.getContext(scopeKey).combine(secondaryContext);
     return new ExpressionProcessor(expressionLanguage, combinedLookup);
   }
 
@@ -383,7 +383,7 @@ public final class ExpressionProcessor {
     if (variableScopeKey < 0) {
       context = EMPTY_EVALUATION_CONTEXT;
     } else {
-      context = contextLookup.getContext(variableScopeKey);
+      context = evaluationContextLookup.getContext(variableScopeKey);
     }
 
     return expressionLanguage.evaluateExpression(expression, context);
@@ -411,7 +411,7 @@ public final class ExpressionProcessor {
   }
 
   private record VariableStateEvaluationContextLookup(VariablesLookup lookup)
-      implements ContextLookup {
+      implements EvaluationContextLookup {
 
     @Override
     public EvaluationContext getContext(final long scopeKey) {
@@ -427,7 +427,7 @@ public final class ExpressionProcessor {
   }
 
   @FunctionalInterface
-  public interface ContextLookup {
+  public interface EvaluationContextLookup {
     EvaluationContext getContext(final long scopeKey);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
@@ -47,7 +47,6 @@ public final class ExpressionProcessor {
     contextLookup = lookup;
   }
 
-
   /**
    * Returns a new {@code ExpressionProcessor} instance. This new instance will use {@code
    * primaryContext} for all lookups. Only if it doesn't find a variable in {@code primaryContext},

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableStateEvaluationContextLookup.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableStateEvaluationContextLookup.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.variable;
+
+import static io.camunda.zeebe.util.EnsureUtil.ensureGreaterThan;
+
+import io.camunda.zeebe.el.EvaluationContext;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationContextLookup;
+import io.camunda.zeebe.engine.state.immutable.VariableState;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+
+public record VariableStateEvaluationContextLookup(VariableState variableState)
+    implements EvaluationContextLookup {
+
+  @Override
+  public EvaluationContext getContext(final long scopeKey) {
+    ensureGreaterThan("variable scope key", scopeKey, 0);
+
+    return (name) -> variableState.getVariable(scopeKey, BufferUtil.wrapString(name));
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
@@ -9,9 +9,10 @@ package io.camunda.zeebe.engine.processing.common;
 
 import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
 
+import io.camunda.zeebe.el.EvaluationContext;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
-import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.VariablesLookup;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationContextLookup;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.stream.Stream;
@@ -26,7 +27,8 @@ class ExpressionProcessorTest {
 
   private static final ExpressionLanguage EXPRESSION_LANGUAGE =
       ExpressionLanguageFactory.createExpressionLanguage();
-  private static final VariablesLookup EMPTY_LOOKUP = (x, y) -> null;
+  private static final EvaluationContext EMPTY_LOOKUP = x -> null;
+  private static final EvaluationContextLookup DEFAULT_CONTEXT_LOOKUP = scope -> EMPTY_LOOKUP;
 
   @Nested
   @TestInstance(Lifecycle.PER_CLASS)
@@ -35,7 +37,7 @@ class ExpressionProcessorTest {
     @ParameterizedTest
     @MethodSource("arrayOfStringsExpressions")
     void testSuccessfulEvaluations(final String expression, final List<String> expected) {
-      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, EMPTY_LOOKUP);
+      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
       final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression(expression);
       assertThat(processor.evaluateArrayOfStringsExpression(parsedExpression, -1L))
           .isRight()
@@ -46,7 +48,7 @@ class ExpressionProcessorTest {
     @ParameterizedTest
     @MethodSource("notArrayOfStringsExpressions")
     void testFailingEvaluations(final String expression, final String message) {
-      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, EMPTY_LOOKUP);
+      final var processor = new ExpressionProcessor(EXPRESSION_LANGUAGE, DEFAULT_CONTEXT_LOOKUP);
       final var parsedExpression = EXPRESSION_LANGUAGE.parseExpression(expression);
       assertThat(processor.evaluateArrayOfStringsExpression(parsedExpression, -1L))
           .isLeft()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessValidationUtil.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessValidationUtil.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
-import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.VariablesLookup;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationContextLookup;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.traversal.ModelWalker;
@@ -51,7 +51,7 @@ public class ProcessValidationUtil {
     final ModelWalker walker = new ModelWalker(model);
     final ExpressionLanguage expressionLanguage =
         ExpressionLanguageFactory.createExpressionLanguage();
-    final VariablesLookup emptyLookup = (name, scopeKey) -> null;
+    final EvaluationContextLookup emptyLookup = scopeKey -> name -> null;
     final var expressionProcessor = new ExpressionProcessor(expressionLanguage, emptyLookup);
     final ValidationVisitor visitor =
         new ValidationVisitor(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.fail;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
-import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.VariablesLookup;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationContextLookup;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.ExpressionTransformer;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -399,7 +399,7 @@ public final class ZeebeRuntimeValidationTest {
     final ModelWalker walker = new ModelWalker(model);
     final ExpressionLanguage expressionLanguage =
         ExpressionLanguageFactory.createExpressionLanguage();
-    final VariablesLookup emptyLookup = (name, scopeKey) -> null;
+    final EvaluationContextLookup emptyLookup = scopeKey -> name -> null;
     final var expressionProcessor = new ExpressionProcessor(expressionLanguage, emptyLookup);
     final ValidationVisitor visitor =
         new ValidationVisitor(

--- a/expression-language/src/main/java/io/camunda/zeebe/el/EvaluationContext.java
+++ b/expression-language/src/main/java/io/camunda/zeebe/el/EvaluationContext.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.el;
 
+import java.util.Optional;
 import org.agrona.DirectBuffer;
 
 /** The context for evaluating an expression. */
@@ -20,4 +21,19 @@ public interface EvaluationContext {
    *     not present
    */
   DirectBuffer getVariable(String variableName);
+
+  /**
+   * Combines two evaluation contexts. The combined evaluation context will first search for the
+   * variable in {@code this} evaluation context. If the variable is not found, it will attempt the
+   * lookup in {@code secondaryEvaluationContext}.
+   *
+   * @param secondaryEvaluationContext secondary evaluation context; this will be used to lookup
+   *     variables which are not found in {@code this} evaluation context
+   * @return combined evaluation context
+   */
+  default EvaluationContext combine(final EvaluationContext secondaryEvaluationContext) {
+    return variable ->
+        Optional.ofNullable(getVariable(variable))
+            .orElseGet(() -> secondaryEvaluationContext.getVariable(variable));
+  }
 }


### PR DESCRIPTION
## Description

* Allows to chain variable lookups
* applies refactoring to make the code more readable

## Related issues
<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
