### PR TITLE
Refactor the ElasticsearchClient integration tests

### DIFF
--- a/exporters/elasticsearch-exporter/pom.xml
+++ b/exporters/elasticsearch-exporter/pom.xml
@@ -128,6 +128,24 @@
     </dependency>
 
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>elasticsearch</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>co.elastic.clients</groupId>
+      <artifactId>elasticsearch-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/exporters/elasticsearch-exporter/pom.xml
+++ b/exporters/elasticsearch-exporter/pom.xml
@@ -157,6 +157,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Dependencies needed for the integration tests only. See https://github.com/camunda/zeebe/issues/8609 -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -26,7 +26,7 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 
-class ElasticsearchClient {
+class ElasticsearchClient implements AutoCloseable {
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private final RestClient client;
@@ -68,6 +68,7 @@ class ElasticsearchClient {
     this.metrics = metrics;
   }
 
+  @Override
   public void close() throws IOException {
     client.close();
   }

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
@@ -7,31 +7,77 @@
  */
 package io.camunda.zeebe.exporter;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import co.elastic.clients.elasticsearch._types.Refresh;
+import io.camunda.zeebe.exporter.TestClient.ComponentTemplatesDto.ComponentTemplateWrapper;
+import io.camunda.zeebe.exporter.TestClient.IndexTemplatesDto.IndexTemplateWrapper;
+import io.camunda.zeebe.exporter.dto.Template;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import org.junit.Before;
-import org.junit.Test;
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+import org.agrona.CloseHelper;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
-public class ElasticsearchClientIT extends AbstractElasticsearchExporterIntegrationTestCase {
+@Testcontainers
+@Execution(ExecutionMode.CONCURRENT)
+final class ElasticsearchClientIT {
+  // configuring a superuser will allow us to create more users, which will let us test
+  // authentication
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      TestSupport.createDefaultContainer()
+          .withEnv("xpack.license.self_generated.type", "trial")
+          .withEnv("xpack.security.enabled", "true")
+          .withEnv("xpack.security.authc.anonymous.username", "anon")
+          .withEnv("xpack.security.authc.anonymous.roles", "superuser")
+          .withEnv("xpack.security.authc.anonymous.authz_exception", "true");
+
   private final ProtocolFactory recordFactory = new ProtocolFactory();
+  private final ElasticsearchExporterConfiguration config =
+      new ElasticsearchExporterConfiguration();
+  private final TemplateReader templateReader = new TemplateReader(config.index);
+  private final RecordIndexRouter indexRouter = new RecordIndexRouter(config.index);
+  private final BulkIndexRequest bulkRequest = new BulkIndexRequest();
 
-  private ElasticsearchExporterConfiguration config;
+  private TestClient testClient;
   private ElasticsearchClient client;
-  private BulkIndexRequest bulkRequest;
 
-  @Before
-  public void init() {
-    elastic.start();
+  @BeforeEach
+  public void beforeEach() {
+    // as all tests use the same endpoint, we need a per-test unique prefix
+    config.index.prefix = UUID.randomUUID() + "-test-record";
+    config.url = CONTAINER.getHttpHostAddress();
 
-    config = getDefaultConfiguration();
-    bulkRequest = new BulkIndexRequest();
-    client = new ElasticsearchClient(config, bulkRequest);
+    testClient = new TestClient(config, indexRouter);
+    client =
+        new ElasticsearchClient(
+            config,
+            bulkRequest,
+            RestClientFactory.of(config),
+            indexRouter,
+            templateReader,
+            new ElasticsearchMetrics(1));
+  }
+
+  @AfterEach
+  void afterEach() {
+    CloseHelper.quietCloseAll(testClient, client);
   }
 
   @Test
-  public void shouldThrowExceptionIfFailToFlushBulk() {
+  void shouldThrowExceptionIfFailToFlushBulk() {
     // given - a record with a negative timestamp will not be indexed because its field in ES is a
     // date, which must be a positive number of milliseconds since the UNIX epoch
     final var invalidRecord =
@@ -45,5 +91,99 @@ public class ElasticsearchClientIT extends AbstractElasticsearchExporterIntegrat
         .isInstanceOf(ElasticsearchExporterException.class)
         .hasMessageContaining(
             "Failed to flush bulk request: [Failed to flush 1 item(s) of bulk request [type: mapper_parsing_exception, reason: failed to parse field [timestamp]");
+  }
+
+  @Test
+  void shouldPutIndexTemplate() {
+    // given
+    final var valueType = ValueType.VARIABLE;
+    final String indexTemplateName = indexRouter.indexPrefixForValueType(valueType);
+    final String indexTemplateAlias = indexRouter.aliasNameForValueType(valueType);
+    final Template expectedTemplate =
+        templateReader.readIndexTemplate(
+            valueType, indexRouter.searchPatternForValueType(valueType), indexTemplateAlias);
+
+    // required since all index templates are composed with it
+    client.putComponentTemplate();
+
+    // when
+    client.putIndexTemplate(valueType);
+
+    // then
+    final var templateWrapper = testClient.getIndexTemplate(valueType);
+    assertThat(templateWrapper)
+        .as("should have created template for value type %s", valueType)
+        .isPresent()
+        .get()
+        .extracting(IndexTemplateWrapper::name)
+        .isEqualTo(indexTemplateName);
+
+    final var template = templateWrapper.get().template();
+    assertIndexTemplate(template, expectedTemplate);
+  }
+
+  @Test
+  void shouldPutComponentTemplate() {
+    // given
+    final Template expectedTemplate = templateReader.readComponentTemplate();
+
+    // when
+    client.putComponentTemplate();
+
+    // then
+    final var templateWrapper = testClient.getComponentTemplate();
+    assertThat(templateWrapper)
+        .as("should have created component template")
+        .isPresent()
+        .get()
+        .extracting(ComponentTemplateWrapper::name)
+        .isEqualTo(config.index.prefix);
+
+    final var template = templateWrapper.get().template();
+    assertIndexTemplate(template, expectedTemplate);
+  }
+
+  @Test
+  void shouldAuthenticateWithBasicAuth() throws IOException {
+    // given
+    testClient
+        .getEsClient()
+        .security()
+        .putUser(
+            b -> b.username("user").password("password").refresh(Refresh.True).roles("superuser"));
+    config.getAuthentication().setUsername("user");
+    config.getAuthentication().setPassword("password");
+
+    // when
+    // force recreating the client
+    final var authenticatedClient = new ElasticsearchClient(config, bulkRequest);
+    authenticatedClient.putComponentTemplate();
+
+    // then
+    assertThat(testClient.getComponentTemplate()).isPresent();
+  }
+
+  private void assertIndexTemplate(final Template actualTemplate, final Template expectedTemplate) {
+    assertThat(actualTemplate.patterns()).isEqualTo(expectedTemplate.patterns());
+    assertThat(actualTemplate.composedOf()).isEqualTo(expectedTemplate.composedOf());
+    assertThat(actualTemplate.priority()).isEqualTo(expectedTemplate.priority());
+    assertThat(actualTemplate.version()).isEqualTo(expectedTemplate.version());
+    assertThat(actualTemplate.template().aliases())
+        .isEqualTo(expectedTemplate.template().aliases());
+    assertThat(actualTemplate.template().mappings())
+        .isEqualTo(expectedTemplate.template().mappings());
+
+    // cannot compare settings because we never get flat settings, instead we get { index : {
+    // number_of_shards: 1, queries: { cache : { enabled : false } } } }
+    // so instead we decompose how we compare the settings. I've tried with flat_settings parameter
+    // but that doesn't seem to be doing anything
+    assertThat(actualTemplate.template().settings())
+        .as("should contain a map of index settings")
+        .extractingByKey("index")
+        .isInstanceOf(Map.class)
+        .asInstanceOf(InstanceOfAssertFactories.map(String.class, Object.class))
+        .containsEntry("number_of_shards", "1")
+        .containsEntry("number_of_replicas", "0")
+        .containsEntry("queries", Map.of("cache", Map.of("enabled", "false")));
   }
 }

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestClient.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestClient.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.exporter.TestClient.ComponentTemplatesDto.ComponentTemplateWrapper;
+import io.camunda.zeebe.exporter.TestClient.IndexTemplatesDto.IndexTemplateWrapper;
+import io.camunda.zeebe.exporter.dto.Template;
+import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.util.CloseableSilently;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Optional;
+import org.agrona.CloseHelper;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RestClient;
+
+/**
+ * A thin client to verify properties from Elastic. Wraps both the low and high level clients from
+ * Elastic in a closeable resource.
+ */
+final class TestClient implements CloseableSilently {
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper().registerModule(new ZeebeProtocolModule());
+
+  private final ElasticsearchExporterConfiguration config;
+  private final RestClient restClient;
+  private final ElasticsearchClient esClient;
+  private final RecordIndexRouter indexRouter;
+
+  TestClient(final ElasticsearchExporterConfiguration config, final RecordIndexRouter indexRouter) {
+    this.config = config;
+    this.indexRouter = indexRouter;
+
+    restClient = RestClientFactory.of(config);
+
+    final var transport = new RestClientTransport(restClient, new JacksonJsonpMapper(MAPPER));
+    esClient = new ElasticsearchClient(transport);
+  }
+
+  Optional<IndexTemplateWrapper> getIndexTemplate(final ValueType valueType) {
+    try {
+      final var request =
+          new Request("GET", "/_index_template/" + indexRouter.indexPrefixForValueType(valueType));
+      final var response = restClient.performRequest(request);
+      final var templates =
+          MAPPER.readValue(response.getEntity().getContent(), IndexTemplatesDto.class);
+      return templates.wrappers().stream().findFirst();
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  Optional<ComponentTemplateWrapper> getComponentTemplate() {
+    try {
+      final var request = new Request("GET", "/_component_template/" + config.index.prefix);
+      final var response = restClient.performRequest(request);
+      final var templates =
+          MAPPER.readValue(response.getEntity().getContent(), ComponentTemplatesDto.class);
+      return templates.wrappers().stream().findFirst();
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  ElasticsearchClient getEsClient() {
+    return esClient;
+  }
+
+  @Override
+  public void close() {
+    CloseHelper.quietCloseAll(esClient._transport());
+  }
+
+  record IndexTemplatesDto(@JsonProperty("index_templates") List<IndexTemplateWrapper> wrappers) {
+    record IndexTemplateWrapper(String name, @JsonProperty("index_template") Template template) {}
+  }
+
+  record ComponentTemplatesDto(
+      @JsonProperty("component_templates") List<ComponentTemplateWrapper> wrappers) {
+    record ComponentTemplateWrapper(
+        String name, @JsonProperty("component_template") Template template) {}
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -25,7 +25,7 @@ final class TestSupport {
   /**
    * Returns an Elasticsearch container pointing at the same version as the {@link RestClient}.
    *
-   * <p>The container is configured to use 750m of heap and 750m of direct memory. This is required
+   * <p>The container is configured to use 512m of heap and 512m of direct memory. This is required
    * because Elasticsearch 7.x, by default, will grab all the RAM available otherwise.
    *
    * <p>Additionally, security is explicitly disabled to avoid having tons of warning printed out.

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -10,10 +10,32 @@ package io.camunda.zeebe.exporter;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.util.EnumSet;
 import java.util.stream.Stream;
+import org.elasticsearch.client.RestClient;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
 
 /** Collection of utilities for unit and integration tests. */
 final class TestSupport {
+  private static final DockerImageName ELASTIC_IMAGE =
+      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+          .withTag(RestClient.class.getPackage().getImplementationVersion());
+
   private TestSupport() {}
+
+  /**
+   * Returns an Elasticsearch container pointing at the same version as the {@link RestClient}.
+   *
+   * <p>The container is configured to use 750m of heap and 750m of direct memory. This is required
+   * because Elasticsearch 7.x, by default, will grab all the RAM available otherwise.
+   *
+   * <p>Additionally, security is explicitly disabled to avoid having tons of warning printed out.
+   */
+  static ElasticsearchContainer createDefaultContainer() {
+    return new ElasticsearchContainer(ELASTIC_IMAGE)
+        .withEnv("ES_JAVA_OPTS", "-Xms256m -Xmx512m -XX:MaxDirectMemorySize=536870912")
+        .withEnv("action.auto_create_index", "true")
+        .withEnv("xpack.security.enabled", "false");
+  }
 
   /**
    * Returns a stream of value types which are export-able by the exporter, i.e. the ones with an

--- a/exporters/elasticsearch-exporter/src/test/resources/log4j2-test.xml
+++ b/exporters/elasticsearch-exporter/src/test/resources/log4j2-test.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Zeebe Community License 1.1. You may not use this file
+  ~ except in compliance with the Zeebe Community License 1.1.
+  -->
+<Configuration status="WARN">
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout
+        pattern="%d{HH:mm:ss.SSS} [%X{actor-name}] [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="io.camunda.zeebe" level="debug"/>
+
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+
+</Configuration>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -580,6 +580,12 @@
       </dependency>
 
       <dependency>
+        <groupId>co.elastic.clients</groupId>
+        <artifactId>elasticsearch-java</artifactId>
+        <version>${version.elasticsearch}</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${version.guava}</version>


### PR DESCRIPTION
## Description

This PR refactors the `ElasticsearchClient` integration tests. This somewhat increases test coverage by adding new tests with a reduced blast radius, as opposed to testing the client indirectly via the exporter running in a broker.

## Related issues

closes #9331
closes #9320 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
