### PR TITLE
Fix bom/pom.xml plugin version definition error

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -41,6 +41,7 @@
 
     <plugin.version.flatten>1.2.7</plugin.version.flatten>
     <plugin.version.javadoc>3.4.0</plugin.version.javadoc>
+    <plugin.version.spotless>2.22.1</plugin.version.spotless>
   </properties>
 
   <dependencyManagement>
@@ -104,6 +105,15 @@
   </repositories>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>${plugin.version.spotless}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
 
     <plugins>
       <plugin>
@@ -138,11 +148,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -143,7 +143,6 @@
     <plugin.version.sonar>3.9.1.2184</plugin.version.sonar>
     <plugin.version.sortpom>3.0.1</plugin.version.sortpom>
     <plugin.version.spotbugs>4.5.3.0</plugin.version.spotbugs>
-    <plugin.version.spotless>2.22.1</plugin.version.spotless>
     <plugin.version.surefire>3.0.0-M6</plugin.version.surefire>
     <plugin.version.versions>2.10.0</plugin.version.versions>
 
@@ -1415,28 +1414,6 @@
           <version>${plugin.version.versions}</version>
         </plugin>
 
-        <!-- Google code format plugin -->
-        <plugin>
-          <groupId>com.diffplug.spotless</groupId>
-          <artifactId>spotless-maven-plugin</artifactId>
-          <version>${plugin.version.spotless}</version>
-          <configuration>
-            <java>
-              <googleJavaFormat>
-                <version>${plugin.version.google-java-format}</version>
-                <style>GOOGLE</style>
-              </googleJavaFormat>
-            </java>
-          </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>com.google.googlejavaformat</groupId>
-              <artifactId>google-java-format</artifactId>
-              <version>${plugin.version.google-java-format}</version>
-            </dependency>
-          </dependencies>
-        </plugin>
-
         <!-- protobuf generation -->
         <plugin>
           <groupId>org.xolstice.maven.plugins</groupId>
@@ -1641,6 +1618,28 @@
           <flattenMode>ossrh</flattenMode>
         </configuration>
       </plugin>
+
+      <!-- Google code format plugin -->
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <configuration>
+          <java>
+            <googleJavaFormat>
+              <version>${plugin.version.google-java-format}</version>
+              <style>GOOGLE</style>
+            </googleJavaFormat>
+          </java>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>com.google.googlejavaformat</groupId>
+            <artifactId>google-java-format</artifactId>
+            <version>${plugin.version.google-java-format}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
     </plugins>
     <extensions>
       <extension>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

#9184 added support for running `mvn spotless:apply` and `mvn spotless:check` by adding the spotless plugin to the bom/pom.xml. In that PR, we added no version for the plugin, because I expected that the bom/pom.xml inherited from the parent/pom.xml. That assumption was wrong. Instead, the parent/pom.xml actually inherits from bom/pom.xml.

To fix the spotless definition in bom/pom.xml we therefore should define it in the plugin management. This makes the spotless plugin available to all sub-poms including the parent/pom and its children.

By defining the version in the bom/pom.xml we can remove the version definition from the parent/pom.xml.

Lastly, since the spotless plugin is now managed by the bom/pom.xml, I've moved further configuration added by the parent/pom.xml into the build/plugins tag to avoid managing the plugin in 2 different poms.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes NA

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
