### PR TITLE
Support running `mvn spotless:apply` for convenience

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -139,6 +139,11 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

When the spotless check fails, it recommends running `mvn spotless:apply` to automatically the formatting. However, if you try to run this locally you'll be greeted by the following message:

> [ERROR] No plugin found for prefix 'spotless' in the current project and in the plugin groups [org.apache.maven.plugins, org.codehaus.mojo] available from the repositories [local (/Users/korthout/.m2/repository), central (https://repo.maven.apache.org/maven2)] -> [Help 1]

The 'spotless' prefix is not available, because the first project that is run, is not the root-project but the zeebe-bom. And the zeebe-bom project does not have knowledge of the spotless plugin in its build plugins.

This PR fixes this by adding the spotless plugin to the zeebe-bom's build plugins. Adding the plugin like this to the build doesn't do anything else except register the plugin for usage, because no executions are specified. The executions are still controlled by the profiles defined in the parent-pom.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9117

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.
