### PR TITLE
Archive JVM error dumps on failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,9 @@ jobs:
         if: failure()
         with:
           name: Integration test results
-          path: "**/target/failsafe-reports/"
+          path: |
+            **/target/failsafe-reports/
+            **/hs_err_*.log
           retention-days: 7
   exporter-tests:
     name: Exporter tests
@@ -67,7 +69,9 @@ jobs:
         if: failure()
         with:
           name: Exporter test results
-          path: "**/target/failsafe-reports/"
+          path: |
+            **/target/failsafe-reports/
+            **/hs_err_*.log
           retention-days: 7
   project-list:
     # Builds a list of projects where unit tests can be run on hosted runners
@@ -118,7 +122,9 @@ jobs:
         if: failure()
         with:
           name: Unit test results for ${{ matrix.project }}
-          path: "**/target/surefire-reports/"
+          path: |
+            **/target/surefire-reports/
+            **/hs_err_*.log
           retention-days: 7
   slow-unit-tests:
     name: Slow unit tests
@@ -148,7 +154,9 @@ jobs:
         if: failure()
         with:
           name: Slow unit test results
-          path: "**/target/surefire-reports/"
+          path: |
+            **/target/surefire-reports/
+            **/hs_err_*.log
           retention-days: 7
   smoke-tests:
     # This name is hard-referenced from bors.toml
@@ -188,7 +196,9 @@ jobs:
         if: failure()
         with:
           name: Smoke test results for ${{ matrix.os }}
-          path: "**/target/failsafe-reports/"
+          path: |
+            **/target/surefire-reports/
+            **/hs_err_*.log
           retention-days: 7
   go-client:
     name: Go client tests


### PR DESCRIPTION
## Description

This PR adds an extra post step to archive JVM error dumps when the jobs have failed. This means archiving any file with the pattern `hs_err_*.log` produced by the job.

Archiving dump files generated by the JVM on crashes (e.g. SIGSEV, SIGBUS, etc.). This is particularly useful when dealing with native memory and running into unrecoverable crashes to get the stacktrace of the failing frame, as this is often not logged to standard out.

NOTE: the post steps are getting bigger, but there is a follow up issue to group these together.

## Related issues

closes #9129 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
