### PR TITLE
Set higher timeout for awaitility in ControlledActorClockEndpointIT

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
@@ -129,6 +129,10 @@ final class ControlledActorClockEndpointIT {
         .collect(Collectors.toList());
   }
 
+  private int getExportedRecordsCount() throws IOException, InterruptedException {
+    return searchExportedRecords().size();
+  }
+
   void startElasticsearch() {
     final var version = RestClient.class.getPackage().getImplementationVersion();
     elasticsearchContainer =
@@ -177,11 +181,10 @@ final class ControlledActorClockEndpointIT {
     Awaitility.await("Waiting for a stable number of exported records")
         .during(Duration.ofSeconds(5))
         .until(
-            this::searchExportedRecords,
-            (records) -> {
-              final var now = records.size();
-              final var previous = previouslySeenRecords.getAndSet(now);
-              return now == previous;
+            this::getExportedRecordsCount,
+            (recordCount) -> {
+              final var previous = previouslySeenRecords.getAndSet(recordCount);
+              return recordCount == previous;
             });
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
@@ -180,6 +180,7 @@ final class ControlledActorClockEndpointIT {
     final AtomicInteger previouslySeenRecords = new AtomicInteger(1);
     Awaitility.await("Waiting for a stable number of exported records")
         .during(Duration.ofSeconds(5))
+        .timeout(Duration.ofSeconds(30))
         .until(
             this::getExportedRecordsCount,
             (recordCount) -> {


### PR DESCRIPTION
## Description

* Instead of returning all records, which are printed by awaitility (it doesn't help in this case) we return only the size of the exported record list which we want to assert. This is of course can be discussed, but for me it felt much useful to print all records, because what I want to know in this case is the count/size of the list.
* Per default the timeout is around 10 seconds. This might be quite low if we want to archive that during 5 seconds the record size hasn't changed. Increasing the timeout makes the test less flaky. I run it multiple times locally after this change without failure, before it failed quite quickly.

![timeout](https://user-images.githubusercontent.com/2758593/175039496-460907f9-64a6-4db1-8deb-930a533185d3.png)


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/9499

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
