### PR TITLE
ci: test the go client

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,6 +205,6 @@ jobs:
           cache: 'maven'
       - run: mvn -T1C -B -DskipChecks -DskipTests install
       - run: docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t camunda/zeebe:current-test .
-      - run: cd clients/go
       - run: go test -mod=vendor -v ./...
+        working-directory: clients/go
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,4 +190,21 @@ jobs:
           name: Smoke test results for ${{ matrix.os }}
           path: "**/target/failsafe-reports/"
           retention-days: 7
+  go-client:
+    name: Go client tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.15"
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+      - run: mvn -T1C -B -DskipChecks -DskipTests install
+      - run: docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t camunda/zeebe:current-test .
+      - run: cd clients/go
+      - run: go test -mod=vendor -v ./...
 


### PR DESCRIPTION
Adds another job to our test workflow that runs tests for the Go client. In Jenkins we used gotestsum to generate JUnit reports but since we don't do anything with test reports yet, I've left that part out. Container logs are printed out on test failure.

closes #9128 