### PR TITLE
Integrate Jenkins pipeline with TC Cloud

### DIFF
--- a/.ci/podSpecs/integration-test-template.yml
+++ b/.ci/podSpecs/integration-test-template.yml
@@ -25,15 +25,13 @@ spec:
         - name: JAVA_TOOL_OPTIONS
           value: |
             -XX:+UseContainerSupport
-        - name: DOCKER_HOST
-          value: tcp://localhost:2375
       resources:
         limits:
-          cpu: 12
-          memory: 48Gi
+          cpu: 26
+          memory: 104Gi
         requests:
-          cpu: 12
-          memory: 48Gi
+          cpu: 26
+          memory: 104Gi
       securityContext:
         privileged: true
     - name: docker
@@ -41,9 +39,6 @@ spec:
       args:
         - --storage-driver
         - overlay2
-        - --ipv6
-        - --fixed-cidr-v6
-        - "2001:db8:1::/64"
       env:
         # The new dind versions expect secure access using cert
         # Setting DOCKER_TLS_CERTDIR to empty string will disable the secure access
@@ -52,17 +47,17 @@ spec:
           value: ""
       securityContext:
         privileged: true
+      tty: true
       volumeMounts:
         - mountPath: /var/lib/docker
           name: docker-storage
-      tty: true
       resources:
         limits:
-          cpu: 18
-          memory: 60Gi
+          cpu: 4
+          memory: 4Gi
         requests:
-          cpu: 18
-          memory: 60Gi
+          cpu: 4
+          memory: 4Gi
     - name: python
       image: python:3.10
       command: [ "cat" ]

--- a/.ci/scripts/distribution/it-prepare.sh
+++ b/.ci/scripts/distribution/it-prepare.sh
@@ -1,5 +1,16 @@
 #!/bin/bash -eux
 
+# install the TestContainers Cloud agent and our local repository
+curl -L -o testcontainers-agent https://app.testcontainers.cloud/download/testcontainers-cloud-agent_linux_x86-64
+chmod +x testcontainers-agent
+
+echo "Starting TestContainers Cloud agent (output at /tmp/agent-output.log)..."
+export TC_CLOUD_CONCURRENCY=${TC_CLOUD_CONCURRENCY:-4}
+./testcontainers-agent \
+  '--private-registry-url=http://localhost:5000' \
+  '--private-registry-allowed-image-name-globs=*,*/*' > /tmp/agent-output.log 2>&1 &
+./testcontainers-agent wait
+
 # getconf is a POSIX way to get the number of processors available which works on both Linux and macOS
 LIMITS_CPU=${LIMITS_CPU:-$(getconf _NPROCESSORS_ONLN)}
 MAVEN_PARALLELISM=${MAVEN_PARALLELISM:-$LIMITS_CPU}

--- a/.ci/scripts/docker/local-registry.sh
+++ b/.ci/scripts/docker/local-registry.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -eux
+
+dockerImageName="localhost:5000/${IMAGE}:${TAG}"
+
+# Build, push image, and start TC Cloud agent
+echo "Starting local Docker registry"
+docker run --rm -d -p 5000:5000 --name registry registry:2
+
+echo "Building Zeebe Docker image ${dockerImageName}"
+docker build --no-cache --build-arg DISTBALL=camunda-zeebe.tar.gz -t "${dockerImageName}" --target app .
+docker push "${dockerImageName}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ jobs:
   integration-tests:
     name: Integration tests
     runs-on: "n1-standard-32-netssd-preempt"
+    env:
+      TC_CLOUD_TOKEN: ${{ secrets.TC_CLOUD_TOKEN }}
+      TC_CLOUD_CONCURRENCY: 4
+      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3.3.0
@@ -26,8 +30,16 @@ jobs:
         with:
           maven-version: 3.8.5
       - uses: ./.github/actions/use-ci-nexus-cache
+      - run: docker run --rm -d -p 5000:5000 --name registry registry:2
       - run: mvn -T1C -B -DskipChecks -DskipTests install
-      - run: docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t camunda/zeebe:current-test .
+      - run: docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t "${ZEEBE_TEST_DOCKER_IMAGE}" .
+      - run: docker push "${ZEEBE_TEST_DOCKER_IMAGE}"
+      - name: Prepare Testcontainers Cloud agent
+        run: |
+          curl -L -o agent https://app.testcontainers.cloud/download/testcontainers-cloud-agent_linux_x86-64
+          chmod +x agent
+          ./agent --private-registry-url=http://localhost:5000 '--private-registry-allowed-image-name-globs=*,*/*' &
+          ./agent wait
       - run: >
           mvn -B -T2 --no-snapshot-updates
           -D junitThreadCount=12

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,11 @@ jobs:
       TC_CLOUD_TOKEN: ${{ secrets.TC_CLOUD_TOKEN }}
       TC_CLOUD_CONCURRENCY: 4
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3.3.0
@@ -30,7 +35,6 @@ jobs:
         with:
           maven-version: 3.8.5
       - uses: ./.github/actions/use-ci-nexus-cache
-      - run: docker run --rm -d -p 5000:5000 --name registry registry:2
       - run: mvn -T1C -B -DskipChecks -DskipTests install
       - run: docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t "${ZEEBE_TEST_DOCKER_IMAGE}" .
       - run: docker push "${ZEEBE_TEST_DOCKER_IMAGE}"

--- a/exporters/elasticsearch-exporter/pom.xml
+++ b/exporters/elasticsearch-exporter/pom.xml
@@ -146,6 +146,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>toxiproxy</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
@@ -36,14 +36,20 @@ import org.elasticsearch.client.RestClient;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
 
 public abstract class AbstractElasticsearchExporterIntegrationTestCase {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(AbstractElasticsearchExporterIntegrationTestCase.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
 
+  protected final Network network = Network.newNetwork();
   protected ElasticsearchNode<ElasticsearchContainer> elastic;
   protected ElasticsearchExporterConfiguration configuration;
   protected ElasticsearchExporterFaultToleranceIT.ElasticsearchTestClient esClient;
@@ -53,7 +59,11 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
 
   @Before
   public void setUp() {
-    elastic = new ElasticsearchContainer().withEnv("ES_JAVA_OPTS", "-Xms750m -Xmx750m");
+    elastic =
+        new ElasticsearchContainer()
+            .withEnv("ES_JAVA_OPTS", "-Xms750m -Xmx750m")
+            .withNetwork(network)
+            .withNetworkAliases("elastic");
   }
 
   @After
@@ -65,6 +75,7 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
 
     exporterIntegrationRule.stop();
     elastic.stop();
+    network.close();
     configuration = null;
   }
 
@@ -93,7 +104,14 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
         .atMost(Duration.ofMinutes(2))
         .pollInterval(Duration.ofSeconds(1))
         .until(
-            () -> esClient.getIndexTemplateCount(configuration.index.prefix),
+            () -> {
+              try {
+                return esClient.getIndexTemplateCount(configuration.index.prefix);
+              } catch (final Exception e) {
+                LOGGER.warn("Failed to get index template count", e);
+                return -1;
+              }
+            },
             size -> size >= expectedIndexTemplatesCount);
   }
 

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/util/ElasticsearchContainer.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/util/ElasticsearchContainer.java
@@ -95,7 +95,6 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
   @Override
   public ElasticsearchContainer withPort(final int port) {
     this.port = port;
-    addFixedExposedPort(port, DEFAULT_HTTP_PORT);
     return this;
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/Ipv6IntegrationTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/Ipv6IntegrationTest.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.client.api.response.Topology;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import io.camunda.zeebe.test.util.testcontainers.ZeebeTestContainerDefaults;
 import io.zeebe.containers.ZeebeBrokerContainer;
 import io.zeebe.containers.ZeebeGatewayContainer;
 import io.zeebe.containers.ZeebePort;
@@ -41,7 +42,7 @@ public class Ipv6IntegrationTest {
   private static final int PARTITION_COUNT = 1;
   private static final int REPLICATION_FACTOR = 3;
   private static final DockerImageName ZEEBE_IMAGE_VERSION =
-      DockerImageName.parse("camunda/zeebe:current-test");
+      ZeebeTestContainerDefaults.defaultTestImage();
   private static final String NETWORK_ALIAS = Ipv6IntegrationTest.class.getName();
   private static final String BASE_PART_OF_SUBNET = "2081::aede:4844:fe00:";
   private static final String SUBNET = BASE_PART_OF_SUBNET + "0/123";

--- a/qa/update-tests/src/test/java/io/camunda/zeebe/test/OldGatewayTest.java
+++ b/qa/update-tests/src/test/java/io/camunda/zeebe/test/OldGatewayTest.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.test;
 import static io.camunda.zeebe.test.ContainerStateAssert.assertThat;
 import static io.camunda.zeebe.test.UpdateTestCaseProvider.PROCESS_ID;
 
-import io.camunda.zeebe.util.VersionUtil;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterAll;
@@ -24,8 +23,6 @@ import org.testcontainers.containers.Network;
 @ExtendWith(ContainerStateExtension.class)
 final class OldGatewayTest {
 
-  public static final String LAST_VERSION = VersionUtil.getPreviousVersion();
-  public static final String CURRENT_VERSION = "current-test";
   private static Network network;
 
   @BeforeAll
@@ -44,11 +41,7 @@ final class OldGatewayTest {
   @SuppressWarnings("java:S2699") // there is an assertion when awaiting completion
   void update(final String name, final UpdateTestCase testCase, final ContainerState state) {
     // given
-    state
-        .withNetwork(network)
-        .broker(CURRENT_VERSION)
-        .withStandaloneGateway(LAST_VERSION)
-        .start(true);
+    state.withNetwork(network).withNewBroker().withOldGateway().start(true);
     final long processInstanceKey = testCase.setUp(state.client());
 
     // when

--- a/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.ContainerState;
 import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
 
 /**
  * These tests are here to detect when rolling update between one version to the next are not
@@ -50,9 +51,10 @@ import org.testcontainers.containers.Network;
  */
 final class RollingUpdateTest {
 
-  public static final String TEST_IMAGE_TAG = "current-test";
-  private static final String OLD_VERSION = VersionUtil.getPreviousVersion();
-  private static final String NEW_VERSION = VersionUtil.getVersion();
+  private static final DockerImageName PREVIOUS_VERSION =
+      DockerImageName.parse("camunda/zeebe").withTag(VersionUtil.getPreviousVersion());
+  private static final DockerImageName CURRENT_VERSION =
+      ZeebeTestContainerDefaults.defaultTestImage();
   private static final BpmnModelInstance PROCESS =
       Bpmn.createExecutableProcess("process")
           .startEvent()
@@ -259,10 +261,7 @@ final class RollingUpdateTest {
   }
 
   private void updateBroker(final ZeebeBrokerNode<?> broker) {
-    broker.setDockerImageName(
-        ZeebeTestContainerDefaults.defaultTestImage()
-            .withTag(TEST_IMAGE_TAG)
-            .asCanonicalNameString());
+    broker.setDockerImageName(CURRENT_VERSION.asCanonicalNameString());
   }
 
   private ProcessInstanceEvent createProcessInstance(final ZeebeClient client) {
@@ -277,7 +276,7 @@ final class RollingUpdateTest {
 
   private void deployProcess(final ZeebeClient client) {
     client
-        .newDeployCommand()
+        .newDeployResourceCommand()
         .addProcessModel(PROCESS, "process.bpmn")
         .send()
         .join(10, TimeUnit.SECONDS);
@@ -293,7 +292,9 @@ final class RollingUpdateTest {
         .hasBrokerSatisfying(
             brokerInfo -> {
               assertThat(brokerInfo.getNodeId()).as("the broker's node ID").isEqualTo(brokerId);
-              assertThat(brokerInfo.getVersion()).as("the broker's version").isEqualTo(NEW_VERSION);
+              assertThat(brokerInfo.getVersion())
+                  .as("the broker's version")
+                  .isEqualTo(VersionUtil.getVersion());
             });
   }
 
@@ -339,7 +340,6 @@ final class RollingUpdateTest {
         .withEnv("ZEEBE_BROKER_CLUSTER_MEMBERSHIP_FAILURETIMEOUT", "2s")
         .withEnv("ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SUSPECTPROBES", "2")
         .withEnv("ZEEBE_LOG_LEVEL", "DEBUG");
-    broker.setDockerImageName(
-        ZeebeTestContainerDefaults.defaultTestImage().withTag(OLD_VERSION).asCanonicalNameString());
+    broker.setDockerImageName(PREVIOUS_VERSION.asCanonicalNameString());
   }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/ZeebeTestContainerDefaults.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/ZeebeTestContainerDefaults.java
@@ -7,11 +7,14 @@
  */
 package io.camunda.zeebe.test.util.testcontainers;
 
+import java.util.Optional;
 import org.testcontainers.utility.DockerImageName;
 
 public final class ZeebeTestContainerDefaults {
-  private static final DockerImageName DEFAULT_TEST_IMAGE =
-      DockerImageName.parse("camunda/zeebe:current-test");
+  private static final String TEST_IMAGE_NAME =
+      Optional.ofNullable(System.getenv("ZEEBE_TEST_DOCKER_IMAGE"))
+          .orElse("camunda/zeebe:current-test");
+  private static final DockerImageName DEFAULT_TEST_IMAGE = DockerImageName.parse(TEST_IMAGE_NAME);
 
   private ZeebeTestContainerDefaults() {}
 


### PR DESCRIPTION
## Description

This PR updates both the Jenkins pipeline and the GHA pipeline to run against Testcontainers Cloud (TCC).

Since TCC cannot access your local images, it relies on us starting a local registry and proxying it to the remote VM. This means the image under test changes from `camunda/zeebe:current-test` (which is really `docker.io/camunda/zeebe:current-test`) to specify the local registry's URL, `localhost:5000/camunda/zeebe:current-test`.

To make our build work (while keeping our local workflow), some preliminary changes were necessary, mainly about finding the right image name. The most notable change is that the name of the image under test can now be overwritten via an environment variable, `ZEEBE_TEST_DOCKER_IMAGE` (but will fallback to `camunda/zeebe:current-test` when not defined).

### How it works

TCC generally works by providing you a remote VM where your containers are started. While you can broadly think of it as Docker-as-a-Service, Docker is implementation detail as far as TCC is concerned, so we shouldn't rely on that. To do so, you start the TCC agent locally, which the `testcontainers-java` library will use to communicate with the VM. No changes are required in your tests. That said, under the hood, we still use only one VM, so we're still limited in terms of resources.

One way to overcome this is to specify the concurrency, which will allocate more VMs for your tests. Right now, this is limited to 4, but hopefully we can increase this. How it works is, each JVM is pinned to a single VM in a round robin fashion. So if you have VMs 0-4 (`VM_0`, `VM_1`, etc.) and JVMs 0-4 (`JVM_0`, `JVM_1`, etc.), then you can imagine that `JVM_0` is starts containers on `VM_0`, `JVM_1` on `VM_1`, etc. This is just an example, of course. This means that if you have more JVMs than VMs, then of course the VMs are shared. So you can still run out of resources depending on test ordering and execution, but it's a little more spread out than the previous situation of one large VM.

Right now, I only configured the integration tests to run with TCC. The Go tests and the Elasticsearch exporter tests also make use of containers, but as they are not resource heavy, we can run them in the same job for now. If we see to increase parallelism, then we might want to look into setting them up with TCC as well.

## Related issues

closes #8350

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
