### PR TITLE
Engine abstraction - process context refactoring

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -25,7 +25,7 @@ import io.camunda.zeebe.engine.processing.incident.IncidentEventProcessors;
 import io.camunda.zeebe.engine.processing.job.JobEventProcessors;
 import io.camunda.zeebe.engine.processing.message.MessageEventProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
-import io.camunda.zeebe.engine.processing.streamprocessor.ProcessingContext;
+import io.camunda.zeebe.engine.processing.streamprocessor.EngineProcessingContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Builders;
@@ -35,7 +35,6 @@ import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.migration.DbMigrationController;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
@@ -46,7 +45,7 @@ import java.util.function.Consumer;
 public final class EngineProcessors {
 
   public static TypedRecordProcessors createEngineProcessors(
-      final ProcessingContext processingContext,
+      final EngineProcessingContext processingContext,
       final int partitionsCount,
       final SubscriptionCommandSender subscriptionCommandSender,
       final DeploymentDistributor deploymentDistributor,
@@ -64,8 +63,7 @@ public final class EngineProcessors {
 
     typedRecordProcessors.withListener(processingContext.getZeebeState());
 
-    final LogStream stream = processingContext.getLogStream();
-    final int partitionId = stream.getPartitionId();
+    final int partitionId = processingContext.getPartitionId();
 
     final var variablesState = zeebeState.getVariableState();
     final var expressionProcessor =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/Engine.java
@@ -53,10 +53,10 @@ public final class Engine implements StreamProcessor {
   }
 
   @Override
-  public void init(final ProcessingContext context) {
+  public void init(final EngineProcessingContext context) {
     final TransactionContext transactionContext = zeebeDb.createContext();
 
-    final var partitionId = context.getLogStream().getPartitionId();
+    final var partitionId = context.getPartitionId();
     zeebeState = new ZeebeDbState(partitionId, zeebeDb, transactionContext);
 
     context.transactionContext(transactionContext);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineProcessingContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineProcessingContext.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Builders;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.RecordsBuilder;
+import io.camunda.zeebe.engine.state.EventApplier;
+import io.camunda.zeebe.engine.state.ZeebeDbState;
+import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+
+public interface EngineProcessingContext {
+
+  MutableZeebeState getZeebeState();
+
+  Builders getWriters();
+
+  int getPartitionId();
+
+  void transactionContext(TransactionContext transactionContext);
+
+  void zeebeState(ZeebeDbState zeebeState);
+
+  void initBuilders(RecordsBuilder recordsBuilder, EventApplier eventApplier);
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineProcessingContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineProcessingContext.java
@@ -7,11 +7,9 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
-import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Builders;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.RecordsBuilder;
 import io.camunda.zeebe.engine.state.EventApplier;
-import io.camunda.zeebe.engine.state.ZeebeDbState;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 
 public interface EngineProcessingContext {
@@ -21,10 +19,6 @@ public interface EngineProcessingContext {
   Builders getWriters();
 
   int getPartitionId();
-
-  void transactionContext(TransactionContext transactionContext);
-
-  void zeebeState(ZeebeDbState zeebeState);
 
   void initBuilders(RecordsBuilder recordsBuilder, EventApplier eventApplier);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingContext.java
@@ -172,21 +172,19 @@ public final class ProcessingContext implements ReadonlyProcessingContext, Engin
   }
 
   @Override
-  public void transactionContext(final TransactionContext transactionContext) {
-    this.transactionContext = transactionContext;
-  }
-
-  @Override
-  public void zeebeState(final ZeebeDbState zeebeState) {
-    this.zeebeState = zeebeState;
-  }
-
-  @Override
   public void initBuilders(final RecordsBuilder recordsBuilder, final EventApplier eventApplier) {
     builders =
         new Builders(
             recordsBuilder,
             eventApplier,
             new TypedResponseWriterImpl(commandResponseWriter, getLogStream().getPartitionId()));
+  }
+
+  public void transactionContext(final TransactionContext transactionContext) {
+    this.transactionContext = transactionContext;
+  }
+
+  public void zeebeState(final ZeebeDbState zeebeState) {
+    this.zeebeState = zeebeState;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingContext.java
@@ -24,7 +24,7 @@ import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.util.sched.ActorControl;
 import java.util.function.BooleanSupplier;
 
-public final class ProcessingContext implements ReadonlyProcessingContext {
+public final class ProcessingContext implements ReadonlyProcessingContext, EngineProcessingContext {
 
   private static final StreamProcessorListener NOOP_LISTENER = processedCommand -> {};
 
@@ -60,16 +60,6 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
 
   public ProcessingContext eventCache(final RecordValues recordValues) {
     this.recordValues = recordValues;
-    return this;
-  }
-
-  public ProcessingContext zeebeState(final ZeebeDbState zeebeState) {
-    this.zeebeState = zeebeState;
-    return this;
-  }
-
-  public ProcessingContext transactionContext(final TransactionContext transactionContext) {
-    this.transactionContext = transactionContext;
     return this;
   }
 
@@ -171,16 +161,32 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
     return streamProcessorMode;
   }
 
+  public void processingSchedulingService(
+      final ProcessingSchedulingServiceImpl processingSchedulingService) {
+    this.processingSchedulingService = processingSchedulingService;
+  }
+
+  @Override
+  public int getPartitionId() {
+    return getLogStream().getPartitionId();
+  }
+
+  @Override
+  public void transactionContext(final TransactionContext transactionContext) {
+    this.transactionContext = transactionContext;
+  }
+
+  @Override
+  public void zeebeState(final ZeebeDbState zeebeState) {
+    this.zeebeState = zeebeState;
+  }
+
+  @Override
   public void initBuilders(final RecordsBuilder recordsBuilder, final EventApplier eventApplier) {
     builders =
         new Builders(
             recordsBuilder,
             eventApplier,
             new TypedResponseWriterImpl(commandResponseWriter, getLogStream().getPartitionId()));
-  }
-
-  public void processingSchedulingService(
-      final ProcessingSchedulingServiceImpl processingSchedulingService) {
-    this.processingSchedulingService = processingSchedulingService;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.processing.streamprocessor;
 
 public interface StreamProcessor extends StreamProcessorLifecycleAware {
 
-  void init(ProcessingContext context);
+  void init(EngineProcessingContext context);
 
   void apply(TypedRecord typedEvent);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorFactory.java
@@ -13,9 +13,9 @@ public interface TypedRecordProcessorFactory {
   /**
    * Creates typed record processors with the given context.
    *
-   * @param processingContext the processing context which contains value information to create
-   *     record processors
+   * @param context the processing context which contains value information to create record
+   *     processors
    * @return the created typed record processors
    */
-  TypedRecordProcessors createProcessors(ProcessingContext processingContext);
+  TypedRecordProcessors createProcessors(EngineProcessingContext context);
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.util;
 import static io.camunda.zeebe.engine.util.Records.processInstance;
 
 import io.camunda.zeebe.db.ZeebeDbFactory;
-import io.camunda.zeebe.engine.processing.streamprocessor.ReadonlyProcessingContext;
+import io.camunda.zeebe.engine.processing.streamprocessor.EngineProcessingContext;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamPlatform;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
@@ -63,11 +63,9 @@ public class StreamProcessingComposite {
   }
 
   private TypedRecordProcessors createTypedRecordProcessors(
-      final StreamProcessorTestFactory factory,
-      final io.camunda.zeebe.engine.processing.streamprocessor.ProcessingContext
-          processingContext) {
+      final StreamProcessorTestFactory factory, final EngineProcessingContext processingContext) {
     zeebeState = processingContext.getZeebeState();
-    lastProcessedPositionState = processingContext.getLastProcessedPositionState();
+    lastProcessedPositionState = processingContext.getZeebeState().getLastProcessedPositionState();
     return factory.build(
         TypedRecordProcessors.processors(
             zeebeState.getKeyGenerator(), processingContext.getWriters()),
@@ -85,7 +83,8 @@ public class StreamProcessingComposite {
         zeebeDbFactory,
         (processingContext -> {
           zeebeState = processingContext.getZeebeState();
-          lastProcessedPositionState = processingContext.getLastProcessedPositionState();
+          lastProcessedPositionState =
+              processingContext.getZeebeState().getLastProcessedPositionState();
           return factory.createProcessors(processingContext);
         }));
   }
@@ -108,7 +107,8 @@ public class StreamProcessingComposite {
         zeebeDbFactory,
         (processingContext -> {
           zeebeState = processingContext.getZeebeState();
-          lastProcessedPositionState = processingContext.getLastProcessedPositionState();
+          lastProcessedPositionState =
+              processingContext.getZeebeState().getLastProcessedPositionState();
           return factory.createProcessors(processingContext);
         }));
   }
@@ -122,7 +122,8 @@ public class StreamProcessingComposite {
         zeebeDbFactory,
         (processingContext -> {
           zeebeState = processingContext.getZeebeState();
-          lastProcessedPositionState = processingContext.getLastProcessedPositionState();
+          lastProcessedPositionState =
+              processingContext.getZeebeState().getLastProcessedPositionState();
           return factory.createProcessors(processingContext);
         }),
         streamWriterFactory);
@@ -296,6 +297,6 @@ public class StreamProcessingComposite {
   @FunctionalInterface
   public interface StreamProcessorTestFactory {
     TypedRecordProcessors build(
-        TypedRecordProcessors builder, ReadonlyProcessingContext processingContext);
+        TypedRecordProcessors builder, EngineProcessingContext processingContext);
   }
 }


### PR DESCRIPTION
## Description

Explores splitting up the processing context in context used by the platform and context used by the engine.

Features a new interface `EngineProcessingContext` which looks pretty clean. 

Quick and dirty refactoring. It doesn't compile. But I don't think this is related to the changes I made :thinking: 

Feel free to reject the merge. Was more of an experiment. But if you like it, please merge it to the PoC