### PR TITLE
Extracts record index routing logic from ElasticsearchClient

### DIFF
--- a/exporters/elasticsearch-exporter/pom.xml
+++ b/exporters/elasticsearch-exporter/pom.xml
@@ -145,6 +145,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-test-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Dependencies needed for the integration tests only. See https://github.com/camunda/zeebe/issues/8609 -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordIndexRouter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordIndexRouter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter;
+
+import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration.IndexConfiguration;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.util.VersionUtil;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+/** Computes the name of the index, alias, or search pattern for a record or its value type. */
+final class RecordIndexRouter {
+  private static final DateTimeFormatter DEFAULT_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
+  private static final String INDEX_DELIMITER = "_";
+  private static final String ALIAS_DELIMITER = "-";
+
+  private final DateTimeFormatter formatter;
+  private final IndexConfiguration config;
+
+  RecordIndexRouter(final IndexConfiguration config) {
+    this(config, DEFAULT_FORMATTER);
+  }
+
+  RecordIndexRouter(final IndexConfiguration config, final DateTimeFormatter formatter) {
+    this.config = config;
+    this.formatter = formatter;
+  }
+
+  /**
+   * Returns the name of the index for the given record. This consists of the configured prefix,
+   * followed by the value type, the current broker version, and then the current date.
+   */
+  String indexFor(final Record<?> record) {
+    final Instant timestamp = Instant.ofEpochMilli(record.getTimestamp());
+    return (indexPrefixForValueType(record.getValueType()) + INDEX_DELIMITER)
+        + formatter.format(timestamp);
+  }
+
+  /** Returns a cluster-unique ID for the record consisting of it's "partitionId-position". */
+  String idFor(final Record<?> record) {
+    return record.getPartitionId() + "-" + record.getPosition();
+  }
+
+  /**
+   * Returns the index template's alias name for the given value type, prefixed by {@link
+   * IndexConfiguration#prefix}, e.g. for {@link ValueType#VARIABLE}, you get
+   * "my-super-prefix-variable".
+   */
+  String aliasNameForValueType(final ValueType valueType) {
+    return config.prefix + ALIAS_DELIMITER + valueTypeToString(valueType);
+  }
+
+  /** Returns the index for this value type, minus the current date. */
+  String indexPrefixForValueType(final ValueType valueType) {
+    final String version = VersionUtil.getVersionLowerCase();
+    return config.prefix
+        + INDEX_DELIMITER
+        + valueTypeToString(valueType)
+        + INDEX_DELIMITER
+        + version;
+  }
+
+  /**
+   * Returns the search pattern for this value type, which consists of the index followed by a
+   * separator and a wildcard, without the date. This allows one to search for this pattern and get
+   * all indices regardless of their date.
+   */
+  String searchPatternForValueType(final ValueType valueType) {
+    return indexPrefixForValueType(valueType) + INDEX_DELIMITER + "*";
+  }
+
+  /**
+   * Returns the routing for this record. The routing field of a document controls to which shard it
+   * will be assigned.
+   */
+  String routingFor(final Record<?> record) {
+    return String.valueOf(record.getPartitionId());
+  }
+
+  private String valueTypeToString(final ValueType valueType) {
+    return valueType.name().toLowerCase().replace("_", "-");
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
@@ -168,8 +168,8 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
     if (configuration != null && configuration.index.getNumberOfShards() != null) {
       return configuration.index.getNumberOfShards();
     } else if (indexName.startsWith(
-            esClient.indexPrefixForValueTypeWithDelimiter(ValueType.PROCESS_INSTANCE))
-        || indexName.startsWith(esClient.indexPrefixForValueTypeWithDelimiter(ValueType.JOB))) {
+            esClient.indexRouter.indexPrefixForValueType(ValueType.PROCESS_INSTANCE))
+        || indexName.startsWith(esClient.indexRouter.indexPrefixForValueType(ValueType.JOB))) {
       return 3;
     } else {
       return 1;
@@ -210,8 +210,11 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
   public static class ElasticsearchTestClient extends ElasticsearchClient {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
+    protected final RecordIndexRouter indexRouter;
+
     ElasticsearchTestClient(final ElasticsearchExporterConfiguration configuration) {
       super(configuration);
+      indexRouter = new RecordIndexRouter(configuration.index);
     }
 
     public GetSettingsForIndicesResponse getSettingsForIndices() {
@@ -253,7 +256,8 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
 
     public Map<String, Object> getDocument(final Record<?> record) {
       final var request =
-          new Request("GET", "/" + indexFor(record) + "/" + typeFor() + "/" + idFor(record));
+          new Request(
+              "GET", "/" + indexRouter.indexFor(record) + "/_doc/" + indexRouter.idFor(record));
       request.addParameter("routing", String.valueOf(record.getPartitionId()));
       try {
         final var response = client.performRequest(request);
@@ -262,7 +266,11 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
         return document.getSource();
       } catch (final IOException e) {
         throw new ElasticsearchExporterException(
-            "Failed to get record " + idFor(record) + " from index " + indexFor(record), e);
+            "Failed to get record "
+                + indexRouter.idFor(record)
+                + " from index "
+                + indexRouter.indexFor(record),
+            e);
       }
     }
   }

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordIndexRouterTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordIndexRouterTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration.IndexConfiguration;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.camunda.zeebe.util.VersionUtil;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+/**
+ * While these tests are generally testing simple methods, I think their value is mostly in ensuring
+ * our API remains stable. Consumers of the exported documents expect indices, IDs, etc., to have
+ * stable names/values, so any changes should require one to think twice about this.
+ *
+ * <p>This isn't a cure-all, but it should at least raise a flag when one of these fails.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+final class RecordIndexRouterTest {
+  private final ProtocolFactory recordFactory = new ProtocolFactory();
+  private final IndexConfiguration config = new IndexConfiguration();
+  private final RecordIndexRouter router = new RecordIndexRouter(config);
+
+  @Test
+  void shouldReturnIndexForRecord() {
+    // given
+    config.prefix = "foo-bar";
+    final var timestamp = Instant.parse("2022-04-01T00:00:00Z");
+    final var valueType = ValueType.VARIABLE;
+    final var record =
+        recordFactory.generateRecord(
+            b -> b.withValueType(valueType).withTimestamp(timestamp.toEpochMilli()));
+
+    // when
+    final var index = router.indexFor(record);
+
+    // then
+    assertThat(index)
+        .isEqualTo("foo-bar_variable_" + VersionUtil.getVersionLowerCase() + "_2022-04-01");
+  }
+
+  @Test
+  void shouldReturnIdForRecord() {
+    // given
+    final var record = recordFactory.generateRecord(b -> b.withPosition(1).withPartitionId(32));
+
+    // when
+    final var id = router.idFor(record);
+
+    // then
+    assertThat(id).isEqualTo("32-1");
+  }
+
+  @Test
+  void shouldReturnIndexPrefixForValueType() {
+    // given
+    config.prefix = "foo-bar";
+    final var valueType = ValueType.PROCESS;
+
+    // when
+    final var prefix = router.indexPrefixForValueType(valueType);
+
+    // then
+    assertThat(prefix).isEqualTo("foo-bar_process_" + VersionUtil.getVersionLowerCase());
+  }
+
+  @Test
+  void shouldReturnIndexPrefixForValueTypeWithUnderscores() {
+    // given
+    config.prefix = "foo-bar";
+    final var valueType = ValueType.PROCESS_MESSAGE_SUBSCRIPTION;
+
+    // when
+    final var prefix = router.indexPrefixForValueType(valueType);
+
+    // then
+    assertThat(prefix)
+        .isEqualTo("foo-bar_process-message-subscription_" + VersionUtil.getVersionLowerCase());
+  }
+
+  @Test
+  void shouldReturnSearchPatternForValueTypeWithUnderscores() {
+    // given
+    config.prefix = "foo-bar";
+    final var valueType = ValueType.PROCESS_MESSAGE_SUBSCRIPTION;
+
+    // when
+    final var prefix = router.searchPatternForValueType(valueType);
+
+    // then
+    assertThat(prefix)
+        .isEqualTo(
+            "foo-bar_process-message-subscription_" + VersionUtil.getVersionLowerCase() + "_*");
+  }
+
+  @Test
+  void shouldReturnSearchPatternForValueType() {
+    // given
+    config.prefix = "foo-bar";
+    final var valueType = ValueType.PROCESS;
+
+    // when
+    final var prefix = router.searchPatternForValueType(valueType);
+
+    // then
+    assertThat(prefix).isEqualTo("foo-bar_process_" + VersionUtil.getVersionLowerCase() + "_*");
+  }
+
+  @Test
+  void shouldReturnPartitionIdAsRoutingFor() {
+    // given
+    final var record = recordFactory.generateRecord(b -> b.withPartitionId(3));
+
+    // when
+    final var routing = router.routingFor(record);
+
+    // then
+    assertThat(routing).isEqualTo("3");
+  }
+}


### PR DESCRIPTION
## Description

This PR extracts the index routing logic from `ElasticsearchClient` into its own class, `RecordIndexRouter`. While it's very simple logic, since it defines the public API used by consumers of the exporter, it's useful to have it separate and well tested, even if the tests seem somewhat simple.

Part of the PR is refactoring some existing test utilities to make them work. These will go away at the end of the KR, so I wouldn't spend too much time on them. Similarly, once all the issues in #9320 are done, I will do a final pass to clean up the `ElasticsearchClient` class itself. Right now I tried to keep the refactoring to a minimal to create the PRs in parallel.

## Related issues

closes #9327 
related to #9320 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
