### PR TITLE
Subscribe to events when starting a process instance anywhere

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
@@ -100,7 +100,12 @@ public final class ProcessEventProcessors {
         zeebeState.getKeyGenerator(),
         writers.state());
     addProcessInstanceCreationStreamProcessors(
-        typedRecordProcessors, zeebeState, writers, variableBehavior, processEngineMetrics);
+        typedRecordProcessors,
+        zeebeState,
+        writers,
+        variableBehavior,
+        catchEventBehavior,
+        processEngineMetrics);
 
     return bpmnStreamProcessor;
   }
@@ -203,13 +208,19 @@ public final class ProcessEventProcessors {
       final MutableZeebeState zeebeState,
       final Writers writers,
       final VariableBehavior variableBehavior,
+      final CatchEventBehavior catchEventBehavior,
       final ProcessEngineMetrics metrics) {
     final MutableElementInstanceState elementInstanceState = zeebeState.getElementInstanceState();
     final KeyGenerator keyGenerator = zeebeState.getKeyGenerator();
 
     final CreateProcessInstanceProcessor createProcessor =
         new CreateProcessInstanceProcessor(
-            zeebeState.getProcessState(), keyGenerator, writers, variableBehavior, metrics);
+            zeebeState.getProcessState(),
+            keyGenerator,
+            writers,
+            variableBehavior,
+            catchEventBehavior,
+            metrics);
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationIntent.CREATE, createProcessor);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -91,7 +91,7 @@ public final class CreateProcessInstanceProcessor
   public boolean onCommand(
       final TypedRecord<ProcessInstanceCreationRecord> command,
       final CommandControl<ProcessInstanceCreationRecord> controller) {
-
+    // cleanup side effects from previous command
     sideEffectQueue.clear();
 
     final ProcessInstanceCreationRecord record = command.getValue();
@@ -321,6 +321,10 @@ public final class CreateProcessInstanceProcessor
     createEventSubscriptions(element, elementRecord, elementInstanceKey);
   }
 
+  /**
+   * Create the event subscriptions of the given element. Assuming that the element instance is in
+   * state ACTIVATED.
+   */
   private void createEventSubscriptions(
       final ExecutableFlowElement element,
       final ProcessInstanceRecord elementRecord,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -241,12 +241,7 @@ public final class CreateProcessInstanceProcessor
       final long processInstanceKey,
       final ProcessInstanceRecord processInstance) {
 
-    stateWriter.appendFollowUpEvent(
-        processInstanceKey, ProcessInstanceIntent.ELEMENT_ACTIVATING, processInstance);
-    stateWriter.appendFollowUpEvent(
-        processInstanceKey, ProcessInstanceIntent.ELEMENT_ACTIVATED, processInstance);
-
-    createEventSubscriptions(process.getProcess(), processInstance, processInstanceKey);
+    activateElementInstance(process.getProcess(), processInstanceKey, processInstance);
 
     final Map<DirectBuffer, Long> activatedFlowScopeIds = new HashMap<>();
     activatedFlowScopeIds.put(processInstance.getElementIdBuffer(), processInstanceKey);
@@ -307,15 +302,23 @@ public final class CreateProcessInstanceProcessor
       final long elementInstanceKey = keyGenerator.nextKey();
       activatedFlowScopeIds.put(flowScope.getId(), elementInstanceKey);
 
-      stateWriter.appendFollowUpEvent(
-          elementInstanceKey, ProcessInstanceIntent.ELEMENT_ACTIVATING, flowScopeRecord);
-      stateWriter.appendFollowUpEvent(
-          elementInstanceKey, ProcessInstanceIntent.ELEMENT_ACTIVATED, flowScopeRecord);
-
-      createEventSubscriptions(flowScope, flowScopeRecord, elementInstanceKey);
+      activateElementInstance(flowScope, elementInstanceKey, flowScopeRecord);
 
       return elementInstanceKey;
     }
+  }
+
+  private void activateElementInstance(
+      final ExecutableFlowElement element,
+      final long elementInstanceKey,
+      final ProcessInstanceRecord elementRecord) {
+
+    stateWriter.appendFollowUpEvent(
+        elementInstanceKey, ProcessInstanceIntent.ELEMENT_ACTIVATING, elementRecord);
+    stateWriter.appendFollowUpEvent(
+        elementInstanceKey, ProcessInstanceIntent.ELEMENT_ACTIVATED, elementRecord);
+
+    createEventSubscriptions(element, elementRecord, elementInstanceKey);
   }
 
   private void createEventSubscriptions(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -11,9 +11,13 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContextImpl;
+import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventSupplier;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectQueue;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -54,8 +58,14 @@ public final class CreateProcessInstanceProcessor
       "Expected to set variables from document, but the document is invalid";
 
   private final ProcessInstanceRecord newProcessInstance = new ProcessInstanceRecord();
+
+  private final SideEffectQueue sideEffectQueue = new SideEffectQueue();
+
   private final ProcessState processState;
   private final VariableBehavior variableBehavior;
+
+  private final CatchEventBehavior catchEventBehavior;
+
   private final KeyGenerator keyGenerator;
   private final TypedCommandWriter commandWriter;
   private final StateWriter stateWriter;
@@ -66,9 +76,11 @@ public final class CreateProcessInstanceProcessor
       final KeyGenerator keyGenerator,
       final Writers writers,
       final VariableBehavior variableBehavior,
+      final CatchEventBehavior catchEventBehavior,
       final ProcessEngineMetrics metrics) {
     this.processState = processState;
     this.variableBehavior = variableBehavior;
+    this.catchEventBehavior = catchEventBehavior;
     this.keyGenerator = keyGenerator;
     commandWriter = writers.command();
     stateWriter = writers.state();
@@ -79,6 +91,9 @@ public final class CreateProcessInstanceProcessor
   public boolean onCommand(
       final TypedRecord<ProcessInstanceCreationRecord> command,
       final CommandControl<ProcessInstanceCreationRecord> controller) {
+
+    sideEffectQueue.clear();
+
     final ProcessInstanceCreationRecord record = command.getValue();
     final DeployedProcess process = getProcess(record, controller);
     if (process == null || !isValidProcess(controller, process, record.startInstructions())) {
@@ -225,10 +240,13 @@ public final class CreateProcessInstanceProcessor
       final DeployedProcess process,
       final long processInstanceKey,
       final ProcessInstanceRecord processInstance) {
+
     stateWriter.appendFollowUpEvent(
         processInstanceKey, ProcessInstanceIntent.ELEMENT_ACTIVATING, processInstance);
     stateWriter.appendFollowUpEvent(
         processInstanceKey, ProcessInstanceIntent.ELEMENT_ACTIVATED, processInstance);
+
+    createEventSubscriptions(process.getProcess(), processInstance, processInstanceKey);
 
     final Map<DirectBuffer, Long> activatedFlowScopeIds = new HashMap<>();
     activatedFlowScopeIds.put(processInstance.getElementIdBuffer(), processInstanceKey);
@@ -245,6 +263,9 @@ public final class CreateProcessInstanceProcessor
           commandWriter.appendFollowUpCommand(
               elementInstanceKey, ProcessInstanceIntent.ACTIVATE_ELEMENT, elementRecord);
         });
+
+    // applying the side effects is part of creating the event subscriptions
+    sideEffectQueue.flush();
   }
 
   /**
@@ -285,11 +306,30 @@ public final class CreateProcessInstanceProcessor
 
       final long elementInstanceKey = keyGenerator.nextKey();
       activatedFlowScopeIds.put(flowScope.getId(), elementInstanceKey);
+
       stateWriter.appendFollowUpEvent(
           elementInstanceKey, ProcessInstanceIntent.ELEMENT_ACTIVATING, flowScopeRecord);
       stateWriter.appendFollowUpEvent(
           elementInstanceKey, ProcessInstanceIntent.ELEMENT_ACTIVATED, flowScopeRecord);
+
+      createEventSubscriptions(flowScope, flowScopeRecord, elementInstanceKey);
+
       return elementInstanceKey;
+    }
+  }
+
+  private void createEventSubscriptions(
+      final ExecutableFlowElement element,
+      final ProcessInstanceRecord elementRecord,
+      final long elementInstanceKey) {
+
+    if (element instanceof ExecutableCatchEventSupplier catchEventSupplier) {
+      final var bpmnElementContext = new BpmnElementContextImpl();
+      bpmnElementContext.init(
+          elementInstanceKey, elementRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+
+      catchEventBehavior.subscribeToEvents(
+          bpmnElementContext, catchEventSupplier, sideEffectQueue, commandWriter);
     }
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceAnywhereTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceAnywhereTest.java
@@ -15,10 +15,13 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
 import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -620,6 +623,254 @@ public class CreateProcessInstanceAnywhereTest {
             tuple(BpmnElementType.MANUAL_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldSubscribeToProcessEvents() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .eventSubProcess(
+                    "message-event-subprocess",
+                    s ->
+                        s.startEvent()
+                            .interrupting(false)
+                            .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
+                            .endEvent())
+                .eventSubProcess(
+                    "timer-event-subprocess",
+                    s -> s.startEvent().interrupting(false).timerWithCycle("R/PT1H").endEvent())
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("task"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withStartInstruction(newStartInstruction("task"))
+            .withVariable("key", "key-1")
+            .create();
+
+    // when
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    ENGINE.message().withName("message").withCorrelationKey("key-1").publish();
+
+    RecordingExporter.timerRecords(TimerIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    ENGINE.increaseTime(Duration.ofHours(1));
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.EVENT_SUB_PROCESS)
+                .limit(2)
+                .count())
+        .describedAs("Await until the events are triggered")
+        .isEqualTo(2);
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("task").complete();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(
+            record -> record.getValue().getElementId(),
+            record -> record.getValue().getBpmnElementType(),
+            Record::getIntent)
+        .containsSequence(
+            tuple(PROCESS_ID, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(PROCESS_ID, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("task", BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ACTIVATE_ELEMENT))
+        .containsSubsequence(
+            tuple(
+                "message-event-subprocess",
+                BpmnElementType.EVENT_SUB_PROCESS,
+                ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(
+                "timer-event-subprocess",
+                BpmnElementType.EVENT_SUB_PROCESS,
+                ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldSubscribeToScopeEvents() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess(
+                    "subprocess",
+                    subprocess -> {
+                      subprocess
+                          .embeddedSubProcess()
+                          .startEvent()
+                          .serviceTask("task", t -> t.zeebeJobType("task"))
+                          .endEvent();
+
+                      subprocess
+                          .boundaryEvent("message-boundary-event")
+                          .cancelActivity(false)
+                          .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
+                          .endEvent();
+
+                      subprocess
+                          .boundaryEvent("timer-boundary-event")
+                          .cancelActivity(false)
+                          .timerWithCycle("R/PT1H")
+                          .endEvent();
+                    })
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withStartInstruction(newStartInstruction("task"))
+            .withVariable("key", "key-1")
+            .create();
+
+    // when
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    ENGINE.message().withName("message").withCorrelationKey("key-1").publish();
+
+    RecordingExporter.timerRecords(TimerIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    ENGINE.increaseTime(Duration.ofHours(1));
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.BOUNDARY_EVENT)
+                .limit(2)
+                .count())
+        .describedAs("Await until the events are triggered")
+        .isEqualTo(2);
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("task").complete();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(
+            record -> record.getValue().getElementId(),
+            record -> record.getValue().getBpmnElementType(),
+            Record::getIntent)
+        .containsSequence(
+            tuple(PROCESS_ID, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(PROCESS_ID, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                "subprocess",
+                BpmnElementType.SUB_PROCESS,
+                ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(
+                "subprocess", BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("task", BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ACTIVATE_ELEMENT))
+        .containsSubsequence(
+            tuple(
+                "message-boundary-event",
+                BpmnElementType.BOUNDARY_EVENT,
+                ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(
+                "timer-boundary-event",
+                BpmnElementType.BOUNDARY_EVENT,
+                ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldSubscribeToEventsOnlyOnce() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .eventSubProcess(
+                    "message-event-subprocess",
+                    s ->
+                        s.startEvent()
+                            .interrupting(false)
+                            .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
+                            .endEvent())
+                .eventSubProcess(
+                    "timer-event-subprocess",
+                    s -> s.startEvent().interrupting(false).timerWithCycle("R/PT1H").endEvent())
+                .startEvent()
+                .parallelGateway("forking")
+                .manualTask("task1")
+                .parallelGateway("joining")
+                .moveToNode("forking")
+                .manualTask("task2")
+                .connectTo("joining")
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withStartInstruction(newStartInstruction("task1"))
+            .withStartInstruction(newStartInstruction("task2"))
+            .withVariable("key", "key-1")
+            .create();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(
+            record -> record.getValue().getElementId(),
+            record -> record.getValue().getBpmnElementType(),
+            Record::getIntent)
+        .containsSequence(
+            tuple(PROCESS_ID, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(PROCESS_ID, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("task1", BpmnElementType.MANUAL_TASK, ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple("task2", BpmnElementType.MANUAL_TASK, ProcessInstanceIntent.ACTIVATE_ELEMENT));
+
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .processMessageSubscriptionRecords()
+                .withProcessInstanceKey(processInstanceKey))
+        .extracting(Record::getIntent)
+        .describedAs("Expected to create the message subscription only once")
+        .containsOnlyOnce(ProcessMessageSubscriptionIntent.CREATED);
+
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .timerRecords()
+                .withProcessInstanceKey(processInstanceKey))
+        .extracting(Record::getIntent)
+        .describedAs("Expected to create the timer only once")
+        .containsOnlyOnce(TimerIntent.CREATED);
   }
 
   private ProcessInstanceCreationStartInstruction newStartInstruction(final String elementId) {


### PR DESCRIPTION
## Description

* reuse the existing logic to subscribe to events (i.e. to create event subscriptions)
* create the event subscriptions for the process and the flow scope of the given elements
* test the creation of the event subscriptions indirectly by verifying that the event subprocess / boundary event is triggered. This way, we verify that the events can also be triggered without repeating the code.

## Related issues

closes #9391 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
