### PR TITLE
Yield control if too many timers due

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -55,6 +55,7 @@ import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
+import io.camunda.zeebe.util.FeatureFlags;
 import io.camunda.zeebe.util.sched.ActorSchedulingService;
 import io.camunda.zeebe.util.sched.ConcurrencyControl;
 import io.camunda.zeebe.util.startup.StartupStep;
@@ -112,7 +113,8 @@ final class PartitionFactory {
   List<ZeebePartition> constructPartitions(
       final RaftPartitionGroup partitionGroup,
       final List<PartitionListener> partitionListeners,
-      final TopologyManager topologyManager) {
+      final TopologyManager topologyManager,
+      final FeatureFlags featureFlags) {
     final var partitions = new ArrayList<ZeebePartition>();
     final var communicationService = clusterServices.getCommunicationService();
     final var eventService = clusterServices.getEventService();
@@ -131,7 +133,8 @@ final class PartitionFactory {
             localBroker,
             communicationService,
             eventService,
-            deploymentRequestHandler);
+            deploymentRequestHandler,
+            featureFlags);
 
     for (final RaftPartition owningPartition : owningPartitions) {
       final var partitionId = owningPartition.id().id();
@@ -200,7 +203,8 @@ final class PartitionFactory {
       final BrokerInfo localBroker,
       final ClusterCommunicationService communicationService,
       final ClusterEventService eventService,
-      final PushDeploymentRequestHandler deploymentRequestHandler) {
+      final PushDeploymentRequestHandler deploymentRequestHandler,
+      final FeatureFlags featureFlags) {
     return (ProcessingContext processingContext) -> {
       final var actor = processingContext.getActor();
 
@@ -229,7 +233,8 @@ final class PartitionFactory {
               subscriptionCommandSender,
               deploymentDistributor,
               deploymentRequestHandler,
-              jobsAvailableNotification::onJobsAvailable);
+              jobsAvailableNotification::onJobsAvailable,
+              featureFlags);
 
       return processor.withListener(
           new StreamProcessorLifecycleAware() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -149,7 +149,10 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
 
               partitions.addAll(
                   partitionFactory.constructPartitions(
-                      partitionGroup, partitionListeners, topologyManager));
+                      partitionGroup,
+                      partitionListeners,
+                      topologyManager,
+                      brokerCfg.getExperimental().getFeatures().toFeatureFlags()));
 
               final var futures =
                   partitions.stream()

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
@@ -30,8 +30,18 @@ public final class FeatureFlagsCfg {
   //    this.enableFoo = enableFoo;
   //  }
 
-  FeatureFlags toFeatureFlags() {
-    return new FeatureFlags(/*enableFoo*/ );
+  private boolean enableYieldingDueDateChecker = DEFAULT_SETTINGS.yieldingDueDateChecker();
+
+  public boolean isEnableYieldingDueDateChecker() {
+    return enableYieldingDueDateChecker;
+  }
+
+  public void setEnableYieldingDueDateChecker(final boolean enableYieldingDueDateChecker) {
+    this.enableYieldingDueDateChecker = enableYieldingDueDateChecker;
+  }
+
+  public FeatureFlags toFeatureFlags() {
+    return new FeatureFlags(enableYieldingDueDateChecker /*, enableFoo*/);
   }
 
   @Override

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfgTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class FeatureFlagsCfgTest {
+
+  public final Map<String, String> environment = new HashMap<>();
+
+  @Test
+  public void shouldSetEnableYieldingDueDateCheckerFromConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);
+    final var featureFlagsCfg = cfg.getExperimental().getFeatures();
+
+    // then
+    assertThat(featureFlagsCfg.isEnableYieldingDueDateChecker()).isTrue();
+  }
+
+  @Test
+  public void shouldSetEnableYieldingDueDateCheckerFromEnv() {
+    // given
+    environment.put("zeebe.broker.experimental.features.enableYieldingDueDateChecker", "false");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);
+    final var featureFlagsCfg = cfg.getExperimental().getFeatures();
+
+    // then
+    assertThat(featureFlagsCfg.isEnableYieldingDueDateChecker()).isFalse();
+  }
+}

--- a/broker/src/test/resources/system/feature-flags-cfg.yaml
+++ b/broker/src/test/resources/system/feature-flags-cfg.yaml
@@ -1,0 +1,5 @@
+zeebe:
+  broker:
+    experimental:
+      features:
+        enableYieldingDueDateChecker: true

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -714,3 +714,17 @@
         # Enables the query api in the broker.
         # This setting can also be set using the environmentvariable ZEEBE_BROKER_EXPERIMENTAL_QUERYAPI_ENABLED
         # enabled: false
+
+      # Allows to configure feature flags. These are used to test new features in dev and int environments prior
+      # to rolling them out to production
+      # features:
+        # Changes the DueDateTimerChecker to give yield to other processing steps in situations where
+        # it has many (i.e. millions of) timers to process. If set to false (default) the DueDateTimerChecker will activate all
+        # due timers. In the worst case, this can lead to the node being blocked for indefinite amount of time,
+        # being subsequently flagged as unhealthy. Currently, there is no known way to recover from this situation
+        # If set to true, the DueDateTimerChecker will give yield to other processing steps. This avoids the worst case
+        # described above. However, under consistent high load it may happen that the activated timers will fall behind real time,
+        # if more timers become due than can be activated during a certain time period.
+        #
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEYIELDINGDUEDATECHECKER
+        # enableYieldingDueDateChecker: false

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -651,3 +651,17 @@
         # Enables the query api in the broker.
         # This setting can also be set using the environmentvariable ZEEBE_BROKER_EXPERIMENTAL_QUERYAPI_ENABLED
         # enabled: false
+
+      # Allows to configure feature flags. These are used to test new features in dev and int environments prior
+      # to rolling them out to production
+      # features:
+        # Changes the DueDateTimerChecker to give yield to other processing steps in situations where
+        # it has many (i.e. millions of) timers to process. If set to false (default) the DueDateTimerChecker will activate all
+        # due timers. In the worst case, this can lead to the node being blocked for indefinite amount of time,
+        # being subsequently flagged as unhealthy. Currently, there is no known way to recover from this situation
+        # If set to true, the DueDateTimerChecker will give yield to other processing steps. This avoids the worst case
+        # described above. However, under consistent high load it may happen that the activated timers will fall behind real time,
+        # if more timers become due than can be activated during a certain time period.
+        #
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEYIELDINGDUEDATECHECKER
+        # enableYieldingDueDateChecker: false

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -40,6 +40,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.util.FeatureFlags;
 import io.camunda.zeebe.util.sched.ActorControl;
 import java.util.function.Consumer;
 
@@ -51,7 +52,8 @@ public final class EngineProcessors {
       final SubscriptionCommandSender subscriptionCommandSender,
       final DeploymentDistributor deploymentDistributor,
       final DeploymentResponder deploymentResponder,
-      final Consumer<String> onJobsAvailableCallback) {
+      final Consumer<String> onJobsAvailableCallback,
+      final FeatureFlags featureFlags) {
 
     final var actor = processingContext.getActor();
     final MutableZeebeState zeebeState = processingContext.getZeebeState();
@@ -73,7 +75,8 @@ public final class EngineProcessors {
             ExpressionLanguageFactory.createExpressionLanguage(),
             new VariableStateEvaluationContextLookup(variablesState));
 
-    final DueDateTimerChecker timerChecker = new DueDateTimerChecker(zeebeState.getTimerState());
+    final DueDateTimerChecker timerChecker =
+        new DueDateTimerChecker(zeebeState.getTimerState(), featureFlags);
     final CatchEventBehavior catchEventBehavior =
         new CatchEventBehavior(
             zeebeState,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerChecker.java
@@ -10,42 +10,22 @@ package io.camunda.zeebe.engine.processing.timer;
 import io.camunda.zeebe.engine.processing.scheduled.DueDateChecker;
 import io.camunda.zeebe.engine.processing.streamprocessor.ReadonlyProcessingContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.util.sched.clock.ActorClock;
 import java.time.Duration;
+import java.util.function.Function;
 
 public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
 
   private static final long TIMER_RESOLUTION = Duration.ofMillis(100).toMillis();
   private final DueDateChecker dueDateChecker;
 
-  private final TimerRecord timerRecord = new TimerRecord();
-
   public DueDateTimerChecker(final TimerInstanceState timerInstanceState) {
     dueDateChecker =
-        new DueDateChecker(
-            TIMER_RESOLUTION,
-            typedCommandWriter ->
-                timerInstanceState.processTimersWithDueDateBefore(
-                    ActorClock.currentTimeMillis(),
-                    timer -> {
-                      timerRecord.reset();
-                      timerRecord
-                          .setElementInstanceKey(timer.getElementInstanceKey())
-                          .setProcessInstanceKey(timer.getProcessInstanceKey())
-                          .setDueDate(timer.getDueDate())
-                          .setTargetElementId(timer.getHandlerNodeId())
-                          .setRepetitions(timer.getRepetitions())
-                          .setProcessDefinitionKey(timer.getProcessDefinitionKey());
-
-                      typedCommandWriter.reset();
-                      typedCommandWriter.appendFollowUpCommand(
-                          timer.getKey(), TimerIntent.TRIGGER, timerRecord);
-
-                      return typedCommandWriter.flush() > 0; // means the write was successful
-                    }));
+        new DueDateChecker(TIMER_RESOLUTION, new TriggerTimersSideEffect(timerInstanceState));
   }
 
   public void scheduleTimer(final long dueDate) {
@@ -75,5 +55,39 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
   @Override
   public void onResumed() {
     dueDateChecker.onResumed();
+  }
+
+  protected static final class TriggerTimersSideEffect
+      implements Function<TypedCommandWriter, Long> {
+
+    private final TimerRecord timerRecord = new TimerRecord();
+
+    private final TimerInstanceState timerInstanceState;
+
+    public TriggerTimersSideEffect(final TimerInstanceState timerInstanceState) {
+      this.timerInstanceState = timerInstanceState;
+    }
+
+    @Override
+    public Long apply(final TypedCommandWriter typedCommandWriter) {
+      return timerInstanceState.processTimersWithDueDateBefore(
+          ActorClock.currentTimeMillis(),
+          timer -> {
+            timerRecord.reset();
+            timerRecord
+                .setElementInstanceKey(timer.getElementInstanceKey())
+                .setProcessInstanceKey(timer.getProcessInstanceKey())
+                .setDueDate(timer.getDueDate())
+                .setTargetElementId(timer.getHandlerNodeId())
+                .setRepetitions(timer.getRepetitions())
+                .setProcessDefinitionKey(timer.getProcessDefinitionKey());
+
+            typedCommandWriter.reset();
+            typedCommandWriter.appendFollowUpCommand(
+                timer.getKey(), TimerIntent.TRIGGER, timerRecord);
+
+            return typedCommandWriter.flush() > 0; // means the write was successful
+          });
+    }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerChecker.java
@@ -25,7 +25,9 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
 
   public DueDateTimerChecker(final TimerInstanceState timerInstanceState) {
     dueDateChecker =
-        new DueDateChecker(TIMER_RESOLUTION, new TriggerTimersSideEffect(timerInstanceState));
+        new DueDateChecker(
+            TIMER_RESOLUTION,
+            new TriggerTimersSideEffect(timerInstanceState, ActorClock.current()));
   }
 
   public void scheduleTimer(final long dueDate) {
@@ -63,15 +65,18 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
     private final TimerRecord timerRecord = new TimerRecord();
 
     private final TimerInstanceState timerInstanceState;
+    private final ActorClock actorClock;
 
-    public TriggerTimersSideEffect(final TimerInstanceState timerInstanceState) {
+    public TriggerTimersSideEffect(
+        final TimerInstanceState timerInstanceState, final ActorClock actorClock) {
       this.timerInstanceState = timerInstanceState;
+      this.actorClock = actorClock;
     }
 
     @Override
     public Long apply(final TypedCommandWriter typedCommandWriter) {
       return timerInstanceState.processTimersWithDueDateBefore(
-          ActorClock.currentTimeMillis(),
+          actorClock.getTimeMillis(),
           timer -> {
             timerRecord.reset();
             timerRecord

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerChecker.java
@@ -12,6 +12,8 @@ import io.camunda.zeebe.engine.processing.streamprocessor.ReadonlyProcessingCont
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
+import io.camunda.zeebe.engine.state.immutable.TimerInstanceState.TimerVisitor;
+import io.camunda.zeebe.engine.state.instance.TimerInstance;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.util.sched.clock.ActorClock;
@@ -62,10 +64,9 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
   protected static final class TriggerTimersSideEffect
       implements Function<TypedCommandWriter, Long> {
 
-    private final TimerRecord timerRecord = new TimerRecord();
+    private final ActorClock actorClock;
 
     private final TimerInstanceState timerInstanceState;
-    private final ActorClock actorClock;
 
     public TriggerTimersSideEffect(
         final TimerInstanceState timerInstanceState, final ActorClock actorClock) {
@@ -76,23 +77,35 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
     @Override
     public Long apply(final TypedCommandWriter typedCommandWriter) {
       return timerInstanceState.processTimersWithDueDateBefore(
-          actorClock.getTimeMillis(),
-          timer -> {
-            timerRecord.reset();
-            timerRecord
-                .setElementInstanceKey(timer.getElementInstanceKey())
-                .setProcessInstanceKey(timer.getProcessInstanceKey())
-                .setDueDate(timer.getDueDate())
-                .setTargetElementId(timer.getHandlerNodeId())
-                .setRepetitions(timer.getRepetitions())
-                .setProcessDefinitionKey(timer.getProcessDefinitionKey());
+          actorClock.getTimeMillis(), new WriteTriggerTimerCommandVisitor(typedCommandWriter));
+    }
+  }
 
-            typedCommandWriter.reset();
-            typedCommandWriter.appendFollowUpCommand(
-                timer.getKey(), TimerIntent.TRIGGER, timerRecord);
+  protected static final class WriteTriggerTimerCommandVisitor implements TimerVisitor {
 
-            return typedCommandWriter.flush() > 0; // means the write was successful
-          });
+    private final TimerRecord timerRecord = new TimerRecord();
+
+    private final TypedCommandWriter typedCommandWriter;
+
+    public WriteTriggerTimerCommandVisitor(final TypedCommandWriter typedCommandWriter) {
+      this.typedCommandWriter = typedCommandWriter;
+    }
+
+    @Override
+    public boolean visit(final TimerInstance timer) {
+      timerRecord.reset();
+      timerRecord
+          .setElementInstanceKey(timer.getElementInstanceKey())
+          .setProcessInstanceKey(timer.getProcessInstanceKey())
+          .setDueDate(timer.getDueDate())
+          .setTargetElementId(timer.getHandlerNodeId())
+          .setRepetitions(timer.getRepetitions())
+          .setProcessDefinitionKey(timer.getProcessDefinitionKey());
+
+      typedCommandWriter.reset();
+      typedCommandWriter.appendFollowUpCommand(timer.getKey(), TimerIntent.TRIGGER, timerRecord);
+
+      return typedCommandWriter.flush() > 0; // means the write was successful
     }
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckerTest.java
@@ -58,7 +58,7 @@ class DueDateTimerCheckerTest {
           new TestTimerInstanceStateThatSimulatesAnEndlessListOfDueTimers(
               mockTimer, testActorClock);
 
-      final var sut = new TriggerTimersSideEffect(testTimerInstanceState, testActorClock);
+      final var sut = new TriggerTimersSideEffect(testTimerInstanceState, testActorClock, true);
 
       // when
       sut.apply(mockTypedCommandWriter);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckerTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.timer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker.YieldingDecorator;
+import io.camunda.zeebe.engine.state.immutable.TimerInstanceState.TimerVisitor;
+import io.camunda.zeebe.engine.state.instance.TimerInstance;
+import io.camunda.zeebe.util.sched.clock.ActorClock;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class DueDateTimerCheckerTest {
+
+  @Nested
+  final class YieldingDecoratorTest {
+
+    public static final int TIME_TO_YIELD = 100;
+
+    @Test
+    void shouldForwardCallToDelegateWhenTimeToYieldIsNotYetReached() {
+      // given
+      final var mockTimer = mock(TimerInstance.class);
+
+      final var mockDelegate = mock(TimerVisitor.class);
+      when(mockDelegate.visit(Mockito.any())).thenReturn(true);
+
+      final var testActorClock = new TestActorClock();
+      testActorClock.setTime(TIME_TO_YIELD - 50);
+
+      final var sut = new YieldingDecorator(testActorClock, TIME_TO_YIELD, mockDelegate);
+
+      // when
+      final var actual = sut.visit(mockTimer);
+
+      // then
+      assertThat(actual).isTrue();
+      verify(mockDelegate).visit(mockTimer);
+    }
+
+    @Test
+    void shouldNotForwardCallToDelegateWhenTimeToYieldIsReached() {
+      // given
+      final var mockTimer = mock(TimerInstance.class);
+
+      final var mockDelegate = mock(TimerVisitor.class);
+      when(mockDelegate.visit(Mockito.any())).thenReturn(true);
+
+      final var testActorClock = new TestActorClock();
+      testActorClock.setTime(TIME_TO_YIELD);
+
+      final var sut = new YieldingDecorator(testActorClock, TIME_TO_YIELD, mockDelegate);
+
+      // when
+      final var actual = sut.visit(mockTimer);
+
+      // then
+      assertThat(actual).isFalse();
+      verifyNoInteractions(mockDelegate);
+    }
+
+    @Test
+    void shouldNotForwardCallToDelegateWhenTimeToYieldHasPassed() {
+      // given
+      final var mockTimer = mock(TimerInstance.class);
+
+      final var mockDelegate = mock(TimerVisitor.class);
+      when(mockDelegate.visit(Mockito.any())).thenReturn(true);
+
+      final var testActorClock = new TestActorClock();
+      testActorClock.setTime(TIME_TO_YIELD + 50);
+
+      final var sut = new YieldingDecorator(testActorClock, TIME_TO_YIELD, mockDelegate);
+
+      // when
+      final var actual = sut.visit(mockTimer);
+
+      // then
+      assertThat(actual).isFalse();
+      verifyNoInteractions(mockDelegate);
+    }
+  }
+
+  private final class TestActorClock implements ActorClock {
+
+    private long time = 0;
+
+    public void setTime(final long time) {
+      this.time = time;
+    }
+
+    @Override
+    public boolean update() {
+      time = time + 10;
+      return true;
+    }
+
+    @Override
+    public long getTimeMillis() {
+      time = time + 10;
+      return time;
+    }
+
+    @Override
+    public long getNanosSinceLastMillisecond() {
+      return 0;
+    }
+
+    @Override
+    public long getNanoTime() {
+      return Duration.ofMillis(getTimeMillis()).toNanos();
+    }
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -54,6 +54,7 @@ import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.util.TestUtil;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.camunda.zeebe.util.FeatureFlags;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.camunda.zeebe.util.sched.ActorControl;
@@ -190,6 +191,8 @@ public final class EngineRule extends ExternalResource {
         partitionId -> {
           final var reprocessingCompletedListener = new ReprocessingCompletedListener();
           partitionReprocessingCompleteListeners.put(partitionId, reprocessingCompletedListener);
+          final var featureFlags = FeatureFlags.createDefaultForTests();
+
           environmentRule.startTypedStreamProcessor(
               partitionId,
               (processingContext) ->
@@ -213,7 +216,8 @@ public final class EngineRule extends ExternalResource {
                               partitionId, new PartitionCommandSenderImpl()),
                           deploymentDistributor,
                           (key, partition) -> {},
-                          jobsAvailableCallback)
+                          jobsAvailableCallback,
+                          featureFlags)
                       .withListener(new ProcessingExporterTransistor())
                       .withListener(reprocessingCompletedListener));
 

--- a/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
+++ b/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.util;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
-public record FeatureFlags(/*boolean foo*/ ) {
+public record FeatureFlags(boolean yieldingDueDateChecker /*, boolean foo*/) {
 
   /* To add a new feature toggle, please follow these steps:
    *
@@ -22,19 +22,36 @@ public record FeatureFlags(/*boolean foo*/ ) {
    *   As we gain more confidence in the efficacy of the feature flag, the
    *   default value can be set to 'true'
    *
+   * - define a default value to be used in tests
+   *
+   * - make sure that all relevant tests use the default value for tests
+   *
    * - add a field, getter and setter to FeatureFlagsCfg
    *
    * - add a description of the feature flag to
    *    - dist/src/main/config/broker.standalone.yaml.template
    *    - dist/src/main/config/broker.yaml.template
    *
+   * - add test cases to FeaturesFlagCfgTest and feature-flags-cfg.yaml
+   *
    * Be careful with parameter order in constructor calls!
    */
 
   //  protected static final boolean FOO_DEFAULT = false;
-  //
+
+  private static final boolean YIELDING_DUE_DATE_CHECKER = false;
+
   public static FeatureFlags createDefault() {
-    return new FeatureFlags(/*FOO_DEFAULT*/ );
+    return new FeatureFlags(YIELDING_DUE_DATE_CHECKER /*, FOO_DEFAULT*/);
+  }
+
+  /**
+   * Only to be used in tests
+   *
+   * @return
+   */
+  public static FeatureFlags createDefaultForTests() {
+    return new FeatureFlags(/* YIELDING_DUE_DATE_CHECKER*/ true /*, FOO_DEFAULT*/);
   }
 
   @Override

--- a/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 
 public class FeatureFlagsTest {
@@ -17,6 +19,15 @@ public class FeatureFlagsTest {
     final var sut = FeatureFlags.createDefault();
 
     // then
-    // assertThat(sut.foo()).isFalse();
+    assertThat(sut.yieldingDueDateChecker()).isFalse();
+  }
+
+  @Test
+  void testDefaultValuesForTests() {
+    // given
+    final var sut = FeatureFlags.createDefaultForTests();
+
+    // then
+    assertThat(sut.yieldingDueDateChecker()).isTrue();
   }
 }


### PR DESCRIPTION
## Description

Adds a mechanism for the `DueDateTimeChecker` to yield control after some time. This is to stop it from iterating over an unknown number of due timer events and blocking execution while doing so.

Overall, this change should work well in cases where there is a huge backlog of timers. This backlog would then be reduced bit by bit.

The change is potentially bad for cases in which there is a constant and high load with many timers being created all the time. In this case, the change of this PR can lead to due timers continuously growing and the timers triggered will fall more and more behind real time.

Overall, this tradeoff was deemed advantageous. At least it removes that dangers that the iteration blocks the execution for so long that the node is marked as unhealthy. When this situation is reached there is currently no practical recovery possible.

Even before this point is reached, execution will be blocked for long stretches of time, and no progress can be made on that partition. So one faulty process can block all others from executing.

Both issues are addressed by this PR. With this PR it should be always possible to make some progress, albeit small. This would allow users to cancel or change any faulty process, or to reduce the load if needed. 

Further work will be needed to figure out a way how to trigger timers without potentially falling further and further behind real time.

## Review Hints
This PR has duplicate commits from #9237 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9238

<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [X] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually **to be done**
* [x] The change has been verified by a QA run 
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
