### PR TITLE
[Backports stable/1.3] Preallocate segment files

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -508,6 +508,19 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
       return this;
     }
 
+    /**
+     * Sets whether segment files are pre-allocated at creation. If true, segment files are
+     * pre-allocated to the maximum segment size (see {@link #withSegmentSize(long)}) at creation
+     * before any writes happen.
+     *
+     * @param preallocateSegmentFiles true to preallocate files, false otherwise
+     * @return this builder for chaining
+     */
+    public Builder withPreallocateSegmentFiles(final boolean preallocateSegmentFiles) {
+      config.getStorageConfig().setPreallocateSegmentFiles(preallocateSegmentFiles);
+      return this;
+    }
+
     @Override
     public RaftPartitionGroup build() {
       return new RaftPartitionGroup(config);

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
@@ -29,11 +29,14 @@ public class RaftStorageConfig {
   private static final long DEFAULT_FREE_DISK_SPACE = 1024L * 1024 * 1024;
   private static final int DEFAULT_JOURNAL_INDEX_DENSITY = 100;
 
+  private static final boolean DEFAULT_PREALLOCATE_SEGMENT_FILES = true;
+
   private String directory;
   private long segmentSize = DEFAULT_MAX_SEGMENT_SIZE;
   private boolean flushExplicitly = DEFAULT_FLUSH_EXPLICITLY;
   private long freeDiskSpace = DEFAULT_FREE_DISK_SPACE;
   private int journalIndexDensity = DEFAULT_JOURNAL_INDEX_DENSITY;
+  private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
 
   @Optional("SnapshotStoreFactory")
   private ReceivableSnapshotStoreFactory persistedSnapshotStoreFactory;
@@ -151,5 +154,22 @@ public class RaftStorageConfig {
   public RaftStorageConfig setJournalIndexDensity(final int journalIndexDensity) {
     this.journalIndexDensity = journalIndexDensity;
     return this;
+  }
+
+  /**
+   * @return true to preallocate segment files, false otherwise
+   */
+  public boolean isPreallocateSegmentFiles() {
+    return preallocateSegmentFiles;
+  }
+
+  /**
+   * Sets whether segment files are pre-allocated at creation. If true, segment files are
+   * pre-allocated to {@link #segmentSize} at creation before any writes happen.
+   *
+   * @param preallocateSegmentFiles true to preallocate files, false otherwise
+   */
+  public void setPreallocateSegmentFiles(final boolean preallocateSegmentFiles) {
+    this.preallocateSegmentFiles = preallocateSegmentFiles;
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
@@ -156,9 +156,7 @@ public class RaftStorageConfig {
     return this;
   }
 
-  /**
-   * @return true to preallocate segment files, false otherwise
-   */
+  /** @return true to preallocate segment files, false otherwise */
   public boolean isPreallocateSegmentFiles() {
     return preallocateSegmentFiles;
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -343,6 +343,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
         .withFreeDiskSpace(storageConfig.getFreeDiskSpace())
         .withSnapshotStore(persistedSnapshotStore)
         .withJournalIndexDensity(storageConfig.getJournalIndexDensity())
+        .withPreallocateSegmentFiles(storageConfig.isPreallocateSegmentFiles())
         .build();
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -57,6 +57,7 @@ public final class RaftStorage {
   private final boolean flushExplicitly;
   private final ReceivableSnapshotStore persistedSnapshotStore;
   private final int journalIndexDensity;
+  private final boolean preallocateSegmentFiles;
 
   private RaftStorage(
       final String prefix,
@@ -65,7 +66,8 @@ public final class RaftStorage {
       final long freeDiskSpace,
       final boolean flushExplicitly,
       final ReceivableSnapshotStore persistedSnapshotStore,
-      final int journalIndexDensity) {
+      final int journalIndexDensity,
+      final boolean preallocateSegmentFiles) {
     this.prefix = prefix;
     this.directory = directory;
     this.maxSegmentSize = maxSegmentSize;
@@ -73,6 +75,7 @@ public final class RaftStorage {
     this.flushExplicitly = flushExplicitly;
     this.persistedSnapshotStore = persistedSnapshotStore;
     this.journalIndexDensity = journalIndexDensity;
+    this.preallocateSegmentFiles = preallocateSegmentFiles;
 
     try {
       FileUtil.ensureDirectoryExists(directory.toPath());
@@ -172,6 +175,7 @@ public final class RaftStorage {
         .withFlushExplicitly(flushExplicitly)
         .withJournalIndexDensity(journalIndexDensity)
         .withLastWrittenIndex(lastWrittenIndex)
+        .withPreallocateSegmentFiles(preallocateSegmentFiles)
         .build();
   }
 
@@ -218,6 +222,7 @@ public final class RaftStorage {
     private static final long DEFAULT_FREE_DISK_SPACE = 1024L * 1024 * 1024;
     private static final boolean DEFAULT_FLUSH_EXPLICITLY = true;
     private static final int DEFAULT_JOURNAL_INDEX_DENSITY = 100;
+    private static final boolean DEFAULT_PREALLOCATE_SEGMENT_FILES = true;
 
     private String prefix = DEFAULT_PREFIX;
     private File directory = new File(DEFAULT_DIRECTORY);
@@ -226,6 +231,7 @@ public final class RaftStorage {
     private boolean flushExplicitly = DEFAULT_FLUSH_EXPLICITLY;
     private ReceivableSnapshotStore persistedSnapshotStore;
     private int journalIndexDensity = DEFAULT_JOURNAL_INDEX_DENSITY;
+    private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
 
     private Builder() {}
 
@@ -317,6 +323,19 @@ public final class RaftStorage {
     }
 
     /**
+     * Sets whether segment files are pre-allocated at creation. If true, segment files are
+     * pre-allocated to the maximum segment size (see {@link #withMaxSegmentSize(int)}}) at creation
+     * before any writes happen.
+     *
+     * @param preallocateSegmentFiles true to preallocate files, false otherwise
+     * @return this builder for chaining
+     */
+    public Builder withPreallocateSegmentFiles(final boolean preallocateSegmentFiles) {
+      this.preallocateSegmentFiles = preallocateSegmentFiles;
+      return this;
+    }
+
+    /**
      * Builds the {@link RaftStorage} object.
      *
      * @return The built storage configuration.
@@ -330,7 +349,8 @@ public final class RaftStorage {
           freeDiskSpace,
           flushExplicitly,
           persistedSnapshotStore,
-          journalIndexDensity);
+          journalIndexDensity,
+          preallocateSegmentFiles);
     }
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
@@ -118,6 +118,19 @@ public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
     return this;
   }
 
+  /**
+   * Sets whether segment files are pre-allocated at creation. If true, segment files are
+   * pre-allocated to the maximum segment size (see {@link #withMaxSegmentSize(int)}}) at creation
+   * before any writes happen.
+   *
+   * @param preallocateSegmentFiles true to preallocate files, false otherwise
+   * @return this builder for chaining
+   */
+  public RaftLogBuilder withPreallocateSegmentFiles(final boolean preallocateSegmentFiles) {
+    journalBuilder.withPreallocateSegmentFiles(preallocateSegmentFiles);
+    return this;
+  }
+
   @Override
   public RaftLog build() {
     final Journal journal = journalBuilder.build();

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
@@ -77,7 +77,8 @@ final class RaftPartitionGroupFactory {
             .withMaxQuorumResponseTimeout(experimentalCfg.getRaft().getMaxQuorumResponseTimeout())
             .withMinStepDownFailureCount(experimentalCfg.getRaft().getMinStepDownFailureCount())
             .withPreferSnapshotReplicationThreshold(
-                experimentalCfg.getRaft().getPreferSnapshotReplicationThreshold());
+                experimentalCfg.getRaft().getPreferSnapshotReplicationThreshold())
+            .withPreallocateSegmentFiles(experimentalCfg.getRaft().isPreallocateSegmentFiles());
 
     final int maxMessageSize = (int) networkCfg.getMaxMessageSizeInBytes();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
@@ -15,11 +15,14 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
   private static final Duration DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT = Duration.ofSeconds(0);
   private static final int DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT = 3;
   private static final int DEFAULT_PREFER_SNAPSHOT_REPLICATION_THRESHOLD = 100;
+  private static final boolean DEFAULT_PREALLOCATE_SEGMENT_FILES = true;
 
   private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
   private Duration maxQuorumResponseTimeout = DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT;
   private int minStepDownFailureCount = DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT;
   private int preferSnapshotReplicationThreshold = DEFAULT_PREFER_SNAPSHOT_REPLICATION_THRESHOLD;
+
+  private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
 
   public Duration getRequestTimeout() {
     return requestTimeout;
@@ -51,5 +54,13 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
 
   public void setPreferSnapshotReplicationThreshold(final int preferSnapshotReplicationThreshold) {
     this.preferSnapshotReplicationThreshold = preferSnapshotReplicationThreshold;
+  }
+
+  public boolean isPreallocateSegmentFiles() {
+    return preallocateSegmentFiles;
+  }
+
+  public void setPreallocateSegmentFiles(final boolean preallocateSegmentFiles) {
+    this.preallocateSegmentFiles = preallocateSegmentFiles;
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
@@ -20,8 +20,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.util.unit.DataSize;
 
-class RaftPartitionGroupFactoryTest {
-
+final class RaftPartitionGroupFactoryTest {
   private static final ReceivableSnapshotStoreFactory SNAPSHOT_STORE_FACTORY =
       (directory, partitionId) -> mock(ReceivableSnapshotStore.class);
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactoryTest.java
@@ -16,6 +16,8 @@ import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStoreFactory;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.util.unit.DataSize;
 
 class RaftPartitionGroupFactoryTest {
@@ -151,6 +153,19 @@ class RaftPartitionGroupFactoryTest {
 
     // then
     assertThat(config.getPartitionConfig().getPreferSnapshotReplicationThreshold()).isEqualTo(1000);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldSetSegmentFilesPreallocation(final boolean value) {
+    // given
+    brokerCfg.getExperimental().getRaft().setPreallocateSegmentFiles(value);
+
+    // when
+    final var config = buildRaftPartitionGroup();
+
+    // then
+    assertThat(config.getStorageConfig().isPreallocateSegmentFiles()).isEqualTo(value);
   }
 
   private RaftPartitionGroupConfig buildRaftPartitionGroup() {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfgTest.java
@@ -12,14 +12,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
-public class ExperimentalCfgTest {
+@Execution(ExecutionMode.CONCURRENT)
+final class ExperimentalCfgTest {
 
-  public final Map<String, String> environment = new HashMap<>();
+  final Map<String, String> environment = new HashMap<>();
 
   @Test
-  public void shouldSetRaftRequestTimeoutFromConfig() {
+  void shouldSetRaftRequestTimeoutFromConfig() {
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
     final var raft = cfg.getExperimental().getRaft();
@@ -29,7 +32,7 @@ public class ExperimentalCfgTest {
   }
 
   @Test
-  public void shouldSetRaftRequestTimeoutFromEnv() {
+  void shouldSetRaftRequestTimeoutFromEnv() {
     // given
     environment.put("zeebe.broker.experimental.raft.requestTimeout", "15s");
 
@@ -42,7 +45,7 @@ public class ExperimentalCfgTest {
   }
 
   @Test
-  public void shouldSetRaftMaxQuorumResponseTimeoutFromConfig() {
+  void shouldSetRaftMaxQuorumResponseTimeoutFromConfig() {
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
     final var raft = cfg.getExperimental().getRaft();
@@ -52,7 +55,7 @@ public class ExperimentalCfgTest {
   }
 
   @Test
-  public void shouldSetRaftMaxQuorumResponseTimeoutFromEnv() {
+  void shouldSetRaftMaxQuorumResponseTimeoutFromEnv() {
     // given
     environment.put("zeebe.broker.experimental.raft.maxQuorumResponseTimeout", "15s");
 
@@ -65,7 +68,7 @@ public class ExperimentalCfgTest {
   }
 
   @Test
-  public void shouldSetRaftMinStepDownFailureCountFromConfig() {
+  void shouldSetRaftMinStepDownFailureCountFromConfig() {
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
     final var raft = cfg.getExperimental().getRaft();
@@ -75,7 +78,7 @@ public class ExperimentalCfgTest {
   }
 
   @Test
-  public void shouldSetRaftMinStepDownFailureCountFromEnv() {
+  void shouldSetRaftMinStepDownFailureCountFromEnv() {
     // given
     environment.put("zeebe.broker.experimental.raft.minStepDownFailureCount", "10");
 
@@ -88,7 +91,7 @@ public class ExperimentalCfgTest {
   }
 
   @Test
-  public void shouldSetPreferSnapshotReplicationThresholdFromConfig() {
+  void shouldSetPreferSnapshotReplicationThresholdFromConfig() {
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
     final var raft = cfg.getExperimental().getRaft();
@@ -98,7 +101,7 @@ public class ExperimentalCfgTest {
   }
 
   @Test
-  public void shouldSetPreferSnapshotReplicationThresholdFromEnv() {
+  void shouldSetPreferSnapshotReplicationThresholdFromEnv() {
     // given
     environment.put("zeebe.broker.experimental.raft.preferSnapshotReplicationThreshold", "10");
 
@@ -108,5 +111,28 @@ public class ExperimentalCfgTest {
 
     // then
     assertThat(raft.getPreferSnapshotReplicationThreshold()).isEqualTo(10);
+  }
+
+  @Test
+  void shouldSetPreallocateSegmentFilesFromEnv() {
+    // given
+    environment.put("zeebe.broker.experimental.raft.preallocateSegmentFiles", "false");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
+    final var raftCfg = cfg.getExperimental().getRaft();
+
+    // then
+    assertThat(raftCfg.isPreallocateSegmentFiles()).isFalse();
+  }
+
+  @Test
+  void shouldSetPreallocateSegmentFilesFromConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
+    final var raftCfg = cfg.getExperimental().getRaft();
+
+    // then
+    assertThat(raftCfg.isPreallocateSegmentFiles()).isTrue();
   }
 }

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -603,13 +603,13 @@
       # raft:
         # Sets the timeout for all requests send by raft leaders and followers.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_REQUESTTIMEOUT
-        # requestTimeout = 5s
+        # requestTimeout: 5s
 
         # If the leader is not able to reach the quorum, the leader may step down.
         # This is triggered after a number of requests, to a quorum of followers, has failed, and the number of failures
         # reached minStepDownFailureCount. The maxQuorumResponseTime also influences when the leader step down.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_MINSTEPDOWNFAILURECOUNT
-        # minStepDownFailureCount = 3
+        # minStepDownFailureCount: 3
 
         # If the leader is not able to reach the quorum, the leader may step down.
         # This is triggered if the leader is not able to reach the quorum of the followers for maxQuorumResponseTimeout.
@@ -618,13 +618,24 @@
         # When the timeout is lower, there might be false positives, and the leader might step down too quickly.
         # When this value is 0, it will use a default value of electionTimeout * 2.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_MAXQUORUMRESPONSETIMEOUT
-        # maxQuorumResponseTimeout = 0ms
+        # maxQuorumResponseTimeout: 0ms
 
         # Threshold used by the leader to decide between replicating a snapshot or records.
         # The unit is number of records by which the follower may lag behind before the leader
         # prefers replicating snapshots instead of records.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_PREFERSNAPSHOTREPLICATIONTHRESHOLD.
-        # preferSnapshotReplicationThreshold = 100
+        # preferSnapshotReplicationThreshold: 100
+
+        # Defines whether segment files are pre-allocated to their full size on creation or not. If
+        # true, when a new segment is created on demand, disk space will be reserved for its full
+        # maximum size. This helps avoid potential out of disk space errors which can be fatal when
+        # using memory mapped files, especially when running on network storage. In the best cases,
+        # it will also allocate contiguous blocks, giving a small performance boost.
+        #
+        # You may want to turn this off if your system does not support efficient file allocation
+        # via system calls, or if you notice an I/O penalty when creating segments.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_PREALLOCATESEGMENTFILES.
+        # preallocateSegmentFiles: true
 
       # Allows to configure RocksDB properties, which is used for state management.
       # rocksdb:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -541,13 +541,13 @@
       # raft:
         # Sets the timeout for all requests send by raft leaders and followers.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_REQUESTTIMEOUT
-        # requestTimeout = 5s
+        # requestTimeout: 5s
 
         # If the leader is not able to reach the quorum, the leader may step down.
         # This is triggered after a number of requests, to a quorum of followers, has failed, and the number of failures
         # reached minStepDownFailureCount. The maxQuorumResponseTime also influences when the leader step down.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_MINSTEPDOWNFAILURECOUNT
-        # minStepDownFailureCount = 3
+        # minStepDownFailureCount: 3
 
         # If the leader is not able to reach the quorum, the leader may step down.
         # This is triggered if the leader is not able to reach the quorum of the followers for maxQuorumResponseTimeout.
@@ -556,13 +556,24 @@
         # When the timeout is lower, there might be false positives, and the leader might step down too quickly.
         # When this value is 0, it will use a default value of electionTimeout * 2.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_MAXQUORUMRESPONSETIMEOUT
-        # maxQuorumResponseTimeout = 0ms
+        # maxQuorumResponseTimeout: 0ms
 
         # Threshold used by the leader to decide between replicating a snapshot or records.
         # The unit is number of records by which the follower may lag behind before the leader
         # prefers replicating snapshots instead of records.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_PREFERSNAPSHOTREPLICATIONTHRESHOLD.
-        # preferSnapshotReplicationThreshold = 100
+        # preferSnapshotReplicationThreshold: 100
+
+        # Defines whether segment files are pre-allocated to their full size on creation or not. If
+        # true, when a new segment is created on demand, disk space will be reserved for its full
+        # maximum size. This helps avoid potential out of disk space errors which can be fatal when
+        # using memory mapped files, especially when running on network storage. In the best cases,
+        # it will also allocate contiguous blocks, giving a small performance boost.
+        #
+        # You may want to turn this off if your system does not support efficient file allocation
+        # via system calls, or if you notice an I/O penalty when creating segments.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_RAFT_PREALLOCATESEGMENTFILES.
+        # preallocateSegmentFiles: true
 
       # Allows to configure RocksDB properties, which is used for state management.
       # rocksdb:

--- a/journal/pom.xml
+++ b/journal/pom.xml
@@ -65,6 +65,12 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-posix</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalBuilder.java
@@ -29,6 +29,7 @@ public class SegmentedJournalBuilder {
   private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
   private static final long DEFAULT_MIN_FREE_DISK_SPACE = 1024L * 1024 * 1024;
   private static final int DEFAULT_JOURNAL_INDEX_DENSITY = 100;
+  private static final boolean DEFAULT_PREALLOCATE_SEGMENT_FILES = true;
 
   protected String name = DEFAULT_NAME;
   protected File directory = new File(DEFAULT_DIRECTORY);
@@ -37,6 +38,7 @@ public class SegmentedJournalBuilder {
   private long freeDiskSpace = DEFAULT_MIN_FREE_DISK_SPACE;
   private int journalIndexDensity = DEFAULT_JOURNAL_INDEX_DENSITY;
   private long lastWrittenIndex = -1L;
+  private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
 
   protected SegmentedJournalBuilder() {}
 
@@ -128,9 +130,29 @@ public class SegmentedJournalBuilder {
     return this;
   }
 
+  /**
+   * Sets whether segment files are pre-allocated at creation. If true, segment files are
+   * pre-allocated to the maximum segment size (see {@link #withMaxSegmentSize(int)}}) at creation
+   * before any writes happen.
+   *
+   * @param preallocateSegmentFiles true to preallocate files, false otherwise
+   * @return this builder for chaining
+   */
+  public SegmentedJournalBuilder withPreallocateSegmentFiles(
+      final boolean preallocateSegmentFiles) {
+    this.preallocateSegmentFiles = preallocateSegmentFiles;
+    return this;
+  }
+
   public SegmentedJournal build() {
     final JournalIndex journalIndex = new SparseJournalIndex(journalIndexDensity);
     return new SegmentedJournal(
-        name, directory, maxSegmentSize, freeDiskSpace, journalIndex, lastWrittenIndex);
+        name,
+        directory,
+        maxSegmentSize,
+        freeDiskSpace,
+        journalIndex,
+        lastWrittenIndex,
+        preallocateSegmentFiles);
   }
 }

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -24,12 +24,19 @@ import io.camunda.zeebe.journal.file.record.CorruptedLogException;
 import io.camunda.zeebe.journal.file.record.RecordData;
 import io.camunda.zeebe.journal.file.record.SBESerializer;
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import jnr.posix.FileStat;
+import jnr.posix.POSIX;
+import jnr.posix.POSIXFactory;
+import jnr.posix.util.Platform;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
@@ -373,7 +380,7 @@ class SegmentedJournalTest {
   @Test
   void shouldHandlePartiallyWrittenDescriptor() throws Exception {
     // given
-    final File dataFile = directory.resolve("data").toFile();
+    final File dataFile = getJournalDirectory();
     assertThat(dataFile.mkdirs()).isTrue();
     final File emptyLog = new File(dataFile, "journal-1.log");
     assertThat(emptyLog.createNewFile()).isTrue();
@@ -395,7 +402,7 @@ class SegmentedJournalTest {
     // given
     var journal = openJournal(1);
     journal.close();
-    final File dataFile = directory.resolve("data").toFile();
+    final File dataFile = getJournalDirectory();
     final File logFile =
         Objects.requireNonNull(dataFile.listFiles(f -> f.getName().endsWith(".log")))[0];
     LogCorrupter.corruptDescriptor(logFile);
@@ -420,7 +427,7 @@ class SegmentedJournalTest {
     journal.append(data);
 
     journal.close();
-    final File dataFile = directory.resolve("data").toFile();
+    final File dataFile = getJournalDirectory();
     final File logFile =
         Objects.requireNonNull(dataFile.listFiles(f -> f.getName().endsWith("2.log")))[0];
     LogCorrupter.corruptDescriptor(logFile);
@@ -445,7 +452,7 @@ class SegmentedJournalTest {
     final long index = journal.append(data).index();
 
     journal.close();
-    final File dataFile = directory.resolve("data").toFile();
+    final File dataFile = getJournalDirectory();
     final File logFile =
         Objects.requireNonNull(dataFile.listFiles(f -> f.getName().endsWith(".log")))[0];
     LogCorrupter.corruptDescriptor(logFile);
@@ -454,7 +461,7 @@ class SegmentedJournalTest {
     assertThatThrownBy(
             () ->
                 SegmentedJournal.builder()
-                    .withDirectory(directory.resolve("data").toFile())
+                    .withDirectory(getJournalDirectory())
                     .withMaxSegmentSize(entrySize + JournalSegmentDescriptor.getEncodingLength())
                     .withJournalIndexDensity(journalIndexDensity)
                     .withLastWrittenIndex(index)
@@ -475,7 +482,7 @@ class SegmentedJournalTest {
     journal.reset(100);
 
     // then
-    final File logDirectory = directory.resolve("data").toFile();
+    final File logDirectory = getJournalDirectory();
     assertThat(logDirectory)
         .isDirectoryContaining(
             file -> JournalSegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
@@ -550,7 +557,7 @@ class SegmentedJournalTest {
     reader.close();
 
     // then
-    final File logDirectory = directory.resolve("data").toFile();
+    final File logDirectory = getJournalDirectory();
     assertThat(logDirectory)
         .isDirectoryNotContaining(
             file -> JournalSegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
@@ -568,7 +575,7 @@ class SegmentedJournalTest {
     journal.reset(100);
 
     // then
-    final File logDirectory = directory.resolve("data").toFile();
+    final File logDirectory = getJournalDirectory();
     assertThat(logDirectory)
         .isDirectoryNotContaining(
             file -> JournalSegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
@@ -589,7 +596,7 @@ class SegmentedJournalTest {
     // scenario.
     try (final var ignored = openJournal(2)) {
       // then
-      final File logDirectory = directory.resolve("data").toFile();
+      final File logDirectory = getJournalDirectory();
       assertThat(logDirectory)
           .isDirectoryNotContaining(
               file -> JournalSegmentFile.isDeletedSegmentFile(JOURNAL_NAME, file.getName()))
@@ -611,7 +618,7 @@ class SegmentedJournalTest {
     journal.reset(200);
 
     // then
-    final File logDirectory = directory.resolve("data").toFile();
+    final File logDirectory = getJournalDirectory();
 
     // there are two files deferred for deletion
     assertThat(
@@ -650,18 +657,155 @@ class SegmentedJournalTest {
     assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
   }
 
+  @Test
+  void shouldPreallocateSegmentFiles() {
+    // given
+    final var segmentSize = 1024 * 1024L;
+    final var journal = openJournal(segmentSize, true);
+
+    // when
+    final var segment = Objects.requireNonNull(journal.getFirstSegment());
+    final var segmentFile = segment.file().file().toPath();
+
+    // then
+    final var realSize = getRealSize(segmentFile);
+    final var maxRealSize = segmentSize + getBlockSize(segmentFile);
+    assertThat(realSize)
+        .as(
+            "Expected <%s> to have a real size between <%d> and <%d> bytes, but it had <%d>",
+            segmentFile, segmentSize, maxRealSize, realSize)
+        .isBetween((long) segmentSize, maxRealSize);
+  }
+
+  @Test
+  void shouldNotPreallocateSegmentFiles() {
+    // given
+    final var segmentSize = 1024 * 1024L;
+    final var journal = openJournal(segmentSize, false);
+
+    // when
+    final var segment = Objects.requireNonNull(journal.getFirstSegment());
+    final var segmentFile = segment.file().file().toPath();
+
+    // then
+    final var realSize = getRealSize(segmentFile);
+    assertThat(realSize)
+        .as(
+            "Expected <%s> to have a real size less than <%d> bytes, but it had <%d>",
+            segmentFile, segmentSize, realSize)
+        .isLessThan(segmentSize);
+  }
+
+  @Test
+  void shouldPreallocateNewFileIfUnusedSegmentAlreadyExists() throws IOException {
+    // given - a journal with two segments, but nothing written in the second segment
+    // it's important that the max segment size is at least more than a couple blocks, as otherwise
+    // we aren't really testing anything
+    final var segmentSize = 1024 * 1024L;
+    final var journal = openJournal(segmentSize, true);
+
+    // when - the segment is "unused" if the lastWrittenIndex is less than the expected first index
+    // this can happen if we crashed in the middle of creating the new segment
+    final var secondSegment =
+        JournalSegmentFile.createSegmentFile(JOURNAL_NAME, directory.toFile(), 2).toPath();
+    Files.writeString(secondSegment, "foo");
+
+    // write until we get to the second segment
+    JournalSegment segment = Objects.requireNonNull(journal.getLastSegment());
+    while (segment.id() != 2) {
+      journal.append(data);
+      segment = Objects.requireNonNull(journal.getLastSegment());
+    }
+    final var segmentFile = segment.file().file().toPath();
+
+    // then
+    final var realSize = getRealSize(segmentFile);
+    final var maxRealSize = segmentSize + getBlockSize(segmentFile);
+    assertThat(realSize)
+        .as(
+            "Expected <%s> to have a real size between <%d> and <%d> bytes, but it had <%d>",
+            segmentFile, segmentSize, maxRealSize, realSize)
+        .isBetween((long) segmentSize, maxRealSize);
+  }
+
+  /**
+   * Returns the actual size of the file on disk by checking the blocks allocated for this file. On
+   * most modern UNIX systems, doing {@link Files#size(Path)} returns that size as reported by the
+   * file's metadata, which may not be the real size (e.g. compressed file systems, sparse files,
+   * etc.). Using the {@code lstat} function from the C library we can get the actual size on disk
+   * of the file.
+   *
+   * <p>{@code lstat} will return the number of 512-bytes blocks used by a file. To get the real
+   * size, you simply multiply by 512. Note that unless your file size is aligned with the block
+   * size of your device, then the real size may be slightly larger, as more blocks may have been
+   * allocated.
+   *
+   * <p>NOTE: on Windows, sparse files are not the default, so {@link File#length()} is appropriate.
+   * Plus, there is no {@code lstat} function, and the equivalent function {@code wstat} does not
+   * return the number of blocks.
+   *
+   * @param file the file to get the size of
+   * @return the actual size on disk of the file
+   */
+  private long getRealSize(final Path file) {
+    if (Platform.IS_WINDOWS) {
+      try {
+        return Files.size(file);
+      } catch (final IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+
+    final POSIX posixFunctions = POSIXFactory.getNativePOSIX();
+    final var pathString = file.toString();
+    final FileStat stat = posixFunctions.stat(pathString);
+
+    return stat.blocks() * 512;
+  }
+
+  /**
+   * Returns the I/O block size of the device containing the given file. This can be used to compute
+   * an upper bound for the real file size. On Windows, as we use {@link Files#size(Path)} for the
+   * real size, this simply returns 0.
+   *
+   * @param file the file to get the block size of
+   * @return the I/O block size of the device containing the file
+   */
+  private long getBlockSize(final Path file) {
+    if (Platform.IS_WINDOWS) {
+      return 0;
+    }
+
+    final POSIX posixFunctions = POSIXFactory.getNativePOSIX();
+    final var pathString = file.toString();
+    final FileStat stat = posixFunctions.stat(pathString);
+
+    return stat.blockSize();
+  }
+
   private SegmentedJournal openJournal(final float entriesPerSegment) {
     return openJournal(entriesPerSegment, entrySize);
   }
 
   private SegmentedJournal openJournal(final float entriesPerSegment, final int entrySize) {
+    final var maxSegmentSize =
+        (long) (entrySize * entriesPerSegment) + JournalSegmentDescriptor.getEncodingLength();
+    return openJournal(maxSegmentSize, true);
+  }
+
+  private SegmentedJournal openJournal(
+      final long maxSegmentSize, final boolean preallocateSegmentFiles) {
     return SegmentedJournal.builder()
-        .withDirectory(directory.resolve("data").toFile())
-        .withMaxSegmentSize(
-            (int) (entrySize * entriesPerSegment) + JournalSegmentDescriptor.getEncodingLength())
+        .withDirectory(getJournalDirectory())
+        .withMaxSegmentSize((int) maxSegmentSize)
         .withJournalIndexDensity(journalIndexDensity)
         .withName(JOURNAL_NAME)
+        .withPreallocateSegmentFiles(preallocateSegmentFiles)
         .build();
+  }
+
+  private File getJournalDirectory() {
+    return directory.resolve("data").toFile();
   }
 
   private int getSerializedSize(final DirectBuffer data) {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -110,6 +110,7 @@
     <version.immutables>2.8.9-ea-1</version.immutables>
     <version.jsr305>3.0.2</version.jsr305>
     <version.jcip>1.0</version.jcip>
+    <version.jnr-posix>3.1.15</version.jnr-posix>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.0.0</plugin.version.antrun>
@@ -783,6 +784,12 @@
         <artifactId>bcprov-jdk15on</artifactId>
         <version>${version.bouncycastle}</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.jnr</groupId>
+        <artifactId>jnr-posix</artifactId>
+        <version>${version.jnr-posix}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -127,6 +127,12 @@
       <artifactId>byte-buddy</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-posix</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/util/src/main/java/io/camunda/zeebe/util/FileUtil.java
+++ b/util/src/main/java/io/camunda/zeebe/util/FileUtil.java
@@ -23,6 +23,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Objects;
+import org.agrona.IoUtil;
 import org.agrona.SystemUtil;
 import org.slf4j.Logger;
 
@@ -81,6 +82,22 @@ public final class FileUtil {
       throws IOException {
     Files.move(source, target, options);
     flushDirectory(target.getParent());
+  }
+
+  /**
+   * Allocates a new file at the given path with the given size. This method guarantees that the
+   * file will have at least the expected size (but may have one page more).
+   *
+   * @param length the length of the file
+   */
+  public static void preallocate(final FileChannel channel, final long length) {
+    if (length < 0) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected to preallocate [%d] bytes, but the length cannot be negative", length));
+    }
+
+    IoUtil.fill(channel, 0, length, (byte) 0);
   }
 
   public static void deleteFolder(final String path) throws IOException {

--- a/util/src/test/java/io/camunda/zeebe/util/FileUtilTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/FileUtilTest.java
@@ -13,10 +13,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.channels.FileChannel;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import jnr.posix.FileStat;
+import jnr.posix.POSIX;
+import jnr.posix.POSIXFactory;
+import jnr.posix.util.Platform;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -89,5 +96,82 @@ final class FileUtilTest {
 
     // then
     assertThat(Files.list(target)).contains(target.resolve(snapshotFile));
+  }
+
+  @Test
+  void shouldPreallocateFile() throws IOException {
+    // given
+    final var path = tmpDir.resolve("file");
+    final var length = 1024 * 1024L;
+
+    // when
+    try (final FileChannel channel =
+        FileChannel.open(path, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+      FileUtil.preallocate(channel, length);
+    }
+
+    // then
+    final var realSize = getRealSize(path);
+    final var maxRealSize = length + getBlockSize(path);
+    assertThat(realSize)
+        .as(
+            "Expected <%s> to have a real size between <%d> and <%d> bytes, but it had <%d>",
+            path, length, maxRealSize, realSize)
+        .isBetween(length, maxRealSize);
+  }
+
+  /**
+   * Returns the actual size of the file on disk by checking the blocks allocated for this file. On
+   * most modern UNIX systems, doing {@link Files#size(Path)} returns that size as reported by the
+   * file's metadata, which may not be the real size (e.g. compressed file systems, sparse files,
+   * etc.). Using the {@code lstat} function from the C library we can get the actual size on disk
+   * of the file.
+   *
+   * <p>{@code lstat} will return the number of 512-bytes blocks used by a file. To get the real
+   * size, you simply multiply by 512. Note that unless your file size is aligned with the block
+   * size of your device, then the real size may be slightly larger, as more blocks may have been
+   * allocated.
+   *
+   * <p>NOTE: on Windows, sparse files are not the default, so {@link File#length()} is appropriate.
+   * Plus, there is no {@code lstat} function, and the equivalent function {@code wstat} does not
+   * return the number of blocks.
+   *
+   * @param file the file to get the size of
+   * @return the actual size on disk of the file
+   */
+  private long getRealSize(final Path file) {
+    if (Platform.IS_WINDOWS) {
+      try {
+        return Files.size(file);
+      } catch (final IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+
+    final POSIX posixFunctions = POSIXFactory.getNativePOSIX();
+    final var pathString = file.toString();
+    final FileStat stat = posixFunctions.stat(pathString);
+
+    return stat.blocks() * 512;
+  }
+
+  /**
+   * Returns the I/O block size of the device containing the given file. This can be used to compute
+   * an upper bound for the real file size. On Windows, as we use {@link Files#size(Path)} for the
+   * real size, this simply returns 0.
+   *
+   * @param file the file to get the block size of
+   * @return the I/O block size of the device containing the file
+   */
+  private long getBlockSize(final Path file) {
+    if (Platform.IS_WINDOWS) {
+      return 0;
+    }
+
+    final POSIX posixFunctions = POSIXFactory.getNativePOSIX();
+    final var pathString = file.toString();
+    final FileStat stat = posixFunctions.stat(pathString);
+
+    return stat.blockSize();
   }
 }

--- a/util/src/test/java/io/camunda/zeebe/util/FileUtilTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/FileUtilTest.java
@@ -14,47 +14,39 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public final class FileUtilTest {
-
-  @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+final class FileUtilTest {
+  private @TempDir Path tmpDir;
 
   @Test
-  public void shouldDeleteFolder() throws IOException {
-    final File root = tempFolder.getRoot();
+  void shouldDeleteFolder() throws IOException {
+    Files.createFile(tmpDir.resolve("file1"));
+    Files.createFile(tmpDir.resolve("file2"));
+    Files.createDirectory(tmpDir.resolve("testFolder"));
 
-    tempFolder.newFile("file1");
-    tempFolder.newFile("file2");
-    tempFolder.newFolder("testFolder");
+    FileUtil.deleteFolder(tmpDir);
 
-    FileUtil.deleteFolder(root.getAbsolutePath());
-
-    assertThat(root.exists()).isFalse();
+    assertThat(tmpDir).doesNotExist();
   }
 
   @Test
-  public void shouldThrowExceptionForNonExistingFolder() {
-    final File root = tempFolder.getRoot();
+  void shouldThrowExceptionForNonExistingFolder() throws IOException {
+    final Path root = Files.createDirectory(tmpDir.resolve("other"));
+    Files.delete(root);
 
-    tempFolder.delete();
-
-    assertThatThrownBy(
-            () -> {
-              FileUtil.deleteFolder(root.getAbsolutePath());
-            })
-        .isInstanceOf(NoSuchFileException.class);
+    assertThatThrownBy(() -> FileUtil.deleteFolder(root)).isInstanceOf(NoSuchFileException.class);
   }
 
   // regression test
   @Test
-  public void shouldNotThrowErrorIfFolderDoesNotExist() {
+  void shouldNotThrowErrorIfFolderDoesNotExist() {
     // given
-    final Path nonExistent = tempFolder.getRoot().toPath().resolve("something");
+    final Path nonExistent = tmpDir.resolve("something");
 
     // when - then
     assertThatCode(() -> FileUtil.deleteFolderIfExists(nonExistent))
@@ -63,10 +55,10 @@ public final class FileUtilTest {
   }
 
   @Test
-  public void shouldThrowExceptionWhenCopySnapshotForNonExistingFolder() {
+  void shouldThrowExceptionWhenCopySnapshotForNonExistingFolder() {
     // given
-    final File source = tempFolder.getRoot().toPath().resolve("src").toFile();
-    final File target = tempFolder.getRoot().toPath().resolve("target").toFile();
+    final File source = tmpDir.resolve("src").toFile();
+    final File target = tmpDir.resolve("target").toFile();
 
     // when - then
     assertThatThrownBy(() -> FileUtil.copySnapshot(source.toPath(), target.toPath()))
@@ -74,28 +66,28 @@ public final class FileUtilTest {
   }
 
   @Test
-  public void shouldThrowExceptionWhenyCopySnapshotIfTargetAlreadyExists() throws IOException {
+  void shouldThrowExceptionWhenyCopySnapshotIfTargetAlreadyExists() throws IOException {
     // given
-    final File source = tempFolder.newFolder("src");
-    final File target = tempFolder.newFolder("target");
+    final Path source = Files.createDirectory(tmpDir.resolve("src"));
+    final Path target = Files.createDirectory(tmpDir.resolve("target"));
 
     // when -then
-    assertThatThrownBy(() -> FileUtil.copySnapshot(source.toPath(), target.toPath()))
+    assertThatThrownBy(() -> FileUtil.copySnapshot(source, target))
         .isInstanceOf(FileAlreadyExistsException.class);
   }
 
   @Test
-  public void shouldCopySnapshot() throws Exception {
+  void shouldCopySnapshot() throws Exception {
     // given
-    final File source = tempFolder.newFolder("src");
-    final String snapshotFile = "file1";
-    source.toPath().resolve(snapshotFile).toFile().createNewFile();
-    final File target = tempFolder.getRoot().toPath().resolve("target").toFile();
+    final var snapshotFile = "file1";
+    final Path source = Files.createDirectory(tmpDir.resolve("src"));
+    final Path target = tmpDir.resolve("target");
+    Files.createFile(source.resolve(snapshotFile));
 
     // when
-    FileUtil.copySnapshot(source.toPath(), target.toPath());
+    FileUtil.copySnapshot(source, target);
 
     // then
-    assertThat(target.list()).containsExactly(snapshotFile);
+    assertThat(Files.list(target)).contains(target.resolve(snapshotFile));
   }
 }


### PR DESCRIPTION
## Description

Backports #9731 to 1.3.x.

## Related issues

closes #6504
closes #8099

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
