### PR TITLE
Enable gateway to use reverse proxy for cluster communication

### DIFF
--- a/broker/src/test/resources/system/specific-hosts.yaml
+++ b/broker/src/test/resources/system/specific-hosts.yaml
@@ -10,6 +10,3 @@ zeebe:
 
       internalApi:
         host: internalHost
-
-      monitoringApi:
-        host: monitoringHost

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -158,6 +158,16 @@
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_COMMANDAPI_PORT.
         # port: 26501
 
+        # Controls the advertised host; if omitted defaults to the host. This is particularly useful if your
+        # broker stands behind a proxy.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_COMMANDAPI_ADVERTISEDHOST.
+        # advertisedHost: 0.0.0.0
+
+        # Controls the advertised port; if omitted defaults to the port. This is particularly useful if your
+        # broker stands behind a proxy.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_COMMANDAPI_ADVERTISEDPORT.
+        # advertisedPort: 25601
+
       # internalApi:
         # Overrides the host used for internal broker-to-broker communication
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_INTERNALAPI_HOST.
@@ -166,6 +176,16 @@
         # Sets the port used for internal broker-to-broker communication
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_INTERNALAPI_PORT.
         # port: 26502
+
+        # Controls the advertised host; if omitted defaults to the host. This is particularly useful if your
+        # broker stands behind a proxy.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_INTERNALAPI_ADVERTISEDHOST.
+        # advertisedHost: 0.0.0.0
+
+        # Controls the advertised port; if omitted defaults to the port. This is particularly useful if your
+        # broker stands behind a proxy.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_INTERNALAPI_ADVERTISEDPORT.
+        # advertisedPort: 25602
 
     # data:
       # This section allows to configure Zeebe's data storage. Data is stored in

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -90,6 +90,16 @@
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_COMMANDAPI_PORT.
         # port: 26501
 
+        # Controls the advertised host; if omitted defaults to the host. This is particularly useful if your
+        # broker stands behind a proxy.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_COMMANDAPI_ADVERTISEDHOST.
+        # advertisedHost: 0.0.0.0
+
+        # Controls the advertised port; if omitted defaults to the port. This is particularly useful if your
+        # broker stands behind a proxy.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_COMMANDAPI_ADVERTISEDPORT.
+        # advertisedPort: 25601
+
       # internalApi:
         # Overrides the host used for internal broker-to-broker communication
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_INTERNALAPI_HOST.
@@ -98,6 +108,16 @@
         # Sets the port used for internal broker-to-broker communication
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_INTERNALAPI_PORT.
         # port: 26502
+
+        # Controls the advertised host; if omitted defaults to the host. This is particularly useful if your
+        # broker stands behind a proxy.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_INTERNALAPI_ADVERTISEDHOST.
+        # advertisedHost: 0.0.0.0
+
+        # Controls the advertised port; if omitted defaults to the port. This is particularly useful if your
+        # broker stands behind a proxy.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_INTERNALAPI_ADVERTISEDPORT.
+        # advertisedPort: 25602
 
     # data:
       # This section allows to configure Zeebe's data storage. Data is stored in

--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -72,6 +72,16 @@
       # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_PORT.
       # port: 26502
 
+      # Controls the advertised host; if omitted defaults to the host. This is particularly useful if your
+      # gateway stands behind a proxy.
+      # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_ADVERTISEDHOST.
+      # advertisedHost: 0.0.0.0
+
+      # Controls the advertised port; if omitted defaults to the port. This is particularly useful if your
+      # gateway stands behind a proxy.
+      # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_ADVERTISEDPORT.
+      # advertisedPort: 25602
+
       # Configure parameters for SWIM protocol which is used to propagate cluster membership
       # information among brokers and gateways
       # membership:

--- a/dist/src/main/java/io/camunda/zeebe/gateway/AtomixComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/AtomixComponent.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway;
+
+import io.atomix.cluster.AtomixCluster;
+import io.atomix.cluster.AtomixClusterBuilder;
+import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
+import io.atomix.cluster.protocol.GroupMembershipProtocol;
+import io.atomix.cluster.protocol.SwimMembershipProtocol;
+import io.atomix.utils.net.Address;
+import io.camunda.zeebe.gateway.impl.configuration.ClusterCfg;
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.camunda.zeebe.gateway.impl.configuration.MembershipCfg;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.ApplicationScope;
+
+@Component
+final class AtomixComponent {
+  private final GatewayCfg config;
+
+  @Autowired
+  AtomixComponent(final GatewayCfg config) {
+    this.config = config;
+  }
+
+  @Bean("atomixCluster")
+  @ApplicationScope(proxyMode = ScopedProxyMode.NO)
+  AtomixCluster createAtomixCluster() {
+    final var clusterConfig = config.getCluster();
+    final var membershipProtocol = createMembershipProtocol(clusterConfig.getMembership());
+
+    final var builder =
+        AtomixCluster.builder()
+            .withMemberId(clusterConfig.getMemberId())
+            .withMessagingInterface(clusterConfig.getHost())
+            .withMessagingPort(clusterConfig.getPort())
+            .withAddress(
+                Address.from(clusterConfig.getAdvertisedHost(), clusterConfig.getAdvertisedPort()))
+            .withClusterId(clusterConfig.getClusterName())
+            .withMembershipProvider(
+                BootstrapDiscoveryProvider.builder()
+                    .withNodes(Address.from(clusterConfig.getContactPoint()))
+                    .build())
+            .withMembershipProtocol(membershipProtocol)
+            .withMessageCompression(clusterConfig.getMessageCompression());
+
+    if (clusterConfig.getSecurity().isEnabled()) {
+      applyClusterSecurityConfig(clusterConfig, builder);
+    }
+
+    return builder.build();
+  }
+
+  private GroupMembershipProtocol createMembershipProtocol(final MembershipCfg config) {
+    return SwimMembershipProtocol.builder()
+        .withFailureTimeout(config.getFailureTimeout())
+        .withGossipInterval(config.getGossipInterval())
+        .withProbeInterval(config.getProbeInterval())
+        .withProbeTimeout(config.getProbeTimeout())
+        .withBroadcastDisputes(config.isBroadcastDisputes())
+        .withBroadcastUpdates(config.isBroadcastUpdates())
+        .withGossipFanout(config.getGossipFanout())
+        .withNotifySuspect(config.isNotifySuspect())
+        .withSuspectProbes(config.getSuspectProbes())
+        .withSyncInterval(config.getSyncInterval())
+        .build();
+  }
+
+  private void applyClusterSecurityConfig(
+      final ClusterCfg config, final AtomixClusterBuilder builder) {
+    final var security = config.getSecurity();
+    final var certificateChainPath = security.getCertificateChainPath();
+    final var privateKeyPath = security.getPrivateKeyPath();
+
+    if (certificateChainPath == null) {
+      throw new IllegalArgumentException(
+          "Expected to have a valid certificate chain path for cluster security, but none "
+              + "configured");
+    }
+
+    if (privateKeyPath == null) {
+      throw new IllegalArgumentException(
+          "Expected to have a valid private key path for cluster security, but none was "
+              + "configured");
+    }
+
+    if (!certificateChainPath.canRead()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected the configured cluster security certificate chain path '%s' to point to a"
+                  + " readable file, but it does not",
+              certificateChainPath));
+    }
+
+    if (!privateKeyPath.canRead()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected the configured cluster security private key path '%s' to point to a "
+                  + "readable file, but it does not",
+              privateKeyPath));
+    }
+
+    builder.withSecurity(certificateChainPath, privateKeyPath);
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
@@ -8,18 +8,11 @@
 package io.camunda.zeebe.gateway;
 
 import io.atomix.cluster.AtomixCluster;
-import io.atomix.cluster.AtomixClusterBuilder;
-import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
-import io.atomix.cluster.protocol.GroupMembershipProtocol;
-import io.atomix.cluster.protocol.SwimMembershipProtocol;
-import io.atomix.utils.net.Address;
 import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
-import io.camunda.zeebe.gateway.impl.configuration.ClusterCfg;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
-import io.camunda.zeebe.gateway.impl.configuration.MembershipCfg;
 import io.camunda.zeebe.shared.ActorClockConfiguration;
 import io.camunda.zeebe.shared.Profile;
 import io.camunda.zeebe.util.CloseableSilently;
@@ -59,8 +52,8 @@ public class StandaloneGateway
   private final GatewayCfg configuration;
   private final SpringGatewayBridge springGatewayBridge;
   private final ActorClockConfiguration clockConfig;
+  private final AtomixCluster atomixCluster;
 
-  private AtomixCluster atomixCluster;
   private Gateway gateway;
   private ActorScheduler actorScheduler;
 
@@ -68,10 +61,12 @@ public class StandaloneGateway
   public StandaloneGateway(
       final GatewayCfg configuration,
       final SpringGatewayBridge springGatewayBridge,
-      final ActorClockConfiguration clockConfig) {
+      final ActorClockConfiguration clockConfig,
+      final AtomixCluster atomixCluster) {
     this.configuration = configuration;
     this.springGatewayBridge = springGatewayBridge;
     this.clockConfig = clockConfig;
+    this.atomixCluster = atomixCluster;
   }
 
   public static void main(final String[] args) {
@@ -98,7 +93,6 @@ public class StandaloneGateway
       LOG.info("Starting standalone gateway with configuration {}", configuration.toJson());
     }
 
-    atomixCluster = createAtomixCluster(configuration.getCluster());
     actorScheduler = createActorScheduler(configuration);
     gateway = new Gateway(configuration, this::createBrokerClient, actorScheduler);
 
@@ -159,42 +153,6 @@ public class StandaloneGateway
         false);
   }
 
-  private AtomixCluster createAtomixCluster(final ClusterCfg config) {
-    final var membershipProtocol = createMembershipProtocol(config.getMembership());
-    final var builder =
-        AtomixCluster.builder()
-            .withMemberId(config.getMemberId())
-            .withAddress(Address.from(config.getHost(), config.getPort()))
-            .withClusterId(config.getClusterName())
-            .withMembershipProvider(
-                BootstrapDiscoveryProvider.builder()
-                    .withNodes(Address.from(config.getContactPoint()))
-                    .build())
-            .withMembershipProtocol(membershipProtocol)
-            .withMessageCompression(config.getMessageCompression());
-
-    if (config.getSecurity().isEnabled()) {
-      applyClusterSecurityConfig(config, builder);
-    }
-
-    return builder.build();
-  }
-
-  private GroupMembershipProtocol createMembershipProtocol(final MembershipCfg config) {
-    return SwimMembershipProtocol.builder()
-        .withFailureTimeout(config.getFailureTimeout())
-        .withGossipInterval(config.getGossipInterval())
-        .withProbeInterval(config.getProbeInterval())
-        .withProbeTimeout(config.getProbeTimeout())
-        .withBroadcastDisputes(config.isBroadcastDisputes())
-        .withBroadcastUpdates(config.isBroadcastUpdates())
-        .withGossipFanout(config.getGossipFanout())
-        .withNotifySuspect(config.isNotifySuspect())
-        .withSuspectProbes(config.getSuspectProbes())
-        .withSyncInterval(config.getSyncInterval())
-        .build();
-  }
-
   private ActorScheduler createActorScheduler(final GatewayCfg config) {
     return ActorScheduler.newActorScheduler()
         .setCpuBoundActorThreadCount(config.getThreads().getManagementThreads())
@@ -202,42 +160,5 @@ public class StandaloneGateway
         .setSchedulerName("gateway-scheduler")
         .setActorClock(clockConfig.getClock())
         .build();
-  }
-
-  private void applyClusterSecurityConfig(
-      final ClusterCfg config, final AtomixClusterBuilder builder) {
-    final var security = config.getSecurity();
-    final var certificateChainPath = security.getCertificateChainPath();
-    final var privateKeyPath = security.getPrivateKeyPath();
-
-    if (certificateChainPath == null) {
-      throw new IllegalArgumentException(
-          "Expected to have a valid certificate chain path for cluster security, but none "
-              + "configured");
-    }
-
-    if (privateKeyPath == null) {
-      throw new IllegalArgumentException(
-          "Expected to have a valid private key path for cluster security, but none was "
-              + "configured");
-    }
-
-    if (!certificateChainPath.canRead()) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Expected the configured cluster security certificate chain path '%s' to point to a"
-                  + " readable file, but it does not",
-              certificateChainPath));
-    }
-
-    if (!privateKeyPath.canRead()) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Expected the configured cluster security private key path '%s' to point to a "
-                  + "readable file, but it does not",
-              privateKeyPath));
-    }
-
-    builder.withSecurity(certificateChainPath, privateKeyPath);
   }
 }

--- a/dist/src/test/java/io/camunda/zeebe/gateway/AtomixComponentTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/gateway/AtomixComponentTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.utils.net.Address;
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class AtomixComponentTest {
+  private final GatewayCfg config = new GatewayCfg();
+  private final AtomixComponent component = new AtomixComponent(config);
+
+  @Nested
+  final class MessagingServiceTest {
+    @Test
+    void shouldAdvertiseConfiguredAddress() {
+      // given
+      config.getCluster().setAdvertisedHost("foo").setAdvertisedPort(5);
+
+      // when
+      final var cluster = component.createAtomixCluster();
+
+      // then
+      assertThat(cluster.getMessagingService().address()).isEqualTo(Address.from("foo", 5));
+      assertThat(cluster.getMessagingService().bindingAddresses())
+          .doesNotContain(Address.from("foo", 5));
+    }
+
+    @Test
+    void shouldBindToCorrectAddress() {
+      // given
+      config.getCluster().setHost("foo").setPort(5).setAdvertisedPort(6).setAdvertisedHost("bar");
+
+      // when
+      final var cluster = component.createAtomixCluster();
+
+      // then
+      assertThat(cluster.getMessagingService().address()).isNotEqualTo(Address.from("foo", 5));
+      assertThat(cluster.getMessagingService().bindingAddresses())
+          .containsExactly(Address.from("foo", 5));
+    }
+  }
+}

--- a/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
@@ -60,11 +60,8 @@ final class StandaloneGatewaySecurityTest {
     final GatewayCfg cfg = createGatewayCfg();
     cfg.getCluster().getSecurity().setCertificateChainPath(new File("/tmp/i-dont-exist.crt"));
 
-    // when
-    gateway = buildGateway(cfg);
-
-    // then
-    assertThatCode(() -> gateway.run())
+    // when - then
+    assertThatCode(() -> buildGateway(cfg))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "Expected the configured cluster security certificate chain path "
@@ -77,11 +74,8 @@ final class StandaloneGatewaySecurityTest {
     final GatewayCfg cfg = createGatewayCfg();
     cfg.getCluster().getSecurity().setPrivateKeyPath(new File("/tmp/i-dont-exist.key"));
 
-    // when
-    gateway = buildGateway(cfg);
-
-    // then
-    assertThatCode(() -> gateway.run())
+    // when - then
+    assertThatCode(() -> buildGateway(cfg))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "Expected the configured cluster security private key path '/tmp/i-dont-exist.key' to "
@@ -94,11 +88,8 @@ final class StandaloneGatewaySecurityTest {
     final GatewayCfg cfg = createGatewayCfg();
     cfg.getCluster().getSecurity().setPrivateKeyPath(null);
 
-    // when
-    gateway = buildGateway(cfg);
-
-    // then
-    assertThatCode(() -> gateway.run())
+    // when - then
+    assertThatCode(() -> buildGateway(cfg))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "Expected to have a valid private key path for cluster security, but none was configured");
@@ -110,11 +101,8 @@ final class StandaloneGatewaySecurityTest {
     final GatewayCfg cfg = createGatewayCfg();
     cfg.getCluster().getSecurity().setCertificateChainPath(null);
 
-    // when
-    gateway = buildGateway(cfg);
-
-    // then
-    assertThatCode(() -> gateway.run())
+    // when - then
+    assertThatCode(() -> buildGateway(cfg))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "Expected to have a valid certificate chain path for cluster security, but none "
@@ -141,7 +129,12 @@ final class StandaloneGatewaySecurityTest {
   }
 
   private StandaloneGateway buildGateway(final GatewayCfg gatewayCfg) {
+    final AtomixComponent clusterComponent = new AtomixComponent(gatewayCfg);
+
     return new StandaloneGateway(
-        gatewayCfg, new SpringGatewayBridge(), new ActorClockConfiguration(false));
+        gatewayCfg,
+        new SpringGatewayBridge(),
+        new ActorClockConfiguration(false),
+        clusterComponent.createAtomixCluster());
   }
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ClusterCfg.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ClusterCfg.java
@@ -26,7 +26,9 @@ public final class ClusterCfg {
   private String clusterName = DEFAULT_CLUSTER_NAME;
   private String memberId = DEFAULT_CLUSTER_MEMBER_ID;
   private String host = DEFAULT_CLUSTER_HOST;
+  private String advertisedHost = host;
   private int port = DEFAULT_CLUSTER_PORT;
+  private int advertisedPort = port;
   private MembershipCfg membership = new MembershipCfg();
   private SecurityCfg security = new SecurityCfg();
   private CompressionAlgorithm messageCompression = CompressionAlgorithm.NONE;
@@ -49,12 +51,34 @@ public final class ClusterCfg {
     return this;
   }
 
+  public String getAdvertisedHost() {
+    if (advertisedHost == null) {
+      return getHost();
+    }
+
+    return advertisedHost;
+  }
+
+  public ClusterCfg setAdvertisedHost(final String advertisedHost) {
+    this.advertisedHost = advertisedHost;
+    return this;
+  }
+
   public int getPort() {
     return port;
   }
 
   public ClusterCfg setPort(final int port) {
     this.port = port;
+    return this;
+  }
+
+  public int getAdvertisedPort() {
+    return advertisedPort;
+  }
+
+  public ClusterCfg setAdvertisedPort(final int advertisedPort) {
+    this.advertisedPort = advertisedPort;
     return this;
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/RandomPortInitializer.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/RandomPortInitializer.java
@@ -40,7 +40,6 @@ public final class RandomPortInitializer
                 "zeebe.gateway.monitoring.port", monitoringPort,
                 "zeebe.broker.gateway.network.port", gatewayPort,
                 "zeebe.broker.network.commandApi.port", commandPort,
-                "zeebe.broker.network.internalApi.port", internalPort,
-                "zeebe.broker.network.monitoringApi.port", monitoringPort)));
+                "zeebe.broker.network.internalApi.port", internalPort)));
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/StandaloneGatewayIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/StandaloneGatewayIT.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;


### PR DESCRIPTION
## Description

This PR adds the advertised host/port configuration to the cluster configuration of the standalone gateway. This enables the use case where the gateway and broker must communicate with a reverse proxy in between, such as when one is using a sidecar-contained based service mesh (e.g. Istio or Linkerd).

To improve test-ability, I extracted the creation of the `AtomixCluster` into a Spring component which is injected when the standalone gateway starts. That way we can test the component by itself. There's still an integration test which ensures it works end-to-end of course.

## Related issues

closes #9342 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
