### PR TITLE
feat(engine): support cron expression for timer cycle.

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -106,6 +106,11 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.cronutils</groupId>
+      <artifactId>cron-utils</artifactId>
+    </dependency>
+
     <!-- TEST DEPENDENCIES -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/CatchEventTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/CatchEventTransformer.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMes
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
+import io.camunda.zeebe.engine.processing.timer.CronTimer;
 import io.camunda.zeebe.model.bpmn.instance.CatchEvent;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
@@ -98,7 +99,13 @@ public final class CatchEventTransformer implements ModelElementTransformer<Catc
             try {
               return expressionProcessor
                   .evaluateStringExpression(expression, scopeKey)
-                  .map(RepeatingInterval::parse);
+                  .map(
+                      text -> {
+                        if (text.startsWith("R")) {
+                          return RepeatingInterval.parse(text);
+                        }
+                        return CronTimer.parse(text);
+                      });
             } catch (final DateTimeParseException e) {
               // todo(#4323): replace this caught exception with Either
               return Either.left(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/TimerCatchEventExpressionValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/TimerCatchEventExpressionValidator.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.timer.CronTimer;
 import io.camunda.zeebe.model.bpmn.instance.CatchEvent;
 import io.camunda.zeebe.model.bpmn.instance.Process;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
@@ -89,7 +90,13 @@ public class TimerCatchEventExpressionValidator implements ModelElementValidator
         try {
           return expressionProcessor
               .evaluateStringExpression(expression, NO_VARIABLE_SCOPE)
-              .map(RepeatingInterval::parse)
+              .map(
+                  text -> {
+                    if (text.startsWith("R")) {
+                      return RepeatingInterval.parse(text);
+                    }
+                    return CronTimer.parse(text);
+                  })
               .mapLeft(wrapFailure("cycle"));
         } catch (final DateTimeParseException e) {
           final var failureDetails = new Failure(e.getMessage());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/CronTimer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/CronTimer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.timer;
+
+import com.cronutils.model.Cron;
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.model.time.ExecutionTime;
+import com.cronutils.parser.CronParser;
+import io.camunda.zeebe.model.bpmn.util.time.Interval;
+import io.camunda.zeebe.model.bpmn.util.time.Timer;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Objects;
+
+public class CronTimer implements Timer {
+
+  private final Cron cron;
+
+  private int repetitions;
+
+  public CronTimer(final Cron cron) {
+    this.cron = cron;
+  }
+
+  @Override
+  public Interval getInterval() {
+    return null;
+  }
+
+  @Override
+  public int getRepetitions() {
+    return repetitions;
+  }
+
+  @Override
+  public long getDueDate(final long fromEpochMilli) {
+    // set default value to -1
+    repetitions = -1;
+
+    final var next =
+        ExecutionTime.forCron(cron)
+            .nextExecution(
+                ZonedDateTime.ofInstant(
+                    Instant.ofEpochMilli(fromEpochMilli), ZoneId.systemDefault()))
+            .map(ZonedDateTime::toInstant)
+            .map(Instant::toEpochMilli);
+
+    // set `repetitions` to 0 when the next execution time does not exist
+    if (next.isEmpty()) {
+      repetitions = 0;
+    }
+
+    return next.orElse(fromEpochMilli);
+  }
+
+  public static CronTimer parse(final String text) {
+    try {
+      final var cron =
+          new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.SPRING53))
+              .parse(text);
+      return new CronTimer(cron);
+    } catch (final IllegalArgumentException | NullPointerException ex) {
+      throw new DateTimeParseException(ex.getMessage(), Objects.requireNonNullElse(text, ""), 0);
+    }
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/TimerValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/TimerValidationTest.java
@@ -32,10 +32,7 @@ public final class TimerValidationTest {
     final var process = timerEventBuilder.timerWithCycle("foo").done();
 
     ProcessValidationUtil.validateProcess(
-        process,
-        expect(
-            timerEventElementId,
-            "Invalid timer cycle expression (Repetition spec must start with R)"));
+        process, expect(timerEventElementId, "Invalid timer cycle expression"));
   }
 
   @ParameterizedTest(name = "[{index}] {0}")

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/CronTimerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/CronTimerTest.java
@@ -1,0 +1,470 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.timer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import org.junit.Test;
+
+public class CronTimerTest {
+
+  @Test
+  public void shouldFailToParseIfWrongExpression() {
+    assertThatThrownBy(() -> CronTimer.parse(null)).isInstanceOf(DateTimeParseException.class);
+    assertThatThrownBy(() -> CronTimer.parse("")).isInstanceOf(DateTimeParseException.class);
+    assertThatThrownBy(() -> CronTimer.parse("*")).isInstanceOf(DateTimeParseException.class);
+    assertThatThrownBy(() -> CronTimer.parse("* * * * *"))
+        .isInstanceOf(DateTimeParseException.class);
+    assertThatThrownBy(() -> CronTimer.parse("* * * * * * *"))
+        .isInstanceOf(DateTimeParseException.class);
+
+    // second range [0, 59]
+    assertThatThrownBy(() -> CronTimer.parse("60 * * * * *"))
+        .isInstanceOf(DateTimeParseException.class);
+    assertThatThrownBy(() -> CronTimer.parse("20-10 * * * * *"))
+        .isInstanceOf(DateTimeParseException.class);
+
+    // minute range [0, 59]
+    assertThatThrownBy(() -> CronTimer.parse("* 60 * * * *"))
+        .isInstanceOf(DateTimeParseException.class);
+    assertThatThrownBy(() -> CronTimer.parse("* 20-10 * * * *"))
+        .isInstanceOf(DateTimeParseException.class);
+
+    // hour range [0, 23]
+    assertThatThrownBy(() -> CronTimer.parse("* * 24 * * *"))
+        .isInstanceOf(DateTimeParseException.class);
+    assertThatThrownBy(() -> CronTimer.parse("* * 20-10 * * *"))
+        .isInstanceOf(DateTimeParseException.class);
+
+    // day range [1, 31]
+    assertThatThrownBy(() -> CronTimer.parse("* * * 0 * *"))
+        .isInstanceOf(DateTimeParseException.class);
+    assertThatThrownBy(() -> CronTimer.parse("* * * 32 * *"))
+        .isInstanceOf(DateTimeParseException.class);
+
+    // month range [1, 12]
+    assertThatThrownBy(() -> CronTimer.parse("* * * * 0 *"))
+        .isInstanceOf(DateTimeParseException.class);
+    assertThatThrownBy(() -> CronTimer.parse("* * * * 13 *"))
+        .isInstanceOf(DateTimeParseException.class);
+
+    // week range (0 or 7 is Sunday, or MON-SUN)
+    assertThatThrownBy(() -> CronTimer.parse("* * * * * 8"))
+        .isInstanceOf(DateTimeParseException.class);
+    assertThatThrownBy(() -> CronTimer.parse("* * * * * *SUN"))
+        .isInstanceOf(DateTimeParseException.class);
+    assertThatThrownBy(() -> CronTimer.parse("* * * * * SUN*"))
+        .isInstanceOf(DateTimeParseException.class);
+  }
+
+  @Test
+  public void shouldParseWithCronExpression() {
+    // given
+    final String text = "*/10 * * * * *";
+    final long now = System.currentTimeMillis();
+    final long expected = now + 10_000L;
+
+    // when
+    final CronTimer timer = CronTimer.parse(text);
+    final long dueDate = timer.getDueDate(now);
+
+    // then
+    assertThat(dueDate).isBetween(now, expected);
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldMatchAll() {
+    // given
+    final String text = "* * * * * *";
+    final ZonedDateTime last = ZonedDateTime.now(ZoneId.systemDefault());
+    final long expected = last.plusSeconds(1).toInstant().toEpochMilli();
+
+    // when
+    final CronTimer timer = CronTimer.parse(text);
+    final long dueDate = timer.getDueDate(last.toInstant().toEpochMilli());
+
+    // then
+    assertThat(dueDate).isEqualTo(expected);
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldMatchLastSecond() {
+    // given
+    final String text = "* * * * * *";
+    final ZonedDateTime last = ZonedDateTime.now(ZoneId.systemDefault()).withSecond(58);
+    final long expected = last.plusSeconds(1).toInstant().toEpochMilli();
+
+    // when
+    final CronTimer timer = CronTimer.parse(text);
+    final long dueDate = timer.getDueDate(last.toInstant().toEpochMilli());
+
+    // then
+    assertThat(dueDate).isEqualTo(expected);
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldMatchSpecificSecond() {
+    // given
+    final String text = "10 * * * * *";
+    final ZonedDateTime last = ZonedDateTime.now(ZoneId.systemDefault()).withSecond(9);
+    final long expected = last.withSecond(10).withNano(0).toInstant().toEpochMilli();
+
+    // when
+    final CronTimer timer = CronTimer.parse(text);
+    final long dueDate = timer.getDueDate(last.toInstant().toEpochMilli());
+
+    // then
+    assertThat(dueDate).isEqualTo(expected);
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldParseSecondRange() {
+    final String text = "10-15 * * * * *";
+    final CronTimer timer = CronTimer.parse(text);
+    final ZonedDateTime now = ZonedDateTime.now(ZoneId.systemDefault()).withNano(0);
+
+    for (int i = 9; i < 15; i++) {
+      final ZonedDateTime last = now.withSecond(i);
+      final long expected = last.plusSeconds(1).toInstant().toEpochMilli();
+      assertThat(timer.getDueDate(last.toInstant().toEpochMilli())).isEqualTo(expected);
+      assertThat(timer.getRepetitions()).isEqualTo(-1);
+    }
+  }
+
+  @Test
+  public void shouldParseSpecificMinuteSecond() {
+    // given
+    final String text = "55 5 * * * *";
+    final CronTimer timer = CronTimer.parse(text);
+    final ZonedDateTime last =
+        ZonedDateTime.now(ZoneId.systemDefault()).withMinute(4).withSecond(54);
+    long fromEpochMilli = last.toInstant().toEpochMilli();
+    final ZonedDateTime expected = last.plusMinutes(1).withSecond(55).withNano(0);
+
+    // when
+    long dueDate = timer.getDueDate(fromEpochMilli);
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+
+    // when
+    fromEpochMilli = dueDate;
+    dueDate = timer.getDueDate(fromEpochMilli);
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.plusHours(1).toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldParseSpecificHourSecond() {
+    // given
+    final String text = "55 * 10 * * *";
+    final CronTimer timer = CronTimer.parse(text);
+    final ZonedDateTime last = ZonedDateTime.now(ZoneId.systemDefault()).withHour(9).withSecond(54);
+    long fromEpochMilli = last.toInstant().toEpochMilli();
+    final ZonedDateTime expected = last.plusHours(1).withMinute(0).withSecond(55).withNano(0);
+
+    // when
+    long dueDate = timer.getDueDate(fromEpochMilli);
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+
+    // when
+    fromEpochMilli = dueDate;
+    dueDate = timer.getDueDate(fromEpochMilli);
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.plusMinutes(1).toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldParseSpecificMinuteHour() {
+    // given
+    final String text = "* 5 10 * * *";
+    final CronTimer timer = CronTimer.parse(text);
+    final ZonedDateTime last = ZonedDateTime.now(ZoneId.systemDefault()).withHour(9).withMinute(4);
+    long fromEpochMilli = last.toInstant().toEpochMilli();
+    final ZonedDateTime expected = last.plusHours(1).plusMinutes(1).withSecond(0).withNano(0);
+
+    // when
+    long dueDate = timer.getDueDate(fromEpochMilli);
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+
+    // when
+    fromEpochMilli = dueDate;
+    dueDate = timer.getDueDate(fromEpochMilli);
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.plusSeconds(1).toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldParseSpecificDayOfMonthSecond() {
+    // given
+    final String text = "55 * * 3 * *";
+    final CronTimer timer = CronTimer.parse(text);
+    final ZonedDateTime last =
+        ZonedDateTime.now(ZoneId.systemDefault()).withDayOfMonth(2).withSecond(54);
+    long fromEpochMilli = last.toInstant().toEpochMilli();
+    final ZonedDateTime expected =
+        last.plusDays(1).withHour(0).withMinute(0).withSecond(55).withNano(0);
+
+    // when
+    long dueDate = timer.getDueDate(fromEpochMilli);
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+
+    // when
+    fromEpochMilli = dueDate;
+    dueDate = timer.getDueDate(fromEpochMilli);
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.plusMinutes(1).toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldParseSpecificDate() {
+    // given
+    final String text = "* * * 3 11 *";
+    final CronTimer timer = CronTimer.parse(text);
+    final ZonedDateTime last =
+        ZonedDateTime.now(ZoneId.systemDefault()).withMonth(10).withDayOfMonth(2);
+    long fromEpochMilli = last.toInstant().toEpochMilli();
+    final ZonedDateTime expected =
+        last.of(last.getYear(), 11, 3, 0, 0, 0, 0, ZoneId.systemDefault());
+
+    // when
+    long dueDate = timer.getDueDate(fromEpochMilli);
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+
+    // when
+    fromEpochMilli = dueDate;
+    dueDate = timer.getDueDate(fromEpochMilli);
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.plusSeconds(1).toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldParseNonExistentSpecificDate() {
+    // given
+    final String text = "0 0 0 31 6 *";
+    final ZonedDateTime last =
+        ZonedDateTime.now(ZoneId.systemDefault()).withMonth(3).withDayOfMonth(10);
+
+    // when
+    final CronTimer timer = CronTimer.parse(text);
+    final long dueDate = timer.getDueDate(last.toInstant().toEpochMilli());
+
+    // then
+    assertThat(dueDate).isEqualTo(last.toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldParseQuartzLastDayOfMonthEveryHour() {
+    // given
+    final String text = "0 0 * L * *";
+    final CronTimer timer = CronTimer.parse(text);
+    ZonedDateTime last = ZonedDateTime.of(2022, 1, 30, 0, 1, 0, 0, ZoneId.systemDefault());
+    ZonedDateTime expected = ZonedDateTime.of(2022, 1, 31, 0, 0, 0, 0, ZoneId.systemDefault());
+
+    // when
+    long dueDate = timer.getDueDate(last.toInstant().toEpochMilli());
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+
+    // when
+    last = ZonedDateTime.of(2022, 1, 31, 1, 0, 0, 0, ZoneId.systemDefault());
+    expected = ZonedDateTime.of(2022, 1, 31, 2, 0, 0, 0, ZoneId.systemDefault());
+    dueDate = timer.getDueDate(last.toInstant().toEpochMilli());
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldParseQuartzLastDayOfMonthOffset() {
+    // L-3 =  third-to-last day of the month
+    final String text = "0 0 0 L-3 * *";
+    final CronTimer timer = CronTimer.parse(text);
+
+    final ZonedDateTime last =
+        ZonedDateTime.now(ZoneId.systemDefault()).withYear(2022).withMonth(1).withDayOfMonth(10);
+    long fromEpochMilli = last.toInstant().toEpochMilli();
+    ZonedDateTime expected =
+        ZonedDateTime.now(ZoneId.systemDefault())
+            .withYear(2022)
+            .withMonth(1)
+            .withDayOfMonth(28)
+            .withHour(0)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0);
+
+    // when
+    long dueDate = timer.getDueDate(fromEpochMilli);
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+
+    // when
+    fromEpochMilli = dueDate;
+    expected =
+        ZonedDateTime.now(ZoneId.systemDefault())
+            .withYear(2022)
+            .withMonth(2)
+            .withDayOfMonth(25)
+            .withHour(0)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0);
+    dueDate = timer.getDueDate(fromEpochMilli);
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+
+    // when
+    fromEpochMilli = dueDate;
+    expected =
+        ZonedDateTime.now(ZoneId.systemDefault())
+            .withYear(2022)
+            .withMonth(3)
+            .withDayOfMonth(28)
+            .withHour(0)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0);
+    dueDate = timer.getDueDate(fromEpochMilli);
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+
+    // when
+    fromEpochMilli = dueDate;
+    expected =
+        ZonedDateTime.now(ZoneId.systemDefault())
+            .withYear(2022)
+            .withMonth(4)
+            .withDayOfMonth(27)
+            .withHour(0)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0);
+    dueDate = timer.getDueDate(fromEpochMilli);
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldParseQuartzLastDayOfMonthOffsetEveryHour() {
+    // given
+    final String text = "0 0 * L-1 * *";
+    final CronTimer timer = CronTimer.parse(text);
+    ZonedDateTime last = ZonedDateTime.of(2022, 1, 29, 0, 1, 0, 0, ZoneId.systemDefault());
+    ZonedDateTime expected = ZonedDateTime.of(2022, 1, 30, 0, 0, 0, 0, ZoneId.systemDefault());
+
+    // when
+    long dueDate = timer.getDueDate(last.toInstant().toEpochMilli());
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+
+    // when
+    last = ZonedDateTime.of(2022, 1, 30, 1, 0, 0, 0, ZoneId.systemDefault());
+    expected = ZonedDateTime.of(2022, 1, 30, 2, 0, 0, 0, ZoneId.systemDefault());
+    dueDate = timer.getDueDate(last.toInstant().toEpochMilli());
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldParseQuartzFirstWeekdayOfMonthEveryHour() {
+    // given
+    final String text = "0 0 * 1W * *";
+    final CronTimer timer = CronTimer.parse(text);
+    ZonedDateTime last = ZonedDateTime.of(2022, 6, 29, 0, 1, 0, 0, ZoneId.systemDefault());
+    ZonedDateTime expected = ZonedDateTime.of(2022, 7, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+
+    // when
+    long dueDate = timer.getDueDate(last.toInstant().toEpochMilli());
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+
+    // when
+    last = ZonedDateTime.of(2022, 7, 1, 1, 0, 0, 0, ZoneId.systemDefault());
+    expected = ZonedDateTime.of(2022, 7, 1, 2, 0, 0, 0, ZoneId.systemDefault());
+    dueDate = timer.getDueDate(last.toInstant().toEpochMilli());
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldParseQuartzLastWeekdayOfMonthEveryHour() {
+    // given
+    final String text = "0 0 * LW * *";
+    final CronTimer timer = CronTimer.parse(text);
+    ZonedDateTime last = ZonedDateTime.of(2022, 6, 29, 0, 1, 0, 0, ZoneId.systemDefault());
+    ZonedDateTime expected = ZonedDateTime.of(2022, 6, 30, 0, 0, 0, 0, ZoneId.systemDefault());
+
+    // when
+    long dueDate = timer.getDueDate(last.toInstant().toEpochMilli());
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+
+    // when
+    last = ZonedDateTime.of(2022, 6, 30, 1, 0, 0, 0, ZoneId.systemDefault());
+    expected = ZonedDateTime.of(2022, 6, 30, 2, 0, 0, 0, ZoneId.systemDefault());
+    dueDate = timer.getDueDate(last.toInstant().toEpochMilli());
+
+    // then
+    assertThat(dueDate).isEqualTo(expected.toInstant().toEpochMilli());
+    assertThat(timer.getRepetitions()).isEqualTo(-1);
+  }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,6 +46,7 @@
     <version.commons-math>3.6.1</version.commons-math>
     <version.commons-codec>1.15</version.commons-codec>
     <version.commons-text>1.9</version.commons-text>
+    <version.cron-utils>9.2.0</version.cron-utils>
     <version.docker-java-api>3.2.13</version.docker-java-api>
     <version.elasticsearch>7.17.0</version.elasticsearch>
     <version.error-prone>2.14.0</version.error-prone>
@@ -951,6 +952,12 @@
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>${version.gson}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.cronutils</groupId>
+        <artifactId>cron-utils</artifactId>
+        <version>${version.cron-utils}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
As a user, I want to be able to set the `cron expression` for `timer cycle`.

Parse the given crontab expression  string. The string has six single space-separated time and date fields:

   <pre>
   &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; second (0-59)
   &#9474; &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; minute (0 - 59)
   &#9474; &#9474; &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; hour (0 - 23)
   &#9474; &#9474; &#9474; &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; day of the month (1 - 31)
   &#9474; &#9474; &#9474; &#9474; &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; month (1 - 12) (or JAN-DEC)
   &#9474; &#9474; &#9474; &#9474; &#9474; &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; day of the week (0 - 7)
   &#9474; &#9474; &#9474; &#9474; &#9474; &#9474;          (0 or 7 is Sunday, or MON-SUN)
   &#9474; &#9474; &#9474; &#9474; &#9474; &#9474;
   &#42; &#42; &#42; &#42; &#42; &#42;
   </pre>
     
The following rules apply:
* A field may be an asterisk (*), which always stands for "first-last". For the "day of the month" or "day of the week" fields, a question mark (?) may be used instead of an asterisk.
* Ranges of numbers are expressed by two numbers separated with a hyphen (-). The specified range is inclusive.
* Following a range (or *) with /n specifies the interval of the number's value through the range.
* English names can also be used for the "month" and "day of week" fields. Use the first three letters of the particular day or month (case does not matter).
* The "day of month" and "day of week" fields can contain a L-character, which stands for "last", and has a different meaning in each field:
  * In the "day of month" field, L stands for "the last day of the month". If followed by an negative offset (i.e. L-n), it means "nth-to-last day of the month". If followed by W (i.e. LW), it means "the last weekday of the month".
  * In the "day of week" field, L stands for "the last day of the week". If prefixed by a number or three-letter name (i.e. dL or DDDL), it means "the last day of week d (or DDD) in the month".
* The "day of month" field can be nW, which stands for "the nearest weekday to day of the month n". If n falls on * Saturday, this yields the Friday before it. If n falls on Sunday, this yields the Monday after, which also happens if n is 1 and falls on a Saturday (i.e. 1W stands for "the first weekday of the month").
* The "day of week" field can be d#n (or DDD#n), which stands for "the n-th day of week d (or DDD) in the month".

#### Example expressions:

* "0 0 * * * *" = the top of every hour of every day.
* "*/10 * * * * *" = every ten seconds.
* "0 0 8-10 * * *" = 8, 9 and 10 o'clock of every day.
* "0 0 6,19 * * *" = 6:00 AM and 7:00 PM every day.
* "0 0/30 8-10 * * *" = 8:00, 8:30, 9:00, 9:30, 10:00 and 10:30 every day.
* "0 0 9-17 * * MON-FRI" = on the hour nine-to-five weekdays
* "0 0 0 25 12 ?" = every Christmas Day at midnight
* "0 0 0 L * *" = last day of the month at midnight
* "0 0 0 L-3 * *" = third-to-last day of the month at midnight
* "0 0 0 1W * *" = first weekday of the month at midnight
* "0 0 0 LW * *" = last weekday of the month at midnight
* "0 0 0 * * 5L" = last Friday of the month at midnight
* "0 0 0 * * THUL" = last Thursday of the month at midnight
* "0 0 0 ? * 5#2" = the second Friday in the month at midnight
* "0 0 0 ? * MON#1" = the first Monday in the month at midnight
 of the month at midnight
* "0 0 0 * * 5L" = last Friday of the month at midnight
* "0 0 0 * * THUL" = last Thursday of the month at midnight
* "0 0 0 ? * 5#2" = the second Friday in the month at midnight
* "0 0 0 ? * MON#1" = the first Monday in the month at midnight
## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9673 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
