### PR TITLE
Extract template handling from ElasticsearchClient

### DIFF
--- a/exporters/elasticsearch-exporter/pom.xml
+++ b/exporters/elasticsearch-exporter/pom.xml
@@ -36,11 +36,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.elasticsearch</groupId>
-      <artifactId>elasticsearch-x-content</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpasyncclient</artifactId>
     </dependency>

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -201,16 +201,16 @@ public class ElasticsearchExporter implements Exporter {
   }
 
   private void createComponentTemplate() {
-    final String templateName = configuration.index.prefix;
-    final String filename = ZEEBE_RECORD_TEMPLATE_JSON;
-    if (!client.createComponentTemplate(templateName, filename)) {
-      log.warn("Put index template {} from file {} was not acknowledged", templateName, filename);
+    if (!client.putComponentTemplate()) {
+      log.warn("Failed to acknowledge the creation or update of the component template");
     }
   }
 
   private void createValueIndexTemplate(final ValueType valueType) {
     if (!client.putIndexTemplate(valueType)) {
-      log.warn("Put index template for value type {} was not acknowledged", valueType);
+      log.warn(
+          "Failed to acknowledge the creation or update of the index template for value type {}",
+          valueType);
     }
   }
 

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/TemplateReader.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration.IndexConfiguration;
+import io.camunda.zeebe.exporter.dto.Template;
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Map;
+
+/** Utility class to read index and component templates from the resources in a logical format. */
+@SuppressWarnings("ClassCanBeRecord") // not semantically a data class
+final class TemplateReader {
+  @SuppressWarnings("java:S1075") // not an actual URI
+  private static final String INDEX_TEMPLATE_FILENAME_PATTERN = "/zeebe-record-%s-template.json";
+
+  private static final String ZEEBE_RECORD_TEMPLATE_JSON = "/zeebe-record-template.json";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final ElasticsearchExporterConfiguration.IndexConfiguration config;
+
+  public TemplateReader(final IndexConfiguration config) {
+    this.config = config;
+  }
+
+  /** Reads the shared component template from the resources. */
+  Template readComponentTemplate() {
+    return readTemplate(ZEEBE_RECORD_TEMPLATE_JSON);
+  }
+
+  /**
+   * Reads the index template for the given value type from the resources, and replaces the alias
+   * and search patterns with the given ones. Additionally, will update the composed_of to match the
+   * configured index prefix.
+   */
+  Template readIndexTemplate(
+      final ValueType valueType, final String searchPattern, final String aliasName) {
+    final Template template = readTemplate(findResourceForTemplate(valueType));
+
+    // update prefix in template in case it was changed in configuration
+    template.composedOf().set(0, config.prefix);
+
+    template.patterns().set(0, searchPattern);
+    template.template().aliases().clear();
+    template.template().aliases().put(aliasName, Collections.emptyMap());
+
+    return template;
+  }
+
+  private String findResourceForTemplate(final ValueType valueType) {
+    return String.format(INDEX_TEMPLATE_FILENAME_PATTERN, valueTypeToString(valueType));
+  }
+
+  private String valueTypeToString(final ValueType valueType) {
+    return valueType.name().toLowerCase().replace("_", "-");
+  }
+
+  private Template readTemplate(final String resourcePath) {
+    final Template template = getTemplateFromClasspath(resourcePath);
+    final Map<String, Object> settings = template.template().settings();
+
+    substituteConfiguration(settings);
+
+    return template;
+  }
+
+  private void substituteConfiguration(final Map<String, Object> settings) {
+    // update number of shards in template in case it was changed in configuration
+    final Integer numberOfShards = config.getNumberOfShards();
+    if (numberOfShards != null) {
+      settings.put("number_of_shards", numberOfShards);
+    }
+
+    // update number of replicas in template in case it was changed in configuration
+    final Integer numberOfReplicas = config.getNumberOfReplicas();
+    if (numberOfReplicas != null) {
+      settings.put("number_of_replicas", numberOfReplicas);
+    }
+  }
+
+  private Template getTemplateFromClasspath(final String filename) {
+    try (final InputStream inputStream =
+        ElasticsearchExporter.class.getResourceAsStream(filename)) {
+      return MAPPER.readValue(inputStream, Template.class);
+    } catch (final IOException e) {
+      throw new ElasticsearchExporterException(
+          "Failed to load index template from classpath " + filename, e);
+    }
+  }
+}

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/PutIndexTemplateResponse.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/PutIndexTemplateResponse.java
@@ -10,15 +10,4 @@ package io.camunda.zeebe.exporter.dto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class PutIndexTemplateResponse {
-
-  private boolean acknowledged;
-
-  public boolean isAcknowledged() {
-    return acknowledged;
-  }
-
-  public void setAcknowledged(final boolean acknowledged) {
-    this.acknowledged = acknowledged;
-  }
-}
+public record PutIndexTemplateResponse(boolean acknowledged) {}

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/Template.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/Template.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Index template representation. You can read more about index templates <a
+ * href="https://www.elastic.co/guide/en/elasticsearch/reference/current/index-templates.html">here</a>.
+ */
+@JsonInclude(Include.NON_EMPTY)
+public record Template(
+    @JsonProperty("index_patterns") List<String> patterns,
+    @JsonProperty("composed_of") List<String> composedOf,
+    TemplateProperty template,
+    Long priority,
+    Long version) {
+
+  @JsonInclude(Include.NON_EMPTY)
+  public record TemplateProperty(
+      Map<String, Object> aliases, Map<String, Object> settings, Map<String, Object> mappings) {}
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.exporter;
 
-import static io.camunda.zeebe.exporter.ElasticsearchExporter.ZEEBE_RECORD_TEMPLATE_JSON;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -97,7 +96,7 @@ final class ElasticsearchExporterTest {
     exporter.export(mock(Record.class));
 
     // then
-    verify(client).createComponentTemplate("foo-bar", ZEEBE_RECORD_TEMPLATE_JSON);
+    verify(client).putComponentTemplate();
 
     verify(client).putIndexTemplate(ValueType.DEPLOYMENT);
     verify(client).putIndexTemplate(ValueType.PROCESS);

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TemplateReaderTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TemplateReaderTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration.IndexConfiguration;
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+final class TemplateReaderTest {
+  private final IndexConfiguration config = new IndexConfiguration();
+  private final TemplateReader templateReader = new TemplateReader(config);
+
+  @Test
+  void shouldReadComponentTemplate() {
+    // given
+
+    // when
+    final var template = templateReader.readComponentTemplate();
+
+    // then
+    assertThat(template.composedOf())
+        .as("component template is not composed of anything")
+        .isNullOrEmpty();
+    assertThat(template.patterns())
+        .as(
+            "component template has no search patterns as it's meant to be combined"
+                + " with one or more index templates")
+        .isNullOrEmpty();
+    assertThat(template.template().aliases())
+        .as("component template has no need for aliases")
+        .isNullOrEmpty();
+    assertThat(template.template().settings())
+        .containsEntry("number_of_shards", 1)
+        .containsEntry("number_of_replicas", 0)
+        .containsEntry("index.queries.cache.enabled", false);
+  }
+
+  @Test
+  void shouldSetNumberOfShardsInComponentTemplate() {
+    // given
+    config.setNumberOfShards(30);
+
+    // when
+    final var template = templateReader.readComponentTemplate();
+
+    // then
+    assertThat(template.template().settings())
+        .as("should have the configured number of shards")
+        .containsEntry("number_of_shards", 30);
+  }
+
+  @Test
+  void shouldSetNumberOfReplicasInComponentTemplate() {
+    // given
+    config.setNumberOfReplicas(20);
+
+    // when
+    final var template = templateReader.readComponentTemplate();
+
+    // then
+    assertThat(template.template().settings())
+        .as("should have the configured number of replicas")
+        .containsEntry("number_of_replicas", 20);
+  }
+
+  @Test
+  void shouldSetNumberOfShardsInIndexTemplate() {
+    // given
+    final var valueType = ValueType.VARIABLE;
+    config.setNumberOfShards(43);
+
+    // when
+    final var template = templateReader.readIndexTemplate(valueType, "searchPattern", "alias");
+
+    // then
+    assertThat(template.template().settings())
+        .as("should have the configured number of shards")
+        .containsEntry("number_of_shards", 43);
+  }
+
+  @Test
+  void shouldSetNumberOfReplicasInIndexTemplate() {
+    // given
+    final var valueType = ValueType.VARIABLE;
+    config.setNumberOfReplicas(10);
+
+    // when
+    final var template = templateReader.readIndexTemplate(valueType, "searchPattern", "alias");
+
+    // then
+    assertThat(template.template().settings())
+        .as("should have the configured number of replicas")
+        .containsEntry("number_of_replicas", 10);
+  }
+
+  @Test
+  void shouldReadIndexTemplate() {
+    // given
+    final var valueType = ValueType.VARIABLE;
+
+    // when
+    final var template = templateReader.readIndexTemplate(valueType, "searchPattern", "alias");
+
+    // then
+    assertThat(template.composedOf())
+        .as("index template is composed of the component template")
+        .containsExactly(config.prefix);
+    assertThat(template.patterns()).containsExactly("searchPattern");
+    assertThat(template.template().aliases())
+        .containsExactlyEntriesOf(Map.of("alias", Collections.emptyMap()));
+    assertThat(template.priority()).isEqualTo(20);
+    assertThat(template.template().settings())
+        .containsEntry("number_of_shards", 1)
+        .containsEntry("number_of_replicas", 0)
+        .containsEntry("index.queries.cache.enabled", false);
+  }
+
+  @Test
+  void shouldReadIndexTemplateWithDifferentPrefix() {
+    // given
+    config.prefix = "foo-bar";
+    final var valueType = ValueType.VARIABLE;
+
+    // when
+    final var template = templateReader.readIndexTemplate(valueType, "searchPattern", "alias");
+
+    // then
+    assertThat(template.composedOf()).allMatch(composedOf -> composedOf.equals(config.prefix));
+  }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -572,12 +572,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.elasticsearch</groupId>
-        <artifactId>elasticsearch-x-content</artifactId>
-        <version>${version.elasticsearch}</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.elasticsearch.client</groupId>
         <artifactId>elasticsearch-rest-client</artifactId>
         <version>${version.elasticsearch}</version>


### PR DESCRIPTION
## Description

This PR extracts the template handling logic (reading, parsing, configuring) logic from the `ElasticsearchClient` class into its own class. This will help increase maintainability and test-ability of how index templates are handled. The PR doesn't increase the test coverage marginally - for example, one could unit test the templates themselves (i.e. ensure fields are correctly typed). As this was not done previously, and it falls outside the scope of the KR, this is left as a recommendation.

## Related issues

closes #9328
related to #9320 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
