### PR TITLE
Reject create process instance command if unable to subscribe to events

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -484,6 +484,7 @@ public final class CreateProcessInstanceProcessor
                 .formatted(
                     BufferUtil.bufferAsString(element.getId()),
                     subscribedOrFailure.getLeft().getMessage());
+        // todo(#9644): reject command using logical transaction instead of exception throwing
         throw new UncheckedExecutionException(message);
       }
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -13,6 +13,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContextImpl;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
+import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventSupplier;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
@@ -37,6 +38,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.exception.UncheckedExecutionException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -471,8 +473,13 @@ public final class CreateProcessInstanceProcessor
       bpmnElementContext.init(
           elementInstanceKey, elementRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
 
-      catchEventBehavior.subscribeToEvents(
-          bpmnElementContext, catchEventSupplier, sideEffectQueue, commandWriter);
+      final Either<Failure, ?> subscribedOrFailure =
+          catchEventBehavior.subscribeToEvents(
+              bpmnElementContext, catchEventSupplier, sideEffectQueue, commandWriter);
+
+      if (subscribedOrFailure.isLeft()) {
+        throw new UncheckedExecutionException(subscribedOrFailure.getLeft().getMessage());
+      }
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.exception.UncheckedExecutionException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -478,7 +479,12 @@ public final class CreateProcessInstanceProcessor
               bpmnElementContext, catchEventSupplier, sideEffectQueue, commandWriter);
 
       if (subscribedOrFailure.isLeft()) {
-        throw new UncheckedExecutionException(subscribedOrFailure.getLeft().getMessage());
+        final var message =
+            "expected to subscribe to catch event(s) of '%s' but %s"
+                .formatted(
+                    BufferUtil.bufferAsString(element.getId()),
+                    subscribedOrFailure.getLeft().getMessage());
+        throw new UncheckedExecutionException(message);
       }
     }
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceCreationRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceCreationRecordStream.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.test.util.record;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue.ProcessInstanceCreationStartInstructionValue;
 import io.camunda.zeebe.test.util.collection.Maps;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -58,6 +59,14 @@ public final class ProcessInstanceCreationRecordStream
   public ProcessInstanceCreationRecordStream withVariables(
       final Predicate<Map<String, Object>> matcher) {
     return valueFilter(v -> matcher.test(v.getVariables()));
+  }
+
+  public ProcessInstanceCreationRecordStream withStartInstruction(final String elementId) {
+    return valueFilter(
+        v ->
+            v.getStartInstructions().stream()
+                .map(ProcessInstanceCreationStartInstructionValue::getElementId)
+                .anyMatch(elementId::equals));
   }
 
   public ProcessInstanceCreationRecordStream limitToProcessInstanceCreated(

--- a/util/src/main/java/io/camunda/zeebe/util/exception/UncheckedExecutionException.java
+++ b/util/src/main/java/io/camunda/zeebe/util/exception/UncheckedExecutionException.java
@@ -13,6 +13,10 @@ package io.camunda.zeebe.util.exception;
  */
 public final class UncheckedExecutionException extends RuntimeException {
 
+  public UncheckedExecutionException(final String message) {
+    super(message);
+  }
+
   public UncheckedExecutionException(final String message, final Throwable cause) {
     super(message, cause);
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This provides an initial implementation to reject the Create Process Instance command when it's unable to subscribe to events. It's implemented using a workaround for the lack of support for
- #9420

The workaround has some implications:
- an error record is written along with the rejection
- the process instance is blacklisted (although the process instance is not really created)
- an exception is logged as an error including its stacktrace
- the rejection message is rather technical

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9422 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
