### PR TITLE
Escalate errors in output mapping evaluation

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -80,17 +80,16 @@ import org.apache.commons.text.StringEscapeUtils;
  * <p>To account for this the expression, was amended to
  *
  * <pre>
- *  if (targetVar = null or not(is defined(outputMappingResult)) )
- *    then outputMappingResult
- *    else put all(targetVar,outputMappingResult)
+ *  if (targetVar != null and is defined(outputMappingResult))
+ *    then put all(targetVar,outputMappingResult)
+ *    else outputMappingResult
  * </pre>
  *
  * <p>This is a workaround which hopefully can be removed in the future. It first checks whether the
- * result of the output mapping is defined. If it is not defined, or if the target variable does not
- * exist, we return the raw result of the output mapping evaluation. If it is not defined, it will
- * be evaluated to an error and this error is propagated to the result of the evaluation. The put
- * all(...) method is only called if the target variable exists and the result of the output mapping
- * is defined
+ * result of the output mapping is defined, and the target variable exists. If this is true, the put
+ * all(...) method is called to merge the result into the existing target variable. In all other
+ * cases the output mapping result is returned as is. If it evaluates to en error, this error is
+ * propagated to the final result of the evaluation
  */
 public final class VariableMappingTransformer {
 
@@ -207,8 +206,8 @@ public final class VariableMappingTransformer {
     // example: x = 1 and a = {'c':2} results in a = {'b':1, 'c':2}
     final var existingContext = String.join(".", contextPath);
     return String.format(
-        "if (%s = null or not(is defined(%s)) ) then %s else put all(%s,%s)",
-        existingContext, nestedContext, nestedContext, existingContext, nestedContext);
+        "if (%s != null and is defined(%s)) then put all(%s,%s) else %s",
+        existingContext, nestedContext, existingContext, nestedContext, nestedContext);
   }
 
   private Expression parseExpression(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
@@ -135,7 +135,7 @@ public final class VariableOutputMappingTransformerTest {
       {
         List.of(mapping("x", "a.b")),
         Map.of(),
-        "failed to evaluate expression '{a:if (a = null or not(is defined({b: x})) ) then {b: x} else put all(a,{b: x})}': no variable found for name 'x'"
+        "failed to evaluate expression '{a:if (a != null and is defined({b: x})) then put all(a,{b: x}) else {b: x}}': no variable found for name 'x'"
       }, // #9543
     };
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
@@ -19,30 +19,16 @@ import io.camunda.zeebe.test.util.MsgPackUtil;
 import java.util.List;
 import java.util.Map;
 import org.agrona.DirectBuffer;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public final class VariableOutputMappingTransformerTest {
-
-  @Parameter(0)
-  public List<ZeebeMapping> mappings;
-
-  @Parameter(1)
-  public Map<String, DirectBuffer> variables;
-
-  @Parameter(2)
-  public String expectedOutput;
 
   private final VariableMappingTransformer transformer = new VariableMappingTransformer();
   private final ExpressionLanguage expressionLanguage =
       ExpressionLanguageFactory.createExpressionLanguage();
 
-  @Parameters(name = "with {0} to {2}")
-  public static Object[][] parameters() {
+  public static Object[][] parametersSuccessfulEvaluationToObject() {
     return new Object[][] {
       // no mappings
       {List.of(), Map.of(), "{}"},
@@ -143,8 +129,12 @@ public final class VariableOutputMappingTransformerTest {
     };
   }
 
-  @Test
-  public void shouldApplyMappings() {
+  @ParameterizedTest(name = "{index}: with {0} to {2}")
+  @MethodSource("parametersSuccessfulEvaluationToObject")
+  public void shouldEvaluateToObject(
+      final List<ZeebeMapping> mappings,
+      final Map<String, DirectBuffer> variables,
+      final String expectedOutput) {
     // given
     final var expression = transformer.transformOutputMappings(mappings, expressionLanguage);
 


### PR DESCRIPTION
## Description

Changes the expression which merges the result of the output mapping to be consistent

## Review Hints
There are two versions of the expression. The last one is easier to comprehend, in my mind. If you like the first one better, we can just drop the last commit.

## Related issues

closes #9543

<!-- Cut-off marker
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
