### PR TITLE
fix: send slack notifications based on qa result

### DIFF
--- a/.github/workflows/qa-testbench.yaml
+++ b/.github/workflows/qa-testbench.yaml
@@ -130,7 +130,7 @@ jobs:
       - id: slack-failure-notify
         name: Send failure slack notification
         uses: slackapi/slack-github-action@v1.19.0
-        if: ${{ failure() }}
+        if: ${{ always() && needs.qa-testbench.result != 'success' }}
         with:
           payload: |
             {
@@ -159,7 +159,7 @@ jobs:
       - id: slack-success-notify
         name: Send success slack notification
         uses: slackapi/slack-github-action@v1.19.0
-        if: ${{ !failure() }}
+        if: ${{ always() && needs.qa-testbench.result == 'success' }}
         with:
           payload: |
             {

--- a/.github/workflows/qa-testbench.yaml
+++ b/.github/workflows/qa-testbench.yaml
@@ -147,7 +147,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Please check: ${{ env.BUILD_URL }}\n"
+                    "text": "Please check: ${{ env.BUILD_URL }}\n \\cc @zeebe-medic"
                   }
                 }
               ]


### PR DESCRIPTION
There seem to be multiple subtleties with conditional job execution, for example here: https://github.com/actions/runner/issues/491.

In our case, the success notification was always send, even when the qa test run failed. Here we adjust the condition to explicitly use the qa test run result instead of the generic `if failure()`.