### PR TITLE
Do not delete a snapshot when it is reserved

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/cluster/NoopSnapshotStore.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/NoopSnapshotStore.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivedSnapshot;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.Set;
 
 class NoopSnapshotStore implements ReceivableSnapshotStore {
 
@@ -35,6 +36,11 @@ class NoopSnapshotStore implements ReceivableSnapshotStore {
   @Override
   public Optional<PersistedSnapshot> getLatestSnapshot() {
     return Optional.empty();
+  }
+
+  @Override
+  public ActorFuture<Set<PersistedSnapshot>> getAvailableSnapshots() {
+    return null;
   }
 
   @Override

--- a/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
@@ -130,9 +130,6 @@ public class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapshot {
   }
 
   @Override
-  public void delete() {}
-
-  @Override
   public Path getPath() {
     return null;
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.snapshots.ReceivedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotChunk;
 import io.camunda.zeebe.snapshots.SnapshotChunkReader;
 import io.camunda.zeebe.snapshots.SnapshotId;
+import io.camunda.zeebe.snapshots.SnapshotReservation;
 import io.camunda.zeebe.util.StringUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.nio.ByteBuffer;
@@ -149,6 +150,11 @@ public class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapshot {
   @Override
   public long getChecksum() {
     return 0;
+  }
+
+  @Override
+  public ActorFuture<SnapshotReservation> reserve() {
+    return null;
   }
 
   @Override

--- a/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotStore.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotStore.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.snapshots.ReceivedSnapshot;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -46,6 +47,11 @@ public class TestSnapshotStore implements ReceivableSnapshotStore {
   @Override
   public Optional<PersistedSnapshot> getLatestSnapshot() {
     return Optional.ofNullable(currentPersistedSnapshot.get());
+  }
+
+  @Override
+  public ActorFuture<Set<PersistedSnapshot>> getAvailableSnapshots() {
+    return null;
   }
 
   @Override

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshot.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.snapshots;
 
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.CloseableSilently;
 import java.nio.file.Path;
 
@@ -75,4 +76,18 @@ public interface PersistedSnapshot extends CloseableSilently {
    * @return the checksum of the snapshot
    */
   long getChecksum();
+
+  /**
+   * Reserves this snapshot. When the snapshot is reserved, it is not deleted until it is released.
+   * The reservation status is not persisted. After a restart the snapshot will be in state
+   * released.
+   *
+   * <p>Returns a SnapshotReservation if the snapshot exists and is successfully reserved. Fails
+   * exceptionally if the snapshot does not exist.
+   *
+   * <p>To release the reservation use {@link SnapshotReservation#release()}
+   *
+   * @return future with SnapshotReservation
+   */
+  ActorFuture<SnapshotReservation> reserve();
 }

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshot.java
@@ -49,9 +49,6 @@ public interface PersistedSnapshot extends CloseableSilently {
    */
   SnapshotChunkReader newChunkReader();
 
-  /** Deletes the snapshot. */
-  void delete();
-
   /**
    * @return a path to the snapshot location
    */

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshotStore.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.CloseableSilently;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Represents a store, which allows to persist snapshots on a storage, which is implementation
@@ -36,6 +37,13 @@ public interface PersistedSnapshotStore extends CloseableSilently {
    * @return the latest {@link PersistedSnapshot} if exists
    */
   Optional<PersistedSnapshot> getLatestSnapshot();
+
+  /**
+   * Returns a set of all available snapshots.
+   *
+   * @return
+   */
+  ActorFuture<Set<PersistedSnapshot>> getAvailableSnapshots();
 
   /**
    * Purges all ongoing pending/transient/volatile snapshots.

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotReservation.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotReservation.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.snapshots;
+
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+
+/** Returned when a snapshot is reserved * */
+public interface SnapshotReservation {
+
+  /**
+   * Releases the reservation of a snapshot.
+   *
+   * @return
+   */
+  ActorFuture<Void> release();
+}

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
@@ -7,13 +7,21 @@
  */
 package io.camunda.zeebe.snapshots.impl;
 
+import io.camunda.zeebe.scheduler.ActorControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotChunkReader;
+import io.camunda.zeebe.snapshots.SnapshotException.SnapshotNotFoundException;
+import io.camunda.zeebe.snapshots.SnapshotReservation;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,16 +34,26 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
   private final Path checksumFile;
   private final long checksum;
   private final FileBasedSnapshotMetadata metadata;
+  private final Consumer<FileBasedSnapshot> onSnapshotDeleted;
+
+  private final Set<FileBasedSnapshotReservation> reservations = new HashSet<>();
+  private final ActorControl actor;
+
+  private boolean deleted = false;
 
   FileBasedSnapshot(
       final Path directory,
       final Path checksumFile,
       final long checksum,
-      final FileBasedSnapshotMetadata metadata) {
+      final FileBasedSnapshotMetadata metadata,
+      final Consumer<FileBasedSnapshot> onSnapshotDeleted,
+      final ActorControl actor) {
     this.directory = directory;
     this.checksumFile = checksumFile;
     this.checksum = checksum;
     this.metadata = metadata;
+    this.onSnapshotDeleted = onSnapshotDeleted;
+    this.actor = actor;
   }
 
   public FileBasedSnapshotMetadata getMetadata() {
@@ -88,6 +106,9 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
     } catch (final IOException e) {
       LOGGER.warn("Failed to delete snapshot {}", directory, e);
     }
+
+    deleted = true;
+    onSnapshotDeleted.accept(this);
   }
 
   @Override
@@ -108,6 +129,26 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
   @Override
   public long getChecksum() {
     return checksum;
+  }
+
+  @Override
+  public ActorFuture<SnapshotReservation> reserve() {
+    final CompletableActorFuture<SnapshotReservation> snapshotLocked =
+        new CompletableActorFuture<>();
+    actor.run(
+        () -> {
+          if (!deleted) {
+            final FileBasedSnapshotReservation reservation = new FileBasedSnapshotReservation(this);
+            reservations.add(reservation);
+            snapshotLocked.complete(reservation);
+          } else {
+            snapshotLocked.completeExceptionally(
+                new SnapshotNotFoundException(
+                    String.format(
+                        "Expected to reserve snapshot %s, but snapshot is deleted.", getId())));
+          }
+        });
+    return snapshotLocked;
   }
 
   @Override
@@ -159,5 +200,17 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
         + ", metadata="
         + metadata
         + '}';
+  }
+
+  boolean isReserved() {
+    return !reservations.isEmpty();
+  }
+
+  ActorFuture<Void> removeReservation(final FileBasedSnapshotReservation reservation) {
+    return actor.call(
+        () -> {
+          reservations.remove(reservation);
+          return null;
+        });
   }
 }

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
@@ -93,25 +93,6 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
   }
 
   @Override
-  public void delete() {
-    // the checksum, as a mark file, should be deleted first
-    try {
-      Files.deleteIfExists(checksumFile);
-    } catch (final IOException e) {
-      LOGGER.warn("Failed to delete snapshot checksum file {}", checksumFile, e);
-    }
-
-    try {
-      FileUtil.deleteFolderIfExists(directory);
-    } catch (final IOException e) {
-      LOGGER.warn("Failed to delete snapshot {}", directory, e);
-    }
-
-    deleted = true;
-    onSnapshotDeleted.accept(this);
-  }
-
-  @Override
   public Path getPath() {
     return getDirectory();
   }
@@ -149,6 +130,24 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
           }
         });
     return snapshotLocked;
+  }
+
+  void delete() {
+    // the checksum, as a mark file, should be deleted first
+    try {
+      Files.deleteIfExists(checksumFile);
+    } catch (final IOException e) {
+      LOGGER.warn("Failed to delete snapshot checksum file {}", checksumFile, e);
+    }
+
+    try {
+      FileUtil.deleteFolderIfExists(directory);
+    } catch (final IOException e) {
+      LOGGER.warn("Failed to delete snapshot {}", directory, e);
+    }
+
+    deleted = true;
+    onSnapshotDeleted.accept(this);
   }
 
   @Override

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotReservation.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotReservation.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.snapshots.impl;
+
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.snapshots.SnapshotReservation;
+
+public class FileBasedSnapshotReservation implements SnapshotReservation {
+
+  private final FileBasedSnapshot snapshot;
+
+  public FileBasedSnapshotReservation(final FileBasedSnapshot snapshot) {
+    this.snapshot = snapshot;
+  }
+
+  @Override
+  public ActorFuture<Void> release() {
+    return snapshot.removeReservation(this);
+  }
+}

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -30,6 +30,7 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Map;
@@ -242,7 +243,7 @@ public final class FileBasedSnapshotStore extends Actor
   @Override
   public ActorFuture<Set<PersistedSnapshot>> getAvailableSnapshots() {
     // return a new set so that caller cannot modify availableSnapshot
-    return actor.call(() -> new HashSet<>(availableSnapshots));
+    return actor.call(() -> Collections.unmodifiableSet(availableSnapshots));
   }
 
   @Override

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -66,6 +66,9 @@ public final class FileBasedSnapshotStore extends Actor
   // used to write concurrently received snapshots in different pending directories
   private final AtomicLong receivingSnapshotStartCount;
   private final Set<PersistableSnapshot> pendingSnapshots = new HashSet<>();
+
+  private final Set<FileBasedSnapshot> availableSnapshots = new HashSet<>();
+
   private final String actorName;
   private final int partitionId;
 
@@ -99,7 +102,11 @@ public final class FileBasedSnapshotStore extends Actor
 
   @Override
   protected void onActorStarting() {
-    currentPersistedSnapshotRef.set(loadLatestSnapshot(snapshotsDirectory));
+    final FileBasedSnapshot latestSnapshot = loadLatestSnapshot(snapshotsDirectory);
+    currentPersistedSnapshotRef.set(latestSnapshot);
+    if (latestSnapshot != null) {
+      availableSnapshots.add(latestSnapshot);
+    }
     purgePendingSnapshotsDirectory();
   }
 
@@ -193,7 +200,13 @@ public final class FileBasedSnapshotStore extends Actor
         return null;
       }
 
-      return new FileBasedSnapshot(path, checksumPath, actualChecksum.getCombinedValue(), metadata);
+      return new FileBasedSnapshot(
+          path,
+          checksumPath,
+          actualChecksum.getCombinedValue(),
+          metadata,
+          this::onSnapshotDeleted,
+          actor);
     } catch (final Exception e) {
       LOGGER.warn("Could not load snapshot in {}", path, e);
       return null;
@@ -224,6 +237,12 @@ public final class FileBasedSnapshotStore extends Actor
   @Override
   public Optional<PersistedSnapshot> getLatestSnapshot() {
     return Optional.ofNullable(currentPersistedSnapshotRef.get());
+  }
+
+  @Override
+  public ActorFuture<Set<PersistedSnapshot>> getAvailableSnapshots() {
+    // return a new set so that caller cannot modify availableSnapshot
+    return actor.call(() -> new HashSet<>(availableSnapshots));
   }
 
   @Override
@@ -499,7 +518,12 @@ public final class FileBasedSnapshotStore extends Actor
 
     final var newPersistedSnapshot =
         new FileBasedSnapshot(
-            destination, checksumPath, actualChecksum.getCombinedValue(), metadata);
+            destination,
+            checksumPath,
+            actualChecksum.getCombinedValue(),
+            metadata,
+            this::onSnapshotDeleted,
+            actor);
     final var failed =
         !currentPersistedSnapshotRef.compareAndSet(currentPersistedSnapshot, newPersistedSnapshot);
     if (failed) {
@@ -515,25 +539,35 @@ public final class FileBasedSnapshotStore extends Actor
               currentPersistedSnapshotRef.get()));
     }
 
+    availableSnapshots.add(newPersistedSnapshot);
+
     LOGGER.info("Committed new snapshot {}", newPersistedSnapshot.getId());
 
     snapshotMetrics.incrementSnapshotCount();
     observeSnapshotSize(newPersistedSnapshot);
 
-    LOGGER.trace(
-        "Purging snapshots older than {}",
-        newPersistedSnapshot.getMetadata().getSnapshotIdAsString());
-    if (currentPersistedSnapshot != null) {
-      LOGGER.debug(
-          "Deleting previous snapshot {}",
-          currentPersistedSnapshot.getMetadata().getSnapshotIdAsString());
-      currentPersistedSnapshot.delete();
-    }
-    purgePendingSnapshots(newPersistedSnapshot.getMetadata());
+    deleteOlderSnapshots(newPersistedSnapshot);
 
     listeners.forEach(listener -> listener.onNewSnapshot(newPersistedSnapshot));
 
     return newPersistedSnapshot;
+  }
+
+  private void deleteOlderSnapshots(final FileBasedSnapshot newPersistedSnapshot) {
+    LOGGER.trace(
+        "Purging snapshots older than {}",
+        newPersistedSnapshot.getMetadata().getSnapshotIdAsString());
+    final var snapshotsToDelete =
+        availableSnapshots.stream()
+            .filter(s -> !s.getId().equals(newPersistedSnapshot.getId()))
+            .filter(s -> !s.isReserved())
+            .toList();
+    snapshotsToDelete.forEach(
+        previousSnapshot -> {
+          LOGGER.debug("Deleting previous snapshot {}", previousSnapshot.getId());
+          previousSnapshot.delete();
+        });
+    purgePendingSnapshots(newPersistedSnapshot.getMetadata());
   }
 
   private void moveToSnapshotDirectory(final Path directory, final Path destination) {
@@ -596,5 +630,9 @@ public final class FileBasedSnapshotStore extends Actor
 
   SnapshotMetrics getSnapshotMetrics() {
     return snapshotMetrics;
+  }
+
+  void onSnapshotDeleted(final FileBasedSnapshot snapshot) {
+    availableSnapshots.remove(snapshot);
   }
 }

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotTest.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.snapshots;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
 import io.camunda.zeebe.util.FileUtil;
@@ -19,7 +17,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public final class PersistedSnapshotTest {
@@ -37,20 +34,6 @@ public final class PersistedSnapshotTest {
 
     factory.createReceivableSnapshotStore(root.toPath(), partitionId);
     snapshotStore = factory.getConstructableSnapshotStore(partitionId);
-  }
-
-  @Test
-  public void shouldDeleteSnapshot() {
-    // given
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).get();
-    transientSnapshot.take(this::writeSnapshot);
-    final var persistedSnapshot = transientSnapshot.persist().join();
-
-    // when
-    persistedSnapshot.delete();
-
-    // then
-    assertThat(persistedSnapshot.getPath()).doesNotExist();
   }
 
   private boolean writeSnapshot(final Path path) {

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -169,7 +169,9 @@ public class FileBasedReceivedSnapshotTest {
             persistedSnapshot.getDirectory(),
             persistedSnapshot.getChecksumFile(),
             0xDEADBEEFL,
-            persistedSnapshot.getMetadata());
+            persistedSnapshot.getMetadata(),
+            s -> {},
+            null);
 
     // when
     final var receivedSnapshot = receiveSnapshot(corruptedSnapshot);

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -280,6 +280,7 @@ public class FileBasedSnapshotStoreTest {
     assertThat(snapshotStore.getAvailableSnapshots().join())
         .containsExactlyInAnyOrder(reservedSnapshot, newSnapshot);
     assertThat(reservedSnapshot.getPath()).exists();
+    assertThat(newSnapshot.getPath()).exists();
   }
 
   @Test
@@ -295,6 +296,7 @@ public class FileBasedSnapshotStoreTest {
     // then
     assertThat(snapshotStore.getAvailableSnapshots().join()).containsExactly(newSnapshot);
     assertThat(reservedSnapshot.getPath()).doesNotExist();
+    assertThat(newSnapshot.getPath()).exists();
   }
 
   @Test
@@ -316,6 +318,7 @@ public class FileBasedSnapshotStoreTest {
     assertThat(snapshotStore.getAvailableSnapshots().join())
         .containsExactlyInAnyOrder(reservedSnashot, newSnapshot);
     assertThat(reservedSnashot.getPath()).exists();
+    assertThat(newSnapshot.getPath()).exists();
   }
 
   private boolean createSnapshotDir(final Path path) {

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -269,6 +269,18 @@ public class FileBasedSnapshotStoreTest {
   }
 
   @Test
+  public void shouldDeleteSnapshot() {
+    // given
+    final var persistedSnapshot = (FileBasedSnapshot) takeTransientSnapshot().persist().join();
+
+    // when
+    persistedSnapshot.delete();
+
+    // then
+    assertThat(persistedSnapshot.getPath()).doesNotExist();
+  }
+
+  @Test
   public void shouldNotDeleteReservedSnapshot() {
     // given
     final var reservedSnapshot = takeTransientSnapshot(1, snapshotStore).persist().join();


### PR DESCRIPTION
## Description

To enable backups to run asynchronousle, the snapshot needed for the backup must be preserved until the backup is completed. Otherwise the backup will fail. To allow this, we expose new interfaces to the PeristedSnapshot to "reserve" and "release" the snapshot. When the snapshot is reserved, we guarantee that it won't be deleted. As a result, there are more than one valid snapshots available in PersistedSnapshotStore. 
Snapshot can be deleted once it is released. To keep it simple, we don't immediately delete the snapshot once it is released. But it will be released when a new snapshot is committed.

## Related issues

closes #9626 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
