### PR TITLE
Fix flaky Raft.shouldReconnect test

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -48,6 +48,7 @@ import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -261,6 +262,10 @@ public final class RaftRule extends ExternalResource {
 
   public List<MemberId> getMemberIds() {
     return members.stream().map(RaftMember::memberId).collect(Collectors.toList());
+  }
+
+  public Collection<RaftServer> getServers() {
+    return servers.values();
   }
 
   public void shutdownServer(final RaftServer raftServer) throws Exception {

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftServerDisconnectTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftServerDisconnectTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftServer.Role;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+
+public class RaftServerDisconnectTest {
+
+  @Rule @Parameter public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);
+
+  @Test
+  public void shouldLeaderStepDownOnDisconnect() throws Throwable {
+    final RaftServer leader = raftRule.getLeader().orElseThrow();
+
+    final CountDownLatch stepDownListener = new CountDownLatch(1);
+    leader.addRoleChangeListener(
+        (role, term) -> {
+          if (role == Role.FOLLOWER) {
+            stepDownListener.countDown();
+          }
+        });
+
+    // when
+    raftRule.partition(leader);
+
+    // then
+    assertThat(stepDownListener.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(leader.isLeader()).isFalse();
+  }
+
+  @Test
+  public void shouldReconnect() throws Throwable {
+    // given
+    final RaftServer leader = raftRule.getLeader().orElseThrow();
+    final AtomicLong commitIndex = new AtomicLong();
+    leader.getContext().addCommitListener(commitIndex::set);
+    raftRule.appendEntry();
+    raftRule.partition(leader);
+    Awaitility.await().until(() -> !leader.isLeader());
+
+    // when
+    raftRule.awaitNewLeader();
+    final var newLeader = raftRule.getLeader().orElseThrow();
+    assertThat(leader).isNotEqualTo(newLeader);
+    final var secondCommit = raftRule.appendEntry();
+    raftRule.reconnect(leader);
+
+    // then - the old leader has received and committed the new entry
+    Awaitility.await().until(() -> commitIndex.get() >= secondCommit);
+  }
+
+  @Test
+  public void shouldFailOverOnLeaderDisconnect() throws Throwable {
+    final RaftServer leader = raftRule.getLeader().orElseThrow();
+    final MemberId leaderId = leader.getContext().getCluster().getLocalMember().memberId();
+
+    final CountDownLatch newLeaderElected = new CountDownLatch(1);
+    final AtomicReference<MemberId> newLeaderId = new AtomicReference<>();
+    raftRule
+        .getServers()
+        .forEach(
+            s ->
+                s.addRoleChangeListener(
+                    (role, term) -> {
+                      if (role == Role.LEADER && !s.equals(leader)) {
+                        newLeaderId.set(s.getContext().getCluster().getLocalMember().memberId());
+                        newLeaderElected.countDown();
+                      }
+                    }));
+    // when
+    raftRule.partition(leader);
+
+    // then
+    assertThat(newLeaderElected.await(30, TimeUnit.SECONDS)).isTrue();
+    assertThat(leaderId).isNotEqualTo(newLeaderId.get());
+  }
+}

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -444,12 +444,13 @@ public class RaftTest extends ConcurrentTestCase {
     Awaitility.await().until(() -> !leader.isLeader());
 
     // when
-    final var newLeader = servers.stream().filter(RaftServer::isLeader).findFirst().orElseThrow();
+    Awaitility.await().until(() -> getLeader(servers).isPresent());
+    final var newLeader = getLeader(servers).orElseThrow();
     assertThat(leader).isNotEqualTo(newLeader);
     final var secondCommit = appendEntry(newLeader);
     protocolFactory.heal(leaderId);
 
-    // then
+    // then - the old leader has received and committed the new entry
     Awaitility.await().until(() -> commitIndex.get() >= secondCommit);
   }
 


### PR DESCRIPTION
## Description

* Test was flaky because it doesn't wait until a new leader is elected.
* Moved the tests that verified network partition into a separate class. This is just one step towards cleaning up `RaftTest`. 

## Related issues

closes #9155 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
