### PR TITLE
Start instructions in compact logger

### DIFF
--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 
 public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
@@ -68,6 +69,11 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   public ProcessInstanceCreationRecord setProcessDefinitionKey(final long key) {
     processDefinitionKeyProperty.setValue(key);
     return this;
+  }
+
+  @Override
+  public List<ProcessInstanceCreationStartInstructionValue> getStartInstructions() {
+    return startInstructionsProperty.stream().collect(Collectors.toList());
   }
 
   public ProcessInstanceCreationRecord setVersion(final int version) {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationStartInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationStartInstruction.java
@@ -15,8 +15,12 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
-@JsonIgnoreProperties({"encodedLength"})
-public class ProcessInstanceCreationStartInstruction extends ObjectValue
+@JsonIgnoreProperties({
+  /* 'encodedLength' is a technical field needed for MsgPack and inherited from ObjectValue; it has
+  no purpose in exported JSON records*/
+  "encodedLength"
+})
+public final class ProcessInstanceCreationStartInstruction extends ObjectValue
     implements ProcessInstanceCreationStartInstructionValue {
 
   private final StringProperty elementIdProp = new StringProperty("elementId");

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationStartInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationStartInstruction.java
@@ -8,12 +8,16 @@
 package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue.ProcessInstanceCreationStartInstructionValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
-public class ProcessInstanceCreationStartInstruction extends ObjectValue {
+@JsonIgnoreProperties({"encodedLength"})
+public class ProcessInstanceCreationStartInstruction extends ObjectValue
+    implements ProcessInstanceCreationStartInstructionValue {
 
   private final StringProperty elementIdProp = new StringProperty("elementId");
 
@@ -26,6 +30,7 @@ public class ProcessInstanceCreationStartInstruction extends ObjectValue {
     return elementIdProp.getValue();
   }
 
+  @Override
   public String getElementId() {
     return BufferUtil.bufferAsString(elementIdProp.getValue());
   }

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -724,7 +724,8 @@ final class JsonSerializableToJsonTest {
                   .setVariables(
                       new UnsafeBuffer(
                           MsgPackConverter.convertToMsgPack("{'foo':'bar','baz':'boz'}")))
-                  .addStartInstruction(new ProcessInstanceCreationStartInstruction().setElementId("element"))
+                  .addStartInstruction(
+                      new ProcessInstanceCreationStartInstruction().setElementId("element"))
                   .setProcessInstanceKey(instanceKey);
             },
         "{'variables':{'foo':'bar','baz':'boz'},'bpmnProcessId':'process','processDefinitionKey':1,'version':1,'processInstanceKey':2,'startInstructions':[{'elementId':'element'}]}"

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -32,6 +32,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubs
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
@@ -723,9 +724,10 @@ final class JsonSerializableToJsonTest {
                   .setVariables(
                       new UnsafeBuffer(
                           MsgPackConverter.convertToMsgPack("{'foo':'bar','baz':'boz'}")))
+                  .addStartInstruction(new ProcessInstanceCreationStartInstruction().setElementId("element"))
                   .setProcessInstanceKey(instanceKey);
             },
-        "{'variables':{'foo':'bar','baz':'boz'},'bpmnProcessId':'process','processDefinitionKey':1,'version':1,'processInstanceKey':2}"
+        "{'variables':{'foo':'bar','baz':'boz'},'bpmnProcessId':'process','processDefinitionKey':1,'version':1,'processInstanceKey':2,'startInstructions':[{'elementId':'element'}]}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -734,7 +736,7 @@ final class JsonSerializableToJsonTest {
       {
         "Empty ProcessInstanceCreationRecord",
         (Supplier<UnifiedRecordValue>) ProcessInstanceCreationRecord::new,
-        "{'variables':{},'bpmnProcessId':'','processDefinitionKey':-1,'version':-1,'processInstanceKey':-1}"
+        "{'variables':{},'bpmnProcessId':'','processDefinitionKey':-1,'version':-1,'processInstanceKey':-1, 'startInstructions':[]}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.protocol.record.value;
 
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
+import java.util.List;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -37,4 +38,15 @@ public interface ProcessInstanceCreationRecordValue
    * @return the unique key of the BPMN process definition to create a process from
    */
   long getProcessDefinitionKey();
+
+  /**
+   * @return list of start instructions (if available)
+   */
+  List<ProcessInstanceCreationStartInstructionValue> getStartInstructions();
+
+  @Value.Immutable
+  @ImmutableProtocol(builder = ImmutableProcessInstanceCreationStartInstructionValue.Builder.class)
+  interface ProcessInstanceCreationStartInstructionValue {
+    String getElementId();
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
@@ -40,7 +40,7 @@ public interface ProcessInstanceCreationRecordValue
   long getProcessDefinitionKey();
 
   /**
-   * @return list of start instructions (if available)
+   * @return list of start instructions (if available), or an empty list
    */
   List<ProcessInstanceCreationStartInstructionValue> getStartInstructions();
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecor
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessEventRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue.ProcessInstanceCreationStartInstructionValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
@@ -471,8 +472,20 @@ public class CompactRecordLogger {
         .append("new <process ")
         .append(formatId(value.getBpmnProcessId()))
         .append(">")
+        .append(summarizeStartInstructions(value.getStartInstructions()))
         .append(summarizeVariables(value.getVariables()))
         .toString();
+  }
+
+  private String summarizeStartInstructions(
+      final List<ProcessInstanceCreationStartInstructionValue> startInstructions) {
+    if (startInstructions.isEmpty()) {
+      return " (default start) ";
+    } else {
+      return startInstructions.stream()
+          .map(ProcessInstanceCreationStartInstructionValue::getElementId)
+          .collect(Collectors.joining(", ", " (starting before elements: ", ") "));
+    }
   }
 
   private String summarizeProcessInstanceSubscription(final Record<?> record) {


### PR DESCRIPTION
## Description

- add information about start instructions to interface layer
- use this information in compact logger to summarize start instructions

## Related issues

closes #9555 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
