### PR TITLE
Ensure leaders are evenly distributed before proceeding with asymmetric partition test

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/MessageCorrelationTestCase.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/network/MessageCorrelationTestCase.java
@@ -30,9 +30,9 @@ final class MessageCorrelationTestCase implements AsymmetricNetworkPartitionTest
             .done();
     client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
     // make sure that the message is correlated to correct partition
-    assertThat(SubscriptionUtil.getSubscriptionPartitionId(BufferUtil.wrapString("key"), 3))
-        .describedAs("message should correlated to partition three")
-        .isEqualTo(3);
+    assertThat(SubscriptionUtil.getSubscriptionPartitionId(BufferUtil.wrapString("key"), 2))
+        .describedAs("message should correlated to partition two")
+        .isEqualTo(2);
 
     client
         .newPublishMessageCommand()


### PR DESCRIPTION
## Description

This PR resolves the flakiness in `AsymmetricNetworkPartitionIT` by ensuring that we have different leaders for all partitions before proceeding with the test case. It does so by using the rebalancing API in combination with priority election.

I took the opportunity to also clean up the test a bit. The first commit is the fix itself. The second commit cleans up a little by making use of new APIs in `ZeebeCluster` and reusing the Testcontainers JUnit 5 extension. The final commit makes the cluster static, such that it's reused by all test cases. Utilities are only installed once at the beginning, and we guarantee unreachable routes are flushed between cases. I also reduced the number of partitions 2 if only to make the containers a little lighter - I didn't see a big need for 3 partitions, to be honest.

I'm happy to split this and take the last two commits in a separate PR if you'd prefer.

## Related issues

closes #9266 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
