### PR TITLE
test(gateway): add tests for the `io.camunda.zeebe.util.jar.ExternalJarClassLoader` and resources in jar.

### DIFF
--- a/util/src/test/java/io/camunda/zeebe/util/jar/ExternalJarClassLoaderTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/jar/ExternalJarClassLoaderTest.java
@@ -11,7 +11,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.util.jar.ExternalService.Service;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
@@ -51,5 +55,27 @@ final class ExternalJarClassLoaderTest {
     assertThat(classLoader.getParent())
         .isEqualTo(getClass().getClassLoader())
         .isEqualTo(ClassLoader.getSystemClassLoader());
+  }
+
+  @Test
+  void shouldLoadResourceFiles(final @TempDir File tempDir) throws Exception {
+    final String testResourceValue = "test-value";
+    final String resourceName = "test-resource.txt";
+    final File jarFile = new File(tempDir, "with-resource.jar");
+    try (final FileOutputStream fileOutputStream = new FileOutputStream(jarFile)) {
+      try (final JarOutputStream jarOutputStream = new JarOutputStream(fileOutputStream)) {
+        jarOutputStream.putNextEntry(new JarEntry(resourceName));
+        jarOutputStream.write(testResourceValue.getBytes(StandardCharsets.UTF_8));
+        jarOutputStream.closeEntry();
+      }
+    }
+    final var classLoader = ExternalJarClassLoader.ofPath(jarFile.toPath());
+
+    // when
+    final String storedValue =
+        new String(classLoader.getResourceAsStream(resourceName).readAllBytes());
+
+    // then
+    assertThat(storedValue).isEqualTo(testResourceValue);
   }
 }

--- a/util/src/test/java/io/camunda/zeebe/util/jar/ExternalJarClassLoaderTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/jar/ExternalJarClassLoaderTest.java
@@ -59,11 +59,11 @@ final class ExternalJarClassLoaderTest {
 
   @Test
   void shouldLoadResourceFiles(final @TempDir File tempDir) throws Exception {
-    final String testResourceValue = "test-value";
-    final String resourceName = "test-resource.txt";
-    final File jarFile = new File(tempDir, "with-resource.jar");
-    try (final FileOutputStream fileOutputStream = new FileOutputStream(jarFile)) {
-      try (final JarOutputStream jarOutputStream = new JarOutputStream(fileOutputStream)) {
+    final var testResourceValue = "test-value";
+    final var resourceName = "test-resource.txt";
+    final var jarFile = new File(tempDir, "with-resource.jar");
+    try (final var fileOutputStream = new FileOutputStream(jarFile)) {
+      try (final var jarOutputStream = new JarOutputStream(fileOutputStream)) {
         jarOutputStream.putNextEntry(new JarEntry(resourceName));
         jarOutputStream.write(testResourceValue.getBytes(StandardCharsets.UTF_8));
         jarOutputStream.closeEntry();
@@ -72,7 +72,7 @@ final class ExternalJarClassLoaderTest {
     final var classLoader = ExternalJarClassLoader.ofPath(jarFile.toPath());
 
     // when
-    final String storedValue =
+    final var storedValue =
         new String(classLoader.getResourceAsStream(resourceName).readAllBytes());
 
     // then


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
I've decided to create this one to be sure that my resources will be properly loaded and could be accessible from the class loader.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8982 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
