### PR TITLE
Engine abstraction - explore side effects

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -51,6 +51,7 @@ import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.ProcessingContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContextImpl;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
@@ -223,6 +224,8 @@ final class PartitionFactory {
       final SubscriptionCommandSender subscriptionCommandSender =
           new SubscriptionCommandSender(stream.getPartitionId(), partitionCommandSender);
 
+      processingContext.setSideEffectContext(new SideEffectContextImpl(subscriptionCommandSender));
+
       final LongPollingJobNotification jobsAvailableNotification =
           new LongPollingJobNotification(eventService);
 
@@ -230,7 +233,6 @@ final class PartitionFactory {
           EngineProcessors.createEngineProcessors(
               processingContext,
               localBroker.getPartitionsCount(),
-              subscriptionCommandSender,
               deploymentDistributor,
               deploymentRequestHandler,
               jobsAvailableNotification::onJobsAvailable,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentRedist
 import io.camunda.zeebe.engine.processing.incident.IncidentEventProcessors;
 import io.camunda.zeebe.engine.processing.job.JobEventProcessors;
 import io.camunda.zeebe.engine.processing.message.MessageEventProcessors;
-import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.ProcessingContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
@@ -50,7 +49,6 @@ public final class EngineProcessors {
   public static TypedRecordProcessors createEngineProcessors(
       final ProcessingContext processingContext,
       final int partitionsCount,
-      final SubscriptionCommandSender subscriptionCommandSender,
       final DeploymentDistributor deploymentDistributor,
       final DeploymentResponder deploymentResponder,
       final Consumer<String> onJobsAvailableCallback,
@@ -83,7 +81,6 @@ public final class EngineProcessors {
             zeebeState,
             zeebeState.getKeyGenerator(),
             expressionProcessor,
-            subscriptionCommandSender,
             writers.state(),
             timerChecker,
             partitionsCount);
@@ -112,12 +109,7 @@ public final class EngineProcessors {
         actor,
         deploymentDistributor,
         zeebeState.getKeyGenerator());
-    addMessageProcessors(
-        eventTriggerBehavior,
-        subscriptionCommandSender,
-        zeebeState,
-        typedRecordProcessors,
-        writers);
+    addMessageProcessors(eventTriggerBehavior, zeebeState, typedRecordProcessors, writers);
 
     final var jobMetrics = new JobMetrics(partitionId);
 
@@ -126,7 +118,6 @@ public final class EngineProcessors {
             zeebeState,
             expressionProcessor,
             typedRecordProcessors,
-            subscriptionCommandSender,
             catchEventBehavior,
             eventTriggerBehavior,
             writers,
@@ -157,7 +148,6 @@ public final class EngineProcessors {
       final MutableZeebeState zeebeState,
       final ExpressionProcessor expressionProcessor,
       final TypedRecordProcessors typedRecordProcessors,
-      final SubscriptionCommandSender subscriptionCommandSender,
       final CatchEventBehavior catchEventBehavior,
       final EventTriggerBehavior eventTriggerBehavior,
       final Writers writers,
@@ -168,7 +158,6 @@ public final class EngineProcessors {
         zeebeState,
         expressionProcessor,
         typedRecordProcessors,
-        subscriptionCommandSender,
         catchEventBehavior,
         timerChecker,
         eventTriggerBehavior,
@@ -243,15 +232,10 @@ public final class EngineProcessors {
 
   private static void addMessageProcessors(
       final EventTriggerBehavior eventTriggerBehavior,
-      final SubscriptionCommandSender subscriptionCommandSender,
       final MutableZeebeState zeebeState,
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers) {
     MessageEventProcessors.addMessageProcessors(
-        eventTriggerBehavior,
-        typedRecordProcessors,
-        zeebeState,
-        subscriptionCommandSender,
-        writers);
+        eventTriggerBehavior, typedRecordProcessors, zeebeState, writers);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSen
 import io.camunda.zeebe.engine.processing.streamprocessor.ProcessingContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
 import io.camunda.zeebe.engine.processing.variable.VariableStateEvaluationContextLookup;
@@ -89,7 +90,11 @@ public final class EngineProcessors {
 
     final var eventTriggerBehavior =
         new EventTriggerBehavior(
-            zeebeState.getKeyGenerator(), catchEventBehavior, writers, zeebeState);
+            zeebeState.getKeyGenerator(),
+            catchEventBehavior,
+            writers,
+            zeebeState,
+            processingContext.getSideEffectContext());
 
     final var eventPublicationBehavior =
         new BpmnEventPublicationBehavior(
@@ -126,7 +131,8 @@ public final class EngineProcessors {
             eventTriggerBehavior,
             writers,
             timerChecker,
-            jobMetrics);
+            jobMetrics,
+            processingContext.getSideEffectContext());
 
     JobEventProcessors.addJobProcessors(
         typedRecordProcessors,
@@ -156,7 +162,8 @@ public final class EngineProcessors {
       final EventTriggerBehavior eventTriggerBehavior,
       final Writers writers,
       final DueDateTimerChecker timerChecker,
-      final JobMetrics jobMetrics) {
+      final JobMetrics jobMetrics,
+      final SideEffectContext context) {
     return ProcessEventProcessors.addProcessProcessors(
         zeebeState,
         expressionProcessor,
@@ -166,7 +173,8 @@ public final class EngineProcessors {
         timerChecker,
         eventTriggerBehavior,
         writers,
-        jobMetrics);
+        jobMetrics,
+        context);
   }
 
   private static void addDeploymentRelatedProcessorAndServices(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.engine.processing.message.PendingProcessMessageSubscript
 import io.camunda.zeebe.engine.processing.message.ProcessMessageSubscriptionCorrelateProcessor;
 import io.camunda.zeebe.engine.processing.message.ProcessMessageSubscriptionCreateProcessor;
 import io.camunda.zeebe.engine.processing.message.ProcessMessageSubscriptionDeleteProcessor;
-import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.processinstance.CreateProcessInstanceProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.CreateProcessInstanceWithResultProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCommandProcessor;
@@ -51,7 +50,6 @@ public final class ProcessEventProcessors {
       final MutableZeebeState zeebeState,
       final ExpressionProcessor expressionProcessor,
       final TypedRecordProcessors typedRecordProcessors,
-      final SubscriptionCommandSender subscriptionCommandSender,
       final CatchEventBehavior catchEventBehavior,
       final DueDateTimerChecker timerChecker,
       final EventTriggerBehavior eventTriggerBehavior,
@@ -82,12 +80,7 @@ public final class ProcessEventProcessors {
     addBpmnStepProcessor(typedRecordProcessors, bpmnStreamProcessor);
 
     addMessageStreamProcessors(
-        typedRecordProcessors,
-        subscriptionState,
-        subscriptionCommandSender,
-        eventTriggerBehavior,
-        zeebeState,
-        writers);
+        typedRecordProcessors, subscriptionState, eventTriggerBehavior, zeebeState, writers);
     addTimerStreamProcessors(
         typedRecordProcessors,
         timerChecker,
@@ -144,7 +137,6 @@ public final class ProcessEventProcessors {
   private static void addMessageStreamProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final MutableProcessMessageSubscriptionState subscriptionState,
-      final SubscriptionCommandSender subscriptionCommandSender,
       final EventTriggerBehavior eventTriggerBehavior,
       final MutableZeebeState zeebeState,
       final Writers writers) {
@@ -158,18 +150,14 @@ public final class ProcessEventProcessors {
             ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
             ProcessMessageSubscriptionIntent.CORRELATE,
             new ProcessMessageSubscriptionCorrelateProcessor(
-                subscriptionState,
-                subscriptionCommandSender,
-                zeebeState,
-                eventTriggerBehavior,
-                writers))
+                subscriptionState, zeebeState, eventTriggerBehavior, writers))
         .onCommand(
             ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
             ProcessMessageSubscriptionIntent.DELETE,
             new ProcessMessageSubscriptionDeleteProcessor(subscriptionState, writers))
         .withListener(
             new PendingProcessMessageSubscriptionChecker(
-                subscriptionCommandSender, zeebeState.getPendingProcessMessageSubscriptionState()));
+                zeebeState.getPendingProcessMessageSubscriptionState()));
   }
 
   private static void addTimerStreamProcessors(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.engine.processing.processinstance.CreateProcessInstanceW
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCommandProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.CancelTimerProcessor;
@@ -55,7 +56,8 @@ public final class ProcessEventProcessors {
       final DueDateTimerChecker timerChecker,
       final EventTriggerBehavior eventTriggerBehavior,
       final Writers writers,
-      final JobMetrics jobMetrics) {
+      final JobMetrics jobMetrics,
+      final SideEffectContext sideEffectContext) {
     final MutableProcessMessageSubscriptionState subscriptionState =
         zeebeState.getProcessMessageSubscriptionState();
     final VariableBehavior variableBehavior =
@@ -75,7 +77,8 @@ public final class ProcessEventProcessors {
             zeebeState,
             writers,
             jobMetrics,
-            processEngineMetrics);
+            processEngineMetrics,
+            sideEffectContext);
     addBpmnStepProcessor(typedRecordProcessors, bpmnStreamProcessor);
 
     addMessageStreamProcessors(
@@ -105,7 +108,8 @@ public final class ProcessEventProcessors {
         writers,
         variableBehavior,
         catchEventBehavior,
-        processEngineMetrics);
+        processEngineMetrics,
+        sideEffectContext);
 
     return bpmnStreamProcessor;
   }
@@ -209,7 +213,8 @@ public final class ProcessEventProcessors {
       final Writers writers,
       final VariableBehavior variableBehavior,
       final CatchEventBehavior catchEventBehavior,
-      final ProcessEngineMetrics metrics) {
+      final ProcessEngineMetrics metrics,
+      final SideEffectContext sideEffectContext) {
     final MutableElementInstanceState elementInstanceState = zeebeState.getElementInstanceState();
     final KeyGenerator keyGenerator = zeebeState.getKeyGenerator();
 
@@ -220,7 +225,8 @@ public final class ProcessEventProcessors {
             writers,
             variableBehavior,
             catchEventBehavior,
-            metrics);
+            metrics,
+            sideEffectContext);
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationIntent.CREATE, createProcessor);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectQueue;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -57,7 +58,8 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
       final MutableZeebeState zeebeState,
       final Writers writers,
       final JobMetrics jobMetrics,
-      final ProcessEngineMetrics processEngineMetrics) {
+      final ProcessEngineMetrics processEngineMetrics,
+      final SideEffectContext sideEffectContext) {
     processState = zeebeState.getProcessState();
 
     final var bpmnBehaviors =
@@ -71,7 +73,8 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
             this::getContainerProcessor,
             writers,
             jobMetrics,
-            processEngineMetrics);
+            processEngineMetrics,
+            sideEffectContext);
     rejectionWriter = writers.rejection();
     incidentBehavior = bpmnBehaviors.incidentBehavior();
     processors = new BpmnElementProcessors(bpmnBehaviors);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffects;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -52,7 +53,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
           processorLookup,
       final Writers writers,
       final JobMetrics jobMetrics,
-      final ProcessEngineMetrics processEngineMetrics) {
+      final ProcessEngineMetrics processEngineMetrics,
+      final SideEffectContext sideEffectContext) {
 
     final StateWriter stateWriter = writers.state();
     final var commandWriter = writers.command();
@@ -94,7 +96,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
         new BpmnEventPublicationBehavior(
             zeebeState, zeebeState.getKeyGenerator(), eventTriggerBehavior, writers);
     processResultSenderBehavior =
-        new BpmnProcessResultSenderBehavior(zeebeState, writers.response());
+        new BpmnProcessResultSenderBehavior(zeebeState, writers.response(), sideEffectContext);
     bufferedMessageStartEventBehavior =
         new BpmnBufferedMessageStartEventBehavior(
             zeebeState, zeebeState.getKeyGenerator(), eventTriggerBehavior, writers);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessResultSenderBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessResultSenderBehavior.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.cloneBuffer;
 
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnProcessingException;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
@@ -32,11 +33,16 @@ public final class BpmnProcessResultSenderBehavior {
   private final VariableState variableState;
   private final TypedResponseWriter responseWriter;
 
+  private final SideEffectContext sideEffectContext;
+
   public BpmnProcessResultSenderBehavior(
-      final ZeebeState zeebeState, final TypedResponseWriter responseWriter) {
+      final ZeebeState zeebeState,
+      final TypedResponseWriter responseWriter,
+      final SideEffectContext sideEffectContext) {
     elementInstanceState = zeebeState.getElementInstanceState();
     variableState = zeebeState.getVariableState();
     this.responseWriter = responseWriter;
+    this.sideEffectContext = sideEffectContext;
   }
 
   public void sendResult(final BpmnElementContext context) {
@@ -75,7 +81,7 @@ public final class BpmnProcessResultSenderBehavior {
         requestMetadata.getRequestId(),
         requestMetadata.getRequestStreamId());
 
-    responseWriter.produce();
+    responseWriter.produce(sideEffectContext);
   }
 
   private DirectBuffer collectVariables(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessResultSenderBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessResultSenderBehavior.java
@@ -75,7 +75,7 @@ public final class BpmnProcessResultSenderBehavior {
         requestMetadata.getRequestId(),
         requestMetadata.getRequestStreamId());
 
-    responseWriter.flush();
+    responseWriter.produce();
   }
 
   private DirectBuffer collectVariables(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCat
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMessage;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffects;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -390,7 +391,7 @@ public final class CatchEventBehavior {
     }
 
     @Override
-    public boolean produce() {
+    public boolean produce(final SideEffectContext sideEffectContext) {
       return subscriptionCommandSender.closeMessageSubscription(
           subscriptionPartitionId, processInstanceKey, elementInstanceKey, messageName);
     }
@@ -427,7 +428,7 @@ public final class CatchEventBehavior {
     }
 
     @Override
-    public boolean produce() {
+    public boolean produce(final SideEffectContext context) {
       return subscriptionCommandSender.openMessageSubscription(
           subscriptionPartitionId,
           processInstanceKey,
@@ -519,7 +520,7 @@ public final class CatchEventBehavior {
     }
 
     @Override
-    public boolean produce() {
+    public boolean produce(final SideEffectContext context) {
       /* timerChecker implements onRecovered to recover from restart, so no need to schedule
       this in TimerCreatedApplier.*/
       timerChecker.scheduleTimer(dueDate);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -420,9 +420,9 @@ public final class CatchEventBehavior {
       this.subscriptionPartitionId = subscriptionPartitionId;
       this.processInstanceKey = processInstanceKey;
       this.elementInstanceKey = elementInstanceKey;
-      this.bpmnProcessId = bpmnProcessId;
-      this.messageName = messageName;
-      this.correlationKey = correlationKey;
+      this.bpmnProcessId = BufferUtil.cloneBuffer(bpmnProcessId);
+      this.messageName = BufferUtil.cloneBuffer(messageName);
+      this.correlationKey = BufferUtil.cloneBuffer(correlationKey);
       this.closeOnCorrelate = closeOnCorrelate;
     }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -390,7 +390,7 @@ public final class CatchEventBehavior {
     }
 
     @Override
-    public boolean flush() {
+    public boolean produce() {
       return subscriptionCommandSender.closeMessageSubscription(
           subscriptionPartitionId, processInstanceKey, elementInstanceKey, messageName);
     }
@@ -427,7 +427,7 @@ public final class CatchEventBehavior {
     }
 
     @Override
-    public boolean flush() {
+    public boolean produce() {
       return subscriptionCommandSender.openMessageSubscription(
           subscriptionPartitionId,
           processInstanceKey,
@@ -519,7 +519,7 @@ public final class CatchEventBehavior {
     }
 
     @Override
-    public boolean flush() {
+    public boolean produce() {
       /* timerChecker implements onRecovered to recover from restart, so no need to schedule
       this in TimerCreatedApplier.*/
       timerChecker.scheduleTimer(dueDate);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventTriggerBehavior.java
@@ -64,7 +64,7 @@ public class EventTriggerBehavior {
     catchEventBehavior.unsubscribeEventSubprocesses(context, commandWriter, sideEffectQueue);
 
     // side effect can immediately executed, since on restart we not reprocess anymore the commands
-    sideEffectQueue.flush();
+    sideEffectQueue.produce();
   }
 
   public void triggerEventSubProcess(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.incident;
 
+import io.camunda.zeebe.engine.processing.streamprocessor.FlushResponseWriterSideEffectProducer;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
@@ -111,7 +112,7 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
         .ifRightOrLeft(
             failedCommand -> {
               sideEffects.clear();
-              sideEffects.add(responseWriter::flush);
+              sideEffects.add(new FlushResponseWriterSideEffectProducer(responseWriter));
 
               bpmnStreamProcessor.processRecord(
                   failedCommand, noopResponseWriter, streamWriter, sideEffects::add);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -124,7 +124,7 @@ public final class JobFailProcessor implements CommandProcessor<JobRecord> {
     }
 
     @Override
-    public boolean flush() {
+    public boolean produce() {
       jobBackoffChecker.scheduleBackOff(dueDate);
       return true;
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -124,7 +125,7 @@ public final class JobFailProcessor implements CommandProcessor<JobRecord> {
     }
 
     @Override
-    public boolean produce() {
+    public boolean produce(final SideEffectContext sideEffectContext) {
       jobBackoffChecker.scheduleBackOff(dueDate);
       return true;
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
-import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
@@ -21,17 +20,12 @@ import org.agrona.collections.MutableBoolean;
 public final class MessageCorrelator {
 
   private final MessageState messageState;
-  private final SubscriptionCommandSender commandSender;
   private final StateWriter stateWriter;
 
   private Consumer<SideEffectProducer> sideEffect;
 
-  public MessageCorrelator(
-      final MessageState messageState,
-      final SubscriptionCommandSender commandSender,
-      final StateWriter stateWriter) {
+  public MessageCorrelator(final MessageState messageState, final StateWriter stateWriter) {
     this.messageState = messageState;
-    this.commandSender = commandSender;
     this.stateWriter = stateWriter;
   }
 
@@ -75,8 +69,7 @@ public final class MessageCorrelator {
       stateWriter.appendFollowUpEvent(
           subscriptionKey, MessageSubscriptionIntent.CORRELATING, subscriptionRecord);
 
-      sideEffect.accept(
-          new SendCorrelateCommandSideEffectProducer(commandSender, subscriptionRecord));
+      sideEffect.accept(new SendCorrelateCommandSideEffectProducer(subscriptionRecord));
     }
 
     return correlateMessage;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
@@ -15,9 +15,7 @@ import io.camunda.zeebe.engine.state.message.StoredMessage;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
-import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.function.Consumer;
-import org.agrona.DirectBuffer;
 import org.agrona.collections.MutableBoolean;
 
 public final class MessageCorrelator {
@@ -82,43 +80,5 @@ public final class MessageCorrelator {
     }
 
     return correlateMessage;
-  }
-
-  private static final class SendCorrelateCommandSideEffectProducer implements SideEffectProducer {
-
-    private final SubscriptionCommandSender commandSender;
-    private final long processInstanceKey;
-    private final long elementInstanceKey;
-    private final DirectBuffer bpmnProcessIdBuffer;
-    private final DirectBuffer messageNameBuffer;
-    private final long messageKey;
-    private final DirectBuffer variablesBuffer;
-    private final DirectBuffer correlationKeyBuffer;
-
-    private SendCorrelateCommandSideEffectProducer(
-        final SubscriptionCommandSender commandSender,
-        final MessageSubscriptionRecord subscriptionRecord) {
-      this.commandSender = commandSender;
-
-      processInstanceKey = subscriptionRecord.getProcessInstanceKey();
-      elementInstanceKey = subscriptionRecord.getElementInstanceKey();
-      bpmnProcessIdBuffer = BufferUtil.cloneBuffer(subscriptionRecord.getBpmnProcessIdBuffer());
-      messageNameBuffer = BufferUtil.cloneBuffer(subscriptionRecord.getMessageNameBuffer());
-      messageKey = subscriptionRecord.getMessageKey();
-      variablesBuffer = BufferUtil.cloneBuffer(subscriptionRecord.getVariablesBuffer());
-      correlationKeyBuffer = BufferUtil.cloneBuffer(subscriptionRecord.getCorrelationKeyBuffer());
-    }
-
-    @Override
-    public boolean flush() {
-      return commandSender.correlateProcessMessageSubscription(
-          processInstanceKey,
-          elementInstanceKey,
-          bpmnProcessIdBuffer,
-          messageNameBuffer,
-          messageKey,
-          variablesBuffer,
-          correlationKeyBuffer);
-    }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.processing.message;
 
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
-import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.KeyGenerator;
@@ -27,7 +26,6 @@ public final class MessageEventProcessors {
       final EventTriggerBehavior eventTriggerBehavior,
       final TypedRecordProcessors typedRecordProcessors,
       final MutableZeebeState zeebeState,
-      final SubscriptionCommandSender subscriptionCommandSender,
       final Writers writers) {
 
     final MutableMessageState messageState = zeebeState.getMessageState();
@@ -49,7 +47,6 @@ public final class MessageEventProcessors {
                 subscriptionState,
                 startEventSubscriptionState,
                 eventScopeInstanceState,
-                subscriptionCommandSender,
                 keyGenerator,
                 writers,
                 processState,
@@ -60,26 +57,20 @@ public final class MessageEventProcessors {
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CREATE,
             new MessageSubscriptionCreateProcessor(
-                messageState, subscriptionState, subscriptionCommandSender, writers, keyGenerator))
+                messageState, subscriptionState, writers, keyGenerator))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CORRELATE,
-            new MessageSubscriptionCorrelateProcessor(
-                messageState, subscriptionState, subscriptionCommandSender, writers))
+            new MessageSubscriptionCorrelateProcessor(messageState, subscriptionState, writers))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.DELETE,
-            new MessageSubscriptionDeleteProcessor(
-                subscriptionState, subscriptionCommandSender, writers))
+            new MessageSubscriptionDeleteProcessor(subscriptionState, writers))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.REJECT,
-            new MessageSubscriptionRejectProcessor(
-                messageState, subscriptionState, subscriptionCommandSender, writers))
+            new MessageSubscriptionRejectProcessor(messageState, subscriptionState, writers))
         .withListener(
-            new MessageObserver(
-                messageState,
-                zeebeState.getPendingMessageSubscriptionState(),
-                subscriptionCommandSender));
+            new MessageObserver(messageState, zeebeState.getPendingMessageSubscriptionState()));
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
-import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.ReadonlyProcessingContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
@@ -22,15 +21,11 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
   public static final Duration SUBSCRIPTION_TIMEOUT = Duration.ofSeconds(10);
   public static final Duration SUBSCRIPTION_CHECK_INTERVAL = Duration.ofSeconds(30);
 
-  private final SubscriptionCommandSender subscriptionCommandSender;
   private final MessageState messageState;
   private final MutablePendingMessageSubscriptionState pendingState;
 
   public MessageObserver(
-      final MessageState messageState,
-      final MutablePendingMessageSubscriptionState pendingState,
-      final SubscriptionCommandSender subscriptionCommandSender) {
-    this.subscriptionCommandSender = subscriptionCommandSender;
+      final MessageState messageState, final MutablePendingMessageSubscriptionState pendingState) {
     this.messageState = messageState;
     this.pendingState = pendingState;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -210,7 +210,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
     }
 
     @Override
-    public boolean flush() {
+    public boolean produce() {
       final var success =
           correlatingSubscriptions.visitSubscriptions(
               subscription ->
@@ -223,7 +223,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
                       variablesBuffer,
                       correlationKeyBUffer));
 
-      return success && responseWriter.flush();
+      return success && responseWriter.produce();
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -210,7 +211,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
     }
 
     @Override
-    public boolean produce() {
+    public boolean produce(final SideEffectContext context) {
       final var success =
           correlatingSubscriptions.visitSubscriptions(
               subscription ->
@@ -223,7 +224,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
                       variablesBuffer,
                       correlationKeyBUffer));
 
-      return success && responseWriter.produce();
+      return success && responseWriter.produce(context);
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
-import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
@@ -40,12 +39,11 @@ public final class MessageSubscriptionCorrelateProcessor
   public MessageSubscriptionCorrelateProcessor(
       final MessageState messageState,
       final MessageSubscriptionState subscriptionState,
-      final SubscriptionCommandSender commandSender,
       final Writers writers) {
     this.subscriptionState = subscriptionState;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
-    messageCorrelator = new MessageCorrelator(messageState, commandSender, stateWriter);
+    messageCorrelator = new MessageCorrelator(messageState, stateWriter);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
@@ -114,7 +114,7 @@ public final class MessageSubscriptionCreateProcessor
     }
 
     @Override
-    public boolean flush() {
+    public boolean produce() {
       return commandSender.openProcessMessageSubscription(
           processInstanceKey, elementInstanceKey, messageNameBuffer, isInterrupting);
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.message;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -114,7 +115,7 @@ public final class MessageSubscriptionCreateProcessor
     }
 
     @Override
-    public boolean produce() {
+    public boolean produce(final SideEffectContext context) {
       return commandSender.openProcessMessageSubscription(
           processInstanceKey, elementInstanceKey, messageNameBuffer, isInterrupting);
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
@@ -102,7 +102,7 @@ public final class MessageSubscriptionDeleteProcessor
     }
 
     @Override
-    public boolean flush() {
+    public boolean produce() {
       return commandSender.closeProcessMessageSubscription(
           processInstanceKey, elementInstanceKey, messageNameBuffer);
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.message;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -102,7 +103,7 @@ public final class MessageSubscriptionDeleteProcessor
     }
 
     @Override
-    public boolean produce() {
+    public boolean produce(final SideEffectContext context) {
       return commandSender.closeProcessMessageSubscription(
           processInstanceKey, elementInstanceKey, messageNameBuffer);
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
-import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
@@ -29,18 +28,15 @@ public final class MessageSubscriptionRejectProcessor
 
   private final MessageState messageState;
   private final MessageSubscriptionState subscriptionState;
-  private final SubscriptionCommandSender commandSender;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
 
   public MessageSubscriptionRejectProcessor(
       final MessageState messageState,
       final MessageSubscriptionState subscriptionState,
-      final SubscriptionCommandSender commandSender,
       final Writers writers) {
     this.messageState = messageState;
     this.subscriptionState = subscriptionState;
-    this.commandSender = commandSender;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
   }
@@ -101,8 +97,7 @@ public final class MessageSubscriptionRejectProcessor
                 MessageSubscriptionIntent.CORRELATING,
                 correlatingSubscription);
 
-            sideEffect.accept(
-                new SendCorrelateCommandSideEffectProducer(commandSender, correlatingSubscription));
+            sideEffect.accept(new SendCorrelateCommandSideEffectProducer(correlatingSubscription));
           }
           return !canBeCorrelated;
         });

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
@@ -101,21 +101,11 @@ public final class MessageSubscriptionRejectProcessor
                 MessageSubscriptionIntent.CORRELATING,
                 correlatingSubscription);
 
-            sideEffect.accept(() -> sendCorrelateCommand(correlatingSubscription));
+            sideEffect.accept(
+                new SendCorrelateCommandSideEffectProducer(commandSender, correlatingSubscription));
           }
           return !canBeCorrelated;
         });
-  }
-
-  private boolean sendCorrelateCommand(final MessageSubscriptionRecord subscription) {
-    return commandSender.correlateProcessMessageSubscription(
-        subscription.getProcessInstanceKey(),
-        subscription.getElementInstanceKey(),
-        subscription.getBpmnProcessIdBuffer(),
-        subscription.getMessageNameBuffer(),
-        subscription.getMessageKey(),
-        subscription.getVariablesBuffer(),
-        subscription.getCorrelationKeyBuffer());
   }
 
   private void rejectCommand(final TypedRecord<MessageSubscriptionRecord> record) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
-import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.ReadonlyProcessingContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.state.message.ProcessMessageSubscription;
@@ -23,7 +22,6 @@ public final class PendingProcessMessageSubscriptionChecker
   private static final Duration SUBSCRIPTION_TIMEOUT = Duration.ofSeconds(10);
   private static final Duration SUBSCRIPTION_CHECK_INTERVAL = Duration.ofSeconds(30);
 
-  private final SubscriptionCommandSender commandSender;
   private final MutablePendingProcessMessageSubscriptionState pendingState;
   private final long subscriptionTimeoutInMillis;
 
@@ -31,9 +29,7 @@ public final class PendingProcessMessageSubscriptionChecker
   private ScheduledTimer timer;
 
   public PendingProcessMessageSubscriptionChecker(
-      final SubscriptionCommandSender commandSender,
       final MutablePendingProcessMessageSubscriptionState pendingState) {
-    this.commandSender = commandSender;
     this.pendingState = pendingState;
     subscriptionTimeoutInMillis = SUBSCRIPTION_TIMEOUT.toMillis();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -12,7 +12,6 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
-import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
@@ -47,7 +46,6 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
           + "but it is already closing";
 
   private final ProcessMessageSubscriptionState subscriptionState;
-  private final SubscriptionCommandSender subscriptionCommandSender;
   private final ProcessState processState;
   private final ElementInstanceState elementInstanceState;
   private final StateWriter stateWriter;
@@ -56,12 +54,10 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
 
   public ProcessMessageSubscriptionCorrelateProcessor(
       final ProcessMessageSubscriptionState subscriptionState,
-      final SubscriptionCommandSender subscriptionCommandSender,
       final MutableZeebeState zeebeState,
       final EventTriggerBehavior eventTriggerBehavior,
       final Writers writers) {
     this.subscriptionState = subscriptionState;
-    this.subscriptionCommandSender = subscriptionCommandSender;
     processState = zeebeState.getProcessState();
     elementInstanceState = zeebeState.getElementInstanceState();
     stateWriter = writers.state();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/SendCorrelateCommandSideEffectProducer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/SendCorrelateCommandSideEffectProducer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+
+final class SendCorrelateCommandSideEffectProducer implements SideEffectProducer {
+
+  private final SubscriptionCommandSender commandSender;
+  private final long processInstanceKey;
+  private final long elementInstanceKey;
+  private final DirectBuffer bpmnProcessIdBuffer;
+  private final DirectBuffer messageNameBuffer;
+  private final long messageKey;
+  private final DirectBuffer variablesBuffer;
+  private final DirectBuffer correlationKeyBuffer;
+
+  SendCorrelateCommandSideEffectProducer(
+      final SubscriptionCommandSender commandSender,
+      final MessageSubscriptionRecord subscriptionRecord) {
+    this.commandSender = commandSender;
+
+    processInstanceKey = subscriptionRecord.getProcessInstanceKey();
+    elementInstanceKey = subscriptionRecord.getElementInstanceKey();
+    bpmnProcessIdBuffer = BufferUtil.cloneBuffer(subscriptionRecord.getBpmnProcessIdBuffer());
+    messageNameBuffer = BufferUtil.cloneBuffer(subscriptionRecord.getMessageNameBuffer());
+    messageKey = subscriptionRecord.getMessageKey();
+    variablesBuffer = BufferUtil.cloneBuffer(subscriptionRecord.getVariablesBuffer());
+    correlationKeyBuffer = BufferUtil.cloneBuffer(subscriptionRecord.getCorrelationKeyBuffer());
+  }
+
+  @Override
+  public boolean flush() {
+    return commandSender.correlateProcessMessageSubscription(
+        processInstanceKey,
+        elementInstanceKey,
+        bpmnProcessIdBuffer,
+        messageNameBuffer,
+        messageKey,
+        variablesBuffer,
+        correlationKeyBuffer);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/SendCorrelateCommandSideEffectProducer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/SendCorrelateCommandSideEffectProducer.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
-import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
@@ -16,7 +15,6 @@ import org.agrona.DirectBuffer;
 
 final class SendCorrelateCommandSideEffectProducer implements SideEffectProducer {
 
-  private final SubscriptionCommandSender commandSender;
   private final long processInstanceKey;
   private final long elementInstanceKey;
   private final DirectBuffer bpmnProcessIdBuffer;
@@ -25,10 +23,7 @@ final class SendCorrelateCommandSideEffectProducer implements SideEffectProducer
   private final DirectBuffer variablesBuffer;
   private final DirectBuffer correlationKeyBuffer;
 
-  SendCorrelateCommandSideEffectProducer(
-      final SubscriptionCommandSender commandSender,
-      final MessageSubscriptionRecord subscriptionRecord) {
-    this.commandSender = commandSender;
+  SendCorrelateCommandSideEffectProducer(final MessageSubscriptionRecord subscriptionRecord) {
 
     processInstanceKey = subscriptionRecord.getProcessInstanceKey();
     elementInstanceKey = subscriptionRecord.getElementInstanceKey();
@@ -41,13 +36,15 @@ final class SendCorrelateCommandSideEffectProducer implements SideEffectProducer
 
   @Override
   public boolean produce(final SideEffectContext context) {
-    return commandSender.correlateProcessMessageSubscription(
-        processInstanceKey,
-        elementInstanceKey,
-        bpmnProcessIdBuffer,
-        messageNameBuffer,
-        messageKey,
-        variablesBuffer,
-        correlationKeyBuffer);
+    return context
+        .getSiSubscriptionCommandSender()
+        .correlateProcessMessageSubscription(
+            processInstanceKey,
+            elementInstanceKey,
+            bpmnProcessIdBuffer,
+            messageNameBuffer,
+            messageKey,
+            variablesBuffer,
+            correlationKeyBuffer);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/SendCorrelateCommandSideEffectProducer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/SendCorrelateCommandSideEffectProducer.java
@@ -39,7 +39,7 @@ final class SendCorrelateCommandSideEffectProducer implements SideEffectProducer
   }
 
   @Override
-  public boolean flush() {
+  public boolean produce() {
     return commandSender.correlateProcessMessageSubscription(
         processInstanceKey,
         elementInstanceKey,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/SendCorrelateCommandSideEffectProducer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/SendCorrelateCommandSideEffectProducer.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.message;
 
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -39,7 +40,7 @@ final class SendCorrelateCommandSideEffectProducer implements SideEffectProducer
   }
 
   @Override
-  public boolean produce() {
+  public boolean produce(final SideEffectContext context) {
     return commandSender.correlateProcessMessageSubscription(
         processInstanceKey,
         elementInstanceKey,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/Subscriptions.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/Subscriptions.java
@@ -21,6 +21,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 public final class Subscriptions {
 
+  // TODO doesn't need to be reusable anymore
   private final ReusableObjectList<Subscription> subscriptions =
       new ReusableObjectList<>(Subscription::new);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutablePro
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSequenceFlow;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectQueue;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -84,13 +85,16 @@ public final class CreateProcessInstanceProcessor
   private final StateWriter stateWriter;
   private final ProcessEngineMetrics metrics;
 
+  private final SideEffectContext sideEffectContext;
+
   public CreateProcessInstanceProcessor(
       final ProcessState processState,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final VariableBehavior variableBehavior,
       final CatchEventBehavior catchEventBehavior,
-      final ProcessEngineMetrics metrics) {
+      final ProcessEngineMetrics metrics,
+      final SideEffectContext sideEffectContext) {
     this.processState = processState;
     this.variableBehavior = variableBehavior;
     this.catchEventBehavior = catchEventBehavior;
@@ -98,6 +102,7 @@ public final class CreateProcessInstanceProcessor
     commandWriter = writers.command();
     stateWriter = writers.state();
     this.metrics = metrics;
+    this.sideEffectContext = sideEffectContext;
   }
 
   @Override
@@ -399,7 +404,7 @@ public final class CreateProcessInstanceProcessor
         });
 
     // applying the side effects is part of creating the event subscriptions
-    sideEffectQueue.produce();
+    sideEffectQueue.produce(sideEffectContext);
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -399,7 +399,7 @@ public final class CreateProcessInstanceProcessor
         });
 
     // applying the side effects is part of creating the event subscriptions
-    sideEffectQueue.flush();
+    sideEffectQueue.produce();
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
@@ -76,7 +76,7 @@ public final class CommandProcessorImpl<T extends UnifiedRecordValue>
 
     sideEffect.accept(sideEffectQueue);
     sideEffectQueue.clear();
-    sideEffectQueue.add(responseWriter::flush);
+    sideEffectQueue.add(new FlushResponseWriterSideEffectProducer(responseWriter));
 
     final boolean shouldRespond = wrappedProcessor.onCommand(command, this, sideEffectQueue::add);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/FlushResponseWriterSideEffectProducer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/FlushResponseWriterSideEffectProducer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+
+public final class FlushResponseWriterSideEffectProducer implements SideEffectProducer {
+
+  private final TypedResponseWriter responseWriter;
+
+  public FlushResponseWriterSideEffectProducer(final TypedResponseWriter responseWriter) {
+    this.responseWriter = responseWriter;
+  }
+
+  @Override
+  public boolean flush() {
+    return responseWriter.flush();
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/FlushResponseWriterSideEffectProducer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/FlushResponseWriterSideEffectProducer.java
@@ -19,7 +19,7 @@ public final class FlushResponseWriterSideEffectProducer implements SideEffectPr
   }
 
   @Override
-  public boolean flush() {
-    return responseWriter.flush();
+  public boolean produce() {
+    return responseWriter.produce();
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/FlushResponseWriterSideEffectProducer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/FlushResponseWriterSideEffectProducer.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 
@@ -19,7 +20,7 @@ public final class FlushResponseWriterSideEffectProducer implements SideEffectPr
   }
 
   @Override
-  public boolean produce() {
-    return responseWriter.produce();
+  public boolean produce(final SideEffectContext sideEffectContext) {
+    return responseWriter.produce(sideEffectContext);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingContext.java
@@ -26,7 +26,7 @@ import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.scheduler.ActorControl;
 import java.util.function.BooleanSupplier;
 
-public final class ProcessingContext implements ReadonlyProcessingContext, SideEffectContext {
+public final class ProcessingContext implements ReadonlyProcessingContext {
 
   private static final StreamProcessorListener NOOP_LISTENER = processedCommand -> {};
 
@@ -51,6 +51,8 @@ public final class ProcessingContext implements ReadonlyProcessingContext, SideE
 
   private int maxFragmentSize;
   private StreamProcessorMode streamProcessorMode = StreamProcessorMode.PROCESSING;
+
+  private SideEffectContext sideEffectContext;
 
   public ProcessingContext() {
     streamWriterProxy.wrap(logStreamWriter);
@@ -222,6 +224,10 @@ public final class ProcessingContext implements ReadonlyProcessingContext, SideE
 
   @Deprecated // this should be removed
   public SideEffectContext getSideEffectContext() {
-    return this;
+    return sideEffectContext;
+  }
+
+  public void setSideEffectContext(final SideEffectContext sideEffectContext) {
+    this.sideEffectContext = sideEffectContext;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingContext.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.TypedStreamWriterProxy;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.EventApplyingStateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.NoopTypedStreamWriter;
@@ -25,7 +26,7 @@ import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.scheduler.ActorControl;
 import java.util.function.BooleanSupplier;
 
-public final class ProcessingContext implements ReadonlyProcessingContext {
+public final class ProcessingContext implements ReadonlyProcessingContext, SideEffectContext {
 
   private static final StreamProcessorListener NOOP_LISTENER = processedCommand -> {};
 
@@ -217,5 +218,10 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
 
   public StreamProcessorMode getProcessorMode() {
     return streamProcessorMode;
+  }
+
+  @Deprecated // this should be removed
+  public SideEffectContext getSideEffectContext() {
+    return this;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -435,7 +435,7 @@ public final class ProcessingStateMachine {
 
   private void executeSideEffects() {
     final ActorFuture<Boolean> retryFuture =
-        sideEffectsRetryStrategy.runWithRetry(sideEffectProducer::flush, abortCondition);
+        sideEffectsRetryStrategy.runWithRetry(sideEffectProducer::produce, abortCondition);
 
     actor.runOnCompletion(
         retryFuture,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
@@ -42,11 +42,11 @@ public interface TypedRecordProcessor<T extends UnifiedRecordValue>
    * @param position the position of the current record to process
    * @param record the record to process
    * @param responseWriter the default side effect that can be used for sending responses. {@link
-   *     TypedResponseWriter#flush()} must not be called in this method.
+   *     TypedResponseWriter#produce()} must not be called in this method.
    * @param streamWriter
    * @param sideEffect consumer to replace the default side effect (response writer). Can be used to
    *     implement other types of side effects or composite side effects. If a composite side effect
-   *     involving the response writer is used, {@link TypedResponseWriter#flush()} must be called
+   *     involving the response writer is used, {@link TypedResponseWriter#produce()} must be called
    *     in the {@link SideEffectProducer} implementation.
    */
   default void processRecord(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/sideeffect/SideEffectContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/sideeffect/SideEffectContext.java
@@ -7,17 +7,4 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor.sideeffect;
 
-/**
- * An action that is executed at the end of the processing. It will <b>not</b> be executed during
- * the re-processing.
- */
-@FunctionalInterface
-public interface SideEffectProducer {
-
-  /**
-   * Applies the side effect.
-   *
-   * @return <code>false</code> to indicate that the side effect could not be applied successfully
-   */
-  boolean produce(SideEffectContext context);
-}
+public interface SideEffectContext {}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/sideeffect/SideEffectContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/sideeffect/SideEffectContextImpl.java
@@ -9,7 +9,16 @@ package io.camunda.zeebe.engine.processing.streamprocessor.sideeffect;
 
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 
-public interface SideEffectContext {
+public class SideEffectContextImpl implements SideEffectContext {
 
-  SubscriptionCommandSender getSiSubscriptionCommandSender();
+  private final SubscriptionCommandSender subscriptionCommandSender;
+
+  public SideEffectContextImpl(final SubscriptionCommandSender subscriptionCommandSender) {
+    this.subscriptionCommandSender = subscriptionCommandSender;
+  }
+
+  @Override
+  public SubscriptionCommandSender getSiSubscriptionCommandSender() {
+    return subscriptionCommandSender;
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/sideeffect/SideEffectProducer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/sideeffect/SideEffectProducer.java
@@ -19,5 +19,5 @@ public interface SideEffectProducer {
    *
    * @return <code>false</code> to indicate that the side effect could not be applied successfully
    */
-  boolean flush();
+  boolean produce();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/sideeffect/SideEffectQueue.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/sideeffect/SideEffectQueue.java
@@ -18,7 +18,7 @@ public final class SideEffectQueue implements SideEffectProducer, SideEffects {
   }
 
   @Override
-  public boolean flush() {
+  public boolean produce() {
     if (sideEffects.isEmpty()) {
       return true;
     }
@@ -32,7 +32,7 @@ public final class SideEffectQueue implements SideEffectProducer, SideEffects {
       final SideEffectProducer sideEffect = sideEffects.get(i);
 
       if (sideEffect != null) {
-        if (sideEffect.flush()) {
+        if (sideEffect.produce()) {
           sideEffects.set(i, null);
         } else {
           flushed = false;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/sideeffect/SideEffectQueue.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/sideeffect/SideEffectQueue.java
@@ -18,7 +18,7 @@ public final class SideEffectQueue implements SideEffectProducer, SideEffects {
   }
 
   @Override
-  public boolean produce() {
+  public boolean produce(final SideEffectContext context) {
     if (sideEffects.isEmpty()) {
       return true;
     }
@@ -32,7 +32,7 @@ public final class SideEffectQueue implements SideEffectProducer, SideEffects {
       final SideEffectProducer sideEffect = sideEffects.get(i);
 
       if (sideEffect != null) {
-        if (sideEffect.produce()) {
+        if (sideEffect.produce(context)) {
           sideEffects.set(i, null);
         } else {
           flushed = false;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/NoopResponseWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/NoopResponseWriter.java
@@ -39,7 +39,7 @@ public final class NoopResponseWriter implements TypedResponseWriter {
       final int requestStreamId) {}
 
   @Override
-  public boolean flush() {
+  public boolean produce() {
     return false;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/NoopResponseWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/NoopResponseWriter.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContext;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -39,10 +40,10 @@ public final class NoopResponseWriter implements TypedResponseWriter {
       final int requestStreamId) {}
 
   @Override
-  public boolean produce() {
-    return false;
-  }
+  public void reset() {}
 
   @Override
-  public void reset() {}
+  public boolean produce(final SideEffectContext sideEffectContext) {
+    return false;
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -37,7 +38,7 @@ public interface TypedResponseWriter extends SideEffectProducer {
    * @return false in case of backpressure, else true
    */
   @Override
-  boolean produce();
+  boolean produce(SideEffectContext sideEffectContext);
 
   void reset();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
@@ -36,7 +36,8 @@ public interface TypedResponseWriter extends SideEffectProducer {
    *
    * @return false in case of backpressure, else true
    */
-  boolean flush();
+  @Override
+  boolean produce();
 
   void reset();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriterImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriterImpl.java
@@ -109,11 +109,16 @@ public final class TypedResponseWriterImpl implements TypedResponseWriter, SideE
   }
 
   @Override
-  public boolean flush() {
+  public boolean produce() {
     if (isResponseStaged) {
       writer.tryWriteResponse(requestStreamId, requestId);
     }
     return true;
+  }
+
+  @Override
+  public void reset() {
+    isResponseStaged = false;
   }
 
   private void stage(
@@ -139,9 +144,5 @@ public final class TypedResponseWriterImpl implements TypedResponseWriter, SideE
     this.requestId = requestId;
     this.requestStreamId = requestStreamId;
     isResponseStaged = true;
-  }
-
-  public void reset() {
-    isResponseStaged = false;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriterImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriterImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecord;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -109,7 +110,7 @@ public final class TypedResponseWriterImpl implements TypedResponseWriter, SideE
   }
 
   @Override
-  public boolean produce() {
+  public boolean produce(final SideEffectContext sideEffectContext) {
     if (isResponseStaged) {
       writer.tryWriteResponse(requestStreamId, requestId);
     }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
@@ -355,7 +355,7 @@ public final class StreamProcessorTest {
                       final Consumer<SideEffectProducer> sideEffect) {
 
                     sideEffect.accept(
-                        () -> {
+                        (context) -> {
                           processLatch.countDown();
                           return true;
                         });
@@ -388,7 +388,7 @@ public final class StreamProcessorTest {
                       final TypedStreamWriter streamWriter,
                       final Consumer<SideEffectProducer> sideEffect) {
                     sideEffect.accept(
-                        () -> {
+                        (context) -> {
                           processLatch.countDown();
                           return processLatch.getCount() < 1;
                         });
@@ -422,7 +422,7 @@ public final class StreamProcessorTest {
                       final Consumer<SideEffectProducer> sideEffect) {
 
                     sideEffect.accept(
-                        () -> {
+                        (context) -> {
                           throw new RuntimeException("expected");
                         });
                     processLatch.countDown();


### PR DESCRIPTION
cc @saig0 @Zelldon 

This branch explores side effects. It is meant as a contribution to the engine abstraction epic.

Please also have a look at #9686 for a background of which questions I am exploring, and where I am heading

Changes:
* Transforms all anonymous side effects into classes. This way we have a repertoire of side effects
* Then it adds a new interface side effect context, which holds components that are only used during the execution of side effects. The hope is that by filling the side effect context, we can strip down the processing context and reduce dependencies for components in the engine
* As a proof of concept, it then adds the command sender to the side effect context. This last commit does not compile. It exposes instances where sending a command is currently not a side effect (`PendingProcessMessageSubscriptionChecker`) which raises the question whether the lifecycle of that object shall remain part of the engine or become part of the platform