### PR TITLE
Split loading and managing segments out of SegmentedJournal

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
@@ -25,13 +25,13 @@ import java.util.HashSet;
 import java.util.Set;
 
 /** Create a segment file. Load a segment from the segment file. */
-public class SegmentLoader {
+final class SegmentLoader {
 
   private static final ByteOrder ENDIANNESS = ByteOrder.LITTLE_ENDIAN;
   private final long lastWrittenIndex;
   private final JournalIndex journalIndex;
 
-  public SegmentLoader(final long lastWrittenIndex, final JournalIndex journalIndex) {
+  SegmentLoader(final long lastWrittenIndex, final JournalIndex journalIndex) {
     this.lastWrittenIndex = lastWrittenIndex;
     this.journalIndex = journalIndex;
   }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import io.camunda.zeebe.journal.JournalException;
+import io.camunda.zeebe.journal.file.record.CorruptedLogException;
+import io.camunda.zeebe.util.FileUtil;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileChannel.MapMode;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.OpenOption;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/** Create a segment file. Load a segment from the segment file. */
+public class SegmentLoader {
+
+  private static final ByteOrder ENDIANNESS = ByteOrder.LITTLE_ENDIAN;
+  private final long lastWrittenIndex;
+  private final JournalIndex journalIndex;
+
+  public SegmentLoader(final long lastWrittenIndex, final JournalIndex journalIndex) {
+    this.lastWrittenIndex = lastWrittenIndex;
+    this.journalIndex = journalIndex;
+  }
+
+  JournalSegment createSegment(final JournalSegmentDescriptor descriptor, final File segmentFile) {
+    final MappedByteBuffer mappedSegment;
+
+    try {
+      mappedSegment = mapNewSegment(segmentFile, descriptor);
+    } catch (final IOException e) {
+      throw new JournalException(String.format("Failed to map new segment %s", segmentFile), e);
+    }
+
+    try {
+      descriptor.copyTo(mappedSegment);
+      mappedSegment.force();
+    } catch (final InternalError e) {
+      throw new JournalException(
+          String.format(
+              "Failed to ensure durability of segment %s with descriptor %s, rolling back",
+              segmentFile, descriptor),
+          e);
+    }
+
+    // while flushing the file's contents ensures its data is present on disk on recovery, it's also
+    // necessary to flush the directory to ensure that the file itself is visible as an entry of
+    // that directory after recovery
+    try {
+      final var directory = segmentFile.toPath().getParent();
+      FileUtil.flushDirectory(directory);
+    } catch (final IOException e) {
+      throw new JournalException(
+          String.format("Failed to flush journal directory after creating segment %s", segmentFile),
+          e);
+    }
+
+    return loadSegment(segmentFile, mappedSegment, descriptor);
+  }
+
+  JournalSegment loadExistingSegment(final File segmentFile) {
+    final var descriptor = readDescriptor(segmentFile);
+    final MappedByteBuffer mappedSegment;
+
+    try {
+      mappedSegment = mapSegment(segmentFile, descriptor, Collections.emptySet());
+    } catch (final IOException e) {
+      throw new JournalException(
+          String.format("Failed to load existing segment %s", segmentFile), e);
+    }
+
+    return loadSegment(segmentFile, mappedSegment, descriptor);
+  }
+
+  /* ---- Internal methods ------ */
+  private JournalSegment loadSegment(
+      final File file, final MappedByteBuffer buffer, final JournalSegmentDescriptor descriptor) {
+    final JournalSegmentFile segmentFile = new JournalSegmentFile(file);
+    return new JournalSegment(segmentFile, descriptor, buffer, lastWrittenIndex, journalIndex);
+  }
+
+  private MappedByteBuffer mapSegment(
+      final File segmentFile,
+      final JournalSegmentDescriptor descriptor,
+      final Set<OpenOption> extraOptions)
+      throws IOException {
+    final var options = new HashSet<>(extraOptions);
+    options.add(StandardOpenOption.READ);
+    options.add(StandardOpenOption.WRITE);
+
+    try (final var channel = FileChannel.open(segmentFile.toPath(), options)) {
+      final var mappedSegment = channel.map(MapMode.READ_WRITE, 0, descriptor.maxSegmentSize());
+      mappedSegment.order(ENDIANNESS);
+
+      return mappedSegment;
+    }
+  }
+
+  private JournalSegmentDescriptor readDescriptor(final File file) {
+    try (final FileChannel channel = FileChannel.open(file.toPath(), StandardOpenOption.READ)) {
+      final byte version = readVersion(channel, file.getName());
+      final int length = JournalSegmentDescriptor.getEncodingLengthForVersion(version);
+      if (file.length() < length) {
+        throw new CorruptedLogException(
+            String.format(
+                "Expected segment '%s' with version %d to be at least %d bytes long but it only has %d.",
+                file.getName(), version, length, file.length()));
+      }
+
+      final ByteBuffer buffer = ByteBuffer.allocate(length);
+      final int readBytes = channel.read(buffer, 0);
+
+      if (readBytes != -1 && readBytes < length) {
+        throw new JournalException(
+            String.format(
+                "Expected to read %d bytes of segment '%s' with %d version but only read %d bytes.",
+                length, file.getName(), version, readBytes));
+      }
+
+      buffer.flip();
+      return new JournalSegmentDescriptor(buffer);
+    } catch (final IndexOutOfBoundsException e) {
+      throw new JournalException(
+          String.format(
+              "Expected to read descriptor of segment '%s', but nothing was read.", file.getName()),
+          e);
+    } catch (final UnknownVersionException e) {
+      throw new CorruptedLogException(
+          String.format("Couldn't read or recognize version of segment '%s'.", file.getName()), e);
+    } catch (final IOException e) {
+      throw new JournalException(e);
+    }
+  }
+
+  private byte readVersion(final FileChannel channel, final String fileName) throws IOException {
+    final ByteBuffer buffer = ByteBuffer.allocate(1);
+    final int readBytes = channel.read(buffer);
+
+    if (readBytes == 0) {
+      throw new JournalException(
+          String.format(
+              "Expected to read the version byte from segment '%s' but nothing was read.",
+              fileName));
+    } else if (readBytes == -1) {
+      throw new CorruptedLogException(
+          String.format(
+              "Expected to read the version byte from segment '%s' but got EOF instead.",
+              fileName));
+    }
+
+    return buffer.get(0);
+  }
+
+  private MappedByteBuffer mapNewSegment(
+      final File segmentFile, final JournalSegmentDescriptor descriptor) throws IOException {
+    try {
+      return mapSegment(segmentFile, descriptor, Set.of(StandardOpenOption.CREATE_NEW));
+    } catch (final FileAlreadyExistsException e) {
+      // assuming we haven't written in that segment, just overwrite it; if we have, we may be able
+      // reuse, but that's up to the caller
+      if (lastWrittenIndex >= descriptor.index()) {
+        throw new JournalException(
+            String.format(
+                "Failed to create journal segment %s, as it already exists, and the last written "
+                    + "index %d indicates we've already written to it",
+                segmentFile, lastWrittenIndex),
+            e);
+      }
+
+      return mapSegment(segmentFile, descriptor, Set.of(StandardOpenOption.TRUNCATE_EXISTING));
+    }
+  }
+}

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -52,16 +52,14 @@ public final class SegmentedJournal implements Journal {
       final int maxSegmentSize,
       final long minFreeSpace,
       final JournalIndex journalIndex,
-      final long lastWrittenIndex) {
+      final SegmentsManager segmentsManager) {
     this.name = checkNotNull(name, "name cannot be null");
     this.directory = checkNotNull(directory, "directory cannot be null");
     this.maxSegmentSize = maxSegmentSize;
     journalMetrics = new JournalMetrics(name);
     minFreeDiskSpace = minFreeSpace;
     this.journalIndex = journalIndex;
-    segments =
-        new SegmentsManager(
-            journalMetrics, journalIndex, maxSegmentSize, directory, lastWrittenIndex, name);
+    segments = segmentsManager;
     segments.open();
     writer = new SegmentedJournalWriter(this);
   }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -24,59 +24,27 @@ import io.camunda.zeebe.journal.Journal;
 import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.journal.JournalReader;
 import io.camunda.zeebe.journal.JournalRecord;
-import io.camunda.zeebe.journal.file.record.CorruptedLogException;
-import io.camunda.zeebe.util.FileUtil;
 import java.io.File;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.MappedByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.channels.FileChannel.MapMode;
-import java.nio.file.DirectoryStream;
-import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.Files;
-import java.nio.file.OpenOption;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.locks.StampedLock;
 import org.agrona.DirectBuffer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** A file based journal. The journal is split into multiple segments files. */
 public final class SegmentedJournal implements Journal {
   public static final long ASQN_IGNORE = -1;
-  private static final ByteOrder ENDIANNESS = ByteOrder.LITTLE_ENDIAN;
   private static final int SEGMENT_BUFFER_FACTOR = 3;
-  private static final int FIRST_SEGMENT_ID = 1;
-  private static final int INITIAL_INDEX = 1;
   private final JournalMetrics journalMetrics;
-  private final Logger log = LoggerFactory.getLogger(getClass());
-  private final String name;
   private final File directory;
   private final int maxSegmentSize;
-  private final NavigableMap<Long, JournalSegment> segments = new ConcurrentSkipListMap<>();
   private final Collection<SegmentedJournalReader> readers = Sets.newConcurrentHashSet();
-  private volatile JournalSegment currentSegment;
   private volatile boolean open = true;
   private final long minFreeDiskSpace;
   private final JournalIndex journalIndex;
   private final SegmentedJournalWriter writer;
-  private final long lastWrittenIndex;
   private final StampedLock rwlock = new StampedLock();
+
+  private final SegmentsManager segments;
+  private final String name;
 
   public SegmentedJournal(
       final String name,
@@ -91,8 +59,10 @@ public final class SegmentedJournal implements Journal {
     journalMetrics = new JournalMetrics(name);
     minFreeDiskSpace = minFreeSpace;
     this.journalIndex = journalIndex;
-    this.lastWrittenIndex = lastWrittenIndex;
-    open();
+    segments =
+        new SegmentsManager(
+            journalMetrics, journalIndex, maxSegmentSize, directory, lastWrittenIndex, name);
+    segments.open();
     writer = new SegmentedJournalWriter(this);
   }
 
@@ -137,39 +107,11 @@ public final class SegmentedJournal implements Journal {
 
   @Override
   public void deleteUntil(final long index) {
-    final Map.Entry<Long, JournalSegment> segmentEntry = segments.floorEntry(index);
-    if (segmentEntry != null) {
-      final SortedMap<Long, JournalSegment> compactSegments =
-          segments.headMap(segmentEntry.getValue().index());
-      if (compactSegments.isEmpty()) {
-        log.debug(
-            "No segments can be deleted with index < {} (first log index: {})",
-            index,
-            getFirstIndex());
-        return;
-      }
-
-      final var stamp = rwlock.writeLock();
-      try {
-        log.debug(
-            "{} - Deleting log up from {} up to {} (removing {} segments)",
-            name,
-            getFirstIndex(),
-            compactSegments.get(compactSegments.lastKey()).index(),
-            compactSegments.size());
-        for (final JournalSegment segment : compactSegments.values()) {
-          log.trace("{} - Deleting segment: {}", name, segment);
-          segment.delete();
-          journalMetrics.decSegmentCount();
-        }
-
-        // removes them from the segment map
-        compactSegments.clear();
-
-        journalIndex.deleteUntil(index);
-      } finally {
-        rwlock.unlockWrite(stamp);
-      }
+    final var stamp = rwlock.writeLock();
+    try {
+      segments.deleteUntil(index);
+    } finally {
+      rwlock.unlockWrite(stamp);
     }
   }
 
@@ -191,11 +133,8 @@ public final class SegmentedJournal implements Journal {
 
   @Override
   public long getFirstIndex() {
-    if (!segments.isEmpty()) {
-      return segments.firstEntry().getValue().index();
-    } else {
-      return 0;
-    }
+    final var firstSegment = segments.getFirstSegment();
+    return firstSegment != null ? firstSegment.index() : 0;
   }
 
   @Override
@@ -227,49 +166,8 @@ public final class SegmentedJournal implements Journal {
 
   @Override
   public void close() {
-    segments
-        .values()
-        .forEach(
-            segment -> {
-              log.debug("Closing segment: {}", segment);
-              segment.close();
-            });
-    currentSegment = null;
+    segments.close();
     open = false;
-  }
-
-  /** Opens the segments. */
-  private synchronized void open() {
-    final var openDurationTimer = journalMetrics.startJournalOpenDurationTimer();
-    // Load existing log segments from disk.
-    for (final JournalSegment segment : loadSegments()) {
-      segments.put(segment.descriptor().index(), segment);
-      journalMetrics.incSegmentCount();
-    }
-
-    // If a segment doesn't already exist, create an initial segment starting at index 1.
-    if (!segments.isEmpty()) {
-      currentSegment = segments.lastEntry().getValue();
-    } else {
-      final JournalSegmentDescriptor descriptor =
-          JournalSegmentDescriptor.builder()
-              .withId(FIRST_SEGMENT_ID)
-              .withIndex(INITIAL_INDEX)
-              .withMaxSegmentSize(maxSegmentSize)
-              .build();
-
-      currentSegment = createSegment(descriptor);
-
-      segments.put(1L, currentSegment);
-      journalMetrics.incSegmentCount();
-    }
-    // observe the journal open duration
-    openDurationTimer.close();
-
-    // Delete files that were previously marked for deletion but did not get deleted because the
-    // node was stopped. It is safe to delete it now since there are no readers opened for these
-    // segments.
-    deleteDeferredFiles();
   }
 
   /**
@@ -278,7 +176,7 @@ public final class SegmentedJournal implements Journal {
    * @throws IllegalStateException if the journal is not open
    */
   private void assertOpen() {
-    checkState(currentSegment != null, "journal not open");
+    checkState(segments.getCurrentSegment() != null, "journal not open");
   }
 
   /** Asserts that enough disk space is available to allocate a new segment. */
@@ -298,53 +196,6 @@ public final class SegmentedJournal implements Journal {
     return directory;
   }
 
-  /** Resets the current segment, creating a new segment if necessary. */
-  private synchronized void resetCurrentSegment() {
-    final JournalSegment lastSegment = getLastSegment();
-    if (lastSegment != null) {
-      currentSegment = lastSegment;
-    } else {
-      final JournalSegmentDescriptor descriptor =
-          JournalSegmentDescriptor.builder()
-              .withId(1)
-              .withIndex(1)
-              .withMaxSegmentSize(maxSegmentSize)
-              .build();
-
-      currentSegment = createSegment(descriptor);
-
-      segments.put(1L, currentSegment);
-      journalMetrics.incSegmentCount();
-    }
-  }
-
-  /**
-   * Resets and returns the first segment in the journal.
-   *
-   * @param index the starting index of the journal
-   * @return the first segment
-   */
-  JournalSegment resetSegments(final long index) {
-    assertOpen();
-
-    for (final JournalSegment segment : segments.values()) {
-      segment.delete();
-      journalMetrics.decSegmentCount();
-    }
-    segments.clear();
-
-    final JournalSegmentDescriptor descriptor =
-        JournalSegmentDescriptor.builder()
-            .withId(1)
-            .withIndex(index)
-            .withMaxSegmentSize(maxSegmentSize)
-            .build();
-    currentSegment = createSegment(descriptor);
-    segments.put(index, currentSegment);
-    journalMetrics.incSegmentCount();
-    return currentSegment;
-  }
-
   /**
    * Returns the first segment in the log.
    *
@@ -352,8 +203,7 @@ public final class SegmentedJournal implements Journal {
    */
   JournalSegment getFirstSegment() {
     assertOpen();
-    final Map.Entry<Long, JournalSegment> segment = segments.firstEntry();
-    return segment != null ? segment.getValue() : null;
+    return segments.getFirstSegment();
   }
 
   /**
@@ -363,33 +213,13 @@ public final class SegmentedJournal implements Journal {
    */
   JournalSegment getLastSegment() {
     assertOpen();
-    final Map.Entry<Long, JournalSegment> segment = segments.lastEntry();
-    return segment != null ? segment.getValue() : null;
+    return segments.getLastSegment();
   }
 
-  /**
-   * Creates and returns the next segment.
-   *
-   * @return The next segment.
-   * @throws IllegalStateException if the segment manager is not open
-   */
-  synchronized JournalSegment getNextSegment() {
+  JournalSegment getNextSegment() {
     assertOpen();
     assertDiskSpace();
-
-    final JournalSegment lastSegment = getLastSegment();
-    final JournalSegmentDescriptor descriptor =
-        JournalSegmentDescriptor.builder()
-            .withId(lastSegment != null ? lastSegment.descriptor().id() + 1 : 1)
-            .withIndex(currentSegment.lastIndex() + 1)
-            .withMaxSegmentSize(maxSegmentSize)
-            .build();
-
-    currentSegment = createSegment(descriptor);
-
-    segments.put(descriptor.index(), currentSegment);
-    journalMetrics.incSegmentCount();
-    return currentSegment;
+    return segments.getNextSegment();
   }
 
   /**
@@ -399,8 +229,7 @@ public final class SegmentedJournal implements Journal {
    * @return The next segment for the given index.
    */
   JournalSegment getNextSegment(final long index) {
-    final Map.Entry<Long, JournalSegment> nextSegment = segments.higherEntry(index);
-    return nextSegment != null ? nextSegment.getValue() : null;
+    return segments.getNextSegment(index);
   }
 
   /**
@@ -409,20 +238,23 @@ public final class SegmentedJournal implements Journal {
    * @param index The index for which to return the segment.
    * @throws IllegalStateException if the segment manager is not open
    */
-  synchronized JournalSegment getSegment(final long index) {
+  JournalSegment getSegment(final long index) {
     assertOpen();
-    // Check if the current segment contains the given index first in order to prevent an
-    // unnecessary map lookup.
-    if (currentSegment != null && index > currentSegment.index()) {
-      return currentSegment;
-    }
+    return segments.getSegment(index);
+  }
 
-    // If the index is in another segment, get the entry with the next lowest first index.
-    final Map.Entry<Long, JournalSegment> segment = segments.floorEntry(index);
-    if (segment != null) {
-      return segment.getValue();
-    }
-    return getFirstSegment();
+  public void closeReader(final SegmentedJournalReader segmentedJournalReader) {
+    readers.remove(segmentedJournalReader);
+  }
+
+  /**
+   * Resets and returns the first segment in the journal.
+   *
+   * @param index the starting index of the journal
+   * @return the first segment
+   */
+  JournalSegment resetSegments(final long index) {
+    return segments.resetSegments(index);
   }
 
   /**
@@ -431,193 +263,8 @@ public final class SegmentedJournal implements Journal {
    * @param segment The segment to remove.
    */
   synchronized void removeSegment(final JournalSegment segment) {
-    segments.remove(segment.index());
-    journalMetrics.decSegmentCount();
-    segment.delete();
-    resetCurrentSegment();
+    segments.removeSegment(segment);
   }
-
-  /**
-   * Loads all segments from disk.
-   *
-   * @return A collection of segments for the log.
-   */
-  protected Collection<JournalSegment> loadSegments() {
-    // Ensure log directories are created.
-    directory.mkdirs();
-    final List<JournalSegment> segments = new ArrayList<>();
-
-    final List<File> files = getSortedLogSegments();
-    for (int i = 0; i < files.size(); i++) {
-      final File file = files.get(i);
-
-      try {
-        log.debug("Found segment file: {}", file.getName());
-        final JournalSegment segment = loadExistingSegment(file);
-
-        if (i > 0) {
-          checkForIndexGaps(segments.get(i - 1), segment);
-        }
-
-        segments.add(segment);
-      } catch (final CorruptedLogException e) {
-        if (handleSegmentCorruption(files, segments, i)) {
-          return segments;
-        }
-
-        throw e;
-      }
-    }
-
-    return segments;
-  }
-
-  private void checkForIndexGaps(final JournalSegment prevSegment, final JournalSegment segment) {
-    if (prevSegment.lastIndex() != segment.index() - 1) {
-      throw new CorruptedLogException(
-          String.format(
-              "Log segment %s is not aligned with previous segment %s (last index: %d).",
-              segment, prevSegment, prevSegment.lastIndex()));
-    }
-  }
-
-  /** Returns true if segments after corrupted segment were deleted; false, otherwise */
-  private boolean handleSegmentCorruption(
-      final List<File> files, final List<JournalSegment> segments, final int failedIndex) {
-    long lastSegmentIndex = 0;
-
-    if (!segments.isEmpty()) {
-      final JournalSegment previousSegment = segments.get(segments.size() - 1);
-      lastSegmentIndex = previousSegment.lastIndex();
-    }
-
-    if (lastWrittenIndex > lastSegmentIndex) {
-      return false;
-    }
-
-    log.debug(
-        "Found corrupted segment after last ack'ed index {}. Deleting segments {} - {}",
-        lastWrittenIndex,
-        files.get(failedIndex).getName(),
-        files.get(files.size() - 1).getName());
-
-    for (int i = failedIndex; i < files.size(); i++) {
-      final File file = files.get(i);
-      try {
-        Files.delete(file.toPath());
-      } catch (final IOException e) {
-        throw new JournalException(
-            String.format(
-                "Failed to delete log segment '%s' when handling corruption.", file.getName()),
-            e);
-      }
-    }
-
-    return true;
-  }
-
-  /** Returns an array of valid log segments sorted by their id which may be empty but not null. */
-  private List<File> getSortedLogSegments() {
-    final File[] files =
-        directory.listFiles(file -> file.isFile() && JournalSegmentFile.isSegmentFile(name, file));
-
-    if (files == null) {
-      throw new IllegalStateException(
-          String.format(
-              "Could not list files in directory '%s'. Either the path doesn't point to a directory or an I/O error occurred.",
-              directory));
-    }
-
-    Arrays.sort(
-        files, Comparator.comparingInt(f -> JournalSegmentFile.getSegmentIdFromPath(f.getName())));
-
-    return Arrays.asList(files);
-  }
-
-  private void deleteDeferredFiles() {
-    try (final DirectoryStream<Path> segmentsToDelete =
-        Files.newDirectoryStream(
-            directory.toPath(),
-            path -> JournalSegmentFile.isDeletedSegmentFile(name, path.getFileName().toString()))) {
-      segmentsToDelete.forEach(this::deleteDeferredFile);
-    } catch (final IOException e) {
-      log.warn(
-          "Could not delete segment files marked for deletion in {}. This can result in unnecessary disk usage.",
-          directory.toPath(),
-          e);
-    }
-  }
-
-  private void deleteDeferredFile(final Path segmentFileToDelete) {
-    try {
-      Files.deleteIfExists(segmentFileToDelete);
-    } catch (final IOException e) {
-      log.warn(
-          "Could not delete file {} which is marked for deletion. This can result in unnecessary disk usage.",
-          segmentFileToDelete,
-          e);
-    }
-  }
-
-  private JournalSegmentDescriptor readDescriptor(final File file) {
-    try (final FileChannel channel = FileChannel.open(file.toPath(), StandardOpenOption.READ)) {
-      final byte version = readVersion(channel, file.getName());
-      final int length = JournalSegmentDescriptor.getEncodingLengthForVersion(version);
-      if (file.length() < length) {
-        throw new CorruptedLogException(
-            String.format(
-                "Expected segment '%s' with version %d to be at least %d bytes long but it only has %d.",
-                file.getName(), version, length, file.length()));
-      }
-
-      final ByteBuffer buffer = ByteBuffer.allocate(length);
-      final int readBytes = channel.read(buffer, 0);
-
-      if (readBytes != -1 && readBytes < length) {
-        throw new JournalException(
-            String.format(
-                "Expected to read %d bytes of segment '%s' with %d version but only read %d bytes.",
-                length, file.getName(), version, readBytes));
-      }
-
-      buffer.flip();
-      return new JournalSegmentDescriptor(buffer);
-    } catch (final IndexOutOfBoundsException e) {
-      throw new JournalException(
-          String.format(
-              "Expected to read descriptor of segment '%s', but nothing was read.", file.getName()),
-          e);
-    } catch (final UnknownVersionException e) {
-      throw new CorruptedLogException(
-          String.format("Couldn't read or recognize version of segment '%s'.", file.getName()), e);
-    } catch (final IOException e) {
-      throw new JournalException(e);
-    }
-  }
-
-  private byte readVersion(final FileChannel channel, final String fileName) throws IOException {
-    final ByteBuffer buffer = ByteBuffer.allocate(1);
-    final int readBytes = channel.read(buffer);
-
-    if (readBytes == 0) {
-      throw new JournalException(
-          String.format(
-              "Expected to read the version byte from segment '%s' but nothing was read.",
-              fileName));
-    } else if (readBytes == -1) {
-      throw new CorruptedLogException(
-          String.format(
-              "Expected to read the version byte from segment '%s' but got EOF instead.",
-              fileName));
-    }
-
-    return buffer.get(0);
-  }
-
-  public void closeReader(final SegmentedJournalReader segmentedJournalReader) {
-    readers.remove(segmentedJournalReader);
-  }
-
   /**
    * Resets journal readers to the given index, if they are at a larger index.
    *
@@ -645,97 +292,5 @@ public final class SegmentedJournal implements Journal {
 
   void releaseReadlock(final long stamp) {
     rwlock.unlockRead(stamp);
-  }
-
-  private JournalSegment createSegment(final JournalSegmentDescriptor descriptor) {
-    final var segmentFile = JournalSegmentFile.createSegmentFile(name, directory, descriptor.id());
-    final MappedByteBuffer mappedSegment;
-
-    try {
-      mappedSegment = mapNewSegment(segmentFile, descriptor);
-    } catch (final IOException e) {
-      throw new JournalException(String.format("Failed to map new segment %s", segmentFile), e);
-    }
-
-    try {
-      descriptor.copyTo(mappedSegment);
-      mappedSegment.force();
-    } catch (final InternalError e) {
-      throw new JournalException(
-          String.format(
-              "Failed to ensure durability of segment %s with descriptor %s, rolling back",
-              segmentFile, descriptor),
-          e);
-    }
-
-    // while flushing the file's contents ensures its data is present on disk on recovery, it's also
-    // necessary to flush the directory to ensure that the file itself is visible as an entry of
-    // that directory after recovery
-    try {
-      FileUtil.flushDirectory(directory.toPath());
-    } catch (final IOException e) {
-      throw new JournalException(
-          String.format("Failed to flush journal directory after creating segment %s", segmentFile),
-          e);
-    }
-
-    return loadSegment(segmentFile, mappedSegment, descriptor);
-  }
-
-  private JournalSegment loadExistingSegment(final File segmentFile) {
-    final var descriptor = readDescriptor(segmentFile);
-    final MappedByteBuffer mappedSegment;
-
-    try {
-      mappedSegment = mapSegment(segmentFile, descriptor, Collections.emptySet());
-    } catch (final IOException e) {
-      throw new JournalException(
-          String.format("Failed to load existing segment %s", segmentFile), e);
-    }
-
-    return loadSegment(segmentFile, mappedSegment, descriptor);
-  }
-
-  private JournalSegment loadSegment(
-      final File file, final MappedByteBuffer buffer, final JournalSegmentDescriptor descriptor) {
-    final JournalSegmentFile segmentFile = new JournalSegmentFile(file);
-    return new JournalSegment(segmentFile, descriptor, buffer, lastWrittenIndex, journalIndex);
-  }
-
-  private MappedByteBuffer mapNewSegment(
-      final File segmentFile, final JournalSegmentDescriptor descriptor) throws IOException {
-    try {
-      return mapSegment(segmentFile, descriptor, Set.of(StandardOpenOption.CREATE_NEW));
-    } catch (final FileAlreadyExistsException e) {
-      // assuming we haven't written in that segment, just overwrite it; if we have, we may be able
-      // reuse, but that's up to the caller
-      if (lastWrittenIndex >= descriptor.index()) {
-        throw new JournalException(
-            String.format(
-                "Failed to create journal segment %s, as it already exists, and the last written "
-                    + "index %d indicates we've already written to it",
-                segmentFile, lastWrittenIndex),
-            e);
-      }
-
-      return mapSegment(segmentFile, descriptor, Set.of(StandardOpenOption.TRUNCATE_EXISTING));
-    }
-  }
-
-  private MappedByteBuffer mapSegment(
-      final File segmentFile,
-      final JournalSegmentDescriptor descriptor,
-      final Set<OpenOption> extraOptions)
-      throws IOException {
-    final var options = new HashSet<>(extraOptions);
-    options.add(StandardOpenOption.READ);
-    options.add(StandardOpenOption.WRITE);
-
-    try (final var channel = FileChannel.open(segmentFile.toPath(), options)) {
-      final var mappedSegment = channel.map(MapMode.READ_WRITE, 0, descriptor.maxSegmentSize());
-      mappedSegment.order(ENDIANNESS);
-
-      return mappedSegment;
-    }
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
@@ -131,6 +131,11 @@ public class SegmentedJournalBuilder {
   public SegmentedJournal build() {
     final JournalIndex journalIndex = new SparseJournalIndex(journalIndexDensity);
     return new SegmentedJournal(
-        name, directory, maxSegmentSize, freeDiskSpace, journalIndex, lastWrittenIndex);
+        name,
+        directory,
+        maxSegmentSize,
+        freeDiskSpace,
+        journalIndex,
+        new SegmentsManager(journalIndex, maxSegmentSize, directory, lastWrittenIndex, name));
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -1,0 +1,391 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import io.camunda.zeebe.journal.JournalException;
+import io.camunda.zeebe.journal.file.record.CorruptedLogException;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.SortedMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Create new segments. Load existing segments from the segment file. Keep track of all segments.
+ */
+final class SegmentsManager {
+
+  private static final int FIRST_SEGMENT_ID = 1;
+  private static final int INITIAL_INDEX = 1;
+
+  private static final Logger log = LoggerFactory.getLogger(SegmentsManager.class);
+
+  private final JournalMetrics journalMetrics;
+  private final NavigableMap<Long, JournalSegment> segments = new ConcurrentSkipListMap<>();
+  private volatile JournalSegment currentSegment;
+
+  private final JournalIndex journalIndex;
+  private final int maxSegmentSize;
+
+  private final File directory;
+
+  private final SegmentLoader segmentLoader;
+
+  private final long lastWrittenIndex;
+
+  private final String name;
+
+  public SegmentsManager(
+      final JournalMetrics journalMetrics,
+      final JournalIndex journalIndex,
+      final int maxSegmentSize,
+      final File directory,
+      final long lastWrittenIndex,
+      final String name) {
+    this.journalMetrics = journalMetrics;
+    this.journalIndex = journalIndex;
+    this.maxSegmentSize = maxSegmentSize;
+    this.directory = directory;
+    this.lastWrittenIndex = lastWrittenIndex;
+    this.name = name;
+    segmentLoader = new SegmentLoader(lastWrittenIndex, this.journalIndex);
+  }
+
+  void close() {
+    segments
+        .values()
+        .forEach(
+            segment -> {
+              log.debug("Closing segment: {}", segment);
+              segment.close();
+            });
+    currentSegment = null;
+  }
+
+  JournalSegment getCurrentSegment() {
+    return currentSegment;
+  }
+
+  JournalSegment getFirstSegment() {
+    final Map.Entry<Long, JournalSegment> segment = segments.firstEntry();
+    return segment != null ? segment.getValue() : null;
+  }
+
+  JournalSegment getLastSegment() {
+    final Map.Entry<Long, JournalSegment> segment = segments.lastEntry();
+    return segment != null ? segment.getValue() : null;
+  }
+
+  /**
+   * Creates and returns the next segment.
+   *
+   * @return The next segment.
+   * @throws IllegalStateException if the segment manager is not open
+   */
+  JournalSegment getNextSegment() {
+
+    final JournalSegment lastSegment = getLastSegment();
+    final JournalSegmentDescriptor descriptor =
+        JournalSegmentDescriptor.builder()
+            .withId(lastSegment != null ? lastSegment.descriptor().id() + 1 : 1)
+            .withIndex(currentSegment.lastIndex() + 1)
+            .withMaxSegmentSize(maxSegmentSize)
+            .build();
+
+    currentSegment = createSegment(descriptor);
+
+    segments.put(descriptor.index(), currentSegment);
+    journalMetrics.incSegmentCount();
+    return currentSegment;
+  }
+
+  JournalSegment getNextSegment(final long index) {
+    final Map.Entry<Long, JournalSegment> nextSegment = segments.higherEntry(index);
+    return nextSegment != null ? nextSegment.getValue() : null;
+  }
+
+  JournalSegment getSegment(final long index) {
+    // Check if the current segment contains the given index first in order to prevent an
+    // unnecessary map lookup.
+    if (currentSegment != null && index > currentSegment.index()) {
+      return currentSegment;
+    }
+
+    // If the index is in another segment, get the entry with the next lowest first index.
+    final Map.Entry<Long, JournalSegment> segment = segments.floorEntry(index);
+    if (segment != null) {
+      return segment.getValue();
+    }
+    return getFirstSegment();
+  }
+
+  private long getFirstIndex() {
+    final var firstSegment = getFirstSegment();
+    return firstSegment != null ? firstSegment.index() : 0;
+  }
+
+  void deleteUntil(final long index) {
+    final Map.Entry<Long, JournalSegment> segmentEntry = segments.floorEntry(index);
+    if (segmentEntry != null) {
+      final SortedMap<Long, JournalSegment> compactSegments =
+          segments.headMap(segmentEntry.getValue().index());
+      if (compactSegments.isEmpty()) {
+        log.debug(
+            "No segments can be deleted with index < {} (first log index: {})",
+            index,
+            getFirstIndex());
+        return;
+      }
+
+      log.debug(
+          "{} - Deleting log up from {} up to {} (removing {} segments)",
+          name,
+          getFirstIndex(),
+          compactSegments.get(compactSegments.lastKey()).index(),
+          compactSegments.size());
+      for (final JournalSegment segment : compactSegments.values()) {
+        log.trace("{} - Deleting segment: {}", name, segment);
+        segment.delete();
+        journalMetrics.decSegmentCount();
+      }
+
+      // removes them from the segment map
+      compactSegments.clear();
+
+      journalIndex.deleteUntil(index);
+    }
+  }
+
+  /**
+   * Resets and returns the first segment in the journal.
+   *
+   * @param index the starting index of the journal
+   * @return the first segment
+   */
+  JournalSegment resetSegments(final long index) {
+    for (final JournalSegment segment : segments.values()) {
+      segment.delete();
+      journalMetrics.decSegmentCount();
+    }
+    segments.clear();
+
+    final JournalSegmentDescriptor descriptor =
+        JournalSegmentDescriptor.builder()
+            .withId(1)
+            .withIndex(index)
+            .withMaxSegmentSize(maxSegmentSize)
+            .build();
+    currentSegment = createSegment(descriptor);
+    segments.put(index, currentSegment);
+    journalMetrics.incSegmentCount();
+    return currentSegment;
+  }
+
+  /**
+   * Removes a segment.
+   *
+   * @param segment The segment to remove.
+   */
+  void removeSegment(final JournalSegment segment) {
+    segments.remove(segment.index());
+    journalMetrics.decSegmentCount();
+    segment.delete();
+    resetCurrentSegment();
+  }
+
+  /** Resets the current segment, creating a new segment if necessary. */
+  private void resetCurrentSegment() {
+    final JournalSegment lastSegment = getLastSegment();
+    if (lastSegment != null) {
+      currentSegment = lastSegment;
+    } else {
+      final JournalSegmentDescriptor descriptor =
+          JournalSegmentDescriptor.builder()
+              .withId(1)
+              .withIndex(1)
+              .withMaxSegmentSize(maxSegmentSize)
+              .build();
+
+      currentSegment = createSegment(descriptor);
+
+      segments.put(1L, currentSegment);
+      journalMetrics.incSegmentCount();
+    }
+  }
+
+  void open() {
+    final var openDurationTimer = journalMetrics.startJournalOpenDurationTimer();
+    // Load existing log segments from disk.
+    for (final JournalSegment segment : loadSegments()) {
+      segments.put(segment.descriptor().index(), segment);
+      journalMetrics.incSegmentCount();
+    }
+
+    // If a segment doesn't already exist, create an initial segment starting at index 1.
+    if (!segments.isEmpty()) {
+      currentSegment = segments.lastEntry().getValue();
+    } else {
+      final JournalSegmentDescriptor descriptor =
+          JournalSegmentDescriptor.builder()
+              .withId(FIRST_SEGMENT_ID)
+              .withIndex(INITIAL_INDEX)
+              .withMaxSegmentSize(maxSegmentSize)
+              .build();
+
+      currentSegment = createSegment(descriptor);
+
+      segments.put(1L, currentSegment);
+      journalMetrics.incSegmentCount();
+    }
+    // observe the journal open duration
+    openDurationTimer.close();
+
+    // Delete files that were previously marked for deletion but did not get deleted because the
+    // node was stopped. It is safe to delete it now since there are no readers opened for these
+    // segments.
+    deleteDeferredFiles();
+  }
+
+  private JournalSegment createSegment(final JournalSegmentDescriptor descriptor) {
+    final var segmentFile = JournalSegmentFile.createSegmentFile(name, directory, descriptor.id());
+    return segmentLoader.createSegment(descriptor, segmentFile);
+  }
+
+  /**
+   * Loads all segments from disk.
+   *
+   * @return A collection of segments for the log.
+   */
+  private Collection<JournalSegment> loadSegments() {
+    // Ensure log directories are created.
+    directory.mkdirs();
+    final List<JournalSegment> segments = new ArrayList<>();
+
+    final List<File> files = getSortedLogSegments();
+    for (int i = 0; i < files.size(); i++) {
+      final File file = files.get(i);
+
+      try {
+        log.debug("Found segment file: {}", file.getName());
+        final JournalSegment segment = segmentLoader.loadExistingSegment(file);
+
+        if (i > 0) {
+          checkForIndexGaps(segments.get(i - 1), segment);
+        }
+
+        segments.add(segment);
+      } catch (final CorruptedLogException e) {
+        if (handleSegmentCorruption(files, segments, i)) {
+          return segments;
+        }
+
+        throw e;
+      }
+    }
+
+    return segments;
+  }
+
+  private void checkForIndexGaps(final JournalSegment prevSegment, final JournalSegment segment) {
+    if (prevSegment.lastIndex() != segment.index() - 1) {
+      throw new CorruptedLogException(
+          String.format(
+              "Log segment %s is not aligned with previous segment %s (last index: %d).",
+              segment, prevSegment, prevSegment.lastIndex()));
+    }
+  }
+
+  /** Returns true if segments after corrupted segment were deleted; false, otherwise */
+  private boolean handleSegmentCorruption(
+      final List<File> files, final List<JournalSegment> segments, final int failedIndex) {
+    long lastSegmentIndex = 0;
+
+    if (!segments.isEmpty()) {
+      final JournalSegment previousSegment = segments.get(segments.size() - 1);
+      lastSegmentIndex = previousSegment.lastIndex();
+    }
+
+    if (lastWrittenIndex > lastSegmentIndex) {
+      return false;
+    }
+
+    log.debug(
+        "Found corrupted segment after last ack'ed index {}. Deleting segments {} - {}",
+        lastWrittenIndex,
+        files.get(failedIndex).getName(),
+        files.get(files.size() - 1).getName());
+
+    for (int i = failedIndex; i < files.size(); i++) {
+      final File file = files.get(i);
+      try {
+        Files.delete(file.toPath());
+      } catch (final IOException e) {
+        throw new JournalException(
+            String.format(
+                "Failed to delete log segment '%s' when handling corruption.", file.getName()),
+            e);
+      }
+    }
+
+    return true;
+  }
+
+  /** Returns an array of valid log segments sorted by their id which may be empty but not null. */
+  private List<File> getSortedLogSegments() {
+    final File[] files =
+        directory.listFiles(file -> file.isFile() && JournalSegmentFile.isSegmentFile(name, file));
+
+    if (files == null) {
+      throw new IllegalStateException(
+          String.format(
+              "Could not list files in directory '%s'. Either the path doesn't point to a directory or an I/O error occurred.",
+              directory));
+    }
+
+    Arrays.sort(
+        files, Comparator.comparingInt(f -> JournalSegmentFile.getSegmentIdFromPath(f.getName())));
+
+    return Arrays.asList(files);
+  }
+
+  private void deleteDeferredFiles() {
+    try (final DirectoryStream<Path> segmentsToDelete =
+        Files.newDirectoryStream(
+            directory.toPath(),
+            path -> JournalSegmentFile.isDeletedSegmentFile(name, path.getFileName().toString()))) {
+      segmentsToDelete.forEach(this::deleteDeferredFile);
+    } catch (final IOException e) {
+      log.warn(
+          "Could not delete segment files marked for deletion in {}. This can result in unnecessary disk usage.",
+          directory.toPath(),
+          e);
+    }
+  }
+
+  private void deleteDeferredFile(final Path segmentFileToDelete) {
+    try {
+      Files.deleteIfExists(segmentFileToDelete);
+    } catch (final IOException e) {
+      log.warn(
+          "Could not delete file {} which is marked for deletion. This can result in unnecessary disk usage.",
+          segmentFileToDelete,
+          e);
+    }
+  }
+}

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.journal.file;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.journal.file.record.CorruptedLogException;
 import java.io.File;
@@ -52,18 +54,17 @@ final class SegmentsManager {
   private final String name;
 
   public SegmentsManager(
-      final JournalMetrics journalMetrics,
       final JournalIndex journalIndex,
       final int maxSegmentSize,
       final File directory,
       final long lastWrittenIndex,
       final String name) {
-    this.journalMetrics = journalMetrics;
+    this.name = checkNotNull(name, "name cannot be null");
+    journalMetrics = new JournalMetrics(name);
     this.journalIndex = journalIndex;
     this.maxSegmentSize = maxSegmentSize;
     this.directory = directory;
     this.lastWrittenIndex = lastWrittenIndex;
-    this.name = name;
     segmentLoader = new SegmentLoader(lastWrittenIndex, this.journalIndex);
   }
 

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.journal.file.record.CorruptedLogException;
+import io.camunda.zeebe.journal.file.record.RecordData;
+import io.camunda.zeebe.journal.file.record.SBESerializer;
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Objects;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SegmentsManagerTest {
+
+  private static final String JOURNAL_NAME = "journal";
+
+  @TempDir Path directory;
+  private final int journalIndexDensity = 1;
+  private final DirectBuffer data = new UnsafeBuffer("test".getBytes(StandardCharsets.UTF_8));
+  private final int entrySize = getSerializedSize(data);
+
+  @Test
+  void shouldDeleteFilesMarkedForDeletionsOnLoad() {
+    // given
+    final var segments = createSegmentsManager(0);
+    segments.open();
+    segments.getFirstSegment().createReader();
+    segments.getFirstSegment().delete();
+
+    // when
+    // if we close the current journal, it will delete the files on closing. So we cannot test this
+    // scenario.
+    createSegmentsManager(0).open();
+
+    // then
+    final File logDirectory = directory.resolve("data").toFile();
+    assertThat(logDirectory)
+        .isDirectoryNotContaining(
+            file -> JournalSegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
+        .isDirectoryContaining(
+            file -> JournalSegmentFile.isSegmentFile(JOURNAL_NAME, file.getName()));
+  }
+
+  @Test
+  void shouldDetectCorruptionAtDescriptorWithAckedEntries() throws Exception {
+    // given
+    final var journal = openJournal(1);
+    final long index = journal.append(data).index();
+
+    journal.close();
+    final File dataFile = directory.resolve("data").toFile();
+    final File logFile =
+        Objects.requireNonNull(dataFile.listFiles(f -> f.getName().endsWith(".log")))[0];
+    LogCorrupter.corruptDescriptor(logFile);
+
+    // when/then
+    final var segments = createSegmentsManager(index);
+    assertThatThrownBy(segments::open).isInstanceOf(CorruptedLogException.class);
+  }
+
+  @Test
+  void shouldNotThrowExceptionWhenCorruptionAtNotAckEntries() throws Exception {
+    // given
+    final var journal = openJournal(1);
+    final var index = journal.append(data).index();
+    journal.append(data);
+
+    journal.close();
+    final File dataFile = directory.resolve("data").toFile();
+    final File logFile =
+        Objects.requireNonNull(dataFile.listFiles(f -> f.getName().endsWith("2.log")))[0];
+    LogCorrupter.corruptDescriptor(logFile);
+
+    // when/then
+    final var segments = createSegmentsManager(index);
+    assertThatNoException().isThrownBy(segments::open);
+    assertThat(segments.getFirstSegment().index()).isEqualTo(index);
+    assertThat(segments.getLastSegment().index()).isEqualTo(index);
+  }
+
+  @Test
+  void shouldNotThrowExceptionWhenCorruptionAtDescriptorWithoutAckedEntries() throws Exception {
+    // given
+    final var journal = openJournal(1);
+    journal.close();
+    final File dataFile = directory.resolve("data").toFile();
+    final File logFile =
+        Objects.requireNonNull(dataFile.listFiles(f -> f.getName().endsWith(".log")))[0];
+    LogCorrupter.corruptDescriptor(logFile);
+
+    // when/then
+    final var segments = createSegmentsManager(0);
+    assertThatNoException().isThrownBy(segments::open);
+    assertThat(segments.getFirstSegment().index()).isEqualTo(1);
+    assertThat(segments.getFirstSegment().lastIndex()).isEqualTo(0);
+  }
+
+  @Test
+  void shouldHandlePartiallyWrittenDescriptor() throws Exception {
+    // given
+    final File dataFile = directory.resolve("data").toFile();
+    assertThat(dataFile.mkdirs()).isTrue();
+    final File emptyLog = new File(dataFile, "journal-1.log");
+    assertThat(emptyLog.createNewFile()).isTrue();
+
+    // when
+    final var segments = createSegmentsManager(0);
+
+    // then
+    assertThatNoException().isThrownBy(segments::open);
+    assertThat(segments.getFirstSegment().index()).isEqualTo(1);
+    assertThat(segments.getFirstSegment().lastIndex()).isEqualTo(0);
+  }
+
+  private SegmentsManager createSegmentsManager(final long lastWrittenIndex) {
+    return new SegmentsManager(
+        new SparseJournalIndex(journalIndexDensity),
+        entrySize + JournalSegmentDescriptor.getEncodingLength(),
+        directory.resolve("data").toFile(),
+        lastWrittenIndex,
+        JOURNAL_NAME);
+  }
+
+  private SegmentedJournal openJournal(final float entriesPerSegment) {
+    return openJournal(entriesPerSegment, entrySize);
+  }
+
+  private SegmentedJournal openJournal(final float entriesPerSegment, final int entrySize) {
+    return SegmentedJournal.builder()
+        .withDirectory(directory.resolve("data").toFile())
+        .withMaxSegmentSize(
+            (int) (entrySize * entriesPerSegment) + JournalSegmentDescriptor.getEncodingLength())
+        .withJournalIndexDensity(journalIndexDensity)
+        .withName(JOURNAL_NAME)
+        .build();
+  }
+
+  private int getSerializedSize(final DirectBuffer data) {
+    final var record = new RecordData(1, 1, data);
+    final var serializer = new SBESerializer();
+    final ByteBuffer buffer = ByteBuffer.allocate(128);
+    return serializer.writeData(record, new UnsafeBuffer(buffer), 0).get()
+        + FrameUtil.getLength()
+        + serializer.getMetadataLength();
+  }
+}


### PR DESCRIPTION
## Description

Split loading and managing segments out of `SegmentedJournal`. The goal is not reduce the responsbility of `SegmentedJournal` class.

This PR only moved some code around. In addition, it also removed `synchronized` from a lot of methods. It seems unnecessary, as we already assume a single-writer multiple-readers semantics. Having `synchronized` is not helping us to prevent any race conditions. 

## Related issues

closes #7604 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
