### PR TITLE
Complete start/close futures when an actor fails

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -234,7 +234,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
         actor.getLifecyclePhase(),
         failure,
         failure);
-    actor.fail();
+    actor.fail(failure);
 
     if (failure instanceof UnrecoverableException) {
       healthReport = HealthReport.dead(this).withIssue(failure);

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
@@ -373,7 +373,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   private void onFailure(final Throwable throwable) {
     LOG.error("Actor {} failed in phase {}.", actorName, actor.getLifecyclePhase(), throwable);
-    actor.fail();
+    actor.fail(throwable);
     if (!openFuture.isDone()) {
       openFuture.completeExceptionally(throwable);
     }

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
@@ -247,7 +247,7 @@ final class LogStorageAppender extends Actor implements HealthMonitorable {
 
   private void onFailure(final Throwable error) {
     LOG.error("Actor {} failed in phase {}.", name, actor.getLifecyclePhase(), error);
-    actor.fail();
+    actor.fail(error);
     final var report = HealthReport.unhealthy(this).withIssue(error);
     failureListeners.forEach(l -> l.onFailure(report));
   }

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
@@ -398,8 +398,8 @@ public class ActorControl implements ConcurrencyControl {
   }
 
   /** Mark actor as failed. This sets the lifecycle phase to 'FAILED' and discards all jobs. */
-  public void fail() {
+  public void fail(final Throwable error) {
     ensureCalledFromWithinActor("fail()");
-    task.fail();
+    task.fail(error);
   }
 }

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/lifecycle/ActorLifecyclePhasesTest.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/lifecycle/ActorLifecyclePhasesTest.java
@@ -377,7 +377,7 @@ public final class ActorLifecyclePhasesTest {
                 ActorLifecyclePhase.STARTING,
                 ActorLifecyclePhase.STARTED,
                 ActorLifecyclePhase.FAILED));
-    assertThat(closeFuture).succeedsWithin(Duration.ofSeconds(1));
+    assertThat(closeFuture).failsWithin(Duration.ofSeconds(1));
   }
 
   @Test
@@ -436,7 +436,7 @@ public final class ActorLifecyclePhasesTest {
                 ActorLifecyclePhase.CLOSE_REQUESTED,
                 ActorLifecyclePhase.CLOSING,
                 ActorLifecyclePhase.FAILED));
-    assertThat(closeFuture).succeedsWithin(Duration.ofSeconds(1));
+    assertThat(closeFuture).failsWithin(Duration.ofSeconds(1));
   }
 
   @Test
@@ -460,7 +460,7 @@ public final class ActorLifecyclePhasesTest {
     assertThat(actor.phases)
         .isEqualTo(List.of(ActorLifecyclePhase.STARTING, ActorLifecyclePhase.FAILED));
     assertThat(startFuture).failsWithin(Duration.ofSeconds(1));
-    assertThat(closeFuture).succeedsWithin(Duration.ofSeconds(1));
+    assertThat(closeFuture).failsWithin(Duration.ofSeconds(1));
   }
 
   @Test
@@ -483,6 +483,63 @@ public final class ActorLifecyclePhasesTest {
     // then
     assertThat(actor.phases).isEqualTo(List.of(ActorLifecyclePhase.STARTING));
     assertThat(startFuture).failsWithin(Duration.ofSeconds(1));
-    assertThat(closeFuture).succeedsWithin(Duration.ofSeconds(1));
+    assertThat(closeFuture).failsWithin(Duration.ofSeconds(1));
+  }
+
+  @Test
+  public void shouldCompleteCloseFutureWhenFailingOnCloseRequested() {
+    // given
+    final LifecycleRecordingActor actor =
+        new LifecycleRecordingActor() {
+          @Override
+          public void onActorCloseRequested() {
+            super.onActorCloseRequested();
+            actor.fail(new RuntimeException("hello"));
+          }
+        };
+
+    // when
+    schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+    final ActorFuture<Void> closeFuture = actor.closeAsync();
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(actor.phases)
+        .isEqualTo(
+            List.of(
+                ActorLifecyclePhase.STARTING,
+                ActorLifecyclePhase.STARTED,
+                ActorLifecyclePhase.CLOSE_REQUESTED,
+                ActorLifecyclePhase.FAILED));
+    assertThat(closeFuture).failsWithin(Duration.ofSeconds(1));
+  }
+
+  @Test
+  public void shouldCompleteCloseFutureWhenExceptionOnCloseRequested() {
+    // given
+    final LifecycleRecordingActor actor =
+        new LifecycleRecordingActor() {
+          @Override
+          public void onActorCloseRequested() {
+            super.onActorCloseRequested();
+            throw new RuntimeException("hello");
+          }
+        };
+
+    // when
+    schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+    final ActorFuture<Void> closeFuture = actor.closeAsync();
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(actor.phases)
+        .isEqualTo(
+            List.of(
+                ActorLifecyclePhase.STARTING,
+                ActorLifecyclePhase.STARTED,
+                ActorLifecyclePhase.CLOSE_REQUESTED));
+    assertThat(closeFuture).failsWithin(Duration.ofSeconds(1));
   }
 }

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/lifecycle/ActorLifecyclePhasesTest.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/lifecycle/ActorLifecyclePhasesTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.scheduler.ActorTask.ActorLifecyclePhase;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerRule;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -333,7 +334,7 @@ public final class ActorLifecyclePhasesTest {
           @Override
           public void onActorStarted() {
             super.onActorStarted();
-            actor.submit(actor::fail);
+            actor.submit(() -> actor.fail(new RuntimeException("foo")));
             actor.submit(invocations::incrementAndGet);
           }
         };
@@ -350,5 +351,138 @@ public final class ActorLifecyclePhasesTest {
                 ActorLifecyclePhase.STARTING,
                 ActorLifecyclePhase.STARTED,
                 ActorLifecyclePhase.FAILED));
+  }
+
+  @Test
+  public void shouldCompleteCloseFutureWhenFailingInStarted() {
+    // given
+    final LifecycleRecordingActor actor =
+        new LifecycleRecordingActor() {
+          @Override
+          public void onActorStarted() {
+            super.onActorStarted();
+            actor.fail(new RuntimeException("foo"));
+          }
+        };
+
+    // when - explicitly do not work after close as it should be completed already
+    schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+    final ActorFuture<Void> closeFuture = actor.closeAsync();
+
+    // then
+    assertThat(actor.phases)
+        .isEqualTo(
+            List.of(
+                ActorLifecyclePhase.STARTING,
+                ActorLifecyclePhase.STARTED,
+                ActorLifecyclePhase.FAILED));
+    assertThat(closeFuture).succeedsWithin(Duration.ofSeconds(1));
+  }
+
+  @Test
+  public void shouldCompleteCloseFutureOnExceptionOnClosing() {
+    // given
+    final LifecycleRecordingActor actor =
+        new LifecycleRecordingActor() {
+          @Override
+          public void onActorClosing() {
+            super.onActorClosing();
+            throw new RuntimeException("foo");
+          }
+        };
+
+    // when
+    schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+    final ActorFuture<Void> closeFuture = actor.closeAsync();
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(actor.phases)
+        .isEqualTo(
+            List.of(
+                ActorLifecyclePhase.STARTING,
+                ActorLifecyclePhase.STARTED,
+                ActorLifecyclePhase.CLOSE_REQUESTED,
+                ActorLifecyclePhase.CLOSING));
+    assertThat(closeFuture).failsWithin(Duration.ofSeconds(1));
+  }
+
+  @Test
+  public void shouldCompleteCloseFutureWhenFailingOnClosing() {
+    // given
+    final LifecycleRecordingActor actor =
+        new LifecycleRecordingActor() {
+          @Override
+          public void onActorClosing() {
+            super.onActorClosing();
+            actor.fail(new RuntimeException("foo"));
+          }
+        };
+
+    // when
+    schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+    final ActorFuture<Void> closeFuture = actor.closeAsync();
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(actor.phases)
+        .isEqualTo(
+            List.of(
+                ActorLifecyclePhase.STARTING,
+                ActorLifecyclePhase.STARTED,
+                ActorLifecyclePhase.CLOSE_REQUESTED,
+                ActorLifecyclePhase.CLOSING,
+                ActorLifecyclePhase.FAILED));
+    assertThat(closeFuture).succeedsWithin(Duration.ofSeconds(1));
+  }
+
+  @Test
+  public void shouldCompleteFuturesWhenFailingOnStarting() {
+    // given
+    final LifecycleRecordingActor actor =
+        new LifecycleRecordingActor() {
+          @Override
+          public void onActorStarting() {
+            super.onActorStarting();
+            actor.fail(new RuntimeException("foo"));
+          }
+        };
+
+    // when - explicitly do not work after close as it should be completed already
+    final ActorFuture<Void> startFuture = schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+    final ActorFuture<Void> closeFuture = actor.closeAsync();
+
+    // then
+    assertThat(actor.phases)
+        .isEqualTo(List.of(ActorLifecyclePhase.STARTING, ActorLifecyclePhase.FAILED));
+    assertThat(startFuture).failsWithin(Duration.ofSeconds(1));
+    assertThat(closeFuture).succeedsWithin(Duration.ofSeconds(1));
+  }
+
+  @Test
+  public void shouldCompleteFuturesOnExceptionOnStarting() {
+    // given
+    final LifecycleRecordingActor actor =
+        new LifecycleRecordingActor() {
+          @Override
+          public void onActorStarting() {
+            super.onActorStarting();
+            throw new RuntimeException("hello");
+          }
+        };
+
+    // when - explicitly do not work after close as it should be completed already
+    final ActorFuture<Void> startFuture = schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+    final ActorFuture<Void> closeFuture = actor.closeAsync();
+
+    // then
+    assertThat(actor.phases).isEqualTo(List.of(ActorLifecyclePhase.STARTING));
+    assertThat(startFuture).failsWithin(Duration.ofSeconds(1));
+    assertThat(closeFuture).succeedsWithin(Duration.ofSeconds(1));
   }
 }


### PR DESCRIPTION
## Description

When explicitly failing an actor, we want to ensure that anyone waiting on its start and/or close futures is notified that these will never complete. We complete the start future exceptionally on failure, and the close future successfully. This is because a caller may want to react differently if the actor did not start correctly, but most likely does not care if it did not close correctly.

Hopefully this helps reduce the number of deadlocks where an actor is waiting on another actor to start/close and it never does.

## Related issues

related to #8302

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
