### PR TITLE
Fix gocompat compilation issue

### DIFF
--- a/.ci/scripts/release/prepare-go.sh
+++ b/.ci/scripts/release/prepare-go.sh
@@ -9,7 +9,15 @@ git config --global user.name "${GITHUB_TOKEN_USR}"
 # `go install` (and possibly GO111MODULE=on is not required)
 export CGO_ENABLED=0
 export GO111MODULE=on
-go get -u "github.com/smola/gocompat/...@v0.3.0"
+
+# We cannot build tooling dependencies from scratch, as these might suddenly rely on a dependency
+# does not build on our system anymore. Better to fetch the pre-compiled binary, unfortunately.
+# With Go 1.17, it might be possible that `go install` will solve this issue, so we should try again
+curl -sL https://github.com/smola/gocompat/releases/download/v0.3.0/gocompat_linux_amd64.tar.gz | tar -xz
+mv gocompat_linux_amd64 $GOPATH/bin/gocompat
+
+# go-bindata does not provided pre-compiled binaries, so we have to build it ourselves. That said,
+# we should switch to go:embed once we update the go version we use.
 go get -u "github.com/go-bindata/go-bindata/...@v3"
 
 # Verify binary is available under $GOPATH/bin


### PR DESCRIPTION
## Description

This PR fixes a compilation error with gocompat. It seems the tool (which hasn't been updated in a year) has some distant transitive dependency on a package which simply does not support Go 1.15 anymore, so when we compile it from scratch it fails. So this commit just downloads the pre-compiled binary. We cannot do this for go-bindata as this does not provide pre-compiled binaries.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
