### PR TITLE
Ensure we only generate positive long-typed properties with generated records

### DIFF
--- a/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
+++ b/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
@@ -29,6 +29,7 @@ import org.jeasy.random.EasyRandom;
 import org.jeasy.random.EasyRandomParameters;
 import org.jeasy.random.FieldPredicates;
 import org.jeasy.random.api.Randomizer;
+import org.jeasy.random.randomizers.range.LongRangeRandomizer;
 import org.jeasy.random.randomizers.registry.CustomRandomizerRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -208,6 +209,13 @@ public final class ProtocolFactory {
   private void registerRandomizers() {
     findProtocolTypes().forEach(this::registerProtocolType);
     randomizerRegistry.registerRandomizer(Object.class, new RawObjectRandomizer());
+
+    // restrict longs to be between 0 and max value - this is because many of our long properties
+    // are timestamps, which are semantically between 0 and any future time
+    randomizerRegistry.registerRandomizer(
+        Long.class, new LongRangeRandomizer(0L, Long.MAX_VALUE, getSeed()));
+    randomizerRegistry.registerRandomizer(
+        long.class, new LongRangeRandomizer(0L, Long.MAX_VALUE, getSeed()));
 
     // never use NULL_VAL or SBE_UNKNOWN for ValueType or RecordType
     randomizerRegistry.registerRandomizer(

--- a/protocol-test-util/src/test/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactoryTest.java
+++ b/protocol-test-util/src/test/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactoryTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.ValueTypeMapping;
 import java.util.EnumSet;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -184,6 +185,36 @@ final class ProtocolFactoryTest {
 
     // then
     assertThat(records).extracting(Record::getRecordType).hasSameElementsAs(acceptedRecordTypes);
+  }
+
+  @Test
+  void shouldNeverProduceANegativeLong() {
+    // given
+
+    // when
+    final var generatedValues =
+        IntStream.range(0, 10)
+            .mapToLong(ignored -> factory.generateObject(Long.class))
+            .boxed()
+            .toList();
+
+    // then
+    assertThat(generatedValues).allSatisfy(value -> assertThat(value).isNotNegative());
+  }
+
+  @Test
+  void shouldNeverProduceANegativePrimitiveLong() {
+    // given
+
+    // when
+    final var generatedValues =
+        IntStream.range(0, 10)
+            .mapToLong(ignored -> factory.generateObject(long.class))
+            .boxed()
+            .toList();
+
+    // then
+    assertThat(generatedValues).allSatisfy(value -> assertThat(value).isNotNegative());
   }
 
   private static Stream<ValueType> provideValueTypes() {


### PR DESCRIPTION
## Description

This PR ensures long-typed properties of generated records are always positive. This is a simple workaround, as many of the properties of type long are actually timestamps, or are expected to behave like timestamps. Since other parts will expect these to be positive, at the very least, we can do that here.

NOTE: I added some state in the test, but only use it in the new tests. #9322 will refactor existing tests to use it, so no need to do that here too.

## Related issues

closes #9317 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
