### PR TITLE
feat(gateway): map start instructions for CreateProcessInstanceWithResult

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -128,6 +128,7 @@ public final class RequestMapper {
         .setKey(request.getProcessDefinitionKey())
         .setVersion(request.getVersion())
         .setVariables(ensureJsonSet(request.getVariables()))
+        .setStartInstructions(request.getStartInstructionsList())
         .setFetchVariables(grpcRequest.getFetchVariablesList());
 
     return brokerRequest;

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceWithResultRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateProcessInstanceWithResultRequest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.impl.broker.request;
 
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ProcessInstanceCreationStartInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -41,6 +42,19 @@ public final class BrokerCreateProcessInstanceWithResultRequest
 
   public BrokerCreateProcessInstanceWithResultRequest setVariables(final DirectBuffer variables) {
     requestDto.setVariables(variables);
+    return this;
+  }
+
+  public BrokerCreateProcessInstanceWithResultRequest setStartInstructions(
+      final List<ProcessInstanceCreationStartInstruction> startInstructionsList) {
+    startInstructionsList.stream()
+        .map(
+            startInstructionReq ->
+                new io.camunda.zeebe.protocol.impl.record.value.processinstance
+                        .ProcessInstanceCreationStartInstruction()
+                    .setElementId(startInstructionReq.getElementId()))
+        .forEach(requestDto::addStartInstruction);
+
     return this;
   }
 


### PR DESCRIPTION
## Description

Initially, the plan was to omit this mapping to reduce scope. However, when working on #9398 we
decided to include the mapping. Reason is that both the request to create a process instance and
the request to create a process instance with result share code, which enables both to take
start instructions. On balance, we prefer to support it for both cases rather than implementing
additional logic to remove this capability from one of the cases.

## Related issues

closes #9397 

<!-- Cut-off marker
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
