### PR TITLE
[Backport stable/8.0] Await until all index templates are present before running ES test

### DIFF
--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
@@ -19,33 +19,36 @@ import io.camunda.zeebe.exporter.dto.GetSettingsForIndicesResponse.IndexSettings
 import io.camunda.zeebe.exporter.util.ElasticsearchContainer;
 import io.camunda.zeebe.exporter.util.ElasticsearchNode;
 import io.camunda.zeebe.exporter.util.it.ExporterIntegrationRule;
+import io.camunda.zeebe.exporter.util.it.NonStartableBrokerRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import org.awaitility.Awaitility;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.ResponseException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
 
 public abstract class AbstractElasticsearchExporterIntegrationTestCase {
   private static final ObjectMapper MAPPER = new ObjectMapper();
-
-  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
 
-  protected final ExporterIntegrationRule exporterBrokerRule = new ExporterIntegrationRule();
-
   protected ElasticsearchNode<ElasticsearchContainer> elastic;
   protected ElasticsearchExporterConfiguration configuration;
   protected ElasticsearchExporterFaultToleranceIT.ElasticsearchTestClient esClient;
+
+  private final ExporterIntegrationRule exporterIntegrationRule = new ExporterIntegrationRule();
+  protected final NonStartableBrokerRule exporterBrokerRule = exporterIntegrationRule;
 
   @Before
   public void setUp() {
@@ -59,9 +62,36 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
       esClient = null;
     }
 
-    exporterBrokerRule.stop();
+    exporterIntegrationRule.stop();
     elastic.stop();
     configuration = null;
+  }
+
+  /**
+   * Starts the broker AND waits for all index templates to be present in Elastic before continuing.
+   */
+  protected void startBroker() {
+    startBrokerWithoutWaitingForIndexTemplates();
+    awaitIndexTemplatesCreation();
+  }
+
+  protected void startBrokerWithoutWaitingForIndexTemplates() {
+    exporterIntegrationRule.start();
+  }
+
+  protected void awaitIndexTemplatesCreation() {
+    final var expectedIndexTemplatesCount =
+        Arrays.stream(ValueType.values()).filter(configuration::shouldIndexValueType).count();
+
+    // force exporting to ensure that we create the index templates, then wait for them to have been
+    // created
+    exporterBrokerRule.publishMessage("dummy", "");
+    Awaitility.await("until all indices have been created")
+        .atMost(Duration.ofMinutes(2))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(
+            () -> esClient.getIndexTemplateCount(configuration.index.prefix),
+            size -> size >= expectedIndexTemplatesCount);
   }
 
   protected void assertIndexSettings() {
@@ -175,14 +205,14 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
     return configuration;
   }
 
-  protected static class ElasticsearchTestClient extends ElasticsearchClient {
+  public static class ElasticsearchTestClient extends ElasticsearchClient {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     ElasticsearchTestClient(final ElasticsearchExporterConfiguration configuration) {
       super(configuration);
     }
 
-    GetSettingsForIndicesResponse getSettingsForIndices() {
+    public GetSettingsForIndicesResponse getSettingsForIndices() {
       final var request = new Request("GET", "/_all/_settings");
       try {
         final var response = client.performRequest(request);
@@ -199,7 +229,27 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
       }
     }
 
-    Map<String, Object> getDocument(final Record<?> record) {
+    public int getIndexTemplateCount(final String indexPrefix) {
+      final var request = new Request("GET", "/_index_template/" + indexPrefix + "*");
+      try {
+        final var response = client.performRequest(request);
+        final Map<String, List<Object>> indexTemplates =
+            MAPPER.readValue(response.getEntity().getContent(), new TypeReference<>() {});
+        return indexTemplates.getOrDefault("index_templates", new ArrayList<>()).size();
+      } catch (final ResponseException e) {
+        // you might get a 404 if there are no templates matching the pattern yet, but the response
+        // will be valid and of the same format
+        if (e.getResponse().getStatusLine().getStatusCode() == 404) {
+          return 0;
+        }
+
+        throw new ElasticsearchExporterException("Failed to get index template count", e);
+      } catch (final Exception e) {
+        throw new ElasticsearchExporterException("Failed to get index template count", e);
+      }
+    }
+
+    public Map<String, Object> getDocument(final Record<?> record) {
       final var request =
           new Request("GET", "/" + indexFor(record) + "/" + typeFor() + "/" + idFor(record));
       request.addParameter("routing", String.valueOf(record.getPartitionId()));

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterAuthenticationIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterAuthenticationIT.java
@@ -54,17 +54,14 @@ public class ElasticsearchExporterAuthenticationIT
     // given
     configuration = getDefaultConfiguration();
     exporterConfigurator.accept(configuration);
+    exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
+    esClient = createElasticsearchClient(configuration);
 
     // when
-    exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
-    exporterBrokerRule.start();
+    startBroker();
     exporterBrokerRule.performSampleWorkload();
 
     // then
-
-    // assert index settings for all created indices
-    esClient = createElasticsearchClient(configuration);
-
     // assert all records which where recorded during the tests where exported
     exporterBrokerRule.visitExportedRecords(
         r -> {

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfigurationIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfigurationIT.java
@@ -33,7 +33,7 @@ public class ElasticsearchExporterConfigurationIT
 
     // when
     exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
-    exporterBrokerRule.start();
+    startBroker();
     exporterBrokerRule.publishMessage("message", "123");
 
     // then
@@ -60,7 +60,7 @@ public class ElasticsearchExporterConfigurationIT
     exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
 
     // then
-    assertThatThrownBy(() -> exporterBrokerRule.start())
+    assertThatThrownBy(this::startBroker)
         .isInstanceOf(IllegalStateException.class)
         .getRootCause()
         .isInstanceOf(ExporterException.class)
@@ -83,7 +83,7 @@ public class ElasticsearchExporterConfigurationIT
     exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
 
     // then
-    assertThatThrownBy(() -> exporterBrokerRule.start())
+    assertThatThrownBy(this::startBroker)
         .isInstanceOf(IllegalStateException.class)
         .getRootCause()
         .isInstanceOf(ExporterException.class)

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterFaultToleranceIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterFaultToleranceIT.java
@@ -30,9 +30,10 @@ public class ElasticsearchExporterFaultToleranceIT
 
     // when
     exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
-    exporterBrokerRule.start();
+    startBrokerWithoutWaitingForIndexTemplates();
     exporterBrokerRule.publishMessage("message", "123");
     elastic.start();
+    awaitIndexTemplatesCreation();
 
     // then
     final var records =

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/records/ElasticsearchExporterDmnRecordIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/records/ElasticsearchExporterDmnRecordIT.java
@@ -34,7 +34,7 @@ public final class ElasticsearchExporterDmnRecordIT
     esClient = createElasticsearchClient(configuration);
 
     exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
-    exporterBrokerRule.start();
+    startBroker();
   }
 
   @Test

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/records/ElasticsearchExporterJobRecordIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/records/ElasticsearchExporterJobRecordIT.java
@@ -34,7 +34,7 @@ public class ElasticsearchExporterJobRecordIT
     esClient = createElasticsearchClient(configuration);
 
     exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
-    exporterBrokerRule.start();
+    startBroker();
   }
 
   @After

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/util/ElasticsearchContainer.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/util/ElasticsearchContainer.java
@@ -44,6 +44,9 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
 
   public ElasticsearchContainer(final String version) {
     super(DEFAULT_IMAGE + ":" + version);
+
+    // disable xpack by default to disable all these security warnings
+    withEnv("xpack.security.enabled", "false");
   }
 
   @Override

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/util/it/NonStartableBrokerRule.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/util/it/NonStartableBrokerRule.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter.util.it;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import io.camunda.zeebe.client.api.worker.JobHandler;
+import io.camunda.zeebe.client.api.worker.JobWorker;
+import io.camunda.zeebe.exporter.AbstractElasticsearchExporterIntegrationTestCase;
+import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Record;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * This interface is a temporary workaround to prevent actual tests from starting a broker manually.
+ * Instead, you should use {@link AbstractElasticsearchExporterIntegrationTestCase#startBroker()}.
+ *
+ * <p>As all of these utility classes will be removed by the end of Q2-2022, it's an OK trade-off to
+ * avoid rewriting most of the tests (which will be rewritten differently anyway).
+ */
+public interface NonStartableBrokerRule {
+
+  BrokerCfg getBrokerConfig();
+
+  List<ExporterCfg> getConfiguredExporters();
+
+  boolean hasConfiguredExporters();
+
+  <T, E extends Exporter> ExporterIntegrationRule configure(
+      String id, Class<E> exporterClass, T configuration);
+
+  <E extends Exporter> ExporterIntegrationRule configure(
+      String id, Class<E> exporterClass, Map<String, Object> arguments);
+
+  void performSampleWorkload();
+
+  void visitExportedRecords(Consumer<Record<?>> visitor);
+
+  void deployProcess(BpmnModelInstance process, String filename);
+
+  void deployResourceFromClasspath(String classpathResource);
+
+  long createProcessInstance(String processId, Map<String, Object> variables);
+
+  JobWorker createJobWorker(String type, JobHandler handler);
+
+  void publishMessage(String messageName, String correlationKey);
+}

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
               <exclude>**/target/**/*.md</exclude>
               <exclude>clients/go/vendor/**/*.md</exclude>
             </excludes>
-            <flexmark />
+            <flexmark/>
           </markdown>
         </configuration>
       </plugin>

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -97,6 +97,7 @@ public final class RecordingExporter implements Exporter {
   public static void reset() {
     LOCK.lock();
     try {
+      maximumWaitTime = DEFAULT_MAX_WAIT_TIME;
       RECORDS.clear();
     } finally {
       LOCK.unlock();


### PR DESCRIPTION
## Description

This PR backports the exporter flakiness fixes to stable/8.0.

## Related issues

backports #9131

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
