### PR TITLE
Migrate value class to record

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/cmd/BrokerRejectionException.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/cmd/BrokerRejectionException.java
@@ -24,9 +24,9 @@ public class BrokerRejectionException extends BrokerException {
     super(
         String.format(
             ERROR_MESSAGE_FORMAT,
-            rejection.getIntent().name(),
-            rejection.getType().name(),
-            rejection.getReason()),
+            rejection.intent().name(),
+            rejection.type().name(),
+            rejection.reason()),
         cause);
     this.rejection = rejection;
   }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -156,10 +156,10 @@ public final class GrpcErrorMapper {
     final String message =
         String.format(
             "Command '%s' rejected with code '%s': %s",
-            rejection.getIntent(), rejection.getType(), rejection.getReason());
+            rejection.intent(), rejection.type(), rejection.reason());
     final Builder builder = Status.newBuilder().setMessage(message);
 
-    switch (rejection.getType()) {
+    switch (rejection.type()) {
       case INVALID_ARGUMENT:
         builder.setCode(Code.INVALID_ARGUMENT_VALUE);
         break;

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/response/BrokerRejection.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/response/BrokerRejection.java
@@ -12,39 +12,17 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
-public final class BrokerRejection {
-
-  private final Intent intent;
-  private final long key;
-  private final RejectionType type;
-  private final String reason;
-
+/**
+ * Represents a command rejection from the broker.
+ *
+ * @param intent the intent of the command that was rejected
+ * @param key the key of the command that was rejected
+ * @param type the type of the rejection
+ * @param reason the reason for the rejection
+ */
+public record BrokerRejection(Intent intent, long key, RejectionType type, String reason) {
   public BrokerRejection(
       final Intent intent, final long key, final RejectionType type, final DirectBuffer reason) {
     this(intent, key, type, BufferUtil.bufferAsString(reason));
-  }
-
-  public BrokerRejection(
-      final Intent intent, final long key, final RejectionType type, final String reason) {
-    this.intent = intent;
-    this.key = key;
-    this.type = type;
-    this.reason = reason;
-  }
-
-  public RejectionType getType() {
-    return type;
-  }
-
-  public String getReason() {
-    return reason;
-  }
-
-  public Intent getIntent() {
-    return intent;
-  }
-
-  public long getKey() {
-    return key;
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayIntegrationTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayIntegrationTest.java
@@ -88,8 +88,8 @@ public final class GatewayIntegrationTest {
     final var error = errorResponse.get();
     assertThat(error).isInstanceOf(BrokerRejectionException.class);
     final BrokerRejection rejection = ((BrokerRejectionException) error).getRejection();
-    assertThat(rejection.getType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(rejection.getReason())
+    assertThat(rejection.type()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.reason())
         .isEqualTo("Expected at least a bpmnProcessId or a key greater than -1, but none given");
   }
 }


### PR DESCRIPTION
## Description

This tiny PR migrates the `BrokerRejection` data class from the gateway to a record. Generally, we do want to do that wherever possible, but at the same time this should take care of https://github.com/camunda/zeebe/security/code-scanning/229

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
