### PR TITLE
Reject duplicate parallel gateway activate command

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -106,7 +106,7 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
     final ExecutableFlowElement element = getElement(recordValue, processor);
 
     stateTransitionGuard
-        .isValidStateTransition(context)
+        .isValidStateTransition(context, element)
         .ifRightOrLeft(
             ok -> {
               LOGGER.trace("Process process instance event [context: {}]", context);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
@@ -50,13 +50,13 @@ public final class ProcessInstanceStateTransitionGuard {
       case ACTIVATE_ELEMENT -> hasActiveFlowScopeInstance(context)
           .flatMap(ok -> canActivateParallelGateway(context, element));
       case COMPLETE_ELEMENT ->
-        // an incident is resolved by writing a COMPLETE command when the element instance is in
-        // state COMPLETING
-          hasElementInstanceWithState(
+      // an incident is resolved by writing a COMPLETE command when the element instance is in
+      // state COMPLETING
+      hasElementInstanceWithState(
               context,
               ProcessInstanceIntent.ELEMENT_ACTIVATED,
               ProcessInstanceIntent.ELEMENT_COMPLETING)
-              .flatMap(ok -> hasActiveFlowScopeInstance(context));
+          .flatMap(ok -> hasActiveFlowScopeInstance(context));
       case TERMINATE_ELEMENT -> hasElementInstanceWithState(
           context,
           ProcessInstanceIntent.ELEMENT_ACTIVATING,
@@ -180,8 +180,7 @@ public final class ProcessInstanceStateTransitionGuard {
           : Either.left(
               String.format(
                   "Expected to be able to activate parallel gateway '%s',"
-                      + " but not all sequence flows have been taken. "
-                      + "This could occur when a sequence flow is taken multiple times.",
+                      + " but not all sequence flows have been taken.",
                   BufferUtil.bufferAsString(element.getId())));
     }
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.engine.processing.bpmn;
 
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -37,15 +39,19 @@ public final class ProcessInstanceStateTransitionGuard {
    *
    * @return {@code true} if the preconditions are met and the transition command is valid.
    */
-  public Either<Failure, ?> isValidStateTransition(final BpmnElementContext context) {
-    return checkStateTransition(context).mapLeft(Failure::new);
+  public Either<Failure, ?> isValidStateTransition(
+      final BpmnElementContext context, final ExecutableFlowElement element) {
+    return checkStateTransition(context, element).mapLeft(Failure::new);
   }
 
-  private Either<String, ?> checkStateTransition(final BpmnElementContext context) {
+  private Either<String, ?> checkStateTransition(
+      final BpmnElementContext context, final ExecutableFlowElement element) {
     switch (context.getIntent()) {
       case ACTIVATE_ELEMENT:
-        return hasActiveFlowScopeInstance(context);
-
+        final Either<String, ?> hasActiveFlowScopeInstance = hasActiveFlowScopeInstance(context);
+        return hasActiveFlowScopeInstance.isLeft()
+            ? hasActiveFlowScopeInstance
+            : canActivateParallelGateway(context, element);
       case COMPLETE_ELEMENT:
         // an incident is resolved by writing a COMPLETE command when the element instance is in
         // state COMPLETING
@@ -164,6 +170,26 @@ public final class ProcessInstanceStateTransitionGuard {
                   hasFlowScopeInstanceInState(
                       flowScopeInstance, ProcessInstanceIntent.ELEMENT_ACTIVATED))
           .flatMap(flowScopeInstance -> hasNonInterruptedFlowScope(flowScopeInstance, context));
+    }
+  }
+
+  private Either<String, ?> canActivateParallelGateway(
+      final BpmnElementContext context, final ExecutableFlowElement executableFlowElement) {
+    if (context.getBpmnElementType() != BpmnElementType.PARALLEL_GATEWAY) {
+      return Either.right(null);
+    } else {
+      final var element = (ExecutableFlowNode) executableFlowElement;
+      final int numberOfIncomingSequenceFlows = element.getIncoming().size();
+      final int numberOfTakenSequenceFlows =
+          stateBehavior.getNumberOfTakenSequenceFlows(context.getFlowScopeKey(), element.getId());
+      return numberOfTakenSequenceFlows >= numberOfIncomingSequenceFlows
+          ? Either.right(null)
+          : Either.left(
+              String.format(
+                  "Expected to be able to activate parallel gateway '%s',"
+                      + " but not all sequence flows have been taken. "
+                      + "This could occur when a sequence flow is taken multiple times.",
+                  BufferUtil.bufferAsString(element.getId())));
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -199,4 +199,9 @@ public final class BpmnStateBehavior {
         && flowScopeInstance.isInterrupted()
         && flowScopeInstance.isActive();
   }
+
+  public int getNumberOfTakenSequenceFlows(
+      final long flowScopeKey, final DirectBuffer gatewayElementId) {
+    return elementInstanceState.getNumberOfTakenSequenceFlows(flowScopeKey, gatewayElementId);
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -250,26 +250,7 @@ public final class BpmnStateTransitionBehavior {
         context.copy(
             sequenceFlowKey, followUpInstanceRecord, ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN);
 
-    if (canActivateTargetElement(context, target)) {
-      activateElementInstanceInFlowScope(sequenceFlowTaken, target);
-    }
-  }
-
-  private boolean canActivateTargetElement(
-      final BpmnElementContext context, final ExecutableFlowNode targetElement) {
-
-    final int numberOfIncomingSequenceFlows = targetElement.getIncoming().size();
-
-    if (targetElement.getElementType() == BpmnElementType.PARALLEL_GATEWAY) {
-      // activate the parallel gateway only if all incoming sequence flows are taken at least once
-      final int numberOfTakenSequenceFlows =
-          elementInstanceState.getNumberOfTakenSequenceFlows(
-              context.getFlowScopeKey(), targetElement.getId());
-      return numberOfTakenSequenceFlows == numberOfIncomingSequenceFlows;
-
-    } else {
-      return true;
-    }
+    activateElementInstanceInFlowScope(sequenceFlowTaken, target);
   }
 
   public void completeElement(final BpmnElementContext context) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableProcess.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableProcess.java
@@ -33,6 +33,10 @@ public class ExecutableProcess extends ExecutableFlowElementContainer {
     return flowElements.get(id);
   }
 
+  public AbstractFlowElement getElementById(final String id) {
+    return flowElements.get(wrapString(id));
+  }
+
   /** convenience function for transformation */
   public <T extends ExecutableFlowElement> T getElementById(
       final String id, final Class<T> expectedType) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
@@ -48,6 +49,7 @@ public final class EventAppliers implements EventApplier {
 
   public EventAppliers(final MutableZeebeState state) {
     registerProcessInstanceEventAppliers(state);
+    registerProcessInstanceCreationAppliers(state);
 
     register(ProcessIntent.CREATED, new ProcessCreatedApplier(state));
     register(ErrorIntent.CREATED, new ErrorCreatedApplier(state.getBlackListState()));
@@ -134,6 +136,15 @@ public final class EventAppliers implements EventApplier {
     register(
         ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN,
         new ProcessInstanceSequenceFlowTakenApplier(elementInstanceState, processState));
+  }
+
+  private void registerProcessInstanceCreationAppliers(final MutableZeebeState state) {
+    final var processState = state.getProcessState();
+    final var elementInstanceState = state.getElementInstanceState();
+
+    register(
+        ProcessInstanceCreationIntent.CREATED,
+        new ProcessInstanceCreationCreatedApplier(processState, elementInstanceState));
   }
 
   private void registerJobIntentEventAppliers(final MutableZeebeState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceCreationCreatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceCreationCreatedApplier.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.util.List;
+import org.agrona.DirectBuffer;
+
+final class ProcessInstanceCreationCreatedApplier
+    implements TypedEventApplier<ProcessInstanceCreationIntent, ProcessInstanceCreationRecord> {
+
+  private final ProcessState processState;
+  private final MutableElementInstanceState elementInstanceState;
+
+  public ProcessInstanceCreationCreatedApplier(
+      final MutableProcessState processState,
+      final MutableElementInstanceState elementInstanceState) {
+    this.processState = processState;
+    this.elementInstanceState = elementInstanceState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceCreationRecord value) {
+    if (value.hasStartInstructions()) {
+      final var process =
+          processState.getProcessByKey(value.getProcessDefinitionKey()).getProcess();
+      final ElementInstance processInstance =
+          elementInstanceState.getInstance(value.getProcessInstanceKey());
+
+      value.getStartInstructions().stream()
+          .map(instruction -> process.getElementById(instruction.getElementId()))
+          .filter(element -> element.getElementType().equals(BpmnElementType.PARALLEL_GATEWAY))
+          .map(ExecutableFlowNode.class::cast)
+          .forEach(
+              element -> {
+                final var parentElementId = element.getFlowScope().getId();
+                final ElementInstance flowScope =
+                    findParentFlowScope(processInstance, parentElementId);
+                incrementNumberOfTakenSequenceFlows(element, flowScope);
+              });
+    }
+  }
+
+  /**
+   * Traverses the element instances to find one that matches the parent element id. If this is the
+   * process instance, it is returned immediately. This will work because we will always activate
+   * the flow scope of a start instruction once.
+   *
+   * @param processInstance the highest element instance of a process
+   * @param targetElementId the id we are looking for
+   * @return the element instance which matches the targetElementId
+   */
+  private ElementInstance findParentFlowScope(
+      final ElementInstance processInstance, final DirectBuffer targetElementId) {
+    final ElementInstance flowScope;
+    if (processInstance.getValue().getElementIdBuffer().equals(targetElementId)) {
+      flowScope = processInstance;
+    } else {
+      flowScope = findFlowScopeInChildren(processInstance, targetElementId);
+    }
+    return flowScope;
+  }
+
+  private ElementInstance findFlowScopeInChildren(
+      final ElementInstance processInstance, final DirectBuffer targetElementId) {
+    ElementInstance found = null;
+    final List<ElementInstance> children =
+        elementInstanceState.getChildren(processInstance.getKey());
+
+    for (final ElementInstance childInstance : children) {
+      if (childInstance.getValue().getElementIdBuffer().equals(targetElementId)) {
+        found = childInstance;
+        break;
+      } else {
+        found = findFlowScopeInChildren(childInstance, targetElementId);
+        if (found != null) {
+          break;
+        }
+      }
+    }
+
+    return found;
+  }
+
+  private void incrementNumberOfTakenSequenceFlows(
+      final ExecutableFlowNode element, final ElementInstance flowScope) {
+    element
+        .getIncoming()
+        .forEach(
+            incoming ->
+                elementInstanceState.incrementNumberOfTakenSequenceFlows(
+                    flowScope.getKey(), element.getId(), incoming.getId()));
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceCreationCreatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceCreationCreatedApplier.java
@@ -65,13 +65,10 @@ final class ProcessInstanceCreationCreatedApplier
    */
   private ElementInstance findParentFlowScope(
       final ElementInstance processInstance, final DirectBuffer targetElementId) {
-    final ElementInstance flowScope;
     if (processInstance.getValue().getElementIdBuffer().equals(targetElementId)) {
-      flowScope = processInstance;
-    } else {
-      flowScope = findFlowScopeInChildren(processInstance, targetElementId);
+      return processInstance;
     }
-    return flowScope;
+    return findFlowScopeInChildren(processInstance, targetElementId);
   }
 
   private ElementInstance findFlowScopeInChildren(

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceRecordStream.java
@@ -64,6 +64,12 @@ public final class ProcessInstanceRecordStream
                 && r.getKey() == r.getValue().getProcessInstanceKey());
   }
 
+  public ProcessInstanceRecordStream limit(
+      final String elementId, final ProcessInstanceIntent intent) {
+    return limit(
+        r -> r.getValue().getElementId().equals(elementId) && r.getIntent().equals(intent));
+  }
+
   public ProcessInstanceRecordStream withElementType(final BpmnElementType elementType) {
     return valueFilter(v -> v.getBpmnElementType() == elementType);
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Parallel gateways get activated by taking a sequence flow and checking if the number of taken flows is greater or equal to the number of incoming sequence flows. If this is the case an activate command is sent. The number of taken sequence flows get rest upon activation of the parallel gateway.

This proves troublesome when a "bad" model causes one of the incoming sequence flows to be taken twice. This could result in the activation command being sent twice. Imagine there is a parallel gateway with 2 incoming flows. What would happen is:

1. First flow is taken
2. Second flow is taken. Incoming flows == taken flows so an activate command is sent.
3. Second flow is taken again. The first activate command has not been processed yet. The number of taken flows has not been reset. As a result incoming flows < taken flows. A second activate command is sent.

This is solved by always sending an activate command when a sequence flow is taken. Once the `BpmnStreamProcessor` tries to process the record it will check if the state is valid. Here a check has been added to verify that when we receive an activate command for a parallel gateway we will first check if all the incoming flows have been taken. If this is not the case we will reject the command.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6778 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
