### PR TITLE
fix(broker): do not log transition failure due to term mismatch as error

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -250,7 +250,6 @@ public final class ZeebePartition extends Actor
                 });
             onRecoveredInternal();
           } else {
-            LOG.error("Failed to install leader partition {}", context.getPartitionId(), error);
             onInstallFailure(error);
           }
         });
@@ -274,7 +273,6 @@ public final class ZeebePartition extends Actor
                 });
             onRecoveredInternal();
           } else {
-            LOG.error("Failed to install follower partition {}", context.getPartitionId(), error);
             onInstallFailure(error);
           }
         });
@@ -340,6 +338,7 @@ public final class ZeebePartition extends Actor
           context.getPartitionId(),
           error.getMessage());
     } else {
+      LOG.error("Failed to install partition {}", context.getPartitionId(), error);
       handleRecoverableFailure();
     }
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -84,9 +84,7 @@ final class PartitionTransitionProcess {
 
   private void onStepCompletion(final ActorFuture<Void> future, final Throwable error) {
     if (error != null) {
-      LOG.error(error.getMessage(), error);
       future.completeExceptionally(error);
-
       return;
     }
 


### PR DESCRIPTION
## Description

If a transition failed due to a term mismatch, there will be a new transition following. There is no need to log it as an error because conceptually it is not an error. It is expected to fail to prevent inconsistencies. When this failure happens, it is ignored and ZeebePartition continue with the next transition.

## Related issues

closes #9040 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
