### PR TITLE
Disable some auto configuration

### DIFF
--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -23,3 +23,8 @@ management.endpoint.prometheus.enabled=true
 management.metrics.export.prometheus.enabled=true
 # Allow runtime configuration of log levels
 management.endpoint.loggers.enabled=true
+# Disable specific autoconfiguration classes which are triggered automatically (e.g. creating an
+# Elastic client which spawns 16 threads)
+spring.autoconfigure.exclude=\
+  org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration, \
+  org.springframework.boot.autoconfigure.netty.NettyAutoConfiguration


### PR DESCRIPTION
## Description

Disables some built-in auto configuration from Spring, specifically Netty and Elastic. These cause unnecessary resources to be created which we don't use down the road. For example, the Elastic client created by Spring will spawn 16 threads which will just idle/poll.

To test, start the application as you would without this. You'll see 16 `I/O Dispatcher` threads coming from Apache's HTTP Async client. Then start the standalone broker again but with this patch, and they will magically disappear :ghost: 

I'm not sure how to make a real test here - testing the number of threads is brittle in general, and we do use the async client for ES (just our own). Open to ideas!

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
