### PR TITLE
Reproducible ProtocolFactory across runs

### DIFF
--- a/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
+++ b/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
@@ -34,7 +34,10 @@ import org.slf4j.LoggerFactory;
 /**
  * A {@link Record} factory which produces randomized records deterministically. A seed can be given
  * on construction to reproduce the same records. On failure, the seed can be fetched via {@link
- * #getSeed()}.
+ * #getSeed()}. By default, calling {@link ProtocolFactory#ProtocolFactory()} will always return a
+ * factory which produces the same records. This is useful for reproducible tests, such that running
+ * the same test twice (regardless of the environment, e.g. CI or locally) will produce the same
+ * results.
  *
  * <p>Every property is fully randomized and cannot be relied upon semantically, except the value
  * type, the value, and the intent. These will always all match the implicit assumptions of the
@@ -54,12 +57,13 @@ public final class ProtocolFactory {
   private final EasyRandom random;
 
   /**
-   * Every call to this constructor will always return a factory which will produce different
-   * records. If you wish to reproduce past results, consider using {@link
-   * ProtocolFactory#ProtocolFactory(long)}.
+   * Every call to this constructor will always return a factory which produces the exact same
+   * record. This is useful for reproducible tests. If you want a different behavior, then you can
+   * use {@link ProtocolFactory#ProtocolFactory(long)} and pass something like {@link
+   * ThreadLocalRandom#nextLong()}.
    */
   public ProtocolFactory() {
-    this(ThreadLocalRandom.current().nextLong());
+    this(0);
   }
 
   /**

--- a/protocol-test-util/src/test/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactoryTest.java
+++ b/protocol-test-util/src/test/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactoryTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 @Execution(ExecutionMode.CONCURRENT)
 final class ProtocolFactoryTest {
   @Test
-  void shouldUseADifferentSeedOnConstruction() {
+  void shouldUseSameSeedOnConstruction() {
     // given
     final var factoryA = new ProtocolFactory();
     final var factoryB = new ProtocolFactory();
@@ -35,7 +35,7 @@ final class ProtocolFactoryTest {
     final var seedB = factoryB.getSeed();
 
     // then
-    assertThat(seedA).isNotEqualTo(seedB);
+    assertThat(seedA).isEqualTo(seedB);
   }
 
   @Test
@@ -70,7 +70,7 @@ final class ProtocolFactoryTest {
   void shouldRandomizeRecordsWithDifferentSeeds() {
     // given
     final var factoryA = new ProtocolFactory();
-    final var factoryB = new ProtocolFactory();
+    final var factoryB = new ProtocolFactory(factoryA.getSeed() + 1);
 
     // when
     final var recordA = factoryA.generateRecord();

--- a/protocol-test-util/src/test/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactoryTest.java
+++ b/protocol-test-util/src/test/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactoryTest.java
@@ -24,14 +24,15 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 @Execution(ExecutionMode.CONCURRENT)
 final class ProtocolFactoryTest {
+  private final ProtocolFactory factory = new ProtocolFactory();
+
   @Test
   void shouldUseSameSeedOnConstruction() {
     // given
-    final var factoryA = new ProtocolFactory();
     final var factoryB = new ProtocolFactory();
 
     // when
-    final var seedA = factoryA.getSeed();
+    final var seedA = factory.getSeed();
     final var seedB = factoryB.getSeed();
 
     // then
@@ -41,11 +42,10 @@ final class ProtocolFactoryTest {
   @Test
   void shouldGenerateRecordDeterministically() {
     // given
-    final var factoryA = new ProtocolFactory();
-    final var factoryB = new ProtocolFactory(factoryA.getSeed());
+    final var factoryB = new ProtocolFactory(factory.getSeed());
 
     // when
-    final var recordA = factoryA.generateRecord();
+    final var recordA = factory.generateRecord();
     final var recordB = factoryB.generateRecord();
 
     // then
@@ -55,11 +55,10 @@ final class ProtocolFactoryTest {
   @Test
   void shouldGenerateRecordsDeterministically() {
     // given
-    final var factoryA = new ProtocolFactory();
-    final var factoryB = new ProtocolFactory(factoryA.getSeed());
+    final var factoryB = new ProtocolFactory(factory.getSeed());
 
     // when
-    final var recordsA = factoryA.generateRecords().limit(5).collect(Collectors.toList());
+    final var recordsA = factory.generateRecords().limit(5).collect(Collectors.toList());
     final var recordsB = factoryB.generateRecords().limit(5).collect(Collectors.toList());
 
     // then
@@ -69,11 +68,10 @@ final class ProtocolFactoryTest {
   @Test
   void shouldRandomizeRecordsWithDifferentSeeds() {
     // given
-    final var factoryA = new ProtocolFactory();
-    final var factoryB = new ProtocolFactory(factoryA.getSeed() + 1);
+    final var factoryB = new ProtocolFactory(1L);
 
     // when
-    final var recordA = factoryA.generateRecord();
+    final var recordA = factory.generateRecord();
     final var recordB = factoryB.generateRecord();
 
     // then
@@ -83,7 +81,6 @@ final class ProtocolFactoryTest {
   @Test
   void shouldRandomizeRecords() {
     // given
-    final var factory = new ProtocolFactory();
 
     // then
     assertThat(factory.generateRecord())
@@ -95,7 +92,6 @@ final class ProtocolFactoryTest {
   @MethodSource("provideValueTypes")
   void shouldSetAllPropertiesOfGeneratedRecordValue(final ValueType valueType) {
     // given
-    final var factory = new ProtocolFactory();
     final var valueClass = ValueTypeMapping.get(valueType).getValueClass();
 
     // when
@@ -108,7 +104,6 @@ final class ProtocolFactoryTest {
   @Test
   void shouldSetAllPropertiesOfGeneratedRecord() {
     // given
-    final var factory = new ProtocolFactory();
 
     // when
     final var record = factory.generateRecord();
@@ -120,7 +115,6 @@ final class ProtocolFactoryTest {
   @Test
   void shouldGenerateForAllAcceptedValueTypes() {
     // given
-    final var factory = new ProtocolFactory();
     final var acceptedValueTypes = ValueTypeMapping.getAcceptedValueTypes();
 
     // when
@@ -137,7 +131,6 @@ final class ProtocolFactoryTest {
   @MethodSource("provideValueTypes")
   void shouldGenerateRecordWithCorrectValueAndIntentTypes(final ValueType valueType) {
     // given
-    final var factory = new ProtocolFactory();
     final var valueTypeMapping = ValueTypeMapping.get(valueType);
 
     // when
@@ -153,7 +146,6 @@ final class ProtocolFactoryTest {
   @MethodSource("provideProtocolClasses")
   void shouldGenerateForAllProtocolClasses(final Class<?> protocolClass) {
     // given
-    final var factory = new ProtocolFactory();
 
     // when - Record cannot be generated directly due to its generic parameter
     final Object generatedObject =


### PR DESCRIPTION
## Description

This PR ensures runs using a `ProtocolFactory` are always reproducible by default, while keeping the option to overwrite the seed at construction time if need be. See the issue for context/motivation.

## Related issues

closes #9315 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
