### PR TITLE
feat(broker): add feature flag template

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -233,6 +233,10 @@
       <artifactId>sbe-tool</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
       <version>${project.version}</version>

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -30,6 +30,8 @@ public class ExperimentalCfg implements ConfigurationEntry {
   private QueryApiCfg queryApi = new QueryApiCfg();
   private ConsistencyCheckCfg consistencyChecks = new ConsistencyCheckCfg();
 
+  private FeatureFlagsCfg features = new FeatureFlagsCfg();
+
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
     rocksdb.init(globalConfig, brokerBase);
@@ -104,6 +106,14 @@ public class ExperimentalCfg implements ConfigurationEntry {
     this.consistencyChecks = consistencyChecks;
   }
 
+  public FeatureFlagsCfg getFeatures() {
+    return features;
+  }
+
+  public void setFeatures(final FeatureFlagsCfg features) {
+    this.features = features;
+  }
+
   @Override
   public String toString() {
     return "ExperimentalCfg{"
@@ -121,6 +131,8 @@ public class ExperimentalCfg implements ConfigurationEntry {
         + queryApi
         + ", consistencyChecks="
         + consistencyChecks
+        + ", features="
+        + features
         + '}';
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.camunda.zeebe.util.FeatureFlags;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+@JsonSerialize // this annotation seems to implicitly disable
+// SerializationFeature.FAIL_ON_EMPTY_BEANS
+public final class FeatureFlagsCfg {
+
+  // To add a new feature flag, read the comments in FeatureFlags
+
+  private static final FeatureFlags DEFAULT_SETTINGS = FeatureFlags.createDefault();
+  //
+  //  private boolean enableFoo = DEFAULT_SETTINGS.foo();
+  //
+  //  public boolean isEnableFoo() {
+  //    return enableFoo;
+  //  }
+  //
+  //  public void setEnableFoo(final boolean enableFoo) {
+  //    this.enableFoo = enableFoo;
+  //  }
+
+  FeatureFlags toFeatureFlags() {
+    return new FeatureFlags(/*enableFoo*/ );
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+  }
+}

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -82,6 +82,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>provided</scope>

--- a/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
+++ b/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public record FeatureFlags(/*boolean foo*/ ) {
+
+  /* To add a new feature toggle, please follow these steps:
+   *
+   * - add a record property to this class, and extend the test for this class
+   *
+   * - define the default value. When introducing a new feature flag the default
+   *   value should be 'false'. This way the feature is disabled by default
+   *   for all customers who do not change their configuration.
+   *   As we gain more confidence in the efficacy of the feature flag, the
+   *   default value can be set to 'true'
+   *
+   * - add a field, getter and setter to FeatureFlagsCfg
+   *
+   * - add a description of the feature flag to
+   *    - dist/src/main/config/broker.standalone.yaml.template
+   *    - dist/src/main/config/broker.yaml.template
+   *
+   * Be careful with parameter order in constructor calls!
+   */
+
+  //  protected static final boolean FOO_DEFAULT = false;
+  //
+  public static FeatureFlags createDefault() {
+    return new FeatureFlags(/*FOO_DEFAULT*/ );
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+  }
+}

--- a/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util;
+
+import org.junit.jupiter.api.Test;
+
+public class FeatureFlagsTest {
+
+  @Test
+  void testDefaultValues() {
+    // given
+    final var sut = FeatureFlags.createDefault();
+
+    // then
+    // assertThat(sut.foo()).isFalse();
+  }
+}


### PR DESCRIPTION
## Description

Adds template to add feature flags. The template consists of two parts:
* `FeatureFlags` to hold the flags and default values. Visible in most of the code base
* `FeatureFlagsCfg` to make feature flags configurable. Instances of this class can be used to obtain a `FeatureFlags` object

## Review Hints
* I did try to implement reflection based tests to check that e.g. the cfg object and the feature flags object have the same getters, and that values are passed in correctly. However, this spiraled out of control into a big chunk of over-engineered tests. So I dropped these completely
* Secondly there are often config tests like `ExperimentalCfgTest` not sure if these add value. Let me know if you miss them as part of the template
* Overall, this is a minimal implementation. Please let me know if you want to change any names or such things.

## Related issues

closes #9254

<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
