### PR TITLE
Add record and valuetype for checkpoint

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -194,6 +194,9 @@ public class ElasticsearchExporter implements Exporter {
       if (index.decisionEvaluation) {
         createValueIndexTemplate(ValueType.DECISION_EVALUATION);
       }
+      if (index.checkpoint) {
+        createValueIndexTemplate(ValueType.CHECKPOINT);
+      }
     }
 
     indexTemplatesCreated = true;

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -85,6 +85,8 @@ public class ElasticsearchExporterConfiguration {
         return index.decision;
       case DECISION_EVALUATION:
         return index.decisionEvaluation;
+      case CHECKPOINT:
+        return index.checkpoint;
       default:
         return false;
     }
@@ -132,6 +134,8 @@ public class ElasticsearchExporterConfiguration {
     public boolean processMessageSubscription = true;
     public boolean variable = true;
     public boolean variableDocument = true;
+
+    public boolean checkpoint = false;
 
     // index settings
     private Integer numberOfShards = null;
@@ -197,6 +201,8 @@ public class ElasticsearchExporterConfiguration {
           + decision
           + ", decisionEvaluation="
           + decisionEvaluation
+          + ", checkpoint="
+          + checkpoint
           + '}';
     }
   }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-checkpoint-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-checkpoint-template.json
@@ -1,0 +1,33 @@
+{
+  "index_patterns": [
+    "zeebe-record_checkpoint_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-checkpoint": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "checkpointId": {
+              "type": "long"
+            },
+            "checkpointPosition": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -65,6 +65,7 @@ final class TestSupport {
       case DECISION -> config.decision = value;
       case DECISION_REQUIREMENTS -> config.decisionRequirements = value;
       case DECISION_EVALUATION -> config.decisionEvaluation = value;
+      case CHECKPOINT -> config.checkpoint = value;
       default -> throw new IllegalArgumentException(
           "No known indexing configuration option for value type " + valueType);
     }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/management/CheckpointRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/management/CheckpointRecord.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.management;
+
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointRecordValue;
+
+public class CheckpointRecord extends UnifiedRecordValue implements CheckpointRecordValue {
+
+  private static final String CHECKPOINT_ID_KEY = "id";
+  private static final String CHECKPOINT_POSITION_KEY = "position";
+
+  private final LongProperty checkpointIdProperty = new LongProperty(CHECKPOINT_ID_KEY, -1L);
+  private final LongProperty checkpointPositionProperty =
+      new LongProperty(CHECKPOINT_POSITION_KEY, -1L);
+
+  public CheckpointRecord() {
+    declareProperty(checkpointIdProperty).declareProperty(checkpointPositionProperty);
+  }
+
+  @Override
+  public long getCheckpointId() {
+    return checkpointIdProperty.getValue();
+  }
+
+  @Override
+  public long getCheckpointPosition() {
+    return checkpointPositionProperty.getValue();
+  }
+
+  public CheckpointRecord setCheckpointPosition(final long checkpointPosition) {
+    checkpointPositionProperty.setValue(checkpointPosition);
+    return this;
+  }
+
+  public CheckpointRecord setCheckpointId(final long checkpointId) {
+    checkpointIdProperty.setValue(checkpointId);
+    return this;
+  }
+}

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
@@ -954,6 +955,20 @@ final class JsonSerializableToJsonTest {
               "evaluatedDecisions":[],
               "evaluationFailureMessage":"",
               "failedDecisionId":""
+          }
+          """
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// Checkpoint record ////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Checkpoint record",
+        (Supplier<UnifiedRecordValue>)
+            () -> new CheckpointRecord().setCheckpointId(1L).setCheckpointPosition(10L),
+        """
+          {
+              "checkpointId":1,
+              "checkpointPosition":10
           }
           """
       },

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
@@ -58,6 +59,7 @@ import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
+import io.camunda.zeebe.protocol.record.value.management.CheckpointRecordValue;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.EnumSet;
@@ -162,6 +164,8 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.VARIABLE_DOCUMENT,
         new Mapping<>(VariableDocumentRecordValue.class, VariableDocumentIntent.class));
+    mapping.put(
+        ValueType.CHECKPOINT, new Mapping<>(CheckpointRecordValue.class, CheckpointIntent.class));
 
     return mapping;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.protocol.record.intent;
 
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -42,7 +43,8 @@ public interface Intent {
           DecisionRequirementsIntent.class,
           DecisionEvaluationIntent.class,
           MessageStartEventSubscriptionIntent.class,
-          ProcessInstanceResultIntent.class);
+          ProcessInstanceResultIntent.class,
+          CheckpointIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN =
       new Intent() {
@@ -105,6 +107,8 @@ public interface Intent {
         return DecisionRequirementsIntent.from(intent);
       case DECISION_EVALUATION:
         return DecisionEvaluationIntent.from(intent);
+      case CHECKPOINT:
+        return CheckpointIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -160,6 +164,8 @@ public interface Intent {
         return DecisionRequirementsIntent.valueOf(intent);
       case DECISION_EVALUATION:
         return DecisionEvaluationIntent.valueOf(intent);
+      case CHECKPOINT:
+        return CheckpointIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/management/CheckpointIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/management/CheckpointIntent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent.management;
+
+import io.camunda.zeebe.protocol.record.intent.Intent;
+
+public enum CheckpointIntent implements Intent {
+  CREATE(0),
+  CREATED(1),
+  IGNORED(2);
+
+  private final short value;
+
+  CheckpointIntent(final int value) {
+    this.value = (short) value;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return CREATE;
+      case 1:
+        return CREATED;
+      case 2:
+        return IGNORED;
+      default:
+        return UNKNOWN;
+    }
+  }
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/management/CheckpointRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/management/CheckpointRecordValue.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value.management;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+/** Represents a checkpoint related command or event. */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableCheckpointRecordValue.Builder.class)
+public interface CheckpointRecordValue extends RecordValue {
+
+  /**
+   * @return id of the checkpoint
+   */
+  long getCheckpointId();
+
+  /**
+   * @return the position of the checkpoint
+   */
+  long getCheckpointPosition();
+}

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -42,6 +42,9 @@
       <validValue name="DECISION">25</validValue>
       <validValue name="DECISION_REQUIREMENTS">26</validValue>
       <validValue name="DECISION_EVALUATION">27</validValue>
+
+      <!-- Management records / record not related to process automation -->
+      <validValue name="CHECKPOINT">254</validValue>
     </enum>
 
     <enum name="RecordType" encodingType="uint8">

--- a/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
+++ b/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.protocol.record.intent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -70,6 +71,7 @@ final class IntentEncodingDecodingTest {
     result.addAll(buildParameterSets(TimerIntent.class, TimerIntent::from));
     result.addAll(buildParameterSets(VariableDocumentIntent.class, VariableDocumentIntent::from));
     result.addAll(buildParameterSets(VariableIntent.class, VariableIntent::from));
+    result.addAll(buildParameterSets(CheckpointIntent.class, CheckpointIntent::from));
 
     return result.stream();
   }


### PR DESCRIPTION
## Description

Checkpoints are the basis for the backups. Each backup consists of a consistent checkpoint of partitions.

We are adding the new checkpoint record together with the bpmn records. This is because:
 -  We want to export this record for observability. Adding it as a new ValueType lets us reuse the exporter api. Since we want to export it together anyway, distinguishing these different types of records in the protocol is not valuable.
 - Currently protocol is shared by engine and the platform. So we don't get much value by isolating the non-engine ValueTypes from the engine ValueTypes.

## Related issues

closes #9719 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
