### PR TITLE
Compact logs based on oldest snapshot

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/logstreams/LogDeletionService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/logstreams/LogDeletionService.java
@@ -12,21 +12,20 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshotListener;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
-import java.util.Collection;
 import java.util.Map;
 
 public final class LogDeletionService extends Actor implements PersistedSnapshotListener {
   private final LogCompactor logCompactor;
   private final String actorName;
-  private final Collection<PersistedSnapshotStore> persistedSnapshotStores;
+  private final PersistedSnapshotStore persistedSnapshotStore;
   private final int partitionId;
 
   public LogDeletionService(
       final int nodeId,
       final int partitionId,
       final LogCompactor logCompactor,
-      final Collection<PersistedSnapshotStore> persistedSnapshotStores) {
-    this.persistedSnapshotStores = persistedSnapshotStores;
+      final PersistedSnapshotStore persistedSnapshotStore) {
+    this.persistedSnapshotStore = persistedSnapshotStore;
     this.logCompactor = logCompactor;
     actorName = buildActorName(nodeId, "DeletionService", partitionId);
     this.partitionId = partitionId;
@@ -46,12 +45,12 @@ public final class LogDeletionService extends Actor implements PersistedSnapshot
 
   @Override
   protected void onActorStarting() {
-    persistedSnapshotStores.forEach(store -> store.addSnapshotListener(this));
+    persistedSnapshotStore.addSnapshotListener(this);
   }
 
   @Override
   protected void onActorClosing() {
-    persistedSnapshotStores.forEach(store -> store.removeSnapshotListener(this));
+    persistedSnapshotStore.removeSnapshotListener(this);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -159,7 +159,6 @@ final class PartitionFactory {
               commandApiService::newCommandResponseWriter,
               () -> commandApiService.getOnProcessedListener(partitionId),
               constructableSnapshotStore,
-              snapshotStoreFactory.getReceivableSnapshotStore(partitionId),
               stateController,
               typedRecordProcessorsFactory,
               exporterRepository,

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -30,8 +30,7 @@ import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
-import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
+import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import java.util.Collection;
 import java.util.Collections;
@@ -58,8 +57,7 @@ public class PartitionStartupAndTransitionContextImpl
   private final TypedRecordProcessorsFactory typedRecordProcessorsFactory;
   private final Supplier<CommandResponseWriter> commandResponseWriterSupplier;
   private final Supplier<Consumer<TypedRecord<?>>> onProcessedListenerSupplier;
-  private final ConstructableSnapshotStore constructableSnapshotStore;
-  private final ReceivableSnapshotStore receivableSnapshotStore;
+  private final PersistedSnapshotStore persistedSnapshotStore;
   private final Integer partitionId;
   private final int maxFragmentSize;
   private final ExporterRepository exporterRepository;
@@ -91,8 +89,7 @@ public class PartitionStartupAndTransitionContextImpl
       final BrokerCfg brokerCfg,
       final Supplier<CommandResponseWriter> commandResponseWriterSupplier,
       final Supplier<Consumer<TypedRecord<?>>> onProcessedListenerSupplier,
-      final ConstructableSnapshotStore constructableSnapshotStore,
-      final ReceivableSnapshotStore receivableSnapshotStore,
+      final PersistedSnapshotStore persistedSnapshotStore,
       final StateController stateController,
       final TypedRecordProcessorsFactory typedRecordProcessorsFactory,
       final ExporterRepository exporterRepository,
@@ -105,8 +102,7 @@ public class PartitionStartupAndTransitionContextImpl
     this.typedRecordProcessorsFactory = typedRecordProcessorsFactory;
     this.onProcessedListenerSupplier = onProcessedListenerSupplier;
     this.commandResponseWriterSupplier = commandResponseWriterSupplier;
-    this.constructableSnapshotStore = constructableSnapshotStore;
-    this.receivableSnapshotStore = receivableSnapshotStore;
+    this.persistedSnapshotStore = persistedSnapshotStore;
     this.partitionListeners = Collections.unmodifiableList(partitionListeners);
     partitionId = raftPartition.id().id();
     this.actorSchedulingService = actorSchedulingService;
@@ -302,13 +298,8 @@ public class PartitionStartupAndTransitionContextImpl
   }
 
   @Override
-  public ConstructableSnapshotStore getConstructableSnapshotStore() {
-    return constructableSnapshotStore;
-  }
-
-  @Override
-  public ReceivableSnapshotStore getReceivableSnapshotStore() {
-    return receivableSnapshotStore;
+  public PersistedSnapshotStore getPersistedSnapshotStore() {
+    return persistedSnapshotStore;
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupContext.java
@@ -14,8 +14,7 @@ import io.camunda.zeebe.engine.state.ZbColumnFamilies;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ScheduledTimer;
-import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
-import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
+import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 
 public interface PartitionStartupContext {
 
@@ -28,9 +27,7 @@ public interface PartitionStartupContext {
 
   ActorSchedulingService getActorSchedulingService();
 
-  ConstructableSnapshotStore getConstructableSnapshotStore();
-
-  ReceivableSnapshotStore getReceivableSnapshotStore();
+  PersistedSnapshotStore getPersistedSnapshotStore();
 
   // injected before bootstrap
   /**

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogDeletionPartitionStartupStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogDeletionPartitionStartupStep.java
@@ -34,9 +34,7 @@ public class LogDeletionPartitionStartupStep implements PartitionStartupStep {
             partitionStartupContext.getNodeId(),
             partitionStartupContext.getPartitionId(),
             logCompactor,
-            List.of(
-                partitionStartupContext.getConstructableSnapshotStore(),
-                partitionStartupContext.getReceivableSnapshotStore()));
+            List.of(partitionStartupContext.getPersistedSnapshotStore()));
 
     partitionStartupContext.setLogDeletionService(deletionService);
     final ActorFuture<PartitionStartupContext> startupFuture = new CompletableActorFuture<>();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogDeletionPartitionStartupStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogDeletionPartitionStartupStep.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.broker.system.partitions.PartitionStartupStep;
 import io.camunda.zeebe.scheduler.SchedulingHints;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import java.util.List;
 
 public class LogDeletionPartitionStartupStep implements PartitionStartupStep {
 
@@ -34,7 +33,7 @@ public class LogDeletionPartitionStartupStep implements PartitionStartupStep {
             partitionStartupContext.getNodeId(),
             partitionStartupContext.getPartitionId(),
             logCompactor,
-            List.of(partitionStartupContext.getPersistedSnapshotStore()));
+            partitionStartupContext.getPersistedSnapshotStore());
 
     partitionStartupContext.setLogDeletionService(deletionService);
     final ActorFuture<PartitionStartupContext> startupFuture = new CompletableActorFuture<>();

--- a/broker/src/test/java/io/camunda/zeebe/broker/logstreams/LogDeletionServiceTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/logstreams/LogDeletionServiceTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.logstreams;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.ActorScheduler.ActorSchedulerBuilder;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
+import io.camunda.zeebe.snapshots.SnapshotChunkReader;
+import io.camunda.zeebe.snapshots.SnapshotReservation;
+import java.nio.file.Path;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LogDeletionServiceTest {
+
+  private PersistedSnapshotStore snapshotStore;
+  private LogCompactor compactor;
+  private LogDeletionService service;
+  private ActorScheduler actorScheduler;
+
+  @BeforeEach
+  void before() {
+    actorScheduler = new ActorSchedulerBuilder().build();
+    actorScheduler.start();
+    snapshotStore = mock(PersistedSnapshotStore.class);
+    compactor = mock(LogCompactor.class);
+
+    service = new LogDeletionService(1, 1, compactor, snapshotStore);
+    actorScheduler.submitActor(service).join();
+  }
+
+  @AfterEach
+  void after() throws Exception {
+    service.close();
+    actorScheduler.close();
+  }
+
+  @Test
+  void shouldCompactOldestSnapshotIndex() {
+    // given
+    final Set<PersistedSnapshot> availableSnapshots =
+        Set.of(
+            new TestPersistedSnapshot(10),
+            new TestPersistedSnapshot(5),
+            new TestPersistedSnapshot(11));
+    final var actorFuture = CompletableActorFuture.completed(availableSnapshots);
+    when(snapshotStore.getAvailableSnapshots()).thenReturn(actorFuture);
+
+    // when
+    service.onNewSnapshot(new TestPersistedSnapshot(11));
+
+    // then
+    verify(compactor, timeout(1000).times(1)).compactLog(5);
+  }
+
+  static class TestPersistedSnapshot implements PersistedSnapshot {
+
+    private final long compactionBound;
+
+    TestPersistedSnapshot(final long compactionBound) {
+      this.compactionBound = compactionBound;
+    }
+
+    @Override
+    public int version() {
+      return 0;
+    }
+
+    @Override
+    public long getIndex() {
+      return 0;
+    }
+
+    @Override
+    public long getTerm() {
+      return 0;
+    }
+
+    @Override
+    public SnapshotChunkReader newChunkReader() {
+      return null;
+    }
+
+    @Override
+    public Path getPath() {
+      return null;
+    }
+
+    @Override
+    public long getCompactionBound() {
+      return compactionBound;
+    }
+
+    @Override
+    public String getId() {
+      return null;
+    }
+
+    @Override
+    public long getChecksum() {
+      return 0;
+    }
+
+    @Override
+    public ActorFuture<SnapshotReservation> reserve() {
+      return null;
+    }
+
+    @Override
+    public void close() {}
+  }
+}


### PR DESCRIPTION
## Description

For taking backups asynchronously, we have to keep the snapshot needed for the backup until the backup is completed. We should also not compact the log segments that are needed for the backup. To enable this we will now only compact the logs based on the oldest snapshot. The backup manager is expected to reserve the snapshot so that the snapshot store doesn't delete the snapshot. Thus even if there is a new snapshot, we won't compact the logs until the backup is completed.

## Related issues

closes #9627 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
