### PR TITLE
fix(broker): do not log error if follower fails to take snapshot when log is not uptodate

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/NoEntryAtSnapshotPosition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/NoEntryAtSnapshotPosition.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions;
+
+/**
+ * Used when there is no entry at the determined snapshot position while taking a transient
+ * snapshot.
+ */
+public class NoEntryAtSnapshotPosition extends RuntimeException {
+
+  public NoEntryAtSnapshotPosition(final String message) {
+    super(message);
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.partitions.impl;
 
 import io.camunda.zeebe.broker.system.partitions.AtomixRecordEntrySupplier;
+import io.camunda.zeebe.broker.system.partitions.NoEntryAtSnapshotPosition;
 import io.camunda.zeebe.broker.system.partitions.StateController;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbFactory;
@@ -155,7 +156,7 @@ public class StateControllerImpl implements StateController {
 
       if (optionalIndexed.isEmpty()) {
         future.completeExceptionally(
-            new IllegalStateException(
+            new NoEntryAtSnapshotPosition(
                 String.format(
                     "Failed to take snapshot. Expected to find an indexed entry for determined snapshot position %d (processedPosition = %d, exportedPosition=%d), but found no matching indexed entry which contains this position.",
                     snapshotPosition, lowerBoundSnapshotPosition, exportedPosition)));

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -12,6 +12,8 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
+import io.camunda.zeebe.broker.system.partitions.AtomixRecordEntrySupplier;
+import io.camunda.zeebe.broker.system.partitions.NoEntryAtSnapshotPosition;
 import io.camunda.zeebe.broker.system.partitions.TestIndexedRaftLogEntry;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
@@ -28,6 +30,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Comparator;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import org.agrona.collections.MutableLong;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.Before;
@@ -45,6 +48,14 @@ public final class StateControllerImplTest {
   private StateControllerImpl snapshotController;
   private FileBasedSnapshotStore store;
   private Path runtimeDirectory;
+
+  private final AtomixRecordEntrySupplier indexedRaftLogEntry =
+      l ->
+          Optional.of(
+              new TestIndexedRaftLogEntry(l, 1, new ApplicationEntry(1, 10, new UnsafeBuffer())));
+  private final AtomixRecordEntrySupplier emptyEntrySupplier = l -> Optional.empty();
+  private final AtomicReference<AtomixRecordEntrySupplier> atomixRecordEntrySupplier =
+      new AtomicReference<>(indexedRaftLogEntry);
 
   @Before
   public void setup() throws IOException {
@@ -64,10 +75,7 @@ public final class StateControllerImplTest {
             DefaultZeebeDbFactory.defaultFactory(),
             store,
             runtimeDirectory,
-            l ->
-                Optional.of(
-                    new TestIndexedRaftLogEntry(
-                        l, 1, new ApplicationEntry(1, 10, new UnsafeBuffer()))),
+            l -> atomixRecordEntrySupplier.get().getPreviousIndexedEntry(l),
             db -> exporterPosition.get(),
             store);
 
@@ -82,6 +90,17 @@ public final class StateControllerImplTest {
     assertThat(snapshotController.isDbOpened()).isFalse();
     assertThatThrownBy(() -> snapshotController.takeTransientSnapshot(1).join())
         .hasCauseInstanceOf(StateClosedException.class);
+  }
+
+  @Test
+  public void shouldNotTakeSnapshotIfNoIndexedEntry() {
+    // given
+    atomixRecordEntrySupplier.set(emptyEntrySupplier);
+    snapshotController.recover().join();
+
+    // then
+    assertThatThrownBy(() -> snapshotController.takeTransientSnapshot(1).join())
+        .hasCauseInstanceOf(NoEntryAtSnapshotPosition.class);
   }
 
   @Test


### PR DESCRIPTION
## Description

Previously, this case was logged as error. Now AsyncSnapshotDirector treat it as a special case, log it in debug level.

Alternative options where to prevent taking snapshot in such cases. But it is very difficult to identify this case. All options prevented taking snapshots in scenarios where we want to take snapshot.
1. One option was to return -1 as processed position in ReplayStateMachine when no events after snapshot position is replayed. But this also prevents taking snapshot when there are no new records, but the exporter position increases.
2. Another options was to skip snapshot in StateController, when the determined snapshot position <= position in latest snapshot. This would not fix the bug, because if the exporter position has changed, it will still try to take snapshot and enter the same situation where it cannot find the indexed entry. Other options were attempted, but all failed in one or the other edge case.

So, the easiest solution is to treat it as a special case in AsyncSnapshotDirector.

## Related issues

closes #7911 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
