### PR TITLE
feat(zb-db): replace the reflection RocksDB seek method calls with calls the RocksDB API with `ByteBuffer`

### DIFF
--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyChecker.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyChecker.java
@@ -90,7 +90,8 @@ public final class ForeignKeyChecker {
         transaction.newIterator(
             transactionDb.getPrefixReadOptions(), transactionDb.getDefaultHandle())) {
 
-      iterator.seek(ByteBuffer.wrap(prefix, 0, prefixLength));
+      final ByteBuffer bufferView = ByteBuffer.wrap(prefix, 0, prefixLength);
+      iterator.seek(bufferView);
       boolean exists = false;
       if (iterator.isValid()) {
         final byte[] keyBytes = iterator.key();

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyChecker.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ForeignKeyChecker.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.db.ZeebeDbInconsistentException;
 import io.camunda.zeebe.db.impl.DbForeignKey;
 import io.camunda.zeebe.db.impl.ZeebeDbConstants;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.nio.ByteBuffer;
 import org.agrona.ExpandableArrayBuffer;
 
 /**
@@ -89,8 +90,7 @@ public final class ForeignKeyChecker {
         transaction.newIterator(
             transactionDb.getPrefixReadOptions(), transactionDb.getDefaultHandle())) {
 
-      RocksDbInternal.seek(
-          iterator, ZeebeTransactionDb.getNativeHandle(iterator), prefix, prefixLength);
+      iterator.seek(ByteBuffer.wrap(prefix, 0, prefixLength));
       boolean exists = false;
       if (iterator.isValid()) {
         final byte[] keyBytes = iterator.key();

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RocksDbInternal.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RocksDbInternal.java
@@ -17,12 +17,10 @@ import static org.rocksdb.Status.Code.TimedOut;
 import static org.rocksdb.Status.Code.TryAgain;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.EnumSet;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
-import org.rocksdb.RocksIterator;
 import org.rocksdb.RocksObject;
 import org.rocksdb.Status;
 import org.rocksdb.Status.Code;
@@ -38,8 +36,6 @@ public final class RocksDbInternal {
   static Method putWithHandle;
   static Method getWithHandle;
   static Method removeWithHandle;
-
-  static Method seekMethod;
 
   static {
     RocksDB.loadLibrary();
@@ -57,8 +53,6 @@ public final class RocksDbInternal {
     putWithHandle();
     getWithHandle();
     removeWithHandle();
-
-    seekWithHandle();
   }
 
   private static void nativeHandles() throws NoSuchFieldException {
@@ -96,24 +90,6 @@ public final class RocksDbInternal {
         Transaction.class.getDeclaredMethod(
             "delete", Long.TYPE, byte[].class, Integer.TYPE, Long.TYPE, Boolean.TYPE);
     removeWithHandle.setAccessible(true);
-  }
-
-  private static void seekWithHandle() throws NoSuchMethodException {
-    seekMethod =
-        RocksIterator.class.getDeclaredMethod("seek0", long.class, byte[].class, int.class);
-    seekMethod.setAccessible(true);
-  }
-
-  public static void seek(
-      final RocksIterator iterator,
-      final long nativeHandle,
-      final byte[] target,
-      final int targetLength) {
-    try {
-      seekMethod.invoke(iterator, nativeHandle, target, targetLength);
-    } catch (final IllegalAccessException | InvocationTargetException e) {
-      throw new RuntimeException("Unexpected error occurred trying to seek with RocksIterator", e);
-    }
   }
 
   static boolean isRocksDbExceptionRecoverable(final RocksDBException rdbex) {

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -333,7 +333,8 @@ class TransactionalColumnFamily<
 
             boolean shouldVisitNext = true;
 
-            for (iterator.seek(ByteBuffer.wrap(prefixKey, 0, prefixLength));
+            final ByteBuffer bufferView = ByteBuffer.wrap(prefixKey, 0, prefixLength);
+            for (iterator.seek(bufferView);
                 iterator.isValid() && shouldVisitNext;
                 iterator.next()) {
               final byte[] keyBytes = iterator.key();

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.db.KeyValuePairVisitor;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDbInconsistentException;
+import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -332,11 +333,7 @@ class TransactionalColumnFamily<
 
             boolean shouldVisitNext = true;
 
-            for (RocksDbInternal.seek(
-                    iterator,
-                    ZeebeTransactionDb.getNativeHandle(iterator),
-                    prefixKey,
-                    prefixLength);
+            for (iterator.seek(ByteBuffer.wrap(prefixKey, 0, prefixLength));
                 iterator.isValid() && shouldVisitNext;
                 iterator.next()) {
               final byte[] keyBytes = iterator.key();


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
I've just replaced the seek method calls with the `ByteBuffer` API. I'm just wrapping it in the `ByteBuffer` type and calling the `ByteBuffer` API. I'm not sure about any other calls but I can't find any other opportunities to replace reflection calls with `ByteBuffer` API calls.

Also I think that we should benchmark this but I don't know how to do it properly 😅

## Related issues

<!-- Which issues are closed by this PR or are related -->

#3959.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
