### PR TITLE
[Backport stable/8.0] fix(broker): do not log error if follower fails to take snapshot when log is not uptodate

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/NoEntryAtSnapshotPosition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/NoEntryAtSnapshotPosition.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions;
+
+/**
+ * Used when there is no entry at the determined snapshot position while taking a transient
+ * snapshot.
+ */
+public class NoEntryAtSnapshotPosition extends RuntimeException {
+
+  public NoEntryAtSnapshotPosition(final String message) {
+    super(message);
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.partitions.impl;
 
 import io.atomix.raft.RaftCommittedEntryListener;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
+import io.camunda.zeebe.broker.system.partitions.NoEntryAtSnapshotPosition;
 import io.camunda.zeebe.broker.system.partitions.StateController;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorMode;
@@ -51,6 +52,7 @@ public final class AsyncSnapshotDirector extends Actor
   private final String processorName;
   private final StreamProcessor streamProcessor;
   private final String actorName;
+  private final StreamProcessorMode streamProcessorMode;
   private final Set<FailureListener> listeners = new HashSet<>();
   private final BooleanSupplier isLastWrittenPositionCommitted;
 
@@ -79,6 +81,7 @@ public final class AsyncSnapshotDirector extends Actor
     this.snapshotRate = snapshotRate;
     this.partitionId = partitionId;
     actorName = buildActorName(nodeId, "SnapshotDirector", this.partitionId);
+    this.streamProcessorMode = streamProcessorMode;
     if (streamProcessorMode == StreamProcessorMode.REPLAY) {
       isLastWrittenPositionCommitted = () -> true;
     } else {
@@ -256,17 +259,27 @@ public final class AsyncSnapshotDirector extends Actor
     transientSnapshotFuture.onComplete(
         (transientSnapshot, snapshotTakenError) -> {
           if (snapshotTakenError != null) {
-            if (snapshotTakenError instanceof SnapshotException.SnapshotAlreadyExistsException) {
-              LOG.debug("Did not take a snapshot. {}", snapshotTakenError.getMessage());
-            } else {
-              LOG.error("Failed to take a snapshot for {}", processorName, snapshotTakenError);
-            }
+            logSnapshotTakenError(snapshotTakenError);
             resetStateOnFailure(snapshotTakenError);
             return;
           }
 
           onTransientSnapshotTaken(transientSnapshot);
         });
+  }
+
+  private void logSnapshotTakenError(final Throwable snapshotTakenError) {
+    if (snapshotTakenError instanceof SnapshotException.SnapshotAlreadyExistsException) {
+      LOG.debug("Did not take a snapshot. {}", snapshotTakenError.getMessage());
+    } else if (snapshotTakenError instanceof NoEntryAtSnapshotPosition
+        && streamProcessorMode == StreamProcessorMode.REPLAY) {
+      LOG.debug(
+          "Did not take a snapshot: {}. Most likely this partition has not received the entry yet. Will retry in {}",
+          snapshotTakenError.getMessage(),
+          snapshotRate);
+    } else {
+      LOG.error("Failed to take a snapshot for {}", processorName, snapshotTakenError);
+    }
   }
 
   private void onTransientSnapshotTaken(final TransientSnapshot transientSnapshot) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.partitions.impl;
 
 import io.camunda.zeebe.broker.system.partitions.AtomixRecordEntrySupplier;
+import io.camunda.zeebe.broker.system.partitions.NoEntryAtSnapshotPosition;
 import io.camunda.zeebe.broker.system.partitions.StateController;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbFactory;
@@ -155,7 +156,7 @@ public class StateControllerImpl implements StateController {
 
       if (optionalIndexed.isEmpty()) {
         future.completeExceptionally(
-            new IllegalStateException(
+            new NoEntryAtSnapshotPosition(
                 String.format(
                     "Failed to take snapshot. Expected to find an indexed entry for determined snapshot position %d (processedPosition = %d, exportedPosition=%d), but found no matching indexed entry which contains this position.",
                     snapshotPosition, lowerBoundSnapshotPosition, exportedPosition)));

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -12,6 +12,8 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
+import io.camunda.zeebe.broker.system.partitions.AtomixRecordEntrySupplier;
+import io.camunda.zeebe.broker.system.partitions.NoEntryAtSnapshotPosition;
 import io.camunda.zeebe.broker.system.partitions.TestIndexedRaftLogEntry;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
@@ -28,6 +30,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Comparator;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import org.agrona.collections.MutableLong;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.Before;
@@ -45,6 +48,14 @@ public final class StateControllerImplTest {
   private StateControllerImpl snapshotController;
   private FileBasedSnapshotStore store;
   private Path runtimeDirectory;
+
+  private final AtomixRecordEntrySupplier indexedRaftLogEntry =
+      l ->
+          Optional.of(
+              new TestIndexedRaftLogEntry(l, 1, new ApplicationEntry(1, 10, new UnsafeBuffer())));
+  private final AtomixRecordEntrySupplier emptyEntrySupplier = l -> Optional.empty();
+  private final AtomicReference<AtomixRecordEntrySupplier> atomixRecordEntrySupplier =
+      new AtomicReference<>(indexedRaftLogEntry);
 
   @Before
   public void setup() throws IOException {
@@ -64,10 +75,7 @@ public final class StateControllerImplTest {
             DefaultZeebeDbFactory.defaultFactory(),
             store,
             runtimeDirectory,
-            l ->
-                Optional.of(
-                    new TestIndexedRaftLogEntry(
-                        l, 1, new ApplicationEntry(1, 10, new UnsafeBuffer()))),
+            l -> atomixRecordEntrySupplier.get().getPreviousIndexedEntry(l),
             db -> exporterPosition.get(),
             store);
 
@@ -82,6 +90,17 @@ public final class StateControllerImplTest {
     assertThat(snapshotController.isDbOpened()).isFalse();
     assertThatThrownBy(() -> snapshotController.takeTransientSnapshot(1).join())
         .hasCauseInstanceOf(StateClosedException.class);
+  }
+
+  @Test
+  public void shouldNotTakeSnapshotIfNoIndexedEntry() {
+    // given
+    atomixRecordEntrySupplier.set(emptyEntrySupplier);
+    snapshotController.recover().join();
+
+    // then
+    assertThatThrownBy(() -> snapshotController.takeTransientSnapshot(1).join())
+        .hasCauseInstanceOf(NoEntryAtSnapshotPosition.class);
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #9624 to `stable/8.0`.

relates to #7911