### PR TITLE
Add overview dashboard to benchmark/zeebe-io clusters

### DIFF
--- a/benchmarks/docs/setup/prometheus-operator-values.yml
+++ b/benchmarks/docs/setup/prometheus-operator-values.yml
@@ -42,6 +42,8 @@ grafana:
     default:
       zeebe:
         url: https://raw.githubusercontent.com/camunda/zeebe/main/monitor/grafana/zeebe.json
+      zeebe-overview:
+        url: https://raw.githubusercontent.com/camunda/zeebe/main/monitor/grafana/zeebe-overview.json
   persistence:
     enabled: true
     storageClassName: ssd

--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - grafana:/var/lib/grafana
       - ./grafana/dashboards/:/var/lib/grafana/dashboards/
       - ./grafana/zeebe.json/:/var/lib/grafana/dashboards/zeebe.json
+      - ./grafana/zeebe-overview.json/:/var/lib/grafana/dashboards/zeebe-overview.json
       - ./grafana/provisioning/:/etc/grafana/provisioning/
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=camunda


### PR DESCRIPTION
## Description

This PR adds the overview dashboard to the local monitoring testing set up, as well as to the zeebe-io/benchmark clusters setup. To update our existing Helm installations, you go to the benchmarks/docs/setup folder, then switch to the K8s context/namespace you want to update (e.g. the zeebe-io context and namespace default), then run:

```sh
helm upgrade metrics stable/prometheus-operator --atomic --reuse-values -f prometheus-operator-values.yml
```

You can see the overview dashboard is now in both the long running and the default cluster.

## Related issues

closes #9075 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
