### PR TITLE
Implement a job backoff timeout on Zeebe Java client side

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/FailJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/FailJobCommandStep1.java
@@ -38,8 +38,8 @@ public interface FailJobCommandStep1 {
     /**
      * Set the backoff timeout for failing this job.
      *
-     * <p>If the backoff timeout is greater than zero and retries are greater than zero then after
-     * the job this job will be picked up again after this backoff timeout will pass.
+     * <p>If the backoff timeout is greater than zero and retries are greater than zero then this
+     * job will be picked up again after the given backoff timeout is expired.
      *
      * @param backoffTimeout the backoff timeout of this job
      * @return the builder for this command. Call {@link #send()} to complete the command and send *

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/FailJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/FailJobCommandStep1.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.client.api.command;
 
 import io.camunda.zeebe.client.api.response.FailJobResponse;
+import java.time.Duration;
 
 public interface FailJobCommandStep1 {
 
@@ -33,6 +34,18 @@ public interface FailJobCommandStep1 {
 
   interface FailJobCommandStep2 extends FinalCommandStep<FailJobResponse> {
     // the place for new optional parameters
+
+    /**
+     * Set the backoff timeout for failing this job.
+     *
+     * <p>If the backoff timeout is greater than zero and retries are greater than zero then after
+     * the job this job will be picked up again after this backoff timeout will pass.
+     *
+     * @param backoffTimeout the backoff timeout of this job
+     * @return the builder for this command. Call {@link #send()} to complete the command and send *
+     *     it to the broker.
+     */
+    FailJobCommandStep2 retryBackoff(final Duration backoffTimeout);
 
     /**
      * Provide an error message describing the reason for the job failure. If failing the job

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/FailJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/FailJobCommandImpl.java
@@ -57,6 +57,12 @@ public final class FailJobCommandImpl implements FailJobCommandStep1, FailJobCom
   }
 
   @Override
+  public FailJobCommandStep2 retryBackoff(final Duration backoffTimeout) {
+    builder.setRetryBackOff(backoffTimeout.toMillis());
+    return this;
+  }
+
+  @Override
   public FailJobCommandStep2 errorMessage(final String errorMsg) {
     builder.setErrorMessage(errorMsg);
     return this;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor.CommandControl;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectQueue;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -34,6 +35,8 @@ import java.util.function.Consumer;
  */
 public final class CommandProcessorImpl<T extends UnifiedRecordValue>
     implements TypedRecordProcessor<T>, CommandControl<T> {
+
+  private final SideEffectQueue sideEffectQueue = new SideEffectQueue();
 
   private final CommandProcessor<T> wrappedProcessor;
 
@@ -70,7 +73,12 @@ public final class CommandProcessorImpl<T extends UnifiedRecordValue>
       final Consumer<SideEffectProducer> sideEffect) {
 
     entityKey = command.getKey();
-    final boolean shouldRespond = wrappedProcessor.onCommand(command, this, sideEffect);
+
+    sideEffect.accept(sideEffectQueue);
+    sideEffectQueue.clear();
+    sideEffectQueue.add(responseWriter::flush);
+
+    final boolean shouldRespond = wrappedProcessor.onCommand(command, this, sideEffectQueue::add);
 
     final boolean respond = shouldRespond && command.hasRequestMetadata();
 
@@ -79,13 +87,11 @@ public final class CommandProcessorImpl<T extends UnifiedRecordValue>
       wrappedProcessor.afterAccept(commandWriter, stateWriter, entityKey, newState, updatedValue);
       if (respond) {
         responseWriter.writeEventOnCommand(entityKey, newState, updatedValue, command);
-        responseWriter.flush();
       }
     } else {
       rejectionWriter.appendRejection(command, rejectionType, rejectionReason);
       if (respond) {
         responseWriter.writeRejectionOnCommand(command, rejectionType, rejectionReason);
-        responseWriter.flush();
       }
     }
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
@@ -79,11 +79,13 @@ public final class CommandProcessorImpl<T extends UnifiedRecordValue>
       wrappedProcessor.afterAccept(commandWriter, stateWriter, entityKey, newState, updatedValue);
       if (respond) {
         responseWriter.writeEventOnCommand(entityKey, newState, updatedValue, command);
+        responseWriter.flush();
       }
     } else {
       rejectionWriter.appendRejection(command, rejectionType, rejectionReason);
       if (respond) {
         responseWriter.writeRejectionOnCommand(command, rejectionType, rejectionReason);
+        responseWriter.flush();
       }
     }
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
I implemented the usage of the backoff parameter in the Zeebe Java Client and @saig0 fixed the problem with flushing responses.

## Related issues

<!-- Which issues are closed by this PR or are related -->

#5629 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
