### PR TITLE
[Backport stable/1.3] fix(broker): do not log error if follower fails to take snapshot when log is not uptodate

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/NoEntryAtSnapshotPosition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/NoEntryAtSnapshotPosition.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions;
+
+/**
+ * Used when there is no entry at the determined snapshot position while taking a transient
+ * snapshot.
+ */
+public class NoEntryAtSnapshotPosition extends RuntimeException {
+
+  public NoEntryAtSnapshotPosition(final String message) {
+    super(message);
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.partitions.impl;
 
 import io.atomix.raft.RaftCommittedEntryListener;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
+import io.camunda.zeebe.broker.system.partitions.NoEntryAtSnapshotPosition;
 import io.camunda.zeebe.broker.system.partitions.StateController;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorMode;
@@ -51,6 +52,7 @@ public final class AsyncSnapshotDirector extends Actor
   private final String processorName;
   private final StreamProcessor streamProcessor;
   private final String actorName;
+  private final StreamProcessorMode streamProcessorMode;
   private final Set<FailureListener> listeners = new HashSet<>();
   private final BooleanSupplier isLastWrittenPositionCommitted;
 
@@ -79,6 +81,7 @@ public final class AsyncSnapshotDirector extends Actor
     this.snapshotRate = snapshotRate;
     this.partitionId = partitionId;
     actorName = buildActorName(nodeId, "SnapshotDirector", this.partitionId);
+    this.streamProcessorMode = streamProcessorMode;
     if (streamProcessorMode == StreamProcessorMode.REPLAY) {
       isLastWrittenPositionCommitted = () -> true;
     } else {
@@ -256,17 +259,27 @@ public final class AsyncSnapshotDirector extends Actor
     transientSnapshotFuture.onComplete(
         (transientSnapshot, snapshotTakenError) -> {
           if (snapshotTakenError != null) {
-            if (snapshotTakenError instanceof SnapshotException.SnapshotAlreadyExistsException) {
-              LOG.debug("Did not take a snapshot. {}", snapshotTakenError.getMessage());
-            } else {
-              LOG.error("Failed to take a snapshot for {}", processorName, snapshotTakenError);
-            }
+            logSnapshotTakenError(snapshotTakenError);
             resetStateOnFailure(snapshotTakenError);
             return;
           }
 
           onTransientSnapshotTaken(transientSnapshot);
         });
+  }
+
+  private void logSnapshotTakenError(final Throwable snapshotTakenError) {
+    if (snapshotTakenError instanceof SnapshotException.SnapshotAlreadyExistsException) {
+      LOG.debug("Did not take a snapshot. {}", snapshotTakenError.getMessage());
+    } else if (snapshotTakenError instanceof NoEntryAtSnapshotPosition
+        && streamProcessorMode == StreamProcessorMode.REPLAY) {
+      LOG.debug(
+          "Did not take a snapshot: {}. Most likely this partition has not received the entry yet. Will retry in {}",
+          snapshotTakenError.getMessage(),
+          snapshotRate);
+    } else {
+      LOG.error("Failed to take a snapshot for {}", processorName, snapshotTakenError);
+    }
   }
 
   private void onTransientSnapshotTaken(final TransientSnapshot transientSnapshot) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.partitions.impl;
 
 import io.camunda.zeebe.broker.system.partitions.AtomixRecordEntrySupplier;
+import io.camunda.zeebe.broker.system.partitions.NoEntryAtSnapshotPosition;
 import io.camunda.zeebe.broker.system.partitions.StateController;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbFactory;
@@ -155,7 +156,7 @@ public class StateControllerImpl implements StateController {
 
       if (optionalIndexed.isEmpty()) {
         future.completeExceptionally(
-            new IllegalStateException(
+            new NoEntryAtSnapshotPosition(
                 String.format(
                     "Failed to take snapshot. Expected to find an indexed entry for determined snapshot position %d (processedPosition = %d, exportedPosition=%d), but found no matching indexed entry which contains this position.",
                     snapshotPosition, lowerBoundSnapshotPosition, exportedPosition)));


### PR DESCRIPTION
# Description
Backport of #9624 to `stable/1.3`.

relates to #7911