### PR TITLE
ci: deploy snapshot artifacts from new GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: { }
+
+jobs:
+  tests:
+    name: Tests
+    uses: ./.github/workflows/test.yml
+  deploy-snapshots:
+    name: Deploy snapshot artifacts
+    needs: [ tests ]
+    runs-on: ubuntu-latest
+    if: github.repository == 'camunda/zeebe'
+    concurrency: deploy-snapshots
+    steps:
+      - uses: actions/checkout@v3
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/common/github.com/actions/camunda/zeebe ARTIFACTS_USR;
+            secret/data/common/github.com/actions/camunda/zeebe ARTIFACTS_PSW;
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+          server-id: camunda-nexus
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - run: mvn -B -D skipTests -D skipChecks compile generate-sources source:jar javadoc:jar deploy
+        env:
+          MAVEN_USERNAME: ${{ steps.secrets.outputs.ARTIFACTS_USR }}
+          MAVEN_PASSWORD: ${{ steps.secrets.outputs.ARTIFACTS_PSW }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,9 @@ jobs:
           server-id: camunda-nexus
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
+      # compile and generate-sources to ensure that the Javadoc can be properly generated; compile is
+      # necessary when using annotation preprocessors for code generation, as otherwise the symbols are
+      # not resolve-able by the Javadoc generator
       - run: mvn -B -D skipTests -D skipChecks compile generate-sources source:jar javadoc:jar deploy
         env:
           MAVEN_USERNAME: ${{ steps.secrets.outputs.ARTIFACTS_USR }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - stable/*
-      - release/*
+      - release-*
       - trying
       - staging
   pull_request: {}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,13 +3,13 @@ name: Tests
 on:
   push:
     branches:
-      - main
       - stable/*
       - release/*
       - trying
       - staging
   pull_request: {}
   workflow_dispatch: {}
+  workflow_call: {}
 
 jobs:
   integration-tests:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -398,17 +398,6 @@ pipeline {
             }
         }
 
-        stage('Upload') {
-            when { allOf { branch mainBranchName; not { triggeredBy 'TimerTrigger' } } }
-            steps {
-                retry(3) {
-                    timeout(time: shortTimeoutMinutes, unit: 'MINUTES') {
-                        runMavenContainerCommand('.ci/scripts/distribution/upload.sh')
-                    }
-                }
-            }
-        }
-
         stage('Post') {
             when { not { triggeredBy 'TimerTrigger' } }
 


### PR DESCRIPTION
Adds another workflow that react on manual triggers and pushes on `main`. The workflow triggers the test pipeline first and then builds and uploads artifacts to our maven server.

Successful run here: https://github.com/camunda/zeebe/actions/runs/2207456731


closes #9140