### PR TITLE
fix: remove subscription consumer instead of re-registering

### DIFF
--- a/dispatcher/src/main/java/io/camunda/zeebe/dispatcher/Subscription.java
+++ b/dispatcher/src/main/java/io/camunda/zeebe/dispatcher/Subscription.java
@@ -82,7 +82,7 @@ public class Subscription implements ConsumableChannel {
 
   @Override
   public void removeConsumer(final ActorCondition consumer) {
-    actorConditions.registerConsumer(consumer);
+    actorConditions.removeConsumer(consumer);
   }
 
   protected long getLimit() {

--- a/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/SubscriptionConsumerTest.java
+++ b/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/SubscriptionConsumerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.dispatcher;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.zeebe.dispatcher.impl.log.LogBuffer;
+import io.camunda.zeebe.util.sched.ActorCondition;
+import org.junit.jupiter.api.Test;
+
+final class SubscriptionConsumerTest {
+  @Test
+  void consumersAreNotSignaledAfterRemoving() {
+    // given
+    final var consumer = mock(ActorCondition.class);
+    final var subscription =
+        new Subscription(
+            mock(AtomicPosition.class),
+            mock(AtomicPosition.class),
+            0,
+            "",
+            consumer,
+            mock(LogBuffer.class));
+
+    // when
+    subscription.removeConsumer(consumer);
+
+    // then
+    subscription.getActorConditions().signalConsumers();
+    verifyNoInteractions(consumer);
+  }
+}

--- a/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/SubscriptionConsumerTest.java
+++ b/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/SubscriptionConsumerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dispatcher;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import io.camunda.zeebe.dispatcher.impl.log.LogBuffer;
@@ -15,6 +16,28 @@ import io.camunda.zeebe.util.sched.ActorCondition;
 import org.junit.jupiter.api.Test;
 
 final class SubscriptionConsumerTest {
+
+  @Test
+  void consumersAreSignaledAfterRegistering() {
+    // given
+    final var consumer = mock(ActorCondition.class);
+    final var subscription =
+        new Subscription(
+            mock(AtomicPosition.class),
+            mock(AtomicPosition.class),
+            0,
+            "",
+            mock(ActorCondition.class),
+            mock(LogBuffer.class));
+
+    // when
+    subscription.registerConsumer(consumer);
+
+    // then
+    subscription.getActorConditions().signalConsumers();
+    verify(consumer).signal();
+  }
+
   @Test
   void consumersAreNotSignaledAfterRemoving() {
     // given
@@ -25,8 +48,9 @@ final class SubscriptionConsumerTest {
             mock(AtomicPosition.class),
             0,
             "",
-            consumer,
+            mock(ActorCondition.class),
             mock(LogBuffer.class));
+    subscription.registerConsumer(consumer);
 
     // when
     subscription.removeConsumer(consumer);


### PR DESCRIPTION
This was probably not an issue because it was mitigated by other circumstances.

closes #9123 
