### PR TITLE
Trigger boundary events after an interrupting event subprocess is triggered

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -75,6 +75,7 @@ public final class EngineProcessors {
     final CatchEventBehavior catchEventBehavior =
         new CatchEventBehavior(
             zeebeState,
+            zeebeState.getKeyGenerator(),
             expressionProcessor,
             subscriptionCommandSender,
             writers.state(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
@@ -56,7 +56,7 @@ public final class BpmnEventPublicationBehavior {
     final ElementInstance eventScopeInstance = catchEventTuple.getElementInstance();
     final ExecutableCatchEvent catchEvent = catchEventTuple.getCatchEvent();
 
-    if (eventHandle.canTriggerElement(eventScopeInstance)) {
+    if (eventHandle.canTriggerElement(eventScopeInstance, catchEvent.getId())) {
       eventHandle.activateElement(
           catchEvent, eventScopeInstance.getKey(), eventScopeInstance.getValue());
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -24,9 +24,9 @@ import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.ProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.instance.TimerInstance;
 import io.camunda.zeebe.engine.state.message.ProcessMessageSubscription;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.model.bpmn.util.time.Timer;
 import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
@@ -59,7 +59,8 @@ public final class CatchEventBehavior {
   private final KeyGenerator keyGenerator;
 
   public CatchEventBehavior(
-      final MutableZeebeState zeebeState,
+      final ZeebeState zeebeState,
+      final KeyGenerator keyGenerator,
       final ExpressionProcessor expressionProcessor,
       final SubscriptionCommandSender subscriptionCommandSender,
       final StateWriter stateWriter,
@@ -74,8 +75,7 @@ public final class CatchEventBehavior {
     processMessageSubscriptionState = zeebeState.getProcessMessageSubscriptionState();
     processState = zeebeState.getProcessState();
 
-    keyGenerator = zeebeState.getKeyGenerator();
-
+    this.keyGenerator = keyGenerator;
     this.timerChecker = timerChecker;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -101,7 +101,7 @@ public final class CatchEventBehavior {
    * @param commandWriter the writer for unsubscribe commands
    * @param sideEffects the side effects for unsubscribe actions
    */
-  public void unsubscribeFromEventSubprocesses(
+  public void unsubscribeEventSubprocesses(
       final BpmnElementContext context,
       final TypedCommandWriter commandWriter,
       final SideEffects sideEffects) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -311,14 +311,13 @@ public final class CatchEventBehavior {
         subscription -> {
           final var elementId = subscription.getRecord().getElementIdBuffer();
           if (elementIdFilter.test(elementId)) {
-            return unsubscribeFromMessageEvent(subscription, sideEffects);
-          } else {
-            return true;
+            unsubscribeFromMessageEvent(subscription, sideEffects);
           }
+          return true;
         });
   }
 
-  private boolean unsubscribeFromMessageEvent(
+  private void unsubscribeFromMessageEvent(
       final ProcessMessageSubscription subscription, final SideEffects sideEffects) {
 
     final DirectBuffer messageName = cloneBuffer(subscription.getRecord().getMessageNameBuffer());
@@ -332,8 +331,6 @@ public final class CatchEventBehavior {
         () ->
             sendCloseMessageSubscriptionCommand(
                 subscriptionPartitionId, processInstanceKey, elementInstanceKey, messageName));
-
-    return true;
   }
 
   private boolean sendCloseMessageSubscriptionCommand(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.sched.clock.ActorClock;
 import java.util.List;
+import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
 
 public final class CatchEventBehavior {
@@ -74,13 +75,37 @@ public final class CatchEventBehavior {
     this.timerChecker = timerChecker;
   }
 
+  /**
+   * Unsubscribe from all events in the scope of the context.
+   *
+   * @param context the context to subscript from
+   * @param commandWriter the writer for unsubscribe commands
+   * @param sideEffects the side effects for unsubscribe actions
+   */
   public void unsubscribeFromEvents(
       final BpmnElementContext context,
       final TypedCommandWriter commandWriter,
       final SideEffects sideEffects) {
+    unsubscribeFromEvents(context, commandWriter, sideEffects, elementId -> true);
+  }
 
-    unsubscribeFromTimerEvents(context, commandWriter);
-    unsubscribeFromMessageEvents(context, sideEffects);
+  /**
+   * Unsubscribe from all events in the scope of the context that matches the given filter. Ignore
+   * other event subscriptions that don't match the filter.
+   *
+   * @param context the context to subscript from
+   * @param commandWriter the writer for unsubscribe commands
+   * @param sideEffects the side effects for unsubscribe actions
+   * @param elementIdFilter the filter for events to unsubscribe
+   */
+  public void unsubscribeFromEvents(
+      final BpmnElementContext context,
+      final TypedCommandWriter commandWriter,
+      final SideEffects sideEffects,
+      final Predicate<DirectBuffer> elementIdFilter) {
+
+    unsubscribeFromTimerEvents(context, commandWriter, elementIdFilter);
+    unsubscribeFromMessageEvents(context, sideEffects, elementIdFilter);
   }
 
   /**
@@ -251,9 +276,16 @@ public final class CatchEventBehavior {
   }
 
   private void unsubscribeFromTimerEvents(
-      final BpmnElementContext context, final TypedCommandWriter commandWriter) {
+      final BpmnElementContext context,
+      final TypedCommandWriter commandWriter,
+      final Predicate<DirectBuffer> elementIdFilter) {
     timerInstanceState.forEachTimerForElementInstance(
-        context.getElementInstanceKey(), t -> unsubscribeFromTimerEvent(t, commandWriter));
+        context.getElementInstanceKey(),
+        timer -> {
+          if (elementIdFilter.test(timer.getHandlerNodeId())) {
+            unsubscribeFromTimerEvent(timer, commandWriter);
+          }
+        });
   }
 
   public void unsubscribeFromTimerEvent(
@@ -271,10 +303,19 @@ public final class CatchEventBehavior {
   }
 
   private void unsubscribeFromMessageEvents(
-      final BpmnElementContext context, final SideEffects sideEffects) {
+      final BpmnElementContext context,
+      final SideEffects sideEffects,
+      final Predicate<DirectBuffer> elementIdFilter) {
     processMessageSubscriptionState.visitElementSubscriptions(
         context.getElementInstanceKey(),
-        subscription -> unsubscribeFromMessageEvent(subscription, sideEffects));
+        subscription -> {
+          final var elementId = subscription.getRecord().getElementIdBuffer();
+          if (elementIdFilter.test(elementId)) {
+            return unsubscribeFromMessageEvent(subscription, sideEffects);
+          } else {
+            return true;
+          }
+        });
   }
 
   private boolean unsubscribeFromMessageEvent(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
@@ -58,10 +58,11 @@ public final class EventHandle {
     this.eventTriggerBehavior = eventTriggerBehavior;
   }
 
-  public boolean canTriggerElement(final ElementInstance eventScopeInstance) {
+  public boolean canTriggerElement(
+      final ElementInstance eventScopeInstance, final DirectBuffer elementId) {
     return eventScopeInstance != null
         && eventScopeInstance.isActive()
-        && eventScopeInstanceState.isAcceptingEvent(eventScopeInstance.getKey());
+        && eventScopeInstanceState.canTriggerEvent(eventScopeInstance.getKey(), elementId);
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
@@ -59,9 +59,9 @@ public class EventTriggerBehavior {
         new VariableBehavior(zeebeState.getVariableState(), writers.state(), keyGenerator);
   }
 
-  private void unsubscribeFromEventSubprocesses(final BpmnElementContext context) {
+  private void unsubscribeEventSubprocesses(final BpmnElementContext context) {
     final var sideEffectQueue = new SideEffectQueue();
-    catchEventBehavior.unsubscribeFromEventSubprocesses(context, commandWriter, sideEffectQueue);
+    catchEventBehavior.unsubscribeEventSubprocesses(context, commandWriter, sideEffectQueue);
 
     // side effect can immediately executed, since on restart we not reprocess anymore the commands
     sideEffectQueue.flush();
@@ -98,7 +98,7 @@ public class EventTriggerBehavior {
     }
 
     if (startEvent.interrupting()) {
-      unsubscribeFromEventSubprocesses(flowScopeContext);
+      unsubscribeEventSubprocesses(flowScopeContext);
 
       final var noActiveChildInstances = terminateChildInstances(flowScopeContext);
       if (!noActiveChildInstances) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableActivity.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableActivity.java
@@ -19,6 +19,7 @@ public class ExecutableActivity extends ExecutableFlowNode implements Executable
 
   private final List<ExecutableCatchEvent> catchEvents = new ArrayList<>();
   private final List<DirectBuffer> interruptingIds = new ArrayList<>();
+  private final List<DirectBuffer> boundaryElementIds = new ArrayList<>();
 
   public ExecutableActivity(final String id) {
     super(id);
@@ -28,8 +29,11 @@ public class ExecutableActivity extends ExecutableFlowNode implements Executable
     boundaryEvents.add(boundaryEvent);
     catchEvents.add(boundaryEvent);
 
+    final var boundaryEventElementId = boundaryEvent.getId();
+    boundaryElementIds.add(boundaryEventElementId);
+
     if (boundaryEvent.interrupting()) {
-      interruptingIds.add(boundaryEvent.getId());
+      interruptingIds.add(boundaryEventElementId);
     }
   }
 
@@ -55,6 +59,11 @@ public class ExecutableActivity extends ExecutableFlowNode implements Executable
   @Override
   public Collection<DirectBuffer> getInterruptingElementIds() {
     return interruptingIds;
+  }
+
+  @Override
+  public Collection<DirectBuffer> getBoundaryElementIds() {
+    return boundaryElementIds;
   }
 
   public List<ExecutableBoundaryEvent> getBoundaryEvents() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEventElement.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEventElement.java
@@ -85,6 +85,11 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
     return Collections.singleton(getId());
   }
 
+  @Override
+  public Collection<DirectBuffer> getBoundaryElementIds() {
+    return Collections.emptySet();
+  }
+
   public boolean interrupting() {
     return interrupting;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEventSupplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEventSupplier.java
@@ -14,5 +14,17 @@ import org.agrona.DirectBuffer;
 public interface ExecutableCatchEventSupplier extends ExecutableFlowElement {
   List<ExecutableCatchEvent> getEvents();
 
+  /**
+   * Returns the ids of the containing elements that interrupt the event scope (e.g. interrupting
+   * event subprocesses). An interrupted event scope can not be triggered by other interrupting or
+   * non-interrupting events. But the event scope can still be triggered by boundary events.
+   */
   Collection<DirectBuffer> getInterruptingElementIds();
+
+  /**
+   * Returns the ids of the boundary events. An interrupting boundary event must return its id also
+   * with {@link #getInterruptingElementIds()}. Otherwise, it is handled as non-interrupting
+   * boundary event.
+   */
+  Collection<DirectBuffer> getBoundaryElementIds();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableEventBasedGateway.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableEventBasedGateway.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.deployment.model.element;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import org.agrona.DirectBuffer;
 
@@ -39,5 +40,10 @@ public class ExecutableEventBasedGateway extends ExecutableFlowNode
   @Override
   public Collection<DirectBuffer> getInterruptingElementIds() {
     return eventIds;
+  }
+
+  @Override
+  public Collection<DirectBuffer> getBoundaryElementIds() {
+    return Collections.emptySet();
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -124,8 +124,9 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
       commandControl.reject(
           RejectionType.INVALID_STATE,
           "Expected to find active service task, but was " + serviceTaskInstance);
-    } else if (!eventScopeInstanceState.isAcceptingEvent(
-        foundCatchEvent.get().getElementInstance().getKey())) {
+    } else if (!eventScopeInstanceState.canTriggerEvent(
+        foundCatchEvent.get().getElementInstance().getKey(),
+        foundCatchEvent.get().getCatchEvent().getId())) {
       commandControl.reject(
           RejectionType.INVALID_STATE,
           "Expected to find event scope that is accepting events, but was "

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -97,7 +97,9 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
 
     } else {
       final var elementInstance = elementInstanceState.getInstance(elementInstanceKey);
-      final var canTriggerElement = eventHandle.canTriggerElement(elementInstance);
+      final var canTriggerElement =
+          eventHandle.canTriggerElement(
+              elementInstance, subscription.getRecord().getElementIdBuffer());
 
       if (!canTriggerElement) {
         rejectCommand(command, RejectionType.INVALID_STATE, NO_EVENT_OCCURRED_MESSAGE);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
@@ -110,7 +110,7 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
           processDefinitionKey, processInstanceKey, timer.getTargetElementIdBuffer(), NO_VARIABLES);
     } else {
       final var elementInstance = elementInstanceState.getInstance(elementInstanceKey);
-      if (!eventHandle.canTriggerElement(elementInstance)) {
+      if (!eventHandle.canTriggerElement(elementInstance, timer.getTargetElementIdBuffer())) {
         rejectNoActiveTimer(record);
         return;
       }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
@@ -239,18 +239,20 @@ final class ProcessInstanceElementActivatingApplier
             elementRecord.getElementIdBuffer(),
             flowElementClass);
 
-    if (flowElement instanceof ExecutableCatchEventSupplier) {
-      final var eventSupplier = (ExecutableCatchEventSupplier) flowElement;
+    if (flowElement instanceof final ExecutableCatchEventSupplier eventSupplier) {
 
       final var hasEvents = !eventSupplier.getEvents().isEmpty();
       if (hasEvents
           || flowElement instanceof ExecutableJobWorkerElement
           || flowElement instanceof ExecutableCallActivity) {
         eventScopeInstanceState.createInstance(
-            elementInstanceKey, eventSupplier.getInterruptingElementIds());
+            elementInstanceKey,
+            eventSupplier.getInterruptingElementIds(),
+            eventSupplier.getBoundaryElementIds());
       }
     } else if (flowElement instanceof ExecutableJobWorkerElement) {
-      eventScopeInstanceState.createInstance(elementInstanceKey, Collections.emptyList());
+      eventScopeInstanceState.createInstance(
+          elementInstanceKey, Collections.emptySet(), Collections.emptySet());
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
@@ -251,6 +251,7 @@ final class ProcessInstanceElementActivatingApplier
             eventSupplier.getBoundaryElementIds());
       }
     } else if (flowElement instanceof ExecutableJobWorkerElement) {
+      // job worker elements without events (e.g. message throw events)
       eventScopeInstanceState.createInstance(
           elementInstanceKey, Collections.emptySet(), Collections.emptySet());
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/EventScopeInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/EventScopeInstanceState.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.state.instance.EventScopeInstance;
 import io.camunda.zeebe.engine.state.instance.EventTrigger;
+import org.agrona.DirectBuffer;
 
 public interface EventScopeInstanceState {
 
@@ -30,8 +31,11 @@ public interface EventScopeInstanceState {
   EventTrigger peekEventTrigger(long eventScopeKey);
 
   /**
+   * Checks if the event scope can be triggered for the given event.
+   *
    * @param eventScopeKey the key of the event scope the event is triggered in
-   * @return true if the event can be accepted
+   * @param elementId the element id of the event that is triggered
+   * @return {@code true} if the event can be triggered, otherwise {@code false}
    */
-  boolean isAcceptingEvent(long eventScopeKey);
+  boolean canTriggerEvent(long eventScopeKey, final DirectBuffer elementId);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
@@ -110,7 +110,6 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
       final var isBoundaryElementId = instance.isBoundaryElementId(elementId);
 
       if (isInterruptingElementId) {
-        // only accept boundary events after an interrupting event is triggered
         instance.setInterrupted(true);
       }
       if (isBoundaryElementId && isInterruptingElementId) {
@@ -168,6 +167,12 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
     return canTriggerEvent(instance, elementId);
   }
 
+  /**
+   * An event scope can be triggered if no interrupting event was triggered (i.e. it is not
+   * interrupted). If an interrupting event was triggered then no other event can be triggered,
+   * except for boundary events. If an interrupting boundary event was triggered then no other
+   * events, including boundary events, can be triggered (i.e. it is not accepting any events).
+   */
   private boolean canTriggerEvent(final EventScopeInstance instance, final DirectBuffer elementId) {
     return instance != null
         && instance.isAccepting()

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
@@ -49,13 +49,20 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
 
   @Override
   public void createInstance(
-      final long eventScopeKey, final Collection<DirectBuffer> interruptingIds) {
+      final long eventScopeKey,
+      final Collection<DirectBuffer> interruptingElementIds,
+      final Collection<DirectBuffer> boundaryElementIds) {
     eventScopeInstance.reset();
 
     this.eventScopeKey.wrapLong(eventScopeKey);
     eventScopeInstance.setAccepting(true);
-    for (final DirectBuffer interruptingId : interruptingIds) {
-      eventScopeInstance.addInterrupting(interruptingId);
+    eventScopeInstance.setInterrupted(false);
+
+    for (final DirectBuffer elementId : interruptingElementIds) {
+      eventScopeInstance.addInterruptingElementId(elementId);
+    }
+    for (final DirectBuffer elementId : boundaryElementIds) {
+      eventScopeInstance.addBoundaryElementId(elementId);
     }
 
     eventScopeInstanceColumnFamily.insert(this.eventScopeKey, eventScopeInstance);
@@ -98,11 +105,19 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
     this.eventScopeKey.wrapLong(eventScopeKey);
     final EventScopeInstance instance = eventScopeInstanceColumnFamily.get(this.eventScopeKey);
 
-    if (isAcceptingEvent(instance)) {
-      if (instance.isInterrupting(elementId)) {
-        instance.setAccepting(false);
-        eventScopeInstanceColumnFamily.update(this.eventScopeKey, instance);
+    if (canTriggerEvent(instance, elementId)) {
+      final var isInterruptingElementId = instance.isInterruptingElementId(elementId);
+      final var isBoundaryElementId = instance.isBoundaryElementId(elementId);
+
+      if (isInterruptingElementId) {
+        // only accept boundary events after an interrupting event is triggered
+        instance.setInterrupted(true);
       }
+      if (isBoundaryElementId && isInterruptingElementId) {
+        // don't accept other events after an interrupting boundary is triggered
+        instance.setAccepting(false);
+      }
+      eventScopeInstanceColumnFamily.update(this.eventScopeKey, instance);
 
       createTrigger(eventScopeKey, eventKey, elementId, variables);
     }
@@ -146,15 +161,17 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
   }
 
   @Override
-  public boolean isAcceptingEvent(final long eventScopeKey) {
+  public boolean canTriggerEvent(final long eventScopeKey, final DirectBuffer elementId) {
     this.eventScopeKey.wrapLong(eventScopeKey);
     final EventScopeInstance instance = eventScopeInstanceColumnFamily.get(this.eventScopeKey);
 
-    return isAcceptingEvent(instance);
+    return canTriggerEvent(instance, elementId);
   }
 
-  private boolean isAcceptingEvent(final EventScopeInstance instance) {
-    return instance != null && instance.isAccepting();
+  private boolean canTriggerEvent(final EventScopeInstance instance, final DirectBuffer elementId) {
+    return instance != null
+        && instance.isAccepting()
+        && (!instance.isInterrupted() || instance.isBoundaryElementId(elementId));
   }
 
   private void createTrigger(

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
@@ -48,30 +48,6 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
   }
 
   @Override
-  public void shutdownInstance(final long eventScopeKey) {
-    final EventScopeInstance instance = getInstance(eventScopeKey);
-    if (instance != null) {
-      this.eventScopeKey.wrapLong(eventScopeKey);
-      instance.setAccepting(false);
-      eventScopeInstanceColumnFamily.update(this.eventScopeKey, instance);
-    }
-  }
-
-  @Override
-  public boolean createIfNotExists(
-      final long eventScopeKey, final Collection<DirectBuffer> interruptingIds) {
-    this.eventScopeKey.wrapLong(eventScopeKey);
-    boolean wasCreated = false;
-
-    if (!eventScopeInstanceColumnFamily.exists(this.eventScopeKey)) {
-      createInstance(eventScopeKey, interruptingIds);
-      wasCreated = true;
-    }
-
-    return wasCreated;
-  }
-
-  @Override
   public void createInstance(
       final long eventScopeKey, final Collection<DirectBuffer> interruptingIds) {
     eventScopeInstance.reset();

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/EventScopeInstance.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/EventScopeInstance.java
@@ -20,11 +20,19 @@ import org.agrona.concurrent.UnsafeBuffer;
 public final class EventScopeInstance extends UnpackedObject implements DbValue {
 
   private final BooleanProperty acceptingProp = new BooleanProperty("accepting");
-  private final ArrayProperty<StringValue> interruptingProp =
+  private final BooleanProperty interruptedProp = new BooleanProperty("interrupted", false);
+
+  private final ArrayProperty<StringValue> interruptingElementIdsProp =
       new ArrayProperty<>("interrupting", new StringValue());
 
+  private final ArrayProperty<StringValue> boundaryElementIdsProp =
+      new ArrayProperty<>("boundaryElementIds", new StringValue());
+
   public EventScopeInstance() {
-    declareProperty(acceptingProp).declareProperty(interruptingProp);
+    declareProperty(acceptingProp)
+        .declareProperty(interruptingElementIdsProp)
+        .declareProperty(boundaryElementIdsProp)
+        .declareProperty(interruptedProp);
   }
 
   public EventScopeInstance(final EventScopeInstance other) {
@@ -45,14 +53,28 @@ public final class EventScopeInstance extends UnpackedObject implements DbValue 
     return this;
   }
 
-  public EventScopeInstance addInterrupting(final DirectBuffer elementId) {
-    interruptingProp.add().wrap(elementId);
+  public boolean isInterrupted() {
+    return interruptedProp.getValue();
+  }
+
+  public EventScopeInstance setInterrupted(final boolean interrupted) {
+    interruptedProp.setValue(interrupted);
     return this;
   }
 
-  public boolean isInterrupting(final DirectBuffer elementId) {
-    for (final StringValue stringValue : interruptingProp) {
-      if (stringValue.getValue().equals(elementId)) {
+  public EventScopeInstance addInterruptingElementId(final DirectBuffer elementId) {
+    interruptingElementIdsProp.add().wrap(elementId);
+    return this;
+  }
+
+  public EventScopeInstance addBoundaryElementId(final DirectBuffer elementId) {
+    boundaryElementIdsProp.add().wrap(elementId);
+    return this;
+  }
+
+  public boolean isInterruptingElementId(final DirectBuffer elementId) {
+    for (final StringValue interruptingElementId : interruptingElementIdsProp) {
+      if (interruptingElementId.getValue().equals(elementId)) {
         return true;
       }
     }
@@ -60,9 +82,19 @@ public final class EventScopeInstance extends UnpackedObject implements DbValue 
     return false;
   }
 
+  public boolean isBoundaryElementId(final DirectBuffer elementId) {
+    for (final StringValue boundaryElementId : boundaryElementIdsProp) {
+      if (boundaryElementId.getValue().equals(elementId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(acceptingProp, interruptingProp);
+    return Objects.hash(
+        acceptingProp, interruptingElementIdsProp, boundaryElementIdsProp, interruptedProp);
   }
 
   @Override
@@ -75,6 +107,8 @@ public final class EventScopeInstance extends UnpackedObject implements DbValue 
     }
     final EventScopeInstance that = (EventScopeInstance) o;
     return Objects.equals(acceptingProp, that.acceptingProp)
-        && Objects.equals(interruptingProp, that.interruptingProp);
+        && Objects.equals(interruptingElementIdsProp, that.interruptingElementIdsProp)
+        && Objects.equals(boundaryElementIdsProp, that.boundaryElementIdsProp)
+        && Objects.equals(interruptedProp, that.interruptedProp);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableEventScopeInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableEventScopeInstanceState.java
@@ -15,12 +15,20 @@ import org.agrona.DirectBuffer;
 public interface MutableEventScopeInstanceState extends EventScopeInstanceState {
 
   /**
-   * Creates a new event scope instance in the state
+   * Creates a new event scope instance in the state. The event scope is interrupted if one of the
+   * interrupting elements is triggered. An interrupted event scope can not be triggered by other
+   * interrupting or non-interrupting events, except boundary events. After a interrupting boundary
+   * event is triggered, no other event, including boundary events, can be triggered for the event
+   * scope.
    *
    * @param eventScopeKey the event scope key
-   * @param interruptingIds list of element IDs which should set accepting to false
+   * @param interruptingElementIds element IDs that interrupt the event scope
+   * @param boundaryElementIds element IDs of boundary events
    */
-  void createInstance(long eventScopeKey, Collection<DirectBuffer> interruptingIds);
+  void createInstance(
+      long eventScopeKey,
+      Collection<DirectBuffer> interruptingElementIds,
+      Collection<DirectBuffer> boundaryElementIds);
 
   /**
    * Delete an event scope from the state. Does not fail in case the scope does not exist.
@@ -40,7 +48,9 @@ public interface MutableEventScopeInstanceState extends EventScopeInstanceState 
 
   /**
    * Creates a new event trigger for the given event scope. Ignores the trigger if the event scope
-   * is not accepting anymore or doesn't exist.
+   * doesn't exist or if the event can be triggered in the scope (e.g. the scope is interrupted).
+   * Use {@link #canTriggerEvent(long, DirectBuffer)} to check if the event can be triggered before
+   * calling this method.
    *
    * @param eventScopeKey the key of the event scope the event is triggered in
    * @param eventKey the key of the event record (used for ordering)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableEventScopeInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableEventScopeInstanceState.java
@@ -15,22 +15,6 @@ import org.agrona.DirectBuffer;
 public interface MutableEventScopeInstanceState extends EventScopeInstanceState {
 
   /**
-   * If the scope exists, sets its accepting property to false.
-   *
-   * @param eventScopeKey the event scope key
-   */
-  void shutdownInstance(long eventScopeKey);
-
-  /**
-   * Creates a new event scope instance in the state
-   *
-   * @param eventScopeKey the event scope key
-   * @param interruptingIds list of element IDs which should set accepting to false
-   * @return whether the scope was created or not
-   */
-  boolean createIfNotExists(long eventScopeKey, Collection<DirectBuffer> interruptingIds);
-
-  /**
    * Creates a new event scope instance in the state
    *
    * @param eventScopeKey the event scope key

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
@@ -48,6 +49,7 @@ public class InterruptingEventSubprocessTest {
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
   private static final String PROCESS_ID = "proc";
   private static final String JOB_TYPE = "type";
+  private static final String MESSAGE_CORRELATION_KEY = "123";
 
   private static String messageName;
 
@@ -90,7 +92,11 @@ public class InterruptingEventSubprocessTest {
                   .withProcessInstanceKey(key)
                   .withMessageName(messageName)
                   .await();
-              ENGINE.message().withName(messageName).withCorrelationKey("123").publish();
+              ENGINE
+                  .message()
+                  .withName(messageName)
+                  .withCorrelationKey(MESSAGE_CORRELATION_KEY)
+                  .publish();
             })
       },
       {
@@ -316,7 +322,7 @@ public class InterruptingEventSubprocessTest {
     final Record<JobBatchRecordValue> job = ENGINE.jobs().withType(helper.getJobType()).activate();
     final Map<String, Object> jobVariables =
         job.getValue().getJobs().iterator().next().getVariables();
-    assertThat(jobVariables).containsOnly(Map.entry("key", 123));
+    assertThat(jobVariables).containsOnly(Map.entry("key", MESSAGE_CORRELATION_KEY));
   }
 
   @Test
@@ -393,6 +399,240 @@ public class InterruptingEventSubprocessTest {
         .isPresent();
   }
 
+  @Test
+  public void shouldNotCloseEventSubscriptionsOfBoundaryEvent() {
+    // given
+    final Consumer<EventSubProcessBuilder> eventSubprocess =
+        eventSubProcess ->
+            builder
+                .apply(eventSubProcess.startEvent().interrupting(true))
+                .serviceTask("event_sub_task", t -> t.zeebeJobType("event_sub_task"));
+
+    final Consumer<SubProcessBuilder> embeddedSubprocess =
+        subProcess ->
+            subProcess
+                .embeddedSubProcess()
+                .eventSubProcess("event_sub_proc", eventSubprocess)
+                .startEvent()
+                .serviceTask("sub_task", t -> t.zeebeJobType(JOB_TYPE))
+                .endEvent();
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess("sub_proc", embeddedSubprocess)
+            .boundaryEvent()
+            .message(m -> m.name("boundary").zeebeCorrelationKeyExpression("key"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("key", MESSAGE_CORRELATION_KEY)
+            .create();
+
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(JOB_TYPE)
+        .await();
+
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withMessageName("boundary")
+        .await();
+
+    // when
+    triggerEventSubprocess.accept(processInstanceKey);
+
+    // then
+    final var serviceTaskActivated =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId("event_sub_task")
+            .getFirst();
+
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getPosition() >= serviceTaskActivated.getPosition())
+                .processMessageSubscriptionRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("boundary"))
+        .extracting(Record::getIntent)
+        .describedAs("Expected the boundary event subscription to be open")
+        .contains(ProcessMessageSubscriptionIntent.CREATED)
+        .doesNotContain(ProcessMessageSubscriptionIntent.DELETED);
+  }
+
+  @Test
+  public void shouldTriggerInterruptingEventSubprocessAndInterruptingBoundaryEvent() {
+    // given
+    final var boundaryEventMessageName = "boundary-" + helper.getMessageName();
+
+    final Consumer<EventSubProcessBuilder> eventSubprocess =
+        eventSubProcess ->
+            builder
+                .apply(eventSubProcess.startEvent().interrupting(true))
+                .serviceTask("event_sub_task", t -> t.zeebeJobType("event_sub_task"));
+
+    final Consumer<SubProcessBuilder> embeddedSubprocess =
+        subProcess ->
+            subProcess
+                .embeddedSubProcess()
+                .eventSubProcess("event_sub_proc", eventSubprocess)
+                .startEvent()
+                .serviceTask("sub_task", t -> t.zeebeJobType(JOB_TYPE))
+                .endEvent();
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess("sub_proc", embeddedSubprocess)
+            .boundaryEvent()
+            .cancelActivity(true)
+            .message(m -> m.name(boundaryEventMessageName).zeebeCorrelationKeyExpression("key"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("key", MESSAGE_CORRELATION_KEY)
+            .create();
+
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(JOB_TYPE)
+        .await();
+
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withMessageName(boundaryEventMessageName)
+        .await();
+
+    // when
+    triggerEventSubprocess.accept(processInstanceKey);
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.SERVICE_TASK)
+        .withElementId("event_sub_task")
+        .await();
+
+    ENGINE
+        .message()
+        .withName(boundaryEventMessageName)
+        .withCorrelationKey(MESSAGE_CORRELATION_KEY)
+        .publish();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .describedAs("Expected the boundary event to be triggered")
+        .containsSubsequence(
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldTriggerInterruptingEventSubprocessAndNonInterruptingBoundaryEvent() {
+    // given
+    final var boundaryEventMessageName = "boundary-" + helper.getMessageName();
+
+    final Consumer<EventSubProcessBuilder> eventSubprocess =
+        eventSubProcess ->
+            builder
+                .apply(eventSubProcess.startEvent().interrupting(true))
+                .serviceTask("event_sub_task", t -> t.zeebeJobType("event_sub_task"));
+
+    final Consumer<SubProcessBuilder> embeddedSubprocess =
+        subProcess ->
+            subProcess
+                .embeddedSubProcess()
+                .eventSubProcess("event_sub_proc", eventSubprocess)
+                .startEvent()
+                .serviceTask("sub_task", t -> t.zeebeJobType(JOB_TYPE))
+                .endEvent();
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess("sub_proc", embeddedSubprocess)
+            .boundaryEvent()
+            .cancelActivity(false)
+            .message(m -> m.name(boundaryEventMessageName).zeebeCorrelationKeyExpression("key"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("key", MESSAGE_CORRELATION_KEY)
+            .create();
+
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(JOB_TYPE)
+        .await();
+
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withMessageName(boundaryEventMessageName)
+        .await();
+
+    // when
+    triggerEventSubprocess.accept(processInstanceKey);
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.SERVICE_TASK)
+        .withElementId("event_sub_task")
+        .await();
+
+    ENGINE
+        .message()
+        .withName(boundaryEventMessageName)
+        .withCorrelationKey(MESSAGE_CORRELATION_KEY)
+        .publish();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.BOUNDARY_EVENT)
+        .await();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("event_sub_task").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
   private static void assertEventSubprocessLifecycle(final long processInstanceKey) {
     final List<Record<ProcessInstanceRecordValue>> events =
         RecordingExporter.processInstanceRecords()
@@ -442,7 +682,7 @@ public class InterruptingEventSubprocessTest {
         ENGINE
             .processInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariables(Map.of("key", 123))
+            .withVariables(Map.of("key", MESSAGE_CORRELATION_KEY))
             .create();
     assertThat(
             RecordingExporter.jobRecords(JobIntent.CREATED)

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/EventScopeInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/EventScopeInstanceStateTest.java
@@ -12,31 +12,31 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.engine.util.ZeebeStateRule;
+import io.camunda.zeebe.engine.util.ZeebeStateExtension;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
 import org.agrona.DirectBuffer;
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ZeebeStateExtension.class)
 public final class EventScopeInstanceStateTest {
 
-  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+  private MutableZeebeState zeebeState;
 
   private MutableEventScopeInstanceState state;
 
-  @Before
-  public void setUp() {
-    final MutableZeebeState zeebeState = stateRule.getZeebeState();
+  @BeforeEach
+  void setUp() {
     state = zeebeState.getEventScopeInstanceState();
   }
 
   @Test
-  public void shouldCreateInterruptingEventScopeInstance() {
+  void shouldCreateInterruptingEventScopeInstance() {
     // given
     final long key = 123;
 
@@ -50,7 +50,7 @@ public final class EventScopeInstanceStateTest {
   }
 
   @Test
-  public void shouldCreateNonInterruptingEventScopeInstance() {
+  void shouldCreateNonInterruptingEventScopeInstance() {
     // given
     final long key = 123;
 
@@ -64,7 +64,7 @@ public final class EventScopeInstanceStateTest {
   }
 
   @Test
-  public void shouldTriggerInterruptingEventScopeInstance() {
+  void shouldTriggerInterruptingEventScopeInstance() {
     // given
     final long key = 123;
     final long eventKey = 456;
@@ -83,7 +83,7 @@ public final class EventScopeInstanceStateTest {
   }
 
   @Test
-  public void shouldTriggerInterruptingEventScopeInstanceOnlyOnce() {
+  void shouldTriggerInterruptingEventScopeInstanceOnlyOnce() {
     // given
     final long key = 123;
     final long eventKey1 = 456;
@@ -106,7 +106,7 @@ public final class EventScopeInstanceStateTest {
   }
 
   @Test
-  public void shouldTriggerNonInterruptingEventScopeInstanceMultipleTimes() {
+  void shouldTriggerNonInterruptingEventScopeInstanceMultipleTimes() {
     // given
     final long key = 123;
     final long eventKey1 = 456;
@@ -130,7 +130,7 @@ public final class EventScopeInstanceStateTest {
   }
 
   @Test
-  public void shouldTriggerStartEventForNonExistingEventScope() {
+  void shouldTriggerStartEventForNonExistingEventScope() {
     // given
     final long scopeKey = 123;
     final EventTrigger eventTrigger = createEventTrigger();
@@ -143,7 +143,7 @@ public final class EventScopeInstanceStateTest {
   }
 
   @Test
-  public void shouldPeekEventTrigger() {
+  void shouldPeekEventTrigger() {
     // given
     final long key = 123;
     final EventTrigger eventTrigger = createEventTrigger();
@@ -158,7 +158,7 @@ public final class EventScopeInstanceStateTest {
   }
 
   @Test
-  public void shouldPollEventTrigger() {
+  void shouldPollEventTrigger() {
     // given
     final long key = 123;
     final EventTrigger eventTrigger1 = createEventTrigger();
@@ -176,7 +176,7 @@ public final class EventScopeInstanceStateTest {
   }
 
   @Test
-  public void shouldPollStartEventTrigger() {
+  void shouldPollStartEventTrigger() {
     // given
     final long scopeKey = 123;
     final EventTrigger eventTrigger1 = createEventTrigger();
@@ -193,7 +193,7 @@ public final class EventScopeInstanceStateTest {
   }
 
   @Test
-  public void shouldDeleteTrigger() {
+  void shouldDeleteTrigger() {
     // given
     final long key = 123;
     final long eventKey = 456;
@@ -209,7 +209,7 @@ public final class EventScopeInstanceStateTest {
   }
 
   @Test
-  public void shouldDeleteStartEventTrigger() {
+  void shouldDeleteStartEventTrigger() {
     // given
     final long scopeKey = 123;
     final EventTrigger eventTrigger1 = createEventTrigger();
@@ -223,7 +223,7 @@ public final class EventScopeInstanceStateTest {
   }
 
   @Test
-  public void shouldDeleteEventScopeAndTriggers() {
+  void shouldDeleteEventScopeAndTriggers() {
     // given
     final long key = 123;
 
@@ -241,7 +241,7 @@ public final class EventScopeInstanceStateTest {
   }
 
   @Test
-  public void shouldDeleteStartEventTriggerOnDeletionOfInstance() {
+  void shouldDeleteStartEventTriggerOnDeletionOfInstance() {
     // given
     final long scopeKey = 123;
     final EventTrigger eventTrigger1 = createEventTrigger();
@@ -255,7 +255,7 @@ public final class EventScopeInstanceStateTest {
   }
 
   @Test
-  public void shouldNotFailOnDeletionOfNonExistingInstance() {
+  void shouldNotFailOnDeletionOfNonExistingInstance() {
     // given
     final long key = 123;
 
@@ -264,7 +264,7 @@ public final class EventScopeInstanceStateTest {
   }
 
   @Test
-  public void shouldResetElementInstance() {
+  void shouldResetElementInstance() {
     // given
     final long firstKey = 123;
     final long secondKey = 345;

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/EventScopeInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/EventScopeInstanceStateTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.engine.util.ZeebeStateRule;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Set;
 import java.util.UUID;
 import org.agrona.DirectBuffer;
 import org.assertj.core.api.Assertions;
@@ -40,7 +41,7 @@ public final class EventScopeInstanceStateTest {
     final long key = 123;
 
     // when
-    state.createIfNotExists(key, Collections.singleton(wrapString("foo")));
+    state.createInstance(key, Collections.singleton(wrapString("foo")), Set.of());
 
     // then
     final EventScopeInstance instance = state.getInstance(key);
@@ -54,7 +55,7 @@ public final class EventScopeInstanceStateTest {
     final long key = 123;
 
     // when
-    state.createIfNotExists(key, Collections.singleton(wrapString("foo")));
+    state.createInstance(key, Collections.singleton(wrapString("foo")), Set.of());
 
     // then
     final EventScopeInstance instance = state.getInstance(key);
@@ -69,7 +70,7 @@ public final class EventScopeInstanceStateTest {
     final long eventKey = 456;
     final EventTrigger eventTrigger = createEventTrigger();
 
-    state.createIfNotExists(key, Collections.singleton(eventTrigger.getElementId()));
+    state.createInstance(key, Collections.singleton(eventTrigger.getElementId()), Set.of());
 
     // when
     triggerEvent(key, eventKey, eventTrigger);
@@ -90,7 +91,7 @@ public final class EventScopeInstanceStateTest {
     final long eventKey2 = 789;
     final EventTrigger eventTrigger2 = createEventTrigger();
 
-    state.createIfNotExists(key, Collections.singleton(eventTrigger1.getElementId()));
+    state.createInstance(key, Collections.singleton(eventTrigger1.getElementId()), Set.of());
 
     // when
     triggerEvent(key, eventKey1, eventTrigger1);
@@ -113,7 +114,7 @@ public final class EventScopeInstanceStateTest {
     final long eventKey2 = 789;
     final EventTrigger eventTrigger2 = createEventTrigger();
 
-    state.createIfNotExists(key, Collections.emptyList());
+    state.createInstance(key, Collections.emptyList(), Set.of());
 
     // when
     triggerEvent(key, eventKey1, eventTrigger1);
@@ -148,7 +149,7 @@ public final class EventScopeInstanceStateTest {
     final EventTrigger eventTrigger = createEventTrigger();
 
     // when
-    state.createIfNotExists(key, Collections.emptyList());
+    state.createInstance(key, Collections.emptyList(), Set.of());
     triggerEvent(key, 1, eventTrigger);
 
     // then
@@ -164,7 +165,7 @@ public final class EventScopeInstanceStateTest {
     final EventTrigger eventTrigger2 = createEventTrigger();
 
     // when
-    state.createIfNotExists(key, Collections.emptyList());
+    state.createInstance(key, Collections.emptyList(), Set.of());
     triggerEvent(key, 1, eventTrigger1);
     triggerEvent(key, 2, eventTrigger2);
 
@@ -197,7 +198,7 @@ public final class EventScopeInstanceStateTest {
     final long key = 123;
     final long eventKey = 456;
 
-    state.createIfNotExists(key, Collections.emptyList());
+    state.createInstance(key, Collections.emptyList(), Set.of());
     triggerEvent(key, eventKey, createEventTrigger());
 
     // when
@@ -226,7 +227,7 @@ public final class EventScopeInstanceStateTest {
     // given
     final long key = 123;
 
-    state.createIfNotExists(key, Collections.emptyList());
+    state.createInstance(key, Collections.emptyList(), Set.of());
     triggerEvent(123, 1, createEventTrigger());
     triggerEvent(123, 2, createEventTrigger());
     triggerEvent(123, 3, createEventTrigger());
@@ -263,33 +264,6 @@ public final class EventScopeInstanceStateTest {
   }
 
   @Test
-  public void shouldShutdownInstance() {
-    // given
-    final long key = 123;
-    state.createIfNotExists(key, Collections.singleton(wrapString("foo")));
-
-    // when
-    state.shutdownInstance(key);
-
-    // then
-    final EventScopeInstance instance = state.getInstance(key);
-    Assertions.assertThat(instance.isAccepting()).isFalse();
-  }
-
-  @Test
-  public void shouldNotCreateInstanceIfTryingToShutdownNonExistentOne() {
-    // given
-    final long key = 123;
-
-    // when
-    state.shutdownInstance(key);
-
-    // then
-    final EventScopeInstance instance = state.getInstance(key);
-    Assertions.assertThat(instance).isNull();
-  }
-
-  @Test
   public void shouldResetElementInstance() {
     // given
     final long firstKey = 123;
@@ -298,8 +272,8 @@ public final class EventScopeInstanceStateTest {
     final Collection<DirectBuffer> firstIds = Collections.singletonList(firstId);
 
     // when
-    state.createIfNotExists(firstKey, firstIds);
-    state.createIfNotExists(secondKey, Collections.emptyList());
+    state.createInstance(firstKey, firstIds, Set.of());
+    state.createInstance(secondKey, Collections.emptyList(), Set.of());
 
     // then
     Assertions.assertThat(state.getInstance(firstKey).isInterrupting(firstId)).isTrue();

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -86,4 +86,10 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
     return new MessageSubscriptionRecordStream(
         filter(r -> r.getValueType() == ValueType.MESSAGE_SUBSCRIPTION).map(Record.class::cast));
   }
+
+  public ProcessMessageSubscriptionRecordStream processMessageSubscriptionRecords() {
+    return new ProcessMessageSubscriptionRecordStream(
+        filter(r -> r.getValueType() == ValueType.PROCESS_MESSAGE_SUBSCRIPTION)
+            .map(Record.class::cast));
+  }
 }


### PR DESCRIPTION
## Description

Fixing the issue that boundary events can't be triggered after an interrupting event subprocess is triggered on the scope. 

Solve the issue by:
* avoid that event subscriptions of boundary event are removed when an interrupting event scope is triggered
  * introduce a filter when removing the event subscriptions
  * filter by event subprocesses and ignore other event subscriptions
* extend the event scope instance state to distinguish interrupting event subscriptions from boundary events
  * add the property `boundaryElementIds` for event scopes to distinguish boundary events from other events in the scope 
  * add the property `interrupted` for event scopes to mark if an interrupting event (subprocess) is triggered
  * if the event scope is interrupted then no other interrupting or non-interrupting events can be triggered
  * only boundary events can be triggered for an interrupted event scope
  * if an interrupting boundary event is triggered then the event scope doesn't accept any other event 

Maintenance:
* remove methods from the event scope state that are not used in production code
* migrate the event scope state test to JUnit 5       

## Related issues

closes #6874 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
