### PR TITLE
Stabilize `LongPollingActivateJobsTest` by awaiting for condition before assertions

### DIFF
--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/LongPollingActivateJobsTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/LongPollingActivateJobsTest.java
@@ -978,14 +978,9 @@ public final class LongPollingActivateJobsTest {
       final Consumer<BrokerActivateJobsRequest> notification) {
     brokerClient.registerHandler(
         BrokerActivateJobsRequest.class,
-        new RequestHandler<BrokerActivateJobsRequest, BrokerResponse<?>>() {
-
-          @Override
-          public BrokerResponse<?> handle(final BrokerActivateJobsRequest request)
-              throws Exception {
-            notification.accept(request);
-            return activateJobsStub.handle(request);
-          }
+        (BrokerActivateJobsRequest request) -> {
+          notification.accept(request);
+          return activateJobsStub.handle(request);
         });
   }
 

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/LongPollingActivateJobsTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/LongPollingActivateJobsTest.java
@@ -57,6 +57,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -127,10 +128,11 @@ public final class LongPollingActivateJobsTest {
     activateJobsStub.addAvailableJobs(TYPE, 1);
     verify(responseSpy, times(0)).onCompleted();
     brokerClient.notifyJobsAvailable(TYPE);
+    Awaitility.await().until(request::isCompleted);
 
     // then
-    verify(responseSpy, timeout(2000).times(1)).onNext(any());
-    verify(responseSpy, timeout(1000).times(1)).onCompleted();
+    verify(responseSpy, times(1)).onNext(any());
+    verify(responseSpy, times(1)).onCompleted();
   }
 
   @Test
@@ -212,10 +214,11 @@ public final class LongPollingActivateJobsTest {
     activateJobsStub.addAvailableJobs(TYPE, 1);
     brokerClient.notifyJobsAvailable(TYPE);
     handler.activateJobs(successRequest);
+    Awaitility.await().until(successRequest::isCompleted);
 
     // then
-    verify(successRequest.getResponseObserver(), timeout(2000).times(1)).onNext(any());
-    verify(successRequest.getResponseObserver(), timeout(1000).times(1)).onCompleted();
+    verify(successRequest.getResponseObserver(), times(1)).onNext(any());
+    verify(successRequest.getResponseObserver(), times(1)).onCompleted();
   }
 
   @Test
@@ -229,9 +232,10 @@ public final class LongPollingActivateJobsTest {
     // when
     final InflightActivateJobsRequest otherRequest = getLongPollingActivateJobsRequest(otherType);
     handler.activateJobs(otherRequest);
+    Awaitility.await().until(otherRequest::isCompleted);
 
     // then
-    verify(otherRequest.getResponseObserver(), timeout(2000).times(1)).onCompleted();
+    verify(otherRequest.getResponseObserver(), times(1)).onCompleted();
   }
 
   @Test
@@ -345,11 +349,12 @@ public final class LongPollingActivateJobsTest {
     waitUntil(shortRequest::isTimedOut);
     activateJobsStub.addAvailableJobs(TYPE, 2);
     brokerClient.notifyJobsAvailable(TYPE);
+    Awaitility.await().until(longRequest::isCompleted);
 
     // then
     assertThat(longRequest.isTimedOut()).isFalse();
-    verify(longRequest.getResponseObserver(), timeout(1000).times(1)).onNext(any());
-    verify(longRequest.getResponseObserver(), timeout(1000).times(1)).onCompleted();
+    verify(longRequest.getResponseObserver(), times(1)).onNext(any());
+    verify(longRequest.getResponseObserver(), times(1)).onCompleted();
   }
 
   @Test
@@ -367,9 +372,10 @@ public final class LongPollingActivateJobsTest {
 
     // when
     handler.activateJobs(request);
-    verify(request.getResponseObserver(), timeout(1000).times(1)).onCompleted();
+    Awaitility.await().until(request::isCompleted);
 
     // then
+    verify(request.getResponseObserver(), times(1)).onCompleted();
     assertThat(request.hasScheduledTimer()).isFalse();
     assertThat(request.isTimedOut()).isFalse();
   }
@@ -475,11 +481,11 @@ public final class LongPollingActivateJobsTest {
         });
     // when
     handler.activateJobs(request);
+    Awaitility.await().until(request::isAborted);
 
     // then
     final ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);
-    verify(request.getResponseObserver(), timeout(1000).times(1))
-        .onError(throwableCaptor.capture());
+    verify(request.getResponseObserver(), times(1)).onError(throwableCaptor.capture());
     verify(request.getResponseObserver(), never()).onNext(Mockito.any());
     verify(request.getResponseObserver(), never()).onCompleted();
 
@@ -615,11 +621,11 @@ public final class LongPollingActivateJobsTest {
     handler.activateJobs(request);
     waitUntil(request::hasScheduledTimer);
     brokerClient.notifyJobsAvailable(TYPE);
+    Awaitility.await().until(request::isAborted);
 
     // then
     final ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);
-    verify(request.getResponseObserver(), timeout(1000).times(1))
-        .onError(throwableCaptor.capture());
+    verify(request.getResponseObserver(), times(1)).onError(throwableCaptor.capture());
     assertThat(throwableCaptor.getValue()).isInstanceOf(StatusException.class);
 
     assertThat(request.hasScheduledTimer()).isFalse();
@@ -656,11 +662,11 @@ public final class LongPollingActivateJobsTest {
     handler.activateJobs(request);
     waitUntil(request::hasScheduledTimer);
     brokerClient.notifyJobsAvailable(TYPE);
+    Awaitility.await().until(request::isAborted);
 
     // then
     final ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);
-    verify(request.getResponseObserver(), timeout(1000).times(1))
-        .onError(throwableCaptor.capture());
+    verify(request.getResponseObserver(), times(1)).onError(throwableCaptor.capture());
     assertThat(throwableCaptor.getValue()).isInstanceOf(BrokerRejectionException.class);
 
     assertThat(request.hasScheduledTimer()).isFalse();

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/LongPollingActivateJobsTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/LongPollingActivateJobsTest.java
@@ -556,7 +556,7 @@ public final class LongPollingActivateJobsTest {
             // ensure that all requests are submitted to
             // the actor jobs queue before executing those
             allRequestsSubmittedLatch.await();
-          } catch (InterruptedException e) {
+          } catch (final InterruptedException e) {
             // ignore
           }
         });
@@ -908,7 +908,7 @@ public final class LongPollingActivateJobsTest {
 
           @Override
           public Either<Exception, Boolean> tryToSendActivatedJobs(
-              ActivateJobsResponse grpcResponse) {
+              final ActivateJobsResponse grpcResponse) {
             activatedJobRef.set(grpcResponse.getJobs(0));
             super.tryToSendActivatedJobs(grpcResponse);
             return Either.right(false);


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This tries to improve the stability of the `LongPollingActivateJobsTest` by awaiting a condition before making the assertions, instead of having an individual timeout on each assertion. Awaitility waits at most 10s for the condition.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #8671

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
