### PR TITLE
Set go version to 1.17 addendum

### DIFF
--- a/.ci/pipelines/release_zeebe.groovy
+++ b/.ci/pipelines/release_zeebe.groovy
@@ -41,7 +41,7 @@ spec:
           cpu: 8
           memory: 32Gi
     - name: golang
-      image: golang:1.15.15
+      image: golang:1.17.11
       command: ["cat"]
       tty: true
       resources:

--- a/.ci/pipelines/release_zeebe_java11.groovy
+++ b/.ci/pipelines/release_zeebe_java11.groovy
@@ -41,7 +41,7 @@ spec:
           cpu: 8
           memory: 32Gi
     - name: golang
-      image: golang:1.15.15
+      image: golang:1.17.11
       command: ["cat"]
       tty: true
       resources:

--- a/.ci/pipelines/release_zeebe_java11.groovy
+++ b/.ci/pipelines/release_zeebe_java11.groovy
@@ -41,7 +41,7 @@ spec:
           cpu: 8
           memory: 32Gi
     - name: golang
-      image: golang:1.17.11
+      image: golang:1.15.15
       command: ["cat"]
       tty: true
       resources:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -39,6 +39,8 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'clients/go/go.mod'
+          cache: true
+          cache-dependency-path: 'clients/go/go.sum'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17      
+          go-version-file: 'clients/go/go.mod'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,8 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'clients/go/go.mod'
+          cache: true
+          cache-dependency-path: 'clients/go/go.sum'
       - name: Build Go
         run: ./build.sh
         working-directory: clients/go/cmd/zbctl

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
           java-version: '17'
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version-file: 'clients/go/go.mod'
       - name: Build Go
         run: ./build.sh
         working-directory: clients/go/cmd/zbctl

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
           java-version: '17'
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.15"
+          go-version: 1.17
       - name: Build Go
         run: ./build.sh
         working-directory: clients/go/cmd/zbctl

--- a/.github/workflows/qa-testbench.yaml
+++ b/.github/workflows/qa-testbench.yaml
@@ -17,7 +17,7 @@ on:
 env:
   BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-jobs:     
+jobs:
   qa-testbench:
     name: QA Testbench run
     runs-on: ubuntu-latest
@@ -60,8 +60,8 @@ jobs:
           tag="$version-$BRANCH_NAME-${GITHUB_SHA::8}"
           echo "TAG=$tag" >> $GITHUB_ENV
           echo "QA_RUN_VARIABLES={\"zeebeImage\": \"$IMAGE:$tag\", \"generationTemplate\": \"$GENERATION_TEMPLATE\", \"channel\": \"Internal Dev\", \"branch\": \"$BRANCH_NAME\", \"build\": \"$BUILD_URL\", \"businessKey\": \"$BUILD_URL\", \"processId\": \"qa-protocol\"}" >> $GITHUB_ENV
-          echo "BUSINESS_KEY=$BUILD_URL" >> $GITHUB_ENV          
-                                    
+          echo "BUSINESS_KEY=$BUILD_URL" >> $GITHUB_ENV
+
       - name: Import Secrets
         id: secrets
         uses: hashicorp/vault-action@v2.4.1
@@ -77,20 +77,20 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.15"
+          go-version: 1.17
       - name: Build Go
         run: ./build.sh
         working-directory: clients/go/cmd/zbctl
       - name: Package Zeebe
         run: mvn -B -DskipTests -DskipChecks package
-        
+
       - name: Login to GCR
         uses: docker/login-action@v2
         with:
           registry: gcr.io
           username: _json_key
           password: ${{ steps.secrets.outputs.ZEEBE_GCR_SERVICEACCOUNT_JSON }}
-      
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
@@ -106,8 +106,8 @@ jobs:
         env:
           ZEEBE_CLIENT_SECRET: ${{ steps.secrets.outputs.TESTBENCH_PROD_CLIENT_SECRET }}
           ZEEBE_ADDRESS: ${{ steps.secrets.outputs.TESTBENCH_PROD_CONTACT_POINT }}
-           
-           
+
+
   notify:
     name: Send slack notification
     runs-on: ubuntu-latest
@@ -152,8 +152,8 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK    
-          
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
       - id: slack-success-notify
         name: Send success slack notification
         uses: slackapi/slack-github-action@v1.19.0
@@ -181,4 +181,4 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK    
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/qa-testbench.yaml
+++ b/.github/workflows/qa-testbench.yaml
@@ -78,6 +78,8 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'clients/go/go.mod'
+          cache: true
+          cache-dependency-path: 'clients/go/go.sum'
       - name: Build Go
         run: ./build.sh
         working-directory: clients/go/cmd/zbctl

--- a/.github/workflows/qa-testbench.yaml
+++ b/.github/workflows/qa-testbench.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version-file: 'clients/go/go.mod'
       - name: Build Go
         run: ./build.sh
         working-directory: clients/go/cmd/zbctl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -240,7 +240,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version-file: 'clients/go/go.mod'
       - uses: actions/setup-java@v3.3.0
         with:
           java-version: '17'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,6 +241,8 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'clients/go/go.mod'
+          cache: true
+          cache-dependency-path: 'clients/go/go.sum'
       - uses: actions/setup-java@v3.3.0
         with:
           java-version: '17'


### PR DESCRIPTION
## Description

- Sets go to 1.17 in the places I missed before
- Reads go version from `go.mod` file
- Enables caching for Go artifacts

**Review hints**
The last commit - enabling caching - is debatable. It doesn't add much, because the slow parts of the build are in the Java and Docker parts, not the go steps.

## Related issues

closes #9270

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
