### PR TITLE
Fix NPE because of missing decisionId of failed decision evaluation

### DIFF
--- a/dmn/src/main/java/io/camunda/zeebe/dmn/impl/DmnScalaDecisionEngine.java
+++ b/dmn/src/main/java/io/camunda/zeebe/dmn/impl/DmnScalaDecisionEngine.java
@@ -92,9 +92,9 @@ public final class DmnScalaDecisionEngine implements DecisionEngine {
 
     if (!decisionRequirementsGraph.isValid()) {
       return new EvaluationFailure(
-          String.format(
-              "Expected to evaluate decision '%s', but the decision requirements graph is invalid",
-              decisionId));
+          "Expected to evaluate decision '%s', but the decision requirements graph is invalid"
+              .formatted(decisionId),
+          decisionId);
     }
 
     final var parsedDmn = ((ParsedDmnScalaDrg) decisionRequirementsGraph).getParsedDmn();

--- a/dmn/src/main/java/io/camunda/zeebe/dmn/impl/DmnScalaDecisionEngine.java
+++ b/dmn/src/main/java/io/camunda/zeebe/dmn/impl/DmnScalaDecisionEngine.java
@@ -107,8 +107,11 @@ public final class DmnScalaDecisionEngine implements DecisionEngine {
     if (result.isLeft()) {
       final var reason = result.left().get().failure().message();
 
-      String failedDecisionId = null;
+      // use the target decision's id as the failed decision
+      String failedDecisionId = decisionId;
       if (!evaluatedDecisions.isEmpty()) {
+        // if we know exactly which decision failed, then we can use that one
+        // it's always the last decision that was evaluated
         failedDecisionId = evaluatedDecisions.get(evaluatedDecisions.size() - 1).decisionId();
       }
 

--- a/dmn/src/main/java/io/camunda/zeebe/dmn/impl/EvaluationFailure.java
+++ b/dmn/src/main/java/io/camunda/zeebe/dmn/impl/EvaluationFailure.java
@@ -19,8 +19,8 @@ public final class EvaluationFailure implements DecisionEvaluationResult {
   private final String failedDecisionId;
   private final List<EvaluatedDecision> evaluatedDecisions;
 
-  public EvaluationFailure(final String message) {
-    this(message, null, List.of());
+  public EvaluationFailure(final String message, final String failedDecisionId) {
+    this(message, failedDecisionId, List.of());
   }
 
   public EvaluationFailure(

--- a/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluationTest.java
+++ b/dmn/src/test/java/io/camunda/zeebe/dmn/DmnEvaluationTest.java
@@ -54,8 +54,8 @@ class DmnEvaluationTest {
 
     assertThat(result.getFailedDecisionId())
         .describedAs(
-            "Expect that the failed decision id is 'null' if the decision was not evaluated")
-        .isNull();
+            "Expect that the failed decision id is the target decision id if the decision was not evaluated")
+        .isEqualTo("not_in_drg");
 
     assertThat(result.getOutput())
         .describedAs("Expect that a failed evaluation has no output")
@@ -113,8 +113,9 @@ class DmnEvaluationTest {
         .contains("the decision requirements graph is invalid");
 
     assertThat(result.getFailedDecisionId())
-        .describedAs("Expect that the failed decision id is 'null' if the DRG is invalid")
-        .isNull();
+        .describedAs(
+            "Expect that the failed decision id is the target decision id if the DRG is invalid")
+        .isEqualTo("jedi_or_sith");
 
     assertThat(result.getOutput())
         .describedAs("Expect that a successful result has no output")


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

When the decision evaluation fails, a DECISION_EVALUATION record with FAILED intent is written, containing relevant information about the failure. This includes the id of the decision that failed. However, in 2 cases it might happen that a `null` value would be used, which cannot be written into a record, leading to a NullPointerException (NPE).

Both NPEs can be avoided by not using `null`, but using reasonable defaults instead. In both cases, the id of the decision that was intended to be evaluated can be used as the replacement of this `null`.

While we were able to discover the NPEs' causes from the code and the stack traces, we were unable to reproduce the situation from a user's perspective. I've thus left out a regression test for it.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9344 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
