### PR TITLE
ci: check gocompat in GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,6 +245,16 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - name: Check gocompat
+        run: |
+          curl -sL https://github.com/smola/gocompat/releases/download/v0.3.0/gocompat_linux_amd64.tar.gz | tar xzvf - gocompat_linux_amd64
+          PREFIX=github.com/camunda/zeebe/clients/go/v8
+          EXCLUDE=""
+          for file in {internal,cmd/zbctl/internal}/*; do
+            EXCLUDE="$EXCLUDE --exclude-package $PREFIX/$file"
+          done
+          ./gocompat_linux_amd64 compare --go1compat ${EXCLUDE} ./...
+        working-directory: clients/go/
       - run: mvn -B -DskipChecks -DskipTests install
       - run: docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t camunda/zeebe:current-test .
       - run: go test -mod=vendor -v ./...


### PR DESCRIPTION
Adds a step to the go-client tests that runs gocompat. 

Installation and invocation are copied from [build-go.sh](https://github.com/camunda/zeebe/blob/f831ee5cb54bc14496e19018e4dad83b64d3c9fc/.ci/scripts/distribution/build-go.sh) and [prepare-go.sh](https://github.com/camunda/zeebe/blob/cc6dcb06f7bd0eb5f0e04ee14376b7ed0dc727d4/.ci/scripts/distribution/prepare-go.sh)