### PR TITLE
Move spotless config and profiles to BOM

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -44,8 +44,8 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
-      - name: Spot bugs
-        run: mvn -B -T1C -DskipTests verify -Pspotbugs
+      - name: SpotBugs
+        run: mvn -B -T1C -DskipTests -DskipChecks verify -Pspotbugs -Dspotbugs.skip=false
   go-lint:
     name: Go linting
     runs-on: ubuntu-latest

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>camunda-release-parent</artifactId>
     <version>3.9.1</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
-    <relativePath />
+    <relativePath></relativePath>
   </parent>
 
   <groupId>io.camunda</groupId>
@@ -39,9 +39,22 @@
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/</nexus.release.repository>
     <nexus.sonatype.url>https://s01.oss.sonatype.org</nexus.sonatype.url>
 
+    <!-- Zeebe Community License v1.1 header -->
+    <license.header>${maven.multiModuleProjectDirectory}/parent/COPYING-HEADER.txt</license.header>
+
     <plugin.version.flatten>1.2.7</plugin.version.flatten>
     <plugin.version.javadoc>3.4.0</plugin.version.javadoc>
+    <plugin.version.license>4.1</plugin.version.license>
     <plugin.version.spotless>2.22.4</plugin.version.spotless>
+
+    <!--
+      Define the skipChecks property here ONLY for the plugins defined in this module;
+      for all others, they should be defined in the parent POM
+    -->
+    <skipChecks>false</skipChecks>
+    <license.skip>${skipChecks}</license.skip>
+    <spotless.apply.skip>${skipChecks}</spotless.apply.skip>
+    <spotless.checks.skip>${skipChecks}</spotless.checks.skip>
   </properties>
 
   <dependencyManagement>
@@ -107,10 +120,41 @@
   <build>
     <pluginManagement>
       <plugins>
+        <!-- Formatting plugin -->
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
           <version>${plugin.version.spotless}</version>
+          <configuration>
+            <pom>
+              <!-- https://github.com/diffplug/spotless/blob/main/plugin-maven/README.md#sortpom -->
+              <sortPom></sortPom>
+            </pom>
+          </configuration>
+        </plugin>
+
+        <!-- LICENSE PLUGIN -->
+        <plugin>
+          <groupId>com.mycila</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>${plugin.version.license}</version>
+          <configuration>
+            <header>${license.header}</header>
+            <properties>
+              <owner>camunda services GmbH</owner>
+              <email>info@camunda.com</email>
+            </properties>
+            <includes>
+              <include>**/*.java</include>
+              <include>**/*.scala</include>
+            </includes>
+            <excludes>
+              <exclude>benchmarks/project/**/*</exclude>
+            </excludes>
+            <mapping>
+              <java>SLASHSTAR_STYLE</java>
+            </mapping>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -135,17 +179,17 @@
         <executions>
           <execution>
             <id>flatten</id>
-            <phase>process-resources</phase>
             <goals>
               <goal>flatten</goal>
             </goals>
+            <phase>process-resources</phase>
           </execution>
           <execution>
             <id>flatten.clean</id>
-            <phase>clean</phase>
             <goals>
               <goal>clean</goal>
             </goals>
+            <phase>clean</phase>
           </execution>
         </executions>
       </plugin>
@@ -153,6 +197,84 @@
   </build>
 
   <profiles>
+    <!-- profile to auto format -->
+    <profile>
+      <id>autoFormat</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <configuration>
+              <ratchetFrom>origin/main</ratchetFrom>
+            </configuration>
+            <executions>
+              <execution>
+                <id>spotless-format</id>
+                <goals>
+                  <goal>apply</goal>
+                </goals>
+                <phase>process-sources</phase>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-license</id>
+                <goals>
+                  <goal>format</goal>
+                </goals>
+                <phase>process-sources</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- profile to perform strict validation checks -->
+    <profile>
+      <id>checkFormat</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>spotless-check</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+                <phase>validate</phase>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>check-license</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+                <phase>validate</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>sonatype-oss-release</id>
       <properties>

--- a/build-tools/src/main/java/io/camunda/zeebe/ZeebeTestListener.java
+++ b/build-tools/src/main/java/io/camunda/zeebe/ZeebeTestListener.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
 package io.camunda.zeebe;
 
 import org.junit.runner.Description;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -27,9 +27,6 @@
   <properties>
     <version.java>17</version.java>
 
-    <!-- Zeebe Community License v1.1 header -->
-    <license.header>${maven.multiModuleProjectDirectory}/parent/COPYING-HEADER.txt</license.header>
-
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <!-- disable jdk8 javadoc checks on release build -->
     <additionalparam>-Xdoclint:none</additionalparam>
@@ -126,7 +123,6 @@
     <plugin.version.failsafe>3.0.0-M6</plugin.version.failsafe>
     <plugin.version.flaky-tests>2.1.1</plugin.version.flaky-tests>
     <plugin.version.jacoco>0.8.8</plugin.version.jacoco>
-    <plugin.version.license>4.1</plugin.version.license>
     <plugin.version.maven-jar>3.2.2</plugin.version.maven-jar>
     <plugin.version.proto-backwards-compatibility>1.0.7</plugin.version.proto-backwards-compatibility>
     <plugin.version.protobuf-maven-plugin>0.6.1</plugin.version.protobuf-maven-plugin>
@@ -136,7 +132,6 @@
     <plugin.version.scala>4.6.1</plugin.version.scala>
     <plugin.version.shade>3.3.0</plugin.version.shade>
     <plugin.version.sonar>3.9.1.2184</plugin.version.sonar>
-    <plugin.version.sortpom>3.0.1</plugin.version.sortpom>
     <plugin.version.spotbugs>4.6.0.0</plugin.version.spotbugs>
     <plugin.version.surefire>3.0.0-M6</plugin.version.surefire>
     <plugin.version.versions>2.10.0</plugin.version.versions>
@@ -1043,30 +1038,6 @@
           </executions>
         </plugin>
 
-        <!-- LICENSE PLUGIN -->
-        <plugin>
-          <groupId>com.mycila</groupId>
-          <artifactId>license-maven-plugin</artifactId>
-          <version>${plugin.version.license}</version>
-          <configuration>
-            <header>${license.header}</header>
-            <properties>
-              <owner>camunda services GmbH</owner>
-              <email>info@camunda.com</email>
-            </properties>
-            <includes>
-              <include>**/*.java</include>
-              <include>**/*.scala</include>
-            </includes>
-            <excludes>
-              <exclude>benchmarks/project/**/*</exclude>
-            </excludes>
-            <mapping>
-              <java>SLASHSTAR_STYLE</java>
-            </mapping>
-          </configuration>
-        </plugin>
-
         <!-- CHECKSTYLE -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -1107,13 +1078,6 @@
           </executions>
         </plugin>
 
-        <plugin>
-          <groupId>com.github.ekryd.sortpom</groupId>
-          <artifactId>sortpom-maven-plugin</artifactId>
-          <version>${plugin.version.sortpom}</version>
-        </plugin>
-
-        <!-- Unit tests -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
@@ -1490,11 +1454,6 @@
       </plugin>
 
       <plugin>
-        <groupId>com.github.ekryd.sortpom</groupId>
-        <artifactId>sortpom-maven-plugin</artifactId>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
@@ -1784,114 +1743,6 @@
                   <goal>sonar</goal>
                 </goals>
                 <phase>verify</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <!-- profile to auto format -->
-    <profile>
-      <id>autoFormat</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.mycila</groupId>
-            <artifactId>license-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>add-license</id>
-                <goals>
-                  <goal>format</goal>
-                </goals>
-                <phase>process-sources</phase>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>com.diffplug.spotless</groupId>
-            <artifactId>spotless-maven-plugin</artifactId>
-            <configuration combine.children="append">
-              <ratchetFrom>origin/main</ratchetFrom>
-            </configuration>
-            <executions>
-              <execution>
-                <id>spotless-format</id>
-                <goals>
-                  <goal>apply</goal>
-                </goals>
-                <phase>process-sources</phase>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>com.github.ekryd.sortpom</groupId>
-            <artifactId>sortpom-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>sortpom</id>
-                <goals>
-                  <goal>sort</goal>
-                </goals>
-                <phase>process-resources</phase>
-                <configuration>
-                  <createBackupFile>false</createBackupFile>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <!-- profile to perform strict validation checks -->
-    <profile>
-      <id>checkFormat</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.mycila</groupId>
-            <artifactId>license-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>check-license</id>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-                <phase>validate</phase>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>com.diffplug.spotless</groupId>
-            <artifactId>spotless-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>spotless-check</id>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-                <phase>validate</phase>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>com.github.ekryd.sortpom</groupId>
-            <artifactId>sortpom-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>sortpom</id>
-                <goals>
-                  <goal>verify</goal>
-                </goals>
-                <phase>validate</phase>
-                <configuration>
-                  <verifyFail>stop</verifyFail>
-                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
## Description

Moves the spotless and license plugin configuration to the BOM, and also the autoFormat and checkFormat profiles. Removes the sortPom module explicit dependency and configuration in favor of the built in sortPom extension from spotless, which is the same backend in the end.

This means we also move the autoFormat/checkFormat profiles into the BOM. Since the autoFormat profile is active by default, the `skipChecks` property for these three plugins is also defined there from now on. I've left the `skipChecks` property in `parent` as well. I know it seems redundant, but I felt otherwise it seemed to come out of "nowhere", but feel free to challenge that.

The BOM is now sorted using sortPom, and for the rest of the modules everything else applies and stays the same. There was no need to add `combine.children` directives anywhere, since what we do want is the default, i.e. merge, not append.

## Related issues

closes #8037 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
