### PR TITLE
ci: strip first letters from paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
         id: list-projects
         # Build a json array of module names that can be used for the matrix in `unit-tests`
         run: >
-          echo "::set-output name=projects::$(find -not -path "./engine/pom.xml" -wholename "./*/pom.xml" -exec dirname {} \; | jq -cnR [inputs])"
+          echo "::set-output name=projects::$(find -not -path "./engine/pom.xml" -wholename "./*/pom.xml" -exec dirname {} \; | cut -c 3- | jq -cnR [inputs])"
     outputs:
       projects: ${{ steps.list-projects.outputs.projects }}
   unit-tests:
@@ -114,11 +114,13 @@ jobs:
           -D skipITs -D skipChecks
           -pl ${{ matrix.project }}
           verify
+      - name: Normalize artifact name
+        run: echo "ARTIFACT_NAME=$(echo ${{ matrix.project }} | sed 's/\//-/g')" >> $GITHUB_ENV
       - name: Archive Test Results
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: Unit test results for ${{ matrix.project }}
+          name: Unit test results for ${{ env.ARTIFACT_NAME }}
           path: |
             **/target/surefire-reports/
             **/hs_err_*.log


### PR DESCRIPTION
## Description


Removes the `./` from the paths, to avoid failing on archive the artifacts as shown here https://github.com/camunda/zeebe/issues/9437

@oleschoenburg I'm wondering whether `atomix/cluster` might be still an issue here? :thinking: 
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9437 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
