### PR TITLE
[Backport stable/1.3] Fix CLA warnings on release due to bot commits

### DIFF
--- a/.ci/scripts/release/prepare-go.sh
+++ b/.ci/scripts/release/prepare-go.sh
@@ -2,7 +2,7 @@
 
 # configure Jenkins GitHub user for GO container
 git config --global user.email "ci@camunda.com"
-git config --global user.name "${GITHUB_TOKEN_USR}"
+git config --global user.name "ci.automation[bot]"
 
 # install binary tools; these are installed under $GOPATH/bin
 # NOTE: this will not work on Go > 1.16 - instead we'll have to replace `go get -u` with

--- a/.ci/scripts/release/prepare.sh
+++ b/.ci/scripts/release/prepare.sh
@@ -10,7 +10,7 @@ git remote add origin "https://${GITHUB_TOKEN_USR}:${GITHUB_TOKEN_PSW}@github.co
 
 # configure Jenkins GitHub user for Maven container
 git config --global user.email "ci@camunda.com"
-git config --global user.name "${GITHUB_TOKEN_USR}"
+git config --global user.name "ci.automation[bot]"
 
 # setup maven central gpg keys
 gpg -q --allow-secret-key-import --import --no-tty --batch --yes "${GPG_SEC_KEY}"


### PR DESCRIPTION
# Description
Backport of #9587 to `stable/1.3`.

relates to 