### PR TITLE
Return empty topology response when not known

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/StandaloneGatewayIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/StandaloneGatewayIT.java
@@ -11,10 +11,8 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.command.ClientStatusException;
 import io.camunda.zeebe.gateway.StandaloneGateway;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
-import io.grpc.Status.Code;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.filter.log.RequestLoggingFilter;
 import io.restassured.filter.log.ResponseLoggingFilter;
@@ -70,16 +68,8 @@ final class StandaloneGatewayIT {
           .then()
           .statusCode(200);
 
-      // depending on how fast the gateway is, we may get an unavailable error or an empty topology
-      try {
-        final var result = topology.join(5L, TimeUnit.SECONDS);
-        assertThat(result.getBrokers()).as("there are no known brokers").isEmpty();
-      } catch (final ClientStatusException e) {
-        assertThat(e).hasRootCauseMessage("UNAVAILABLE: No brokers available");
-        assertThat(e.getStatus().getCode()).isEqualTo(Code.UNAVAILABLE);
-      } catch (final Exception e) {
-        throw e;
-      }
+      final var result = topology.join(5L, TimeUnit.SECONDS);
+      assertThat(result.getBrokers()).as("there are no known brokers").isEmpty();
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The topology is a way to view the cluster from the gateway's point of view. Returning UNAVAILABLE hides this and makes it hard to distinguish between a call where the gateway is unavailable and where the topology is simply not known. By returning an empty topology we can differentiate between an unavailable gateway and a not known topology.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9096 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
