### PR TITLE
Allow self-hosted runners to use CI Nexus cache

### DIFF
--- a/.github/actions/use-ci-nexus-cache/action.yml
+++ b/.github/actions/use-ci-nexus-cache/action.yml
@@ -1,0 +1,51 @@
+---
+name: Use CI Nexus cache
+
+description: Sets up use of co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml.
+
+inputs:
+  vault-url:
+    description: 'Vault URL to use.'
+    default: 'https://stage.vault.int.camunda.com'
+
+runs:
+  using: composite
+  steps:
+  - name: Create ~/.m2/settings.xml with cache configuration
+    shell: bash
+    run: |
+      cat <<EOF > ~/.m2/settings.xml
+      <?xml version="1.0" encoding="UTF-8"?>
+      <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+        <interactiveMode>false</interactiveMode>
+        <servers>
+          <server>
+            <id>camunda-nexus</id>
+            <username>\${env.NEXUS_USERNAME}</username>
+            <password>\${env.NEXUS_PASSWORD}</password>
+          </server>
+        </servers>
+        <mirrors>
+          <mirror>
+            <id>camunda-nexus</id>
+            <mirrorOf>*</mirrorOf>
+            <name>Camunda Nexus</name>
+            <url>http://repository-ci-camunda-cloud.nexus:8081/content/groups/internal/</url>
+          </mirror>
+        </mirrors>
+      </settings>
+      EOF
+
+  - name: Import Secrets
+    uses: hashicorp/vault-action@v2.4.0
+    with:
+      url: "${{ inputs.vault-url }}"
+      method: kubernetes
+      path: kubernetes-camunda-ci
+      role: gha-runner-camunda-agent # needs to align with namespace and serviceaccount name of the runner pod
+      exportEnv: true
+      secrets: |
+        secret/data/k8s-camunda-ci/gha-runner-camunda/agent NEXUS_USERNAME;
+        secret/data/k8s-camunda-ci/gha-runner-camunda/agent NEXUS_PASSWORD;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: stCarolas/setup-maven@v4.3
         with:
           maven-version: 3.8.5
+      - uses: ./.github/actions/use-ci-nexus-cache
       - run: mvn -T1C -B -DskipChecks -DskipTests install
       - run: docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t camunda/zeebe:current-test .
       - run: >
@@ -57,6 +58,7 @@ jobs:
       - uses: stCarolas/setup-maven@v4.3
         with:
           maven-version: 3.8.5
+      - uses: ./.github/actions/use-ci-nexus-cache
       - run: mvn -T1C -B -DskipChecks -DskipTests install
       - run: docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t camunda/zeebe:current-test .
       - run: >
@@ -128,7 +130,7 @@ jobs:
           retention-days: 7
   slow-unit-tests:
     name: Slow unit tests
-    runs-on: ["n1-standard-8-netssd-preempt"]
+    runs-on: "n1-standard-8-netssd-preempt"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3.2.0
@@ -139,6 +141,7 @@ jobs:
       - uses: stCarolas/setup-maven@v4.3
         with:
           maven-version: 3.8.5
+      - uses: ./.github/actions/use-ci-nexus-cache
       - run: >
           mvn -T1C -B
           -D skipTests -D skipChecks
@@ -217,4 +220,3 @@ jobs:
       - run: docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t camunda/zeebe:current-test .
       - run: go test -mod=vendor -v ./...
         working-directory: clients/go
-


### PR DESCRIPTION
## Description

Same as we do in Jenkins to save data traffic and costs in Google Cloud.

## Related issues

Related to INFRA-3255