### PR TITLE
Fix duplicate start instructions in compact record logger

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.engine.metrics;
 
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
-import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.prometheus.client.Counter;
 
 public final class ProcessEngineMetrics {
@@ -72,11 +72,11 @@ public final class ProcessEngineMetrics {
     partitionIdLabel = String.valueOf(partitionId);
   }
 
-  public void processInstanceCreated(final ProcessInstanceCreationRecordValue recordValue) {
+  public void processInstanceCreated(final ProcessInstanceCreationRecord instanceCreationRecord) {
     final var creationMode =
-        recordValue.getStartInstructions().isEmpty()
-            ? CreationMode.CREATION_AT_DEFAULT_START_EVENT
-            : CreationMode.CREATION_AT_GIVEN_ELEMENT;
+        instanceCreationRecord.hasStartInstructions()
+            ? CreationMode.CREATION_AT_GIVEN_ELEMENT
+            : CreationMode.CREATION_AT_DEFAULT_START_EVENT;
 
     CREATED_PROCESS_INSTANCES.labels(partitionIdLabel, creationMode.toString()).inc();
   }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
@@ -99,6 +99,11 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
     return this;
   }
 
+  @JsonIgnore
+  public boolean hasStartInstructions() {
+    return !startInstructionsProperty.isEmpty();
+  }
+
   @Override
   public long getProcessInstanceKey() {
     return processInstanceKeyProperty.getValue();

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 
 public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
@@ -73,7 +72,16 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
 
   @Override
   public List<ProcessInstanceCreationStartInstructionValue> getStartInstructions() {
-    return startInstructionsProperty.stream().collect(Collectors.toList());
+    // we need to make a copy of each element in the ArrayProperty while iterating it because the
+    // inner values are updated during the iteration
+    return startInstructionsProperty.stream()
+        .map(
+            element -> {
+              final var elementCopy = new ProcessInstanceCreationStartInstruction();
+              elementCopy.copy(element);
+              return (ProcessInstanceCreationStartInstructionValue) elementCopy;
+            })
+        .toList();
   }
 
   public ProcessInstanceCreationRecord setVersion(final int version) {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationStartInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationStartInstruction.java
@@ -44,7 +44,7 @@ public final class ProcessInstanceCreationStartInstruction extends ObjectValue
     return this;
   }
 
-  public void copy(final ProcessInstanceCreationStartInstruction startInstruction) {
+  public void copy(final ProcessInstanceCreationStartInstructionValue startInstruction) {
     setElementId(startInstruction.getElementId());
   }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceCreationRecordValue.java
@@ -39,9 +39,7 @@ public interface ProcessInstanceCreationRecordValue
    */
   long getProcessDefinitionKey();
 
-  /**
-   * @return list of start instructions (if available), or an empty list
-   */
+  /** Returns a list of start instructions (if available), or an empty list. */
   List<ProcessInstanceCreationStartInstructionValue> getStartInstructions();
 
   @Value.Immutable


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The compact record logger was printing the same element in the start instructions of the create process instance record. This happens due to a non-optimal implementation of Iterable in the ArrayProperty and ArrayValue that was not taken into account.

The ArrayProperty and ArrayValue classes don't provide a copy of the iterated object but rather provide the internal value that they're pointing at, at that time. So when the iterator is asked for `next()` it points its internal value to the next element. If the iterable consumer stores the value then it will also point to the next element. Using the `stream`, `forEach`, `iterator` or `spliterator` methods (and potentially even some others) is thus not safe for this type of element collecting. Instead, we need to make copies of the objects. 

This PR fixes the duplicate start instructions printed by the compact record logger, by copying the start instructions to collect them into a list. It also removes the usage of this method from the production code.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9656

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
