### PR TITLE
Remove side effects queue usage from BpmnStreamProcessor

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlo
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
-import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectQueue;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
@@ -39,7 +38,6 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
 
   private static final Logger LOGGER = Loggers.PROCESS_PROCESSOR_LOGGER;
 
-  private final SideEffectQueue sideEffectQueue = new SideEffectQueue();
   private final BpmnElementContextImpl context = new BpmnElementContextImpl();
 
   private final ProcessState processState;
@@ -63,7 +61,6 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
     final var bpmnBehaviors =
         new BpmnBehaviorsImpl(
             expressionProcessor,
-            sideEffectQueue,
             zeebeState,
             catchEventBehavior,
             variableBehavior,
@@ -91,11 +88,6 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
       final TypedResponseWriter responseWriter,
       final TypedStreamWriter streamWriter,
       final Consumer<SideEffectProducer> sideEffect) {
-
-    // initialize
-    sideEffectQueue.clear();
-    sideEffect.accept(sideEffectQueue);
-
     final var intent = (ProcessInstanceIntent) record.getIntent();
     final var recordValue = record.getValue();
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
-import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffects;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
@@ -43,7 +42,6 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
   public BpmnBehaviorsImpl(
       final ExpressionProcessor expressionBehavior,
-      final SideEffects sideEffects,
       final MutableZeebeState zeebeState,
       final CatchEventBehavior catchEventBehavior,
       final VariableBehavior variableBehavior,
@@ -85,7 +83,6 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             catchEventBehavior,
             eventTriggerBehavior,
             commandWriter,
-            sideEffects,
             zeebeState,
             zeebeState.getKeyGenerator());
     incidentBehavior =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventSupplier;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
-import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffects;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
@@ -35,8 +34,6 @@ public final class BpmnEventSubscriptionBehavior {
   private final EventScopeInstanceState eventScopeInstanceState;
   private final CatchEventBehavior catchEventBehavior;
 
-  private final SideEffects sideEffects;
-
   private final KeyGenerator keyGenerator;
   private final ProcessState processState;
   private final TypedCommandWriter commandWriter;
@@ -46,13 +43,11 @@ public final class BpmnEventSubscriptionBehavior {
       final CatchEventBehavior catchEventBehavior,
       final EventTriggerBehavior eventTriggerBehavior,
       final TypedCommandWriter commandWriter,
-      final SideEffects sideEffects,
       final ZeebeState zeebeState,
       final KeyGenerator keyGenerator) {
     this.catchEventBehavior = catchEventBehavior;
     this.eventTriggerBehavior = eventTriggerBehavior;
     this.commandWriter = commandWriter;
-    this.sideEffects = sideEffects;
 
     processState = zeebeState.getProcessState();
     eventScopeInstanceState = zeebeState.getEventScopeInstanceState();
@@ -64,11 +59,11 @@ public final class BpmnEventSubscriptionBehavior {
    */
   public <T extends ExecutableCatchEventSupplier> Either<Failure, Void> subscribeToEvents(
       final T element, final BpmnElementContext context) {
-    return catchEventBehavior.subscribeToEvents(context, element, sideEffects, commandWriter);
+    return catchEventBehavior.subscribeToEvents(context, element);
   }
 
   public void unsubscribeFromEvents(final BpmnElementContext context) {
-    catchEventBehavior.unsubscribeFromEvents(context, commandWriter, sideEffects);
+    catchEventBehavior.unsubscribeFromEvents(context, commandWriter);
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -80,24 +80,24 @@ public final class CatchEventBehavior {
 
   /**
    * Unsubscribe from all events in the scope of the context.
-   *  @param context the context to subscript from
+   *
+   * @param context the context to subscript from
    * @param commandWriter the writer for unsubscribe commands
    */
   public void unsubscribeFromEvents(
-      final BpmnElementContext context,
-      final TypedCommandWriter commandWriter) {
+      final BpmnElementContext context, final TypedCommandWriter commandWriter) {
     unsubscribeFromEvents(context, commandWriter, elementId -> true);
   }
 
   /**
    * Unsubscribe from all event subprocesses in the scope of the context. Ignores other event
    * subscriptions in the scope.
-   *  @param context the context to subscript from
+   *
+   * @param context the context to subscript from
    * @param commandWriter the writer for unsubscribe commands
    */
   public void unsubscribeEventSubprocesses(
-      final BpmnElementContext context,
-      final TypedCommandWriter commandWriter) {
+      final BpmnElementContext context, final TypedCommandWriter commandWriter) {
     unsubscribeFromEvents(
         context, commandWriter, elementId -> isEventSubprocess(context, elementId));
   }
@@ -116,7 +116,8 @@ public final class CatchEventBehavior {
   /**
    * Unsubscribe from all events in the scope of the context that matches the given filter. Ignore
    * other event subscriptions that don't match the filter.
-   *  @param context the context to subscript from
+   *
+   * @param context the context to subscript from
    * @param commandWriter the writer for unsubscribe commands
    * @param elementIdFilter the filter for events to unsubscribe
    */
@@ -133,8 +134,7 @@ public final class CatchEventBehavior {
    * @return either a failure or nothing
    */
   public Either<Failure, Void> subscribeToEvents(
-      final BpmnElementContext context,
-      final ExecutableCatchEventSupplier supplier) {
+      final BpmnElementContext context, final ExecutableCatchEventSupplier supplier) {
     final var evaluationResults =
         supplier.getEvents().stream()
             .filter(event -> event.isTimer() || event.isMessage())
@@ -213,15 +213,13 @@ public final class CatchEventBehavior {
   }
 
   private void subscribeToMessageEvents(
-      final BpmnElementContext context,
-      final List<EvalResult> results) {
+      final BpmnElementContext context, final List<EvalResult> results) {
     results.stream()
         .filter(EvalResult::isMessage)
         .forEach(result -> subscribeToMessageEvent(context, result));
   }
 
-  private void subscribeToMessageEvent(
-      final BpmnElementContext context, final EvalResult result) {
+  private void subscribeToMessageEvent(final BpmnElementContext context, final EvalResult result) {
     final var event = result.event;
     final var correlationKey = result.correlationKey;
     final var messageName = result.messageName;
@@ -257,8 +255,7 @@ public final class CatchEventBehavior {
   }
 
   private void subscribeToTimerEvents(
-      final BpmnElementContext context,
-      final List<EvalResult> results) {
+      final BpmnElementContext context, final List<EvalResult> results) {
     results.stream()
         .filter(EvalResult::isTimer)
         .forEach(
@@ -270,8 +267,7 @@ public final class CatchEventBehavior {
                   context.getProcessInstanceKey(),
                   context.getProcessDefinitionKey(),
                   event.getId(),
-                  timer
-              );
+                  timer);
             });
   }
 
@@ -326,8 +322,7 @@ public final class CatchEventBehavior {
   }
 
   private void unsubscribeFromMessageEvents(
-      final BpmnElementContext context,
-      final Predicate<DirectBuffer> elementIdFilter) {
+      final BpmnElementContext context, final Predicate<DirectBuffer> elementIdFilter) {
     processMessageSubscriptionState.visitElementSubscriptions(
         context.getElementInstanceKey(),
         subscription -> {
@@ -339,8 +334,7 @@ public final class CatchEventBehavior {
         });
   }
 
-  private void unsubscribeFromMessageEvent(
-      final ProcessMessageSubscription subscription) {
+  private void unsubscribeFromMessageEvent(final ProcessMessageSubscription subscription) {
 
     final DirectBuffer messageName = cloneBuffer(subscription.getRecord().getMessageNameBuffer());
     final int subscriptionPartitionId = subscription.getRecord().getSubscriptionPartitionId();
@@ -349,7 +343,8 @@ public final class CatchEventBehavior {
 
     stateWriter.appendFollowUpEvent(
         subscription.getKey(), ProcessMessageSubscriptionIntent.DELETING, subscription.getRecord());
-    sendCloseMessageSubscriptionCommand(subscriptionPartitionId, processInstanceKey, elementInstanceKey, messageName);
+    sendCloseMessageSubscriptionCommand(
+        subscriptionPartitionId, processInstanceKey, elementInstanceKey, messageName);
   }
 
   private boolean sendCloseMessageSubscriptionCommand(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
@@ -61,7 +61,7 @@ public class EventTriggerBehavior {
 
   private void unsubscribeEventSubprocesses(final BpmnElementContext context) {
     final var sideEffectQueue = new SideEffectQueue();
-    catchEventBehavior.unsubscribeEventSubprocesses(context, commandWriter, sideEffectQueue);
+    catchEventBehavior.unsubscribeEventSubprocesses(context, commandWriter);
 
     // side effect can immediately executed, since on restart we not reprocess anymore the commands
     sideEffectQueue.flush();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -167,9 +167,7 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
             NO_ELEMENT_INSTANCE,
             processMetadata.getKey(),
             startEvent.getId(),
-            timerOrError.get(),
-            streamWriter,
-            sideEffects);
+            timerOrError.get());
       }
     }
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -472,7 +472,7 @@ public final class CreateProcessInstanceProcessor
           elementInstanceKey, elementRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
 
       catchEventBehavior.subscribeToEvents(
-          bpmnElementContext, catchEventSupplier, sideEffectQueue, commandWriter);
+          bpmnElementContext, catchEventSupplier);
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -471,8 +471,7 @@ public final class CreateProcessInstanceProcessor
       bpmnElementContext.init(
           elementInstanceKey, elementRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
 
-      catchEventBehavior.subscribeToEvents(
-          bpmnElementContext, catchEventSupplier);
+      catchEventBehavior.subscribeToEvents(bpmnElementContext, catchEventSupplier);
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
@@ -168,8 +168,6 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
         record.getProcessInstanceKey(),
         record.getProcessDefinitionKey(),
         event.getId(),
-        repeatingInterval,
-        writer,
-        sideEffects::accept);
+        repeatingInterval);
   }
 }


### PR DESCRIPTION
*NOTE* this is just a first step and I just want to validate with you @saig0 whether this is how you wanted to have it or whether you had something different in your mind. Please have a look. If this is ok with you I can remove the other usages and occurrences, which makes it possible to remove further code, like response writer etc from the processor interface.

## Description

Due to our move to event-sourcing we no longer need the side effects, because commands are only processed on processing once and on replay events are applied, which means we don't need to distinguish between processing / reprocessing or avoid things like sending responses on reprocessing. Responses can be sent immediately on processing, without further delay.


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
