### PR TITLE
9388 - Start Instructions for ProcessInstanceCreation

### DIFF
--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
@@ -37,13 +37,17 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   private final ArrayProperty<StringValue> fetchVariablesProperty =
       new ArrayProperty<>("fetchVariables", new StringValue());
 
+  private final ArrayProperty<ProcessInstanceCreationStartInstruction> startInstructionsProperty =
+      new ArrayProperty<>("startInstructions", new ProcessInstanceCreationStartInstruction());
+
   public ProcessInstanceCreationRecord() {
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
         .declareProperty(versionProperty)
         .declareProperty(variablesProperty)
-        .declareProperty(fetchVariablesProperty);
+        .declareProperty(fetchVariablesProperty)
+        .declareProperty(startInstructionsProperty);
   }
 
   @Override
@@ -51,6 +55,7 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
     return BufferUtil.bufferAsString(bpmnProcessIdProperty.getValue());
   }
 
+  @Override
   public int getVersion() {
     return versionProperty.getValue();
   }
@@ -106,6 +111,22 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
 
   public ProcessInstanceCreationRecord setFetchVariables(final List<String> fetchVariables) {
     fetchVariables.forEach(variable -> fetchVariablesProperty.add().wrap(wrapString(variable)));
+    return this;
+  }
+
+  public ArrayProperty<ProcessInstanceCreationStartInstruction> startInstructions() {
+    return startInstructionsProperty;
+  }
+
+  public ProcessInstanceCreationRecord addStartInstructions(
+      final List<ProcessInstanceCreationStartInstruction> startInstructions) {
+    startInstructions.forEach(this::addStartInstruction);
+    return this;
+  }
+
+  public ProcessInstanceCreationRecord addStartInstruction(
+      final ProcessInstanceCreationStartInstruction startInstruction) {
+    startInstructionsProperty.add().copy(startInstruction);
     return this;
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationStartInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationStartInstruction.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.processinstance;
+
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+
+public class ProcessInstanceCreationStartInstruction extends ObjectValue {
+
+  private final StringProperty elementIdProp = new StringProperty("elementId");
+
+  public ProcessInstanceCreationStartInstruction() {
+    declareProperty(elementIdProp);
+  }
+
+  public String getElementId() {
+    return BufferUtil.bufferAsString(elementIdProp.getValue());
+  }
+
+  public ProcessInstanceCreationStartInstruction setElementId(final String elementId) {
+    elementIdProp.setValue(elementId);
+    return this;
+  }
+
+  public void copy(final ProcessInstanceCreationStartInstruction startInstruction) {
+    setElementId(startInstruction.getElementId());
+  }
+}


### PR DESCRIPTION
## Description

Add minimal start instructions to process instance creation record (based on Option 3 from the linked issue)

## Related issues

closes #9388 

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
