### PR TITLE
Start randomised test at random position in the process 🎲 

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessExecutionRandomizedPropertyTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessExecutionRandomizedPropertyTest.java
@@ -41,8 +41,8 @@ public class ProcessExecutionRandomizedPropertyTest {
    * Increasing the maximum number of blocks, depth or branches could increase the number of
    * possible paths exponentially
    */
-  private static final String PROCESS_COUNT = System.getProperty("processCount", "10");
-  private static final String EXECUTION_PATH_COUNT = System.getProperty("executionCount", "15");
+  private static final String PROCESS_COUNT = System.getProperty("processCount", "3");
+  private static final String EXECUTION_PATH_COUNT = System.getProperty("executionCount", "30");
   @Rule public final EngineRule engineRule = EngineRule.singlePartition();
   @Parameter public TestDataRecord record;
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessExecutionRandomizedPropertyTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessExecutionRandomizedPropertyTest.java
@@ -41,7 +41,7 @@ public class ProcessExecutionRandomizedPropertyTest {
    * Increasing the maximum number of blocks, depth or branches could increase the number of
    * possible paths exponentially
    */
-  private static final String PROCESS_COUNT = System.getProperty("processCount", "3");
+  private static final String PROCESS_COUNT = System.getProperty("processCount", "6");
   private static final String EXECUTION_PATH_COUNT = System.getProperty("executionCount", "30");
   @Rule public final EngineRule engineRule = EngineRule.singlePartition();
   @Parameter public TestDataRecord record;

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessExecutionRandomizedPropertyTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessExecutionRandomizedPropertyTest.java
@@ -41,8 +41,8 @@ public class ProcessExecutionRandomizedPropertyTest {
    * Increasing the maximum number of blocks, depth or branches could increase the number of
    * possible paths exponentially
    */
-  private static final String PROCESS_COUNT = System.getProperty("processCount", "3");
-  private static final String EXECUTION_PATH_COUNT = System.getProperty("executionCount", "30");
+  private static final String PROCESS_COUNT = System.getProperty("processCount", "10");
+  private static final String EXECUTION_PATH_COUNT = System.getProperty("executionCount", "15");
   @Rule public final EngineRule engineRule = EngineRule.singlePartition();
   @Parameter public TestDataRecord record;
 
@@ -85,5 +85,7 @@ public class ProcessExecutionRandomizedPropertyTest {
   public static Collection<TestDataGenerator.TestDataRecord> getTestRecords() {
     return TestDataGenerator.generateTestRecords(
         Integer.parseInt(PROCESS_COUNT), Integer.parseInt(EXECUTION_PATH_COUNT));
+    //    return List.of(
+    //        TestDataGenerator.regenerateTestRecord(-8532388551768899121L, -6565756334590616537L));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessExecutor.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessExecutor.java
@@ -255,9 +255,7 @@ public class ProcessExecutor {
             .ofBpmnProcessId(startProcess.getProcessId())
             .withVariables(startProcess.getProcessVariables());
 
-    startProcess
-        .getStartInstructions()
-        .forEach(processInstanceCreationClient::withStartInstruction);
+    startProcess.getStartElementIds().forEach(processInstanceCreationClient::withStartInstruction);
 
     processInstanceCreationClient.create();
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessExecutor.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessExecutor.java
@@ -255,9 +255,9 @@ public class ProcessExecutor {
             .ofBpmnProcessId(startProcess.getProcessId())
             .withVariables(startProcess.getProcessVariables());
 
-    if (startProcess.getStartInstruction() != null) {
-      processInstanceCreationClient.withStartInstruction(startProcess.getStartInstruction());
-    }
+    startProcess
+        .getStartInstructions()
+        .forEach(processInstanceCreationClient::withStartInstruction);
 
     processInstanceCreationClient.create();
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessExecutor.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessExecutor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.util;
 
+import io.camunda.zeebe.engine.util.client.ProcessInstanceClient.ProcessInstanceCreationClient;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
@@ -248,11 +249,17 @@ public class ProcessExecutor {
   }
 
   private void createProcessInstance(final StepStartProcessInstance startProcess) {
-    engineRule
-        .processInstance()
-        .ofBpmnProcessId(startProcess.getProcessId())
-        .withVariables(startProcess.getProcessVariables())
-        .create();
+    final ProcessInstanceCreationClient processInstanceCreationClient =
+        engineRule
+            .processInstance()
+            .ofBpmnProcessId(startProcess.getProcessId())
+            .withVariables(startProcess.getProcessVariables());
+
+    if (startProcess.getStartInstruction() != null) {
+      processInstanceCreationClient.withStartInstruction(startProcess.getStartInstruction());
+    }
+
+    processInstanceCreationClient.create();
   }
 
   private void triggerTimerStartEvent(final StepTriggerTimerStartEvent timerStep) {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
@@ -37,10 +37,10 @@ public interface BlockBuilder {
 
   default ExecutionPathSegment findRandomExecutionPath(final ExecutionPathContext context) {
     final boolean shouldGenerateExecutionPath =
-        context.hasFoundStartBlockBuilder() || equalsOrContains(context.getStartAtBlockBuilder());
+        context.hasFoundStartBlockBuilder() || equalsOrContains(context.getStartAtElementId());
 
     if (shouldGenerateExecutionPath) {
-      if (this == context.getStartAtBlockBuilder()) {
+      if (getElementId().equals(context.getStartAtElementId())) {
         context.foundBlockBuilder();
       }
       return generateRandomExecutionPath(context);
@@ -56,7 +56,11 @@ public interface BlockBuilder {
 
   List<BlockBuilder> getPossibleStartingBlocks();
 
-  default boolean equalsOrContains(final BlockBuilder blockBuilder) {
-    return getPossibleStartingBlocks().contains(blockBuilder);
+  default List<String> getPossibleStartingElementIds() {
+    return getPossibleStartingBlocks().stream().map(BlockBuilder::getElementId).toList();
+  }
+
+  default boolean equalsOrContains(final String startElementId) {
+    return getPossibleStartingElementIds().contains(startElementId);
   }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
@@ -37,4 +37,6 @@ public interface BlockBuilder {
 
   /** Creates a random execution path segment. */
   ExecutionPathSegment findRandomExecutionPath(final Random random);
+
+  String getElementId();
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
@@ -35,19 +35,7 @@ public interface BlockBuilder {
    */
   AbstractFlowNodeBuilder<?, ?> buildFlowNodes(final AbstractFlowNodeBuilder<?, ?> nodeBuilder);
 
-  default ExecutionPathSegment findRandomExecutionPath(final ExecutionPathContext context) {
-    final boolean shouldGenerateExecutionPath =
-        context.hasFoundStartElement() || equalsOrContains(context.getStartElementIds());
-
-    if (shouldGenerateExecutionPath) {
-      if (context.getStartElementIds().contains(getElementId())) {
-        context.foundStartElement();
-      }
-      return generateRandomExecutionPath(context);
-    } else {
-      return new ExecutionPathSegment();
-    }
-  }
+  ExecutionPathSegment findRandomExecutionPath(final ExecutionPathContext context);
 
   /** Creates a random execution path segment. */
   ExecutionPathSegment generateRandomExecutionPath(final ExecutionPathContext context);
@@ -56,11 +44,7 @@ public interface BlockBuilder {
 
   List<BlockBuilder> getPossibleStartingBlocks();
 
-  default List<String> getPossibleStartingElementIds() {
-    return getPossibleStartingBlocks().stream().map(BlockBuilder::getElementId).toList();
-  }
+  List<String> getPossibleStartingElementIds();
 
-  default boolean equalsOrContains(final List<String> startElementIds) {
-    return getPossibleStartingElementIds().stream().anyMatch(startElementIds::contains);
-  }
+  boolean equalsOrContains(final List<String> startElementIds);
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
@@ -35,8 +35,23 @@ public interface BlockBuilder {
    */
   AbstractFlowNodeBuilder<?, ?> buildFlowNodes(final AbstractFlowNodeBuilder<?, ?> nodeBuilder);
 
+  default ExecutionPathSegment findRandomExecutionPath(
+      final Random random, final ExecutionPathContext context) {
+    final boolean shouldGenerateExecutionPath =
+        context.hasFoundStartBlockBuilder() || equalsOrContains(context.getStartAtBlockBuilder());
+
+    if (shouldGenerateExecutionPath) {
+      if (this == context.getStartAtBlockBuilder()) {
+        context.foundBlockBuilder();
+      }
+      return generateRandomExecutionPath(random, context);
+    } else {
+      return new ExecutionPathSegment();
+    }
+  }
+
   /** Creates a random execution path segment. */
-  ExecutionPathSegment findRandomExecutionPath(
+  ExecutionPathSegment generateRandomExecutionPath(
       final Random random, final ExecutionPathContext context);
 
   String getElementId();
@@ -44,13 +59,4 @@ public interface BlockBuilder {
   BlockBuilder findRandomStartingPlace(final Random random);
 
   boolean equalsOrContains(final BlockBuilder blockBuilder);
-
-  default boolean shouldAddExecutionPath(final ExecutionPathContext context) {
-    if (this == context.getStartAtBlockBuilder()) {
-      context.foundBlockBuilder();
-    }
-
-    return context.hasFoundStartBlockBuilder()
-        || equalsOrContains(context.getStartAtBlockBuilder());
-  }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.test.util.bpmn.random;
 
 import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
+import java.util.List;
 import java.util.Random;
 
 /**
@@ -56,7 +57,7 @@ public interface BlockBuilder {
 
   String getElementId();
 
-  BlockBuilder findRandomStartingPlace(final Random random);
+  List<BlockBuilder> getPossibleStartingBlocks();
 
   boolean equalsOrContains(final BlockBuilder blockBuilder);
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.test.util.bpmn.random;
 
 import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
 import java.util.List;
-import java.util.Random;
 
 /**
  * Implementations of this class build blocks of processes and segments of execution paths.
@@ -36,8 +35,7 @@ public interface BlockBuilder {
    */
   AbstractFlowNodeBuilder<?, ?> buildFlowNodes(final AbstractFlowNodeBuilder<?, ?> nodeBuilder);
 
-  default ExecutionPathSegment findRandomExecutionPath(
-      final Random random, final ExecutionPathContext context) {
+  default ExecutionPathSegment findRandomExecutionPath(final ExecutionPathContext context) {
     final boolean shouldGenerateExecutionPath =
         context.hasFoundStartBlockBuilder() || equalsOrContains(context.getStartAtBlockBuilder());
 
@@ -45,15 +43,14 @@ public interface BlockBuilder {
       if (this == context.getStartAtBlockBuilder()) {
         context.foundBlockBuilder();
       }
-      return generateRandomExecutionPath(random, context);
+      return generateRandomExecutionPath(context);
     } else {
       return new ExecutionPathSegment();
     }
   }
 
   /** Creates a random execution path segment. */
-  ExecutionPathSegment generateRandomExecutionPath(
-      final Random random, final ExecutionPathContext context);
+  ExecutionPathSegment generateRandomExecutionPath(final ExecutionPathContext context);
 
   String getElementId();
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
@@ -41,4 +41,6 @@ public interface BlockBuilder {
   String getElementId();
 
   BlockBuilder findRandomStartingPlace(final Random random);
+
+  boolean equalsOrContains(final BlockBuilder blockBuilder);
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
@@ -36,11 +36,21 @@ public interface BlockBuilder {
   AbstractFlowNodeBuilder<?, ?> buildFlowNodes(final AbstractFlowNodeBuilder<?, ?> nodeBuilder);
 
   /** Creates a random execution path segment. */
-  ExecutionPathSegment findRandomExecutionPath(final Random random);
+  ExecutionPathSegment findRandomExecutionPath(
+      final Random random, final ExecutionPathContext context);
 
   String getElementId();
 
   BlockBuilder findRandomStartingPlace(final Random random);
 
   boolean equalsOrContains(final BlockBuilder blockBuilder);
+
+  default boolean shouldAddExecutionPath(final ExecutionPathContext context) {
+    if (this == context.getStartAtBlockBuilder()) {
+      context.foundBlockBuilder();
+    }
+
+    return context.hasFoundStartBlockBuilder()
+        || equalsOrContains(context.getStartAtBlockBuilder());
+  }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
@@ -39,4 +39,6 @@ public interface BlockBuilder {
   ExecutionPathSegment findRandomExecutionPath(final Random random);
 
   String getElementId();
+
+  BlockBuilder findRandomStartingPlace(final Random random);
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
@@ -37,11 +37,11 @@ public interface BlockBuilder {
 
   default ExecutionPathSegment findRandomExecutionPath(final ExecutionPathContext context) {
     final boolean shouldGenerateExecutionPath =
-        context.hasFoundStartBlockBuilder() || equalsOrContains(context.getStartAtElementId());
+        context.hasFoundStartElement() || equalsOrContains(context.getStartElementIds());
 
     if (shouldGenerateExecutionPath) {
-      if (getElementId().equals(context.getStartAtElementId())) {
-        context.foundBlockBuilder();
+      if (context.getStartElementIds().contains(getElementId())) {
+        context.foundStartElement();
       }
       return generateRandomExecutionPath(context);
     } else {
@@ -60,7 +60,7 @@ public interface BlockBuilder {
     return getPossibleStartingBlocks().stream().map(BlockBuilder::getElementId).toList();
   }
 
-  default boolean equalsOrContains(final String startElementId) {
-    return getPossibleStartingElementIds().contains(startElementId);
+  default boolean equalsOrContains(final List<String> startElementIds) {
+    return getPossibleStartingElementIds().stream().anyMatch(startElementIds::contains);
   }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/BlockBuilder.java
@@ -59,5 +59,7 @@ public interface BlockBuilder {
 
   List<BlockBuilder> getPossibleStartingBlocks();
 
-  boolean equalsOrContains(final BlockBuilder blockBuilder);
+  default boolean equalsOrContains(final BlockBuilder blockBuilder) {
+    return getPossibleStartingBlocks().contains(blockBuilder);
+  }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/ExecutionPathContext.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/ExecutionPathContext.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.bpmn.random;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ExecutionPathContext {
+
+  final BlockBuilder startAtBlockBuilder;
+  final List<BlockBuilder> secondaryStartBlockBuilders;
+  boolean foundBlockBuilder = false;
+
+  public ExecutionPathContext(final BlockBuilder startAtBlockBuilder) {
+    this.startAtBlockBuilder = startAtBlockBuilder;
+    secondaryStartBlockBuilders = new ArrayList<>();
+  }
+
+  public BlockBuilder getStartAtBlockBuilder() {
+    return startAtBlockBuilder;
+  }
+
+  public boolean hasFoundStartBlockBuilder() {
+    return foundBlockBuilder;
+  }
+
+  public ExecutionPathContext foundBlockBuilder() {
+    foundBlockBuilder = true;
+    return this;
+  }
+
+  public void addSecondaryStartBlockBuilder(final BlockBuilder blockBuilder) {
+    secondaryStartBlockBuilders.add(blockBuilder);
+  }
+
+  public List<String> getStartElementIds() {
+    final List<String> startElementIds = new ArrayList<>();
+    startElementIds.add(startAtBlockBuilder.getElementId());
+    startElementIds.addAll(
+        secondaryStartBlockBuilders.stream()
+            .map(BlockBuilder::getElementId)
+            .collect(Collectors.toList()));
+    return startElementIds;
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/ExecutionPathContext.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/ExecutionPathContext.java
@@ -13,45 +13,34 @@ import java.util.Random;
 
 public class ExecutionPathContext {
 
-  final String startAtElementId;
-  final List<String> secondaryStartElementIds;
-  boolean foundBlockBuilder = false;
+  final List<String> startElementIds;
+  boolean foundStartElement = false;
   final Random random;
 
   public ExecutionPathContext(final String startAtElementId, final Random random) {
-    this.startAtElementId = startAtElementId;
-    secondaryStartElementIds = new ArrayList<>();
+    startElementIds = new ArrayList<>();
+    startElementIds.add(startAtElementId);
     this.random = random;
   }
 
-  public String getStartAtElementId() {
-    return startAtElementId;
-  }
-
-  public boolean hasFoundStartBlockBuilder() {
-    return foundBlockBuilder;
+  public boolean hasFoundStartElement() {
+    return foundStartElement;
   }
 
   /**
    * Sets a flag in the context that we have found the block that we want the process to start at.
    * All blocks that we come across after this flag is set to true will always have their execution
    * path generated.
-   *
-   * @return this
    */
-  public ExecutionPathContext foundBlockBuilder() {
-    foundBlockBuilder = true;
-    return this;
+  public void foundStartElement() {
+    foundStartElement = true;
   }
 
   public void addSecondaryStartElementId(final String elementId) {
-    secondaryStartElementIds.add(elementId);
+    startElementIds.add(elementId);
   }
 
   public List<String> getStartElementIds() {
-    final List<String> startElementIds = new ArrayList<>();
-    startElementIds.add(startAtElementId);
-    startElementIds.addAll(secondaryStartElementIds);
     return startElementIds;
   }
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/ExecutionPathContext.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/ExecutionPathContext.java
@@ -14,13 +14,13 @@ import java.util.Random;
 public class ExecutionPathContext {
 
   final String startAtElementId;
-  final List<BlockBuilder> secondaryStartBlockBuilders;
+  final List<String> secondaryStartElementIds;
   boolean foundBlockBuilder = false;
   final Random random;
 
   public ExecutionPathContext(final String startAtElementId, final Random random) {
     this.startAtElementId = startAtElementId;
-    secondaryStartBlockBuilders = new ArrayList<>();
+    secondaryStartElementIds = new ArrayList<>();
     this.random = random;
   }
 
@@ -44,15 +44,14 @@ public class ExecutionPathContext {
     return this;
   }
 
-  public void addSecondaryStartBlockBuilder(final BlockBuilder blockBuilder) {
-    secondaryStartBlockBuilders.add(blockBuilder);
+  public void addSecondaryStartElementId(final String elementId) {
+    secondaryStartElementIds.add(elementId);
   }
 
   public List<String> getStartElementIds() {
     final List<String> startElementIds = new ArrayList<>();
     startElementIds.add(startAtElementId);
-    startElementIds.addAll(
-        secondaryStartBlockBuilders.stream().map(BlockBuilder::getElementId).toList());
+    startElementIds.addAll(secondaryStartElementIds);
     return startElementIds;
   }
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/ExecutionPathContext.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/ExecutionPathContext.java
@@ -30,6 +30,13 @@ public class ExecutionPathContext {
     return foundBlockBuilder;
   }
 
+  /**
+   * Sets a flag in the context that we have found the block that we want the process to start at.
+   * All blocks that we come across after this flag is set to true will always have their execution
+   * path generated.
+   *
+   * @return this
+   */
   public ExecutionPathContext foundBlockBuilder() {
     foundBlockBuilder = true;
     return this;

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/ExecutionPathContext.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/ExecutionPathContext.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.test.util.bpmn.random;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 public class ExecutionPathContext {
@@ -16,10 +17,12 @@ public class ExecutionPathContext {
   final BlockBuilder startAtBlockBuilder;
   final List<BlockBuilder> secondaryStartBlockBuilders;
   boolean foundBlockBuilder = false;
+  final Random random;
 
-  public ExecutionPathContext(final BlockBuilder startAtBlockBuilder) {
+  public ExecutionPathContext(final BlockBuilder startAtBlockBuilder, final Random random) {
     this.startAtBlockBuilder = startAtBlockBuilder;
     secondaryStartBlockBuilders = new ArrayList<>();
+    this.random = random;
   }
 
   public BlockBuilder getStartAtBlockBuilder() {
@@ -54,5 +57,9 @@ public class ExecutionPathContext {
             .map(BlockBuilder::getElementId)
             .collect(Collectors.toList()));
     return startElementIds;
+  }
+
+  public Random getRandom() {
+    return random;
   }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/ExecutionPathContext.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/ExecutionPathContext.java
@@ -10,23 +10,22 @@ package io.camunda.zeebe.test.util.bpmn.random;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import java.util.stream.Collectors;
 
 public class ExecutionPathContext {
 
-  final BlockBuilder startAtBlockBuilder;
+  final String startAtElementId;
   final List<BlockBuilder> secondaryStartBlockBuilders;
   boolean foundBlockBuilder = false;
   final Random random;
 
-  public ExecutionPathContext(final BlockBuilder startAtBlockBuilder, final Random random) {
-    this.startAtBlockBuilder = startAtBlockBuilder;
+  public ExecutionPathContext(final String startAtElementId, final Random random) {
+    this.startAtElementId = startAtElementId;
     secondaryStartBlockBuilders = new ArrayList<>();
     this.random = random;
   }
 
-  public BlockBuilder getStartAtBlockBuilder() {
-    return startAtBlockBuilder;
+  public String getStartAtElementId() {
+    return startAtElementId;
   }
 
   public boolean hasFoundStartBlockBuilder() {
@@ -51,11 +50,9 @@ public class ExecutionPathContext {
 
   public List<String> getStartElementIds() {
     final List<String> startElementIds = new ArrayList<>();
-    startElementIds.add(startAtBlockBuilder.getElementId());
+    startElementIds.add(startAtElementId);
     startElementIds.addAll(
-        secondaryStartBlockBuilders.stream()
-            .map(BlockBuilder::getElementId)
-            .collect(Collectors.toList()));
+        secondaryStartBlockBuilders.stream().map(BlockBuilder::getElementId).toList());
     return startElementIds;
   }
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/AbstractBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/AbstractBlockBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.bpmn.random.blocks;
+
+import io.camunda.zeebe.test.util.bpmn.random.BlockBuilder;
+import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
+import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
+import java.util.List;
+
+public abstract class AbstractBlockBuilder implements BlockBuilder {
+  protected final String elementId;
+  private final String prefix;
+
+  protected AbstractBlockBuilder(final String elementId) {
+    this.elementId = elementId;
+    prefix = "";
+  }
+
+  protected AbstractBlockBuilder(final String prefix, final String elementId) {
+    this.elementId = elementId;
+    this.prefix = prefix;
+  }
+
+  @Override
+  public ExecutionPathSegment findRandomExecutionPath(final ExecutionPathContext context) {
+    final boolean shouldGenerateExecutionPath =
+        context.hasFoundStartElement() || equalsOrContains(context.getStartElementIds());
+
+    if (shouldGenerateExecutionPath) {
+      if (context.getStartElementIds().contains(getElementId())) {
+        context.foundStartElement();
+      }
+      return generateRandomExecutionPath(context);
+    } else {
+      return new ExecutionPathSegment();
+    }
+  }
+
+  @Override
+  public String getElementId() {
+    return prefix + elementId;
+  }
+
+  @Override
+  public List<BlockBuilder> getPossibleStartingBlocks() {
+    return List.of(this);
+  }
+
+  @Override
+  public List<String> getPossibleStartingElementIds() {
+    return getPossibleStartingBlocks().stream().map(BlockBuilder::getElementId).toList();
+  }
+
+  @Override
+  public boolean equalsOrContains(final List<String> startElementIds) {
+    return getPossibleStartingElementIds().stream().anyMatch(startElementIds::contains);
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -84,12 +84,9 @@ public class BlockSequenceBuilder implements BlockBuilder {
 
   @Override
   public ExecutionPathSegment findRandomExecutionPath(final Random random) {
-    final ExecutionPathSegment result = new ExecutionPathSegment();
-
-    blockBuilders.forEach(
-        blockBuilder -> result.append(blockBuilder.findRandomExecutionPath(random)));
-
-    return result;
+    return blockBuilders.size() > 0
+        ? findRandomExecutionPath(random, blockBuilders.get(0))
+        : new ExecutionPathSegment();
   }
 
   /**
@@ -101,6 +98,24 @@ public class BlockSequenceBuilder implements BlockBuilder {
   @Override
   public String getElementId() {
     return null;
+  }
+
+  public ExecutionPathSegment findRandomExecutionPath(
+      final Random random, final BlockBuilder startAtBlockBuilder) {
+    final ExecutionPathSegment result = new ExecutionPathSegment();
+
+    final var blockBuildersFromStartBlock =
+        blockBuilders.subList(blockBuilders.indexOf(startAtBlockBuilder), blockBuilders.size());
+    blockBuildersFromStartBlock.forEach(
+        blockBuilder -> {
+          result.append(blockBuilder.findRandomExecutionPath(random));
+        });
+
+    return result;
+  }
+
+  public List<BlockBuilder> getBlockBuilders() {
+    return blockBuilders;
   }
 
   public static class BlockSequenceBuilderFactory {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -45,8 +45,10 @@ public class BlockSequenceBuilder implements BlockBuilder {
           new IntermediateThrowEventBlockBuilder.Factory());
 
   private final List<BlockBuilder> blockBuilders = new ArrayList<>();
+  private final String dummyElementId;
 
   public BlockSequenceBuilder(final ConstructionContext context) {
+    dummyElementId = context.getIdGenerator().nextId();
     final Random random = context.getRandom();
     final int maxDepth = context.getMaxDepth();
     final int maxBlocks = context.getMaxBlocks();
@@ -95,12 +97,12 @@ public class BlockSequenceBuilder implements BlockBuilder {
 
   /**
    * The BlockSequenceBuilder is a special case. This is not an executable block, but is responsible
-   * for building the sequence of blocks. Instead it will return the element id of the first block
-   * it contains.
+   * for building the sequence of blocks. It has no sensible element id, yet it must be a unique
+   * value, so a dummy element id is generated and returned here.
    */
   @Override
   public String getElementId() {
-    return blockBuilders.get(0).getElementId();
+    return dummyElementId;
   }
 
   @Override
@@ -112,8 +114,9 @@ public class BlockSequenceBuilder implements BlockBuilder {
   }
 
   @Override
-  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
-    return this == blockBuilder || getPossibleStartingBlocks().contains(blockBuilder);
+  public boolean equalsOrContains(final String startingElementId) {
+    return getElementId().equals(startingElementId)
+        || getPossibleStartingElementIds().contains(startingElementId);
   }
 
   public static class BlockSequenceBuilderFactory {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -114,9 +114,9 @@ public class BlockSequenceBuilder implements BlockBuilder {
   }
 
   @Override
-  public boolean equalsOrContains(final String startingElementId) {
-    return getElementId().equals(startingElementId)
-        || getPossibleStartingElementIds().contains(startingElementId);
+  public boolean equalsOrContains(final List<String> startingElementIds) {
+    return startingElementIds.contains(getElementId())
+        || getPossibleStartingElementIds().stream().anyMatch(startingElementIds::contains);
   }
 
   /**

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -105,10 +105,11 @@ public class BlockSequenceBuilder implements BlockBuilder {
   }
 
   @Override
-  public BlockBuilder findRandomStartingPlace(final Random random) {
-    final int index = random.nextInt(blockBuilders.size());
-    final BlockBuilder blockBuilder = blockBuilders.get(index);
-    return blockBuilder.findRandomStartingPlace(random);
+  public List<BlockBuilder> getPossibleStartingBlocks() {
+    final List<BlockBuilder> allBlockBuilders = new ArrayList<>();
+    blockBuilders.forEach(
+        blockBuilder -> allBlockBuilders.addAll(blockBuilder.getPossibleStartingBlocks()));
+    return allBlockBuilders;
   }
 
   @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -24,7 +24,7 @@ import java.util.Random;
  * <p>Hints: Depending on random value this may also create a sequence with no block. If current
  * depth is at max depth it will only pick block builders which do not add depth.
  */
-public class BlockSequenceBuilder implements BlockBuilder {
+public class BlockSequenceBuilder extends AbstractBlockBuilder {
 
   private static final List<BlockBuilderFactory> BLOCK_BUILDER_FACTORIES =
       Arrays.asList(
@@ -45,10 +45,9 @@ public class BlockSequenceBuilder implements BlockBuilder {
           new IntermediateThrowEventBlockBuilder.Factory());
 
   private final List<BlockBuilder> blockBuilders = new ArrayList<>();
-  private final String dummyElementId;
 
   public BlockSequenceBuilder(final ConstructionContext context) {
-    dummyElementId = context.getIdGenerator().nextId();
+    super(context.getIdGenerator().nextId());
     final Random random = context.getRandom();
     final int maxDepth = context.getMaxDepth();
     final int maxBlocks = context.getMaxBlocks();
@@ -93,16 +92,6 @@ public class BlockSequenceBuilder implements BlockBuilder {
         blockBuilder -> result.append(blockBuilder.findRandomExecutionPath(context)));
 
     return result;
-  }
-
-  /**
-   * The BlockSequenceBuilder is a special case. This is not an executable block, but is responsible
-   * for building the sequence of blocks. It has no sensible element id, yet it must be a unique
-   * value, so a dummy element id is generated and returned here.
-   */
-  @Override
-  public String getElementId() {
-    return dummyElementId;
   }
 
   @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -112,12 +112,6 @@ public class BlockSequenceBuilder implements BlockBuilder {
     return allBlockBuilders;
   }
 
-  @Override
-  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
-    final boolean contains = blockBuilders.stream().anyMatch(b -> b.equalsOrContains(blockBuilder));
-    return this == blockBuilder || contains;
-  }
-
   public static class BlockSequenceBuilderFactory {
 
     public BlockSequenceBuilder createBlockSequenceBuilder(final ConstructionContext context) {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -100,6 +100,13 @@ public class BlockSequenceBuilder implements BlockBuilder {
     return null;
   }
 
+  @Override
+  public BlockBuilder findRandomStartingPlace(final Random random) {
+    final int index = random.nextInt(blockBuilders.size());
+    final BlockBuilder blockBuilder = blockBuilders.get(index);
+    return blockBuilder.findRandomStartingPlace(random);
+  }
+
   public ExecutionPathSegment findRandomExecutionPath(
       final Random random, final BlockBuilder startAtBlockBuilder) {
     final ExecutionPathSegment result = new ExecutionPathSegment();

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -119,6 +119,19 @@ public class BlockSequenceBuilder implements BlockBuilder {
         || getPossibleStartingElementIds().contains(startingElementId);
   }
 
+  /**
+   * When building a parallel gateway we need to know the element id of the next element in the
+   * process as we need to append it to the list of start elements. Since each branch of the
+   * parallel gateway is a BlockSequenceBuilder, we cannot use the element id of this block as it is
+   * a dummy id (we cannot start at a BlockSequenceBlock). Instead, we need to return the element id
+   * of the first block inside this block.
+   *
+   * @return the element id of the block inside this block
+   */
+  public String getFirstBlockElementId() {
+    return blockBuilders.get(0).getElementId();
+  }
+
   public static class BlockSequenceBuilderFactory {
 
     public BlockSequenceBuilder createBlockSequenceBuilder(final ConstructionContext context) {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -54,8 +54,8 @@ public class BlockSequenceBuilder implements BlockBuilder {
 
     if (currentDepth < maxDepth) {
 
-      // reduce the number of steps in a sequence when we are nested
-      final int steps = random.nextInt(Math.max(0, maxBlocks - currentDepth));
+      // reduce the number of steps in a sequence when we are nested and guarantee at least 1 step
+      final int steps = random.nextInt(Math.max(0, maxBlocks - currentDepth)) + 1;
 
       for (int step = 0; step < steps; step++) {
 
@@ -90,6 +90,17 @@ public class BlockSequenceBuilder implements BlockBuilder {
         blockBuilder -> result.append(blockBuilder.findRandomExecutionPath(random)));
 
     return result;
+  }
+
+  /**
+   * The BlockSequenceBuilder is a special case. This is not an executable block, but is responsible
+   * for building the sequence of blocks. As a result it does not have an element id.
+   *
+   * @return null
+   */
+  @Override
+  public String getElementId() {
+    return null;
   }
 
   public static class BlockSequenceBuilderFactory {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -84,12 +84,11 @@ public class BlockSequenceBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment generateRandomExecutionPath(
-      final Random random, final ExecutionPathContext context) {
+  public ExecutionPathSegment generateRandomExecutionPath(final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
     blockBuilders.forEach(
-        blockBuilder -> result.append(blockBuilder.findRandomExecutionPath(random, context)));
+        blockBuilder -> result.append(blockBuilder.findRandomExecutionPath(context)));
 
     return result;
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -117,10 +117,6 @@ public class BlockSequenceBuilder implements BlockBuilder {
     return this == blockBuilder || contains;
   }
 
-  public List<BlockBuilder> getBlockBuilders() {
-    return blockBuilders;
-  }
-
   public static class BlockSequenceBuilderFactory {
 
     public BlockSequenceBuilder createBlockSequenceBuilder(final ConstructionContext context) {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -112,6 +112,11 @@ public class BlockSequenceBuilder implements BlockBuilder {
     return allBlockBuilders;
   }
 
+  @Override
+  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
+    return this == blockBuilder || getPossibleStartingBlocks().contains(blockBuilder);
+  }
+
   public static class BlockSequenceBuilderFactory {
 
     public BlockSequenceBuilder createBlockSequenceBuilder(final ConstructionContext context) {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -84,16 +84,12 @@ public class BlockSequenceBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment findRandomExecutionPath(
+  public ExecutionPathSegment generateRandomExecutionPath(
       final Random random, final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
-    if (shouldAddExecutionPath(context)) {
-      blockBuilders.forEach(
-          blockBuilder -> {
-            result.append(blockBuilder.findRandomExecutionPath(random, context));
-          });
-    }
+    blockBuilders.forEach(
+        blockBuilder -> result.append(blockBuilder.findRandomExecutionPath(random, context)));
 
     return result;
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -107,6 +107,12 @@ public class BlockSequenceBuilder implements BlockBuilder {
     return blockBuilder.findRandomStartingPlace(random);
   }
 
+  @Override
+  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
+    final boolean contains = blockBuilders.stream().anyMatch(b -> b.equalsOrContains(blockBuilder));
+    return this == blockBuilder || contains;
+  }
+
   public ExecutionPathSegment findRandomExecutionPath(
       final Random random, final BlockBuilder startAtBlockBuilder) {
     final ExecutionPathSegment result = new ExecutionPathSegment();

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
@@ -88,11 +88,6 @@ public class CallActivityBlockBuilder implements BlockBuilder {
     return List.of(this);
   }
 
-  @Override
-  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
-    return this == blockBuilder;
-  }
-
   private void buildChildProcess() {
     AbstractFlowNodeBuilder<?, ?> workInProgress =
         Bpmn.createExecutableProcess(calledProcessId).startEvent();

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
@@ -73,6 +73,11 @@ public class CallActivityBlockBuilder implements BlockBuilder {
     return result;
   }
 
+  @Override
+  public String getElementId() {
+    return callActivityId;
+  }
+
   private void buildChildProcess() {
     AbstractFlowNodeBuilder<?, ?> workInProgress =
         Bpmn.createExecutableProcess(calledProcessId).startEvent();

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.test.util.bpmn.random.ConstructionContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
+import java.util.List;
 import java.util.Random;
 
 /** Generates a call activity. The called process is a Process that contains any block sequence. */
@@ -81,8 +82,10 @@ public class CallActivityBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public BlockBuilder findRandomStartingPlace(final Random random) {
-    return this;
+  public List<BlockBuilder> getPossibleStartingBlocks() {
+    // We cannot start a process inside of a call activity.
+    // Therefore the blocks of the calledProcessBuilder are not returned here.
+    return List.of(this);
   }
 
   @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
@@ -83,6 +83,11 @@ public class CallActivityBlockBuilder implements BlockBuilder {
     return this;
   }
 
+  @Override
+  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
+    return this == blockBuilder;
+  }
+
   private void buildChildProcess() {
     AbstractFlowNodeBuilder<?, ?> workInProgress =
         Bpmn.createExecutableProcess(calledProcessId).startEvent();

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
@@ -78,6 +78,11 @@ public class CallActivityBlockBuilder implements BlockBuilder {
     return callActivityId;
   }
 
+  @Override
+  public BlockBuilder findRandomStartingPlace(final Random random) {
+    return this;
+  }
+
   private void buildChildProcess() {
     AbstractFlowNodeBuilder<?, ?> workInProgress =
         Bpmn.createExecutableProcess(calledProcessId).startEvent();

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
@@ -64,11 +64,11 @@ public class CallActivityBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment findRandomExecutionPath(
+  public ExecutionPathSegment generateRandomExecutionPath(
       final Random random, final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
-    if (shouldAddExecutionPath(context) && calledProcessBuilder != null) {
+    if (calledProcessBuilder != null) {
       result.append(calledProcessBuilder.findRandomExecutionPath(random, context));
     }
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
 import io.camunda.zeebe.test.util.bpmn.random.BlockBuilder;
 import io.camunda.zeebe.test.util.bpmn.random.BlockBuilderFactory;
 import io.camunda.zeebe.test.util.bpmn.random.ConstructionContext;
+import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import java.util.Random;
@@ -63,11 +64,12 @@ public class CallActivityBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment findRandomExecutionPath(final Random random) {
+  public ExecutionPathSegment findRandomExecutionPath(
+      final Random random, final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
-    if (calledProcessBuilder != null) {
-      result.append(calledProcessBuilder.findRandomExecutionPath(random));
+    if (shouldAddExecutionPath(context) && calledProcessBuilder != null) {
+      result.append(calledProcessBuilder.findRandomExecutionPath(random, context));
     }
 
     return result;

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
@@ -65,12 +65,11 @@ public class CallActivityBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment generateRandomExecutionPath(
-      final Random random, final ExecutionPathContext context) {
+  public ExecutionPathSegment generateRandomExecutionPath(final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
     if (calledProcessBuilder != null) {
-      result.append(calledProcessBuilder.findRandomExecutionPath(random, context));
+      result.append(calledProcessBuilder.findRandomExecutionPath(context));
     }
 
     return result;

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/EventBasedGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/EventBasedGatewayBlockBuilder.java
@@ -88,6 +88,13 @@ public class EventBasedGatewayBlockBuilder implements BlockBuilder {
     return forkGatewayId;
   }
 
+  @Override
+  public BlockBuilder findRandomStartingPlace(final Random random) {
+    // We cannot start at the events of an event based gateway, so we should always start at the
+    // gateway itself
+    return this;
+  }
+
   private AbstractFlowNodeBuilder<?, ?> addBranch(
       final io.camunda.zeebe.model.bpmn.builder.EventBasedGatewayBuilder gatewayBuilder,
       final Tuple<String, BlockBuilder> branch) {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/EventBasedGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/EventBasedGatewayBlockBuilder.java
@@ -95,11 +95,6 @@ public class EventBasedGatewayBlockBuilder implements BlockBuilder {
     return List.of(this);
   }
 
-  @Override
-  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
-    return this == blockBuilder;
-  }
-
   private AbstractFlowNodeBuilder<?, ?> addBranch(
       final io.camunda.zeebe.model.bpmn.builder.EventBasedGatewayBuilder gatewayBuilder,
       final Tuple<String, BlockBuilder> branch) {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/EventBasedGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/EventBasedGatewayBlockBuilder.java
@@ -95,6 +95,11 @@ public class EventBasedGatewayBlockBuilder implements BlockBuilder {
     return this;
   }
 
+  @Override
+  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
+    return this == blockBuilder;
+  }
+
   private AbstractFlowNodeBuilder<?, ?> addBranch(
       final io.camunda.zeebe.model.bpmn.builder.EventBasedGatewayBuilder gatewayBuilder,
       final Tuple<String, BlockBuilder> branch) {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/EventBasedGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/EventBasedGatewayBlockBuilder.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
 import io.camunda.zeebe.test.util.bpmn.random.BlockBuilder;
 import io.camunda.zeebe.test.util.bpmn.random.BlockBuilderFactory;
 import io.camunda.zeebe.test.util.bpmn.random.ConstructionContext;
+import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepPublishMessage;
@@ -67,18 +68,21 @@ public class EventBasedGatewayBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment findRandomExecutionPath(final Random random) {
+  public ExecutionPathSegment findRandomExecutionPath(
+      final Random random, final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
-    final int branchNumber = random.nextInt(branches.size());
-    final var branch = branches.get(branchNumber);
-    final var blockBuilder = branch.getRight();
+    if (shouldAddExecutionPath(context)) {
+      final int branchNumber = random.nextInt(branches.size());
+      final var branch = branches.get(branchNumber);
+      final var blockBuilder = branch.getRight();
 
-    final var executionStep =
-        new StepPublishMessage(
-            getMessageName(branch), CORRELATION_KEY_FIELD, CORRELATION_KEY_VALUE);
-    result.appendDirectSuccessor(executionStep);
-    result.append(blockBuilder.findRandomExecutionPath(random));
+      final var executionStep =
+          new StepPublishMessage(
+              getMessageName(branch), CORRELATION_KEY_FIELD, CORRELATION_KEY_VALUE);
+      result.appendDirectSuccessor(executionStep);
+      result.append(blockBuilder.findRandomExecutionPath(random, context));
+    }
 
     return result;
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/EventBasedGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/EventBasedGatewayBlockBuilder.java
@@ -68,11 +68,10 @@ public class EventBasedGatewayBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment generateRandomExecutionPath(
-      final Random random, final ExecutionPathContext context) {
+  public ExecutionPathSegment generateRandomExecutionPath(final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
-    final int branchNumber = random.nextInt(branches.size());
+    final int branchNumber = context.getRandom().nextInt(branches.size());
     final var branch = branches.get(branchNumber);
     final var blockBuilder = branch.getRight();
 
@@ -80,7 +79,7 @@ public class EventBasedGatewayBlockBuilder implements BlockBuilder {
         new StepPublishMessage(
             getMessageName(branch), CORRELATION_KEY_FIELD, CORRELATION_KEY_VALUE);
     result.appendDirectSuccessor(executionStep);
-    result.append(blockBuilder.findRandomExecutionPath(random, context));
+    result.append(blockBuilder.findRandomExecutionPath(context));
 
     return result;
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/EventBasedGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/EventBasedGatewayBlockBuilder.java
@@ -68,21 +68,19 @@ public class EventBasedGatewayBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment findRandomExecutionPath(
+  public ExecutionPathSegment generateRandomExecutionPath(
       final Random random, final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
-    if (shouldAddExecutionPath(context)) {
-      final int branchNumber = random.nextInt(branches.size());
-      final var branch = branches.get(branchNumber);
-      final var blockBuilder = branch.getRight();
+    final int branchNumber = random.nextInt(branches.size());
+    final var branch = branches.get(branchNumber);
+    final var blockBuilder = branch.getRight();
 
-      final var executionStep =
-          new StepPublishMessage(
-              getMessageName(branch), CORRELATION_KEY_FIELD, CORRELATION_KEY_VALUE);
-      result.appendDirectSuccessor(executionStep);
-      result.append(blockBuilder.findRandomExecutionPath(random, context));
-    }
+    final var executionStep =
+        new StepPublishMessage(
+            getMessageName(branch), CORRELATION_KEY_FIELD, CORRELATION_KEY_VALUE);
+    result.appendDirectSuccessor(executionStep);
+    result.append(blockBuilder.findRandomExecutionPath(random, context));
 
     return result;
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/EventBasedGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/EventBasedGatewayBlockBuilder.java
@@ -83,6 +83,11 @@ public class EventBasedGatewayBlockBuilder implements BlockBuilder {
     return result;
   }
 
+  @Override
+  public String getElementId() {
+    return forkGatewayId;
+  }
+
   private AbstractFlowNodeBuilder<?, ?> addBranch(
       final io.camunda.zeebe.model.bpmn.builder.EventBasedGatewayBuilder gatewayBuilder,
       final Tuple<String, BlockBuilder> branch) {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/EventBasedGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/EventBasedGatewayBlockBuilder.java
@@ -91,10 +91,8 @@ public class EventBasedGatewayBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public BlockBuilder findRandomStartingPlace(final Random random) {
-    // We cannot start at the events of an event based gateway, so we should always start at the
-    // gateway itself
-    return this;
+  public List<BlockBuilder> getPossibleStartingBlocks() {
+    return List.of(this);
   }
 
   @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/EventBasedGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/EventBasedGatewayBlockBuilder.java
@@ -20,22 +20,21 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-public class EventBasedGatewayBlockBuilder implements BlockBuilder {
+public class EventBasedGatewayBlockBuilder extends AbstractBlockBuilder {
 
   private static final String CORRELATION_KEY_FIELD = "correlationKey";
   private static final String CORRELATION_KEY_VALUE = "default_correlation_key";
   private static final String MESSAGE_NAME_PREFIX = "message_";
 
-  private final String forkGatewayId;
   private final String joinGatewayId;
   private final List<Tuple<String, BlockBuilder>> branches = new ArrayList<>();
 
   public EventBasedGatewayBlockBuilder(final ConstructionContext context) {
+    super("fork_", context.getIdGenerator().nextId());
     final Random random = context.getRandom();
     final IDGenerator idGenerator = context.getIdGenerator();
     final int maxBranches = context.getMaxBranches();
 
-    forkGatewayId = "fork_" + idGenerator.nextId();
     joinGatewayId = "join_" + idGenerator.nextId();
 
     final var blockSequenceBuilderFactory = context.getBlockSequenceBuilderFactory();
@@ -55,7 +54,7 @@ public class EventBasedGatewayBlockBuilder implements BlockBuilder {
   public AbstractFlowNodeBuilder<?, ?> buildFlowNodes(
       final AbstractFlowNodeBuilder<?, ?> nodeBuilder) {
 
-    final var forkGateway = nodeBuilder.eventBasedGateway(forkGatewayId);
+    final var forkGateway = nodeBuilder.eventBasedGateway(getElementId());
 
     final var firstBranch = addBranch(forkGateway, branches.get(0));
     final var joinGateway = firstBranch.exclusiveGateway(joinGatewayId);
@@ -82,16 +81,6 @@ public class EventBasedGatewayBlockBuilder implements BlockBuilder {
     result.append(blockBuilder.findRandomExecutionPath(context));
 
     return result;
-  }
-
-  @Override
-  public String getElementId() {
-    return forkGatewayId;
-  }
-
-  @Override
-  public List<BlockBuilder> getPossibleStartingBlocks() {
-    return List.of(this);
   }
 
   private AbstractFlowNodeBuilder<?, ?> addBranch(

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
@@ -96,7 +96,7 @@ public class ExclusiveGatewayBlockBuilder implements BlockBuilder {
 
     final Optional<Integer> branchContainingStartBlock =
         blockBuilders.stream()
-            .filter(b -> b.equalsOrContains(context.getStartAtBlockBuilder()))
+            .filter(b -> b.equalsOrContains(context.getStartAtElementId()))
             .map(blockBuilders::indexOf)
             .findFirst();
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
@@ -102,11 +102,11 @@ public class ExclusiveGatewayBlockBuilder implements BlockBuilder {
 
     final int branch = branchContainingStartBlock.orElse(random.nextInt(branchIds.size()));
 
-    if (branchContainingStartBlock.isEmpty() || this == context.getStartAtBlockBuilder()) {
+    if (branchContainingStartBlock.isEmpty()) {
       if (branch == 0) {
         result.appendDirectSuccessor(
             new StepPickDefaultCase(forkGatewayId, gatewayConditionVariable));
-      } else if (random.nextBoolean() || branchContainingStartBlock.isPresent()) {
+      } else if (random.nextBoolean()) {
         // take a non-default branch
         result.appendDirectSuccessor(
             new StepPickConditionCase(

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
@@ -115,6 +115,11 @@ public class ExclusiveGatewayBlockBuilder implements BlockBuilder {
     return result;
   }
 
+  @Override
+  public String getElementId() {
+    return forkGatewayId;
+  }
+
   static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
@@ -140,12 +140,6 @@ public class ExclusiveGatewayBlockBuilder implements BlockBuilder {
     return allBlockBuilders;
   }
 
-  @Override
-  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
-    final boolean contains = blockBuilders.stream().anyMatch(b -> b.equalsOrContains(blockBuilder));
-    return this == blockBuilder || contains;
-  }
-
   static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
@@ -122,7 +122,7 @@ public class ExclusiveGatewayBlockBuilder implements BlockBuilder {
 
   @Override
   public BlockBuilder findRandomStartingPlace(final Random random) {
-    final boolean shouldGoIntoNestedBlocks = random.nextBoolean();
+    final boolean shouldGoIntoNestedBlocks = true; // TODO random.nextBoolean();
     if (shouldGoIntoNestedBlocks) {
       final int index = random.nextInt(blockBuilders.size());
       final BlockBuilder blockBuilder = blockBuilders.get(index);
@@ -130,6 +130,12 @@ public class ExclusiveGatewayBlockBuilder implements BlockBuilder {
     } else {
       return this;
     }
+  }
+
+  @Override
+  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
+    final boolean contains = blockBuilders.stream().anyMatch(b -> b.equalsOrContains(blockBuilder));
+    return this == blockBuilder || contains;
   }
 
   static class Factory implements BlockBuilderFactory {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
@@ -94,14 +94,14 @@ public class ExclusiveGatewayBlockBuilder implements BlockBuilder {
     final ExecutionPathSegment result = new ExecutionPathSegment();
     final Random random = context.getRandom();
 
-    final Optional<Integer> branchContainingStartBlock =
+    final Optional<Integer> branchContainingStartElement =
         blockBuilders.stream()
-            .filter(b -> b.equalsOrContains(context.getStartAtElementId()))
+            .filter(b -> b.equalsOrContains(context.getStartElementIds()))
             .map(blockBuilders::indexOf)
             .findFirst();
 
-    final int branch = branchContainingStartBlock.orElse(random.nextInt(branchIds.size()));
-    if (branchContainingStartBlock.isEmpty()) {
+    final int branch = branchContainingStartElement.orElse(random.nextInt(branchIds.size()));
+    if (branchContainingStartElement.isEmpty()) {
       addRandomGatewayExecutionStep(result, random, branch);
     }
     addRandomBranchExecutionSteps(context, result, branch);

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
@@ -120,6 +120,18 @@ public class ExclusiveGatewayBlockBuilder implements BlockBuilder {
     return forkGatewayId;
   }
 
+  @Override
+  public BlockBuilder findRandomStartingPlace(final Random random) {
+    final boolean shouldGoIntoNestedBlocks = random.nextBoolean();
+    if (shouldGoIntoNestedBlocks) {
+      final int index = random.nextInt(blockBuilders.size());
+      final BlockBuilder blockBuilder = blockBuilders.get(index);
+      return blockBuilder.findRandomStartingPlace(random);
+    } else {
+      return this;
+    }
+  }
+
   static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
@@ -90,9 +90,9 @@ public class ExclusiveGatewayBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment generateRandomExecutionPath(
-      final Random random, final ExecutionPathContext context) {
+  public ExecutionPathSegment generateRandomExecutionPath(final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
+    final Random random = context.getRandom();
 
     final Optional<Integer> branchContainingStartBlock =
         blockBuilders.stream()
@@ -121,7 +121,7 @@ public class ExclusiveGatewayBlockBuilder implements BlockBuilder {
 
     final BlockBuilder blockBuilder = blockBuilders.get(branch);
 
-    result.append(blockBuilder.findRandomExecutionPath(random, context));
+    result.append(blockBuilder.findRandomExecutionPath(context));
 
     return result;
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
@@ -121,9 +121,9 @@ public class ExclusiveGatewayBlockBuilder extends AbstractBlockBuilder {
       final ExecutionPathSegment result, final Random random, final int branch) {
     // If the branch is the default flow we should always add the default steps
     // If not we randomly match the condition, or throw an incident and resolve it before matching
-    final int stepNumber = isDefaultFlow(branch) ? 0 : random.nextInt(1, 3);
+    final int randomNextStepNumber = isDefaultFlow(branch) ? 0 : random.nextInt(1, 3);
     final var executionStep =
-        switch (stepNumber) {
+        switch (randomNextStepNumber) {
           case 0 -> new StepPickDefaultCase(getElementId(), gatewayConditionVariable);
           case 1 -> new StepPickConditionCase(
               getElementId(), gatewayConditionVariable, branchIds.get(branch));

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
@@ -132,15 +132,12 @@ public class ExclusiveGatewayBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public BlockBuilder findRandomStartingPlace(final Random random) {
-    final boolean shouldGoIntoNestedBlocks = random.nextBoolean();
-    if (shouldGoIntoNestedBlocks) {
-      final int index = random.nextInt(blockBuilders.size());
-      final BlockBuilder blockBuilder = blockBuilders.get(index);
-      return blockBuilder.findRandomStartingPlace(random);
-    } else {
-      return this;
-    }
+  public List<BlockBuilder> getPossibleStartingBlocks() {
+    final List<BlockBuilder> allBlockBuilders = new ArrayList<>();
+    allBlockBuilders.add(this);
+    blockBuilders.forEach(
+        blockBuilder -> allBlockBuilders.addAll(blockBuilder.getPossibleStartingBlocks()));
+    return allBlockBuilders;
   }
 
   @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
@@ -117,15 +117,19 @@ public class ExclusiveGatewayBlockBuilder extends AbstractBlockBuilder {
     return allBlockBuilders;
   }
 
-  private void addRandomGatewayExecutionStep(final ExecutionPathSegment result, final Random random, final int branch) {
+  private void addRandomGatewayExecutionStep(
+      final ExecutionPathSegment result, final Random random, final int branch) {
     // If the branch is the default flow we should always add the default steps
     // If not we randomly match the condition, or throw an incident and resolve it before matching
     final int stepNumber = isDefaultFlow(branch) ? 0 : random.nextInt(1, 3);
-    final var executionStep = switch (stepNumber) {
-      case 0 -> new StepPickDefaultCase(getElementId(), gatewayConditionVariable);
-      case 1 -> new StepPickConditionCase(getElementId(), gatewayConditionVariable, branchIds.get(branch));
-      default -> new StepRaiseIncidentThenResolveAndPickConditionCase(getElementId(), gatewayConditionVariable, branchIds.get(branch));
-    };
+    final var executionStep =
+        switch (stepNumber) {
+          case 0 -> new StepPickDefaultCase(getElementId(), gatewayConditionVariable);
+          case 1 -> new StepPickConditionCase(
+              getElementId(), gatewayConditionVariable, branchIds.get(branch));
+          default -> new StepRaiseIncidentThenResolveAndPickConditionCase(
+              getElementId(), gatewayConditionVariable, branchIds.get(branch));
+        };
     result.appendDirectSuccessor(executionStep);
   }
 
@@ -133,8 +137,8 @@ public class ExclusiveGatewayBlockBuilder extends AbstractBlockBuilder {
     return branch == 0;
   }
 
-  private void addRandomBranchExecutionSteps(final ExecutionPathContext context, final ExecutionPathSegment result,
-      final int branch) {
+  private void addRandomBranchExecutionSteps(
+      final ExecutionPathContext context, final ExecutionPathSegment result, final int branch) {
     final BlockBuilder blockBuilder = blockBuilders.get(branch);
     result.append(blockBuilder.findRandomExecutionPath(context));
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
@@ -72,11 +72,6 @@ public class IntermediateMessageCatchEventBlockBuilder implements BlockBuilder {
     return List.of(this);
   }
 
-  @Override
-  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
-    return this == blockBuilder;
-  }
-
   public static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.model.bpmn.builder.IntermediateCatchEventBuilder;
 import io.camunda.zeebe.test.util.bpmn.random.BlockBuilder;
 import io.camunda.zeebe.test.util.bpmn.random.BlockBuilderFactory;
 import io.camunda.zeebe.test.util.bpmn.random.ConstructionContext;
+import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepPublishMessage;
@@ -50,11 +51,14 @@ public class IntermediateMessageCatchEventBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment findRandomExecutionPath(final Random random) {
+  public ExecutionPathSegment findRandomExecutionPath(
+      final Random random, final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
-    result.appendDirectSuccessor(
-        new StepPublishMessage(messageName, CORRELATION_KEY_FIELD, CORRELATION_KEY_VALUE));
+    if (shouldAddExecutionPath(context)) {
+      result.appendDirectSuccessor(
+          new StepPublishMessage(messageName, CORRELATION_KEY_FIELD, CORRELATION_KEY_VALUE));
+    }
 
     return result;
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
@@ -16,30 +16,27 @@ import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepPublishMessage;
-import java.util.List;
 
 /**
  * Generates an intermediate message catch event. It waits for a message with name {@code
  * message_[id]} and a correlation key of {@code CORRELATION_KEY_VALUE}
  */
-public class IntermediateMessageCatchEventBlockBuilder implements BlockBuilder {
+public class IntermediateMessageCatchEventBlockBuilder extends AbstractBlockBuilder {
 
   public static final String CORRELATION_KEY_FIELD = "correlationKey";
   public static final String CORRELATION_KEY_VALUE = "default_correlation_key";
-
-  private final String id;
   private final String messageName;
 
   public IntermediateMessageCatchEventBlockBuilder(final IDGenerator idGenerator) {
-    id = idGenerator.nextId();
-    messageName = "message_" + id;
+    super(idGenerator.nextId());
+    messageName = "message_" + elementId;
   }
 
   @Override
   public AbstractFlowNodeBuilder<?, ?> buildFlowNodes(
       final AbstractFlowNodeBuilder<?, ?> nodeBuilder) {
 
-    final IntermediateCatchEventBuilder result = nodeBuilder.intermediateCatchEvent(id);
+    final IntermediateCatchEventBuilder result = nodeBuilder.intermediateCatchEvent(getElementId());
 
     result.message(
         messageBuilder -> {
@@ -58,16 +55,6 @@ public class IntermediateMessageCatchEventBlockBuilder implements BlockBuilder {
         new StepPublishMessage(messageName, CORRELATION_KEY_FIELD, CORRELATION_KEY_VALUE));
 
     return result;
-  }
-
-  @Override
-  public String getElementId() {
-    return id;
-  }
-
-  @Override
-  public List<BlockBuilder> getPossibleStartingBlocks() {
-    return List.of(this);
   }
 
   public static class Factory implements BlockBuilderFactory {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
@@ -51,14 +51,12 @@ public class IntermediateMessageCatchEventBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment findRandomExecutionPath(
+  public ExecutionPathSegment generateRandomExecutionPath(
       final Random random, final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
-    if (shouldAddExecutionPath(context)) {
-      result.appendDirectSuccessor(
-          new StepPublishMessage(messageName, CORRELATION_KEY_FIELD, CORRELATION_KEY_VALUE));
-    }
+    result.appendDirectSuccessor(
+        new StepPublishMessage(messageName, CORRELATION_KEY_FIELD, CORRELATION_KEY_VALUE));
 
     return result;
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
@@ -64,6 +64,11 @@ public class IntermediateMessageCatchEventBlockBuilder implements BlockBuilder {
     return id;
   }
 
+  @Override
+  public BlockBuilder findRandomStartingPlace(final Random random) {
+    return this;
+  }
+
   public static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepPublishMessage;
+import java.util.List;
 import java.util.Random;
 
 /**
@@ -67,8 +68,8 @@ public class IntermediateMessageCatchEventBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public BlockBuilder findRandomStartingPlace(final Random random) {
-    return this;
+  public List<BlockBuilder> getPossibleStartingBlocks() {
+    return List.of(this);
   }
 
   @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepPublishMessage;
 import java.util.List;
-import java.util.Random;
 
 /**
  * Generates an intermediate message catch event. It waits for a message with name {@code
@@ -52,8 +51,7 @@ public class IntermediateMessageCatchEventBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment generateRandomExecutionPath(
-      final Random random, final ExecutionPathContext context) {
+  public ExecutionPathSegment generateRandomExecutionPath(final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
     result.appendDirectSuccessor(

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
@@ -59,6 +59,11 @@ public class IntermediateMessageCatchEventBlockBuilder implements BlockBuilder {
     return result;
   }
 
+  @Override
+  public String getElementId() {
+    return id;
+  }
+
   public static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
@@ -69,6 +69,11 @@ public class IntermediateMessageCatchEventBlockBuilder implements BlockBuilder {
     return this;
   }
 
+  @Override
+  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
+    return this == blockBuilder;
+  }
+
   public static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateThrowEventBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateThrowEventBlockBuilder.java
@@ -33,12 +33,10 @@ public class IntermediateThrowEventBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment findRandomExecutionPath(
+  public ExecutionPathSegment generateRandomExecutionPath(
       final Random random, final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
-    if (shouldAddExecutionPath(context)) {
-      result.appendDirectSuccessor(new StepActivateBPMNElement(taskId));
-    }
+    result.appendDirectSuccessor(new StepActivateBPMNElement(taskId));
     return result;
   }
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateThrowEventBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateThrowEventBlockBuilder.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepActivateBPMNElement;
 import java.util.List;
-import java.util.Random;
 
 public class IntermediateThrowEventBlockBuilder implements BlockBuilder {
 
@@ -34,8 +33,7 @@ public class IntermediateThrowEventBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment generateRandomExecutionPath(
-      final Random random, final ExecutionPathContext context) {
+  public ExecutionPathSegment generateRandomExecutionPath(final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
     result.appendDirectSuccessor(new StepActivateBPMNElement(taskId));
     return result;

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateThrowEventBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateThrowEventBlockBuilder.java
@@ -38,6 +38,11 @@ public class IntermediateThrowEventBlockBuilder implements BlockBuilder {
     return result;
   }
 
+  @Override
+  public String getElementId() {
+    return taskId;
+  }
+
   static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateThrowEventBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateThrowEventBlockBuilder.java
@@ -48,6 +48,11 @@ public class IntermediateThrowEventBlockBuilder implements BlockBuilder {
     return this;
   }
 
+  @Override
+  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
+    return this == blockBuilder;
+  }
+
   static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateThrowEventBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateThrowEventBlockBuilder.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepActivateBPMNElement;
+import java.util.List;
 import java.util.Random;
 
 public class IntermediateThrowEventBlockBuilder implements BlockBuilder {
@@ -46,8 +47,8 @@ public class IntermediateThrowEventBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public BlockBuilder findRandomStartingPlace(final Random random) {
-    return this;
+  public List<BlockBuilder> getPossibleStartingBlocks() {
+    return List.of(this);
   }
 
   @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateThrowEventBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateThrowEventBlockBuilder.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
 import io.camunda.zeebe.test.util.bpmn.random.BlockBuilder;
 import io.camunda.zeebe.test.util.bpmn.random.BlockBuilderFactory;
 import io.camunda.zeebe.test.util.bpmn.random.ConstructionContext;
+import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepActivateBPMNElement;
@@ -32,9 +33,12 @@ public class IntermediateThrowEventBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment findRandomExecutionPath(final Random random) {
+  public ExecutionPathSegment findRandomExecutionPath(
+      final Random random, final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
-    result.appendDirectSuccessor(new StepActivateBPMNElement(taskId));
+    if (shouldAddExecutionPath(context)) {
+      result.appendDirectSuccessor(new StepActivateBPMNElement(taskId));
+    }
     return result;
   }
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateThrowEventBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateThrowEventBlockBuilder.java
@@ -13,40 +13,25 @@ import io.camunda.zeebe.test.util.bpmn.random.BlockBuilderFactory;
 import io.camunda.zeebe.test.util.bpmn.random.ConstructionContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
-import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepActivateBPMNElement;
-import java.util.List;
 
-public class IntermediateThrowEventBlockBuilder implements BlockBuilder {
-
-  private final String taskId;
+public class IntermediateThrowEventBlockBuilder extends AbstractBlockBuilder {
 
   public IntermediateThrowEventBlockBuilder(final ConstructionContext context) {
-    final IDGenerator idGenerator = context.getIdGenerator();
-    taskId = idGenerator.nextId();
+    super(context.getIdGenerator().nextId());
   }
 
   @Override
   public AbstractFlowNodeBuilder<?, ?> buildFlowNodes(
       final AbstractFlowNodeBuilder<?, ?> nodeBuilder) {
-    return nodeBuilder.intermediateThrowEvent(taskId).name(taskId);
+    return nodeBuilder.intermediateThrowEvent(getElementId()).name(getElementId());
   }
 
   @Override
   public ExecutionPathSegment generateRandomExecutionPath(final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
-    result.appendDirectSuccessor(new StepActivateBPMNElement(taskId));
+    result.appendDirectSuccessor(new StepActivateBPMNElement(getElementId()));
     return result;
-  }
-
-  @Override
-  public String getElementId() {
-    return taskId;
-  }
-
-  @Override
-  public List<BlockBuilder> getPossibleStartingBlocks() {
-    return List.of(this);
   }
 
   static class Factory implements BlockBuilderFactory {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateThrowEventBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateThrowEventBlockBuilder.java
@@ -43,6 +43,11 @@ public class IntermediateThrowEventBlockBuilder implements BlockBuilder {
     return taskId;
   }
 
+  @Override
+  public BlockBuilder findRandomStartingPlace(final Random random) {
+    return this;
+  }
+
   static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateThrowEventBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/IntermediateThrowEventBlockBuilder.java
@@ -51,11 +51,6 @@ public class IntermediateThrowEventBlockBuilder implements BlockBuilder {
     return List.of(this);
   }
 
-  @Override
-  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
-    return this == blockBuilder;
-  }
-
   static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/JobWorkerTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/JobWorkerTaskBlockBuilder.java
@@ -103,8 +103,7 @@ public class JobWorkerTaskBlockBuilder implements BlockBuilder {
    * activation and complete cycle. The steps before are randomly determined failed attempts.
    */
   @Override
-  public ExecutionPathSegment generateRandomExecutionPath(
-      final Random random, final ExecutionPathContext context) {
+  public ExecutionPathSegment generateRandomExecutionPath(final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
     final var activateStep = new StepActivateBPMNElement(taskId);
@@ -116,9 +115,10 @@ public class JobWorkerTaskBlockBuilder implements BlockBuilder {
           boundaryTimerEventId, AbstractExecutionStep.VIRTUALLY_INFINITE.toString());
     }
 
-    result.append(buildStepsForFailedExecutions(random));
+    result.append(buildStepsForFailedExecutions(context.getRandom()));
 
-    result.appendExecutionSuccessor(buildStepForSuccessfulExecution(random), activateStep);
+    result.appendExecutionSuccessor(
+        buildStepForSuccessfulExecution(context.getRandom()), activateStep);
 
     return result;
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/JobWorkerTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/JobWorkerTaskBlockBuilder.java
@@ -102,24 +102,22 @@ public class JobWorkerTaskBlockBuilder implements BlockBuilder {
    * activation and complete cycle. The steps before are randomly determined failed attempts.
    */
   @Override
-  public ExecutionPathSegment findRandomExecutionPath(
+  public ExecutionPathSegment generateRandomExecutionPath(
       final Random random, final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
-    if (shouldAddExecutionPath(context)) {
-      final var activateStep = new StepActivateBPMNElement(taskId);
-      result.appendDirectSuccessor(activateStep);
+    final var activateStep = new StepActivateBPMNElement(taskId);
+    result.appendDirectSuccessor(activateStep);
 
-      if (hasBoundaryTimerEvent) {
-        // set an infinite timer as default; this can be overwritten by the execution path chosen
-        result.setVariableDefault(
-            boundaryTimerEventId, AbstractExecutionStep.VIRTUALLY_INFINITE.toString());
-      }
-
-      result.append(buildStepsForFailedExecutions(random));
-
-      result.appendExecutionSuccessor(buildStepForSuccessfulExecution(random), activateStep);
+    if (hasBoundaryTimerEvent) {
+      // set an infinite timer as default; this can be overwritten by the execution path chosen
+      result.setVariableDefault(
+          boundaryTimerEventId, AbstractExecutionStep.VIRTUALLY_INFINITE.toString());
     }
+
+    result.append(buildStepsForFailedExecutions(random));
+
+    result.appendExecutionSuccessor(buildStepForSuccessfulExecution(random), activateStep);
 
     return result;
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/JobWorkerTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/JobWorkerTaskBlockBuilder.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.test.util.bpmn.random.steps.StepActivateAndTimeoutJob;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepActivateBPMNElement;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepActivateJobAndThrowError;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepTriggerTimerBoundaryEvent;
+import java.util.List;
 import java.util.Random;
 import java.util.function.Function;
 
@@ -128,8 +129,8 @@ public class JobWorkerTaskBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public BlockBuilder findRandomStartingPlace(final Random random) {
-    return this;
+  public List<BlockBuilder> getPossibleStartingBlocks() {
+    return List.of(this);
   }
 
   @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/JobWorkerTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/JobWorkerTaskBlockBuilder.java
@@ -120,6 +120,11 @@ public class JobWorkerTaskBlockBuilder implements BlockBuilder {
     return result;
   }
 
+  @Override
+  public String getElementId() {
+    return taskId;
+  }
+
   private ExecutionPathSegment buildStepsForFailedExecutions(final Random random) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/JobWorkerTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/JobWorkerTaskBlockBuilder.java
@@ -130,6 +130,11 @@ public class JobWorkerTaskBlockBuilder implements BlockBuilder {
     return this;
   }
 
+  @Override
+  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
+    return this == blockBuilder;
+  }
+
   private ExecutionPathSegment buildStepsForFailedExecutions(final Random random) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/JobWorkerTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/JobWorkerTaskBlockBuilder.java
@@ -133,11 +133,6 @@ public class JobWorkerTaskBlockBuilder implements BlockBuilder {
     return List.of(this);
   }
 
-  @Override
-  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
-    return this == blockBuilder;
-  }
-
   private ExecutionPathSegment buildStepsForFailedExecutions(final Random random) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/JobWorkerTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/JobWorkerTaskBlockBuilder.java
@@ -125,6 +125,11 @@ public class JobWorkerTaskBlockBuilder implements BlockBuilder {
     return taskId;
   }
 
+  @Override
+  public BlockBuilder findRandomStartingPlace(final Random random) {
+    return this;
+  }
+
   private ExecutionPathSegment buildStepsForFailedExecutions(final Random random) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ManualTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ManualTaskBlockBuilder.java
@@ -43,6 +43,11 @@ public class ManualTaskBlockBuilder implements BlockBuilder {
     return taskId;
   }
 
+  @Override
+  public BlockBuilder findRandomStartingPlace(final Random random) {
+    return this;
+  }
+
   static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ManualTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ManualTaskBlockBuilder.java
@@ -13,40 +13,25 @@ import io.camunda.zeebe.test.util.bpmn.random.BlockBuilderFactory;
 import io.camunda.zeebe.test.util.bpmn.random.ConstructionContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
-import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepActivateBPMNElement;
-import java.util.List;
 
-public class ManualTaskBlockBuilder implements BlockBuilder {
-
-  private final String taskId;
+public class ManualTaskBlockBuilder extends AbstractBlockBuilder {
 
   public ManualTaskBlockBuilder(final ConstructionContext context) {
-    final IDGenerator idGenerator = context.getIdGenerator();
-    taskId = idGenerator.nextId();
+    super(context.getIdGenerator().nextId());
   }
 
   @Override
   public AbstractFlowNodeBuilder<?, ?> buildFlowNodes(
       final AbstractFlowNodeBuilder<?, ?> nodeBuilder) {
-    return nodeBuilder.manualTask(taskId).name(taskId);
+    return nodeBuilder.manualTask(elementId).name(elementId);
   }
 
   @Override
   public ExecutionPathSegment generateRandomExecutionPath(final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
-    result.appendDirectSuccessor(new StepActivateBPMNElement(taskId));
+    result.appendDirectSuccessor(new StepActivateBPMNElement(getElementId()));
     return result;
-  }
-
-  @Override
-  public String getElementId() {
-    return taskId;
-  }
-
-  @Override
-  public List<BlockBuilder> getPossibleStartingBlocks() {
-    return List.of(this);
   }
 
   static class Factory implements BlockBuilderFactory {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ManualTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ManualTaskBlockBuilder.java
@@ -48,6 +48,11 @@ public class ManualTaskBlockBuilder implements BlockBuilder {
     return this;
   }
 
+  @Override
+  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
+    return this == blockBuilder;
+  }
+
   static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ManualTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ManualTaskBlockBuilder.java
@@ -51,11 +51,6 @@ public class ManualTaskBlockBuilder implements BlockBuilder {
     return List.of(this);
   }
 
-  @Override
-  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
-    return this == blockBuilder;
-  }
-
   static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ManualTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ManualTaskBlockBuilder.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepActivateBPMNElement;
+import java.util.List;
 import java.util.Random;
 
 public class ManualTaskBlockBuilder implements BlockBuilder {
@@ -46,8 +47,8 @@ public class ManualTaskBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public BlockBuilder findRandomStartingPlace(final Random random) {
-    return this;
+  public List<BlockBuilder> getPossibleStartingBlocks() {
+    return List.of(this);
   }
 
   @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ManualTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ManualTaskBlockBuilder.java
@@ -38,6 +38,11 @@ public class ManualTaskBlockBuilder implements BlockBuilder {
     return result;
   }
 
+  @Override
+  public String getElementId() {
+    return taskId;
+  }
+
   static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ManualTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ManualTaskBlockBuilder.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepActivateBPMNElement;
 import java.util.List;
-import java.util.Random;
 
 public class ManualTaskBlockBuilder implements BlockBuilder {
 
@@ -34,8 +33,7 @@ public class ManualTaskBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment generateRandomExecutionPath(
-      final Random random, final ExecutionPathContext context) {
+  public ExecutionPathSegment generateRandomExecutionPath(final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
     result.appendDirectSuccessor(new StepActivateBPMNElement(taskId));
     return result;

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ManualTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ManualTaskBlockBuilder.java
@@ -33,12 +33,10 @@ public class ManualTaskBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment findRandomExecutionPath(
+  public ExecutionPathSegment generateRandomExecutionPath(
       final Random random, final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
-    if (shouldAddExecutionPath(context)) {
-      result.appendDirectSuccessor(new StepActivateBPMNElement(taskId));
-    }
+    result.appendDirectSuccessor(new StepActivateBPMNElement(taskId));
     return result;
   }
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ManualTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ManualTaskBlockBuilder.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
 import io.camunda.zeebe.test.util.bpmn.random.BlockBuilder;
 import io.camunda.zeebe.test.util.bpmn.random.BlockBuilderFactory;
 import io.camunda.zeebe.test.util.bpmn.random.ConstructionContext;
+import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepActivateBPMNElement;
@@ -32,9 +33,12 @@ public class ManualTaskBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment findRandomExecutionPath(final Random random) {
+  public ExecutionPathSegment findRandomExecutionPath(
+      final Random random, final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
-    result.appendDirectSuccessor(new StepActivateBPMNElement(taskId));
+    if (shouldAddExecutionPath(context)) {
+      result.appendDirectSuccessor(new StepActivateBPMNElement(taskId));
+    }
     return result;
   }
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
@@ -99,6 +99,18 @@ public class ParallelGatewayBlockBuilder implements BlockBuilder {
     return forkGatewayId;
   }
 
+  @Override
+  public BlockBuilder findRandomStartingPlace(final Random random) {
+    final boolean shouldGoIntoNestedBlocks = random.nextBoolean();
+    if (shouldGoIntoNestedBlocks) {
+      final int index = random.nextInt(blockBuilders.size());
+      final BlockBuilder blockBuilder = blockBuilders.get(index);
+      return blockBuilder.findRandomStartingPlace(random);
+    } else {
+      return this;
+    }
+  }
+
   // shuffles the lists together by iteratively taking the first item from one of the lists
   private void shuffleStepsFromDifferentLists(
       final Random random,

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
@@ -129,12 +129,6 @@ public class ParallelGatewayBlockBuilder implements BlockBuilder {
     return allBlockBuilders;
   }
 
-  @Override
-  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
-    final boolean contains = blockBuilders.stream().anyMatch(b -> b.equalsOrContains(blockBuilder));
-    return this == blockBuilder || contains;
-  }
-
   private BranchPointer findRandomExecutionPathForBranch(
       final Random random,
       final ExecutionPathContext context,

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
@@ -127,10 +127,10 @@ public class ParallelGatewayBlockBuilder implements BlockBuilder {
 
   private BranchPointer findRandomExecutionPathForBranch(
       final ExecutionPathContext context,
-      final ExecutionPathSegment result,
+      final ExecutionPathSegment executionPathSegment,
       final BlockBuilder blockBuilder) {
     final var branchExecutionPath = blockBuilder.findRandomExecutionPath(context);
-    result.mergeVariableDefaults(branchExecutionPath);
+    executionPathSegment.mergeVariableDefaults(branchExecutionPath);
     return new BranchPointer(branchExecutionPath.getScheduledSteps());
   }
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
@@ -94,6 +94,11 @@ public class ParallelGatewayBlockBuilder implements BlockBuilder {
     return result;
   }
 
+  @Override
+  public String getElementId() {
+    return forkGatewayId;
+  }
+
   // shuffles the lists together by iteratively taking the first item from one of the lists
   private void shuffleStepsFromDifferentLists(
       final Random random,

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
@@ -121,15 +121,12 @@ public class ParallelGatewayBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public BlockBuilder findRandomStartingPlace(final Random random) {
-    final boolean shouldGoIntoNestedBlocks = random.nextBoolean();
-    if (shouldGoIntoNestedBlocks) {
-      final int index = random.nextInt(blockBuilders.size());
-      final BlockBuilder blockBuilder = blockBuilders.get(index);
-      return blockBuilder.findRandomStartingPlace(random);
-    } else {
-      return this;
-    }
+  public List<BlockBuilder> getPossibleStartingBlocks() {
+    final List<BlockBuilder> allBlockBuilders = new ArrayList<>();
+    allBlockBuilders.add(this);
+    blockBuilders.forEach(
+        blockBuilder -> allBlockBuilders.addAll(blockBuilder.getPossibleStartingBlocks()));
+    return allBlockBuilders;
   }
 
   @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
@@ -101,7 +101,7 @@ public class ParallelGatewayBlockBuilder implements BlockBuilder {
 
   @Override
   public BlockBuilder findRandomStartingPlace(final Random random) {
-    final boolean shouldGoIntoNestedBlocks = random.nextBoolean();
+    final boolean shouldGoIntoNestedBlocks = true; // TODO random.nextBoolean();
     if (shouldGoIntoNestedBlocks) {
       final int index = random.nextInt(blockBuilders.size());
       final BlockBuilder blockBuilder = blockBuilders.get(index);
@@ -109,6 +109,12 @@ public class ParallelGatewayBlockBuilder implements BlockBuilder {
     } else {
       return this;
     }
+  }
+
+  @Override
+  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
+    final boolean contains = blockBuilders.stream().anyMatch(b -> b.equalsOrContains(blockBuilder));
+    return this == blockBuilder || contains;
   }
 
   // shuffles the lists together by iteratively taking the first item from one of the lists

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
@@ -97,9 +97,7 @@ public class ParallelGatewayBlockBuilder implements BlockBuilder {
       // make sure the execution paths of the other blocks isn't ignored.
       if (blockContainingStartBlock.isPresent()) {
         final var blockBuilder = blockContainingStartBlock.get();
-        final var branchExecutionPath = blockBuilder.findRandomExecutionPath(random, context);
-        result.mergeVariableDefaults(branchExecutionPath);
-        branchPointers.add(new BranchPointer(branchExecutionPath.getScheduledSteps()));
+        branchPointers.add(findRandomExecutionPathForBranch(random, context, result, blockBuilder));
       }
 
       branchPointers.addAll(
@@ -111,11 +109,7 @@ public class ParallelGatewayBlockBuilder implements BlockBuilder {
                     if (blockContainingStartBlock.isPresent()) {
                       context.addSecondaryStartBlockBuilder(blockBuilder);
                     }
-
-                    final var branchExecutionPath =
-                        blockBuilder.findRandomExecutionPath(random, context);
-                    result.mergeVariableDefaults(branchExecutionPath);
-                    return new BranchPointer(branchExecutionPath.getScheduledSteps());
+                    return findRandomExecutionPathForBranch(random, context, result, blockBuilder);
                   })
               .collect(Collectors.toList()));
       shuffleStepsFromDifferentLists(random, result, branchPointers);
@@ -145,6 +139,16 @@ public class ParallelGatewayBlockBuilder implements BlockBuilder {
   public boolean equalsOrContains(final BlockBuilder blockBuilder) {
     final boolean contains = blockBuilders.stream().anyMatch(b -> b.equalsOrContains(blockBuilder));
     return this == blockBuilder || contains;
+  }
+
+  private BranchPointer findRandomExecutionPathForBranch(
+      final Random random,
+      final ExecutionPathContext context,
+      final ExecutionPathSegment result,
+      final BlockBuilder blockBuilder) {
+    final var branchExecutionPath = blockBuilder.findRandomExecutionPath(random, context);
+    result.mergeVariableDefaults(branchExecutionPath);
+    return new BranchPointer(branchExecutionPath.getScheduledSteps());
   }
 
   // shuffles the lists together by iteratively taking the first item from one of the lists

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
@@ -28,7 +28,7 @@ import java.util.Random;
  */
 public class ParallelGatewayBlockBuilder implements BlockBuilder {
 
-  private final List<BlockBuilder> blockBuilders = new ArrayList<>();
+  private final List<BlockSequenceBuilder> blockBuilders = new ArrayList<>();
   private final List<String> branchIds = new ArrayList<>();
   private final String forkGatewayId;
   private final String joinGatewayId;
@@ -82,7 +82,7 @@ public class ParallelGatewayBlockBuilder implements BlockBuilder {
     final var forkingGateway = new StepActivateBPMNElement(forkGatewayId);
     result.appendDirectSuccessor(forkingGateway);
 
-    final Optional<BlockBuilder> blockContainingStartBlock =
+    final Optional<BlockSequenceBuilder> blockContainingStartBlock =
         blockBuilders.stream()
             .filter(b -> b.equalsOrContains(context.getStartAtElementId()))
             .findFirst();
@@ -97,7 +97,8 @@ public class ParallelGatewayBlockBuilder implements BlockBuilder {
       branchPointers.add(findRandomExecutionPathForBranch(context, result, blockBuilder));
       blockBuilders.stream()
           .filter(bb -> bb != blockBuilder)
-          .forEach(context::addSecondaryStartBlockBuilder);
+          .map(BlockSequenceBuilder::getFirstBlockElementId)
+          .forEach(context::addSecondaryStartElementId);
     }
 
     branchPointers.addAll(

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
@@ -84,7 +84,7 @@ public class ParallelGatewayBlockBuilder implements BlockBuilder {
 
     final Optional<BlockBuilder> blockContainingStartBlock =
         blockBuilders.stream()
-            .filter(b -> b.equalsOrContains(context.getStartAtBlockBuilder()))
+            .filter(b -> b.equalsOrContains(context.getStartAtElementId()))
             .findFirst();
 
     final List<ParallelGatewayBlockBuilder.BranchPointer> branchPointers = new ArrayList<>();
@@ -102,8 +102,7 @@ public class ParallelGatewayBlockBuilder implements BlockBuilder {
 
     branchPointers.addAll(
         blockBuilders.stream()
-            .filter(
-                blockBuilder -> !blockBuilder.equalsOrContains(context.getStartAtBlockBuilder()))
+            .filter(blockBuilder -> !blockBuilder.equalsOrContains(context.getStartAtElementId()))
             .map(blockBuilder -> findRandomExecutionPathForBranch(context, result, blockBuilder))
             .toList());
     shuffleStepsFromDifferentLists(random, result, branchPointers);

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
@@ -122,7 +122,8 @@ public final class ProcessBuilder {
   }
 
   public ExecutionPath findRandomExecutionPath(final Random random) {
-    final var startAnywhere = random.nextBoolean();
+    // Give processes a 1/3 chance to start in a random spot
+    final var startAnywhere = random.nextInt(3) == 0;
 
     final ExecutionPathContext context;
     if (startAnywhere) {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
@@ -126,12 +126,12 @@ public final class ProcessBuilder {
 
     final ExecutionPathContext context;
     if (startAnywhere) {
-      final var possibleStartingBlocks = blockBuilder.getPossibleStartingBlocks();
-      final int startBlockIndex = random.nextInt(possibleStartingBlocks.size());
-      final var startAtBlockBuilder = possibleStartingBlocks.get(startBlockIndex);
-      context = new ExecutionPathContext(startAtBlockBuilder, random);
+      final var possibleStartingElementIds = blockBuilder.getPossibleStartingElementIds();
+      final int startBlockIndex = random.nextInt(possibleStartingElementIds.size());
+      final var startAtElementId = possibleStartingElementIds.get(startBlockIndex);
+      context = new ExecutionPathContext(startAtElementId, random);
     } else {
-      context = new ExecutionPathContext(blockBuilder, random);
+      context = new ExecutionPathContext(blockBuilder.getElementId(), random);
     }
 
     final ExecutionPathSegment followingPath = blockBuilder.findRandomExecutionPath(context);

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
@@ -128,6 +128,7 @@ public final class ProcessBuilder {
     final ExecutionPathContext context;
     final ExecutionPathSegment followingPath;
     if (startAnywhere) {
+      // TODO give an equal chance to each block to be started at
       final BlockBuilder startAtBlockBuilder = blockBuilder.findRandomStartingPlace(random);
       context = new ExecutionPathContext(startAtBlockBuilder);
       followingPath = blockBuilder.findRandomExecutionPath(random, context);

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
@@ -129,13 +129,12 @@ public final class ProcessBuilder {
       final var possibleStartingBlocks = blockBuilder.getPossibleStartingBlocks();
       final int startBlockIndex = random.nextInt(possibleStartingBlocks.size());
       final var startAtBlockBuilder = possibleStartingBlocks.get(startBlockIndex);
-      context = new ExecutionPathContext(startAtBlockBuilder);
+      context = new ExecutionPathContext(startAtBlockBuilder, random);
     } else {
-      context = new ExecutionPathContext(blockBuilder);
+      context = new ExecutionPathContext(blockBuilder, random);
     }
 
-    final ExecutionPathSegment followingPath =
-        blockBuilder.findRandomExecutionPath(random, context);
+    final ExecutionPathSegment followingPath = blockBuilder.findRandomExecutionPath(context);
 
     if (hasEventSubProcess) {
       final var shouldTriggerEventSubProcess = random.nextBoolean();

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
@@ -122,18 +122,14 @@ public final class ProcessBuilder {
   }
 
   public ExecutionPath findRandomExecutionPath(final Random random) {
-    final var startAnywhere = random.nextBoolean();
+    final var startAnywhere = true; // TODO random.nextBoolean();
     String startElementId = null;
 
     final ExecutionPathSegment followingPath;
     if (startAnywhere) {
-      // TODO decide start element (filter out not-allowed elements, happens automatically)
-      final var index = random.nextInt(blockBuilder.getBlockBuilders().size());
-      final BlockBuilder startAtBlockBuilder = blockBuilder.getBlockBuilders().get(index);
+      final BlockBuilder startAtBlockBuilder = blockBuilder.findRandomStartingPlace(random);
       startElementId = startAtBlockBuilder.getElementId();
-      // TODO find random executionpath from start element
       followingPath = blockBuilder.findRandomExecutionPath(random, startAtBlockBuilder);
-      // TODO create executionstep to start PI with instructions
     } else {
       followingPath = blockBuilder.findRandomExecutionPath(random);
     }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
@@ -125,20 +125,17 @@ public final class ProcessBuilder {
     final var startAnywhere = random.nextBoolean();
 
     final ExecutionPathContext context;
-    final ExecutionPathSegment followingPath;
     if (startAnywhere) {
       final var possibleStartingBlocks = blockBuilder.getPossibleStartingBlocks();
       final int startBlockIndex = random.nextInt(possibleStartingBlocks.size());
       final var startAtBlockBuilder = possibleStartingBlocks.get(startBlockIndex);
-
       context = new ExecutionPathContext(startAtBlockBuilder);
-      followingPath = blockBuilder.findRandomExecutionPath(random, context);
     } else {
-      context = new ExecutionPathContext(blockBuilder).foundBlockBuilder();
-      followingPath =
-          blockBuilder.findRandomExecutionPath(
-              random, new ExecutionPathContext(blockBuilder).foundBlockBuilder());
+      context = new ExecutionPathContext(blockBuilder);
     }
+
+    final ExecutionPathSegment followingPath =
+        blockBuilder.findRandomExecutionPath(random, context);
 
     if (hasEventSubProcess) {
       final var shouldTriggerEventSubProcess = random.nextBoolean();

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.test.util.bpmn.random.blocks;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
-import io.camunda.zeebe.test.util.bpmn.random.BlockBuilder;
 import io.camunda.zeebe.test.util.bpmn.random.ConstructionContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPath;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
@@ -128,8 +127,10 @@ public final class ProcessBuilder {
     final ExecutionPathContext context;
     final ExecutionPathSegment followingPath;
     if (startAnywhere) {
-      // TODO give an equal chance to each block to be started at
-      final BlockBuilder startAtBlockBuilder = blockBuilder.findRandomStartingPlace(random);
+      final var possibleStartingBlocks = blockBuilder.getPossibleStartingBlocks();
+      final int startBlockIndex = random.nextInt(possibleStartingBlocks.size());
+      final var startAtBlockBuilder = possibleStartingBlocks.get(startBlockIndex);
+
       context = new ExecutionPathContext(startAtBlockBuilder);
       followingPath = blockBuilder.findRandomExecutionPath(random, context);
     } else {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ReceiveTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ReceiveTaskBlockBuilder.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepPublishMessage;
 import java.util.List;
-import java.util.Random;
 
 /**
  * Generates a receive task. It waits for a message with name {@code message_[id]} and a correlation
@@ -50,8 +49,7 @@ public class ReceiveTaskBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment generateRandomExecutionPath(
-      final Random random, final ExecutionPathContext context) {
+  public ExecutionPathSegment generateRandomExecutionPath(final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
     result.appendDirectSuccessor(

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ReceiveTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ReceiveTaskBlockBuilder.java
@@ -57,6 +57,11 @@ public class ReceiveTaskBlockBuilder implements BlockBuilder {
     return result;
   }
 
+  @Override
+  public String getElementId() {
+    return id;
+  }
+
   public static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ReceiveTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ReceiveTaskBlockBuilder.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
 import io.camunda.zeebe.test.util.bpmn.random.BlockBuilder;
 import io.camunda.zeebe.test.util.bpmn.random.BlockBuilderFactory;
 import io.camunda.zeebe.test.util.bpmn.random.ConstructionContext;
+import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepPublishMessage;
@@ -48,11 +49,14 @@ public class ReceiveTaskBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment findRandomExecutionPath(final Random random) {
+  public ExecutionPathSegment findRandomExecutionPath(
+      final Random random, final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
-    result.appendDirectSuccessor(
-        new StepPublishMessage(messageName, CORRELATION_KEY_FIELD, CORRELATION_KEY_VALUE));
+    if (shouldAddExecutionPath(context)) {
+      result.appendDirectSuccessor(
+          new StepPublishMessage(messageName, CORRELATION_KEY_FIELD, CORRELATION_KEY_VALUE));
+    }
 
     return result;
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ReceiveTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ReceiveTaskBlockBuilder.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepPublishMessage;
+import java.util.List;
 import java.util.Random;
 
 /**
@@ -65,8 +66,8 @@ public class ReceiveTaskBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public BlockBuilder findRandomStartingPlace(final Random random) {
-    return this;
+  public List<BlockBuilder> getPossibleStartingBlocks() {
+    return List.of(this);
   }
 
   @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ReceiveTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ReceiveTaskBlockBuilder.java
@@ -15,30 +15,27 @@ import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepPublishMessage;
-import java.util.List;
 
 /**
  * Generates a receive task. It waits for a message with name {@code message_[id]} and a correlation
  * key of {@code CORRELATION_KEY_VALUE}
  */
-public class ReceiveTaskBlockBuilder implements BlockBuilder {
+public class ReceiveTaskBlockBuilder extends AbstractBlockBuilder {
 
   private static final String CORRELATION_KEY_FIELD = "correlationKey";
   private static final String CORRELATION_KEY_VALUE = "default_correlation_key";
-
-  private final String id;
   private final String messageName;
 
   public ReceiveTaskBlockBuilder(final IDGenerator idGenerator) {
-    id = idGenerator.nextId();
-    messageName = "message_" + id;
+    super(idGenerator.nextId());
+    messageName = "message_" + elementId;
   }
 
   @Override
   public AbstractFlowNodeBuilder<?, ?> buildFlowNodes(
       final AbstractFlowNodeBuilder<?, ?> nodeBuilder) {
 
-    final var receiveTask = nodeBuilder.receiveTask(id);
+    final var receiveTask = nodeBuilder.receiveTask(getElementId());
     receiveTask.message(
         messageBuilder -> {
           messageBuilder.zeebeCorrelationKeyExpression(CORRELATION_KEY_FIELD);
@@ -56,16 +53,6 @@ public class ReceiveTaskBlockBuilder implements BlockBuilder {
         new StepPublishMessage(messageName, CORRELATION_KEY_FIELD, CORRELATION_KEY_VALUE));
 
     return result;
-  }
-
-  @Override
-  public String getElementId() {
-    return id;
-  }
-
-  @Override
-  public List<BlockBuilder> getPossibleStartingBlocks() {
-    return List.of(this);
   }
 
   public static class Factory implements BlockBuilderFactory {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ReceiveTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ReceiveTaskBlockBuilder.java
@@ -49,14 +49,12 @@ public class ReceiveTaskBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment findRandomExecutionPath(
+  public ExecutionPathSegment generateRandomExecutionPath(
       final Random random, final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
-    if (shouldAddExecutionPath(context)) {
-      result.appendDirectSuccessor(
-          new StepPublishMessage(messageName, CORRELATION_KEY_FIELD, CORRELATION_KEY_VALUE));
-    }
+    result.appendDirectSuccessor(
+        new StepPublishMessage(messageName, CORRELATION_KEY_FIELD, CORRELATION_KEY_VALUE));
 
     return result;
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ReceiveTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ReceiveTaskBlockBuilder.java
@@ -67,6 +67,11 @@ public class ReceiveTaskBlockBuilder implements BlockBuilder {
     return this;
   }
 
+  @Override
+  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
+    return this == blockBuilder;
+  }
+
   public static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ReceiveTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ReceiveTaskBlockBuilder.java
@@ -62,6 +62,11 @@ public class ReceiveTaskBlockBuilder implements BlockBuilder {
     return id;
   }
 
+  @Override
+  public BlockBuilder findRandomStartingPlace(final Random random) {
+    return this;
+  }
+
   public static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ReceiveTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ReceiveTaskBlockBuilder.java
@@ -70,11 +70,6 @@ public class ReceiveTaskBlockBuilder implements BlockBuilder {
     return List.of(this);
   }
 
-  @Override
-  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
-    return this == blockBuilder;
-  }
-
   public static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
@@ -123,6 +123,11 @@ public class SubProcessBlockBuilder implements BlockBuilder {
     return result;
   }
 
+  @Override
+  public String getElementId() {
+    return subProcessId;
+  }
+
   public static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
@@ -144,17 +144,6 @@ public class SubProcessBlockBuilder implements BlockBuilder {
     return blockBuilders;
   }
 
-  @Override
-  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
-    if (this == blockBuilder) {
-      return true;
-    } else if (embeddedSubProcessBuilder == null) {
-      return false;
-    } else {
-      return embeddedSubProcessBuilder.equalsOrContains(blockBuilder);
-    }
-  }
-
   public static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
@@ -128,6 +128,16 @@ public class SubProcessBlockBuilder implements BlockBuilder {
     return subProcessId;
   }
 
+  @Override
+  public BlockBuilder findRandomStartingPlace(final Random random) {
+    final boolean shouldGoIntoNestedBlocks = random.nextBoolean();
+    if (embeddedSubProcessBuilder != null && shouldGoIntoNestedBlocks) {
+      return embeddedSubProcessBuilder.findRandomStartingPlace(random);
+    } else {
+      return this;
+    }
+  }
+
   public static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
@@ -93,39 +93,37 @@ public class SubProcessBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment findRandomExecutionPath(
+  public ExecutionPathSegment generateRandomExecutionPath(
       final Random random, final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
-    if (shouldAddExecutionPath(context)) {
-      if (hasBoundaryTimerEvent) {
-        // set an infinite timer as default; this can be overwritten by the execution path chosen
-        result.setVariableDefault(
-            subProcessBoundaryTimerEventId, AbstractExecutionStep.VIRTUALLY_INFINITE.toString());
-      }
-      final var activateSubProcess = new StepActivateBPMNElement(subProcessId);
-
-      result.appendDirectSuccessor(activateSubProcess);
-
-      if (embeddedSubProcessBuilder == null) {
-        return result;
-      }
-
-      final var internalExecutionPath =
-          embeddedSubProcessBuilder.findRandomExecutionPath(random, context);
-
-      if (!hasBoundaryEvents || !internalExecutionPath.canBeInterrupted() || random.nextBoolean()) {
-        result.append(internalExecutionPath);
-      } else {
-        internalExecutionPath.cutAtRandomPosition(random);
-        result.append(internalExecutionPath);
-        if (hasBoundaryTimerEvent) {
-          result.appendExecutionSuccessor(
-              new StepTriggerTimerBoundaryEvent(subProcessBoundaryTimerEventId),
-              activateSubProcess);
-        } // extend here for other boundary events
-      }
+    if (hasBoundaryTimerEvent) {
+      // set an infinite timer as default; this can be overwritten by the execution path chosen
+      result.setVariableDefault(
+          subProcessBoundaryTimerEventId, AbstractExecutionStep.VIRTUALLY_INFINITE.toString());
     }
+    final var activateSubProcess = new StepActivateBPMNElement(subProcessId);
+
+    result.appendDirectSuccessor(activateSubProcess);
+
+    if (embeddedSubProcessBuilder == null) {
+      return result;
+    }
+
+    final var internalExecutionPath =
+        embeddedSubProcessBuilder.findRandomExecutionPath(random, context);
+
+    if (!hasBoundaryEvents || !internalExecutionPath.canBeInterrupted() || random.nextBoolean()) {
+      result.append(internalExecutionPath);
+    } else {
+      internalExecutionPath.cutAtRandomPosition(random);
+      result.append(internalExecutionPath);
+      if (hasBoundaryTimerEvent) {
+        result.appendExecutionSuccessor(
+            new StepTriggerTimerBoundaryEvent(subProcessBoundaryTimerEventId), activateSubProcess);
+      } // extend here for other boundary events
+    }
+
     return result;
   }
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
@@ -138,6 +138,17 @@ public class SubProcessBlockBuilder implements BlockBuilder {
     }
   }
 
+  @Override
+  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
+    if (this == blockBuilder) {
+      return true;
+    } else if (embeddedSubProcessBuilder == null) {
+      return false;
+    } else {
+      return embeddedSubProcessBuilder.equalsOrContains(blockBuilder);
+    }
+  }
+
   public static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
@@ -19,6 +19,8 @@ import io.camunda.zeebe.test.util.bpmn.random.RandomProcessGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.steps.AbstractExecutionStep;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepActivateBPMNElement;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepTriggerTimerBoundaryEvent;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 /**
@@ -133,13 +135,13 @@ public class SubProcessBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public BlockBuilder findRandomStartingPlace(final Random random) {
-    final boolean shouldGoIntoNestedBlocks = random.nextBoolean();
-    if (embeddedSubProcessBuilder != null && shouldGoIntoNestedBlocks) {
-      return embeddedSubProcessBuilder.findRandomStartingPlace(random);
-    } else {
-      return this;
+  public List<BlockBuilder> getPossibleStartingBlocks() {
+    final List<BlockBuilder> blockBuilders = new ArrayList<>();
+    blockBuilders.add(this);
+    if (embeddedSubProcessBuilder != null) {
+      blockBuilders.addAll(embeddedSubProcessBuilder.getPossibleStartingBlocks());
     }
+    return blockBuilders;
   }
 
   @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
@@ -95,9 +95,9 @@ public class SubProcessBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment generateRandomExecutionPath(
-      final Random random, final ExecutionPathContext context) {
+  public ExecutionPathSegment generateRandomExecutionPath(final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
+    final Random random = context.getRandom();
 
     if (hasBoundaryTimerEvent) {
       // set an infinite timer as default; this can be overwritten by the execution path chosen
@@ -112,8 +112,7 @@ public class SubProcessBlockBuilder implements BlockBuilder {
       return result;
     }
 
-    final var internalExecutionPath =
-        embeddedSubProcessBuilder.findRandomExecutionPath(random, context);
+    final var internalExecutionPath = embeddedSubProcessBuilder.findRandomExecutionPath(context);
 
     if (!hasBoundaryEvents || !internalExecutionPath.canBeInterrupted() || random.nextBoolean()) {
       result.append(internalExecutionPath);

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
@@ -73,28 +73,26 @@ public class UserTaskBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment findRandomExecutionPath(
+  public ExecutionPathSegment generateRandomExecutionPath(
       final Random random, final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
-    if (shouldAddExecutionPath(context)) {
-      final var activateStep = new StepActivateBPMNElement(taskId);
-      result.appendDirectSuccessor(activateStep);
+    final var activateStep = new StepActivateBPMNElement(taskId);
+    result.appendDirectSuccessor(activateStep);
 
-      if (hasBoundaryTimerEvent) {
-        // set an infinite timer as default; this can be overwritten by the execution path chosen
-        result.setVariableDefault(
-            boundaryTimerEventId, AbstractExecutionStep.VIRTUALLY_INFINITE.toString());
-      }
+    if (hasBoundaryTimerEvent) {
+      // set an infinite timer as default; this can be overwritten by the execution path chosen
+      result.setVariableDefault(
+          boundaryTimerEventId, AbstractExecutionStep.VIRTUALLY_INFINITE.toString());
+    }
 
-      if (hasBoundaryTimerEvent && random.nextBoolean()) {
-        result.appendExecutionSuccessor(
-            new StepTriggerTimerBoundaryEvent(boundaryTimerEventId), activateStep);
-      } else if (hasBoundaryErrorEvent && random.nextBoolean()) {
-        result.appendExecutionSuccessor(new StepThrowError(taskId, errorCode), activateStep);
-      } else {
-        result.appendExecutionSuccessor(new StepCompleteUserTask(taskId), activateStep);
-      }
+    if (hasBoundaryTimerEvent && random.nextBoolean()) {
+      result.appendExecutionSuccessor(
+          new StepTriggerTimerBoundaryEvent(boundaryTimerEventId), activateStep);
+    } else if (hasBoundaryErrorEvent && random.nextBoolean()) {
+      result.appendExecutionSuccessor(new StepThrowError(taskId, errorCode), activateStep);
+    } else {
+      result.appendExecutionSuccessor(new StepCompleteUserTask(taskId), activateStep);
     }
 
     return result;

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
@@ -109,11 +109,6 @@ public class UserTaskBlockBuilder implements BlockBuilder {
     return List.of(this);
   }
 
-  @Override
-  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
-    return this == blockBuilder;
-  }
-
   static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
@@ -105,6 +105,11 @@ public class UserTaskBlockBuilder implements BlockBuilder {
     return this;
   }
 
+  @Override
+  public boolean equalsOrContains(final BlockBuilder blockBuilder) {
+    return this == blockBuilder;
+  }
+
   static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
 import io.camunda.zeebe.test.util.bpmn.random.BlockBuilder;
 import io.camunda.zeebe.test.util.bpmn.random.BlockBuilderFactory;
 import io.camunda.zeebe.test.util.bpmn.random.ConstructionContext;
+import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.camunda.zeebe.test.util.bpmn.random.IDGenerator;
 import io.camunda.zeebe.test.util.bpmn.random.RandomProcessGenerator;
@@ -72,24 +73,28 @@ public class UserTaskBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment findRandomExecutionPath(final Random random) {
+  public ExecutionPathSegment findRandomExecutionPath(
+      final Random random, final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
-    final var activateStep = new StepActivateBPMNElement(taskId);
-    result.appendDirectSuccessor(activateStep);
 
-    if (hasBoundaryTimerEvent) {
-      // set an infinite timer as default; this can be overwritten by the execution path chosen
-      result.setVariableDefault(
-          boundaryTimerEventId, AbstractExecutionStep.VIRTUALLY_INFINITE.toString());
-    }
+    if (shouldAddExecutionPath(context)) {
+      final var activateStep = new StepActivateBPMNElement(taskId);
+      result.appendDirectSuccessor(activateStep);
 
-    if (hasBoundaryTimerEvent && random.nextBoolean()) {
-      result.appendExecutionSuccessor(
-          new StepTriggerTimerBoundaryEvent(boundaryTimerEventId), activateStep);
-    } else if (hasBoundaryErrorEvent && random.nextBoolean()) {
-      result.appendExecutionSuccessor(new StepThrowError(taskId, errorCode), activateStep);
-    } else {
-      result.appendExecutionSuccessor(new StepCompleteUserTask(taskId), activateStep);
+      if (hasBoundaryTimerEvent) {
+        // set an infinite timer as default; this can be overwritten by the execution path chosen
+        result.setVariableDefault(
+            boundaryTimerEventId, AbstractExecutionStep.VIRTUALLY_INFINITE.toString());
+      }
+
+      if (hasBoundaryTimerEvent && random.nextBoolean()) {
+        result.appendExecutionSuccessor(
+            new StepTriggerTimerBoundaryEvent(boundaryTimerEventId), activateStep);
+      } else if (hasBoundaryErrorEvent && random.nextBoolean()) {
+        result.appendExecutionSuccessor(new StepThrowError(taskId, errorCode), activateStep);
+      } else {
+        result.appendExecutionSuccessor(new StepCompleteUserTask(taskId), activateStep);
+      }
     }
 
     return result;

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
@@ -95,6 +95,11 @@ public class UserTaskBlockBuilder implements BlockBuilder {
     return result;
   }
 
+  @Override
+  public String getElementId() {
+    return taskId;
+  }
+
   static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
@@ -100,6 +100,11 @@ public class UserTaskBlockBuilder implements BlockBuilder {
     return taskId;
   }
 
+  @Override
+  public BlockBuilder findRandomStartingPlace(final Random random) {
+    return this;
+  }
+
   static class Factory implements BlockBuilderFactory {
 
     @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.test.util.bpmn.random.steps.StepActivateBPMNElement;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepCompleteUserTask;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepThrowError;
 import io.camunda.zeebe.test.util.bpmn.random.steps.StepTriggerTimerBoundaryEvent;
+import java.util.List;
 import java.util.Random;
 
 /** Generates a user task */
@@ -104,8 +105,8 @@ public class UserTaskBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public BlockBuilder findRandomStartingPlace(final Random random) {
-    return this;
+  public List<BlockBuilder> getPossibleStartingBlocks() {
+    return List.of(this);
   }
 
   @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
@@ -74,9 +74,9 @@ public class UserTaskBlockBuilder implements BlockBuilder {
   }
 
   @Override
-  public ExecutionPathSegment generateRandomExecutionPath(
-      final Random random, final ExecutionPathContext context) {
+  public ExecutionPathSegment generateRandomExecutionPath(final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
+    final Random random = context.getRandom();
 
     final var activateStep = new StepActivateBPMNElement(taskId);
     result.appendDirectSuccessor(activateStep);

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/steps/StepStartProcessInstance.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/steps/StepStartProcessInstance.java
@@ -15,10 +15,19 @@ public final class StepStartProcessInstance extends AbstractExecutionStep
     implements ProcessStartStep {
 
   private final String processId;
+  private final String startInstruction;
 
   public StepStartProcessInstance(final String processId, final Map<String, Object> variables) {
     this.processId = processId;
     this.variables.putAll(variables);
+    startInstruction = null;
+  }
+
+  public StepStartProcessInstance(
+      final String processId, final Map<String, Object> variables, final String startInstruction) {
+    this.processId = processId;
+    this.variables.putAll(variables);
+    this.startInstruction = startInstruction;
   }
 
   @Override
@@ -28,6 +37,10 @@ public final class StepStartProcessInstance extends AbstractExecutionStep
 
   public String getProcessId() {
     return processId;
+  }
+
+  public String getStartInstruction() {
+    return startInstruction;
   }
 
   @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/steps/StepStartProcessInstance.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/steps/StepStartProcessInstance.java
@@ -8,26 +8,30 @@
 package io.camunda.zeebe.test.util.bpmn.random.steps;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public final class StepStartProcessInstance extends AbstractExecutionStep
     implements ProcessStartStep {
 
   private final String processId;
-  private final String startInstruction;
+  private final List<String> startInstructions;
 
   public StepStartProcessInstance(final String processId, final Map<String, Object> variables) {
     this.processId = processId;
     this.variables.putAll(variables);
-    startInstruction = null;
+    startInstructions = new ArrayList<>();
   }
 
   public StepStartProcessInstance(
-      final String processId, final Map<String, Object> variables, final String startInstruction) {
+      final String processId,
+      final Map<String, Object> variables,
+      final List<String> startInstructions) {
     this.processId = processId;
     this.variables.putAll(variables);
-    this.startInstruction = startInstruction;
+    this.startInstructions = startInstructions;
   }
 
   @Override
@@ -39,8 +43,8 @@ public final class StepStartProcessInstance extends AbstractExecutionStep
     return processId;
   }
 
-  public String getStartInstruction() {
-    return startInstruction;
+  public List<String> getStartInstructions() {
+    return startInstructions;
   }
 
   @Override

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/steps/StepStartProcessInstance.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/steps/StepStartProcessInstance.java
@@ -17,21 +17,21 @@ public final class StepStartProcessInstance extends AbstractExecutionStep
     implements ProcessStartStep {
 
   private final String processId;
-  private final List<String> startInstructions;
+  private final List<String> startElementIds;
 
   public StepStartProcessInstance(final String processId, final Map<String, Object> variables) {
     this.processId = processId;
     this.variables.putAll(variables);
-    startInstructions = new ArrayList<>();
+    startElementIds = new ArrayList<>();
   }
 
   public StepStartProcessInstance(
       final String processId,
       final Map<String, Object> variables,
-      final List<String> startInstructions) {
+      final List<String> startElementIds) {
     this.processId = processId;
     this.variables.putAll(variables);
-    this.startInstructions = startInstructions;
+    this.startElementIds = startElementIds;
   }
 
   @Override
@@ -43,8 +43,8 @@ public final class StepStartProcessInstance extends AbstractExecutionStep
     return processId;
   }
 
-  public List<String> getStartInstructions() {
-    return startInstructions;
+  public List<String> getStartElementIds() {
+    return startElementIds;
   }
 
   @Override


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR makes the randomized tests randomly start at a random test in the process 🎲 

I would suggest reviewing this commit by commit. I have tried to explain what I do and why in the commit messages.

**Concept**
When we generate a random process all we do is create a graph of BlockBuilders. By looking at the BlockBuilders you almost see exactly what the process looks like. In the end almost all elements in a process resolves to being a single BlockBuilder.

When we want to generate an execution path there really is only 3 pieces of information we need:
1. The block we want to start at
2. Whether or not this block is part of the "branch" of BlockBuilders we are currently generating the path for
3. Whether or not this block comes after the start block in the process

Knowing this we can have a look at a simple process:
<img width="1065" alt="image" src="https://user-images.githubusercontent.com/5787702/176442280-47cabcee-f967-4ccc-90f9-61f3b82f6b3e.png">

Imagine we want to start at **task 2**. Just looking at the process we know that we want to generate execution steps for task 2 and task 4. After this the process is completed. Programmatically we can do this using the 3 pieces information we have available.

We know the start block, this is `BlockBuilder 4`. Each BlockBuilder is aware of the itself, and BlockBuilder that are nested in here. This means we can check whether or not the start block is part of the current "branch" we want to create an execution path for. In this case:

- BB1 has BB4 as a nested block
- BB2 does not have BB4 as a nested block
- BB3 has BB4 as a nested block
- BB4 is our start block
- BB5 does not have BB4 as a nested block
- BB6 does not have BB4 as a nested block

With this logic we can step-by-step create an execution path starting from the highest-level block builder (BB1):
1. Find a path for BB1. Our starting block is nested within BB1, so we should generate an execution path for this block. Since BB1 has no relevant elements (we can ignore start and end events here) it doesn't have to generate any steps itself. Since it does contain other block builders it will loop over these in order and have them all generate their execution path if required. This means that the next block generating an execution path will be BB2.
2. Find a path for BB2. BB2 != BB4 and does not contain BB4 as a nested block. It also does not appear in the process after BB4. We can ignore this block and don't need to generate an execution path for it. We continue BB1's loop and go to BB3.
3. Find a path for BB3. The starting block is nested within BB3, so we should generate an execution path for this block.Since BB3 != BB4 we can ignore the forking gateway, as it occurs before our starting block. The ExclusiveGatewayBlockBuilder contains 2 branches. A branch is nothing more than another block builder. We can check for each branch whether or not it has BB4 nested within. If it does we will generate an execution path for this branch. If it doesn't we can fully ignore this branch. This means we will now continue to find a path for BB4. BB5 will never search for a path.
4. Find a path for BB4. BB4 is our starting block! We can detect this and finally start generating execution steps. We will also set a flag to true, indicating that any remaining blocks will be behind BB4 and should also generate execution steps. After this BB1's loop will continue and we will go to BB6.
5. Find a path for BB6. BB6 != BB4, nor is BB4 nested within. However, since we turned the flag to true we know that we have already passed BB4. Therefore BB6 knows that it should generate execution steps.

In the end we will end up with a list containing all the execution steps that need to be taken. Since only BB4 and BB6 have added any steps to this list we can safely start at BB4 and the process will complete fully. Generation of variables and messing with timers is not necessary and behave the same way as it does when starting from the start event.

**Parallel gateway**
Parallel gateways are an exception to the rule. If we pretend that the exclusive gateway from the simple process is now a parallel gateway we need some different behaviour. We can nog longer ignore the branch of BB5, because if we do and we start at BB4 the process will get stuck at the joining gateway. To circumvent this the ParallelGatewayBlockBuilder does a little trick. It will first generate the path for branch containing the starting block. This will set the flag that we have passed the starting block to true. Afterwards it will generate the path for all other branches. Because the flag is set to true these branches will add all the steps that they can. Finally it will also add the first block builder of each of those remaining branches to the ExecutionPathContext. When sending the start command we can access these blocks and add the element id of the first element in this block to the start instructions. As a result we will always fully execute those branches.

**Example seeds**
Parallel gateway: TestDataRecord{processSeed=1254551919856219926, executionPathSeed=4670520203149583505}
Inside sub process: TestDataRecord{processSeed=8522066598889189009, executionPathSeed=-3761853929490812223}

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9407

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
