### PR TITLE
Fix flaky shouldNotifyCommitListener test

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/zeebe/ZeebeTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/zeebe/ZeebeTest.java
@@ -18,7 +18,6 @@ package io.atomix.raft.zeebe;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-import com.google.common.base.Stopwatch;
 import io.atomix.raft.RaftCommitListener;
 import io.atomix.raft.partition.impl.RaftPartitionServer;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
@@ -51,8 +50,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Parameterized.class)
 public class ZeebeTest {
@@ -67,8 +64,6 @@ public class ZeebeTest {
   @Parameter(1)
   public Collection<Function<TemporaryFolder, ZeebeTestNode>> nodeSuppliers;
 
-  private final Logger logger = LoggerFactory.getLogger(getClass());
-  private final Stopwatch stopwatch = Stopwatch.createUnstarted();
   private final TestAppender appenderWrapper = new TestAppender();
 
   private Collection<ZeebeTestNode> nodes;
@@ -97,21 +92,13 @@ public class ZeebeTest {
 
   @Before
   public void setUp() throws Exception {
-    stopwatch.reset();
     nodes = buildNodes();
     helper = new ZeebeTestHelper(nodes);
     start();
-
-    stopwatch.start();
   }
 
   @After
   public void tearDown() throws Exception {
-    if (stopwatch.isRunning()) {
-      stopwatch.stop();
-    }
-
-    logger.info("Test run time: {}", stopwatch.toString());
     stop();
   }
 
@@ -220,6 +207,7 @@ public class ZeebeTest {
     }
   }
 
+  @SuppressWarnings("squid:S2699") // helper::await asserts
   @Test
   public void shouldNotifyCommitListeners() {
     // given

--- a/atomix/cluster/src/test/java/io/atomix/raft/zeebe/ZeebeTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/zeebe/ZeebeTest.java
@@ -15,11 +15,8 @@
  */
 package io.atomix.raft.zeebe;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import com.google.common.base.Stopwatch;
 import io.atomix.raft.RaftCommitListener;
@@ -148,7 +145,7 @@ public class ZeebeTest {
     server.snapshot().join();
 
     // then
-    assertTrue(helper.containsIndexed(server, firstAppended));
+    assertThat(helper.containsIndexed(server, firstAppended)).isTrue();
   }
 
   @Test
@@ -169,13 +166,13 @@ public class ZeebeTest {
     server.snapshot().join();
 
     // then
-    assertFalse(helper.containsIndexed(server, firstAppended));
-    assertTrue(helper.containsIndexed(server, appended));
+    assertThat(helper.containsIndexed(server, firstAppended)).isFalse();
+    assertThat(helper.containsIndexed(server, appended)).isTrue();
   }
 
   @Test
   public void shouldFailover() {
-    assumeTrue(nodes.size() > 1);
+    assumeThat(nodes.size() > 1).isTrue();
 
     // given
     final int partitionId = 1;
@@ -189,21 +186,20 @@ public class ZeebeTest {
     originalLeader.start(nodes).join();
 
     // then
-    assertNotEquals(originalLeader, helper.awaitLeader(partitionId));
-    assertEquals(newLeader, helper.awaitLeader(partitionId));
+    assertThat(helper.awaitLeader(partitionId)).isNotEqualTo(originalLeader).isEqualTo(newLeader);
   }
 
   @SuppressWarnings("squid:S2699") // awaitAllContain is the assert here
   @Test
   public void shouldAppendAllEntriesEvenWithFollowerFailures() {
-    assumeTrue(nodes.size() > 1);
+    assumeThat(nodes.size() > 1).isTrue();
 
     // given
     final int partitionId = 1;
     final ZeebeTestNode leader = helper.awaitLeader(partitionId);
     final ZeebeLogAppender appender = helper.awaitLeaderAppender(partitionId);
     final List<ZeebeTestNode> followers =
-        nodes.stream().filter(node -> !node.equals(leader)).collect(Collectors.toList());
+        nodes.stream().filter(node -> !node.equals(leader)).toList();
     final List<IndexedRaftLogEntry> entries = new ArrayList<>();
 
     // when


### PR DESCRIPTION
## Description

Use commitIndex to verify that listener is notified instead of using called count. It is possible that one of the follower committed the InitialEntry after the CommitListener is added. As a result the test failed because the expected call count is different.

## Related issues

closes #9372 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
