### PR TITLE
Hide scheduling behind interface

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -208,15 +208,15 @@ final class PartitionFactory {
       final PushDeploymentRequestHandler deploymentRequestHandler,
       final FeatureFlags featureFlags) {
     return (recordProcessorContext) -> {
-      final var actor = recordProcessorContext.getActor();
+      final var scheduleService = recordProcessorContext.getScheduleService();
 
       final TopologyPartitionListenerImpl partitionListener =
-          new TopologyPartitionListenerImpl(actor);
+          new TopologyPartitionListenerImpl(scheduleService);
       topologyManager.addTopologyPartitionListener(partitionListener);
 
       final DeploymentDistributorImpl deploymentDistributor =
           new DeploymentDistributorImpl(
-              communicationService, eventService, partitionListener, actor);
+              communicationService, eventService, partitionListener, scheduleService);
 
       final PartitionCommandSenderImpl partitionCommandSender =
           new PartitionCommandSenderImpl(communicationService, partitionListener);

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyPartitionListenerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyPartitionListenerImpl.java
@@ -7,24 +7,25 @@
  */
 package io.camunda.zeebe.broker.partitioning.topology;
 
+import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.protocol.record.PartitionRole;
-import io.camunda.zeebe.scheduler.ActorControl;
+import java.time.Duration;
 import org.agrona.collections.Int2IntHashMap;
 
 public final class TopologyPartitionListenerImpl implements TopologyPartitionListener {
 
   private final Int2IntHashMap partitionLeaders = new Int2IntHashMap(-1);
-  private final ActorControl actor;
+  private final ProcessingScheduleService scheduleService;
 
-  public TopologyPartitionListenerImpl(final ActorControl actor) {
-    this.actor = actor;
+  public TopologyPartitionListenerImpl(final ProcessingScheduleService scheduleService) {
+    this.scheduleService = scheduleService;
   }
 
   @Override
   public void onPartitionLeaderUpdated(final int partitionId, final BrokerInfo member) {
     if (member.getPartitionRoles().get(partitionId) == PartitionRole.LEADER) {
-      actor.submit(() -> updatePartitionLeader(partitionId, member));
+      scheduleService.runDelayed(Duration.ZERO, () -> updatePartitionLeader(partitionId, member));
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingScheduleService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingScheduleService.java
@@ -28,7 +28,4 @@ public interface ProcessingScheduleService {
           }
         });
   }
-
-  @Deprecated // only used in tests
-  ActorFuture<Void> call(final Runnable action);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingScheduleService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingScheduleService.java
@@ -15,7 +15,7 @@ public interface ProcessingScheduleService {
 
   void runDelayed(Duration delay, Runnable followUpTask);
 
-  <T> void runOnSuccess(ActorFuture<T> precedingTask, BiConsumer<T, Throwable> followUpTask);
+  <T> void runOnCompletion(ActorFuture<T> precedingTask, BiConsumer<T, Throwable> followUpTask);
 
   default void runAtFixedRate(final Duration delay, final Runnable task) {
     runDelayed(

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingScheduleService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingScheduleService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.api;
+
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.time.Duration;
+import java.util.function.BiConsumer;
+
+public interface ProcessingScheduleService {
+
+  void runDelayed(Duration delay, Runnable followUpTask);
+
+  <T> void runOnSuccess(ActorFuture<T> precedingTask, BiConsumer<T, Throwable> followUpTask);
+
+  default void runAtFixedRate(final Duration delay, final Runnable task) {
+    runDelayed(
+        delay,
+        () -> {
+          try {
+            task.run();
+          } finally {
+            runAtFixedRate(delay, task);
+          }
+        });
+  }
+
+  @Deprecated // only used in tests
+  ActorFuture<Void> call(final Runnable action);
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ReadonlyStreamProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ReadonlyStreamProcessorContext.java
@@ -11,14 +11,10 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWri
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.logstreams.log.LogStream;
-import io.camunda.zeebe.scheduler.ActorControl;
 
 public interface ReadonlyStreamProcessorContext {
 
-  /**
-   * @return the actor on which the processing runs
-   */
-  ActorControl getActor();
+  ProcessingScheduleService getScheduleService();
 
   /**
    * @return the logstream, on which the processor runs

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessorContext.java
@@ -11,13 +11,12 @@ import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorListene
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.LastProcessedPositionState;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.scheduler.ActorControl;
 
 public interface RecordProcessorContext {
 
   int getPartitionId();
 
-  ActorControl getActor();
+  ProcessingScheduleService getScheduleService();
 
   MutableZeebeState getZeebeState();
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing;
 import static io.camunda.zeebe.protocol.record.intent.DeploymentIntent.CREATE;
 
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.api.RecordProcessorContext;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventPublicationBehavior;
@@ -39,7 +40,6 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
-import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.util.FeatureFlags;
 import java.util.function.Consumer;
 
@@ -54,7 +54,7 @@ public final class EngineProcessors {
       final Consumer<String> onJobsAvailableCallback,
       final FeatureFlags featureFlags) {
 
-    final var actor = recordProcessorContext.getActor();
+    final var scheduleService = recordProcessorContext.getScheduleService();
     final MutableZeebeState zeebeState = recordProcessorContext.getZeebeState();
     final var writers = recordProcessorContext.getWriters();
     final TypedRecordProcessors typedRecordProcessors =
@@ -102,7 +102,7 @@ public final class EngineProcessors {
         expressionProcessor,
         writers,
         partitionsCount,
-        actor,
+        scheduleService,
         deploymentDistributor,
         zeebeState.getKeyGenerator());
     addMessageProcessors(
@@ -176,7 +176,7 @@ public final class EngineProcessors {
       final ExpressionProcessor expressionProcessor,
       final Writers writers,
       final int partitionsCount,
-      final ActorControl actor,
+      final ProcessingScheduleService scheduleService,
       final DeploymentDistributor deploymentDistributor,
       final KeyGenerator keyGenerator) {
 
@@ -189,7 +189,7 @@ public final class EngineProcessors {
             expressionProcessor,
             partitionsCount,
             writers,
-            actor,
+            scheduleService,
             deploymentDistributor,
             keyGenerator);
     typedRecordProcessors.onCommand(ValueType.DEPLOYMENT, CREATE, processor);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.deployment;
 
 import static io.camunda.zeebe.engine.state.instance.TimerInstance.NO_ELEMENT_INSTANCE;
 
+import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.api.TypedRecord;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
@@ -37,7 +38,6 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessMetadata;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
-import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.function.Consumer;
@@ -66,7 +66,7 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
       final ExpressionProcessor expressionProcessor,
       final int partitionsCount,
       final Writers writers,
-      final ActorControl actor,
+      final ProcessingScheduleService scheduleService,
       final DeploymentDistributor deploymentDistributor,
       final KeyGenerator keyGenerator) {
     processState = zeebeState.getProcessState();
@@ -81,7 +81,8 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
         new MessageStartEventSubscriptionManager(
             processState, zeebeState.getMessageStartEventSubscriptionState(), keyGenerator);
     deploymentDistributionBehavior =
-        new DeploymentDistributionBehavior(writers, partitionsCount, deploymentDistributor, actor);
+        new DeploymentDistributionBehavior(
+            writers, partitionsCount, deploymentDistributor, scheduleService);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentDistributionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentDistributionBehavior.java
@@ -80,7 +80,7 @@ public final class DeploymentDistributionBehavior {
     final var deploymentPushedFuture =
         deploymentDistributor.pushDeploymentToPartition(key, partitionId, copiedDeploymentBuffer);
 
-    scheduleService.runOnSuccess(
+    scheduleService.runOnCompletion(
         deploymentPushedFuture, new WriteDeploymentDistributionCompleteTask(partitionId, key));
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentRedistributor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentRedistributor.java
@@ -28,11 +28,11 @@ public class DeploymentRedistributor implements StreamProcessorLifecycleAware {
 
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
-    final var actor = context.getActor();
     final var writers = context.getWriters();
 
     final var deploymentDistributionBehavior =
-        new DeploymentDistributionBehavior(writers, partitionsCount, deploymentDistributor, actor);
+        new DeploymentDistributionBehavior(
+            writers, partitionsCount, deploymentDistributor, context.getScheduleService());
 
     deploymentState.foreachPendingDeploymentDistribution(
         (key, partitionId, deployment) ->

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutTrigger.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutTrigger.java
@@ -14,14 +14,14 @@ import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.scheduler.ScheduledTimer;
 import java.time.Duration;
 
 public final class JobTimeoutTrigger implements StreamProcessorLifecycleAware {
   public static final Duration TIME_OUT_POLLING_INTERVAL = Duration.ofSeconds(30);
   private final JobState state;
 
-  private ScheduledTimer timer;
+  private boolean timerRunning = false;
+
   private TypedCommandWriter writer;
   private ReadonlyStreamProcessorContext processingContext;
 
@@ -32,10 +32,8 @@ public final class JobTimeoutTrigger implements StreamProcessorLifecycleAware {
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext processingContext) {
     this.processingContext = processingContext;
-    timer =
-        this.processingContext
-            .getActor()
-            .runAtFixedRate(TIME_OUT_POLLING_INTERVAL, this::deactivateTimedOutJobs);
+    timerRunning = true;
+    scheduleDeactivateTimedOutJobsTask();
     writer = processingContext.getLogStreamWriter();
   }
 
@@ -56,19 +54,19 @@ public final class JobTimeoutTrigger implements StreamProcessorLifecycleAware {
 
   @Override
   public void onResumed() {
-    if (timer == null) {
-      timer =
-          processingContext
-              .getActor()
-              .runAtFixedRate(TIME_OUT_POLLING_INTERVAL, this::deactivateTimedOutJobs);
+    if (timerRunning) {
+      scheduleDeactivateTimedOutJobsTask();
     }
   }
 
+  private void scheduleDeactivateTimedOutJobsTask() {
+    processingContext
+        .getScheduleService()
+        .runDelayed(TIME_OUT_POLLING_INTERVAL, this::deactivateTimedOutJobs);
+  }
+
   private void cancelTimer() {
-    if (timer != null) {
-      timer.cancel();
-      timer = null;
-    }
+    timerRunning = false;
   }
 
   void deactivateTimedOutJobs() {
@@ -81,5 +79,8 @@ public final class JobTimeoutTrigger implements StreamProcessorLifecycleAware {
 
           return writer.flush() >= 0;
         });
+    if (timerRunning) {
+      scheduleDeactivateTimedOutJobsTask();
+    }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutTrigger.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutTrigger.java
@@ -20,7 +20,7 @@ public final class JobTimeoutTrigger implements StreamProcessorLifecycleAware {
   public static final Duration TIME_OUT_POLLING_INTERVAL = Duration.ofSeconds(30);
   private final JobState state;
 
-  private boolean timerRunning = false;
+  private boolean shouldReschedule = false;
 
   private TypedCommandWriter writer;
   private ReadonlyStreamProcessorContext processingContext;
@@ -32,7 +32,7 @@ public final class JobTimeoutTrigger implements StreamProcessorLifecycleAware {
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext processingContext) {
     this.processingContext = processingContext;
-    timerRunning = true;
+    shouldReschedule = true;
     scheduleDeactivateTimedOutJobsTask();
     writer = processingContext.getLogStreamWriter();
   }
@@ -54,7 +54,7 @@ public final class JobTimeoutTrigger implements StreamProcessorLifecycleAware {
 
   @Override
   public void onResumed() {
-    if (timerRunning) {
+    if (shouldReschedule) {
       scheduleDeactivateTimedOutJobsTask();
     }
   }
@@ -66,7 +66,7 @@ public final class JobTimeoutTrigger implements StreamProcessorLifecycleAware {
   }
 
   private void cancelTimer() {
-    timerRunning = false;
+    shouldReschedule = false;
   }
 
   void deactivateTimedOutJobs() {
@@ -79,7 +79,7 @@ public final class JobTimeoutTrigger implements StreamProcessorLifecycleAware {
 
           return writer.flush() >= 0;
         });
-    if (timerRunning) {
+    if (shouldReschedule) {
       scheduleDeactivateTimedOutJobsTask();
     }
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
@@ -7,13 +7,12 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.state.message.ProcessMessageSubscription;
 import io.camunda.zeebe.engine.state.mutable.MutablePendingProcessMessageSubscriptionState;
-import io.camunda.zeebe.scheduler.ActorControl;
-import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import java.time.Duration;
 
@@ -27,8 +26,8 @@ public final class PendingProcessMessageSubscriptionChecker
   private final MutablePendingProcessMessageSubscriptionState pendingState;
   private final long subscriptionTimeoutInMillis;
 
-  private ActorControl actor;
-  private ScheduledTimer timer;
+  private ProcessingScheduleService scheduleService;
+  private boolean timerRunning = false;
 
   public PendingProcessMessageSubscriptionChecker(
       final SubscriptionCommandSender commandSender,
@@ -40,8 +39,9 @@ public final class PendingProcessMessageSubscriptionChecker
 
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
-    actor = context.getActor();
-    scheduleTimer();
+    scheduleService = context.getScheduleService();
+    timerRunning = true;
+    rescheduleTimer();
   }
 
   @Override
@@ -61,25 +61,24 @@ public final class PendingProcessMessageSubscriptionChecker
 
   @Override
   public void onResumed() {
-    scheduleTimer();
+    timerRunning = true;
+    rescheduleTimer();
   }
 
-  private void scheduleTimer() {
-    if (timer == null) {
-      timer = actor.runAtFixedRate(SUBSCRIPTION_CHECK_INTERVAL, this::checkPendingSubscriptions);
+  private void rescheduleTimer() {
+    if (timerRunning) {
+      scheduleService.runDelayed(SUBSCRIPTION_CHECK_INTERVAL, this::checkPendingSubscriptions);
     }
   }
 
   private void cancelTimer() {
-    if (timer != null) {
-      timer.cancel();
-      timer = null;
-    }
+    timerRunning = false;
   }
 
   private void checkPendingSubscriptions() {
     pendingState.visitSubscriptionBefore(
         ActorClock.currentTimeMillis() - subscriptionTimeoutInMillis, this::sendPendingCommand);
+    rescheduleTimer();
   }
 
   private boolean sendPendingCommand(final ProcessMessageSubscription subscription) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
@@ -27,7 +27,7 @@ public final class PendingProcessMessageSubscriptionChecker
   private final long subscriptionTimeoutInMillis;
 
   private ProcessingScheduleService scheduleService;
-  private boolean timerRunning = false;
+  private boolean schouldRescheduleTimer = false;
 
   public PendingProcessMessageSubscriptionChecker(
       final SubscriptionCommandSender commandSender,
@@ -40,7 +40,7 @@ public final class PendingProcessMessageSubscriptionChecker
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     scheduleService = context.getScheduleService();
-    timerRunning = true;
+    schouldRescheduleTimer = true;
     rescheduleTimer();
   }
 
@@ -61,18 +61,18 @@ public final class PendingProcessMessageSubscriptionChecker
 
   @Override
   public void onResumed() {
-    timerRunning = true;
+    schouldRescheduleTimer = true;
     rescheduleTimer();
   }
 
   private void rescheduleTimer() {
-    if (timerRunning) {
+    if (schouldRescheduleTimer) {
       scheduleService.runDelayed(SUBSCRIPTION_CHECK_INTERVAL, this::checkPendingSubscriptions);
     }
   }
 
   private void cancelTimer() {
-    timerRunning = false;
+    schouldRescheduleTimer = false;
   }
 
   private void checkPendingSubscriptions() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -46,10 +46,12 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     if (!checkerRunning) {
       scheduleService.runDelayed(delay, this::triggerEntities);
       nextDueDate = dueDate;
+      checkerRunning = true;
 
     } else if (nextDueDate - dueDate > timerResolution) {
       scheduleService.runDelayed(delay, this::triggerEntities);
       nextDueDate = dueDate;
+      checkerRunning = true;
     }
   }
 
@@ -61,6 +63,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     if (nextDueDate > 0) {
       final Duration delay = calculateDelayForNextRun(nextDueDate);
       scheduleService.runDelayed(delay, this::triggerEntities);
+      checkerRunning = true;
     } else {
       checkerRunning = false;
     }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
@@ -27,7 +27,7 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService 
   }
 
   @Override
-  public <T> void runOnSuccess(
+  public <T> void runOnCompletion(
       final ActorFuture<T> precedingTask, final BiConsumer<T, Throwable> followUpTask) {
     scheduleOnActor(() -> actorControl.runOnCompletion(precedingTask, followUpTask));
   }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
@@ -23,17 +23,21 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService 
 
   @Override
   public void runDelayed(final Duration delay, final Runnable followUpTask) {
-    actorControl.runDelayed(delay, followUpTask);
+    scheduleOnActor(() -> actorControl.runDelayed(delay, followUpTask));
   }
 
   @Override
   public <T> void runOnSuccess(
       final ActorFuture<T> precedingTask, final BiConsumer<T, Throwable> followUpTask) {
-    actorControl.runOnCompletion(precedingTask, followUpTask);
+    scheduleOnActor(() -> actorControl.runOnCompletion(precedingTask, followUpTask));
   }
 
   @Override
   public ActorFuture<Void> call(final Runnable action) {
     return actorControl.call(action);
+  }
+
+  private void scheduleOnActor(final Runnable task) {
+    actorControl.submit(task);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.streamprocessor;
+
+import io.camunda.zeebe.engine.api.ProcessingScheduleService;
+import io.camunda.zeebe.scheduler.ActorControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.time.Duration;
+import java.util.function.BiConsumer;
+
+public class ProcessingScheduleServiceImpl implements ProcessingScheduleService {
+
+  private final ActorControl actorControl;
+
+  public ProcessingScheduleServiceImpl(final ActorControl actorControl) {
+    this.actorControl = actorControl;
+  }
+
+  @Override
+  public void runDelayed(final Duration delay, final Runnable followUpTask) {
+    actorControl.runDelayed(delay, followUpTask);
+  }
+
+  @Override
+  public <T> void runOnSuccess(
+      final ActorFuture<T> precedingTask, final BiConsumer<T, Throwable> followUpTask) {
+    actorControl.runOnCompletion(precedingTask, followUpTask);
+  }
+
+  @Override
+  public ActorFuture<Void> call(final Runnable action) {
+    return actorControl.call(action);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
@@ -32,11 +32,6 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService 
     scheduleOnActor(() -> actorControl.runOnCompletion(precedingTask, followUpTask));
   }
 
-  @Override
-  public ActorFuture<Void> call(final Runnable action) {
-    return actorControl.call(action);
-  }
-
   private void scheduleOnActor(final Runnable task) {
     actorControl.submit(task);
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/ArchitectureTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/ArchitectureTest.java
@@ -33,5 +33,5 @@ public class ArchitectureTest {
           .resideInAPackage("io.camunda.zeebe.engine..")
           .should()
           .dependOnClassesThat()
-          .resideInAPackage("io.camunda.zeebe.scheduler..");
+          .resideInAPackage("io.camunda.zeebe.scheduler");
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/ArchitectureTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/ArchitectureTest.java
@@ -25,4 +25,13 @@ public class ArchitectureTest {
           .should()
           .dependOnClassesThat()
           .resideInAPackage("io.camunda.zeebe.streamprocessor..");
+
+  @ArchTest
+  public static final ArchRule RULE_ENGINE_CLASSES_MUST_NOT_DEPEND_ON_SCHEDULER_PACKAGE =
+      noClasses()
+          .that()
+          .resideInAPackage("io.camunda.zeebe.engine..")
+          .should()
+          .dependOnClassesThat()
+          .resideInAPackage("io.camunda.zeebe.scheduler..");
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.api.TypedRecord;
@@ -39,7 +40,6 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
-import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.test.util.TestUtil;
 import io.camunda.zeebe.util.exception.RecoverableException;
@@ -66,7 +66,7 @@ public final class StreamProcessorTest {
   private static final JobRecord JOB_RECORD = Records.job(1).setType("test");
 
   @Rule public final StreamProcessorRule streamProcessorRule = new StreamProcessorRule();
-  private ActorControl processingContextActor;
+  private ProcessingScheduleService scheduleService;
 
   @Test
   public void shouldCallStreamProcessorLifecycle() throws Exception {
@@ -406,7 +406,7 @@ public final class StreamProcessorTest {
 
     streamProcessorRule.startTypedStreamProcessor(
         (builder, processingContext) -> {
-          processingContextActor = processingContext.getActor();
+          scheduleService = processingContext.getScheduleService();
           final MutableZeebeState state = processingContext.getZeebeState();
           return builder.onCommand(
               ValueType.PROCESS_INSTANCE,
@@ -437,7 +437,7 @@ public final class StreamProcessorTest {
     verify(streamProcessorRule.getMockStreamProcessorListener(), TIMEOUT.times(2))
         .onProcessed(any());
 
-    processingContextActor
+    scheduleService
         .call(
             () -> {
               final var jobState = streamProcessorRule.getZeebeState().getJobState();
@@ -455,7 +455,7 @@ public final class StreamProcessorTest {
 
     streamProcessorRule.startTypedStreamProcessor(
         (builder, processingContext) -> {
-          processingContextActor = processingContext.getActor();
+          scheduleService = processingContext.getScheduleService();
           final MutableZeebeState state = processingContext.getZeebeState();
           return builder.onCommand(
               ValueType.PROCESS_INSTANCE,
@@ -481,7 +481,7 @@ public final class StreamProcessorTest {
     // then
     verify(streamProcessorRule.getMockStreamProcessorListener(), TIMEOUT).onProcessed(any());
 
-    processingContextActor
+    scheduleService
         .call(
             () -> {
               final var jobState = streamProcessorRule.getZeebeState().getJobState();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
@@ -64,7 +64,7 @@ public final class TimerStartEventTest {
   private static final BpmnModelInstance FEEL_DATE_TIME_EXPRESSION_MODEL =
       Bpmn.createExecutableProcess("process_5")
           .startEvent("start_5")
-          .timerWithDateExpression("date and time(date(\"3978-11-25\"),time(\"T00:00:00@UTC\"))")
+          .timerWithDateExpression("date and time(date(\"2178-11-25\"),time(\"T00:00:00@UTC\"))")
           .endEvent("end_5")
           .done();
 
@@ -143,7 +143,7 @@ public final class TimerStartEventTest {
         .hasElementInstanceKey(TimerInstance.NO_ELEMENT_INSTANCE);
 
     final long expected =
-        ZonedDateTime.of(LocalDate.of(3978, 11, 25), LocalTime.of(0, 0, 0), ZoneId.of("UTC"))
+        ZonedDateTime.of(LocalDate.of(2178, 11, 25), LocalTime.of(0, 0, 0), ZoneId.of("UTC"))
             .toInstant()
             .toEpochMilli();
     assertThat(timerRecord.getDueDate()).isEqualTo(expected);


### PR DESCRIPTION
## Description

In terms of the scope defined in #9730 this implements the following:

- [x] Create a new interface for the ProcessingScheduleService (with narrowed scope)
  - [x] Possibily only two methods, runDelayed and runComplete take a look at the POC #9602 
- [x] Implement the interface
- [x] Before migrating to the new abstraction, migrate the ActorCOntrol#runAtFixedRate consumers to the #runDelayed usage, this means after each run the job needs to be scheduled again
- [x] Migrate step by step the actorControl usage
- [x] Remove the actor control from the ProcessingContext

## Related issues

related to #9730

## Review Hints
* This is not the final form of the scheduling interface, instead the focus of this PR is to hide all the dependencies behind an interface first
* The change is not a pure refactoring. So there is a residual risk that the behavior is different in subtle ways (which is why I would like to have a review by both of you)
* The new code sometimes (indirectly) calls different methods on the `ActorControl`. Therefore there might be differences in the way tasks are scheduled (top of queue/bottom of queue; fast lane or not). The intention of the change was to simplify the interface that is available to the engine. In this regard some subtle changes are unavoidable
* Part of the simplification is also that the engine does not have access to something like a `ScheduledTimer`. Therefore, the engine is unable to cancel tasks which have been scheduled
* `RunAtFixedRate` has been replaced by tasks that reschedule themselves after they are called
* There is a difference in the way exceptions are propagated. See commit message https://github.com/camunda/zeebe/commit/a406d3f0e35186da9f225edaf13fd361f06521b7 for one such example
* Other than that, the tests pass and I just started a QA run, so let's see :crossed_fingers: 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [x] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
