### PR TITLE
ci: improve build failure message

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,7 +106,7 @@ jobs:
           # For posting a rich message using Block Kit
           payload: |
             {
-              "text": ":alarm: Build on `main` failed! :alarm:\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
+              "text": ":alarm: Build on `main` failed! :alarm:\n${{ github.event.head_commit.url }}",
              	"blocks": [
                 {
                   "type": "section",
@@ -119,7 +119,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Please check the related commit: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}\n \\cc @zeebe-medic"
+                    "text": "Please check the related commit: ${{ github.event.head_commit.url }}\n \\cc @zeebe-medic"
                   }
                 }
               ]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,13 +106,20 @@ jobs:
           # For posting a rich message using Block Kit
           payload: |
             {
-              "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
-              "blocks": [
+              "text": ":alarm: Build on `main` failed! :alarm:\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
+             	"blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                    "text": ":alarm: Build on `main` failed! :alarm:"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Please check the related commit: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}\n \\cc @zeebe-medic"
                   }
                 }
               ]


### PR DESCRIPTION
## Description

Improve build failure message, since it reports wrong details

Before:
![ci](https://user-images.githubusercontent.com/2758593/171696529-a23239bc-641a-4d15-b51c-67d91a3f77c7.png)


After (Example):

![example](https://user-images.githubusercontent.com/2758593/171696347-e94a656f-ae0d-4211-a235-920f252b2073.png)

Check out here:

https://app.slack.com/block-kit-builder/T0PM0P1SA#%7B%22blocks%22:%5B%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22:alarm:%20Build%20on%20%60main%60%20failed!%20:alarm:%22%7D%7D,%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22Please%20check%20the%20related%20commit:%20$%7B%7B%20github.event.pull_request.html_url%20%7C%7C%20github.event.head_commit.url%20%7D%7D%5Cn%20%5C%5Ccc%20@zeebe-medic%22%7D%7D%5D%7D
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
