### PR TITLE
ci: unify all java and maven checks in one job

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -32,20 +32,6 @@ jobs:
         run: mvn -B -T1C -DskipTests -DskipChecks install
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
-  spotbug:
-    name: SpotBugs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3.3.0
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'maven'
-      - name: SpotBugs
-        run: mvn -B -T1C -DskipTests -DskipChecks verify -Pspotbugs -Dspotbugs.skip=false
   go-lint:
     name: Go linting
     runs-on: ubuntu-latest
@@ -56,8 +42,8 @@ jobs:
         with:
           version: v1.32
           working-directory: clients/go
-  java-format:
-    name: Java formatting
+  java-checks:
+    name: Java checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -66,6 +52,5 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
-      # install build tools first so changes to tool configuration is available downstream
-      - run: mvn -T1C -B -D skipTests -D skipChecks install -pl build-tools
-      - run: mvn -T1C -B -D skipTests -P checkFormat,-autoFormat validate
+      - run: mvn -T1C -B -D skipTests -D skipChecks install
+      - run: mvn -T1C -B -D skipTests -P !autoFormat,checkFormat,spotbugs verify

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
       - stable/*
-      - release/*
+      - release-*
       - trying
       - staging
   pull_request: {}


### PR DESCRIPTION
This replaces the old java formatting job with a new job that runs `mvn verify` (without tests). This should include all checks that we have configured, including dependency analyzer, spotbugs, spotless and so forth.

closes #9414