### PR TITLE
Do not mark logstream as slow unit test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
         id: list-projects
         # Build a json array of module names that can be used for the matrix in `unit-tests`
         run: >
-          echo "::set-output name=projects::$(mvn -pl !:zeebe-workflow-engine,!:zeebe-logstreams -Dexec.executable='echo' -Dexec.args='${project.artifactId}' exec:exec -q |  jq -cnR [inputs])"
+          echo "::set-output name=projects::$(mvn -pl !:zeebe-workflow-engine -Dexec.executable='echo' -Dexec.args='${project.artifactId}' exec:exec -q |  jq -cnR [inputs])"
     outputs:
       projects: ${{ steps.list-projects.outputs.projects }}
   unit-tests:
@@ -145,12 +145,12 @@ jobs:
       - run: >
           mvn -T1C -B
           -D skipTests -D skipChecks
-          -am -pl :zeebe-workflow-engine,:zeebe-logstreams
+          -am -pl :zeebe-workflow-engine
           install
       - run: >
           mvn -B --no-snapshot-updates
           -D skipITs -D skipChecks
-          -pl :zeebe-workflow-engine,:zeebe-logstreams
+          -pl :zeebe-workflow-engine
           verify
       - name: Archive Test Results
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Description

Now that all the tests in the logstreams relying on Atomix have been moved to the broker, I assume the module doesn't have "slow" unit tests anymore and can be moved back with the rest of the unit tests.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
