### PR TITLE
Add junit engines to list of unused declared deps

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1544,6 +1544,8 @@
                   <dep>org.ow2.asm:asm</dep>
                   <dep>org.bouncycastle:bcpkix-jdk15on</dep>
                   <dep>org.bouncycastle:bcprov-jdk15on</dep>
+                  <dep>org.junit.jupiter:junit-jupiter-engine</dep>
+                  <dep>org.junit.vintage:junit-vintage-engine</dep>
                 </ignoredUnusedDeclaredDependencies>
               </configuration>
             </execution>
@@ -1817,16 +1819,6 @@
           <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>org.junit.jupiter</groupId>
-          <artifactId>junit-jupiter-engine</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.junit.vintage</groupId>
-          <artifactId>junit-vintage-engine</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
           <groupId>org.codehaus.plexus</groupId>
           <artifactId>plexus-utils</artifactId>
           <!--
@@ -1847,8 +1839,6 @@
                 <dep>org.apache.maven.surefire:surefire-junit4</dep>
                 <dep>org.apache.maven.surefire:surefire-junit47</dep>
                 <dep>org.apache.maven.surefire:surefire-junit-platform</dep>
-                <dep>org.junit.jupiter:junit-jupiter-engine</dep>
-                <dep>org.junit.vintage:junit-vintage-engine</dep>
                 <dep>org.codehaus.plexus:plexus-utils</dep>
               </ignoredUnusedDeclaredDependencies>
             </configuration>


### PR DESCRIPTION
## Description

This PR adds Junit engines to the list of unused and declared dependencies, as we often rely on these in our tests but never actually call on them directly, as they're test-runtime dependencies only.

## Related issues

closes #9116

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
