### PR TITLE
[Backport stable/8.0] Set higher timeout for awaitility in ControlledActorClockEndpointIT

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
@@ -129,6 +129,10 @@ final class ControlledActorClockEndpointIT {
         .collect(Collectors.toList());
   }
 
+  private int getExportedRecordsCount() throws IOException, InterruptedException {
+    return searchExportedRecords().size();
+  }
+
   void startElasticsearch() {
     final var version = RestClient.class.getPackage().getImplementationVersion();
     elasticsearchContainer =
@@ -177,11 +181,10 @@ final class ControlledActorClockEndpointIT {
     Awaitility.await("Waiting for a stable number of exported records")
         .during(Duration.ofSeconds(5))
         .until(
-            this::searchExportedRecords,
-            (records) -> {
-              final var now = records.size();
-              final var previous = previouslySeenRecords.getAndSet(now);
-              return now == previous;
+            this::getExportedRecordsCount,
+            (recordCount) -> {
+              final var previous = previouslySeenRecords.getAndSet(recordCount);
+              return recordCount == previous;
             });
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
@@ -180,6 +180,7 @@ final class ControlledActorClockEndpointIT {
     final AtomicInteger previouslySeenRecords = new AtomicInteger(1);
     Awaitility.await("Waiting for a stable number of exported records")
         .during(Duration.ofSeconds(5))
+        .timeout(Duration.ofSeconds(30))
         .until(
             this::getExportedRecordsCount,
             (recordCount) -> {


### PR DESCRIPTION
# Description
Backport of #9579 to `stable/8.0`.

relates to camunda/zeebe#9499