### PR TITLE
Renaming and javadocs

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerChecker.java
@@ -28,7 +28,7 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
         new DueDateChecker(
             TIMER_RESOLUTION,
             typedCommandWriter ->
-                timerInstanceState.findTimersWithDueDateBefore(
+                timerInstanceState.processTimersWithDueDateBefore(
                     ActorClock.currentTimeMillis(),
                     timer -> {
                       timerRecord.reset();
@@ -44,7 +44,7 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
                       typedCommandWriter.appendFollowUpCommand(
                           timer.getKey(), TimerIntent.TRIGGER, timerRecord);
 
-                      return typedCommandWriter.flush() > 0;
+                      return typedCommandWriter.flush() > 0; // means the write was successful
                     }));
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TimerInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TimerInstanceState.java
@@ -12,7 +12,12 @@ import java.util.function.Consumer;
 
 public interface TimerInstanceState {
 
-  long findTimersWithDueDateBefore(long timestamp, TimerVisitor consumer);
+  /**
+   * Finds timers with due date before {@code timestamp}, and presents them to the {@code consumer}
+   *
+   * @return due date of the next scheduled timer (or {@code -1} if no succeeding timer exists)
+   */
+  long processTimersWithDueDateBefore(long timestamp, TimerVisitor consumer);
 
   /**
    * NOTE: the timer instance given to the consumer is shared and will be mutated on the next
@@ -24,6 +29,11 @@ public interface TimerInstanceState {
 
   @FunctionalInterface
   interface TimerVisitor {
+
+    /**
+     * @return {@code true} if the timer was processed, or {@code false} if the timer could not be
+     *     processed and needs to be revisited later on
+     */
     boolean visit(TimerInstance timer);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbTimerInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbTimerInstanceState.java
@@ -31,7 +31,7 @@ public final class DbTimerInstanceState implements MutableTimerInstanceState {
   private final ColumnFamily<
           DbCompositeKey<DbLong, DbCompositeKey<DbForeignKey<DbLong>, DbLong>>, DbNil>
       dueDateColumnFamily;
-  private final DbLong dueDateKey;
+  private final DbLong dueDate;
   private final DbCompositeKey<DbLong, DbCompositeKey<DbForeignKey<DbLong>, DbLong>>
       dueDateCompositeKey;
 
@@ -52,8 +52,8 @@ public final class DbTimerInstanceState implements MutableTimerInstanceState {
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.TIMERS, transactionContext, elementAndTimerKey, timerInstance);
 
-    dueDateKey = new DbLong();
-    dueDateCompositeKey = new DbCompositeKey<>(dueDateKey, elementAndTimerKey);
+    dueDate = new DbLong();
+    dueDateCompositeKey = new DbCompositeKey<>(dueDate, elementAndTimerKey);
     dueDateColumnFamily =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.TIMER_DUE_DATES,
@@ -69,7 +69,7 @@ public final class DbTimerInstanceState implements MutableTimerInstanceState {
 
     timerInstanceColumnFamily.insert(elementAndTimerKey, timer);
 
-    dueDateKey.wrapLong(timer.getDueDate());
+    dueDate.wrapLong(timer.getDueDate());
     dueDateColumnFamily.insert(dueDateCompositeKey, DbNil.INSTANCE);
   }
 
@@ -79,12 +79,12 @@ public final class DbTimerInstanceState implements MutableTimerInstanceState {
     timerKey.wrapLong(timer.getKey());
     timerInstanceColumnFamily.deleteExisting(elementAndTimerKey);
 
-    dueDateKey.wrapLong(timer.getDueDate());
+    dueDate.wrapLong(timer.getDueDate());
     dueDateColumnFamily.deleteExisting(dueDateCompositeKey);
   }
 
   @Override
-  public long findTimersWithDueDateBefore(final long timestamp, final TimerVisitor consumer) {
+  public long processTimersWithDueDateBefore(final long timestamp, final TimerVisitor consumer) {
     nextDueDate = -1L;
 
     dueDateColumnFamily.whileTrue(

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/TimerInstanceStateTest.java
@@ -40,7 +40,7 @@ public final class TimerInstanceStateTest {
 
     // when
     final List<TimerInstance> timers = new ArrayList<>();
-    state.findTimersWithDueDateBefore(1000L, timers::add);
+    state.processTimersWithDueDateBefore(1000L, timers::add);
 
     // then
     Assertions.assertThat(timers).hasSize(1);
@@ -65,7 +65,7 @@ public final class TimerInstanceStateTest {
 
     // then
     final List<TimerInstance> timers = new ArrayList<>();
-    state.findTimersWithDueDateBefore(2000L, timers::add);
+    state.processTimersWithDueDateBefore(2000L, timers::add);
 
     Assertions.assertThat(timers).hasSize(1);
     Assertions.assertThat(timers.get(0).getElementInstanceKey()).isEqualTo(2L);
@@ -105,7 +105,7 @@ public final class TimerInstanceStateTest {
 
     // when
     final List<Long> keys = new ArrayList<>();
-    state.findTimersWithDueDateBefore(2000L, t -> keys.add(t.getElementInstanceKey()));
+    state.processTimersWithDueDateBefore(2000L, t -> keys.add(t.getElementInstanceKey()));
 
     // then
     assertThat(keys).hasSize(2).containsExactly(1L, 2L);
@@ -119,7 +119,7 @@ public final class TimerInstanceStateTest {
     createTimerInstance(3, 3, 3000L);
 
     // when
-    final long nextDueDate = state.findTimersWithDueDateBefore(2000L, t -> true);
+    final long nextDueDate = state.processTimersWithDueDateBefore(2000L, t -> true);
 
     // then
     assertThat(nextDueDate).isEqualTo(3000L);
@@ -129,7 +129,7 @@ public final class TimerInstanceStateTest {
   public void shouldReturnNegativeDueDateIfEmpty() {
 
     // when
-    final long nextDueDate = state.findTimersWithDueDateBefore(2000L, t -> true);
+    final long nextDueDate = state.processTimersWithDueDateBefore(2000L, t -> true);
 
     // then
     assertThat(nextDueDate).isEqualTo(-1L);
@@ -143,7 +143,7 @@ public final class TimerInstanceStateTest {
     createTimerInstance(3, 3, 3000L);
 
     // when
-    final long nextDueDate = state.findTimersWithDueDateBefore(3000L, t -> true);
+    final long nextDueDate = state.processTimersWithDueDateBefore(3000L, t -> true);
 
     // then
     assertThat(nextDueDate).isEqualTo(-1L);
@@ -158,7 +158,7 @@ public final class TimerInstanceStateTest {
     // when
     final List<Long> keys = new ArrayList<>();
     final long nextDueDate =
-        state.findTimersWithDueDateBefore(
+        state.processTimersWithDueDateBefore(
             2000L,
             t -> {
               keys.add(t.getElementInstanceKey());


### PR DESCRIPTION
## Description

- rename dueDateKey -> dueDate - because it is a due date, not a key
- rename findTimersWithDueDateBefore(...) -> processTimersWithDueDateBefore(...) - it's a more precise description of the method
- add JavaDoc comments to TimerInstanceState interface

## Related issues
related to #8991

<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
