### PR TITLE
Reject process instance creation command if an element is unknown or is inside a multi-instance subprocess

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -137,11 +137,8 @@ public final class CreateProcessInstanceProcessor
     final var startInstructions = command.startInstructions();
 
     return validateHasNoneStartEventOrStartInstructions(process, startInstructions)
-        .flatMap(valid -> validateStartInstructionsIfElementsExist(process, startInstructions))
-        .flatMap(
-            valid ->
-                validateStartInstructionsIfElementsAreInsideMultiInstance(
-                    process, startInstructions))
+        .flatMap(valid -> validateElementsExist(process, startInstructions))
+        .flatMap(valid -> validateElementsNotInsideMultiInstance(process, startInstructions))
         .map(valid -> deployedProcess);
   }
 
@@ -157,7 +154,7 @@ public final class CreateProcessInstanceProcessor
     }
   }
 
-  private Either<Rejection, ?> validateStartInstructionsIfElementsExist(
+  private Either<Rejection, ?> validateElementsExist(
       final ExecutableProcess process,
       final ArrayProperty<ProcessInstanceCreationStartInstruction> startInstructions) {
 
@@ -179,7 +176,7 @@ public final class CreateProcessInstanceProcessor
     return process.getElementById(wrapString(elementId)) != null;
   }
 
-  private Either<Rejection, ?> validateStartInstructionsIfElementsAreInsideMultiInstance(
+  private Either<Rejection, ?> validateElementsNotInsideMultiInstance(
       final ExecutableProcess process,
       final ArrayProperty<ProcessInstanceCreationStartInstruction> startInstructions) {
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -98,7 +98,7 @@ public final class CreateProcessInstanceProcessor
     final ProcessInstanceCreationRecord record = command.getValue();
     final DeployedProcess process = getProcess(record, controller);
     if (process == null
-        || !isValidProcess(controller, process, record.startInstructions())
+        || !hasNoneStartEventOrStartInstructions(controller, process, record.startInstructions())
         || !hasValidStartInstructions(
             controller, process.getProcess(), record.startInstructions())) {
       return true;
@@ -129,7 +129,7 @@ public final class CreateProcessInstanceProcessor
     return true;
   }
 
-  private boolean isValidProcess(
+  private boolean hasNoneStartEventOrStartInstructions(
       final CommandControl<ProcessInstanceCreationRecord> controller,
       final DeployedProcess process,
       final ArrayProperty<ProcessInstanceCreationStartInstruction> startInstructions) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -98,6 +98,14 @@ public final class CreateProcessInstanceProcessor
       return true;
     }
 
+    createProcessInstance(controller, record, process);
+    return true;
+  }
+
+  private void createProcessInstance(
+      final CommandControl<ProcessInstanceCreationRecord> controller,
+      final ProcessInstanceCreationRecord record,
+      final DeployedProcess process) {
     final long processInstanceKey = keyGenerator.nextKey();
 
     setVariablesFromDocument(
@@ -118,8 +126,8 @@ public final class CreateProcessInstanceProcessor
         .setVersion(process.getVersion())
         .setProcessDefinitionKey(process.getKey());
     controller.accept(ProcessInstanceCreationIntent.CREATED, record);
+
     metrics.processInstanceCreated(record);
-    return true;
   }
 
   private boolean hasNoneStartEventOrStartInstructions(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceAnywhereTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceAnywhereTest.java
@@ -12,7 +12,6 @@ import static org.assertj.core.groups.Tuple.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
@@ -51,11 +50,7 @@ public class CreateProcessInstanceAnywhereTest {
 
     // When
     final long processInstanceKey =
-        ENGINE
-            .processInstance()
-            .ofBpmnProcessId(PROCESS_ID)
-            .withStartInstruction(newStartInstruction("end"))
-            .create();
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withStartInstruction("end").create();
 
     // Then
     Assertions.assertThat(
@@ -100,8 +95,8 @@ public class CreateProcessInstanceAnywhereTest {
         ENGINE
             .processInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withStartInstruction(newStartInstruction("task1"))
-            .withStartInstruction(newStartInstruction("task2"))
+            .withStartInstruction("task1")
+            .withStartInstruction("task2")
             .create();
 
     // Then
@@ -159,11 +154,7 @@ public class CreateProcessInstanceAnywhereTest {
 
     // When
     final long processInstanceKey =
-        ENGINE
-            .processInstance()
-            .ofBpmnProcessId(PROCESS_ID)
-            .withStartInstruction(newStartInstruction("task"))
-            .create();
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withStartInstruction("task").create();
 
     // Then
     Assertions.assertThat(
@@ -230,8 +221,8 @@ public class CreateProcessInstanceAnywhereTest {
         ENGINE
             .processInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withStartInstruction(newStartInstruction("task1"))
-            .withStartInstruction(newStartInstruction("task2"))
+            .withStartInstruction("task1")
+            .withStartInstruction("task2")
             .create();
 
     // Then
@@ -303,11 +294,7 @@ public class CreateProcessInstanceAnywhereTest {
 
     // When
     final long processInstanceKey =
-        ENGINE
-            .processInstance()
-            .ofBpmnProcessId(PROCESS_ID)
-            .withStartInstruction(newStartInstruction("task"))
-            .create();
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withStartInstruction("task").create();
 
     // Then
     Assertions.assertThat(
@@ -378,7 +365,7 @@ public class CreateProcessInstanceAnywhereTest {
         ENGINE
             .processInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withStartInstruction(newStartInstruction("end"))
+            .withStartInstruction("end")
             .withVariable("variable", 123)
             .create();
 
@@ -415,11 +402,7 @@ public class CreateProcessInstanceAnywhereTest {
 
     // When
     final long processInstanceKey =
-        ENGINE
-            .processInstance()
-            .ofBpmnProcessId(PROCESS_ID)
-            .withStartInstruction(newStartInstruction("task"))
-            .create();
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withStartInstruction("task").create();
 
     // Then
     final var taskActivateCommand =
@@ -461,11 +444,7 @@ public class CreateProcessInstanceAnywhereTest {
 
     // When
     final long processInstanceKey =
-        ENGINE
-            .processInstance()
-            .ofBpmnProcessId(PROCESS_ID)
-            .withStartInstruction(newStartInstruction("task"))
-            .create();
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withStartInstruction("task").create();
 
     // Then
     final var processActivationEvents =
@@ -551,8 +530,8 @@ public class CreateProcessInstanceAnywhereTest {
         ENGINE
             .processInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withStartInstruction(newStartInstruction("task"))
-            .withStartInstruction(newStartInstruction("subprocess"))
+            .withStartInstruction("task")
+            .withStartInstruction("subprocess")
             .create();
 
     // Then
@@ -599,8 +578,8 @@ public class CreateProcessInstanceAnywhereTest {
         ENGINE
             .processInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withStartInstruction(newStartInstruction("subprocess"))
-            .withStartInstruction(newStartInstruction("task"))
+            .withStartInstruction("subprocess")
+            .withStartInstruction("task")
             .create();
 
     // Then
@@ -657,7 +636,7 @@ public class CreateProcessInstanceAnywhereTest {
         ENGINE
             .processInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withStartInstruction(newStartInstruction("task"))
+            .withStartInstruction("task")
             .withVariable("key", "key-1")
             .create();
 
@@ -749,7 +728,7 @@ public class CreateProcessInstanceAnywhereTest {
         ENGINE
             .processInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withStartInstruction(newStartInstruction("task"))
+            .withStartInstruction("task")
             .withVariable("key", "key-1")
             .create();
 
@@ -841,8 +820,8 @@ public class CreateProcessInstanceAnywhereTest {
         ENGINE
             .processInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withStartInstruction(newStartInstruction("task1"))
-            .withStartInstruction(newStartInstruction("task2"))
+            .withStartInstruction("task1")
+            .withStartInstruction("task2")
             .withVariable("key", "key-1")
             .create();
 
@@ -878,9 +857,5 @@ public class CreateProcessInstanceAnywhereTest {
         .extracting(Record::getIntent)
         .describedAs("Expected to create the timer only once")
         .containsOnlyOnce(TimerIntent.CREATED);
-  }
-
-  private ProcessInstanceCreationStartInstruction newStartInstruction(final String elementId) {
-    return new ProcessInstanceCreationStartInstruction().setElementId(elementId);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CreateProcessInstanceRejectionTest {
+
+  private static final String PROCESS_ID = "process-id";
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRejectCommandIfElementIdIsUnknown() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .manualTask("task")
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engine
+        .processInstance()
+        .ofBpmnProcessId(PROCESS_ID)
+        .withStartInstruction(newStartInstruction("task"))
+        .withStartInstruction(newStartInstruction("unknown-element"))
+        .withVariable("x", 1)
+        .expectRejection()
+        .create();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceCreationIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Expected to create instance of process with start instructions but no element found with id 'unknown-element'.");
+  }
+
+  @Test
+  public void shouldRejectCommandIfElementIsInsideMultiInstance() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess(
+                    "subprocess",
+                    s ->
+                        s.embeddedSubProcess()
+                            .startEvent()
+                            .manualTask("task-in-multi-instance")
+                            .done())
+                .multiInstance(m -> m.zeebeInputCollectionExpression("[1,2,3]"))
+                .manualTask("task")
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engine
+        .processInstance()
+        .ofBpmnProcessId(PROCESS_ID)
+        .withStartInstruction(newStartInstruction("task"))
+        .withStartInstruction(newStartInstruction("task-in-multi-instance"))
+        .withVariable("x", 1)
+        .expectRejection()
+        .create();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceCreationIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Expected to create instance of process with start instructions but the element with id 'task-in-multi-instance' is inside a multi-instance subprocess. The creation of elements inside a multi-instance subprocess is not supported.");
+  }
+
+  private ProcessInstanceCreationStartInstruction newStartInstruction(final String elementId) {
+    return new ProcessInstanceCreationStartInstruction().setElementId(elementId);
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
@@ -11,7 +11,6 @@ import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -45,8 +44,8 @@ public class CreateProcessInstanceRejectionTest {
     engine
         .processInstance()
         .ofBpmnProcessId(PROCESS_ID)
-        .withStartInstruction(newStartInstruction("task"))
-        .withStartInstruction(newStartInstruction("unknown-element"))
+        .withStartInstruction("task")
+        .withStartInstruction("unknown-element")
         .withVariable("x", 1)
         .expectRejection()
         .create();
@@ -87,8 +86,8 @@ public class CreateProcessInstanceRejectionTest {
     engine
         .processInstance()
         .ofBpmnProcessId(PROCESS_ID)
-        .withStartInstruction(newStartInstruction("task"))
-        .withStartInstruction(newStartInstruction("task-in-multi-instance"))
+        .withStartInstruction("task")
+        .withStartInstruction("task-in-multi-instance")
         .withVariable("x", 1)
         .expectRejection()
         .create();
@@ -102,9 +101,5 @@ public class CreateProcessInstanceRejectionTest {
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
             "Expected to create instance of process with start instructions but the element with id 'task-in-multi-instance' is inside a multi-instance subprocess. The creation of elements inside a multi-instance subprocess is not supported.");
-  }
-
-  private ProcessInstanceCreationStartInstruction newStartInstruction(final String elementId) {
-    return new ProcessInstanceCreationStartInstruction().setElementId(elementId);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -89,8 +89,8 @@ public final class ProcessInstanceClient {
       return this;
     }
 
-    public ProcessInstanceCreationClient withStartInstruction(
-        final ProcessInstanceCreationStartInstruction instruction) {
+    public ProcessInstanceCreationClient withStartInstruction(final String elementId) {
+      final var instruction = new ProcessInstanceCreationStartInstruction().setElementId(elementId);
       processInstanceCreationRecord.addStartInstruction(instruction);
       return this;
     }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -43,8 +44,28 @@ public final class ProcessInstanceClient {
 
   public static class ProcessInstanceCreationClient {
 
+    private static final Function<Long, Record<ProcessInstanceCreationRecordValue>>
+        SUCCESS_EXPECTATION =
+            (position) ->
+                RecordingExporter.processInstanceCreationRecords()
+                    .withIntent(ProcessInstanceCreationIntent.CREATED)
+                    .withSourceRecordPosition(position)
+                    .getFirst();
+
+    private static final Function<Long, Record<ProcessInstanceCreationRecordValue>>
+        REJECTION_EXPECTATION =
+            (position) ->
+                RecordingExporter.processInstanceCreationRecords()
+                    .onlyCommandRejections()
+                    .withIntent(ProcessInstanceCreationIntent.CREATE)
+                    .withSourceRecordPosition(position)
+                    .getFirst();
+
     private final StreamProcessorRule environmentRule;
     private final ProcessInstanceCreationRecord processInstanceCreationRecord;
+
+    private Function<Long, Record<ProcessInstanceCreationRecordValue>> expectation =
+        SUCCESS_EXPECTATION;
 
     public ProcessInstanceCreationClient(
         final StreamProcessorRule environmentRule, final String bpmnProcessId) {
@@ -84,12 +105,13 @@ public final class ProcessInstanceClient {
           environmentRule.writeCommand(
               ProcessInstanceCreationIntent.CREATE, processInstanceCreationRecord);
 
-      return RecordingExporter.processInstanceCreationRecords()
-          .withIntent(ProcessInstanceCreationIntent.CREATED)
-          .withSourceRecordPosition(position)
-          .getFirst()
-          .getValue()
-          .getProcessInstanceKey();
+      final var resultingRecord = expectation.apply(position);
+      return resultingRecord.getValue().getProcessInstanceKey();
+    }
+
+    public ProcessInstanceCreationClient expectRejection() {
+      expectation = REJECTION_EXPECTATION;
+      return this;
     }
   }
 


### PR DESCRIPTION
## Description

* reject the process instance command if a start instruction
  * reference an element that doesn't exist in the process
  * reference an element that is inside a multi-instance subprocess
* create a new test class for the rejection cases
* refactor the command rejection in the processor to be more explicit when a command is rejected
  * avoid passing the command control in the method by returning a rejection object
  * following a similar code style that is used in other processors for the incident handling 

## Related issues

closes #9392 
closes #9394 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
