### PR TITLE
Extract RestClient creation logic into a specific factory

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RestClientFactory.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RestClientFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.impl.nio.reactor.IOReactorConfig;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+
+final class RestClientFactory {
+  private static final RestClientFactory INSTANCE = new RestClientFactory();
+
+  private RestClientFactory() {}
+
+  /**
+   * Returns a {@link RestClient} instance based on the given configuration. The URL is parsed as a
+   * comma separated list of "host:port" formatted strings. Authentication is supported only as
+   * basic auth; if there is no authentication present, then nothing is configured for it.
+   */
+  static RestClient of(final ElasticsearchExporterConfiguration config) {
+    return INSTANCE.createRestClient(config);
+  }
+
+  private RestClient createRestClient(final ElasticsearchExporterConfiguration config) {
+    final HttpHost[] httpHosts = parseUrl(config);
+    final RestClientBuilder builder =
+        RestClient.builder(httpHosts)
+            .setRequestConfigCallback(
+                b ->
+                    b.setConnectTimeout(config.requestTimeoutMs)
+                        .setSocketTimeout(config.requestTimeoutMs))
+            .setHttpClientConfigCallback(b -> configureHttpClient(config, b));
+
+    return builder.build();
+  }
+
+  private HttpAsyncClientBuilder configureHttpClient(
+      final ElasticsearchExporterConfiguration config, final HttpAsyncClientBuilder builder) {
+    // use single thread for rest client
+    builder.setDefaultIOReactorConfig(IOReactorConfig.custom().setIoThreadCount(1).build());
+
+    if (config.hasAuthenticationPresent()) {
+      setupBasicAuthentication(config, builder);
+    }
+
+    return builder;
+  }
+
+  private void setupBasicAuthentication(
+      final ElasticsearchExporterConfiguration config, final HttpAsyncClientBuilder builder) {
+    final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+    credentialsProvider.setCredentials(
+        AuthScope.ANY,
+        new UsernamePasswordCredentials(
+            config.getAuthentication().getUsername(), config.getAuthentication().getPassword()));
+
+    builder.setDefaultCredentialsProvider(credentialsProvider);
+  }
+
+  private HttpHost[] parseUrl(final ElasticsearchExporterConfiguration config) {
+    final var urls = config.url.split(",");
+    final var hosts = new HttpHost[urls.length];
+
+    for (int i = 0; i < urls.length; i++) {
+      hosts[i] = HttpHost.create(urls[i]);
+    }
+
+    return hosts;
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RestClientFactoryTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RestClientFactoryTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.BasicUserPrincipal;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.protocol.BasicHttpContext;
+import org.elasticsearch.client.Node;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+final class RestClientFactoryTest {
+  private final ElasticsearchExporterConfiguration config =
+      new ElasticsearchExporterConfiguration();
+
+  @Test
+  void shouldConfigureMultipleHosts() {
+    // given
+    config.url = "http://localhost:9201,https://localhost:9202";
+
+    // when
+    final var client = RestClientFactory.of(config);
+
+    // then
+    assertThat(client.getNodes())
+        .hasSize(2)
+        .map(Node::getHost)
+        .containsExactly(
+            HttpHost.create("http://localhost:9201"), HttpHost.create("https://localhost:9202"));
+  }
+
+  @Test
+  void shouldConfigureBasicAuth() {
+    // given
+    config.getAuthentication().setUsername("user");
+    config.getAuthentication().setPassword("password");
+    final var context = new BasicHttpContext();
+
+    // when
+    final var client = RestClientFactory.of(config);
+    client
+        .getHttpClient()
+        .execute(HttpHost.create("localhost:9200"), new HttpGet(), context, NoopCallback.INSTANCE);
+
+    // then
+    final var credentialsProvider =
+        (CredentialsProvider) context.getAttribute(HttpClientContext.CREDS_PROVIDER);
+    assertThat(credentialsProvider)
+        .extracting(c -> c.getCredentials(AuthScope.ANY))
+        .extracting(Credentials::getUserPrincipal, Credentials::getPassword)
+        .containsExactly(new BasicUserPrincipal("user"), "password");
+  }
+
+  @Test
+  void shouldNotConfigureAuthenticationByDefault() {
+    // given
+    final var context = new BasicHttpContext();
+
+    // when
+    final var client = RestClientFactory.of(config);
+    client
+        .getHttpClient()
+        .execute(HttpHost.create("localhost:9200"), new HttpGet(), context, NoopCallback.INSTANCE);
+
+    // then
+    final var credentialsProvider =
+        (CredentialsProvider) context.getAttribute(HttpClientContext.CREDS_PROVIDER);
+    assertThat(credentialsProvider.getCredentials(AuthScope.ANY)).isNull();
+  }
+
+  private static final class NoopCallback implements FutureCallback<HttpResponse> {
+    private static final NoopCallback INSTANCE = new NoopCallback();
+
+    @Override
+    public void completed(final HttpResponse result) {}
+
+    @Override
+    public void failed(final Exception ex) {}
+
+    @Override
+    public void cancelled() {}
+  }
+}


### PR DESCRIPTION
## Description

Extracts the `RestClient` creation logic out of `ElasticsearchClient` and into its own class. This will help unit test this with various user configuration, reduce how much the `ElasticsearchClient` class is doing, and also allow us to reuse this when creating the high level REST clients used to verify the new Elasticsearch exporter tests (although not done in this PR yet).

Note that there will be some clean up required later on once the `ElasticsearchClient` class has been split, which will be done in a follow up PR.

## Related issues

closes #9329 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
