### PR TITLE
Prevent state updates in tests

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
@@ -430,7 +430,6 @@ public final class MultiInstanceIncidentTest {
             .withElementType(BpmnElementType.SERVICE_TASK)
             .getFirst();
     final var job = findNthJob(processInstanceKey, 1);
-    final var nextKey = ENGINE.getZeebeState().getKeyGenerator().nextKey();
     ENGINE.stop();
     RecordingExporter.reset();
 
@@ -470,7 +469,7 @@ public final class MultiInstanceIncidentTest {
             .processInstance(ProcessInstanceIntent.ELEMENT_COMPLETED, serviceTask.getValue()),
         RecordToWrite.event()
             .causedBy(2)
-            .key(nextKey)
+            .key(-1L)
             .processInstance(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN, sequenceFlow),
         RecordToWrite.command()
             .causedBy(2)

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
@@ -11,7 +11,7 @@ import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.processing.message.MessageObserver;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -46,7 +46,7 @@ public final class ProcessExecutionCleanStateTest {
 
   @Rule public EngineRule engineRule = EngineRule.singlePartition();
 
-  private MutableZeebeState zeebeState;
+  private ZeebeState zeebeState;
 
   @Before
   public void init() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -29,7 +29,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandRespons
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
 import io.camunda.zeebe.engine.state.ZeebeDbState;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.util.client.DeploymentClient;
 import io.camunda.zeebe.engine.util.client.IncidentClient;
 import io.camunda.zeebe.engine.util.client.JobActivationClient;
@@ -278,7 +278,7 @@ public final class EngineRule extends ExternalResource {
     return environmentRule.getClock();
   }
 
-  public MutableZeebeState getZeebeState() {
+  public ZeebeState getZeebeState() {
     return environmentRule.getZeebeState();
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Updating the state in tests can result in unexpected error in RocksDb. The reason for this is that the transaction is used by the StreamProcessor. When we modify the state we are using the same transaction, but this time from the test thread, resulting in 2 threads accessing the same transaction (we reuse the same transaction everytime by resetting it).

There is a very low chance that these two threads are interfering with each other. To circumvent the test could create it's own context on the ZeebeDB when it needs to update the state. In this case it is a lot easier to just use a made-up value for the key of a record, as it doesn't matter what we use.

I've also changed the EngineRule to return an immutable ZeebeState to prevent this issue in the future.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9569

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
