### PR TITLE
Set zbctl user agent

### DIFF
--- a/clients/go/cmd/zbctl/internal/commands/root.go
+++ b/clients/go/cmd/zbctl/internal/commands/root.go
@@ -131,6 +131,7 @@ var initClient = func(cmd *cobra.Command, args []string) error {
 	client, err = zbc.NewClient(&zbc.ClientConfig{
 		GatewayAddress:      fmt.Sprintf("%s:%s", host, port),
 		CredentialsProvider: credsProvider,
+		UserAgent:           "zeebe-client-zbctl/" + Version,
 	})
 	return err
 }

--- a/clients/go/pkg/zbc/client.go
+++ b/clients/go/pkg/zbc/client.go
@@ -65,7 +65,10 @@ type ClientConfig struct {
 	// of 45 seconds being used
 	KeepAlive time.Duration
 
-	DialOpts []grpc.DialOption
+	// UserAgent is an optional field, to specify the user-agent header which should be sent by each
+	// gRPC request. Defaults to zeebe-client-go/%version.
+	UserAgent string
+	DialOpts  []grpc.DialOption
 }
 
 // ErrFileNotFound is returned whenever a file can't be found at the provided path. Use this value to do error comparison.
@@ -158,7 +161,11 @@ func NewClient(config *ClientConfig) (Client, error) {
 		return nil, err
 	}
 
-	config.DialOpts = append(config.DialOpts, grpc.WithUserAgent("zeebe-client-go/"+getVersion()))
+	if config.UserAgent == "" {
+		config.UserAgent = "zeebe-client-go/" + getVersion()
+	}
+
+	config.DialOpts = append(config.DialOpts, grpc.WithUserAgent(config.UserAgent))
 
 	conn, err := grpc.Dial(config.GatewayAddress, config.DialOpts...)
 	if err != nil {

--- a/clients/go/pkg/zbc/client_test.go
+++ b/clients/go/pkg/zbc/client_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/camunda/zeebe/clients/go/v8/internal/utils"
+	"google.golang.org/grpc/metadata"
 	"net"
 	"strconv"
 	"strings"
@@ -162,6 +164,61 @@ func (s *clientTestSuite) TestGatewayAddressEnvVar() {
 		s.EqualValues(codes.Unimplemented, errStat.Code())
 	}
 	s.EqualValues(fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]), config.GatewayAddress)
+}
+
+func (s *clientTestSuite) TestDefaultUserAgent() {
+	// given
+	var incomingContext = make(map[string][]string)
+	lis, server := createServerWithUnaryInterceptor(func(ctx context.Context, _ interface{}, _ *grpc.UnaryServerInfo, _ grpc.UnaryHandler) (interface{}, error) {
+		incomingContext, _ = metadata.FromIncomingContext(ctx)
+		return nil, nil
+	})
+	go server.Serve(lis)
+	defer server.Stop()
+
+	// when
+	client, err := NewClient(&ClientConfig{
+		GatewayAddress:         lis.Addr().String(),
+		UsePlaintextConnection: true,
+	})
+	s.Require().NoError(err)
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	_, err = client.NewTopologyCommand().Send(ctx)
+	userAgent := incomingContext["user-agent"]
+
+	// then
+	s.Require().Len(userAgent, 1)
+	s.Require().Contains(userAgent[0], "zeebe-client-go/"+getVersion())
+}
+
+func (s *clientTestSuite) TestSpecificUserAgent() {
+	// given
+	var incomingContext = make(map[string][]string)
+	lis, server := createServerWithUnaryInterceptor(func(ctx context.Context, _ interface{}, _ *grpc.UnaryServerInfo, _ grpc.UnaryHandler) (interface{}, error) {
+		incomingContext, _ = metadata.FromIncomingContext(ctx)
+		return nil, nil
+	})
+	go server.Serve(lis)
+	defer server.Stop()
+
+	// when
+	client, err := NewClient(&ClientConfig{
+		GatewayAddress:         lis.Addr().String(),
+		UsePlaintextConnection: true,
+		UserAgent:              "anotherUserAgentLikeZbctl",
+	})
+	s.Require().NoError(err)
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	_, err = client.NewTopologyCommand().Send(ctx)
+	userAgent := incomingContext["user-agent"]
+
+	// then
+	s.Require().Len(userAgent, 1)
+	s.Require().Contains(userAgent[0], "anotherUserAgentLikeZbctl")
 }
 
 func (s *clientTestSuite) TestCaCertificateEnvVar() {

--- a/clients/go/pkg/zbc/client_test.go
+++ b/clients/go/pkg/zbc/client_test.go
@@ -185,7 +185,7 @@ func (s *clientTestSuite) TestDefaultUserAgent() {
 	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
 	defer cancel()
 
-	_, err = client.NewTopologyCommand().Send(ctx)
+	_, _ = client.NewTopologyCommand().Send(ctx)
 	userAgent := incomingContext["user-agent"]
 
 	// then
@@ -213,7 +213,7 @@ func (s *clientTestSuite) TestSpecificUserAgent() {
 	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
 	defer cancel()
 
-	_, err = client.NewTopologyCommand().Send(ctx)
+	_, _ = client.NewTopologyCommand().Send(ctx)
 	userAgent := incomingContext["user-agent"]
 
 	// then


### PR DESCRIPTION
## Description
In order to distinguish between go-client and zbctl this PR adds a new possibility to set the UserAgent as client config.
Zbctl use that config and set its own user-agent header.

This is useful to understand which client types and versions are mostly used. See slack https://camunda.slack.com/archives/CHBFBRFM2/p1652420371478469?thread_ts=1651237779.179459&cid=CHBFBRFM2


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
