### PR TITLE
Allow convenient implicit casting of generated record's value type

### DIFF
--- a/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
+++ b/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
@@ -81,7 +81,7 @@ public final class ProtocolFactory {
   /**
    * @return a stream of random records
    */
-  public Stream<Record<RecordValue>> generateRecords() {
+  public <T extends RecordValue> Stream<Record<T>> generateRecords() {
     return generateRecords(UnaryOperator.identity());
   }
 
@@ -93,8 +93,8 @@ public final class ProtocolFactory {
    * @return a stream of random records
    * @throws NullPointerException if modifier is null
    */
-  public Stream<Record<RecordValue>> generateRecords(
-      final UnaryOperator<Builder<RecordValue>> modifier) {
+  public <T extends RecordValue> Stream<Record<T>> generateRecords(
+      final UnaryOperator<Builder<T>> modifier) {
     return Stream.generate(() -> generateRecord(modifier));
   }
 
@@ -104,7 +104,7 @@ public final class ProtocolFactory {
    *
    * @return a stream of records, one for each value type
    */
-  public Stream<Record<RecordValue>> generateForAllValueTypes() {
+  public <T extends RecordValue> Stream<Record<T>> generateForAllValueTypes() {
     return generateForAllValueTypes(UnaryOperator.identity());
   }
 
@@ -115,8 +115,8 @@ public final class ProtocolFactory {
    * @return a stream of records, one for each value type
    * @throws NullPointerException if {@code modifier} is null
    */
-  public Stream<Record<RecordValue>> generateForAllValueTypes(
-      final UnaryOperator<Builder<RecordValue>> modifier) {
+  public <T extends RecordValue> Stream<Record<T>> generateForAllValueTypes(
+      final UnaryOperator<Builder<T>> modifier) {
     return ValueTypeMapping.getAcceptedValueTypes().stream()
         .map(valueType -> generateRecord(valueType, modifier));
   }
@@ -124,7 +124,7 @@ public final class ProtocolFactory {
   /**
    * @return a random record with a random value type
    */
-  public Record<RecordValue> generateRecord() {
+  public <T extends RecordValue> Record<T> generateRecord() {
     return generateRecord(UnaryOperator.identity());
   }
 
@@ -137,7 +137,8 @@ public final class ProtocolFactory {
    * @return a randomly generated record
    * @throws NullPointerException if {@code modifier} is null
    */
-  public Record<RecordValue> generateRecord(final UnaryOperator<Builder<RecordValue>> modifier) {
+  public <T extends RecordValue> Record<T> generateRecord(
+      final UnaryOperator<Builder<T>> modifier) {
     final var valueType = random.nextObject(ValueType.class);
     return generateRecord(valueType, modifier);
   }
@@ -155,7 +156,7 @@ public final class ProtocolFactory {
    *     expected types
    * @throws NullPointerException if {@code valueType} is null
    */
-  public Record<RecordValue> generateRecord(final ValueType valueType) {
+  public <T extends RecordValue> Record<T> generateRecord(final ValueType valueType) {
     return generateRecord(valueType, UnaryOperator.identity());
   }
 
@@ -176,8 +177,8 @@ public final class ProtocolFactory {
    *     expected types
    * @throws NullPointerException if {@code modifier} is null or if {@code valueType} is null
    */
-  public Record<RecordValue> generateRecord(
-      final ValueType valueType, final UnaryOperator<Builder<RecordValue>> modifier) {
+  public <T extends RecordValue> Record<T> generateRecord(
+      final ValueType valueType, final UnaryOperator<Builder<T>> modifier) {
     return generateImmutableRecord(valueType, modifier);
   }
 
@@ -262,8 +263,8 @@ public final class ProtocolFactory {
         .excludeField(excludedRecordFields);
   }
 
-  private Record<RecordValue> generateImmutableRecord(
-      final ValueType valueType, final UnaryOperator<Builder<RecordValue>> modifier) {
+  private <T extends RecordValue> Record<T> generateImmutableRecord(
+      final ValueType valueType, final UnaryOperator<Builder<T>> modifier) {
     Objects.requireNonNull(valueType, "must specify a value type");
     Objects.requireNonNull(modifier, "must specify a builder modifier");
 
@@ -273,7 +274,7 @@ public final class ProtocolFactory {
     final var seedRecord = random.nextObject(Record.class);
 
     //noinspection unchecked
-    final Builder<RecordValue> builder =
+    final Builder<T> builder =
         ImmutableRecord.builder()
             .from(seedRecord)
             .withValueType(valueType)


### PR DESCRIPTION
## Description

This PR allows setting the generated record's parametric type via the expected return type. This simplifies using generated records in assertions when the values need to be accessed, and also simplifies modifying the record itself when need be.

As the PR was quite small, I took the opportunity to also ensure we don't generate records using `RecordType.NULL_VAL` or `RecordType.SBE_UNKNOWN`.

NOTE: I added some state to the `ProtocolFactoryTest`, which is only used in the new test. This is covered however in #9322.

## Related issues

closes #9316 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
