### PR TITLE
Interrupting event subprocess is activated more than once

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -133,8 +133,8 @@ public final class ProcessProcessor
       final BpmnElementContext flowScopeContext,
       final BpmnElementContext childContext) {
 
-    if (flowScopeContext.getIntent() != ProcessInstanceIntent.ELEMENT_TERMINATING
-        && stateBehavior.isInterrupted(flowScopeContext)) {
+    if (stateBehavior.isInterrupted(flowScopeContext)) {
+      // an interrupting event subprocess was triggered
       eventSubscriptionBehavior
           .findEventTrigger(flowScopeContext)
           .ifPresent(
@@ -144,6 +144,7 @@ public final class ProcessProcessor
                       flowScopeContext.getElementInstanceKey(),
                       eventTrigger,
                       flowScopeContext));
+
     } else if (stateBehavior.canBeTerminated(childContext)) {
       transitionTo(
           element,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehav
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnVariableMappingBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
-import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 
 public final class SubProcessProcessor
     implements BpmnElementContainerProcessor<ExecutableFlowElementContainer> {
@@ -108,33 +107,9 @@ public final class SubProcessProcessor
       final ExecutableFlowElementContainer element,
       final BpmnElementContext subProcessContext,
       final BpmnElementContext childContext) {
-    if (subProcessContext.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATING) {
 
-      if (childContext == null || stateBehavior.canBeTerminated(childContext)) {
-        // if we are able to terminate we try to trigger boundary events
-        eventSubscriptionBehavior
-            .findEventTrigger(subProcessContext)
-            .ifPresentOrElse(
-                eventTrigger -> {
-                  final var terminated =
-                      stateTransitionBehavior.transitionToTerminated(subProcessContext);
-                  eventSubscriptionBehavior.activateTriggeredEvent(
-                      subProcessContext.getElementInstanceKey(),
-                      subProcessContext.getFlowScopeKey(),
-                      eventTrigger,
-                      terminated);
-                },
-                () -> {
-                  final var terminated =
-                      stateTransitionBehavior.transitionToTerminated(subProcessContext);
-                  stateTransitionBehavior.onElementTerminated(element, terminated);
-                });
-      }
-
-    } else if (stateBehavior.isInterrupted(subProcessContext)) {
-      // if the flow scope is not terminating we allow
-      // * interrupting event sub processes
-      // * non interrupting boundary events
+    if (stateBehavior.isInterrupted(subProcessContext)) {
+      // an interrupting event subprocess was triggered
       eventSubscriptionBehavior
           .findEventTrigger(subProcessContext)
           .ifPresent(
@@ -144,6 +119,26 @@ public final class SubProcessProcessor
                       subProcessContext.getElementInstanceKey(),
                       eventTrigger,
                       subProcessContext));
+
+    } else if (childContext == null || stateBehavior.canBeTerminated(childContext)) {
+      // if we are able to terminate we try to trigger boundary events
+      eventSubscriptionBehavior
+          .findEventTrigger(subProcessContext)
+          .ifPresentOrElse(
+              eventTrigger -> {
+                final var terminated =
+                    stateTransitionBehavior.transitionToTerminated(subProcessContext);
+                eventSubscriptionBehavior.activateTriggeredEvent(
+                    subProcessContext.getElementInstanceKey(),
+                    subProcessContext.getFlowScopeKey(),
+                    eventTrigger,
+                    terminated);
+              },
+              () -> {
+                final var terminated =
+                    stateTransitionBehavior.transitionToTerminated(subProcessContext);
+                stateTransitionBehavior.onElementTerminated(element, terminated);
+              });
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -131,7 +131,7 @@ public final class SubProcessProcessor
                 });
       }
 
-    } else {
+    } else if (stateBehavior.isInterrupted(subProcessContext)) {
       // if the flow scope is not terminating we allow
       // * interrupting event sub processes
       // * non interrupting boundary events


### PR DESCRIPTION
## Description

An interrupting event subprocess is activated more than once if
* the event subprocess is in an embedded subprocess
* more than one element instance is active in the same scope (i.e. the embedded subprocess)

The bug was fixed by aligning the child termination condition on the subprocess with the process. Now, it checks if the number of active child instances is zero. 

## Related issues

closes #9185

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
