### PR TITLE
Update metrics exporter for start process instance anywhere

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
@@ -13,19 +13,24 @@ import io.prometheus.client.Counter;
 
 public final class ProcessEngineMetrics {
 
-  static final Counter EXECUTED_INSTANCES =
-      Counter.build()
-          .namespace("zeebe")
-          .name("executed_instances_total")
-          .help("Number of executed (root) process instances")
-          .labelNames("organizationId", "type", "action", "partition")
-          .register();
+  private static final String NAMESPACE = "zeebe";
+  private static final String ORGANIZATION_ID_LABEL = "organizationId";
+  private static final String PARTITION_LABEL = "partition";
+  private static final String ACTION_LABEL = "action";
   static final Counter EVALUATED_DMN_ELEMENTS =
       Counter.build()
-          .namespace("zeebe")
+          .namespace(NAMESPACE)
           .name("evaluated_dmn_elements_total")
           .help("Number of evaluated DMN elements including required decisions")
-          .labelNames("organizationId", "action", "partition")
+          .labelNames(ORGANIZATION_ID_LABEL, ACTION_LABEL, PARTITION_LABEL)
+          .register();
+  private static final String TYPE_LABEL = "type";
+  static final Counter EXECUTED_INSTANCES =
+      Counter.build()
+          .namespace(NAMESPACE)
+          .name("executed_instances_total")
+          .help("Number of executed (root) process instances")
+          .labelNames(ORGANIZATION_ID_LABEL, TYPE_LABEL, ACTION_LABEL, PARTITION_LABEL)
           .register();
   private static final String ORGANIZATION_ID =
       System.getenv().getOrDefault("CAMUNDA_CLOUD_ORGANIZATION_ID", "null");
@@ -36,10 +41,10 @@ public final class ProcessEngineMetrics {
   private static final String ACTION_EVALUATED_FAILED = "evaluated_failed";
   private static final Counter ELEMENT_INSTANCE_EVENTS =
       Counter.build()
-          .namespace("zeebe")
+          .namespace(NAMESPACE)
           .name("element_instance_events_total")
           .help("Number of process element instance events")
-          .labelNames("action", "type", "partition")
+          .labelNames(ACTION_LABEL, TYPE_LABEL, PARTITION_LABEL)
           .register();
   private final String partitionIdLabel;
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
@@ -17,7 +17,7 @@ public final class ProcessEngineMetrics {
       Counter.build()
           .namespace("zeebe")
           .name("executed_instances_total")
-          .help("Number of executed instances")
+          .help("Number of executed (root) process instances")
           .labelNames("organizationId", "type", "action", "partition")
           .register();
   static final Counter EVALUATED_DMN_ELEMENTS =

--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
@@ -15,7 +15,18 @@ import io.prometheus.client.Counter;
 public final class ProcessEngineMetrics {
 
   private static final String NAMESPACE = "zeebe";
+  /**
+   * Metrics that are annotated with this label are vitally important for usage tracking and
+   * data-based decision-making as part of Camunda's SaaS offering.
+   *
+   * <p>DO NOT REMOVE this label from existing metrics without previous discussion within the team.
+   *
+   * <p>At the same time, NEW METRICS MAY NOT NEED THIS label. In that case, it is preferable to not
+   * add this label to a metric as Prometheus best practices warn against using labels with a high
+   * cardinality of possible values.
+   */
   private static final String ORGANIZATION_ID_LABEL = "organizationId";
+
   private static final String PARTITION_LABEL = "partition";
   private static final String ACTION_LABEL = "action";
   static final Counter EVALUATED_DMN_ELEMENTS =

--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
@@ -53,7 +53,7 @@ public final class ProcessEngineMetrics {
           .namespace(NAMESPACE)
           .name("process_instance_creations_total")
           .help("Number of created (root) process instances")
-          .labelNames(ORGANIZATION_ID_LABEL, PARTITION_LABEL, CREATION_MODE_LABEL)
+          .labelNames(PARTITION_LABEL, CREATION_MODE_LABEL)
           .register();
   private final String partitionIdLabel;
 
@@ -70,9 +70,7 @@ public final class ProcessEngineMetrics {
             ? CreationMode.CREATION_AT_GIVEN_ELEMENT
             : CreationMode.CREATION_AT_DEFAULT_START_EVENT;
 
-    CREATED_PROCESS_INSTANCES
-        .labels(ORGANIZATION_ID, partitionIdLabel, creationMode.toString())
-        .inc();
+    CREATED_PROCESS_INSTANCES.labels(partitionIdLabel, creationMode.toString()).inc();
   }
 
   private void elementInstanceEvent(final String action, final BpmnElementType elementType) {


### PR DESCRIPTION
## Description

Adds metrics to distinguish normal process instance creation from start process instance from anywhere process instance creations.

**Note** This PR does not update the metric from the processing logic, because the processing logic is part of another issue #9390 . Consequently, it also does not implement a test which verifies that the metric gets updated.

## Related issues

closes #9406 

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
