### PR TITLE
Fix CLA warnings on release due to bot commits

### DIFF
--- a/.ci/scripts/release/prepare-go.sh
+++ b/.ci/scripts/release/prepare-go.sh
@@ -2,7 +2,7 @@
 
 # configure Jenkins GitHub user for GO container
 git config --global user.email "ci@camunda.com"
-git config --global user.name "${GITHUB_TOKEN_USR}"
+git config --global user.name "ci.automation[bot]"
 
 # install binary tools; these are installed under $GOPATH/bin
 # NOTE: this will not work on Go > 1.16 - instead we'll have to replace `go get -u` with

--- a/.ci/scripts/release/prepare.sh
+++ b/.ci/scripts/release/prepare.sh
@@ -14,7 +14,7 @@ git remote add origin "https://${GITHUB_TOKEN_USR}:${GITHUB_TOKEN_PSW}@github.co
 
 # configure Jenkins GitHub user for Maven container
 git config --global user.email "ci@camunda.com"
-git config --global user.name "${GITHUB_TOKEN_USR}"
+git config --global user.name "ci.automation[bot]"
 
 # setup maven central gpg keys
 gpg -q --allow-secret-key-import --import --no-tty --batch --yes "${GPG_SEC_KEY}"


### PR DESCRIPTION
## Description

This PR hardcodes a whitelisted name for the Jenkins bot user to use when committing things during release. Hopefully it fixes the CLA warnings. [This came from a suggestion of infra's](https://camunda.slack.com/archives/C5AHF1D8T/p1655737075681649?thread_ts=1655728280.797149&cid=C5AHF1D8T)

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
