### PR TITLE
Check for message names being null during validation

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -129,6 +129,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessMessageStartEventMessageNameValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessMessageStartEventMessageNameValidator.java
@@ -57,6 +57,10 @@ final class ProcessMessageStartEventMessageNameValidator
       return;
     }
     final String nameExpression = message.getName();
+    if (nameExpression == null) {
+      // no need to add an error, this case was already handled by MessageValidator
+      return;
+    }
     final Expression parseResult = expressionLanguage.parseExpression(nameExpression);
 
     final EvaluationResult evaluationResult =

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessMessageStartEventMessageNameValidatorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessMessageStartEventMessageNameValidatorTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.validation;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -15,11 +17,14 @@ import io.camunda.zeebe.el.EvaluationResult;
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ResultType;
+import io.camunda.zeebe.el.impl.FeelExpressionLanguage;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
+import io.camunda.zeebe.util.sched.clock.ActorClock;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -29,76 +34,91 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class ProcessMessageStartEventMessageNameValidatorTest {
 
-  private static final String TEST_EXPRESSION = "expression";
-
-  private static final BpmnModelInstance MODEL =
-      Bpmn.createProcess().startEvent().message(TEST_EXPRESSION).endEvent().done();
-
-  private static final StartEvent START_EVENT =
-      MODEL.getModelElementsByType(StartEvent.class).iterator().next();
-
-  @Mock ExpressionLanguage mockExpressionLanguage;
-
-  @Mock Expression mockExpression;
-
-  @Mock EvaluationResult mockResult;
-
   @Mock ValidationResultCollector mockResultCollector;
 
-  ProcessMessageStartEventMessageNameValidator sutValidator;
-
-  @BeforeEach
-  public void setUp() {
-    when(mockExpressionLanguage.parseExpression(TEST_EXPRESSION)).thenReturn(mockExpression);
-
-    when(mockExpressionLanguage.evaluateExpression(Mockito.eq(mockExpression), Mockito.any()))
-        .thenReturn(mockResult);
-
-    sutValidator = new ProcessMessageStartEventMessageNameValidator(mockExpressionLanguage);
-  }
-
-  @Test
-  public void shouldLetValidMessageNameExpressionsPass() {
+  @Test // regression test for #9083
+  void shouldNotThrowNPEIfMessageNameIsNull() {
     // given
-    when(mockResult.isFailure()).thenReturn(false);
-    when(mockResult.getType()).thenReturn(ResultType.STRING);
+    final var model = Bpmn.createProcess().startEvent().message((String) null).endEvent().done();
+
+    final var startEvent = model.getModelElementsByType(StartEvent.class).iterator().next();
+
+    final var sutValidator =
+        new ProcessMessageStartEventMessageNameValidator(
+            new FeelExpressionLanguage(ActorClock.current()));
 
     // when
-    sutValidator.validate(START_EVENT, mockResultCollector);
-
-    // then
-    verifyNoInteractions(mockResultCollector);
+    assertThatNoException()
+        .isThrownBy(() -> sutValidator.validate(startEvent, mockResultCollector));
   }
 
-  @Test
-  public void shouldAddErrorIfEvaluationFailed() {
-    // given
-    when(mockResult.isFailure()).thenReturn(true);
-    when(mockResult.getFailureMessage()).thenReturn("Test failure message");
+  @Nested
+  final class WithMockedExpressionLanguage {
 
-    // when
-    sutValidator.validate(START_EVENT, mockResultCollector);
+    private static final String TEST_EXPRESSION = "expression";
+    private static final BpmnModelInstance MODEL =
+        Bpmn.createProcess().startEvent().message(TEST_EXPRESSION).endEvent().done();
+    private static final StartEvent START_EVENT =
+        MODEL.getModelElementsByType(StartEvent.class).iterator().next();
+    @Mock ExpressionLanguage mockExpressionLanguage;
+    @Mock Expression mockExpression;
+    @Mock EvaluationResult mockResult;
 
-    // then
-    verify(mockResultCollector)
-        .addError(
-            0,
-            "Expected constant expression but found 'expression', which could not be evaluated without context: Test failure message");
-  }
+    ProcessMessageStartEventMessageNameValidator sutValidator;
 
-  @Test
-  public void shouldAddErrorIfEvaluationDoesNotReturnString() {
-    // given
-    when(mockResult.isFailure()).thenReturn(false);
-    when(mockResult.getType()).thenReturn(ResultType.NUMBER);
+    @BeforeEach
+    void setUp() {
+      when(mockExpressionLanguage.parseExpression(TEST_EXPRESSION)).thenReturn(mockExpression);
 
-    // when
-    sutValidator.validate(START_EVENT, mockResultCollector);
+      when(mockExpressionLanguage.evaluateExpression(eq(mockExpression), Mockito.any()))
+          .thenReturn(mockResult);
 
-    // then
-    verify(mockResultCollector)
-        .addError(
-            0,
-            "Expected constant expression of type String for message name 'expression', but was NUMBER");
+      sutValidator = new ProcessMessageStartEventMessageNameValidator(mockExpressionLanguage);
+    }
+
+    @Test
+    void shouldLetValidMessageNameExpressionsPass() {
+      // given
+      when(mockResult.isFailure()).thenReturn(false);
+      when(mockResult.getType()).thenReturn(ResultType.STRING);
+
+      // when
+      sutValidator.validate(START_EVENT, mockResultCollector);
+
+      // then
+      verifyNoInteractions(mockResultCollector);
+    }
+
+    @Test
+    void shouldAddErrorIfEvaluationFailed() {
+      // given
+      when(mockResult.isFailure()).thenReturn(true);
+      when(mockResult.getFailureMessage()).thenReturn("Test failure message");
+
+      // when
+      sutValidator.validate(START_EVENT, mockResultCollector);
+
+      // then
+      verify(mockResultCollector)
+          .addError(
+              0,
+              "Expected constant expression but found 'expression', which could not be evaluated without context: Test failure message");
+    }
+
+    @Test
+    void shouldAddErrorIfEvaluationDoesNotReturnString() {
+      // given
+      when(mockResult.isFailure()).thenReturn(false);
+      when(mockResult.getType()).thenReturn(ResultType.NUMBER);
+
+      // when
+      sutValidator.validate(START_EVENT, mockResultCollector);
+
+      // then
+      verify(mockResultCollector)
+          .addError(
+              0,
+              "Expected constant expression of type String for message name 'expression', but was NUMBER");
+    }
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessMessageStartEventMessageNameValidatorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessMessageStartEventMessageNameValidatorTest.java
@@ -71,7 +71,7 @@ public class ProcessMessageStartEventMessageNameValidatorTest {
   }
 
   @Test
-  public void shoulAddErrorIfEvaluationFailed() {
+  public void shouldAddErrorIfEvaluationFailed() {
     // given
     when(mockResult.isFailure()).thenReturn(true);
     when(mockResult.getFailureMessage()).thenReturn("Test failure message");
@@ -87,7 +87,7 @@ public class ProcessMessageStartEventMessageNameValidatorTest {
   }
 
   @Test
-  public void shoulAddErrorIfEvaluationDoesNotReturnString() {
+  public void shouldAddErrorIfEvaluationDoesNotReturnString() {
     // given
     when(mockResult.isFailure()).thenReturn(false);
     when(mockResult.getType()).thenReturn(ResultType.NUMBER);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessMessageStartEventMessageNameValidatorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessMessageStartEventMessageNameValidatorTest.java
@@ -19,14 +19,14 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ProcessMessageStartEventMessageNameValidatorTest {
 
   private static final String TEST_EXPRESSION = "expression";
@@ -47,7 +47,7 @@ public class ProcessMessageStartEventMessageNameValidatorTest {
 
   ProcessMessageStartEventMessageNameValidator sutValidator;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     when(mockExpressionLanguage.parseExpression(TEST_EXPRESSION)).thenReturn(mockExpression);
 


### PR DESCRIPTION
## Description

* Adds a test that a validation error is generated if the message name is null
* Adds validation logic for message name being null 

## Related issues

closes #9083

<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
