### PR TITLE
[Backport stable/8.0] Support deploying multiple DMN files at once

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.deployment.transform;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+import static java.util.function.Predicate.not;
 
 import io.camunda.zeebe.dmn.DecisionEngine;
 import io.camunda.zeebe.dmn.DecisionEngineFactory;
@@ -68,8 +69,8 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
       return checkForDuplicateIds(resource, parsedDrg, deployment)
           .map(
               noDuplicates -> {
-                appendMetadataToDeploymentEvent(resource, parsedDrg, deployment);
-                writeRecords(deployment, resource);
+                final var drgKey = appendMetadataToDeploymentEvent(resource, parsedDrg, deployment);
+                writeRecords(deployment, resource, drgKey);
                 return null;
               });
 
@@ -148,7 +149,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
         .orElse("<?>");
   }
 
-  private void appendMetadataToDeploymentEvent(
+  private long appendMetadataToDeploymentEvent(
       final DeploymentResource resource,
       final ParsedDecisionRequirementsGraph parsedDrg,
       final DeploymentRecord deploymentEvent) {
@@ -223,6 +224,8 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                               .setDecisionKey(newDecisionKey.getAsLong())
                               .setVersion(INITIAL_VERSION));
             });
+
+    return drgRecord.getDecisionRequirementsKey();
   }
 
   private boolean isDuplicate(
@@ -234,48 +237,44 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
         && drg.getChecksum().equals(checksum);
   }
 
-  private void writeRecords(final DeploymentRecord deployment, final DeploymentResource resource) {
-    final var metadataRecords =
-        deployment.decisionRequirementsMetadata().stream()
-            .filter(metadata -> metadata.getResourceName().equals(resource.getResourceName()))
-            .collect(Collectors.toList());
+  private void writeRecords(
+      final DeploymentRecord deployment,
+      final DeploymentResource resource,
+      final long decisionRequirementsKey) {
 
-    for (final DecisionRequirementsMetadataRecord drg : metadataRecords) {
-      if (!drg.isDuplicate()) {
-        stateWriter.appendFollowUpEvent(
-            drg.getDecisionRequirementsKey(),
-            DecisionRequirementsIntent.CREATED,
-            new DecisionRequirementsRecord()
-                .setDecisionRequirementsKey(drg.getDecisionRequirementsKey())
-                .setDecisionRequirementsId(drg.getDecisionRequirementsId())
-                .setDecisionRequirementsName(drg.getDecisionRequirementsName())
-                .setDecisionRequirementsVersion(drg.getDecisionRequirementsVersion())
-                .setNamespace(drg.getNamespace())
-                .setResourceName(drg.getResourceName())
-                .setChecksum(drg.getChecksumBuffer())
-                .setResource(resource.getResourceBuffer()));
-      }
-    }
+    deployment.decisionRequirementsMetadata().stream()
+        .filter(drg -> drg.getDecisionRequirementsKey() == decisionRequirementsKey)
+        .filter(not(DecisionRequirementsMetadataRecord::isDuplicate))
+        .findFirst()
+        .ifPresent(
+            drg ->
+                stateWriter.appendFollowUpEvent(
+                    drg.getDecisionRequirementsKey(),
+                    DecisionRequirementsIntent.CREATED,
+                    new DecisionRequirementsRecord()
+                        .setDecisionRequirementsKey(drg.getDecisionRequirementsKey())
+                        .setDecisionRequirementsId(drg.getDecisionRequirementsId())
+                        .setDecisionRequirementsName(drg.getDecisionRequirementsName())
+                        .setDecisionRequirementsVersion(drg.getDecisionRequirementsVersion())
+                        .setNamespace(drg.getNamespace())
+                        .setResourceName(drg.getResourceName())
+                        .setChecksum(drg.getChecksumBuffer())
+                        .setResource(resource.getResourceBuffer())));
 
-    final var decisionRequirementKeys =
-        metadataRecords.stream()
-            .map(DecisionRequirementsMetadataRecord::getDecisionRequirementsKey)
-            .collect(Collectors.toList());
-
-    for (final DecisionRecord decision : deployment.decisionsMetadata()) {
-      if (!decision.isDuplicate()
-          && decisionRequirementKeys.contains(decision.getDecisionRequirementsKey())) {
-        stateWriter.appendFollowUpEvent(
-            decision.getDecisionKey(),
-            DecisionIntent.CREATED,
-            new DecisionRecord()
-                .setDecisionKey(decision.getDecisionKey())
-                .setDecisionId(decision.getDecisionId())
-                .setDecisionName(decision.getDecisionName())
-                .setVersion(decision.getVersion())
-                .setDecisionRequirementsId(decision.getDecisionRequirementsId())
-                .setDecisionRequirementsKey(decision.getDecisionRequirementsKey()));
-      }
-    }
+    deployment.decisionsMetadata().stream()
+        .filter(decision -> decision.getDecisionRequirementsKey() == decisionRequirementsKey)
+        .filter(not(DecisionRecord::isDuplicate))
+        .forEach(
+            decision ->
+                stateWriter.appendFollowUpEvent(
+                    decision.getDecisionKey(),
+                    DecisionIntent.CREATED,
+                    new DecisionRecord()
+                        .setDecisionKey(decision.getDecisionKey())
+                        .setDecisionId(decision.getDecisionId())
+                        .setDecisionName(decision.getDecisionName())
+                        .setVersion(decision.getVersion())
+                        .setDecisionRequirementsId(decision.getDecisionRequirementsId())
+                        .setDecisionRequirementsKey(decision.getDecisionRequirementsKey())));
   }
 }

--- a/engine/src/test/resources/dmn/decision-table-with-renamed-drg-and-decision.dmn
+++ b/engine/src/test/resources/dmn/decision-table-with-renamed-drg-and-decision.dmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="star-wars" name="Star Wars" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.0.0">
+  <decision id="sith_or_jedi" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utwb1e">
+        <inputEntry id="UnaryTests_1v3sd4m">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tgh8k1">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1bwgcym">
+        <inputEntry id="UnaryTests_0n1ewm3">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19xnlkw">
+          <text>"Sith"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="sith_or_jedi">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>


### PR DESCRIPTION
# Description
Backport of #9432 to `stable/8.0`.

relates to camunda/zeebe-process-test#357 #9337 #9115