### PR TITLE
Extract record buffering logic out of ElasticsearchClient

### DIFF
--- a/exporters/elasticsearch-exporter/pom.xml
+++ b/exporters/elasticsearch-exporter/pom.xml
@@ -151,6 +151,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-jackson</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Dependencies needed for the integration tests only. See https://github.com/camunda/zeebe/issues/8609 -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter;
+
+import com.fasterxml.jackson.core.JsonParser.Feature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.exporter.dto.BulkIndexAction;
+import io.camunda.zeebe.protocol.record.Record;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.http.entity.ContentProducer;
+
+/**
+ * Buffers indexing requests of records. Each bulk operation is serialized before being buffered to
+ * avoid having to serialize it again on retry.
+ */
+final class BulkIndexRequest implements ContentProducer {
+  private static final ObjectMapper MAPPER = new ObjectMapper().enable(Feature.ALLOW_SINGLE_QUOTES);
+
+  private final List<BulkOperation> operations = new ArrayList<>();
+
+  private BulkIndexAction lastIndexedMetadata;
+  private int memoryUsageBytes = 0;
+
+  /**
+   * Indexes the given record for the given bulk action. See
+   * https://www.elastic.co/guide/en/elasticsearch/reference/7.17/docs-bulk.html for the types of
+   * actions.
+   *
+   * <p>The call is a no-op if the last indexed action is the same as the given one.
+   *
+   * @param action the bulk action to take
+   * @param record the record that will be the source of the document
+   */
+  void index(final BulkIndexAction action, final Record<?> record) {
+    // exit early in case we're retrying the last indexed record again
+    if (lastIndexedMetadata != null && lastIndexedMetadata.equals(action)) {
+      return;
+    }
+
+    final byte[] source;
+    try {
+      source = MAPPER.writer().writeValueAsBytes(record);
+    } catch (final IOException e) {
+      throw new ElasticsearchExporterException(
+          String.format("Failed to serialize record to JSON for indexing action %s", action), e);
+    }
+
+    final BulkOperation command = new BulkOperation(action, source);
+    memoryUsageBytes += command.source().length;
+    lastIndexedMetadata = action;
+    operations.add(command);
+  }
+
+  /** Returns the number of operations indexed so far. */
+  int size() {
+    return operations.size();
+  }
+
+  /** Returns an approximate amount of memory used by this buffer. */
+  int memoryUsageBytes() {
+    return memoryUsageBytes;
+  }
+
+  /** Returns true if no operations were indexed, i.e. {@link #size()} is 0, false otherwise. */
+  boolean isEmpty() {
+    return operations.isEmpty();
+  }
+
+  /** Clears the buffer entirely. */
+  void clear() {
+    operations.clear();
+    memoryUsageBytes = 0;
+    lastIndexedMetadata = null;
+  }
+
+  /** Returns the last action metadata indexed. May be null. */
+  BulkIndexAction lastIndexedMetadata() {
+    return lastIndexedMetadata;
+  }
+
+  /** Returns the currently indexed operations as an unmodifiable shallow copy. */
+  List<BulkOperation> bulkOperations() {
+    return Collections.unmodifiableList(operations);
+  }
+
+  /**
+   * Writes the JSON serialized entries, separated by a line ending for each, effectively writing
+   * nd-json.
+   */
+  @Override
+  public void writeTo(final OutputStream outStream) throws IOException {
+    for (final var operation : operations) {
+      MAPPER.writeValue(outStream, operation.metadata());
+      outStream.write('\n');
+      outStream.write(operation.source());
+      outStream.write('\n');
+    }
+  }
+
+  record BulkOperation(BulkIndexAction metadata, byte[] source) {}
+}

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -34,8 +34,8 @@ public class ElasticsearchClient {
   private final ElasticsearchExporterConfiguration configuration;
   private final TemplateReader templateReader;
   private final RecordIndexRouter indexRouter;
+  private final List<String> bulkRequest;
 
-  private List<String> bulkRequest;
   private ElasticsearchMetrics metrics;
 
   public ElasticsearchClient(final ElasticsearchExporterConfiguration configuration) {
@@ -98,7 +98,7 @@ public class ElasticsearchClient {
     try (final Histogram.Timer ignored = metrics.measureFlushDuration()) {
       exportBulk();
       // all records where flushed, create new bulk request, otherwise retry next time
-      bulkRequest = new ArrayList<>();
+      bulkRequest.clear();
     } catch (final ElasticsearchExporterException e) {
       metrics.recordFailedFlush();
       throw e;

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -30,7 +30,7 @@ import org.elasticsearch.client.RestClient;
 public class ElasticsearchClient {
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
-  protected final RestClient client;
+  private final RestClient client;
   private final ElasticsearchExporterConfiguration configuration;
   private final TemplateReader templateReader;
   private final RecordIndexRouter indexRouter;

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -28,9 +28,7 @@ public class ElasticsearchExporter implements Exporter {
 
   private Logger log = LoggerFactory.getLogger(getClass().getPackageName());
   private Controller controller;
-
   private ElasticsearchExporterConfiguration configuration;
-
   private ElasticsearchClient client;
 
   private long lastPosition = -1;
@@ -118,6 +116,7 @@ public class ElasticsearchExporter implements Exporter {
     }
   }
 
+  // TODO: remove this and instead allow client to be inject-able for testing
   protected ElasticsearchClient createClient() {
     return new ElasticsearchClient(configuration);
   }

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/BulkIndexAction.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/BulkIndexAction.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * A bulk request consists of multiple metadata/data pairs. The data is the document you wish to
+ * create, update, etc., and the metadata (also known as action) defines how the document will be
+ * affected (e.g. update, create, index, etc.).
+ */
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
+@JsonTypeName(value = "index")
+public record BulkIndexAction(
+    @JsonProperty("_index") String index, @JsonProperty("_id") String id, String routing) {}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import org.awaitility.Awaitility;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.client.RestClient;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -210,11 +211,13 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
   public static class ElasticsearchTestClient extends ElasticsearchClient {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    protected final RecordIndexRouter indexRouter;
+    private final RecordIndexRouter indexRouter;
+    private final RestClient client;
 
     ElasticsearchTestClient(final ElasticsearchExporterConfiguration configuration) {
       super(configuration);
       indexRouter = new RecordIndexRouter(configuration.index);
+      client = RestClientFactory.of(configuration);
     }
 
     public GetSettingsForIndicesResponse getSettingsForIndices() {

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.exporter.BulkIndexRequest.BulkOperation;
+import io.camunda.zeebe.exporter.dto.BulkIndexAction;
+import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+final class BulkIndexRequestTest {
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper().registerModule(new ZeebeProtocolModule());
+
+  private final ProtocolFactory recordFactory = new ProtocolFactory();
+  private final BulkIndexRequest request = new BulkIndexRequest();
+
+  @Test
+  void shouldReturnMemoryUsageAsLengthOfAllSerializedRecords() throws JsonProcessingException {
+    // given
+    final var records = recordFactory.generateRecords().limit(2).toList();
+    final var actions =
+        List.of(
+            new BulkIndexAction("index", "id", "routing"),
+            new BulkIndexAction("index2", "id2", "routing2"));
+
+    // when
+    request.index(actions.get(0), records.get(0));
+    request.index(actions.get(1), records.get(1));
+
+    // then
+    final var expectedMemoryUsage =
+        MAPPER.writeValueAsBytes(records.get(0)).length
+            + MAPPER.writeValueAsBytes(records.get(1)).length;
+    assertThat(request.memoryUsageBytes()).isEqualTo(expectedMemoryUsage);
+  }
+
+  @Test
+  void shouldClear() {
+    // given
+    final var records = recordFactory.generateRecords().limit(2).toList();
+    final var actions =
+        List.of(
+            new BulkIndexAction("index", "id", "routing"),
+            new BulkIndexAction("index2", "id2", "routing2"));
+    request.index(actions.get(0), records.get(0));
+    request.index(actions.get(1), records.get(1));
+
+    // when
+    request.clear();
+
+    // then
+    assertThat(request.bulkOperations()).isEmpty();
+    assertThat(request.isEmpty()).isTrue();
+    assertThat(request.memoryUsageBytes()).isEqualTo(0);
+    assertThat(request.size()).isEqualTo(0);
+    assertThat(request.lastIndexedMetadata()).isNull();
+  }
+
+  @Nested
+  final class IndexTest {
+    @Test
+    void shouldNotIndexWithIdenticalMetadata() {
+      // given
+      final var records = recordFactory.generateRecords().limit(2).toList();
+      final var action = new BulkIndexAction("index", "id", "routing");
+
+      // when - doesn't matter what the records are, if the metadata is the same we skip it
+      request.index(action, records.get(0));
+      request.index(action, records.get(1));
+
+      // then
+      assertThat(request.bulkOperations())
+          .extracting(BulkOperation::metadata)
+          .containsExactly(action);
+      assertThat(request.lastIndexedMetadata()).isEqualTo(action);
+      assertThat(request.isEmpty()).isFalse();
+    }
+
+    @Test
+    void shouldIndexWithDifferentMetadata() {
+      // given
+      final var records = recordFactory.generateRecords().limit(2).toList();
+      final var actions =
+          List.of(
+              new BulkIndexAction("index", "id", "routing"),
+              new BulkIndexAction("index2", "id2", "routing2"));
+
+      // when
+      request.index(actions.get(0), records.get(0));
+      request.index(actions.get(1), records.get(1));
+
+      // then
+      assertThat(request.bulkOperations())
+          .extracting(BulkOperation::metadata)
+          .containsExactlyElementsOf(actions);
+      assertThat(request.lastIndexedMetadata()).isEqualTo(actions.get(1));
+      assertThat(request.isEmpty()).isFalse();
+    }
+  }
+
+  @Nested
+  final class SerializationTest {
+    @Test
+    void shouldIndexRecordSerialized() {
+      // given
+      final var record = recordFactory.generateRecord();
+      final var action = new BulkIndexAction("index", "id", "routing");
+
+      // when
+      request.index(action, record);
+
+      // then
+      final var operations = request.bulkOperations();
+      assertThat(operations)
+          .hasSize(1)
+          .map(BulkOperation::metadata, this::deserializeSource)
+          .containsExactly(Tuple.tuple(action, record));
+    }
+
+    @Test
+    void shouldWriteOperationsAsNDJson() throws IOException {
+      // given
+      final var records = recordFactory.generateRecords().limit(2).toList();
+      final var actions =
+          List.of(
+              new BulkIndexAction("index", "id", "routing"),
+              new BulkIndexAction("index2", "id2", "routing2"));
+      request.index(actions.get(0), records.get(0));
+      request.index(actions.get(1), records.get(1));
+
+      // when
+      final byte[] serializedBuffer;
+      try (final var output = new ByteArrayOutputStream()) {
+        request.writeTo(output);
+        serializedBuffer = output.toByteArray();
+      }
+
+      // then
+      final List<Tuple> deserializedOutput = new ArrayList<>();
+      try (final var input =
+          new BufferedReader(new InputStreamReader(new ByteArrayInputStream(serializedBuffer)))) {
+        deserializedOutput.add(
+            deserializeOperation(input.readLine().getBytes(), input.readLine().getBytes()));
+        deserializedOutput.add(
+            deserializeOperation(input.readLine().getBytes(), input.readLine().getBytes()));
+      }
+
+      assertThat(deserializedOutput)
+          .containsExactly(
+              Tuple.tuple(actions.get(0), records.get(0)),
+              Tuple.tuple(actions.get(1), records.get(1)));
+    }
+
+    private Record<?> deserializeSource(final BulkOperation operation) {
+      try {
+        return MAPPER.readValue(operation.source(), new TypeReference<>() {});
+      } catch (final IOException e) {
+        throw new UncheckedIOException(
+            String.format("Failed to deserialize operation [%s] source", operation.metadata()), e);
+      }
+    }
+
+    private Tuple deserializeOperation(final byte[] metadata, final byte[] source) {
+      try {
+        return Tuple.tuple(
+            MAPPER.readValue(metadata, BulkIndexAction.class),
+            MAPPER.readValue(source, new TypeReference<Record<?>>() {}));
+      } catch (final IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
@@ -9,119 +9,60 @@ package io.camunda.zeebe.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
-import java.util.ArrayList;
-import java.util.function.Function;
-import java.util.stream.IntStream;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import org.junit.Before;
 import org.junit.Test;
 
 public class ElasticsearchClientIT extends AbstractElasticsearchExporterIntegrationTestCase {
+  private final ProtocolFactory recordFactory = new ProtocolFactory();
 
-  private static final long RECORD_KEY = 1234L;
-  private ElasticsearchExporterConfiguration configuration;
+  private ElasticsearchExporterConfiguration config;
   private ElasticsearchClient client;
-  private ArrayList<String> bulkRequest;
+  private BulkIndexRequest bulkRequest;
 
   @Before
   public void init() {
     elastic.start();
 
-    configuration = getDefaultConfiguration();
-    bulkRequest = new ArrayList<>();
-    client = new ElasticsearchClient(configuration, bulkRequest);
+    config = getDefaultConfiguration();
+    bulkRequest = new BulkIndexRequest();
+    client = new ElasticsearchClient(config, bulkRequest, new ElasticsearchMetrics(1));
   }
 
   @Test
   public void shouldThrowExceptionIfFailToFlushBulk() {
-    // given
-    final int bulkSize = 10;
-
-    final Record<VariableRecordValue> recordMock = mock(Record.class);
-    when(recordMock.getPartitionId()).thenReturn(1);
-    when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
-
-    // bulk contains records that fail on flush
-    IntStream.range(0, bulkSize)
-        .forEach(
-            i -> {
-              when(recordMock.getKey()).thenReturn(RECORD_KEY + i);
-              when(recordMock.toJson()).thenReturn("invalid-json-" + i);
-              client.index(recordMock);
-            });
-
-    // and one valid record
-    when(recordMock.getKey()).thenReturn(RECORD_KEY + bulkSize);
-    when(recordMock.toJson()).thenReturn("{}");
-    client.index(recordMock);
+    // given - a record with a negative timestamp will not be indexed because its field in ES is a
+    // date, which must be a positive number of milliseconds since the UNIX epoch
+    final var invalidRecord =
+        recordFactory.generateRecord(ValueType.VARIABLE, b -> b.withTimestamp(Long.MIN_VALUE));
+    client.index(invalidRecord);
+    client.putComponentTemplate();
+    client.putIndexTemplate(ValueType.VARIABLE);
 
     // when/then
     assertThatThrownBy(client::flush)
         .isInstanceOf(ElasticsearchExporterException.class)
         .hasMessageContaining(
-            "Failed to flush 10 item(s) of bulk request [type: mapper_parsing_exception, reason: failed to parse]");
-  }
-
-  @Test
-  public void shouldIgnoreRecordIfDuplicateOfLast() {
-    // given
-    final Record<VariableRecordValue> recordMock = mock(Record.class);
-    when(recordMock.getPartitionId()).thenReturn(1);
-    when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
-    when(recordMock.getKey()).thenReturn(RECORD_KEY + 1);
-    when(recordMock.toJson()).thenReturn("{}");
-
-    client.index(recordMock);
-    assertThat(bulkRequest).hasSize(1);
-
-    // when
-    client.index(recordMock);
-
-    // then
-    assertThat(bulkRequest).hasSize(1);
+            "Failed to flush bulk request: [Failed to flush 1 item(s) of bulk request [type: mapper_parsing_exception, reason: failed to parse field [timestamp]");
   }
 
   @Test
   public void shouldFlushOnMemoryLimit() {
     // given
-    final var bulkMemoryLimit = 1024;
-    final var recordSize = 2;
+    config.bulk.size = Integer.MAX_VALUE;
+    final var firstRecord = recordFactory.generateRecord(ValueType.VARIABLE);
+    final var secondRecord = recordFactory.generateRecord(ValueType.DECISION);
 
-    configuration.bulk.memoryLimit = bulkMemoryLimit;
-    configuration.bulk.size = Integer.MAX_VALUE;
-    configuration.bulk.delay = Integer.MAX_VALUE;
-
-    final var variableValue1 = "x".repeat(bulkMemoryLimit / recordSize);
-    final var variableValue2 = "y".repeat(bulkMemoryLimit / recordSize);
-    final Function<String, String> jsonRecord =
-        (String value) -> String.format("{\"value\":\"%s\"}", value);
-
-    final VariableRecordValue recordValue = mock(VariableRecordValue.class);
-    when(recordValue.getValue()).thenReturn(variableValue1);
-
-    final Record<VariableRecordValue> recordMock = mock(Record.class);
-    when(recordMock.getKey()).thenReturn(1L);
-    when(recordMock.getPartitionId()).thenReturn(1);
-    when(recordMock.getValueType()).thenReturn(ValueType.VARIABLE);
-    when(recordMock.getValue()).thenReturn(recordValue);
-    when(recordMock.toJson()).thenReturn(jsonRecord.apply(variableValue1));
-
-    // when
-    client.index(recordMock);
-
+    // when - index a single record, then set the memory limit specifically to be its size + 1
+    // this decouples the test from whatever is used to serialize the record
+    client.index(firstRecord);
+    config.bulk.memoryLimit = bulkRequest.bulkOperations().get(0).source().length + 1;
     assertThat(client.shouldFlush()).isFalse();
 
-    when(recordMock.getKey()).thenReturn(2L);
-    when(recordMock.toJson()).thenReturn(jsonRecord.apply(variableValue2));
-
-    client.index(recordMock);
-
-    // then
+    // when - then
+    client.index(secondRecord);
     assertThat(client.shouldFlush()).isTrue();
   }
 }


### PR DESCRIPTION
## Description

Initially I was only going to clean up and simplify that part, but I think I'd rather leave the client to only deal with building/sending requests, and handling responses/failures to/from Elastic. If you follow commit by commit, I think you can see how I ended up rolling this together.

This PR extracts the record buffering logic out of `ElasticsearchClient` and into its own component, `BulkIndexRequest`. This class will take care of indexing records, serializing them, and serializing itself at the end as a line separated list of bulk actions (see https://www.elastic.co/guide/en/elasticsearch/reference/7.17/docs-bulk.html for more).

Using a specific DTO for the bulk action (`BulkIndexAction`) makes it clearer what it will be serialized as, and allows us to write simpler assertions for our tests.

Similarly, splitting the `BulkIndexRequest` away from the client makes it easier to understand how the request is built up and serialized, while also making the client (and thus exporter) much more observable. I opted against serializing the metadata of the bulk action, primarily because it has somewhat of an upper bound on how big it can get, and I expect the bulk of the memory usage to be records related. Leaving deserialized makes it much more observable. The one downside I see there is that if there was a serialization error during flush, it's a bit late for that, but I think that's a very unlikely case.

There's some overlap at the moment between the tests, which I will deal with in #9330 and #9331.

## Related issues

closes #9340 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
