### PR TITLE
refactor(engine): Remove StreamProcessorLifecycleAware from TypedRecordProcessor

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
@@ -16,8 +16,7 @@ import java.util.function.Consumer;
 // todo (#8002): remove TypedStreamWriter from this interface's method signatures
 // After the migration, none of these should be in use anymore and replaced by the CommandWriter and
 // StateWriter passed along to the constructors of the concrete processors.
-public interface TypedRecordProcessor<T extends UnifiedRecordValue>
-    extends StreamProcessorLifecycleAware {
+public interface TypedRecordProcessor<T extends UnifiedRecordValue> {
 
   /**
    * @see #processRecord(TypedRecord, TypedResponseWriter, TypedStreamWriter, Consumer)

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
@@ -329,7 +329,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
     lifecycleAwareListeners.addAll(typedRecordProcessors.getLifecycleListeners());
     final RecordProcessorMap recordProcessorMap = typedRecordProcessors.getRecordProcessorMap();
-    recordProcessorMap.values().forEachRemaining(lifecycleAwareListeners::add);
 
     processingContext.recordProcessorMap(recordProcessorMap);
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorReplayModeTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorReplayModeTest.java
@@ -17,9 +17,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.util.Records;
@@ -81,7 +81,6 @@ public final class StreamProcessorReplayModeTest {
     // then
     final InOrder inOrder = inOrder(typedRecordProcessor, eventApplier);
     inOrder.verify(eventApplier, TIMEOUT).applyState(anyLong(), eq(ELEMENT_ACTIVATING), any());
-    inOrder.verify(typedRecordProcessor, TIMEOUT.times(1)).onRecovered(any());
     inOrder
         .verify(typedRecordProcessor, TIMEOUT)
         .processRecord(anyLong(), any(), any(), any(), any());
@@ -103,12 +102,9 @@ public final class StreamProcessorReplayModeTest {
         event().processInstance(ELEMENT_ACTIVATING, RECORD).causedBy(0));
 
     // then
-    final InOrder inOrder = inOrder(typedRecordProcessor, eventApplier);
-    inOrder
-        .verify(eventApplier, TIMEOUT.times(2))
-        .applyState(anyLong(), eq(ELEMENT_ACTIVATING), any());
-    inOrder.verify(typedRecordProcessor, never()).onRecovered(any());
-    inOrder.verifyNoMoreInteractions();
+    verify(eventApplier, TIMEOUT.times(2)).applyState(anyLong(), eq(ELEMENT_ACTIVATING), any());
+
+    verifyNoMoreInteractions(eventApplier);
 
     assertThat(getCurrentPhase(replayContinuously)).isEqualTo(Phase.REPLAY);
   }
@@ -203,12 +199,9 @@ public final class StreamProcessorReplayModeTest {
     replayContinuously.resumeProcessing(1);
 
     // then
-    final var inOrder = inOrder(typedRecordProcessor, eventApplier);
-    inOrder
-        .verify(eventApplier, TIMEOUT.times(1))
-        .applyState(anyLong(), eq(ELEMENT_ACTIVATING), any());
-    inOrder.verify(typedRecordProcessor, never()).onRecovered(any());
-    inOrder.verifyNoMoreInteractions();
+    verify(eventApplier, TIMEOUT.times(1)).applyState(anyLong(), eq(ELEMENT_ACTIVATING), any());
+
+    verifyNoMoreInteractions(eventApplier);
 
     assertThat(getCurrentPhase(replayContinuously)).isEqualTo(Phase.REPLAY);
   }


### PR DESCRIPTION
## Description

- Removes the `StreamProcessorLifecycleAware` interface from `TypedRecordProcessor`. Turns out, none of the record processors implemented these methods
- This will make the engine abstraction easier, because then the new engine does not need to be listener and relay for those events
- Tests were simplified accordingly. I think this deserves most attention in the review. Maybe some tests are now obsolete altogether :thinking: 

## Related issues

related to #9725

<!-- Cut-off marker

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
