### PR TITLE
chore(ci): use prod Vault

### DIFF
--- a/.github/actions/use-ci-nexus-cache/action.yml
+++ b/.github/actions/use-ci-nexus-cache/action.yml
@@ -4,9 +4,12 @@ name: Use CI Nexus cache
 description: Sets up use of co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml.
 
 inputs:
+  # Using an input with a default value as raw string here instead of relying on secrets.VAULT_ADDR
+  # since workflows accessing any GHA secret cannot be run for PRs from outside contributors anymore,
+  # see also https://github.com/camunda/zeebe/pull/9302#issuecomment-1118971782
   vault-url:
     description: 'Vault URL to use.'
-    default: 'https://stage.vault.int.camunda.com'
+    default: 'https://vault.int.camunda.com'
 
 runs:
   using: composite


### PR DESCRIPTION
## Description

This PR is needed to ensure that workflows using GHA self-hosted runners still work (the Nexus caching part of it; workaround could also be disabling that temporarily) after configuring `camunda/zeebe` to use self-hosted runners from the `prod` environment (currently `stage` but INFRA-3257 includes steps to promote it).

Disclaimer: this PR will not be green until the change "configuring `camunda/zeebe` to use self-hosted runners from the `prod` environment" is made, this is expected.

## Related issues

Related to INFRA-3257