### PR TITLE
Prevent looping backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,7 +9,8 @@ jobs:
     name: Create backport PRs
     runs-on: ubuntu-latest
     # Only run when pull request is merged
-    # or when a comment containing `/backport` is created
+    # or when a comment containing `/backport` is created by someone other than the backport-action
+    # bot user (user id: 97796249)
     if: >
       (
         github.event_name == 'pull_request' &&
@@ -17,6 +18,7 @@ jobs:
       ) || (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
+        github.event.comment.user.id != 97796249 &&
         contains(github.event.comment.body, '/backport')
       )
     steps:
@@ -45,5 +47,5 @@ jobs:
           pull_description: |-
             # Description
             Backport of #${pull_number} to `${target_branch}`.
-            
+
             relates to ${issue_refs}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The backport-action bot added comments to PRs contain "/backport". This resulted in the backport workflow being triggered again, causing an infinite loop of backport messages. By checking the user id of the comment we can prevent comments from backport-action triggering the workflow.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9490 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
