### PR TITLE
feat(gateway): add start instructions to PI creation

### DIFF
--- a/docs/developer_handbook.md
+++ b/docs/developer_handbook.md
@@ -1,0 +1,13 @@
+# Developer Handbook
+
+This document contains instructions for developers who want to contribute to this project.
+
+## How to extend the Gateway Protocol?
+
+* The gateway protocol is based on GRPC
+* The single source of truth is the [`gateway.proto`](../gateway-protocol/src/main/proto/gateway.proto) [Protocol Buffers](https://developers.google.com/protocol-buffers) file
+* Source code is generated based on the information in that file
+* Make your changes in that file
+* Add comments to new fields/messages you added
+* Remember to also update the GRPC API documentation https://docs.camunda.io/docs/apis-clients/grpc/
+

--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -98,6 +98,23 @@ message CreateProcessInstanceRequest {
   // "b" respectively, with their associated values. [{ "a": 1, "b": 2 }] would not be a
   // valid argument, as the root of the JSON document is an array and not an object.
   string variables = 4;
+  // List of start instructions. If empty (default) the process instance
+  // will start at the start event. If non-empty the process instance will apply start
+  // instructions after it has been created
+  repeated ProcessInstanceCreationStartInstruction startInstructions = 5;
+}
+
+message ProcessInstanceCreationStartInstruction {
+
+  // future extensions might include
+  // - different types of start instructions
+  // - ability to set local variables for different flow scopes
+
+  // for now, however, the start instruction is implicitly a
+  // "startBeforeElement" instruction
+
+  // element ID
+  string elementId = 1;
 }
 
 message CreateProcessInstanceResponse {

--- a/gateway-protocol/src/main/proto/proto.lock
+++ b/gateway-protocol/src/main/proto/proto.lock
@@ -208,6 +208,22 @@
                 "id": 4,
                 "name": "variables",
                 "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "startInstructions",
+                "type": "ProcessInstanceCreationStartInstruction",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ProcessInstanceCreationStartInstruction",
+            "fields": [
+              {
+                "id": 1,
+                "name": "elementId",
+                "type": "string"
               }
             ]
           },


### PR DESCRIPTION
## Description

Adds minimal start instructions to Gateway protocol

## Related issues

closes #9396 

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
