### PR TITLE
Allow suppressing checks via annotations

### DIFF
--- a/build-tools/src/main/resources/check/.checkstyle.xml
+++ b/build-tools/src/main/resources/check/.checkstyle.xml
@@ -11,9 +11,13 @@
     <property name="eachLine" value="true"/>
   </module>
 
+  <module name="SuppressWarningsFilter"/>
+
   <module name="TreeWalker">
     <property name="tabWidth" value="4"/>
     <property name="severity" value="error"/>
+
+    <module name="SuppressWarningsHolder"/>
 
     <module name="ConstantName"/>
 


### PR DESCRIPTION
## Description

This PR updates the checkstyle configuration to allow suppressing checks via annotations. To test it, check out the branch, then run:

```sh
mvn install -pl build-tools
```

Then add the following block to, say, `BufferAllocators` in `util`:

```java
  public static void main(final String[] args) {
    switch ("hello") {
      case "hello":
        return;
    }

    System.out.println("Hello");
  }
```

Running `mvn validate -DskipChecks -Dcheckstyle.skip=false -pl util` should fail on the `MissingSwitchDefault` check. Now replace this with:

```java
  @SuppressWarnings("checkstyle:MissingSwitchDefault")
  public static void main(final String[] args) {
    switch ("hello") {
      case "hello":
        return;
    }

    System.out.println("Hello");
  }
```

Rerun the command, and it will pass :+1: 

## Related issues

closes #9318 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
