### PR TITLE
Support deploying multiple DMN files at once

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.deployment.transform;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+import static java.util.function.Predicate.not;
 
 import io.camunda.zeebe.dmn.DecisionEngine;
 import io.camunda.zeebe.dmn.DecisionEngineFactory;
@@ -68,8 +69,8 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
       return checkForDuplicateIds(resource, parsedDrg, deployment)
           .map(
               noDuplicates -> {
-                appendMetadataToDeploymentEvent(resource, parsedDrg, deployment);
-                writeRecords(deployment, resource);
+                final var drgKey = appendMetadataToDeploymentEvent(resource, parsedDrg, deployment);
+                writeRecords(deployment, resource, drgKey);
                 return null;
               });
 
@@ -148,7 +149,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
         .orElse("<?>");
   }
 
-  private void appendMetadataToDeploymentEvent(
+  private long appendMetadataToDeploymentEvent(
       final DeploymentResource resource,
       final ParsedDecisionRequirementsGraph parsedDrg,
       final DeploymentRecord deploymentEvent) {
@@ -223,6 +224,8 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                               .setDecisionKey(newDecisionKey.getAsLong())
                               .setVersion(INITIAL_VERSION));
             });
+
+    return drgRecord.getDecisionRequirementsKey();
   }
 
   private boolean isDuplicate(
@@ -234,48 +237,44 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
         && drg.getChecksum().equals(checksum);
   }
 
-  private void writeRecords(final DeploymentRecord deployment, final DeploymentResource resource) {
-    final var metadataRecords =
-        deployment.decisionRequirementsMetadata().stream()
-            .filter(metadata -> metadata.getResourceName().equals(resource.getResourceName()))
-            .collect(Collectors.toList());
+  private void writeRecords(
+      final DeploymentRecord deployment,
+      final DeploymentResource resource,
+      final long decisionRequirementsKey) {
 
-    for (final DecisionRequirementsMetadataRecord drg : metadataRecords) {
-      if (!drg.isDuplicate()) {
-        stateWriter.appendFollowUpEvent(
-            drg.getDecisionRequirementsKey(),
-            DecisionRequirementsIntent.CREATED,
-            new DecisionRequirementsRecord()
-                .setDecisionRequirementsKey(drg.getDecisionRequirementsKey())
-                .setDecisionRequirementsId(drg.getDecisionRequirementsId())
-                .setDecisionRequirementsName(drg.getDecisionRequirementsName())
-                .setDecisionRequirementsVersion(drg.getDecisionRequirementsVersion())
-                .setNamespace(drg.getNamespace())
-                .setResourceName(drg.getResourceName())
-                .setChecksum(drg.getChecksumBuffer())
-                .setResource(resource.getResourceBuffer()));
-      }
-    }
+    deployment.decisionRequirementsMetadata().stream()
+        .filter(drg -> drg.getDecisionRequirementsKey() == decisionRequirementsKey)
+        .filter(not(DecisionRequirementsMetadataRecord::isDuplicate))
+        .findFirst()
+        .ifPresent(
+            drg ->
+                stateWriter.appendFollowUpEvent(
+                    drg.getDecisionRequirementsKey(),
+                    DecisionRequirementsIntent.CREATED,
+                    new DecisionRequirementsRecord()
+                        .setDecisionRequirementsKey(drg.getDecisionRequirementsKey())
+                        .setDecisionRequirementsId(drg.getDecisionRequirementsId())
+                        .setDecisionRequirementsName(drg.getDecisionRequirementsName())
+                        .setDecisionRequirementsVersion(drg.getDecisionRequirementsVersion())
+                        .setNamespace(drg.getNamespace())
+                        .setResourceName(drg.getResourceName())
+                        .setChecksum(drg.getChecksumBuffer())
+                        .setResource(resource.getResourceBuffer())));
 
-    final var decisionRequirementKeys =
-        metadataRecords.stream()
-            .map(DecisionRequirementsMetadataRecord::getDecisionRequirementsKey)
-            .collect(Collectors.toList());
-
-    for (final DecisionRecord decision : deployment.decisionsMetadata()) {
-      if (!decision.isDuplicate()
-          && decisionRequirementKeys.contains(decision.getDecisionRequirementsKey())) {
-        stateWriter.appendFollowUpEvent(
-            decision.getDecisionKey(),
-            DecisionIntent.CREATED,
-            new DecisionRecord()
-                .setDecisionKey(decision.getDecisionKey())
-                .setDecisionId(decision.getDecisionId())
-                .setDecisionName(decision.getDecisionName())
-                .setVersion(decision.getVersion())
-                .setDecisionRequirementsId(decision.getDecisionRequirementsId())
-                .setDecisionRequirementsKey(decision.getDecisionRequirementsKey()));
-      }
-    }
+    deployment.decisionsMetadata().stream()
+        .filter(decision -> decision.getDecisionRequirementsKey() == decisionRequirementsKey)
+        .filter(not(DecisionRecord::isDuplicate))
+        .forEach(
+            decision ->
+                stateWriter.appendFollowUpEvent(
+                    decision.getDecisionKey(),
+                    DecisionIntent.CREATED,
+                    new DecisionRecord()
+                        .setDecisionKey(decision.getDecisionKey())
+                        .setDecisionId(decision.getDecisionId())
+                        .setDecisionName(decision.getDecisionName())
+                        .setVersion(decision.getVersion())
+                        .setDecisionRequirementsId(decision.getDecisionRequirementsId())
+                        .setDecisionRequirementsKey(decision.getDecisionRequirementsKey())));
   }
 }

--- a/engine/src/test/resources/dmn/decision-table-with-renamed-drg-and-decision.dmn
+++ b/engine/src/test/resources/dmn/decision-table-with-renamed-drg-and-decision.dmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="star-wars" name="Star Wars" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.0.0">
+  <decision id="sith_or_jedi" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utwb1e">
+        <inputEntry id="UnaryTests_1v3sd4m">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tgh8k1">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1bwgcym">
+        <inputEntry id="UnaryTests_0n1ewm3">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19xnlkw">
+          <text>"Sith"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="sith_or_jedi">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
When deploying multiple DMN resources in a single command users would receive the error 

```
io.camunda.zeebe.client.api.command.ClientStatusException: Command 'CREATE' rejected with code 'INVALID_ARGUMENT': Expected to deploy new resources, but encountered the following errors:
'dummy2.dmn': Key DbLong{2251799813685250} in ColumnFamily DMN_DECISION_REQUIREMENTS already exists
```

This error is caused by a bug in Zeebe where we are sending multiple events for the same DRG and decisions. This only occurs when the command contains multiple DMN resources.


**Root cause**
In the `DmnResourceTransformer` we will transform each resource, so each dmn file. In here we have the method `appendMetadataToDeploymentEvent` . This method will add a `DecisionRequirementsMetadataRecord` to the `DeploymentRecord`. Once the metadata has been added we write the records:

```
private void writeRecords(final DeploymentRecord deployment, final DeploymentResource resource) {

    for (final DecisionRequirementsMetadataRecord drg : deployment.decisionRequirementsMetadata()) {
      if (!drg.isDuplicate()) {
        stateWriter.appendFollowUpEvent(
            drg.getDecisionRequirementsKey(),
            DecisionRequirementsIntent.CREATED,
            new DecisionRequirementsRecord()
                .setDecisionRequirementsKey(drg.getDecisionRequirementsKey())
                .setDecisionRequirementsId(drg.getDecisionRequirementsId())
                .setDecisionRequirementsName(drg.getDecisionRequirementsName())
                .setDecisionRequirementsVersion(drg.getDecisionRequirementsVersion())
                .setNamespace(drg.getNamespace())
                .setResourceName(drg.getResourceName())
                .setChecksum(drg.getChecksumBuffer())
                .setResource(resource.getResourceBuffer()));
      }
    }
```    

As you can see this method takes the `DeploymentRecord` as a parameter and iterates over all the `DecisionRequirementsMetadataRecords` that have been added. So what happens when we deploy multiple dmns:

1. Send the deploy resource command. We create a new` DeploymentRecord` with an empty list of `DecisionRequirementsMetadataRecords`.
2. We start transforming dmn 1. A new `DecisionRequirementsMetadataRecord` gets appended to the `DeploymentRecord`
3. We write a record for all metadatas in the `DeploymentRecord` . At this point this is only the metadata of dmn 1
4. We start transforming dmn 2. A new `DecisionRequirementsMetadataRecord` gets appended to the `DeploymentRecord`
5. We write a record for all metadatas in the `DeploymentRecord`. At this point this record contains the metadata of both dmn 1 and dmn 2, resulting in a `CREATED` event for dmn 2 containing the metadata keys of dmn 1

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9337 
closes #9115 
Related to https://github.com/camunda/zeebe-process-test/issues/357


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
