### PR TITLE
fix: advertised address should fall back to configured address

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ClusterCfg.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ClusterCfg.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public final class ClusterCfg {
 
@@ -31,9 +32,9 @@ public final class ClusterCfg {
   private String clusterName = DEFAULT_CLUSTER_NAME;
   private String memberId = DEFAULT_CLUSTER_MEMBER_ID;
   private String host = DEFAULT_CLUSTER_HOST;
-  private String advertisedHost = host;
+  private String advertisedHost = null;
   private int port = DEFAULT_CLUSTER_PORT;
-  private int advertisedPort = port;
+  private Integer advertisedPort = null;
   private MembershipCfg membership = new MembershipCfg();
   private SecurityCfg security = new SecurityCfg();
   private CompressionAlgorithm messageCompression = CompressionAlgorithm.NONE;
@@ -57,11 +58,7 @@ public final class ClusterCfg {
   }
 
   public String getAdvertisedHost() {
-    if (advertisedHost == null) {
-      return getHost();
-    }
-
-    return advertisedHost;
+    return Optional.ofNullable(advertisedHost).orElseGet(this::getHost);
   }
 
   public ClusterCfg setAdvertisedHost(final String advertisedHost) {
@@ -79,7 +76,7 @@ public final class ClusterCfg {
   }
 
   public int getAdvertisedPort() {
-    return advertisedPort;
+    return Optional.ofNullable(advertisedPort).orElseGet(this::getPort);
   }
 
   public ClusterCfg setAdvertisedPort(final int advertisedPort) {

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -263,6 +263,22 @@ public final class GatewayCfgTest {
     assertThat(gatewayCfg).isEqualTo(expected);
   }
 
+  @Test
+  public void shouldFallbackIfAdvertisedAddressIsNotConfigured() {
+    // given
+    final var expectedHost = "zeebe";
+    final var expectedPort = "5432";
+    setEnv("zeebe.gateway.cluster.host", expectedHost);
+    setEnv("zeebe.gateway.cluster.port", expectedPort);
+
+    // when
+    final GatewayCfg actual = readEmptyConfig();
+
+    // then
+    assertThat(actual.getCluster().getAdvertisedHost()).isEqualTo(expectedHost);
+    assertThat(actual.getCluster().getAdvertisedPort()).isEqualTo(Integer.parseInt(expectedPort));
+  }
+
   private void setEnv(final String key, final String value) {
     environment.put(key, value);
   }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
@@ -69,8 +69,7 @@ final class LongPollingIT {
             .withEmbeddedGateway(false)
             .withPartitionsCount(3)
             .withReplicationFactor(1)
-            .withBrokerImage(ZeebeTestContainerDefaults.defaultTestImage())
-            .withGatewayImage(ZeebeTestContainerDefaults.defaultTestImage())
+            .withImage(ZeebeTestContainerDefaults.defaultTestImage())
             .build();
     cluster.start();
     final var zeebeClient = cluster.newClientBuilder().build();

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering;
+
+import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
+import io.camunda.zeebe.test.util.testcontainers.ZeebeTestContainerDefaults;
+import io.zeebe.containers.cluster.ZeebeCluster;
+import java.time.Duration;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import org.agrona.CloseHelper;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
+
+final class LongPollingIT {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LongPollingIT.class);
+  private static final BpmnModelInstance PROCESS =
+      Bpmn.createExecutableProcess("process")
+          .startEvent()
+          .serviceTask("task", t -> t.zeebeJobType("foo"))
+          .endEvent()
+          .done();
+
+  private Network network;
+  private ZeebeCluster cluster;
+
+  @SuppressWarnings("unused")
+  @RegisterExtension
+  final ContainerLogsDumper gatewayLogsWatcher =
+      new ContainerLogsDumper(() -> cluster.getGateways(), LOGGER);
+
+  @SuppressWarnings("unused")
+  @RegisterExtension
+  final ContainerLogsDumper brokerLogsWatcher =
+      new ContainerLogsDumper(() -> cluster.getBrokers(), LOGGER);
+
+  @BeforeEach
+  void beforeEach() {
+    network = Network.newNetwork();
+  }
+
+  @AfterEach
+  void afterEach() {
+    CloseHelper.quietCloseAll(cluster, network);
+  }
+
+  // regression test of https://github.com/camunda/zeebe/issues/9658
+  @Test
+  void shouldActivateAndCompleteJobsInTime() {
+    // given
+    cluster =
+        ZeebeCluster.builder()
+            .withBrokersCount(1)
+            .withGatewaysCount(1)
+            .withEmbeddedGateway(false)
+            .withPartitionsCount(3)
+            .withReplicationFactor(1)
+            .withBrokerImage(ZeebeTestContainerDefaults.defaultTestImage())
+            .withGatewayImage(ZeebeTestContainerDefaults.defaultTestImage())
+            .build();
+    cluster.start();
+    final var zeebeClient = cluster.newClientBuilder().build();
+    final var deploymentEvent =
+        zeebeClient
+            .newDeployResourceCommand()
+            .addProcessModel(PROCESS, "process.bpmn")
+            .send()
+            .join();
+    // open the worker first and cause so to run into long polling mode
+    zeebeClient
+        .newWorker()
+        .jobType("foo")
+        .handler((c, j) -> c.newCompleteCommand(j).send())
+        .timeout(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(10))
+        .open();
+
+    // when
+    final var resultZeebeFuture =
+        zeebeClient
+            .newCreateInstanceCommand()
+            .processDefinitionKey(deploymentEvent.getProcesses().get(0).getProcessDefinitionKey())
+            .withResult()
+            .send();
+
+    // then
+    Assertions.assertThat((CompletionStage<ProcessInstanceResult>) resultZeebeFuture)
+        .succeedsWithin(2, TimeUnit.SECONDS)
+        .isNotNull();
+  }
+}


### PR DESCRIPTION
## Description

Since we introduced support for advertised addresses in the gateway in #9572, the atomix communication services were bound to the default host and port (0.0.0.0:26502) if no advertised address was configured instead of falling back to the configured host and port first. 

## Related issues

closes #9658 because job available notifications were not received which caused the delay in job activation.

