### PR TITLE
Cancel job with incident when canceling the process instance

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/JobMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/JobMetrics.java
@@ -56,4 +56,9 @@ public final class JobMetrics {
   public void jobErrorThrown(final String type) {
     jobEvent("error thrown", type);
   }
+
+  /** Clears the metrics counter. You probably only want to use this during testing. */
+  static void clear() {
+    JOB_EVENTS.clear();
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -182,6 +182,8 @@ public final class BpmnJobBehavior {
 
     if (CANCELABLE_STATES.contains(state)) {
       final JobRecord job = jobState.getJob(jobKey);
+      // Note that this logic is duplicated in JobCancelProcessor, if you change this please change
+      // it there as well.
       stateWriter.appendFollowUpEvent(jobKey, JobIntent.CANCELED, job);
       jobMetrics.jobCanceled(job.getType());
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -47,7 +47,7 @@ public final class BpmnJobBehavior {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(BpmnJobBehavior.class.getPackageName());
   private static final Set<State> CANCELABLE_STATES =
-      EnumSet.of(State.ACTIVATABLE, State.ACTIVATED, State.FAILED);
+      EnumSet.of(State.ACTIVATABLE, State.ACTIVATED, State.FAILED, State.ERROR_THROWN);
 
   private final JobRecord jobRecord = new JobRecord().setVariables(DocumentValue.EMPTY_DOCUMENT);
   private final HeaderEncoder headerEncoder = new HeaderEncoder();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -183,6 +183,7 @@ public final class BpmnJobBehavior {
     if (CANCELABLE_STATES.contains(state)) {
       final JobRecord job = jobState.getJob(jobKey);
       stateWriter.appendFollowUpEvent(jobKey, JobIntent.CANCELED, job);
+      jobMetrics.jobCanceled(job.getType());
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
@@ -34,6 +34,8 @@ public final class JobCancelProcessor implements CommandProcessor<JobRecord> {
     final long jobKey = command.getKey();
     final JobRecord job = jobState.getJob(jobKey);
     if (job != null) {
+      // Note that this logic is duplicated in BpmnJobBehavior, if you change this please change
+      // it there as well.
       commandControl.accept(JobIntent.CANCELED, job);
       jobMetrics.jobCanceled(job.getType());
     } else {

--- a/engine/src/test/java/io/camunda/zeebe/engine/metrics/JobMetricsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/metrics/JobMetricsTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class JobMetricsTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String TASK_ID = "task";
+  private static final String JOB_TYPE = "job";
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @BeforeClass
+  public static void deployProcess() {
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(TASK_ID, t -> t.zeebeJobTypeExpression("jobType"))
+                .endEvent()
+                .done())
+        .deploy();
+  }
+
+  @Before
+  public void resetMetrics() {
+    JobMetrics.clear();
+  }
+
+  @Test
+  public void allCountsStartAtNull() {
+    assertThat(jobMetric("created", JOB_TYPE)).isNull();
+    assertThat(jobMetric("activated", JOB_TYPE)).isNull();
+    assertThat(jobMetric("timed out", JOB_TYPE)).isNull();
+    assertThat(jobMetric("completed", JOB_TYPE)).isNull();
+    assertThat(jobMetric("failed", JOB_TYPE)).isNull();
+    assertThat(jobMetric("canceled", JOB_TYPE)).isNull();
+    assertThat(jobMetric("error thrown", JOB_TYPE)).isNull();
+  }
+
+  @Test
+  public void shouldCountCreated() {
+    // when
+    createProcessInstanceWithJob(JOB_TYPE);
+
+    // then
+    assertThat(jobMetric("created", JOB_TYPE)).isNotNull().isEqualTo(1);
+  }
+
+  @Test
+  public void shouldCountActivated() {
+    // given
+
+    // the job type must be unique, because other tests may also have created jobs that can be
+    // activated. We can't depend on the unique process instance when activating a batch of jobs.
+    final String jobType = JOB_TYPE + "_activated";
+    createProcessInstanceWithJob(jobType);
+
+    // when
+    ENGINE.jobs().withType(jobType).activate();
+
+    // then
+    assertThat(jobMetric("activated", jobType)).isNotNull().isEqualTo(1);
+  }
+
+  @Test
+  public void shouldCountTimedOut() {
+    // given
+    final long processInstanceKey = createProcessInstanceWithJob(JOB_TYPE);
+
+    final var timeout = Duration.ofMinutes(10);
+    ENGINE.jobs().withType(JOB_TYPE).withTimeout(timeout.toMillis()).activate();
+
+    // when
+    ENGINE.getClock().addTime(timeout);
+    RecordingExporter.jobRecords(JobIntent.TIMED_OUT)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // then
+    assertThat(jobMetric("timed out", JOB_TYPE)).isNotNull().isEqualTo(1);
+  }
+
+  @Test
+  public void shouldCountCompleted() {
+    // given
+    final long processInstanceKey = createProcessInstanceWithJob(JOB_TYPE);
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType(JOB_TYPE).complete();
+
+    // then
+    assertThat(jobMetric("completed", JOB_TYPE)).isNotNull().isEqualTo(1);
+  }
+
+  @Test
+  public void shouldCountFailed() {
+    // given
+    final long processInstanceKey = createProcessInstanceWithJob(JOB_TYPE);
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType(JOB_TYPE).fail();
+
+    // then
+    assertThat(jobMetric("failed", JOB_TYPE)).isNotNull().isEqualTo(1);
+  }
+
+  @Test
+  public void shouldCountCanceled() {
+    // given
+    final long processInstanceKey = createProcessInstanceWithJob(JOB_TYPE);
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+    RecordingExporter.jobRecords(JobIntent.CANCELED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // then
+    assertThat(jobMetric("canceled", JOB_TYPE)).isNotNull().isEqualTo(1);
+  }
+
+  @Test
+  public void shouldCountErrorThrown() {
+    // given
+    final long processInstanceKey = createProcessInstanceWithJob(JOB_TYPE);
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType(JOB_TYPE).throwError();
+
+    // then
+    assertThat(jobMetric("error thrown", JOB_TYPE)).isNotNull().isEqualTo(1);
+  }
+
+  /**
+   * Creates a process instance with a job, and waits until the job is created
+   *
+   * @param jobType the job type for the service task
+   * @return the key of the created process instance
+   */
+  private static long createProcessInstanceWithJob(final String jobType) {
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("jobType", jobType)
+            .create();
+
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    return processInstanceKey;
+  }
+
+  private static Double jobMetric(final String action, final String type) {
+    return MetricsTestHelper.readMetricValue(
+        "zeebe_job_events_total",
+        entry("action", action),
+        entry("partition", "1"),
+        entry("type", type));
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/metrics/MetricsTestHelper.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/metrics/MetricsTestHelper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import io.prometheus.client.CollectorRegistry;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map.Entry;
+
+final class MetricsTestHelper {
+
+  /**
+   * Reads the value of a metric based on its name and labels.
+   *
+   * <p>This uses the defaultRegistry which is inefficient, so this should only be used in testing.
+   *
+   * @param name the name of the metric
+   * @param labels names and values for labels. This is useful for filtering the right value within
+   *     the metric.
+   * @return the given value or null if it doesn't exist
+   */
+  @SafeVarargs
+  static Double readMetricValue(final String name, final Entry<String, String>... labels) {
+    final List<String> labelNames = Arrays.stream(labels).map(Entry::getKey).toList();
+    final List<String> labelValues = Arrays.stream(labels).map(Entry::getValue).toList();
+    return CollectorRegistry.defaultRegistry.getSampleValue(
+        name, labelNames.toArray(new String[] {}), labelValues.toArray(new String[] {}));
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetricsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetricsTest.java
@@ -16,11 +16,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
-import io.prometheus.client.CollectorRegistry;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -161,7 +157,7 @@ public class ProcessEngineMetricsTest {
   }
 
   private Double executedProcessInstanceMetric(final String action) {
-    return metricValue(
+    return MetricsTestHelper.readMetricValue(
         "zeebe_executed_instances_total",
         entry("organizationId", "null"),
         entry("type", "ROOT_PROCESS_INSTANCE"),
@@ -178,18 +174,10 @@ public class ProcessEngineMetricsTest {
   }
 
   private Double evaluatedDmnElementsMetric(final String action) {
-    return metricValue(
+    return MetricsTestHelper.readMetricValue(
         "zeebe_evaluated_dmn_elements_total",
         entry("organizationId", "null"),
         entry("action", action),
         entry("partition", "1"));
-  }
-
-  @SafeVarargs
-  private Double metricValue(final String name, final Entry<String, String>... labels) {
-    final List<String> labelNames = Arrays.stream(labels).map(Entry::getKey).toList();
-    final List<String> labelValues = Arrays.stream(labels).map(Entry::getValue).toList();
-    return CollectorRegistry.defaultRegistry.getSampleValue(
-        name, labelNames.toArray(new String[] {}), labelValues.toArray(new String[] {}));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/boundary/BoundaryEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/boundary/BoundaryEventTest.java
@@ -131,7 +131,7 @@ public final class BoundaryEventTest {
         .containsSubsequence(
             tuple(ValueType.TIMER, TimerIntent.TRIGGERED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATING),
-            tuple(ValueType.JOB, JobIntent.CANCEL),
+            tuple(ValueType.JOB, JobIntent.CANCELED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATING));
   }
@@ -257,14 +257,13 @@ public final class BoundaryEventTest {
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATING),
-            tuple(ValueType.JOB, JobIntent.CANCEL),
+            tuple(ValueType.JOB, JobIntent.CANCELED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(ValueType.PROCESS_EVENT, ProcessEventIntent.TRIGGERED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.COMPLETE_ELEMENT),
-            tuple(ValueType.JOB, JobIntent.CANCELED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobFailIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobFailIncidentTest.java
@@ -342,10 +342,10 @@ public final class JobFailIncidentTest {
             .withIntent(ProcessInstanceIntent.TERMINATE_ELEMENT)
             .getFirst();
 
-    final Record<JobRecordValue> jobCancelCommand =
+    final Record<JobRecordValue> jobCancelled =
         RecordingExporter.jobRecords()
             .withProcessInstanceKey(processInstanceKey)
-            .withIntent(JobIntent.CANCEL)
+            .withIntent(JobIntent.CANCELED)
             .getFirst();
 
     final Record<IncidentRecordValue> resolvedIncidentEvent =
@@ -357,7 +357,7 @@ public final class JobFailIncidentTest {
     assertThat(resolvedIncidentEvent.getKey()).isEqualTo(incidentCreatedEvent.getKey());
     assertThat(resolvedIncidentEvent.getSourceRecordPosition())
         .isEqualTo(terminateTaskCommand.getPosition());
-    assertThat(jobCancelCommand.getSourceRecordPosition())
+    assertThat(jobCancelled.getSourceRecordPosition())
         .isEqualTo(terminateTaskCommand.getPosition());
 
     assertThat(resolvedIncidentEvent.getValue())

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CancelProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CancelProcessInstanceTest.java
@@ -321,12 +321,6 @@ public final class CancelProcessInstanceTest {
             .withIntent(ProcessInstanceIntent.TERMINATE_ELEMENT)
             .getFirst();
 
-    final Record<JobRecordValue> jobCancelCmd =
-        RecordingExporter.jobRecords()
-            .withProcessInstanceKey(processInstanceKey)
-            .onlyCommands()
-            .withIntent(JobIntent.CANCEL)
-            .getFirst();
     final Record<JobRecordValue> jobCanceledEvent =
         RecordingExporter.jobRecords()
             .withProcessInstanceKey(processInstanceKey)
@@ -334,8 +328,8 @@ public final class CancelProcessInstanceTest {
             .getFirst();
 
     assertThat(jobCanceledEvent.getKey()).isEqualTo(jobCreatedEvent.getKey());
-    assertThat(jobCancelCmd.getSourceRecordPosition()).isEqualTo(terminateActivity.getPosition());
-    assertThat(jobCanceledEvent.getSourceRecordPosition()).isEqualTo(jobCancelCmd.getPosition());
+    assertThat(jobCanceledEvent.getSourceRecordPosition())
+        .isEqualTo(terminateActivity.getPosition());
 
     final JobRecordValue jobCanceledEventValue = jobCanceledEvent.getValue();
     assertThat(jobCanceledEventValue.getProcessInstanceKey()).isEqualTo(processInstanceKey);


### PR DESCRIPTION
## Description

This fixes a bug where canceling a process instance could lead to a job becoming activatable even though the process instance is terminated. See #8588 for more details.

The bug is fixed by making sure the job is immediately canceled (i.e. deleted from the state) when we terminate the related element instance. We achieve this by writing a Job Canceled event when the TERMINATE_ELEMENT command is being processed. 

This PR fixes the bug in a way that can be backported because it doesn't introduce too many changes. Alternatively, the bug could be fixed by tackling the main issue: applying the Incident Resolved event should not affect the state of a job. Instead, the job should be made activatable by writing a separate Job event in the Resolve Incident Processor. That would be a larger change, with more impact on the event appliers than what this PR proposes. Changes to event appliers should generally be avoided.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8588 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
