### PR TITLE
Trigger boundary events only if the flow scope is active 

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -135,9 +135,11 @@ public final class CallActivityProcessor
 
   private void transitionToTerminated(
       final ExecutableCallActivity element, final BpmnElementContext context) {
+    final var flowScopeInstance = stateBehavior.getFlowScopeInstance(context);
 
     eventSubscriptionBehavior
         .findEventTrigger(context)
+        .filter(eventTrigger -> flowScopeInstance.isActive())
         .ifPresentOrElse(
             eventTrigger -> {
               final var terminated = stateTransitionBehavior.transitionToTerminated(context);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -265,10 +265,14 @@ public final class MultiInstanceBodyProcessor
 
   private void terminate(
       final ExecutableMultiInstanceBody element, final BpmnElementContext flowScopeContext) {
+
+    final var flowScopeInstance = stateBehavior.getFlowScopeInstance(flowScopeContext);
+
     incidentBehavior.resolveIncidents(flowScopeContext);
 
     eventSubscriptionBehavior
         .findEventTrigger(flowScopeContext)
+        .filter(eventTrigger -> flowScopeInstance.isActive())
         .ifPresentOrElse(
             eventTrigger -> {
               final var terminated =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -107,6 +107,7 @@ public final class SubProcessProcessor
       final ExecutableFlowElementContainer element,
       final BpmnElementContext subProcessContext,
       final BpmnElementContext childContext) {
+    final var flowScopeInstance = stateBehavior.getFlowScopeInstance(subProcessContext);
 
     if (stateBehavior.isInterrupted(subProcessContext)) {
       // an interrupting event subprocess was triggered
@@ -124,6 +125,7 @@ public final class SubProcessProcessor
       // if we are able to terminate we try to trigger boundary events
       eventSubscriptionBehavior
           .findEventTrigger(subProcessContext)
+          .filter(eventTrigger -> flowScopeInstance.isActive())
           .ifPresentOrElse(
               eventTrigger -> {
                 final var terminated =

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/boundary/BoundaryEventElementTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/boundary/BoundaryEventElementTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.boundary;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractActivityBuilder;
+import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Collection;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public final class BoundaryEventElementTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Parameter public ElementWithBoundaryEventBuilder elementBuilder;
+
+  @Parameters(name = "{0}")
+  public static Collection<Object[]> parameters() {
+    return buildersAsParameters();
+  }
+
+  private BpmnModelInstance process(final ElementWithBoundaryEventBuilder elementBuilder) {
+    final var startEventBuilder = Bpmn.createExecutableProcess(PROCESS_ID).startEvent();
+
+    final var processWithElementBuilder = elementBuilder.build(startEventBuilder);
+
+    return processWithElementBuilder.boundaryEvent().timerWithDuration("PT1H").endEvent().done();
+  }
+
+  @Test
+  public void shouldNotActivateBoundaryEventIfScopeIsTerminating() {
+    // given
+    ENGINE.deployment().withXmlResource(process(elementBuilder)).deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(elementBuilder.elementType)
+        .await();
+
+    final var timerCreated =
+        RecordingExporter.timerRecords(TimerIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // when trigger the boundary event and cancel the process instance concurrently
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .processInstance(ProcessInstanceIntent.CANCEL, new ProcessInstanceRecord())
+            .key(processInstanceKey),
+        RecordToWrite.command()
+            .timer(TimerIntent.TRIGGER, timerCreated.getValue())
+            .key(timerCreated.getKey()));
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(elementBuilder.elementType, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(elementBuilder.elementType, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED))
+        .doesNotContain(
+            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATING));
+  }
+
+  private static Collection<Object[]> buildersAsParameters() {
+    return builders().map(builder -> new Object[] {builder}).collect(Collectors.toList());
+  }
+
+  private static Stream<ElementWithBoundaryEventBuilder> builders() {
+    return Stream.of(
+        // -------------------------------
+        new ElementWithBoundaryEventBuilder(
+            BpmnElementType.SERVICE_TASK,
+            process -> process.serviceTask("task", t -> t.zeebeJobType("task"))),
+        // -------------------------------
+        new ElementWithBoundaryEventBuilder(
+            BpmnElementType.RECEIVE_TASK,
+            process ->
+                process.receiveTask(
+                    "task",
+                    r -> r.message(m -> m.name("wait").zeebeCorrelationKeyExpression("123")))),
+        // -------------------------------
+        new ElementWithBoundaryEventBuilder(
+            BpmnElementType.BUSINESS_RULE_TASK,
+            process -> process.businessRuleTask("task", b -> b.zeebeJobType("task"))),
+        // -------------------------------
+        new ElementWithBoundaryEventBuilder(
+            BpmnElementType.USER_TASK, process -> process.userTask("task")),
+        // -------------------------------
+        new ElementWithBoundaryEventBuilder(
+            BpmnElementType.SCRIPT_TASK,
+            process -> process.scriptTask("task", s -> s.zeebeJobType("task"))),
+        // -------------------------------
+        new ElementWithBoundaryEventBuilder(
+            BpmnElementType.SEND_TASK,
+            process -> process.sendTask("task", s -> s.zeebeJobType("task"))),
+        // -------------------------------
+        new ElementWithBoundaryEventBuilder(
+            BpmnElementType.SUB_PROCESS,
+            process ->
+                process.subProcess(
+                    "subprocess",
+                    s ->
+                        s.embeddedSubProcess()
+                            .startEvent()
+                            .serviceTask("task", t -> t.zeebeJobType("task"))
+                            .endEvent())),
+        // -------------------------------
+        new ElementWithBoundaryEventBuilder(
+            BpmnElementType.MULTI_INSTANCE_BODY,
+            process ->
+                process
+                    .serviceTask("task", t -> t.zeebeJobType("task"))
+                    .multiInstance(m -> m.parallel().zeebeInputCollectionExpression("[1,2,3]"))),
+        // -------------------------------
+        new ElementWithBoundaryEventBuilder(
+            BpmnElementType.CALL_ACTIVITY,
+            process -> process.callActivity("call", c -> c.zeebeProcessId(PROCESS_ID))));
+  }
+
+  private record ElementWithBoundaryEventBuilder(
+      BpmnElementType elementType,
+      Function<AbstractFlowNodeBuilder<?, ?>, AbstractActivityBuilder<?, ?>> builder) {
+
+    public AbstractActivityBuilder<?, ?> build(final AbstractFlowNodeBuilder<?, ?> process) {
+      return builder.apply(process);
+    }
+
+    @Override
+    public String toString() {
+      return elementType.name();
+    }
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/boundary/BoundaryEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/boundary/BoundaryEventTest.java
@@ -13,7 +13,6 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
-import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
@@ -472,54 +471,5 @@ public final class BoundaryEventTest {
                 .withElementType(BpmnElementType.BOUNDARY_EVENT))
         .extracting(r -> r.getValue().getElementId())
         .containsExactlyInAnyOrder(boundaryEventId1, boundaryEventId1, boundaryEventId2);
-  }
-
-  @Test
-  public void shouldNotActivateBoundaryEventIfScopeIsTerminating() {
-    // given
-    final var process =
-        Bpmn.createExecutableProcess(PROCESS_ID)
-            .startEvent()
-            .serviceTask("task", t -> t.zeebeJobType("task"))
-            .boundaryEvent()
-            .timerWithDuration("PT1H")
-            .endEvent()
-            .done();
-
-    ENGINE.deployment().withXmlResource(process).deploy();
-
-    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-
-    RecordingExporter.jobRecords(JobIntent.CREATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .await();
-
-    final var timerCreated =
-        RecordingExporter.timerRecords(TimerIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .getFirst();
-
-    // when trigger the boundary event and cancel the process instance concurrently
-    ENGINE.writeRecords(
-        RecordToWrite.command()
-            .processInstance(ProcessInstanceIntent.CANCEL, new ProcessInstanceRecord())
-            .key(processInstanceKey),
-        RecordToWrite.command()
-            .timer(TimerIntent.TRIGGER, timerCreated.getValue())
-            .key(timerCreated.getKey()));
-
-    // then
-    assertThat(
-            RecordingExporter.processInstanceRecords()
-                .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceTerminated())
-        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
-        .containsSubsequence(
-            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
-            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATING),
-            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED))
-        .doesNotContain(
-            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATING));
   }
 }


### PR DESCRIPTION
## Description

* we have a deadlock if a boundary event is triggered and the flow scope is on termination
* a special case is described in #9233 where a boundary event in a child process instance was triggered and the related call activity is terminated concurrently 
* the issue is caused by writing the `activating` and `activated` events of the boundary event (that create a new element instance)
* in the BPMN element processors, we don't check if the flow scope of the boundary event is still active
* fixing the issue by adding a check before activating the boundary event

## Related issues

closes #9233 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
