### PR TITLE
[Backport stable/1.3] Allow disabling environment variable override in Java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -19,6 +19,10 @@ import java.time.Duration;
 
 public final class ClientProperties {
 
+  /** @see ZeebeClientBuilder#applyEnvironmentVariableOverrides(boolean) */
+  public static final String APPLY_ENVIRONMENT_VARIABLES_OVERRIDES =
+      "zeebe.client.applyEnvironmentVariableOverrides";
+
   /** @see ZeebeClientBuilder#gatewayAddress(String) */
   public static final String GATEWAY_ADDRESS = "zeebe.client.gateway.address";
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -32,6 +32,16 @@ public interface ZeebeClientBuilder {
   ZeebeClientBuilder withProperties(Properties properties);
 
   /**
+   * Allows to disable the mechanism to override some properties by ENVIRONMENT VARIABLES. This is
+   * useful if a client shall be constructed for test cases or in an environment that wants to fully
+   * control properties (like Spring Boot).
+   *
+   * <p>The default value is <code>true</code>.
+   */
+  ZeebeClientBuilder applyEnvironmentVariableOverrides(
+      final boolean applyEnvironmentVariableOverrides);
+
+  /**
    * @param gatewayAddress the IP socket address of a gateway that the client can initially connect
    *     to. Must be in format <code>host:port</code>. The default value is <code>0.0.0.0:26500
    *     </code> .

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -291,7 +291,6 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   public ZeebeClient build() {
     if (applyEnvironmentVariableOverrides) {
       applyOverrides();
-      applyDefaults();
     }
 
     return new ZeebeClientImpl(this);
@@ -313,6 +312,10 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     if (Environment.system().isDefined(KEEP_ALIVE_VAR)) {
       keepAlive(Environment.system().get(KEEP_ALIVE_VAR));
     }
+
+    if (shouldUseDefaultCredentialsProvider()) {
+      credentialsProvider = createDefaultCredentialsProvider();
+    }
   }
 
   @Override
@@ -329,12 +332,6 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     appendProperty(sb, "defaultRequestTimeout", defaultRequestTimeout);
 
     return sb.toString();
-  }
-
-  private void applyDefaults() {
-    if (shouldUseDefaultCredentialsProvider()) {
-      credentialsProvider = createDefaultCredentialsProvider();
-    }
   }
 
   private boolean shouldUseDefaultCredentialsProvider() {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -43,6 +43,8 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   public static final String KEEP_ALIVE_VAR = "ZEEBE_KEEP_ALIVE";
   public static final String DEFAULT_GATEWAY_ADDRESS = "0.0.0.0:26500";
 
+  private boolean applyEnvironmentVariableOverrides = true;
+
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
   private String gatewayAddress = DEFAULT_GATEWAY_ADDRESS;
   private int jobWorkerMaxJobsActive = 32;
@@ -129,7 +131,11 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
   @Override
   public ZeebeClientBuilder withProperties(final Properties properties) {
-
+    if (properties.containsKey(ClientProperties.APPLY_ENVIRONMENT_VARIABLES_OVERRIDES)) {
+      applyEnvironmentVariableOverrides(
+          Boolean.parseBoolean(
+              properties.getProperty(ClientProperties.APPLY_ENVIRONMENT_VARIABLES_OVERRIDES)));
+    }
     if (properties.containsKey(ClientProperties.GATEWAY_ADDRESS)) {
       gatewayAddress(properties.getProperty(ClientProperties.GATEWAY_ADDRESS));
     }
@@ -183,6 +189,13 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     if (properties.containsKey(KEEP_ALIVE)) {
       keepAlive(properties.getProperty(KEEP_ALIVE));
     }
+    return this;
+  }
+
+  @Override
+  public ZeebeClientBuilder applyEnvironmentVariableOverrides(
+      final boolean applyEnvironmentVariableOverrides) {
+    this.applyEnvironmentVariableOverrides = applyEnvironmentVariableOverrides;
     return this;
   }
 
@@ -276,8 +289,10 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
   @Override
   public ZeebeClient build() {
-    applyOverrides();
-    applyDefaults();
+    if (applyEnvironmentVariableOverrides) {
+      applyOverrides();
+      applyDefaults();
+    }
 
     return new ZeebeClientImpl(this);
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -109,6 +109,13 @@ public class ZeebeClientCloudBuilderImpl
   }
 
   @Override
+  public ZeebeClientCloudBuilderStep4 applyEnvironmentVariableOverrides(
+      boolean applyEnvironmentVariableOverrides) {
+    innerBuilder.applyEnvironmentVariableOverrides(applyEnvironmentVariableOverrides);
+    return this;
+  }
+
+  @Override
   public ZeebeClientCloudBuilderStep4 defaultJobWorkerMaxJobsActive(final int maxJobsActive) {
     innerBuilder.defaultJobWorkerMaxJobsActive(maxJobsActive);
     return this;

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -112,6 +112,23 @@ public final class ZeebeClientTest extends ClientTest {
   }
 
   @Test
+  public void shouldNotOverridePropertyWithEnvVariableIfOverridingIsDisabled() {
+    // given
+    Environment.system().put(PLAINTEXT_CONNECTION_VAR, "false");
+    final Properties properties = new Properties();
+    properties.putIfAbsent(USE_PLAINTEXT_CONNECTION, "true");
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    builder.applyEnvironmentVariableOverrides(false);
+    builder.withProperties(properties);
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.isPlaintextConnectionEnabled()).isTrue();
+  }
+
+  @Test
   public void shouldCaCertificateWithEnvVar() {
     // given
     final String certPath = getClass().getClassLoader().getResource("ca.cert.pem").getPath();


### PR DESCRIPTION
## Description

This PR backports #9411 to 1.3.x. I had to adapt it a little for 1.3, so please review (it's fairly small though).

## Related issues

<!-- Which issues are closed by this PR or are related -->

backports #9411 
related to #9401 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
