### PR TITLE
[Backports stable/1.3] Complete start/close futures when an actor fails

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -234,7 +234,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
         actor.getLifecyclePhase(),
         failure,
         failure);
-    actor.fail();
+    actor.fail(failure);
 
     if (failure instanceof UnrecoverableException) {
       healthReport = HealthReport.dead(this).withIssue(failure);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -362,7 +362,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   private void onFailure(final Throwable throwable) {
     LOG.error("Actor {} failed in phase {}.", actorName, actor.getLifecyclePhase(), throwable);
-    actor.fail();
+    actor.fail(throwable);
     if (!openFuture.isDone()) {
       openFuture.completeExceptionally(throwable);
     }

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
@@ -236,7 +236,7 @@ public class LogStorageAppender extends Actor implements HealthMonitorable {
 
   private void onFailure(final Throwable error) {
     LOG.error("Actor {} failed in phase {}.", name, actor.getLifecyclePhase(), error);
-    actor.fail();
+    actor.fail(error);
     final var report = HealthReport.unhealthy(this).withIssue(error);
     failureListeners.forEach((l) -> l.onFailure(report));
   }

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorControl.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorControl.java
@@ -414,8 +414,8 @@ public class ActorControl implements ConcurrencyControl {
   }
 
   /** Mark actor as failed. This sets the lifecycle phase to 'FAILED' and discards all jobs. */
-  public void fail() {
+  public void fail(final Throwable error) {
     ensureCalledFromWithinActor("fail()");
-    task.fail();
+    task.fail(error);
   }
 }

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorTask.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorTask.java
@@ -285,18 +285,21 @@ public class ActorTask {
   }
 
   public void onFailure(final Throwable failure) {
-    switch (lifecyclePhase) {
+    final var currentPhase = lifecyclePhase;
+    switch (currentPhase) {
       case STARTING -> {
         Loggers.ACTOR_LOGGER.error(
             "Actor failed in phase 'STARTING'. Discard all jobs and stop immediately.", failure);
         lifecyclePhase = ActorLifecyclePhase.FAILED;
         discardNextJobs();
         startingFuture.completeExceptionally(failure);
-        closeFuture.complete(null);
+        closeFuture.completeExceptionally(failure);
       }
-      case CLOSING -> {
+      case CLOSING, CLOSE_REQUESTED -> {
         Loggers.ACTOR_LOGGER.error(
-            "Actor failed in phase 'CLOSING'. Discard all jobs and stop immediately.", failure);
+            "Actor failed in phase '{}'. Discard all jobs and stop immediately.",
+            currentPhase,
+            failure);
         lifecyclePhase = ActorLifecyclePhase.FAILED;
         discardNextJobs();
         closeFuture.completeExceptionally(failure);
@@ -548,7 +551,7 @@ public class ActorTask {
     }
 
     if (previousPhase != ActorLifecyclePhase.CLOSED) {
-      closeFuture.complete(null);
+      closeFuture.completeExceptionally(error);
     }
 
     discardNextJobs();

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorTask.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorTask.java
@@ -287,15 +287,16 @@ public class ActorTask {
   public void onFailure(final Throwable failure) {
     final var currentPhase = lifecyclePhase;
     switch (currentPhase) {
-      case STARTING -> {
+      case STARTING:
         Loggers.ACTOR_LOGGER.error(
             "Actor failed in phase 'STARTING'. Discard all jobs and stop immediately.", failure);
         lifecyclePhase = ActorLifecyclePhase.FAILED;
         discardNextJobs();
         startingFuture.completeExceptionally(failure);
         closeFuture.completeExceptionally(failure);
-      }
-      case CLOSING, CLOSE_REQUESTED -> {
+        break;
+      case CLOSING:
+      case CLOSE_REQUESTED:
         Loggers.ACTOR_LOGGER.error(
             "Actor failed in phase '{}'. Discard all jobs and stop immediately.",
             currentPhase,
@@ -303,14 +304,14 @@ public class ActorTask {
         lifecyclePhase = ActorLifecyclePhase.FAILED;
         discardNextJobs();
         closeFuture.completeExceptionally(failure);
-      }
-      case STARTED -> {
+        break;
+      case STARTED:
         actor.handleFailure(failure);
         currentJob.failFuture(failure);
-      }
-      default -> {
+        break;
+      default:
         // do nothing
-      }
+        break;
     }
   }
 

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorTask.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorTask.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,8 +30,11 @@ import org.slf4j.LoggerFactory;
  */
 @SuppressWarnings("restriction")
 public class ActorTask {
-
   private static final Logger LOG = LoggerFactory.getLogger(ActorTask.class);
+  private static final AtomicReferenceFieldUpdater<ActorTask, ActorLifecyclePhase>
+      LIFECYCLE_UPDATER =
+          AtomicReferenceFieldUpdater.newUpdater(
+              ActorTask.class, ActorLifecyclePhase.class, "lifecyclePhase");
 
   public final CompletableActorFuture<Void> closeFuture = new CompletableActorFuture<>();
   final Actor actor;
@@ -282,27 +286,28 @@ public class ActorTask {
 
   public void onFailure(final Throwable failure) {
     switch (lifecyclePhase) {
-      case STARTING:
+      case STARTING -> {
         Loggers.ACTOR_LOGGER.error(
-            "Actor failed in phase 'STARTING'. Discard all jobs and stop immediatly.", failure);
-
+            "Actor failed in phase 'STARTING'. Discard all jobs and stop immediately.", failure);
         lifecyclePhase = ActorLifecyclePhase.FAILED;
         discardNextJobs();
         startingFuture.completeExceptionally(failure);
-        break;
-
-      case CLOSING:
+        closeFuture.complete(null);
+      }
+      case CLOSING -> {
         Loggers.ACTOR_LOGGER.error(
-            "Actor failed in phase 'CLOSING'. Discard all jobs and stop immediatly.", failure);
-
+            "Actor failed in phase 'CLOSING'. Discard all jobs and stop immediately.", failure);
         lifecyclePhase = ActorLifecyclePhase.FAILED;
         discardNextJobs();
         closeFuture.completeExceptionally(failure);
-        break;
-
-      default:
+      }
+      case STARTED -> {
         actor.handleFailure(failure);
         currentJob.failFuture(failure);
+      }
+      default -> {
+        // do nothing
+      }
     }
   }
 
@@ -531,8 +536,21 @@ public class ActorTask {
     fastLaneJobs.addFirst(job);
   }
 
-  public void fail() {
-    lifecyclePhase = ActorLifecyclePhase.FAILED;
+  public void fail(final Throwable error) {
+    final var previousPhase = LIFECYCLE_UPDATER.getAndSet(this, ActorLifecyclePhase.FAILED);
+
+    if (previousPhase == ActorLifecyclePhase.FAILED) {
+      return;
+    }
+
+    if (previousPhase == ActorLifecyclePhase.STARTING) {
+      startingFuture.completeExceptionally(error);
+    }
+
+    if (previousPhase != ActorLifecyclePhase.CLOSED) {
+      closeFuture.complete(null);
+    }
+
     discardNextJobs();
     actor.onActorFailed();
   }

--- a/util/src/test/java/io/camunda/zeebe/util/sched/lifecycle/ActorLifecyclePhasesTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/sched/lifecycle/ActorLifecyclePhasesTest.java
@@ -16,10 +16,12 @@ import static io.camunda.zeebe.util.sched.lifecycle.LifecycleRecordingActor.FULL
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Lists.newArrayList;
 
+import io.camunda.zeebe.scheduler.ActorTask.ActorLifecyclePhase;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerRule;
 import io.camunda.zeebe.util.TestUtil;
-import io.camunda.zeebe.util.sched.future.ActorFuture;
-import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
-import io.camunda.zeebe.util.sched.testing.ControlledActorSchedulerRule;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -324,7 +326,7 @@ public final class ActorLifecyclePhasesTest {
           @Override
           public void onActorStarted() {
             super.onActorStarted();
-            actor.submit(actor::fail);
+            actor.submit(() -> actor.fail(new RuntimeException("foo")));
             actor.submit(invocations::incrementAndGet);
           }
         };
@@ -336,5 +338,138 @@ public final class ActorLifecyclePhasesTest {
     // then
     assertThat(invocations.get()).isEqualTo(0);
     assertThat(actor.phases).isEqualTo(List.of(STARTING, STARTED, FAILED));
+  }
+
+  @Test
+  public void shouldCompleteCloseFutureWhenFailingInStarted() {
+    // given
+    final LifecycleRecordingActor actor =
+        new LifecycleRecordingActor() {
+          @Override
+          public void onActorStarted() {
+            super.onActorStarted();
+            actor.fail(new RuntimeException("foo"));
+          }
+        };
+
+    // when - explicitly do not work after close as it should be completed already
+    schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+    final ActorFuture<Void> closeFuture = actor.closeAsync();
+
+    // then
+    assertThat(actor.phases)
+        .isEqualTo(
+            List.of(
+                ActorLifecyclePhase.STARTING,
+                ActorLifecyclePhase.STARTED,
+                ActorLifecyclePhase.FAILED));
+    assertThat(closeFuture).succeedsWithin(Duration.ofSeconds(1));
+  }
+
+  @Test
+  public void shouldCompleteCloseFutureOnExceptionOnClosing() {
+    // given
+    final LifecycleRecordingActor actor =
+        new LifecycleRecordingActor() {
+          @Override
+          public void onActorClosing() {
+            super.onActorClosing();
+            throw new RuntimeException("foo");
+          }
+        };
+
+    // when
+    schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+    final ActorFuture<Void> closeFuture = actor.closeAsync();
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(actor.phases)
+        .isEqualTo(
+            List.of(
+                ActorLifecyclePhase.STARTING,
+                ActorLifecyclePhase.STARTED,
+                ActorLifecyclePhase.CLOSE_REQUESTED,
+                ActorLifecyclePhase.CLOSING));
+    assertThat(closeFuture).failsWithin(Duration.ofSeconds(1));
+  }
+
+  @Test
+  public void shouldCompleteCloseFutureWhenFailingOnClosing() {
+    // given
+    final LifecycleRecordingActor actor =
+        new LifecycleRecordingActor() {
+          @Override
+          public void onActorClosing() {
+            super.onActorClosing();
+            actor.fail(new RuntimeException("foo"));
+          }
+        };
+
+    // when
+    schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+    final ActorFuture<Void> closeFuture = actor.closeAsync();
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(actor.phases)
+        .isEqualTo(
+            List.of(
+                ActorLifecyclePhase.STARTING,
+                ActorLifecyclePhase.STARTED,
+                ActorLifecyclePhase.CLOSE_REQUESTED,
+                ActorLifecyclePhase.CLOSING,
+                ActorLifecyclePhase.FAILED));
+    assertThat(closeFuture).succeedsWithin(Duration.ofSeconds(1));
+  }
+
+  @Test
+  public void shouldCompleteFuturesWhenFailingOnStarting() {
+    // given
+    final LifecycleRecordingActor actor =
+        new LifecycleRecordingActor() {
+          @Override
+          public void onActorStarting() {
+            super.onActorStarting();
+            actor.fail(new RuntimeException("foo"));
+          }
+        };
+
+    // when - explicitly do not work after close as it should be completed already
+    final ActorFuture<Void> startFuture = schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+    final ActorFuture<Void> closeFuture = actor.closeAsync();
+
+    // then
+    assertThat(actor.phases)
+        .isEqualTo(List.of(ActorLifecyclePhase.STARTING, ActorLifecyclePhase.FAILED));
+    assertThat(startFuture).failsWithin(Duration.ofSeconds(1));
+    assertThat(closeFuture).succeedsWithin(Duration.ofSeconds(1));
+  }
+
+  @Test
+  public void shouldCompleteFuturesOnExceptionOnStarting() {
+    // given
+    final LifecycleRecordingActor actor =
+        new LifecycleRecordingActor() {
+          @Override
+          public void onActorStarting() {
+            super.onActorStarting();
+            throw new RuntimeException("hello");
+          }
+        };
+
+    // when - explicitly do not work after close as it should be completed already
+    final ActorFuture<Void> startFuture = schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+    final ActorFuture<Void> closeFuture = actor.closeAsync();
+
+    // then
+    assertThat(actor.phases).isEqualTo(List.of(ActorLifecyclePhase.STARTING));
+    assertThat(startFuture).failsWithin(Duration.ofSeconds(1));
+    assertThat(closeFuture).succeedsWithin(Duration.ofSeconds(1));
   }
 }

--- a/util/src/test/java/io/camunda/zeebe/util/sched/lifecycle/ActorLifecyclePhasesTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/sched/lifecycle/ActorLifecyclePhasesTest.java
@@ -16,11 +16,11 @@ import static io.camunda.zeebe.util.sched.lifecycle.LifecycleRecordingActor.FULL
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Lists.newArrayList;
 
-import io.camunda.zeebe.scheduler.ActorTask.ActorLifecyclePhase;
-import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerRule;
 import io.camunda.zeebe.util.TestUtil;
+import io.camunda.zeebe.util.sched.ActorTask.ActorLifecyclePhase;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
+import io.camunda.zeebe.util.sched.testing.ControlledActorSchedulerRule;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;


### PR DESCRIPTION
## Description

Backports #9734 to 1.3 in order to fix #8302 for this branch as well.

## Related issues

backports #9734 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
