### PR TITLE
Verify process can start at supported element types

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceSupportedElementTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceSupportedElementTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class CreateProcessInstanceSupportedElementTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  private static final String PROCESS_ID = "processId";
+  private static final String CHILD_PROCESS_ID = "childProcessId";
+  private static final String START_ELEMENT_ID = "startElement";
+  private static final String MESSAGE = "message";
+  private static final String JOBTYPE = "jobtype";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private final Scenario scenario;
+
+  public CreateProcessInstanceSupportedElementTest(final Scenario scenario) {
+    this.scenario = scenario;
+  }
+
+  @Parameters(name = "{0}")
+  public static Collection<Object> scenarios() {
+    return List.of(
+        new Scenario(
+            BpmnElementType.SUB_PROCESS,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess(START_ELEMENT_ID)
+                .embeddedSubProcess()
+                .startEvent()
+                .subProcessDone()
+                .done(),
+            Collections.emptyMap()),
+        new Scenario(
+            BpmnElementType.EVENT_SUB_PROCESS,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .eventSubProcess(
+                    START_ELEMENT_ID, e -> e.startEvent().timerWithDuration("PT1H").endEvent())
+                .startEvent()
+                .endEvent()
+                .done(),
+            Collections.emptyMap()),
+        new Scenario(
+            BpmnElementType.INTERMEDIATE_CATCH_EVENT,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .intermediateCatchEvent(START_ELEMENT_ID)
+                .message(b -> b.name(MESSAGE).zeebeCorrelationKeyExpression("correlationKey"))
+                .done(),
+            Map.of("correlationKey", "value")),
+        new Scenario(
+            BpmnElementType.INTERMEDIATE_THROW_EVENT,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .intermediateThrowEvent(START_ELEMENT_ID)
+                .endEvent()
+                .done(),
+            Collections.emptyMap()),
+        new Scenario(
+            BpmnElementType.END_EVENT,
+            Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent(START_ELEMENT_ID).done(),
+            Collections.emptyMap()),
+        new Scenario(
+            BpmnElementType.SERVICE_TASK,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(START_ELEMENT_ID, b -> b.zeebeJobType(JOBTYPE))
+                .done(),
+            Collections.emptyMap()),
+        new Scenario(
+            BpmnElementType.RECEIVE_TASK,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .receiveTask(START_ELEMENT_ID)
+                .message(b -> b.name(MESSAGE).zeebeCorrelationKeyExpression("correlationKey"))
+                .done(),
+            Map.of("correlationKey", "value")),
+        new Scenario(
+            BpmnElementType.USER_TASK,
+            Bpmn.createExecutableProcess(PROCESS_ID).startEvent().userTask(START_ELEMENT_ID).done(),
+            Collections.emptyMap()),
+        new Scenario(
+            BpmnElementType.MANUAL_TASK,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .manualTask(START_ELEMENT_ID)
+                .endEvent()
+                .done(),
+            Collections.emptyMap()),
+        new Scenario(
+            BpmnElementType.EXCLUSIVE_GATEWAY,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .exclusiveGateway(START_ELEMENT_ID)
+                .defaultFlow()
+                .endEvent()
+                .done(),
+            Collections.emptyMap()),
+        new Scenario(
+            BpmnElementType.PARALLEL_GATEWAY,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .parallelGateway(START_ELEMENT_ID)
+                .endEvent()
+                .done(),
+            Collections.emptyMap()),
+        new Scenario(
+            BpmnElementType.EVENT_BASED_GATEWAY,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .eventBasedGateway(START_ELEMENT_ID)
+                .intermediateCatchEvent()
+                .message(b -> b.name(MESSAGE).zeebeCorrelationKeyExpression("correlationKey"))
+                .moveToLastGateway()
+                .intermediateCatchEvent()
+                .timerWithDuration("PT1H")
+                .done(),
+            Map.of("correlationKey", "value")),
+        new Scenario(
+            BpmnElementType.MULTI_INSTANCE_BODY,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    START_ELEMENT_ID,
+                    t ->
+                        t.zeebeJobType(JOBTYPE)
+                            .multiInstance(m -> m.parallel().zeebeInputCollectionExpression("[1]")))
+                .endEvent()
+                .done(),
+            Collections.emptyMap()),
+        new Scenario(
+            BpmnElementType.CALL_ACTIVITY,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .callActivity(START_ELEMENT_ID, c -> c.zeebeProcessId(CHILD_PROCESS_ID))
+                .endEvent()
+                .done(),
+            Collections.emptyMap()),
+        new Scenario(
+            BpmnElementType.BUSINESS_RULE_TASK,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .businessRuleTask(START_ELEMENT_ID, b -> b.zeebeJobType(JOBTYPE))
+                .done(),
+            Collections.emptyMap()),
+        new Scenario(
+            BpmnElementType.SCRIPT_TASK,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .scriptTask(START_ELEMENT_ID, b -> b.zeebeJobType(JOBTYPE))
+                .done(),
+            Collections.emptyMap()),
+        new Scenario(
+            BpmnElementType.SEND_TASK,
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .sendTask(START_ELEMENT_ID, b -> b.zeebeJobType(JOBTYPE))
+                .done(),
+            Collections.emptyMap()));
+  }
+
+  @Test
+  public void testProcessInstanceCanStartAtElementType() {
+    // given
+    ENGINE.deployment().withXmlResource(scenario.modelInstance).deploy();
+    if (scenario.type == BpmnElementType.CALL_ACTIVITY) {
+      ENGINE.deployment().withXmlResource(getChildProcess()).deploy();
+    }
+
+    // when
+    final long instanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withStartInstruction(START_ELEMENT_ID)
+            .withVariables(scenario.variables)
+            .create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(instanceKey)
+                .onlyEvents()
+                .limit(
+                    r ->
+                        r.getValue().getBpmnElementType() == scenario.type
+                            && r.getIntent() == ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .extracting(record -> record.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(scenario.type, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(scenario.type, ProcessInstanceIntent.ELEMENT_ACTIVATED));
+  }
+
+  private BpmnModelInstance getChildProcess() {
+    return Bpmn.createExecutableProcess(CHILD_PROCESS_ID).startEvent().endEvent().done();
+  }
+
+  record Scenario(
+      BpmnElementType type, BpmnModelInstance modelInstance, Map<String, Object> variables) {}
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Verifies a PI can be started at specific element types. The test will deploy the process, start an instance at the desired start element and verify that it has been activated succesfully.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9621 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
