### PR TITLE
ci: stabilize GHA

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -52,5 +52,5 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
-      - run: mvn -T1C -B -D skipTests -D skipChecks install
+      - run: mvn -B -D skipTests -D skipChecks install
       - run: mvn -T1C -B -D skipTests -P !autoFormat,checkFormat,spotbugs verify

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'maven'
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
@@ -51,6 +50,5 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'maven'
       - run: mvn -B -D skipTests -D skipChecks install
       - run: mvn -T1C -B -D skipTests -P !autoFormat,checkFormat,spotbugs verify

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'maven'
           server-id: camunda-nexus
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
@@ -69,7 +68,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'maven'
       - uses: actions/setup-go@v3
         with:
           go-version: "1.15"
@@ -92,7 +90,7 @@ jobs:
           no-cache: true
           build-args: DISTBALL=dist/target/camunda-zeebe-*-SNAPSHOT.tar.gz
           target: app
-          
+
   notify-if-failed:
     name: Send slack notification on build failure
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'maven'
       - uses: stCarolas/setup-maven@v4.3
         with:
           maven-version: 3.8.5
@@ -71,7 +70,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'maven'
       - uses: stCarolas/setup-maven@v4.3
         with:
           maven-version: 3.8.5
@@ -120,7 +118,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'maven'
       - run: >
           mvn -B
           -D skipTests -D skipChecks
@@ -152,7 +149,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'maven'
       - uses: stCarolas/setup-maven@v4.3
         with:
           maven-version: 3.8.5
@@ -195,7 +191,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'maven'
       - name: Build relevant modules
         run: >
           mvn -B
@@ -227,7 +222,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'maven'
       - run: mvn -B -D skipChecks -D skipTests install
       - run: mvn -T1C -B -D skipChecks -P parallel-tests,include-random-tests test
       - name: Archive Test Results
@@ -251,7 +245,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'maven'
       - run: mvn -B -DskipChecks -DskipTests install
       - run: docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t camunda/zeebe:current-test .
       - run: go test -mod=vendor -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           maven-version: 3.8.5
       - uses: ./.github/actions/use-ci-nexus-cache
-      - run: mvn -T1C -B -DskipChecks -DskipTests install
+      - run: mvn -B -DskipChecks -DskipTests install
       - run: docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t "${ZEEBE_TEST_DOCKER_IMAGE}" .
       - run: docker push "${ZEEBE_TEST_DOCKER_IMAGE}"
       - name: Prepare Testcontainers Cloud agent
@@ -76,7 +76,7 @@ jobs:
         with:
           maven-version: 3.8.5
       - uses: ./.github/actions/use-ci-nexus-cache
-      - run: mvn -T1C -B -DskipChecks -DskipTests install
+      - run: mvn -B -DskipChecks -DskipTests install
       - run: docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t camunda/zeebe:current-test .
       - run: >
           mvn -B --no-snapshot-updates
@@ -122,7 +122,7 @@ jobs:
           java-version: '17'
           cache: 'maven'
       - run: >
-          mvn -B -T1C
+          mvn -B
           -D skipTests -D skipChecks
           -am -pl ${{ matrix.project }}
           install
@@ -158,7 +158,7 @@ jobs:
           maven-version: 3.8.5
       - uses: ./.github/actions/use-ci-nexus-cache
       - run: >
-          mvn -T1C -B
+          mvn -B
           -D skipTests -D skipChecks
           -am -pl :zeebe-workflow-engine
           install
@@ -198,7 +198,7 @@ jobs:
           cache: 'maven'
       - name: Build relevant modules
         run: >
-          mvn -B -T1C
+          mvn -B
           -D skipTests -D skipChecks "-D maven.javadoc.skip=true"
           -am -pl qa/integration-tests
           install
@@ -228,7 +228,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
-      - run: mvn -T1C -B -D skipChecks -D skipTests install
+      - run: mvn -B -D skipChecks -D skipTests install
       - run: mvn -T1C -B -D skipChecks -P parallel-tests,include-random-tests test
       - name: Archive Test Results
         uses: actions/upload-artifact@v3
@@ -252,7 +252,7 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
-      - run: mvn -T1C -B -DskipChecks -DskipTests install
+      - run: mvn -B -DskipChecks -DskipTests install
       - run: docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t camunda/zeebe:current-test .
       - run: go test -mod=vendor -v ./...
         working-directory: clients/go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
         with:
           name: Smoke test results for ${{ matrix.os }}
           path: |
-            **/target/surefire-reports/
+            **/target/failsafe-reports/
             **/hs_err_*.log
           retention-days: 7
   java-randomized-tests:


### PR DESCRIPTION
## Disables the maven cache.
Caching dependencies was not very effective anyway. We can see from previous job runs that most jobs had to download a lot of dependencies anyway. Additionally, looking at the overall time consumption of the pipeline [before](https://github.com/camunda/zeebe/actions/runs/2433189404) and [after](https://github.com/camunda/zeebe/actions/runs/2433151424/attempts/1), removing the cache does not slow down the CI feedback significantly.

One risk I see with this is that we are slightly increasing the chances that jobs will fail when maven central is not available. IMO that shouldn't block us though since we were never close to independent from maven central anyway.

## Single threaded `mvn install`
Previously `mvn install` was, most of the times, called with `-T1C`. On github hosted runners, this would lead to maven resolving dependencies for up to to modules at the same time. We saw multiple cases where resolving dependencies failed and issues such as https://issues.apache.org/jira/browse/MRESOLVER-123 don't inspire confidence. Here we just remove the `-T1C` and fall back to single-threaded `mvn install`
