### PR TITLE
Publish GHA test results as report

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -3,7 +3,7 @@
 name: Publish Unit Test Results
 on:
   workflow_run:
-    workflows: [Build and test]
+    workflows: [Tests]
     types:
       - completed
 jobs:

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -1,14 +1,14 @@
 # Publishing of unit test results has to be a separate workflow in order to support forked PRs
 # See https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches
-name: Publish Unit Test Results
+name: Publish Test Results
 on:
   workflow_run:
     workflows: [Tests]
     types:
       - completed
 jobs:
-  unit-test-results:
-    name: Unit Test Results
+  test-results:
+    name: Test Results
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion != 'skipped'
 
@@ -28,7 +28,7 @@ jobs:
             unzip -d "$name" "$name.zip"
           done
 
-      - name: Publish Unit Test Results
+      - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1.34
         with:
           commit: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -1,0 +1,37 @@
+# Publishing of unit test results has to be a separate workflow in order to support forked PRs
+# See https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches
+name: Publish Unit Test Results
+on:
+  workflow_run:
+    workflows: [Build and test]
+    types:
+      - completed
+jobs:
+  unit-test-results:
+    name: Unit Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          mkdir -p artifacts && cd artifacts
+
+          artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+          gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+          do
+            IFS=$'\t' read name url <<< "$artifact"
+            gh api $url > "$name.zip"
+            unzip -d "$name" "$name.zip"
+          done
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1.34
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/surefire-reports/*.xml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           verify
       - name: Archive Test Results
         uses: actions/upload-artifact@v3
-        if: failure()
+        if: always()
         with:
           name: Integration test results
           path: |
@@ -68,7 +68,7 @@ jobs:
           verify
       - name: Archive Test Results
         uses: actions/upload-artifact@v3
-        if: failure()
+        if: always()
         with:
           name: Exporter test results
           path: |
@@ -116,7 +116,7 @@ jobs:
           verify
       - name: Archive Test Results
         uses: actions/upload-artifact@v3
-        if: failure()
+        if: always()
         with:
           name: Unit test results for ${{ matrix.project }}
           path: |
@@ -149,7 +149,7 @@ jobs:
           verify
       - name: Archive Test Results
         uses: actions/upload-artifact@v3
-        if: failure()
+        if: always()
         with:
           name: Slow unit test results
           path: |
@@ -191,7 +191,7 @@ jobs:
           verify
       - name: Archive Test Results
         uses: actions/upload-artifact@v3
-        if: failure()
+        if: always()
         with:
           name: Smoke test results for ${{ matrix.os }}
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -215,3 +215,18 @@ jobs:
       - run: docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t camunda/zeebe:current-test .
       - run: go test -mod=vendor -v ./...
         working-directory: clients/go
+
+
+  # We need to upload the event file as an artifact in order to support
+  # publishing the results of forked repositories 
+  # https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: Event File
+          path: ${{ github.event_path }}
+          retention-days: 1


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Publish GHA test results as report using https://github.com/EnricoMi/publish-unit-test-result-action.

This workflow is copied from [Zeebe Process Test](https://github.com/camunda/zeebe-process-test) where [this workflow](https://github.com/camunda/zeebe-process-test/blob/main/.github/workflows/publish-test-results.yml) has already been in use for some time. Some minor changes have been made to fit it to the zeebe repository.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9035

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
