### PR TITLE
Fix env vars in config doc

### DIFF
--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -79,44 +79,44 @@
         # Configure whether to broadcast member updates to all members.
         # If set to false updates will be gossiped among the members.
         # If set to true the network traffic may increase but it reduce the time to detect membership changes.
-        # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_BROADCASTUPDATES
+        # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_BROADCASTUPDATES
         # broadcastUpdates: false
 
         # Configure whether to broadcast disputes to all members.
         # If set to true the network traffic may increase but it reduce the time to detect membership changes.
-        # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_BROADCASTDISPUTES
+        # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_BROADCASTDISPUTES
         # broadcastDisputes: true
 
         # Configure whether to notify a suspect node on state changes.
-        # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_NOTIFYSUSPECT
+        # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_NOTIFYSUSPECT
         # notifySuspect: false
 
         # Sets the interval at which the membership updates are sent to a random member.
-        # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_GOSSIPINTERVAL
+        # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_GOSSIPINTERVAL
         # gossipInterval: 250ms
 
         # Sets the number of members to which membership updates are sent at each gossip interval.
-        # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_GOSSIPFANOUT
+        # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_GOSSIPFANOUT
         # gossipFanout: 2
 
         # Sets the interval at which to probe a random member.
-        # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBEINTERVAL
+        # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_PROBEINTERVAL
         # probeInterval: 1s
 
         # Sets the timeout for a probe response
-        # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBETIMEOUT
+        # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_PROBETIMEOUT
         # probeTimeout: 100ms
 
         # Sets the number of probes failed before declaring a member is suspect
-        # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SUSPECTPROBES
+        # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_SUSPECTPROBES
         # suspectProbes: 3
 
         # Sets the timeout for a suspect member is declared dead.
-        # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_FAILURETIMEOUT
+        # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_FAILURETIMEOUT
         # failureTimeout: 10s
 
         # Sets the interval at which this member synchronizes its membership information with a random member.
-        # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SYNCINTERVAL
+        # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_SYNCINTERVAL
         # syncInterval: 10s
 
       # security:
@@ -132,9 +132,9 @@
         # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH.
         # privateKeyPath:
 
-      # Configure compression algorithm for all message sent between the brokers and between the broker and
-      # the gateway. Available options are NONE, GZIP and SNAPPY.
-      # This feature is useful when the network latency between the brokers is very high (for example when the brokers are deployed in different data centers).
+      # Configure compression algorithm for all messages sent between the gateway and
+      # the brokers. Available options are NONE, GZIP and SNAPPY.
+      # This feature is useful when the network latency between the nodes is very high (for example when nodes are deployed in different data centers).
       # When latency is high, the network bandwidth is severely reduced. Hence enabling compression helps to improve the throughput.
       # Note: When there is no latency enabling this may have a performance impact.
       # Note: When this flag is enables, you must also enable compression in standalone broker configuration.


### PR DESCRIPTION
## Description

The names of the environment variables were wrong, they referenced the broker instead of the gateway.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
