### PR TITLE
Increase DRG version if another DRG was deployed with the same decisions

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -176,7 +176,8 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
             latestDrg -> {
               final int latestVersion = latestDrg.getDecisionRequirementsVersion();
               final boolean isDuplicate =
-                  isDuplicate(resource, checksum, latestDrg)
+                  hasSameResourceNameAs(resource, latestDrg)
+                      && hasSameChecksumAs(checksum, latestDrg)
                       && hasSameDecisionRequirementsKeyAs(parsedDrg.getDecisions(), latestDrg);
 
               if (isDuplicate) {
@@ -236,13 +237,14 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
     return drgRecord.getDecisionRequirementsKey();
   }
 
-  private boolean isDuplicate(
-      final DeploymentResource resource,
-      final DirectBuffer checksum,
-      final PersistedDecisionRequirements drg) {
+  private boolean hasSameResourceNameAs(
+      final DeploymentResource resource, final PersistedDecisionRequirements drg) {
+    return drg.getResourceName().equals(resource.getResourceNameBuffer());
+  }
 
-    return drg.getResourceName().equals(resource.getResourceNameBuffer())
-        && drg.getChecksum().equals(checksum);
+  private boolean hasSameChecksumAs(
+      final DirectBuffer checksum, final PersistedDecisionRequirements drg) {
+    return drg.getChecksum().equals(checksum);
   }
 
   private boolean hasSameDecisionRequirementsKeyAs(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentDmnTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentDmnTest.java
@@ -354,8 +354,8 @@ public final class DeploymentDmnTest {
         .extracting(
             DecisionRequirementsMetadataValue::getDecisionRequirementsVersion,
             DecisionRequirementsMetadataValue::isDuplicate)
-        .describedAs("Expect that the DRG is a duplicate")
-        .containsOnly(tuple(1, true));
+        .describedAs("Expect that the DRG version is increased")
+        .containsOnly(tuple(2, false));
 
     assertThat(deploymentEvent.getValue().getDecisionsMetadata())
         .extracting(DecisionRecordValue::getVersion, DecisionRecordValue::isDuplicate)


### PR DESCRIPTION
## Description

* change the duplicate check of a DRG 
* check that all decisions belong to the lastest DRG 
* if another DRG was deployed with the same decision id then it detects that the decision belongs to the other DRG

## Related issues

closes #9272 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
