### PR TITLE
9416 duplicate task headers

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeTaskHeadersValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeTaskHeadersValidator.java
@@ -28,6 +28,11 @@ public class ZeebeTaskHeadersValidator implements ModelElementValidator<ZeebeTas
   @Override
   public void validate(
       final ZeebeTaskHeaders element, final ValidationResultCollector validationResultCollector) {
+    checkForReservedHeaderKeys(element, validationResultCollector);
+  }
+
+  private void checkForReservedHeaderKeys(
+      final ZeebeTaskHeaders element, final ValidationResultCollector validationResultCollector) {
     element.getHeaders().stream()
         .map(ZeebeHeader::getKey)
         .filter(Objects::nonNull)

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeTaskHeadersValidatorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeTaskHeadersValidatorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+import org.junit.jupiter.api.Test;
+
+public class ZeebeTaskHeadersValidatorTest {
+
+  final ZeebeTaskHeadersValidator sut = new ZeebeTaskHeadersValidator();
+
+  @Test
+  public void shouldNotAddErrorAboutDuplicateKeys() {
+    // given
+    final ValidationResultCollector mockValidationResultCollector =
+        mock(ValidationResultCollector.class);
+
+    final ZeebeTaskHeaders element =
+        creatMockTaskHeaders(
+            List.of(
+                new HeaderEntry("testKey", "testValue"),
+                new HeaderEntry("testKey2", "testValue2")));
+
+    // when
+    sut.validate(element, mockValidationResultCollector);
+
+    // then
+    verifyNoInteractions(mockValidationResultCollector);
+  }
+
+  @Test
+  public void shouldAddErrorAboutDuplicateKey() {
+    // given
+    final ValidationResultCollector mockValidationResultCollector =
+        mock(ValidationResultCollector.class);
+
+    final ZeebeTaskHeaders element =
+        creatMockTaskHeaders(
+            List.of(
+                new HeaderEntry("testKey", "testValue"), new HeaderEntry("testKey", "testValue")));
+
+    // when
+    sut.validate(element, mockValidationResultCollector);
+
+    // then
+    verify(mockValidationResultCollector)
+        .addError(0, "Headers contain duplicate entries for key 'testKey'");
+  }
+
+  @Test
+  public void shouldAddErrorsAboutMultipleDuplicateKeys() {
+    // given
+    final ValidationResultCollector mockValidationResultCollector =
+        mock(ValidationResultCollector.class);
+
+    final ZeebeTaskHeaders element =
+        creatMockTaskHeaders(
+            List.of(
+                new HeaderEntry("testKey", "testValue"),
+                new HeaderEntry("testKey", "testValue"),
+                new HeaderEntry("testKey2", "testValue2"), // not duplicate
+                new HeaderEntry("testKey3", "testValue3"),
+                new HeaderEntry("testKey3", "testValue3")));
+
+    // when
+    sut.validate(element, mockValidationResultCollector);
+
+    // then
+    verify(mockValidationResultCollector)
+        .addError(0, "Headers contain duplicate entries for key 'testKey'");
+    verify(mockValidationResultCollector)
+        .addError(0, "Headers contain duplicate entries for key 'testKey3'");
+    verify(mockValidationResultCollector, never())
+        .addError(0, "Headers contain duplicate entries for key 'testKey2'");
+  }
+
+  private ZeebeTaskHeaders creatMockTaskHeaders(final Collection<HeaderEntry> headers) {
+    final var mock = mock(ZeebeTaskHeaders.class);
+
+    final Collection<ZeebeHeader> taskHeaders =
+        headers.stream().map(this::createMockTestHeader).collect(Collectors.toList());
+
+    when(mock.getHeaders()).thenReturn(taskHeaders);
+
+    return mock;
+  }
+
+  private ZeebeHeader createMockTestHeader(final HeaderEntry headerEntry) {
+    final var mock = mock(ZeebeHeader.class);
+    when(mock.getKey()).thenReturn(headerEntry.key());
+    when(mock.getValue()).thenReturn(headerEntry.value());
+    return mock;
+  }
+
+  private record HeaderEntry(String key, String value) {}
+}


### PR DESCRIPTION
## Description
Adds a validation that adds an error when headers have duplicate keys.

## Related issues

closes #9416

<!-- Cut-off marker
* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
