### PR TITLE
Notify on zeebe-ci on gha deploy errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,12 +94,13 @@ jobs:
           target: app
           
   notify-if-failed:
+    name: Send slack notification on build failure
     runs-on: ubuntu-latest
     needs: [tests, deploy-snapshots, deploy-docker-snapshot]
     if: failure()
     steps:
       - id: slack-notify
-        name: Send slack notification about build failure
+        name: Send slack notification
         uses: slackapi/slack-github-action@v1.18.0
         with:
           # For posting a rich message using Block Kit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,3 +92,30 @@ jobs:
           no-cache: true
           build-args: DISTBALL=dist/target/camunda-zeebe-*-SNAPSHOT.tar.gz
           target: app
+          
+  notify-if-failed:
+    runs-on: ubuntu-latest
+    needs: [tests, deploy-snapshots, deploy-docker-snapshot]
+    if: failure()
+    steps:
+      - id: slack-notify
+        name: Send slack notification about build failure
+        uses: slackapi/slack-github-action@v1.18.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## Description

Adds a slack notification for the deploy workflow, which might fail on main without recognization from our side. It happened yesterday for example.

Uses our ZeebeBot and incoming webhook, since this is the preferred approach based on IT. The message will be directly sent to #zeebe-ci.

On the message content, I have no real requirement except that it should notify on failure only and contain a link.

I use the official github action provided by slack https://github.com/slackapi/slack-github-action#technique-3-slack-incoming-webhook and their example which matches pretty good our use case.
Furthermore, I followed https://github.community/t/run-github-actions-job-only-if-previous-job-has-failed/174786/2 regarding executing the job if one previous has failed. 

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/9484

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
