### PR TITLE
Update vulnerable versions of netty and spring in 1.3.8

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -94,7 +94,7 @@
     <version.feel-scala>1.14.1</version.feel-scala>
     <version.dmn-scala>1.7.1</version.dmn-scala>
     <version.rest-assured>4.4.0</version.rest-assured>
-    <version.spring>5.3.18</version.spring>
+    <version.spring>5.3.20</version.spring>
     <version.spring-boot>2.6.7</version.spring-boot>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.config>1.4.1</version.config>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -72,7 +72,7 @@
     <version.mockito-jupiter>4.2.0</version.mockito-jupiter>
     <version.model>7.7.0</version.model>
     <version.msgpack>0.9.0</version.msgpack>
-    <version.netty>4.1.72.Final</version.netty>
+    <version.netty>4.1.77.Final</version.netty>
     <version.objenesis>3.2</version.objenesis>
     <version.prometheus>0.13.0</version.prometheus>
     <version.protobuf>3.19.3</version.protobuf>


### PR DESCRIPTION
Updates netty & spring to non-vulnerable versions. 

Relates to #9427 

We'll upgrade the go version in https://github.com/camunda/zeebe/issues/9270, we'll just need to backport it.