### PR TITLE
[Backport 1.3] Allow nullable variable in Protocol Jackson

### DIFF
--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -414,6 +414,18 @@ public final class JsonSerializableToJsonTest {
         "{'type':'','processDefinitionVersion':-1,'elementId':'','bpmnProcessId':'','processDefinitionKey':-1,'processInstanceKey':-1,'elementInstanceKey':-1,'variables':{},'worker':'','retries':-1,'retryBackoff':0,'recurringTime':-1,'errorMessage':'','errorCode':'','customHeaders':{},'deadline':-1}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////////// JobRecord with nullable variable //////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "JobRecordWithNullableVariable",
+        (Supplier<UnifiedRecordValue>)
+            () ->
+                new JobRecord()
+                    .setVariables(
+                        new UnsafeBuffer(MsgPackConverter.convertToMsgPack("{'foo':null}"))),
+        "{'processDefinitionKey':-1,'processInstanceKey':-1,'bpmnProcessId':'','elementId':'','elementInstanceKey':-1,'retries':-1,'retryBackoff':0,'recurringTime':-1,'processDefinitionVersion':-1,'customHeaders':{},'worker':'','errorMessage':'','errorCode':'','variables':{'foo':null},'deadline':-1,'type':''}"
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
       ///////////////////////////////// MessageRecord /////////////////////////////////////////////
       /////////////////////////////////////////////////////////////////////////////////////////////
       {

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractJobRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractJobRecordValue.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.camunda.zeebe.protocol.jackson.record.JobRecordValueBuilder.ImmutableJobRecordValue;
 import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import java.util.Map;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Default;
 
@@ -23,4 +24,8 @@ public abstract class AbstractJobRecordValue implements JobRecordValue, DefaultJ
   public String getErrorCode() {
     return ErrorCode.NULL_VAL.name();
   }
+
+  @Override
+  @AllowNulls
+  public abstract Map<String, Object> getVariables();
 }

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractProcessInstanceCreationRecordValue.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AbstractProcessInstanceCreationRecordValue.java
@@ -10,10 +10,16 @@ package io.camunda.zeebe.protocol.jackson.record;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.camunda.zeebe.protocol.jackson.record.ProcessInstanceCreationRecordValueBuilder.ImmutableProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import java.util.Map;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @ZeebeStyle
 @JsonDeserialize(as = ImmutableProcessInstanceCreationRecordValue.class)
 public abstract class AbstractProcessInstanceCreationRecordValue
-    implements ProcessInstanceCreationRecordValue, DefaultJsonSerializable {}
+    implements ProcessInstanceCreationRecordValue, DefaultJsonSerializable {
+
+  @Override
+  @AllowNulls
+  public abstract Map<String, Object> getVariables();
+}

--- a/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AllowNulls.java
+++ b/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/record/AllowNulls.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.jackson.record;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is required to notify the Immutable's code generator that there in the collection
+ * (both {@link java.util.Collection} and {@link java.util.Map}) could be nullable values inside it
+ * (in terms of {@link java.util.Map} - the nullable values, not <strong>keys</strong>)
+ *
+ * @see <a href="https://immutables.github.io/immutable.html#nulls-in-collection">Immutables
+ *     approach to allow nullable values in the collection</a>
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.FIELD, ElementType.METHOD})
+public @interface AllowNulls {}

--- a/test/src/main/java/io/camunda/zeebe/test/exporter/ExporterIntegrationRule.java
+++ b/test/src/main/java/io/camunda/zeebe/test/exporter/ExporterIntegrationRule.java
@@ -276,6 +276,7 @@ public class ExporterIntegrationRule extends ExternalResource {
     variables.put("orderId", "foo-bar-123");
     variables.put("largeValue", "x".repeat(8192));
     variables.put("unicode", "Á");
+    variables.put("nullable", null);
 
     final long processInstanceKey = createProcessInstance("testProcess", variables);
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This is just a backport of #9383

## Related issues

<!-- Which issues are closed by this PR or are related -->

#9382

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
