### PR TITLE
test: fix flaky embedded broker tests

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -246,9 +246,10 @@ public final class ZeebePartition extends Actor
                 t -> {
                   if (t != null) {
                     onInstallFailure(t);
+                  } else {
+                    onRecoveredInternal();
                   }
                 });
-            onRecoveredInternal();
           } else {
             onInstallFailure(error);
           }
@@ -269,9 +270,10 @@ public final class ZeebePartition extends Actor
                   // Compare with the current term in case a new role transition happened
                   if (t != null) {
                     onInstallFailure(t);
+                  } else {
+                    onRecoveredInternal();
                   }
                 });
-            onRecoveredInternal();
           } else {
             onInstallFailure(error);
           }

--- a/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -26,9 +26,8 @@ import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
-import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
-import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.test.util.TestConfigurationFactory;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
@@ -249,9 +248,15 @@ public final class EmbeddedBrokerRule extends ExternalResource {
 
       waitUntil(
           () -> {
-            final BrokerTopologyManager topologyManager = brokerClient.getTopologyManager();
-            final BrokerClusterState topology = topologyManager.getTopology();
-            return topology != null && topology.getLeaderForPartition(1) >= 0;
+            final var topology = brokerClient.getTopologyManager().getTopology();
+            if (topology == null) {
+              return false;
+            }
+            final var leader = topology.getLeaderForPartition(1);
+            if (leader < 0) {
+              return false;
+            }
+            return topology.getPartitionHealth(leader, 1) == PartitionHealthStatus.HEALTHY;
           });
     }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -13,7 +13,6 @@ import static io.camunda.zeebe.broker.test.EmbeddedBrokerConfigurator.setCommand
 import static io.camunda.zeebe.broker.test.EmbeddedBrokerConfigurator.setGatewayApiPort;
 import static io.camunda.zeebe.broker.test.EmbeddedBrokerConfigurator.setGatewayClusterPort;
 import static io.camunda.zeebe.broker.test.EmbeddedBrokerConfigurator.setInternalApiPort;
-import static io.camunda.zeebe.test.util.TestUtil.waitUntil;
 
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.zeebe.broker.Broker;
@@ -21,14 +20,13 @@ import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.TestLoggers;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
-import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
 import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.engine.state.QueryService;
-import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.logstreams.log.LogStream;
-import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.test.util.TestConfigurationFactory;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.camunda.zeebe.util.FileUtil;
@@ -36,6 +34,7 @@ import io.camunda.zeebe.util.allocation.DirectBufferAllocator;
 import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
+import io.netty.util.NetUtil;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,6 +48,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.agrona.LangUtil;
 import org.assertj.core.util.Files;
+import org.awaitility.Awaitility;
 import org.junit.rules.ExternalResource;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -241,23 +241,23 @@ public final class EmbeddedBrokerRule extends ExternalResource {
       Thread.currentThread().interrupt();
     }
 
-    final EmbeddedGatewayService embeddedGatewayService =
-        broker.getBrokerContext().getEmbeddedGatewayService();
-    if (embeddedGatewayService != null) {
-      final BrokerClient brokerClient = embeddedGatewayService.get().getBrokerClient();
-
-      waitUntil(
-          () -> {
-            final var topology = brokerClient.getTopologyManager().getTopology();
-            if (topology == null) {
-              return false;
-            }
-            final var leader = topology.getLeaderForPartition(1);
-            if (leader < 0) {
-              return false;
-            }
-            return topology.getPartitionHealth(leader, 1) == PartitionHealthStatus.HEALTHY;
-          });
+    if (brokerCfg.getGateway().isEnable()) {
+      try (final var client =
+          ZeebeClient.newClientBuilder()
+              .gatewayAddress(NetUtil.toSocketAddressString(getGatewayAddress()))
+              .usePlaintext()
+              .build()) {
+        Awaitility.await("until we have a complete topology")
+            .untilAsserted(
+                () -> {
+                  final var topology = client.newTopologyRequest().send().join();
+                  TopologyAssert.assertThat(topology)
+                      .isComplete(
+                          brokerCfg.getCluster().getClusterSize(),
+                          brokerCfg.getCluster().getPartitionsCount())
+                      .isHealthy();
+                });
+      }
     }
 
     dataDirectory = broker.getSystemContext().getBrokerConfiguration().getData().getDirectory();

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/TopologyAssert.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/TopologyAssert.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.test.util.asserts;
 
 import io.camunda.zeebe.client.api.response.BrokerInfo;
+import io.camunda.zeebe.client.api.response.PartitionBrokerHealth;
 import io.camunda.zeebe.client.api.response.PartitionInfo;
 import io.camunda.zeebe.client.api.response.Topology;
 import java.util.List;
@@ -100,6 +101,18 @@ public final class TopologyAssert extends AbstractObjectAssert<TopologyAssert, T
           count, actual.getBrokers());
     }
 
+    return myself;
+  }
+
+  public TopologyAssert isHealthy() {
+    isNotNull();
+    final var partitions =
+        actual.getBrokers().stream()
+            .flatMap(brokerInfo -> brokerInfo.getPartitions().stream())
+            .collect(Collectors.toList());
+    newListAssertInstance(partitions)
+        .as("all partitions are healthy")
+        .allMatch(partition -> partition.getHealth() == PartitionBrokerHealth.HEALTHY);
     return myself;
   }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/TopologyAssert.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/TopologyAssert.java
@@ -26,7 +26,7 @@ public final class TopologyAssert extends AbstractObjectAssert<TopologyAssert, T
     return new TopologyAssert(actual);
   }
 
-  public final TopologyAssert isComplete(final int clusterSize, final int partitionCount) {
+  public TopologyAssert isComplete(final int clusterSize, final int partitionCount) {
     isNotNull();
 
     final List<BrokerInfo> brokers = actual.getBrokers();
@@ -68,7 +68,7 @@ public final class TopologyAssert extends AbstractObjectAssert<TopologyAssert, T
     return myself;
   }
 
-  public final TopologyAssert doesNotContainBroker(final int nodeId) {
+  public TopologyAssert doesNotContainBroker(final int nodeId) {
     isNotNull();
 
     final List<Integer> brokers =
@@ -82,7 +82,7 @@ public final class TopologyAssert extends AbstractObjectAssert<TopologyAssert, T
     return myself;
   }
 
-  public final TopologyAssert hasBrokerSatisfying(final Consumer<BrokerInfo> condition) {
+  public TopologyAssert hasBrokerSatisfying(final Consumer<BrokerInfo> condition) {
     isNotNull();
 
     final List<BrokerInfo> brokers = actual.getBrokers();
@@ -91,7 +91,7 @@ public final class TopologyAssert extends AbstractObjectAssert<TopologyAssert, T
     return myself;
   }
 
-  public final TopologyAssert hasBrokersCount(final int count) {
+  public TopologyAssert hasBrokersCount(final int count) {
     isNotNull();
 
     if (actual.getBrokers().size() != count) {


### PR DESCRIPTION
In this PR I tried to fix the flaky `BrokerReprocessingTest`. The tests failed because no command api handler was available after starting a broker. To fix this I've made two changes:

1. The `EmbeddedBrokerRule` waits for a healthy deployment partition (partition 1) before finishing the startup.
2. Partitions are not marked as healthy until the command-api service (and others) are registered.

For a more detailed description see the commit messages.

closes #9486 