### PR TITLE
Await until all index templates are present before running ES test

### DIFF
--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterAuthenticationIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterAuthenticationIT.java
@@ -54,17 +54,14 @@ public class ElasticsearchExporterAuthenticationIT
     // given
     configuration = getDefaultConfiguration();
     exporterConfigurator.accept(configuration);
+    exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
+    esClient = createElasticsearchClient(configuration);
 
     // when
-    exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
-    exporterBrokerRule.start();
+    startBroker();
     exporterBrokerRule.performSampleWorkload();
 
     // then
-
-    // assert index settings for all created indices
-    esClient = createElasticsearchClient(configuration);
-
     // assert all records which where recorded during the tests where exported
     exporterBrokerRule.visitExportedRecords(
         r -> {

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfigurationIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfigurationIT.java
@@ -33,7 +33,7 @@ public class ElasticsearchExporterConfigurationIT
 
     // when
     exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
-    exporterBrokerRule.start();
+    startBroker();
     exporterBrokerRule.publishMessage("message", "123");
 
     // then
@@ -60,7 +60,7 @@ public class ElasticsearchExporterConfigurationIT
     exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
 
     // then
-    assertThatThrownBy(() -> exporterBrokerRule.start())
+    assertThatThrownBy(this::startBroker)
         .isInstanceOf(IllegalStateException.class)
         .getRootCause()
         .isInstanceOf(ExporterException.class)
@@ -83,7 +83,7 @@ public class ElasticsearchExporterConfigurationIT
     exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
 
     // then
-    assertThatThrownBy(() -> exporterBrokerRule.start())
+    assertThatThrownBy(this::startBroker)
         .isInstanceOf(IllegalStateException.class)
         .getRootCause()
         .isInstanceOf(ExporterException.class)

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterFaultToleranceIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterFaultToleranceIT.java
@@ -30,9 +30,10 @@ public class ElasticsearchExporterFaultToleranceIT
 
     // when
     exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
-    exporterBrokerRule.start();
+    startBrokerWithoutWaitingForIndexTemplates();
     exporterBrokerRule.publishMessage("message", "123");
     elastic.start();
+    awaitIndexTemplatesCreation();
 
     // then
     final var records =

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/records/ElasticsearchExporterDmnRecordIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/records/ElasticsearchExporterDmnRecordIT.java
@@ -34,7 +34,7 @@ public final class ElasticsearchExporterDmnRecordIT
     esClient = createElasticsearchClient(configuration);
 
     exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
-    exporterBrokerRule.start();
+    startBroker();
   }
 
   @Test

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/records/ElasticsearchExporterJobRecordIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/records/ElasticsearchExporterJobRecordIT.java
@@ -34,7 +34,7 @@ public class ElasticsearchExporterJobRecordIT
     esClient = createElasticsearchClient(configuration);
 
     exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
-    exporterBrokerRule.start();
+    startBroker();
   }
 
   @After

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/util/ElasticsearchContainer.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/util/ElasticsearchContainer.java
@@ -44,6 +44,9 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
 
   public ElasticsearchContainer(final String version) {
     super(DEFAULT_IMAGE + ":" + version);
+
+    // disable xpack by default to disable all these security warnings
+    withEnv("xpack.security.enabled", "false");
   }
 
   @Override

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/util/it/ExporterIntegrationRule.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/util/it/ExporterIntegrationRule.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.exporter.util.it;
 
 import static io.camunda.zeebe.exporter.util.it.EmbeddedBrokerRule.TEST_RECORD_EXPORTER_ID;
-import static io.camunda.zeebe.test.util.record.RecordingExporter.processInstanceRecords;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -20,8 +19,6 @@ import io.camunda.zeebe.client.api.worker.JobWorker;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.Record;
-import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
-import io.camunda.zeebe.test.util.TestUtil;
 import io.camunda.zeebe.test.util.WorkloadGenerator;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -111,7 +108,7 @@ import org.junit.runners.model.Statement;
  * NOTE: calls to the various configure methods are additive, so it is possible to configure more
  * than one exporter, as long as the IDs are different.
  */
-public class ExporterIntegrationRule extends ExternalResource {
+public class ExporterIntegrationRule extends ExternalResource implements NonStartableBrokerRule {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -145,6 +142,7 @@ public class ExporterIntegrationRule extends ExternalResource {
    *
    * @return current broker configuration
    */
+  @Override
   public BrokerCfg getBrokerConfig() {
     return brokerRule.getBrokerCfg();
   }
@@ -152,6 +150,7 @@ public class ExporterIntegrationRule extends ExternalResource {
   /**
    * @return the currently configured exporters
    */
+  @Override
   public List<ExporterCfg> getConfiguredExporters() {
     return getBrokerConfig().getExporters().entrySet().stream()
         .filter(entry -> !entry.getKey().equals(TEST_RECORD_EXPORTER_ID))
@@ -162,6 +161,7 @@ public class ExporterIntegrationRule extends ExternalResource {
   /**
    * @return true if any exporter has been configured for the broker, false otherwise
    */
+  @Override
   public boolean hasConfiguredExporters() {
     return getConfiguredExporters().isEmpty();
   }
@@ -175,6 +175,7 @@ public class ExporterIntegrationRule extends ExternalResource {
    * @param <T> type of the configuration
    * @param <E> type of the exporter
    */
+  @Override
   public <T, E extends Exporter> ExporterIntegrationRule configure(
       final String id, final Class<E> exporterClass, final T configuration) {
     final Map<String, Object> arguments = convertConfigToMap(configuration);
@@ -189,6 +190,7 @@ public class ExporterIntegrationRule extends ExternalResource {
    * @param arguments the arguments to pass during configuration
    * @param <E> type of the exporter
    */
+  @Override
   public <E extends Exporter> ExporterIntegrationRule configure(
       final String id, final Class<E> exporterClass, final Map<String, Object> arguments) {
     final ExporterCfg config = new ExporterCfg();
@@ -196,6 +198,105 @@ public class ExporterIntegrationRule extends ExternalResource {
     config.setArgs(arguments);
 
     return configure(Collections.singletonMap(id, config));
+  }
+
+  /** Runs a sample workload on the broker, exporting several records of different types. */
+  @Override
+  public void performSampleWorkload() {
+    WorkloadGenerator.performSampleWorkload(clientRule.getClient());
+  }
+
+  /**
+   * Visits all exported records in the order they were exported.
+   *
+   * @param visitor record consumer
+   */
+  @Override
+  public void visitExportedRecords(final Consumer<Record<?>> visitor) {
+    RecordingExporter.getRecords().forEach(visitor);
+  }
+
+  /**
+   * Deploys the given process to the broker. Note that the filename must have the "bpmn" file
+   * extension, e.g. "resource.bpmn".
+   *
+   * @param process process to deploy
+   * @param filename resource name, e.g. "process.bpmn"
+   */
+  @Override
+  public void deployProcess(final BpmnModelInstance process, final String filename) {
+    clientRule
+        .getClient()
+        .newDeployResourceCommand()
+        .addProcessModel(process, filename)
+        .send()
+        .join();
+  }
+
+  /**
+   * Deploys the given classpath resource to the broker.
+   *
+   * @param classpathResource the resource to deploy
+   */
+  @Override
+  public void deployResourceFromClasspath(final String classpathResource) {
+    clientRule
+        .getClient()
+        .newDeployResourceCommand()
+        .addResourceFromClasspath(classpathResource)
+        .send()
+        .join();
+  }
+
+  /**
+   * Creates a process instance for the given process ID, with the given variables.
+   *
+   * @param processId BPMN process ID
+   * @param variables initial variables for the instance
+   * @return unique ID used to interact with the instance
+   */
+  @Override
+  public long createProcessInstance(final String processId, final Map<String, Object> variables) {
+    return clientRule
+        .getClient()
+        .newCreateInstanceCommand()
+        .bpmnProcessId(processId)
+        .latestVersion()
+        .variables(variables)
+        .send()
+        .join()
+        .getProcessInstanceKey();
+  }
+
+  /**
+   * Creates a new job worker that will handle jobs of type {@param type}.
+   *
+   * <p>Make sure to close the returned job worker.
+   *
+   * @param type type of the jobs to handle
+   * @param handler handler
+   * @return a new JobWorker
+   */
+  @Override
+  public JobWorker createJobWorker(final String type, final JobHandler handler) {
+    return clientRule.getClient().newWorker().jobType(type).handler(handler).open();
+  }
+
+  /**
+   * Publishes a new message to the broker.
+   *
+   * @param messageName name of the message
+   * @param correlationKey correlation key
+   */
+  @Override
+  public void publishMessage(final String messageName, final String correlationKey) {
+    clientRule
+        .getClient()
+        .newPublishMessageCommand()
+        .messageName(messageName)
+        .correlationKey(correlationKey)
+        .send()
+        .join();
   }
 
   /**
@@ -222,111 +323,6 @@ public class ExporterIntegrationRule extends ExternalResource {
     if (clientRule != null) {
       clientRule.destroyClient();
     }
-  }
-
-  /** Runs a sample workload on the broker, exporting several records of different types. */
-  public void performSampleWorkload() {
-    WorkloadGenerator.performSampleWorkload(clientRule.getClient());
-  }
-
-  /**
-   * Visits all exported records in the order they were exported.
-   *
-   * @param visitor record consumer
-   */
-  public void visitExportedRecords(final Consumer<Record<?>> visitor) {
-    RecordingExporter.getRecords().forEach(visitor);
-  }
-
-  /**
-   * Deploys the given process to the broker. Note that the filename must have the "bpmn" file
-   * extension, e.g. "resource.bpmn".
-   *
-   * @param process process to deploy
-   * @param filename resource name, e.g. "process.bpmn"
-   */
-  public void deployProcess(final BpmnModelInstance process, final String filename) {
-    clientRule
-        .getClient()
-        .newDeployResourceCommand()
-        .addProcessModel(process, filename)
-        .send()
-        .join();
-  }
-
-  /**
-   * Deploys the given classpath resource to the broker.
-   *
-   * @param classpathResource the resource to deploy
-   */
-  public void deployResourceFromClasspath(final String classpathResource) {
-    clientRule
-        .getClient()
-        .newDeployResourceCommand()
-        .addResourceFromClasspath(classpathResource)
-        .send()
-        .join();
-  }
-
-  /**
-   * Creates a process instance for the given process ID, with the given variables.
-   *
-   * @param processId BPMN process ID
-   * @param variables initial variables for the instance
-   * @return unique ID used to interact with the instance
-   */
-  public long createProcessInstance(final String processId, final Map<String, Object> variables) {
-    return clientRule
-        .getClient()
-        .newCreateInstanceCommand()
-        .bpmnProcessId(processId)
-        .latestVersion()
-        .variables(variables)
-        .send()
-        .join()
-        .getProcessInstanceKey();
-  }
-
-  /**
-   * Creates a new job worker that will handle jobs of type {@param type}.
-   *
-   * <p>Make sure to close the returned job worker.
-   *
-   * @param type type of the jobs to handle
-   * @param handler handler
-   * @return a new JobWorker
-   */
-  public JobWorker createJobWorker(final String type, final JobHandler handler) {
-    return clientRule.getClient().newWorker().jobType(type).handler(handler).open();
-  }
-
-  /**
-   * Publishes a new message to the broker.
-   *
-   * @param messageName name of the message
-   * @param correlationKey correlation key
-   */
-  public void publishMessage(final String messageName, final String correlationKey) {
-    clientRule
-        .getClient()
-        .newPublishMessageCommand()
-        .messageName(messageName)
-        .correlationKey(correlationKey)
-        .send()
-        .join();
-  }
-
-  /**
-   * Blocks and wait until the process identified by the key has been completed.
-   *
-   * @param processInstanceKey ID of the process
-   */
-  public void awaitProcessCompletion(final long processInstanceKey) {
-    TestUtil.waitUntil(
-        () ->
-            processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
-                .filter(r -> r.getKey() == processInstanceKey)
-                .exists());
   }
 
   private Properties newClientProperties() {

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/util/it/NonStartableBrokerRule.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/util/it/NonStartableBrokerRule.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter.util.it;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import io.camunda.zeebe.client.api.worker.JobHandler;
+import io.camunda.zeebe.client.api.worker.JobWorker;
+import io.camunda.zeebe.exporter.AbstractElasticsearchExporterIntegrationTestCase;
+import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Record;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * This interface is a temporary workaround to prevent actual tests from starting a broker manually.
+ * Instead, you should use {@link AbstractElasticsearchExporterIntegrationTestCase#startBroker()}.
+ *
+ * <p>As all of these utility classes will be removed by the end of Q2-2022, it's an OK trade-off to
+ * avoid rewriting most of the tests (which will be rewritten differently anyway).
+ */
+public interface NonStartableBrokerRule {
+
+  BrokerCfg getBrokerConfig();
+
+  List<ExporterCfg> getConfiguredExporters();
+
+  boolean hasConfiguredExporters();
+
+  <T, E extends Exporter> ExporterIntegrationRule configure(
+      String id, Class<E> exporterClass, T configuration);
+
+  <E extends Exporter> ExporterIntegrationRule configure(
+      String id, Class<E> exporterClass, Map<String, Object> arguments);
+
+  void performSampleWorkload();
+
+  void visitExportedRecords(Consumer<Record<?>> visitor);
+
+  void deployProcess(BpmnModelInstance process, String filename);
+
+  void deployResourceFromClasspath(String classpathResource);
+
+  long createProcessInstance(String processId, Map<String, Object> variables);
+
+  JobWorker createJobWorker(String type, JobHandler handler);
+
+  void publishMessage(String messageName, String correlationKey);
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -97,6 +97,7 @@ public final class RecordingExporter implements Exporter {
   public static void reset() {
     LOCK.lock();
     try {
+      maximumWaitTime = DEFAULT_MAX_WAIT_TIME;
       RECORDS.clear();
     } finally {
       LOCK.unlock();


### PR DESCRIPTION
## Description

This PR is a tentative fix for the flaky ES exporter tests. It does so by extracting a very hacky, nonsensical interface from the `ExporterIntegrationRule` called `NonStartableBrokerRule`. This terrible interface just prevents starting the broker from tests. As such, the broker can only be started via the abstract test case's `startBroker` method. In there we publish a dummy message and await the index templates to be added Elastic. That way all tests benefit from the hack.

Note that this is super hacky, and should never be considered an example of what to do. I think it's worth it in this case because one of my KRs this quarter is refactoring these tests, and the result will be that there will be no brokers involved, so we'll simply sidestep this issue. It also means all these classes will be removed, and there also won't be an abstract test case, so generally all this hacky stuff will disappear.

The PR also ensures we always reset the wait time (which is sometimes reduced in other tests). This guarantees that things like the `RecordingExporterTestWatcher`, which does call reset after each test, will also reset the timeout. This may fix some flaky tests where we sometimes change or reduce the timeout, which is then global for that forked process, and since ordering is random it's very hard to pinpoint/reproduce.

## Related issues

closes #8825 
closes #4709 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
