### PR TITLE
Partition scoped components can register as DiskSpaceUsageListener

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
 import io.camunda.zeebe.broker.system.management.LeaderManagementRequestHandler;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
-import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
@@ -61,10 +60,6 @@ public interface BrokerStartupContext {
   ClusterServicesImpl getClusterServices();
 
   void setClusterServices(ClusterServicesImpl o);
-
-  void addDiskSpaceUsageListener(DiskSpaceUsageListener listener);
-
-  void removeDiskSpaceUsageListener(DiskSpaceUsageListener listener);
 
   CommandApiServiceImpl getCommandApiService();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
 import io.camunda.zeebe.broker.system.management.LeaderManagementRequestHandler;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
-import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
@@ -139,20 +138,6 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public void setClusterServices(final ClusterServicesImpl clusterServices) {
     this.clusterServices = clusterServices;
-  }
-
-  @Override
-  public void addDiskSpaceUsageListener(final DiskSpaceUsageListener listener) {
-    if (diskSpaceUsageMonitor != null) {
-      diskSpaceUsageMonitor.addDiskUsageListener(listener);
-    }
-  }
-
-  @Override
-  public void removeDiskSpaceUsageListener(final DiskSpaceUsageListener listener) {
-    if (diskSpaceUsageMonitor != null) {
-      diskSpaceUsageMonitor.removeDiskUsageListener(listener);
-    }
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStep.java
@@ -41,7 +41,9 @@ final class CommandApiServiceStep extends AbstractBrokerStartupStep {
       return;
     }
     brokerShutdownContext.removePartitionListener(commandApiServiceActor);
-    brokerShutdownContext.removeDiskSpaceUsageListener(commandApiServiceActor);
+    brokerShutdownContext
+        .getDiskSpaceUsageMonitor()
+        .removeDiskUsageListener(commandApiServiceActor);
 
     concurrencyControl.runOnCompletion(
         commandApiServiceActor.closeAsync(),
@@ -105,7 +107,9 @@ final class CommandApiServiceStep extends AbstractBrokerStartupStep {
             () -> {
               brokerStartupContext.setCommandApiService(commandApiService);
               brokerStartupContext.addPartitionListener(commandApiService);
-              brokerStartupContext.addDiskSpaceUsageListener(commandApiService);
+              brokerStartupContext
+                  .getDiskSpaceUsageMonitor()
+                  .addDiskUsageListener(commandApiService);
               startupFuture.complete(brokerStartupContext);
             },
             startupFuture));

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/LeaderManagementRequestHandlerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/LeaderManagementRequestHandlerStep.java
@@ -47,7 +47,9 @@ final class LeaderManagementRequestHandlerStep extends AbstractBrokerStartupStep
           forwardExceptions(
               () -> {
                 brokerStartupContext.addPartitionListener(managementRequestHandler);
-                brokerStartupContext.addDiskSpaceUsageListener(managementRequestHandler);
+                brokerStartupContext
+                    .getDiskSpaceUsageMonitor()
+                    .addDiskUsageListener(managementRequestHandler);
 
                 brokerStartupContext.setLeaderManagementRequestHandler(managementRequestHandler);
 
@@ -82,7 +84,7 @@ final class LeaderManagementRequestHandlerStep extends AbstractBrokerStartupStep
 
           forwardExceptions(
               () -> {
-                brokerShutdownContext.removeDiskSpaceUsageListener(handler);
+                brokerShutdownContext.getDiskSpaceUsageMonitor().removeDiskUsageListener(handler);
                 brokerShutdownContext.removePartitionListener(handler);
                 brokerShutdownContext.setLeaderManagementRequestHandler(null);
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -33,7 +33,7 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
             brokerStartupContext
                 .getLeaderManagementRequestHandler()
                 .getPushDeploymentRequestHandler(),
-            brokerStartupContext::addDiskSpaceUsageListener,
+            brokerStartupContext.getDiskSpaceUsageMonitor(),
             brokerStartupContext.getPartitionListeners(),
             brokerStartupContext.getCommandApiService(),
             brokerStartupContext.getExporterRepository());

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/SubscriptionApiStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/SubscriptionApiStep.java
@@ -37,7 +37,9 @@ class SubscriptionApiStep extends AbstractBrokerStartupStep {
         proceed(
             () -> {
               brokerStartupContext.addPartitionListener(subscriptionApiService);
-              brokerStartupContext.addDiskSpaceUsageListener(subscriptionApiService);
+              brokerStartupContext
+                  .getDiskSpaceUsageMonitor()
+                  .addDiskUsageListener(subscriptionApiService);
 
               brokerStartupContext.setSubscriptionApiService(subscriptionApiService);
               startupFuture.complete(brokerStartupContext);
@@ -63,7 +65,9 @@ class SubscriptionApiStep extends AbstractBrokerStartupStep {
         proceed(
             () -> {
               brokerShutdownContext.removePartitionListener(subscriptionApiService);
-              brokerShutdownContext.removeDiskSpaceUsageListener(subscriptionApiService);
+              brokerShutdownContext
+                  .getDiskSpaceUsageMonitor()
+                  .removeDiskUsageListener(subscriptionApiService);
 
               brokerShutdownContext.setSubscriptionApiService(null);
               shutdownFuture.complete(brokerShutdownContext);

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.broker.partitioning.topology.TopologyPartitionListenerIm
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.deployment.PushDeploymentRequestHandler;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.PartitionStartupAndTransitionContextImpl;
 import io.camunda.zeebe.broker.system.partitions.PartitionStartupContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransition;
@@ -88,6 +89,7 @@ final class PartitionFactory {
   private final ClusterServices clusterServices;
   private final ExporterRepository exporterRepository;
   private final BrokerHealthCheckService healthCheckService;
+  private final DiskSpaceUsageMonitor diskSpaceUsageMonitor;
 
   PartitionFactory(
       final ActorSchedulingService actorSchedulingService,
@@ -98,7 +100,8 @@ final class PartitionFactory {
       final FileBasedSnapshotStoreFactory snapshotStoreFactory,
       final ClusterServices clusterServices,
       final ExporterRepository exporterRepository,
-      final BrokerHealthCheckService healthCheckService) {
+      final BrokerHealthCheckService healthCheckService,
+      final DiskSpaceUsageMonitor diskSpaceUsageMonitor) {
     this.actorSchedulingService = actorSchedulingService;
     this.brokerCfg = brokerCfg;
     this.localBroker = localBroker;
@@ -108,6 +111,7 @@ final class PartitionFactory {
     this.clusterServices = clusterServices;
     this.exporterRepository = exporterRepository;
     this.healthCheckService = healthCheckService;
+    this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
   }
 
   List<ZeebePartition> constructPartitions(
@@ -163,7 +167,8 @@ final class PartitionFactory {
               stateController,
               typedRecordProcessorsFactory,
               exporterRepository,
-              new PartitionProcessingState(owningPartition));
+              new PartitionProcessingState(owningPartition),
+              diskSpaceUsageMonitor);
 
       final PartitionTransition newTransitionBehavior =
           new PartitionTransitionImpl(TRANSITION_STEPS);

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -210,6 +210,7 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
   }
 
   private void stopPartition(final ZeebePartition partition) {
+    diskSpaceUsageMonitor.removeDiskUsageListener(partition);
     healthCheckService.removeMonitoredPartition(partition.getPartitionId());
     partition.close();
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.logstreams.AtomixLogStorage;
 import io.camunda.zeebe.broker.logstreams.LogDeletionService;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionProcessingState;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -64,6 +65,7 @@ public class PartitionStartupAndTransitionContextImpl
   private final int maxFragmentSize;
   private final ExporterRepository exporterRepository;
   private final PartitionProcessingState partitionProcessingState;
+  private final DiskSpaceUsageMonitor diskSpaceUsageMonitor;
   private final StateController stateController;
 
   private StreamProcessor streamProcessor;
@@ -96,7 +98,8 @@ public class PartitionStartupAndTransitionContextImpl
       final StateController stateController,
       final TypedRecordProcessorsFactory typedRecordProcessorsFactory,
       final ExporterRepository exporterRepository,
-      final PartitionProcessingState partitionProcessingState) {
+      final PartitionProcessingState partitionProcessingState,
+      final DiskSpaceUsageMonitor diskSpaceUsageMonitor) {
     this.nodeId = nodeId;
     this.raftPartition = raftPartition;
     this.messagingService = messagingService;
@@ -113,6 +116,7 @@ public class PartitionStartupAndTransitionContextImpl
     maxFragmentSize = (int) brokerCfg.getNetwork().getMaxMessageSizeInBytes();
     this.exporterRepository = exporterRepository;
     this.partitionProcessingState = partitionProcessingState;
+    this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
   }
 
   public PartitionAdminControl getPartitionAdminControl() {
@@ -234,6 +238,11 @@ public class PartitionStartupAndTransitionContextImpl
   @Override
   public void setQueryService(final QueryService queryService) {
     this.queryService = queryService;
+  }
+
+  @Override
+  public DiskSpaceUsageMonitor getDiskSpaceUsageMonitor() {
+    return diskSpaceUsageMonitor;
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.logstreams.AtomixLogStorage;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
@@ -86,4 +87,6 @@ public interface PartitionTransitionContext extends PartitionContext {
   QueryService getQueryService();
 
   void setQueryService(QueryService queryService);
+
+  DiskSpaceUsageMonitor getDiskSpaceUsageMonitor();
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
@@ -65,6 +65,7 @@ class CommandApiServiceStepTest {
             mock(ExporterRepository.class),
             Collections.emptyList());
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
+    testBrokerStartupContext.setDiskSpaceUsageMonitor(mock(DiskSpaceUsageMonitor.class));
   }
 
   @Test
@@ -179,6 +180,7 @@ class CommandApiServiceStepTest {
       testBrokerStartupContext.setCommandApiServerTransport(mockAtomixServerTransport);
       testBrokerStartupContext.setCommandApiService(mockCommandApiService);
       testBrokerStartupContext.addPartitionListener(mockCommandApiService);
+      testBrokerStartupContext.setDiskSpaceUsageMonitor(mock(DiskSpaceUsageMonitor.class));
       testBrokerStartupContext
           .getDiskSpaceUsageMonitor()
           .addDiskUsageListener(mockCommandApiService);

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
@@ -179,7 +179,9 @@ class CommandApiServiceStepTest {
       testBrokerStartupContext.setCommandApiServerTransport(mockAtomixServerTransport);
       testBrokerStartupContext.setCommandApiService(mockCommandApiService);
       testBrokerStartupContext.addPartitionListener(mockCommandApiService);
-      testBrokerStartupContext.addDiskSpaceUsageListener(mockCommandApiService);
+      testBrokerStartupContext
+          .getDiskSpaceUsageMonitor()
+          .addDiskUsageListener(mockCommandApiService);
 
       shutdownFuture = CONCURRENCY_CONTROL.createFuture();
     }

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/LeaderManagementRequestHandlerStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/LeaderManagementRequestHandlerStepTest.java
@@ -58,7 +58,8 @@ class LeaderManagementRequestHandlerStepTest {
         .thenReturn(mockActorSchedulingService);
     when(mockBrokerStartupContext.getLeaderManagementRequestHandler())
         .thenReturn(mockLeaderManagementRequestHandler);
-
+    when(mockBrokerStartupContext.getDiskSpaceUsageMonitor())
+        .thenReturn(mock(DiskSpaceUsageMonitor.class));
     when(mockBrokerStartupContext.getClusterServices())
         .thenReturn(mock(ClusterServicesImpl.class, Mockito.RETURNS_DEEP_STUBS));
 
@@ -108,8 +109,7 @@ class LeaderManagementRequestHandlerStepTest {
     // then
     final var argumentCaptor = ArgumentCaptor.forClass(LeaderManagementRequestHandler.class);
     verify(mockBrokerStartupContext).setLeaderManagementRequestHandler(argumentCaptor.capture());
-    verify(mockBrokerStartupContext)
-        .getDiskSpaceUsageMonitor()
+    verify(mockBrokerStartupContext.getDiskSpaceUsageMonitor())
         .addDiskUsageListener(argumentCaptor.getValue());
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/SubscriptionApiStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/SubscriptionApiStepTest.java
@@ -54,6 +54,8 @@ class SubscriptionApiStepTest {
         .thenReturn(mockActorSchedulingService);
     when(mockBrokerStartupContext.getClusterServices()).thenReturn(mock(ClusterServicesImpl.class));
     when(mockBrokerStartupContext.getBrokerInfo()).thenReturn(mock(BrokerInfo.class));
+    when(mockBrokerStartupContext.getDiskSpaceUsageMonitor())
+        .thenReturn(mock(DiskSpaceUsageMonitor.class));
 
     when(mockActorSchedulingService.submitActor(any()))
         .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.logstreams.AtomixLogStorage;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessor;
@@ -157,6 +158,11 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public void setQueryService(final QueryService queryService) {
     this.queryService = queryService;
+  }
+
+  @Override
+  public DiskSpaceUsageMonitor getDiskSpaceUsageMonitor() {
+    return null;
   }
 
   public void setBrokerCfg(final BrokerCfg brokerCfg) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -53,6 +53,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private AsyncSnapshotDirector snapshotDirector;
   private QueryService queryService;
   private ConcurrencyControl concurrencyControl;
+  private DiskSpaceUsageMonitor diskSpaceUsageMonitor;
 
   @Override
   public int getPartitionId() {
@@ -162,7 +163,11 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
 
   @Override
   public DiskSpaceUsageMonitor getDiskSpaceUsageMonitor() {
-    return null;
+    return diskSpaceUsageMonitor;
+  }
+
+  public void setDiskSpaceUsageMonitor(final DiskSpaceUsageMonitor diskSpaceUsageMonitor) {
+    this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
   }
 
   public void setBrokerCfg(final BrokerCfg brokerCfg) {


### PR DESCRIPTION
## Description

Before this change, adding and removing a disk space usage listener was implemented directly by the broker context and the partition manager only had a callback to add usage listeners.

Since we now want to add partition scoped components as disk space usage listeners directly, the `DiskSpaceMonitor` is made available in the `PartitionTransitionContext`.

I couldn't adjust the `ZeebePartition` to not awkwardly forward the `noDiskAvailable` flag to the stream processor because the StreamProcessor can't be a `DiskSpaceUsageListener` itself due to circular dependencies between broker and engine.

This unblocks #9625 and closes #9712 
