### PR TITLE
test(benchmark): don't run multiple brokers on one node

### DIFF
--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -25,6 +25,19 @@ zeebe:
     capabilities:
       add: ["NET_ADMIN"]
 
+  # PodAntiAffinity defines that brokers shouldn't share nodes since this leads to performance issues
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: "app.kubernetes.io/component"
+                operator: In
+                values:
+                  - zeebe-broker
+          topologyKey: kubernetes.io/hostname
+          namespaceSelector: {} # Affinity across all namespaces
+
   # JavaOpts can be used to set java options for the zeebe brokers
   javaOpts: >-
     -XX:MaxRAMPercentage=25.0


### PR DESCRIPTION
Set's up a cross-namespace pod anti-affinity rule to only schedule one broker per node. This should stabilize our benchmarks and mitigate some of the issues we are seeing here: https://github.com/camunda/zeebe/issues/8551#issuecomment-1176003083

Cross-namespace anti-affinity rules are alpha since k8s 1.21 and stable since 1.24. Our benchmark clusters are on 1.21.