### PR TITLE
Add rootless integration test

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/RootlessImageTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/RootlessImageTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.startup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
+import io.camunda.zeebe.test.util.testcontainers.ZeebeTestContainerDefaults;
+import io.zeebe.containers.ZeebeBrokerContainer;
+import io.zeebe.containers.ZeebeGatewayContainer;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Tests a small deployment of one standalone broker and gateway, running "rootless". While this
+ * cannot guarantee OpenShift compatibility, it's the most common compatibility issue.
+ *
+ * <p>See <a
+ * href="https://docs.openshift.com/container-platform/latest/openshift_images/create-images.html">here</a>
+ * for more.
+ *
+ * <p>From their docs: By default, OpenShift Container Platform runs containers using an arbitrarily
+ * assigned user ID. This provides additional security against processes escaping the container due
+ * to a container engine vulnerability and thereby achieving escalated permissions on the host node.
+ * For an image to support running as an arbitrary user, directories and files that are written to
+ * by processes in the image must be owned by the root group and be read/writable by that group.
+ * Files to be executed must also have "group" execute permissions.
+ *
+ * <p>You can read more about UIDs/GIDs <a
+ * href="https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids">here</a>.
+ */
+@Testcontainers
+final class RootlessImageTest {
+  private final Network network = Network.newNetwork();
+
+  @Container
+  private final ZeebeBrokerContainer broker =
+      new ZeebeBrokerContainer(ZeebeTestContainerDefaults.defaultTestImage())
+          .withNetwork(network)
+          .withCreateContainerCmdModifier(cmd -> cmd.withUser("1000620000:0"));
+
+  @Container
+  private final ZeebeGatewayContainer gateway =
+      new ZeebeGatewayContainer(ZeebeTestContainerDefaults.defaultTestImage())
+          .withNetwork(network)
+          .withCreateContainerCmdModifier(cmd -> cmd.withUser("1000620000:0"))
+          .dependsOn(broker)
+          .withEnv(
+              "ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS", broker.getInternalClusterAddress());
+
+  @SuppressWarnings("unused")
+  @RegisterExtension
+  final ContainerLogsDumper logsWatcher =
+      new ContainerLogsDumper(() -> Map.of("broker", broker, "gateway", gateway));
+
+  @Test
+  void smokeTest() {
+    // given
+    final var process = Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
+    final ProcessInstanceResult result;
+    try (final ZeebeClient client =
+        ZeebeClient.newClientBuilder()
+            .usePlaintext()
+            .gatewayAddress(gateway.getExternalGatewayAddress())
+            .build()) {
+      // when
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .send()
+          .join(10, TimeUnit.SECONDS);
+      result =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("process")
+              .latestVersion()
+              .withResult()
+              .send()
+              .join(10, TimeUnit.SECONDS);
+    }
+
+    // then
+    assertThat(result)
+        .isNotNull()
+        .extracting(ProcessInstanceResult::getBpmnProcessId)
+        .isEqualTo("process");
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a smoke test which checks that both the broker and gateway Docker images can be ran using an arbitrary, non-root user ID, under similar conditions as OpenShift.

## Related issues

closes #9748 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
