### PR TITLE
Add BufferedStreamWriter

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedStreamWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedStreamWriter.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.streamprocessor;
+
+import static io.camunda.zeebe.engine.processing.streamprocessor.TypedEventRegistry.EVENT_REGISTRY;
+import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.HEADER_BLOCK_LENGTH;
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+
+import io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.HashMap;
+import java.util.Map;
+import org.agrona.ExpandableDirectByteBuffer;
+import org.agrona.MutableDirectBuffer;
+
+/** Stream writer that writes into a byte buffer instead of writing directly to the stream */
+final class BufferedStreamWriter {
+
+  private static final Map<Class, Boolean> SUITABLE_TYPES = new HashMap<>();
+  private static final int INITIAL_BUFFER_CAPACITY = 1024 * 32;
+  private final Map<Class<? extends UnpackedObject>, ValueType> typeRegistry;
+  // todo we can allocate one buffer with max message size here and then it would simplify this -
+  // and limit checking
+  private final MutableDirectBuffer eventBuffer =
+      new ExpandableDirectByteBuffer(INITIAL_BUFFER_CAPACITY);
+
+  private final RecordMetadata metadata = new RecordMetadata();
+
+  private final int maxFragmentSize;
+
+  private int eventBufferOffset;
+  private int eventLength;
+  private int eventCount;
+
+  protected BufferedStreamWriter(final int maxFragmentSize) {
+    reset();
+
+    this.maxFragmentSize = maxFragmentSize;
+    typeRegistry = new HashMap<>();
+    EVENT_REGISTRY.forEach((e, c) -> typeRegistry.put(c, e));
+  }
+
+  protected MutableDirectBuffer getEventBuffer() {
+    return eventBuffer;
+  }
+
+  protected int getEventLength() {
+    return eventLength;
+  }
+
+  protected int getEventCount() {
+    return eventCount;
+  }
+
+  protected void appendRecord(
+      final long key,
+      final int sourceIndex,
+      final RecordType type,
+      final Intent intent,
+      final RejectionType rejectionType,
+      final String rejectionReason,
+      final RecordValue value) {
+
+    // copy record to buffer
+    writeKey(key);
+    writeSourceIndex(sourceIndex);
+
+    initMetadata(type, intent, rejectionType, rejectionReason, value);
+    final var metadataLength = metadata.getLength();
+    writeMetadataLength(metadataLength);
+
+    final BufferWriter valueWriter = initValueWriter(value);
+    final var valueLength = valueWriter.getLength();
+    writeValueLength(valueLength);
+
+    writeMetadata(metadataLength);
+    writeValue(valueWriter, valueLength);
+
+    eventLength += metadataLength + valueLength;
+    eventCount += 1;
+  }
+
+  protected boolean canWriteAdditionalEvent(final int length) {
+    final var count = eventCount + 1;
+    final var batchLength = eventLength + length + (count * HEADER_BLOCK_LENGTH);
+    return batchLength < maxFragmentSize;
+  }
+
+  private void writeKey(long key) {
+    if (key < 0) {
+      key = LogEntryDescriptor.KEY_NULL_VALUE;
+    }
+    eventBuffer.putLong(eventBufferOffset, key, Protocol.ENDIANNESS);
+    eventBufferOffset += SIZE_OF_LONG;
+  }
+
+  private void writeSourceIndex(final int sourceIndex) {
+    eventBuffer.putInt(eventBufferOffset, sourceIndex, Protocol.ENDIANNESS);
+    eventBufferOffset += SIZE_OF_INT;
+  }
+
+  private void initMetadata(
+      final RecordType type,
+      final Intent intent,
+      final RejectionType rejectionType,
+      final String rejectionReason,
+      final RecordValue value) {
+    metadata.reset();
+    final ValueType valueType = typeRegistry.get(value.getClass());
+    if (valueType == null) {
+      // usually happens when the record is not registered at the TypedStreamEnvironment
+      throw new RuntimeException("Missing value type mapping for record: " + value.getClass());
+    }
+
+    metadata
+        .recordType(type)
+        .valueType(valueType)
+        .intent(intent)
+        .rejectionType(rejectionType)
+        .rejectionReason(rejectionReason);
+  }
+
+  private void writeMetadataLength(final int metadataLength) {
+    eventBuffer.putInt(eventBufferOffset, metadataLength, Protocol.ENDIANNESS);
+    eventBufferOffset += SIZE_OF_INT;
+  }
+
+  private BufferWriter initValueWriter(final RecordValue value) {
+    final var suitableType =
+        SUITABLE_TYPES.computeIfAbsent(value.getClass(), BufferWriter.class::isAssignableFrom);
+
+    // validation
+    if (!suitableType) {
+      throw new RuntimeException(String.format("The record value %s is not a BufferWriter", value));
+    }
+
+    final var valueWriter = (BufferWriter) value;
+    return valueWriter;
+  }
+
+  private void writeValueLength(final int valueLength) {
+    eventBuffer.putInt(eventBufferOffset, valueLength, Protocol.ENDIANNESS);
+    eventBufferOffset += SIZE_OF_INT;
+  }
+
+  private void writeMetadata(final int metadataLength) {
+    if (metadataLength > 0) {
+      metadata.write(eventBuffer, eventBufferOffset);
+      eventBufferOffset += metadataLength;
+    }
+  }
+
+  private void writeValue(final BufferWriter valueWriter, final int valueLength) {
+    valueWriter.write(eventBuffer, eventBufferOffset);
+    eventBufferOffset += valueLength;
+  }
+
+  protected void reset() {
+    eventBufferOffset = 0;
+    eventLength = 0;
+    eventCount = 0;
+    metadata.reset();
+  }
+}


### PR DESCRIPTION
## Description

* Adds a new class to write records into a byte buffer
* This class will replace much of `TypedStreamWriterImpl` and `LogStreamBatchWriter`

## Why a draft?
This PR is a little different from the previous PRs as part of engine abstraction, because it deviates more from the way that @Zell envisioned. His approach was to start from the code we already have and iteratively refactor from there. My approach is more: Now that we know where we want to end up, let's define the interfaces of what we want and implement the code that satisfies these interfaces.

Because of that, this PR creates a new class, which borrows heavily from `TypedStreamWriterImpl` and `LogStreamBatchWriter`. Refactoring these two classes seems not really feasible, because these classes are in use and there are dependencies to other refactoring steps. So it is difficult to keep the scope small.

Adding a new class is easy, though. With the new class we can iteratively move the code to use the new classes and once that is done, we can ditch the legacy code.

This PR is a draft, because I want to check with you, whether you are overall Ok with this approach. If yes, I would proceed in the same manner with the `TypedResponseWriter`. If not, let's discuss that. 

Second, you will note that the style of the code is different. The legacy code used a builder pattern, whereas this code is quite linear. Personally, I find it easier to read, but your mileage may vary.

Next, I want to ask you how you feel about the exceptions being thrown. In particular, whether you think this should happen on the platform side, or whether it should happen on the engine side?

Also, I wanted to know if you have any ideas how to test this. What would the test harness be for this class? Should it be a randomized test or more a test based on individual testcases?

## Related issues

related to #9780 

<!-- Cut-off marker
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
