### PR TITLE
dec(developer_handbook): document how to regenerate .gocompat.json file

### DIFF
--- a/docs/developer_handbook.md
+++ b/docs/developer_handbook.md
@@ -11,3 +11,10 @@ This document contains instructions for developers who want to contribute to thi
 * Add comments to new fields/messages you added
 * Remember to also update the GRPC API documentation https://docs.camunda.io/docs/apis-clients/grpc/
 
+## How to update the `.gocompat.json` file?
+
+* This file is to detect changes to the Go interface
+* The comparison is part of the build process
+* If changes are deliberate it is necessary to regenerate this file for the build to pass
+* This is achieved by running ``cd clients/go && gocompat save ./...` and comitting the changes
+


### PR DESCRIPTION
## Description
Adds section that explains how to update the `.gocompat.json` file when it becomes necessary

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
