### PR TITLE
Do not log health status unnecessarily

### DIFF
--- a/util/src/main/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitor.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitor.java
@@ -105,7 +105,7 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
     final var previousReport = healthReport;
     healthReport = calculateStatus();
 
-    if (previousReport == healthReport) {
+    if (previousReport.equals(healthReport)) {
       return;
     }
 

--- a/util/src/main/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitor.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitor.java
@@ -110,21 +110,10 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
     }
 
     switch (healthReport.getStatus()) {
-      case HEALTHY:
-        failureListeners.forEach(FailureListener::onRecovered);
-        break;
-
-      case UNHEALTHY:
-        failureListeners.forEach((l) -> l.onFailure(healthReport));
-        break;
-
-      case DEAD:
-        failureListeners.forEach((l) -> l.onUnrecoverableFailure(healthReport));
-        break;
-
-      default:
-        log.warn("Unknown health status {}", healthReport);
-        break;
+      case HEALTHY -> failureListeners.forEach(FailureListener::onRecovered);
+      case UNHEALTHY -> failureListeners.forEach(l -> l.onFailure(healthReport));
+      case DEAD -> failureListeners.forEach(l -> l.onUnrecoverableFailure(healthReport));
+      default -> log.warn("Unknown health status {}", healthReport);
     }
 
     logComponentStatus(healthReport);

--- a/util/src/main/java/io/camunda/zeebe/util/health/HealthIssue.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/HealthIssue.java
@@ -11,17 +11,7 @@ package io.camunda.zeebe.util.health;
  * A health issue contains information about the cause for unhealthy/dead components. It can either
  * be a string message, a {@link Throwable} or another {@link HealthReport}.
  */
-public final class HealthIssue {
-
-  private final String message;
-  private final Throwable throwable;
-  private final HealthReport cause;
-
-  private HealthIssue(final String message, final Throwable throwable, final HealthReport cause) {
-    this.message = message;
-    this.throwable = throwable;
-    this.cause = cause;
-  }
+public record HealthIssue(String message, Throwable throwable, HealthReport cause) {
 
   public static HealthIssue of(final String message) {
     return new HealthIssue(message, null, null);
@@ -33,31 +23,5 @@ public final class HealthIssue {
 
   public static HealthIssue of(final HealthReport cause) {
     return new HealthIssue(null, null, cause);
-  }
-
-  @Override
-  public String toString() {
-    if (cause != null) {
-      return cause.toString();
-    }
-    if (message != null) {
-      return "'" + message + "'";
-    }
-    if (throwable != null) {
-      return throwable.toString();
-    }
-    return "unknown";
-  }
-
-  public String getMessage() {
-    return message;
-  }
-
-  public Throwable getThrowable() {
-    return throwable;
-  }
-
-  public HealthReport getCause() {
-    return cause;
   }
 }

--- a/util/src/main/java/io/camunda/zeebe/util/health/HealthReport.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/HealthReport.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.util.health;
 
+import java.util.Objects;
 import java.util.StringJoiner;
 
 /**
@@ -77,6 +78,38 @@ public final class HealthReport {
 
   public HealthIssue getIssue() {
     return issue;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = component != null ? component.hashCode() : 0;
+    result = 31 * result + (componentName != null ? componentName.hashCode() : 0);
+    result = 31 * result + (status != null ? status.hashCode() : 0);
+    result = 31 * result + (issue != null ? issue.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final HealthReport that = (HealthReport) o;
+
+    if (!Objects.equals(component, that.component)) {
+      return false;
+    }
+    if (!Objects.equals(componentName, that.componentName)) {
+      return false;
+    }
+    if (status != that.status) {
+      return false;
+    }
+    return Objects.equals(issue, that.issue);
   }
 
   @Override

--- a/util/src/test/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitorTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitorTest.java
@@ -173,7 +173,7 @@ public class CriticalComponentsHealthMonitorTest {
     waitUntilAllDone();
 
     // then
-    assertThat(monitor.getHealthReport().getIssue().getCause().getIssue()).isEqualTo(issue);
+    assertThat(monitor.getHealthReport().getIssue().cause().getIssue()).isEqualTo(issue);
   }
 
   private void waitUntilAllDone() {


### PR DESCRIPTION
## Description

* Compare current and previous healthstatus instead of healthreport 

## Related issues

closes #9207

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x ] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
