### PR TITLE
Preallocate segment files

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -508,6 +508,19 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
       return this;
     }
 
+    /**
+     * Sets whether segment files are pre-allocated at creation. If true, segment files are
+     * pre-allocated to the maximum segment size (see {@link #withSegmentSize(long)}) at creation
+     * before any writes happen.
+     *
+     * @param preallocateSegmentFiles true to preallocate files, false otherwise
+     * @return this builder for chaining
+     */
+    public Builder withPreallocateSegmentFiles(final boolean preallocateSegmentFiles) {
+      config.getStorageConfig().setPreallocateSegmentFiles(preallocateSegmentFiles);
+      return this;
+    }
+
     @Override
     public RaftPartitionGroup build() {
       return new RaftPartitionGroup(config);

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
@@ -29,11 +29,14 @@ public class RaftStorageConfig {
   private static final long DEFAULT_FREE_DISK_SPACE = 1024L * 1024 * 1024;
   private static final int DEFAULT_JOURNAL_INDEX_DENSITY = 100;
 
+  private static final boolean DEFAULT_PREALLOCATE_SEGMENT_FILES = true;
+
   private String directory;
   private long segmentSize = DEFAULT_MAX_SEGMENT_SIZE;
   private boolean flushExplicitly = DEFAULT_FLUSH_EXPLICITLY;
   private long freeDiskSpace = DEFAULT_FREE_DISK_SPACE;
   private int journalIndexDensity = DEFAULT_JOURNAL_INDEX_DENSITY;
+  private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
 
   @Optional("SnapshotStoreFactory")
   private ReceivableSnapshotStoreFactory persistedSnapshotStoreFactory;
@@ -151,5 +154,22 @@ public class RaftStorageConfig {
   public RaftStorageConfig setJournalIndexDensity(final int journalIndexDensity) {
     this.journalIndexDensity = journalIndexDensity;
     return this;
+  }
+
+  /**
+   * @return true to preallocate segment files, false otherwise
+   */
+  public boolean isPreallocateSegmentFiles() {
+    return preallocateSegmentFiles;
+  }
+
+  /**
+   * Sets whether segment files are pre-allocated at creation. If true, segment files are
+   * pre-allocated to {@link #segmentSize} at creation before any writes happen.
+   *
+   * @param preallocateSegmentFiles true to preallocate files, false otherwise
+   */
+  public void setPreallocateSegmentFiles(final boolean preallocateSegmentFiles) {
+    this.preallocateSegmentFiles = preallocateSegmentFiles;
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -349,6 +349,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
         .withFreeDiskSpace(storageConfig.getFreeDiskSpace())
         .withSnapshotStore(persistedSnapshotStore)
         .withJournalIndexDensity(storageConfig.getJournalIndexDensity())
+        .withPreallocateSegmentFiles(storageConfig.isPreallocateSegmentFiles())
         .build();
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -57,6 +57,7 @@ public final class RaftStorage {
   private final boolean flushExplicitly;
   private final ReceivableSnapshotStore persistedSnapshotStore;
   private final int journalIndexDensity;
+  private final boolean preallocateSegmentFiles;
 
   private RaftStorage(
       final String prefix,
@@ -65,7 +66,8 @@ public final class RaftStorage {
       final long freeDiskSpace,
       final boolean flushExplicitly,
       final ReceivableSnapshotStore persistedSnapshotStore,
-      final int journalIndexDensity) {
+      final int journalIndexDensity,
+      final boolean preallocateSegmentFiles) {
     this.prefix = prefix;
     this.directory = directory;
     this.maxSegmentSize = maxSegmentSize;
@@ -73,6 +75,7 @@ public final class RaftStorage {
     this.flushExplicitly = flushExplicitly;
     this.persistedSnapshotStore = persistedSnapshotStore;
     this.journalIndexDensity = journalIndexDensity;
+    this.preallocateSegmentFiles = preallocateSegmentFiles;
 
     try {
       FileUtil.ensureDirectoryExists(directory.toPath());
@@ -172,6 +175,7 @@ public final class RaftStorage {
         .withFlushExplicitly(flushExplicitly)
         .withJournalIndexDensity(journalIndexDensity)
         .withLastWrittenIndex(lastWrittenIndex)
+        .withPreallocateSegmentFiles(preallocateSegmentFiles)
         .build();
   }
 
@@ -218,6 +222,7 @@ public final class RaftStorage {
     private static final long DEFAULT_FREE_DISK_SPACE = 1024L * 1024 * 1024;
     private static final boolean DEFAULT_FLUSH_EXPLICITLY = true;
     private static final int DEFAULT_JOURNAL_INDEX_DENSITY = 100;
+    private static final boolean DEFAULT_PREALLOCATE_SEGMENT_FILES = true;
 
     private String prefix = DEFAULT_PREFIX;
     private File directory = new File(DEFAULT_DIRECTORY);
@@ -226,6 +231,7 @@ public final class RaftStorage {
     private boolean flushExplicitly = DEFAULT_FLUSH_EXPLICITLY;
     private ReceivableSnapshotStore persistedSnapshotStore;
     private int journalIndexDensity = DEFAULT_JOURNAL_INDEX_DENSITY;
+    private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
 
     private Builder() {}
 
@@ -317,6 +323,19 @@ public final class RaftStorage {
     }
 
     /**
+     * Sets whether segment files are pre-allocated at creation. If true, segment files are
+     * pre-allocated to the maximum segment size (see {@link #withMaxSegmentSize(int)}}) at creation
+     * before any writes happen.
+     *
+     * @param preallocateSegmentFiles true to preallocate files, false otherwise
+     * @return this builder for chaining
+     */
+    public Builder withPreallocateSegmentFiles(final boolean preallocateSegmentFiles) {
+      this.preallocateSegmentFiles = preallocateSegmentFiles;
+      return this;
+    }
+
+    /**
      * Builds the {@link RaftStorage} object.
      *
      * @return The built storage configuration.
@@ -330,7 +349,8 @@ public final class RaftStorage {
           freeDiskSpace,
           flushExplicitly,
           persistedSnapshotStore,
-          journalIndexDensity);
+          journalIndexDensity,
+          preallocateSegmentFiles);
     }
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
@@ -118,6 +118,19 @@ public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
     return this;
   }
 
+  /**
+   * Sets whether segment files are pre-allocated at creation. If true, segment files are
+   * pre-allocated to the maximum segment size (see {@link #withMaxSegmentSize(int)}}) at creation
+   * before any writes happen.
+   *
+   * @param preallocateSegmentFiles true to preallocate files, false otherwise
+   * @return this builder for chaining
+   */
+  public RaftLogBuilder withPreallocateSegmentFiles(final boolean preallocateSegmentFiles) {
+    journalBuilder.withPreallocateSegmentFiles(preallocateSegmentFiles);
+    return this;
+  }
+
   @Override
   public RaftLog build() {
     final Journal journal = journalBuilder.build();

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
@@ -77,7 +77,8 @@ final class RaftPartitionGroupFactory {
             .withMaxQuorumResponseTimeout(experimentalCfg.getRaft().getMaxQuorumResponseTimeout())
             .withMinStepDownFailureCount(experimentalCfg.getRaft().getMinStepDownFailureCount())
             .withPreferSnapshotReplicationThreshold(
-                experimentalCfg.getRaft().getPreferSnapshotReplicationThreshold());
+                experimentalCfg.getRaft().getPreferSnapshotReplicationThreshold())
+            .withPreallocateSegmentFiles(experimentalCfg.getRaft().isPreallocateSegmentFiles());
 
     final int maxMessageSize = (int) networkCfg.getMaxMessageSizeInBytes();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
@@ -15,11 +15,14 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
   private static final Duration DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT = Duration.ofSeconds(0);
   private static final int DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT = 3;
   private static final int DEFAULT_PREFER_SNAPSHOT_REPLICATION_THRESHOLD = 100;
+  private static final boolean DEFAULT_PREALLOCATE_SEGMENT_FILES = true;
 
   private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
   private Duration maxQuorumResponseTimeout = DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT;
   private int minStepDownFailureCount = DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT;
   private int preferSnapshotReplicationThreshold = DEFAULT_PREFER_SNAPSHOT_REPLICATION_THRESHOLD;
+
+  private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
 
   public Duration getRequestTimeout() {
     return requestTimeout;
@@ -51,5 +54,13 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
 
   public void setPreferSnapshotReplicationThreshold(final int preferSnapshotReplicationThreshold) {
     this.preferSnapshotReplicationThreshold = preferSnapshotReplicationThreshold;
+  }
+
+  public boolean isPreallocateSegmentFiles() {
+    return preallocateSegmentFiles;
+  }
+
+  public void setPreallocateSegmentFiles(final boolean preallocateSegmentFiles) {
+    this.preallocateSegmentFiles = preallocateSegmentFiles;
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
@@ -20,8 +20,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.util.unit.DataSize;
 
-class RaftPartitionGroupFactoryTest {
-
+final class RaftPartitionGroupFactoryTest {
   private static final ReceivableSnapshotStoreFactory SNAPSHOT_STORE_FACTORY =
       (directory, partitionId) -> mock(ReceivableSnapshotStore.class);
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
@@ -16,6 +16,8 @@ import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStoreFactory;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.util.unit.DataSize;
 
 class RaftPartitionGroupFactoryTest {
@@ -151,6 +153,19 @@ class RaftPartitionGroupFactoryTest {
 
     // then
     assertThat(config.getPartitionConfig().getPreferSnapshotReplicationThreshold()).isEqualTo(1000);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldSetSegmentFilesPreallocation(final boolean value) {
+    // given
+    brokerCfg.getExperimental().getRaft().setPreallocateSegmentFiles(value);
+
+    // when
+    final var config = buildRaftPartitionGroup();
+
+    // then
+    assertThat(config.getStorageConfig().isPreallocateSegmentFiles()).isEqualTo(value);
   }
 
   private RaftPartitionGroupConfig buildRaftPartitionGroup() {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfgTest.java
@@ -12,14 +12,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
-public class ExperimentalCfgTest {
+@Execution(ExecutionMode.CONCURRENT)
+final class ExperimentalCfgTest {
 
-  public final Map<String, String> environment = new HashMap<>();
+  final Map<String, String> environment = new HashMap<>();
 
   @Test
-  public void shouldSetRaftRequestTimeoutFromConfig() {
+  void shouldSetRaftRequestTimeoutFromConfig() {
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
     final var raft = cfg.getExperimental().getRaft();
@@ -29,7 +32,7 @@ public class ExperimentalCfgTest {
   }
 
   @Test
-  public void shouldSetRaftRequestTimeoutFromEnv() {
+  void shouldSetRaftRequestTimeoutFromEnv() {
     // given
     environment.put("zeebe.broker.experimental.raft.requestTimeout", "15s");
 
@@ -42,7 +45,7 @@ public class ExperimentalCfgTest {
   }
 
   @Test
-  public void shouldSetRaftMaxQuorumResponseTimeoutFromConfig() {
+  void shouldSetRaftMaxQuorumResponseTimeoutFromConfig() {
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
     final var raft = cfg.getExperimental().getRaft();
@@ -52,7 +55,7 @@ public class ExperimentalCfgTest {
   }
 
   @Test
-  public void shouldSetRaftMaxQuorumResponseTimeoutFromEnv() {
+  void shouldSetRaftMaxQuorumResponseTimeoutFromEnv() {
     // given
     environment.put("zeebe.broker.experimental.raft.maxQuorumResponseTimeout", "15s");
 
@@ -65,7 +68,7 @@ public class ExperimentalCfgTest {
   }
 
   @Test
-  public void shouldSetRaftMinStepDownFailureCountFromConfig() {
+  void shouldSetRaftMinStepDownFailureCountFromConfig() {
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
     final var raft = cfg.getExperimental().getRaft();
@@ -75,7 +78,7 @@ public class ExperimentalCfgTest {
   }
 
   @Test
-  public void shouldSetRaftMinStepDownFailureCountFromEnv() {
+  void shouldSetRaftMinStepDownFailureCountFromEnv() {
     // given
     environment.put("zeebe.broker.experimental.raft.minStepDownFailureCount", "10");
 
@@ -88,7 +91,7 @@ public class ExperimentalCfgTest {
   }
 
   @Test
-  public void shouldSetPreferSnapshotReplicationThresholdFromConfig() {
+  void shouldSetPreferSnapshotReplicationThresholdFromConfig() {
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
     final var raft = cfg.getExperimental().getRaft();
@@ -98,7 +101,7 @@ public class ExperimentalCfgTest {
   }
 
   @Test
-  public void shouldSetPreferSnapshotReplicationThresholdFromEnv() {
+  void shouldSetPreferSnapshotReplicationThresholdFromEnv() {
     // given
     environment.put("zeebe.broker.experimental.raft.preferSnapshotReplicationThreshold", "10");
 
@@ -111,7 +114,7 @@ public class ExperimentalCfgTest {
   }
 
   @Test
-  public void shouldSetEnablePreconditionsFromConfig() {
+  void shouldSetEnablePreconditionsFromConfig() {
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
     final var consistencyChecks = cfg.getExperimental().getConsistencyChecks();
@@ -121,7 +124,7 @@ public class ExperimentalCfgTest {
   }
 
   @Test
-  public void shouldSetEnablePreconditionsFromEnv() {
+  void shouldSetEnablePreconditionsFromEnv() {
     // given
     environment.put("zeebe.broker.experimental.consistencyChecks.enablePreconditions", "false");
 
@@ -134,7 +137,7 @@ public class ExperimentalCfgTest {
   }
 
   @Test
-  public void shouldSetEnableForeignKeyChecksFromConfig() {
+  void shouldSetEnableForeignKeyChecksFromConfig() {
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
     final var consistencyChecks = cfg.getExperimental().getConsistencyChecks();
@@ -144,7 +147,7 @@ public class ExperimentalCfgTest {
   }
 
   @Test
-  public void shouldSetEnableForeignKeyChecksFromEnv() {
+  void shouldSetEnableForeignKeyChecksFromEnv() {
     // given
     environment.put("zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks", "false");
 
@@ -154,5 +157,28 @@ public class ExperimentalCfgTest {
 
     // then
     assertThat(consistencyChecks.isEnableForeignKeyChecks()).isFalse();
+  }
+
+  @Test
+  void shouldSetPreallocateSegmentFilesFromEnv() {
+    // given
+    environment.put("zeebe.broker.experimental.raft.preallocateSegmentFiles", "false");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
+    final var raftCfg = cfg.getExperimental().getRaft();
+
+    // then
+    assertThat(raftCfg.isPreallocateSegmentFiles()).isFalse();
+  }
+
+  @Test
+  void shouldSetPreallocateSegmentFilesFromConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
+    final var raftCfg = cfg.getExperimental().getRaft();
+
+    // then
+    assertThat(raftCfg.isPreallocateSegmentFiles()).isTrue();
   }
 }

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -635,13 +635,13 @@
       # raft:
         # Sets the timeout for all requests send by raft leaders and followers.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_REQUESTTIMEOUT
-        # requestTimeout = 5s
+        # requestTimeout: 5s
 
         # If the leader is not able to reach the quorum, the leader may step down.
         # This is triggered after a number of requests, to a quorum of followers, has failed, and the number of failures
         # reached minStepDownFailureCount. The maxQuorumResponseTime also influences when the leader step down.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_MINSTEPDOWNFAILURECOUNT
-        # minStepDownFailureCount = 3
+        # minStepDownFailureCount: 3
 
         # If the leader is not able to reach the quorum, the leader may step down.
         # This is triggered if the leader is not able to reach the quorum of the followers for maxQuorumResponseTimeout.
@@ -650,13 +650,24 @@
         # When the timeout is lower, there might be false positives, and the leader might step down too quickly.
         # When this value is 0, it will use a default value of electionTimeout * 2.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_MAXQUORUMRESPONSETIMEOUT
-        # maxQuorumResponseTimeout = 0ms
+        # maxQuorumResponseTimeout: 0ms
 
         # Threshold used by the leader to decide between replicating a snapshot or records.
         # The unit is number of records by which the follower may lag behind before the leader
         # prefers replicating snapshots instead of records.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_PREFERSNAPSHOTREPLICATIONTHRESHOLD.
-        # preferSnapshotReplicationThreshold = 100
+        # preferSnapshotReplicationThreshold: 100
+
+        # Defines whether segment files are pre-allocated to their full size on creation or not. If
+        # true, when a new segment is created on demand, disk space will be reserved for its full
+        # maximum size. This helps avoid potential out of disk space errors which can be fatal when
+        # using memory mapped files, especially when running on network storage. In the best cases,
+        # it will also allocate contiguous blocks, giving a small performance boost.
+        #
+        # You may want to turn this off if your system does not support efficient file allocation
+        # via system calls, or if you notice an I/O penalty when creating segments.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_PREALLOCATESEGMENTFILES.
+        # preallocateSegmentFiles: true
 
       # Allows to configure RocksDB properties, which is used for state management.
       # rocksdb:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -569,13 +569,13 @@
       # raft:
         # Sets the timeout for all requests send by raft leaders and followers.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_REQUESTTIMEOUT
-        # requestTimeout = 5s
+        # requestTimeout: 5s
 
         # If the leader is not able to reach the quorum, the leader may step down.
         # This is triggered after a number of requests, to a quorum of followers, has failed, and the number of failures
         # reached minStepDownFailureCount. The maxQuorumResponseTime also influences when the leader step down.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_MINSTEPDOWNFAILURECOUNT
-        # minStepDownFailureCount = 3
+        # minStepDownFailureCount: 3
 
         # If the leader is not able to reach the quorum, the leader may step down.
         # This is triggered if the leader is not able to reach the quorum of the followers for maxQuorumResponseTimeout.
@@ -584,13 +584,24 @@
         # When the timeout is lower, there might be false positives, and the leader might step down too quickly.
         # When this value is 0, it will use a default value of electionTimeout * 2.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_MAXQUORUMRESPONSETIMEOUT
-        # maxQuorumResponseTimeout = 0ms
+        # maxQuorumResponseTimeout: 0ms
 
         # Threshold used by the leader to decide between replicating a snapshot or records.
         # The unit is number of records by which the follower may lag behind before the leader
         # prefers replicating snapshots instead of records.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_PREFERSNAPSHOTREPLICATIONTHRESHOLD.
-        # preferSnapshotReplicationThreshold = 100
+        # preferSnapshotReplicationThreshold: 100
+
+        # Defines whether segment files are pre-allocated to their full size on creation or not. If
+        # true, when a new segment is created on demand, disk space will be reserved for its full
+        # maximum size. This helps avoid potential out of disk space errors which can be fatal when
+        # using memory mapped files, especially when running on network storage. In the best cases,
+        # it will also allocate contiguous blocks, giving a small performance boost.
+        #
+        # You may want to turn this off if your system does not support efficient file allocation
+        # via system calls, or if you notice an I/O penalty when creating segments.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_PREALLOCATESEGMENTFILES.
+        # preallocateSegmentFiles: true
 
       # Allows to configure RocksDB properties, which is used for state management.
       # rocksdb:

--- a/journal/pom.xml
+++ b/journal/pom.xml
@@ -64,6 +64,12 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-posix</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.journal.file;
 import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.journal.file.record.CorruptedLogException;
 import io.camunda.zeebe.util.FileUtil;
-import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -18,31 +17,38 @@ import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
 import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.OpenOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Create a segment file. Load a segment from the segment file. */
 final class SegmentLoader {
-
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentLoader.class);
   private static final ByteOrder ENDIANNESS = ByteOrder.LITTLE_ENDIAN;
+
   private final long lastWrittenIndex;
   private final JournalIndex journalIndex;
+  private final boolean preallocateFiles;
 
-  SegmentLoader(final long lastWrittenIndex, final JournalIndex journalIndex) {
+  SegmentLoader(
+      final long lastWrittenIndex,
+      final JournalIndex journalIndex,
+      final boolean preallocateFiles) {
     this.lastWrittenIndex = lastWrittenIndex;
     this.journalIndex = journalIndex;
+    this.preallocateFiles = preallocateFiles;
   }
 
-  JournalSegment createSegment(final JournalSegmentDescriptor descriptor, final File segmentFile) {
+  JournalSegment createSegment(final Path segmentFile, final JournalSegmentDescriptor descriptor) {
     final MappedByteBuffer mappedSegment;
 
     try {
       mappedSegment = mapNewSegment(segmentFile, descriptor);
     } catch (final IOException e) {
-      throw new JournalException(String.format("Failed to map new segment %s", segmentFile), e);
+      throw new JournalException(
+          String.format("Failed to create new segment file %s", segmentFile), e);
     }
 
     try {
@@ -60,8 +66,7 @@ final class SegmentLoader {
     // necessary to flush the directory to ensure that the file itself is visible as an entry of
     // that directory after recovery
     try {
-      final var directory = segmentFile.toPath().getParent();
-      FileUtil.flushDirectory(directory);
+      FileUtil.flushDirectory(segmentFile.getParent());
     } catch (final IOException e) {
       throw new JournalException(
           String.format("Failed to flush journal directory after creating segment %s", segmentFile),
@@ -71,12 +76,13 @@ final class SegmentLoader {
     return loadSegment(segmentFile, mappedSegment, descriptor);
   }
 
-  JournalSegment loadExistingSegment(final File segmentFile) {
+  JournalSegment loadExistingSegment(final Path segmentFile) {
     final var descriptor = readDescriptor(segmentFile);
     final MappedByteBuffer mappedSegment;
 
-    try {
-      mappedSegment = mapSegment(segmentFile, descriptor, Collections.emptySet());
+    try (final var channel =
+        FileChannel.open(segmentFile, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
+      mappedSegment = mapSegment(channel, descriptor.maxSegmentSize());
     } catch (final IOException e) {
       throw new JournalException(
           String.format("Failed to load existing segment %s", segmentFile), e);
@@ -87,37 +93,31 @@ final class SegmentLoader {
 
   /* ---- Internal methods ------ */
   private JournalSegment loadSegment(
-      final File file, final MappedByteBuffer buffer, final JournalSegmentDescriptor descriptor) {
-    final JournalSegmentFile segmentFile = new JournalSegmentFile(file);
+      final Path file, final MappedByteBuffer buffer, final JournalSegmentDescriptor descriptor) {
+    final JournalSegmentFile segmentFile = new JournalSegmentFile(file.toFile());
     return new JournalSegment(segmentFile, descriptor, buffer, lastWrittenIndex, journalIndex);
   }
 
-  private MappedByteBuffer mapSegment(
-      final File segmentFile,
-      final JournalSegmentDescriptor descriptor,
-      final Set<OpenOption> extraOptions)
+  private MappedByteBuffer mapSegment(final FileChannel channel, final long segmentSize)
       throws IOException {
-    final var options = new HashSet<>(extraOptions);
-    options.add(StandardOpenOption.READ);
-    options.add(StandardOpenOption.WRITE);
+    final var mappedSegment = channel.map(MapMode.READ_WRITE, 0, segmentSize);
+    mappedSegment.order(ENDIANNESS);
 
-    try (final var channel = FileChannel.open(segmentFile.toPath(), options)) {
-      final var mappedSegment = channel.map(MapMode.READ_WRITE, 0, descriptor.maxSegmentSize());
-      mappedSegment.order(ENDIANNESS);
-
-      return mappedSegment;
-    }
+    return mappedSegment;
   }
 
-  private JournalSegmentDescriptor readDescriptor(final File file) {
-    try (final FileChannel channel = FileChannel.open(file.toPath(), StandardOpenOption.READ)) {
-      final byte version = readVersion(channel, file.getName());
+  private JournalSegmentDescriptor readDescriptor(final Path file) {
+    final var fileName = file.getFileName().toString();
+
+    try (final FileChannel channel = FileChannel.open(file, StandardOpenOption.READ)) {
+      final var fileSize = Files.size(file);
+      final byte version = readVersion(channel, fileName);
       final int length = JournalSegmentDescriptor.getEncodingLengthForVersion(version);
-      if (file.length() < length) {
+      if (fileSize < length) {
         throw new CorruptedLogException(
             String.format(
                 "Expected segment '%s' with version %d to be at least %d bytes long but it only has %d.",
-                file.getName(), version, length, file.length()));
+                fileName, version, length, fileSize));
       }
 
       final ByteBuffer buffer = ByteBuffer.allocate(length);
@@ -127,7 +127,7 @@ final class SegmentLoader {
         throw new JournalException(
             String.format(
                 "Expected to read %d bytes of segment '%s' with %d version but only read %d bytes.",
-                length, file.getName(), version, readBytes));
+                length, fileName, version, readBytes));
       }
 
       buffer.flip();
@@ -135,11 +135,11 @@ final class SegmentLoader {
     } catch (final IndexOutOfBoundsException e) {
       throw new JournalException(
           String.format(
-              "Expected to read descriptor of segment '%s', but nothing was read.", file.getName()),
+              "Expected to read descriptor of segment '%s', but nothing was read.", fileName),
           e);
     } catch (final UnknownVersionException e) {
       throw new CorruptedLogException(
-          String.format("Couldn't read or recognize version of segment '%s'.", file.getName()), e);
+          String.format("Couldn't read or recognize version of segment '%s'.", fileName), e);
     } catch (final IOException e) {
       throw new JournalException(e);
     }
@@ -165,22 +165,35 @@ final class SegmentLoader {
   }
 
   private MappedByteBuffer mapNewSegment(
-      final File segmentFile, final JournalSegmentDescriptor descriptor) throws IOException {
-    try {
-      return mapSegment(segmentFile, descriptor, Set.of(StandardOpenOption.CREATE_NEW));
+      final Path segmentPath, final JournalSegmentDescriptor descriptor) throws IOException {
+    try (final var channel =
+        FileChannel.open(
+            segmentPath,
+            StandardOpenOption.READ,
+            StandardOpenOption.WRITE,
+            StandardOpenOption.CREATE_NEW)) {
+      if (preallocateFiles) {
+        FileUtil.preallocate(channel, descriptor.maxSegmentSize());
+      }
+
+      return mapSegment(channel, descriptor.maxSegmentSize());
     } catch (final FileAlreadyExistsException e) {
-      // assuming we haven't written in that segment, just overwrite it; if we have, we may be able
-      // reuse, but that's up to the caller
+      // do not reuse a segment into which we've already written!
       if (lastWrittenIndex >= descriptor.index()) {
         throw new JournalException(
             String.format(
                 "Failed to create journal segment %s, as it already exists, and the last written "
                     + "index %d indicates we've already written to it",
-                segmentFile, lastWrittenIndex),
+                segmentPath, lastWrittenIndex),
             e);
       }
 
-      return mapSegment(segmentFile, descriptor, Set.of(StandardOpenOption.TRUNCATE_EXISTING));
+      LOGGER.warn(
+          "Failed to create segment {}: an unused file already existed, and will be replaced",
+          segmentPath,
+          e);
+      Files.delete(segmentPath);
+      return mapNewSegment(segmentPath, descriptor);
     }
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.zeebe.journal.file;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.collect.Sets;
@@ -26,6 +25,7 @@ import io.camunda.zeebe.journal.JournalReader;
 import io.camunda.zeebe.journal.JournalRecord;
 import java.io.File;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.concurrent.locks.StampedLock;
 import org.agrona.DirectBuffer;
 
@@ -42,25 +42,23 @@ public final class SegmentedJournal implements Journal {
   private final JournalIndex journalIndex;
   private final SegmentedJournalWriter writer;
   private final StampedLock rwlock = new StampedLock();
-
   private final SegmentsManager segments;
-  private final String name;
 
   public SegmentedJournal(
-      final String name,
       final File directory,
       final int maxSegmentSize,
-      final long minFreeSpace,
+      final long minFreeDiskSpace,
       final JournalIndex journalIndex,
-      final SegmentsManager segmentsManager) {
-    this.name = checkNotNull(name, "name cannot be null");
-    this.directory = checkNotNull(directory, "directory cannot be null");
+      final SegmentsManager segments,
+      final JournalMetrics journalMetrics) {
+    this.directory = Objects.requireNonNull(directory, "must specify a journal directory");
     this.maxSegmentSize = maxSegmentSize;
-    journalMetrics = new JournalMetrics(name);
-    minFreeDiskSpace = minFreeSpace;
-    this.journalIndex = journalIndex;
-    segments = segmentsManager;
-    segments.open();
+    this.minFreeDiskSpace = minFreeDiskSpace;
+    this.journalMetrics = Objects.requireNonNull(journalMetrics, "must specify journal metrics");
+    this.journalIndex = Objects.requireNonNull(journalIndex, "must specify a journal index");
+    this.segments = Objects.requireNonNull(segments, "must specify a journal segments manager");
+
+    this.segments.open();
     writer = new SegmentedJournalWriter(this);
   }
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.io.File;
 
 /** Raft log builder. */
+@SuppressWarnings("UnusedReturnValue")
 public class SegmentedJournalBuilder {
 
   private static final String DEFAULT_NAME = "journal";
@@ -145,16 +146,14 @@ public class SegmentedJournalBuilder {
   }
 
   public SegmentedJournal build() {
-    final JournalIndex journalIndex = new SparseJournalIndex(journalIndexDensity);
+    final var journalIndex = new SparseJournalIndex(journalIndexDensity);
+    final var segmentLoader = new SegmentLoader(preallocateSegmentFiles);
     final var segmentsManager =
         new SegmentsManager(
-            journalIndex,
-            maxSegmentSize,
-            directory,
-            lastWrittenIndex,
-            name,
-            preallocateSegmentFiles);
+            journalIndex, maxSegmentSize, directory, lastWrittenIndex, name, segmentLoader);
+    final var journalMetrics = new JournalMetrics(name);
+
     return new SegmentedJournal(
-        name, directory, maxSegmentSize, freeDiskSpace, journalIndex, segmentsManager);
+        directory, maxSegmentSize, freeDiskSpace, journalIndex, segmentsManager, journalMetrics);
   }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -56,14 +56,16 @@ final class SegmentsManager {
       final int maxSegmentSize,
       final File directory,
       final long lastWrittenIndex,
-      final String name) {
+      final String name,
+      final boolean preallocateFiles) {
     this.name = checkNotNull(name, "name cannot be null");
     journalMetrics = new JournalMetrics(name);
     this.journalIndex = journalIndex;
     this.maxSegmentSize = maxSegmentSize;
     this.directory = directory;
     this.lastWrittenIndex = lastWrittenIndex;
-    segmentLoader = new SegmentLoader(lastWrittenIndex, this.journalIndex);
+
+    segmentLoader = new SegmentLoader(lastWrittenIndex, this.journalIndex, preallocateFiles);
   }
 
   void close() {
@@ -264,7 +266,7 @@ final class SegmentsManager {
 
   private JournalSegment createSegment(final JournalSegmentDescriptor descriptor) {
     final var segmentFile = JournalSegmentFile.createSegmentFile(name, directory, descriptor.id());
-    return segmentLoader.createSegment(descriptor, segmentFile);
+    return segmentLoader.createSegment(segmentFile.toPath(), descriptor);
   }
 
   /**
@@ -283,7 +285,7 @@ final class SegmentsManager {
 
       try {
         LOG.debug("Found segment file: {}", file.getName());
-        final JournalSegment segment = segmentLoader.loadExistingSegment(file);
+        final JournalSegment segment = segmentLoader.loadExistingSegment(file.toPath());
 
         if (i > 0) {
           checkForIndexGaps(segments.get(i - 1), segment);

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentLoaderTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentLoaderTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import jnr.posix.FileStat;
+import jnr.posix.POSIX;
+import jnr.posix.POSIXFactory;
+import jnr.posix.util.Platform;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@SuppressWarnings("resource")
+@Execution(ExecutionMode.CONCURRENT)
+final class SegmentLoaderTest {
+  @Test
+  void shouldPreallocateSegmentFiles(final @TempDir Path tmpDir) {
+    // given
+    final var segmentSize = 4 * 1024 * 1024;
+    final var segmentLoader = new SegmentLoader(0, new SparseJournalIndex(1), true);
+    final var segmentFile = tmpDir.resolve("segment.log");
+    final var descriptor =
+        JournalSegmentDescriptor.builder().withId(1).withMaxSegmentSize(segmentSize).build();
+
+    // when
+    final var segment = segmentLoader.createSegment(segmentFile, descriptor);
+
+    // then
+    final var realSize = getRealSize(segmentFile);
+    final var maxRealSize = segmentSize + getBlockSize(segmentFile);
+    assertThat(realSize)
+        .as(
+            "Expected <%s> to have a real size between <%d> and <%d> bytes, but it had <%d>",
+            segmentFile, segmentSize, maxRealSize, realSize)
+        .isBetween((long) segmentSize, maxRealSize);
+  }
+
+  @Test
+  void shouldNotPreallocateSegmentFiles(final @TempDir Path tmpDir) {
+    // given
+    final var segmentSize = 4 * 1024 * 1024;
+    final var segmentLoader = new SegmentLoader(0, new SparseJournalIndex(1), false);
+    final var segmentFile = tmpDir.resolve("segment.log");
+    final var descriptor =
+        JournalSegmentDescriptor.builder().withId(1).withMaxSegmentSize(segmentSize).build();
+
+    // when
+    final var segment = segmentLoader.createSegment(segmentFile, descriptor);
+
+    // then
+    final var realSize = getRealSize(segmentFile);
+    assertThat(realSize)
+        .as(
+            "Expected <%s> to have a real size less than <%d> bytes, but it had <%d>",
+            segmentFile, segmentSize, realSize)
+        .isLessThan(segmentSize);
+  }
+
+  @Test
+  void shouldPreallocateNewFileIfUnusedSegmentAlreadyExists(final @TempDir Path tmpDir)
+      throws IOException {
+    // given
+    final var segmentSize = 4 * 1024 * 1024;
+    final var descriptor =
+        JournalSegmentDescriptor.builder()
+            .withId(1)
+            .withIndex(1)
+            .withMaxSegmentSize(segmentSize)
+            .build();
+    final var lastWrittenIndex = descriptor.index() - 1;
+    final var segmentLoader = new SegmentLoader(lastWrittenIndex, new SparseJournalIndex(1), true);
+    final var segmentFile = tmpDir.resolve("segment.log");
+
+    // when - the segment is "unused" if the lastWrittenIndex is less than the expected first index
+    // this can happen if we crashed in the middle of creating the new segment
+    Files.writeString(segmentFile, "foo");
+    final var segment = segmentLoader.createSegment(segmentFile, descriptor);
+
+    // then
+    final var realSize = getRealSize(segmentFile);
+    final var maxRealSize = segmentSize + getBlockSize(segmentFile);
+    assertThat(realSize)
+        .as(
+            "Expected <%s> to have a real size between <%d> and <%d> bytes, but it had <%d>",
+            segmentFile, segmentSize, maxRealSize, realSize)
+        .isBetween((long) segmentSize, maxRealSize);
+  }
+
+  /**
+   * Returns the actual size of the file on disk by checking the blocks allocated for this file. On
+   * most modern UNIX systems, doing {@link Files#size(Path)} returns that size as reported by the
+   * file's metadata, which may not be the real size (e.g. compressed file systems, sparse files,
+   * etc.). Using the {@code lstat} function from the C library we can get the actual size on disk
+   * of the file.
+   *
+   * <p>{@code lstat} will return the number of 512-bytes blocks used by a file. To get the real
+   * size, you simply multiply by 512. Note that unless your file size is aligned with the block
+   * size of your device, then the real size may be slightly larger, as more blocks may have been
+   * allocated.
+   *
+   * <p>NOTE: on Windows, sparse files are not the default, so {@link File#length()} is appropriate.
+   * Plus, there is no {@code lstat} function, and the equivalent function {@code wstat} does not
+   * return the number of blocks.
+   *
+   * @param file the file to get the size of
+   * @return the actual size on disk of the file
+   */
+  private long getRealSize(final Path file) {
+    if (Platform.IS_WINDOWS) {
+      try {
+        return Files.size(file);
+      } catch (final IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+
+    final POSIX posixFunctions = POSIXFactory.getNativePOSIX();
+    final var pathString = file.toString();
+    final FileStat stat = posixFunctions.stat(pathString);
+
+    return stat.blocks() * 512;
+  }
+
+  /**
+   * Returns the I/O block size of the device containing the given file. This can be used to compute
+   * an upper bound for the real file size. On Windows, as we use {@link Files#size(Path)} for the
+   * real size, this simply returns 0.
+   *
+   * @param file the file to get the block size of
+   * @return the I/O block size of the device containing the file
+   */
+  private long getBlockSize(final Path file) {
+    if (Platform.IS_WINDOWS) {
+      return 0;
+    }
+
+    final POSIX posixFunctions = POSIXFactory.getNativePOSIX();
+    final var pathString = file.toString();
+    final FileStat stat = posixFunctions.stat(pathString);
+
+    return stat.blockSize();
+  }
+}

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentLoaderTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentLoaderTest.java
@@ -30,13 +30,13 @@ final class SegmentLoaderTest {
   void shouldPreallocateSegmentFiles(final @TempDir Path tmpDir) {
     // given
     final var segmentSize = 4 * 1024 * 1024;
-    final var segmentLoader = new SegmentLoader(0, new SparseJournalIndex(1), true);
+    final var segmentLoader = new SegmentLoader(true);
     final var segmentFile = tmpDir.resolve("segment.log");
     final var descriptor =
         JournalSegmentDescriptor.builder().withId(1).withMaxSegmentSize(segmentSize).build();
 
     // when
-    final var segment = segmentLoader.createSegment(segmentFile, descriptor);
+    segmentLoader.createSegment(segmentFile, descriptor, 1, new SparseJournalIndex(1));
 
     // then
     final var realSize = getRealSize(segmentFile);
@@ -52,13 +52,13 @@ final class SegmentLoaderTest {
   void shouldNotPreallocateSegmentFiles(final @TempDir Path tmpDir) {
     // given
     final var segmentSize = 4 * 1024 * 1024;
-    final var segmentLoader = new SegmentLoader(0, new SparseJournalIndex(1), false);
+    final var segmentLoader = new SegmentLoader(false);
     final var segmentFile = tmpDir.resolve("segment.log");
     final var descriptor =
         JournalSegmentDescriptor.builder().withId(1).withMaxSegmentSize(segmentSize).build();
 
     // when
-    final var segment = segmentLoader.createSegment(segmentFile, descriptor);
+    segmentLoader.createSegment(segmentFile, descriptor, 1, new SparseJournalIndex(1));
 
     // then
     final var realSize = getRealSize(segmentFile);
@@ -81,13 +81,14 @@ final class SegmentLoaderTest {
             .withMaxSegmentSize(segmentSize)
             .build();
     final var lastWrittenIndex = descriptor.index() - 1;
-    final var segmentLoader = new SegmentLoader(lastWrittenIndex, new SparseJournalIndex(1), true);
+    final var segmentLoader = new SegmentLoader(true);
     final var segmentFile = tmpDir.resolve("segment.log");
 
     // when - the segment is "unused" if the lastWrittenIndex is less than the expected first index
     // this can happen if we crashed in the middle of creating the new segment
     Files.writeString(segmentFile, "foo");
-    final var segment = segmentLoader.createSegment(segmentFile, descriptor);
+    segmentLoader.createSegment(
+        segmentFile, descriptor, lastWrittenIndex, new SparseJournalIndex(1));
 
     // then
     final var realSize = getRealSize(segmentFile);

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -132,7 +132,8 @@ class SegmentsManagerTest {
         entrySize + JournalSegmentDescriptor.getEncodingLength(),
         directory.resolve("data").toFile(),
         lastWrittenIndex,
-        JOURNAL_NAME);
+        JOURNAL_NAME,
+        true);
   }
 
   private SegmentedJournal openJournal(final float entriesPerSegment) {

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -127,13 +127,14 @@ class SegmentsManagerTest {
   }
 
   private SegmentsManager createSegmentsManager(final long lastWrittenIndex) {
+    final var journalIndex = new SparseJournalIndex(journalIndexDensity);
     return new SegmentsManager(
-        new SparseJournalIndex(journalIndexDensity),
+        journalIndex,
         entrySize + JournalSegmentDescriptor.getEncodingLength(),
         directory.resolve("data").toFile(),
         lastWrittenIndex,
         JOURNAL_NAME,
-        true);
+        new SegmentLoader());
   }
 
   private SegmentedJournal openJournal(final float entriesPerSegment) {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -109,6 +109,7 @@
     <version.archunit>0.23.1</version.archunit>
     <version.easy-random>5.0.0</version.easy-random>
     <version.jcip>1.0</version.jcip>
+    <version.jnr-posix>3.1.15</version.jnr-posix>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.1.0</plugin.version.antrun>
@@ -871,6 +872,12 @@
         <artifactId>bcprov-jdk15on</artifactId>
         <version>${version.bouncycastle}</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.jnr</groupId>
+        <artifactId>jnr-posix</artifactId>
+        <version>${version.jnr-posix}</version>
       </dependency>
 
       <!-- Dependencies present for convergence only -->

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -121,6 +121,12 @@
       <artifactId>byte-buddy</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-posix</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/util/src/main/java/io/camunda/zeebe/util/FileUtil.java
+++ b/util/src/main/java/io/camunda/zeebe/util/FileUtil.java
@@ -23,6 +23,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Objects;
+import org.agrona.IoUtil;
 import org.agrona.SystemUtil;
 import org.slf4j.Logger;
 
@@ -81,6 +82,22 @@ public final class FileUtil {
       throws IOException {
     Files.move(source, target, options);
     flushDirectory(target.getParent());
+  }
+
+  /**
+   * Allocates a new file at the given path with the given size. This method guarantees that the
+   * file will have at least the expected size (but may have one page more).
+   *
+   * @param length the length of the file
+   */
+  public static void preallocate(final FileChannel channel, final long length) {
+    if (length < 0) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected to preallocate [%d] bytes, but the length cannot be negative", length));
+    }
+
+    IoUtil.fill(channel, 0, length, (byte) 0);
   }
 
   public static void deleteFolder(final String path) throws IOException {

--- a/util/src/test/java/io/camunda/zeebe/util/FileUtilTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/FileUtilTest.java
@@ -13,10 +13,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.channels.FileChannel;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import jnr.posix.FileStat;
+import jnr.posix.POSIX;
+import jnr.posix.POSIXFactory;
+import jnr.posix.util.Platform;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -89,5 +96,82 @@ final class FileUtilTest {
 
     // then
     assertThat(Files.list(target)).contains(target.resolve(snapshotFile));
+  }
+
+  @Test
+  void shouldPreallocateFile() throws IOException {
+    // given
+    final var path = tmpDir.resolve("file");
+    final var length = 1024 * 1024L;
+
+    // when
+    try (final FileChannel channel =
+        FileChannel.open(path, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+      FileUtil.preallocate(channel, length);
+    }
+
+    // then
+    final var realSize = getRealSize(path);
+    final var maxRealSize = length + getBlockSize(path);
+    assertThat(realSize)
+        .as(
+            "Expected <%s> to have a real size between <%d> and <%d> bytes, but it had <%d>",
+            path, length, maxRealSize, realSize)
+        .isBetween(length, maxRealSize);
+  }
+
+  /**
+   * Returns the actual size of the file on disk by checking the blocks allocated for this file. On
+   * most modern UNIX systems, doing {@link Files#size(Path)} returns that size as reported by the
+   * file's metadata, which may not be the real size (e.g. compressed file systems, sparse files,
+   * etc.). Using the {@code lstat} function from the C library we can get the actual size on disk
+   * of the file.
+   *
+   * <p>{@code lstat} will return the number of 512-bytes blocks used by a file. To get the real
+   * size, you simply multiply by 512. Note that unless your file size is aligned with the block
+   * size of your device, then the real size may be slightly larger, as more blocks may have been
+   * allocated.
+   *
+   * <p>NOTE: on Windows, sparse files are not the default, so {@link File#length()} is appropriate.
+   * Plus, there is no {@code lstat} function, and the equivalent function {@code wstat} does not
+   * return the number of blocks.
+   *
+   * @param file the file to get the size of
+   * @return the actual size on disk of the file
+   */
+  private long getRealSize(final Path file) {
+    if (Platform.IS_WINDOWS) {
+      try {
+        return Files.size(file);
+      } catch (final IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+
+    final POSIX posixFunctions = POSIXFactory.getNativePOSIX();
+    final var pathString = file.toString();
+    final FileStat stat = posixFunctions.stat(pathString);
+
+    return stat.blocks() * 512;
+  }
+
+  /**
+   * Returns the I/O block size of the device containing the given file. This can be used to compute
+   * an upper bound for the real file size. On Windows, as we use {@link Files#size(Path)} for the
+   * real size, this simply returns 0.
+   *
+   * @param file the file to get the block size of
+   * @return the I/O block size of the device containing the file
+   */
+  private long getBlockSize(final Path file) {
+    if (Platform.IS_WINDOWS) {
+      return 0;
+    }
+
+    final POSIX posixFunctions = POSIXFactory.getNativePOSIX();
+    final var pathString = file.toString();
+    final FileStat stat = posixFunctions.stat(pathString);
+
+    return stat.blockSize();
   }
 }

--- a/util/src/test/java/io/camunda/zeebe/util/FileUtilTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/FileUtilTest.java
@@ -14,47 +14,39 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public final class FileUtilTest {
-
-  @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+final class FileUtilTest {
+  private @TempDir Path tmpDir;
 
   @Test
-  public void shouldDeleteFolder() throws IOException {
-    final File root = tempFolder.getRoot();
+  void shouldDeleteFolder() throws IOException {
+    Files.createFile(tmpDir.resolve("file1"));
+    Files.createFile(tmpDir.resolve("file2"));
+    Files.createDirectory(tmpDir.resolve("testFolder"));
 
-    tempFolder.newFile("file1");
-    tempFolder.newFile("file2");
-    tempFolder.newFolder("testFolder");
+    FileUtil.deleteFolder(tmpDir);
 
-    FileUtil.deleteFolder(root.getAbsolutePath());
-
-    assertThat(root.exists()).isFalse();
+    assertThat(tmpDir).doesNotExist();
   }
 
   @Test
-  public void shouldThrowExceptionForNonExistingFolder() {
-    final File root = tempFolder.getRoot();
+  void shouldThrowExceptionForNonExistingFolder() throws IOException {
+    final Path root = Files.createDirectory(tmpDir.resolve("other"));
+    Files.delete(root);
 
-    tempFolder.delete();
-
-    assertThatThrownBy(
-            () -> {
-              FileUtil.deleteFolder(root.getAbsolutePath());
-            })
-        .isInstanceOf(NoSuchFileException.class);
+    assertThatThrownBy(() -> FileUtil.deleteFolder(root)).isInstanceOf(NoSuchFileException.class);
   }
 
   // regression test
   @Test
-  public void shouldNotThrowErrorIfFolderDoesNotExist() {
+  void shouldNotThrowErrorIfFolderDoesNotExist() {
     // given
-    final Path nonExistent = tempFolder.getRoot().toPath().resolve("something");
+    final Path nonExistent = tmpDir.resolve("something");
 
     // when - then
     assertThatCode(() -> FileUtil.deleteFolderIfExists(nonExistent))
@@ -63,10 +55,10 @@ public final class FileUtilTest {
   }
 
   @Test
-  public void shouldThrowExceptionWhenCopySnapshotForNonExistingFolder() {
+  void shouldThrowExceptionWhenCopySnapshotForNonExistingFolder() {
     // given
-    final File source = tempFolder.getRoot().toPath().resolve("src").toFile();
-    final File target = tempFolder.getRoot().toPath().resolve("target").toFile();
+    final File source = tmpDir.resolve("src").toFile();
+    final File target = tmpDir.resolve("target").toFile();
 
     // when - then
     assertThatThrownBy(() -> FileUtil.copySnapshot(source.toPath(), target.toPath()))
@@ -74,28 +66,28 @@ public final class FileUtilTest {
   }
 
   @Test
-  public void shouldThrowExceptionWhenyCopySnapshotIfTargetAlreadyExists() throws IOException {
+  void shouldThrowExceptionWhenyCopySnapshotIfTargetAlreadyExists() throws IOException {
     // given
-    final File source = tempFolder.newFolder("src");
-    final File target = tempFolder.newFolder("target");
+    final Path source = Files.createDirectory(tmpDir.resolve("src"));
+    final Path target = Files.createDirectory(tmpDir.resolve("target"));
 
     // when -then
-    assertThatThrownBy(() -> FileUtil.copySnapshot(source.toPath(), target.toPath()))
+    assertThatThrownBy(() -> FileUtil.copySnapshot(source, target))
         .isInstanceOf(FileAlreadyExistsException.class);
   }
 
   @Test
-  public void shouldCopySnapshot() throws Exception {
+  void shouldCopySnapshot() throws Exception {
     // given
-    final File source = tempFolder.newFolder("src");
-    final String snapshotFile = "file1";
-    source.toPath().resolve(snapshotFile).toFile().createNewFile();
-    final File target = tempFolder.getRoot().toPath().resolve("target").toFile();
+    final var snapshotFile = "file1";
+    final Path source = Files.createDirectory(tmpDir.resolve("src"));
+    final Path target = tmpDir.resolve("target");
+    Files.createFile(source.resolve(snapshotFile));
 
     // when
-    FileUtil.copySnapshot(source.toPath(), target.toPath());
+    FileUtil.copySnapshot(source, target);
 
     // then
-    assertThat(target.list()).containsExactly(snapshotFile);
+    assertThat(Files.list(target)).contains(target.resolve(snapshotFile));
   }
 }


### PR DESCRIPTION
## Description

This PR introduces segment file pre-allocation in the journal. This is on by default, but can be disabled via an experimental configuration option.

At the moment, the pre-allocation is done in a "dumb" fashion - we allocate a 4Kb blocks of zeroes, and write this until we've reached the expected file length. Note that this means there may be one extra block allocated on disk.

One thing to note, to verify this, we used [jnr-posix](https://github.com/jnr/jnr-posix). The reason behind this is we want to know the actual number of blocks on disk reserved for this file. `Files#size`, or `File#length`, return the reported file size, which is part of the file's metadata (on UNIX systems anyway). If you mmap a file with a size of 1Mb, write one byte, then flush it, the reported size will be 1Mb, but the actual size on disk will be a single block (on most modern UNIX systems anyway). By using [stat](https://linux.die.net/man/2/stat), we can get the actual file size in terms of 512-bytes allocated blocks, so we get a pretty accurate measurement of the actual disk space used by the file.

I would've like to capture this in a test utility, but since `test-util` depends on `util`, there wasn't an easy way to do this, so I just copied the method in two places. One possibility I thought of is moving the whole pre-allocation stuff in `journal`, since we only use it there. The only downside I can see there is about discovery and cohesion, but I'd like to hear your thoughts on this.

A follow-up PR will come which will optimize the pre-allocation by using the [posix_fallocate](https://man7.org/linux/man-pages/man3/posix_fallocate.3.html) on POSIX systems.

Finally, I opted for an experimental configuration option instead of a feature flag. My reasoning is that it isn't a "new" feature, but instead we want to option of disabling this (for performance reasons potentially). So it's more of an advanced option. But I'd also like to hear your thoughts here.

## Related issues

closes #6504
closes #8099
related to #7607  

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
