### PR TITLE
Reject PI creation command when it targets unsupported element types

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -66,8 +66,7 @@ public final class CreateProcessInstanceProcessor
           BpmnElementType.START_EVENT,
           BpmnElementType.SEQUENCE_FLOW,
           BpmnElementType.BOUNDARY_EVENT,
-          BpmnElementType.UNSPECIFIED,
-          BpmnElementType.MULTI_INSTANCE_BODY);
+          BpmnElementType.UNSPECIFIED);
 
   private final ProcessInstanceRecord newProcessInstance = new ProcessInstanceRecord();
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceUnsupportedElementTypeTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceUnsupportedElementTypeTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Arrays;
+import java.util.Collection;
+import org.assertj.core.api.Assertions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class CreateProcessInstanceUnsupportedElementTypeTest {
+
+  private static final String PROCESS_ID = "process-id";
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private final BpmnElementType elementType;
+  private final String elementId;
+
+  public CreateProcessInstanceUnsupportedElementTypeTest(
+      final BpmnElementType elementType, final String elementId) {
+    this.elementType = elementType;
+    this.elementId = elementId;
+  }
+
+  @Test
+  public void shouldRejectCommandIfElementTargetsUnsupportedElementType() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent("rootStartEvent")
+                .sequenceFlowId("sequenceFlow")
+                .subProcess(
+                    "subProcess",
+                    sp ->
+                        sp.embeddedSubProcess()
+                            .startEvent("subStartEvent")
+                            .manualTask("task")
+                            .endEvent())
+                .boundaryEvent("boundaryEvent", b -> b.error("ERROR").endEvent())
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    engine
+        .processInstance()
+        .ofBpmnProcessId(PROCESS_ID)
+        .withStartInstruction(elementId)
+        .expectRejection()
+        .create();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceCreationIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    Assertions.assertThat(rejectionRecord.getRejectionReason())
+        .contains(
+            "Expected to create instance of process with start instructions but the element with id '%s' targets unsupported element type '%s'. Supported element types are:"
+                .formatted(elementId, elementType));
+  }
+
+  @Parameters(name = "{index}: {0} - {1}")
+  public static Collection<Object[]> parameters() {
+    return Arrays.asList(
+        new Object[][] {
+          {BpmnElementType.START_EVENT, "rootStartEvent"},
+          {BpmnElementType.START_EVENT, "subStartEvent"},
+          {BpmnElementType.SEQUENCE_FLOW, "sequenceFlow"},
+          {BpmnElementType.BOUNDARY_EVENT, "boundaryEvent"},
+        });
+  }
+}

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -31,6 +31,12 @@
           "justification": "Ignore Enum order for ValueType as ordinal() is not used",
           "code": "java.field.enumConstantOrderChanged",
           "classQualifiedName": "io.camunda.zeebe.protocol.record.ValueType"
+        },
+        {
+          "justification": "Ignore the removal of this old BpmnElementType that was used for testing.",
+          "code": "java.field.removed",
+          "classQualifiedName": "io.camunda.zeebe.protocol.record.value.BpmnElementType",
+          "fieldName": "TESTING_ONLY"
         }
       ]
     }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BpmnElementType.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BpmnElementType.java
@@ -51,9 +51,6 @@ public enum BpmnElementType {
   MULTI_INSTANCE_BODY(null),
   CALL_ACTIVITY("callActivity"),
 
-  // TODO (saig0): remove element type for testing - #6202
-  TESTING_ONLY(null),
-
   BUSINESS_RULE_TASK("businessRuleTask"),
   SCRIPT_TASK("scriptTask"),
   SEND_TASK("sendTask");


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Reject PI creation command when it targets unsupported element types

The ProcessInstanceCreation command should be rejected:

when one of the target element ids refers directly to a root start event
when one of the target element ids refers directly to a sequence flow
when one of the target element ids refers directly to a boundary event
when one of the target element ids refers directly to an event belonging to an event-based gateway

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9408

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
