### PR TITLE
Fix incorrect creation_mode usage in process instance creations metric

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
@@ -73,7 +73,7 @@ public final class ProcessEngineMetrics {
   }
 
   public void processInstanceCreated(final ProcessInstanceCreationRecordValue recordValue) {
-    final CreationMode creationMode =
+    final var creationMode =
         recordValue.getStartInstructions().isEmpty()
             ? CreationMode.CREATION_AT_GIVEN_ELEMENT
             : CreationMode.CREATION_AT_DEFAULT_START_EVENT;

--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
@@ -75,8 +75,8 @@ public final class ProcessEngineMetrics {
   public void processInstanceCreated(final ProcessInstanceCreationRecordValue recordValue) {
     final var creationMode =
         recordValue.getStartInstructions().isEmpty()
-            ? CreationMode.CREATION_AT_GIVEN_ELEMENT
-            : CreationMode.CREATION_AT_DEFAULT_START_EVENT;
+            ? CreationMode.CREATION_AT_DEFAULT_START_EVENT
+            : CreationMode.CREATION_AT_GIVEN_ELEMENT;
 
     CREATED_PROCESS_INSTANCES.labels(partitionIdLabel, creationMode.toString()).inc();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.engine.metrics;
 
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
-import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.prometheus.client.Counter;
 
 public final class ProcessEngineMetrics {
@@ -72,9 +72,9 @@ public final class ProcessEngineMetrics {
     partitionIdLabel = String.valueOf(partitionId);
   }
 
-  public void processInstanceCreated(final ProcessInstanceCreationRecord record) {
+  public void processInstanceCreated(final ProcessInstanceCreationRecordValue recordValue) {
     final CreationMode creationMode =
-        record.startInstructions().isEmpty()
+        recordValue.getStartInstructions().isEmpty()
             ? CreationMode.CREATION_AT_GIVEN_ELEMENT
             : CreationMode.CREATION_AT_DEFAULT_START_EVENT;
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
@@ -59,7 +59,7 @@ public final class ProcessEngineMetrics {
           .labelNames(ACTION_LABEL, TYPE_LABEL, PARTITION_LABEL)
           .register();
   private static final String CREATION_MODE_LABEL = "creation_mode";
-  private static final Counter CREATED_PROCESS_INSTANCES =
+  static final Counter CREATED_PROCESS_INSTANCES =
       Counter.build()
           .namespace(NAMESPACE)
           .name("process_instance_creations_total")


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
A refactoring in an earlier PR accidentally flipped some boolean logic which resulted in the wrong creation_mode being used in the `process_instance_creations_total` metric. This PR re-flips this logic.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9653

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
