### PR TITLE
feat(engine): support iso8601 <start> for timer cycle

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/time/Interval.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/time/Interval.java
@@ -86,7 +86,7 @@ public class Interval implements TemporalAmount {
           .toEpochMilli();
     }
 
-    return start.get().plus(this).toInstant().toEpochMilli();
+    return start.get().toInstant().toEpochMilli();
   }
 
   /**
@@ -98,7 +98,7 @@ public class Interval implements TemporalAmount {
   public Interval withStart(final Instant start) {
     final ZoneId zoneId = getStart().map(ZonedDateTime::getZone).orElse(ZoneId.systemDefault());
     return new Interval(
-        Optional.of(ZonedDateTime.ofInstant(start, zoneId)), getPeriod(), getDuration());
+        Optional.of(ZonedDateTime.ofInstant(start, zoneId).plus(this)), getPeriod(), getDuration());
   }
 
   /**

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/time/Interval.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/time/Interval.java
@@ -183,7 +183,7 @@ public class Interval implements TemporalAmount {
     int startOffset = 0;
     final int index = text.lastIndexOf("/");
     Optional<ZonedDateTime> start = Optional.empty();
-    if (index != -1) {
+    if (index > 0) {
       start = Optional.ofNullable(ZonedDateTime.parse(text.substring(0, index)));
     }
 

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/util/time/RepeatingIntervalTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/util/time/RepeatingIntervalTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.Period;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
@@ -181,5 +182,20 @@ public class RepeatingIntervalTest {
 
     // then
     assertThat(parsed).isEqualTo(expected);
+  }
+
+  @Test
+  public void shouldCalculateDueDate() {
+    // given
+    final Interval interval = new Interval(Period.ZERO, Duration.ofSeconds(10));
+    final long dueDate = interval.toEpochMilli(System.currentTimeMillis());
+    final long expected = dueDate + 10_000L;
+
+    // when
+    final long newDueDate =
+        interval.withStart(Instant.ofEpochMilli(dueDate)).toEpochMilli(System.currentTimeMillis());
+
+    // then
+    assertThat(newDueDate).isEqualTo(expected);
   }
 }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/util/time/RepeatingIntervalTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/util/time/RepeatingIntervalTest.java
@@ -168,4 +168,18 @@ public class RepeatingIntervalTest {
     // then
     assertThat(parsed).isEqualTo(expected);
   }
+
+  @Test
+  public void shouldParseWithEmptyStartTime() {
+    // given
+    final String text = "R//PT10S";
+    final RepeatingInterval expected =
+        new RepeatingInterval(-1, new Interval(Period.ZERO, Duration.ofSeconds(10)));
+
+    // when
+    final RepeatingInterval parsed = RepeatingInterval.parse(text);
+
+    // then
+    assertThat(parsed).isEqualTo(expected);
+  }
 }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/util/time/RepeatingIntervalTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/util/time/RepeatingIntervalTest.java
@@ -20,7 +20,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
 import java.time.Period;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.Optional;
 import org.junit.Test;
 
 public class RepeatingIntervalTest {
@@ -126,5 +128,44 @@ public class RepeatingIntervalTest {
   @Test
   public void shouldFailToParseEmptyString() {
     assertThatThrownBy(() -> Interval.parse("")).isInstanceOf(DateTimeParseException.class);
+  }
+
+  @Test
+  public void shouldParseWithSpecifiedStartTime() {
+    // given
+    final String text = "R/2022-05-20T08:09:40+02:00[Europe/Berlin]/PT10S";
+    final RepeatingInterval expected =
+        new RepeatingInterval(
+            -1,
+            new Interval(
+                Optional.ofNullable(
+                    ZonedDateTime.parse("2022-05-20T08:09:40+02:00[Europe/Berlin]")),
+                Period.ZERO,
+                Duration.ofSeconds(10)));
+
+    // when
+    final RepeatingInterval parsed = RepeatingInterval.parse(text);
+
+    // then
+    assertThat(parsed).isEqualTo(expected);
+  }
+
+  @Test
+  public void shouldParseWithSpecialUTCStartTime() {
+    // given
+    final String text = "R/2022-05-20T08:09:40Z/PT10S";
+    final RepeatingInterval expected =
+        new RepeatingInterval(
+            -1,
+            new Interval(
+                Optional.ofNullable(ZonedDateTime.parse("2022-05-20T08:09:40Z")),
+                Period.ZERO,
+                Duration.ofSeconds(10)));
+
+    // when
+    final RepeatingInterval parsed = RepeatingInterval.parse(text);
+
+    // then
+    assertThat(parsed).isEqualTo(expected);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
@@ -929,8 +929,8 @@ public final class TimerStartEventTest {
             Instant.ofEpochMilli(engine.getClock().getCurrentTimeInMillis()),
             ZoneId.systemDefault());
 
-    final long firstDueDate = start.plusSeconds(20).toInstant().toEpochMilli();
-    final long secondDueDate = start.plusSeconds(50).toInstant().toEpochMilli();
+    final long firstDueDate = start.plusSeconds(10).toInstant().toEpochMilli();
+    final long secondDueDate = start.plusSeconds(40).toInstant().toEpochMilli();
     final BpmnModelInstance firstModel =
         Bpmn.createExecutableProcess("process_1")
             .startEvent("start_1")
@@ -999,7 +999,7 @@ public final class TimerStartEventTest {
             tuple(secondDeployment.getProcessDefinitionKey(), secondDueDate));
 
     // when
-    engine.increaseTime(Duration.ofSeconds(30));
+    engine.increaseTime(Duration.ofSeconds(20));
 
     // then
     assertThat(
@@ -1122,8 +1122,8 @@ public final class TimerStartEventTest {
                 ZoneId.systemDefault())
             .plusSeconds(10);
 
-    final long dueDate = start.plusSeconds(10).toInstant().toEpochMilli();
-    final long lastDueDate = start.plusSeconds(20).toInstant().toEpochMilli();
+    final long dueDate = start.toInstant().toEpochMilli();
+    final long lastDueDate = dueDate + 10_000L;
     final BpmnModelInstance model =
         Bpmn.createExecutableProcess("process")
             .startEvent("start")
@@ -1141,7 +1141,7 @@ public final class TimerStartEventTest {
     final long processDefinitionKey = deployedProcess.getProcessDefinitionKey();
 
     // when
-    engine.increaseTime(Duration.ofSeconds(25));
+    engine.increaseTime(Duration.ofSeconds(15));
 
     // then
     final TimerRecordValue timerRecord =


### PR DESCRIPTION
## Description
Support ISO8601 `<start>` for time cycle.

Time cycle with start time and duration `R[n]/<start>/<duration>` (see [ISO 8601 Repeating Intervals](https://en.wikipedia.org/wiki/ISO_8601#Repeating_intervals))
```xml
 <bpmn:timerEventDefinition>
    <bpmn:timeCycle>R/2019-10-02T08:09:40+02:00[Europe/Berlin]/P1D</bpmn:timeCycle>
  </bpmn:timerEventDefinition>
```
<!-- Please explain the changes you made here. -->

## Related issues
<!-- Which issues are closed by this PR or are related -->

closes #3038 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
