### PR TITLE
Do not restart broker on snapshot test

### DIFF
--- a/qa/update-tests/src/test/java/io/camunda/zeebe/test/SnapshotTest.java
+++ b/qa/update-tests/src/test/java/io/camunda/zeebe/test/SnapshotTest.java
@@ -46,12 +46,6 @@ final class SnapshotTest {
     final long key = testCase.runBefore(state);
 
     // when
-    // it's necessary to restart without the debug exporter to allow snapshotting
-    state.close();
-    state.withOldBroker().start(false);
-    // there's a slight chance that we'd processed everything before shutting down, so we send a
-    // dummy message to ensure we have processed something since we recovered and so take a snapshot
-    sendDummyMessageToEnforceSnapshot(state);
     EitherAssert.assertThat(state.getPartitionsActuatorClient().takeSnapshot())
         .as("expect successful response as right member")
         .isRight();


### PR DESCRIPTION

## PR Description

Previously we took no snapshot if the exporter hasn't committed the positions, but this is no longer true (see https://github.com/camunda/zeebe/pull/8176).
This means if we run the DebugExporter we still can take snapshots.

This allows to reduce the complexity in the SnapshotTest, as it is no longer necessary to restart the Broker
without the DebugExporter. This will of course also reduce the execution time of the test, and hopefully the flakiness.

## TIL:

I thought I had to make the DebugExporter configurable so it will commit the exporting position if I want it to, which is why I implemented it here https://github.com/camunda/zeebe/tree/zell-debug-exporter

Later I realized (because I wrote tests :grin: ) that we take anyway snapshots, even if we have an exporter not committing the positions so I dropped the changes from the PR. Let me know whether we still want this, maybe worth for other things not sure :man_shrugging: 
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9517 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
