### PR TITLE
Remove "max" value from Grafana dashboards

### DIFF
--- a/monitor/grafana/zeebe-overview.json
+++ b/monitor/grafana/zeebe-overview.json
@@ -766,7 +766,7 @@
           "format": "short",
           "label": null,
           "logBase": 1,
-          "max": "5000",
+          "max": null,
           "min": "0",
           "show": true
         },
@@ -946,7 +946,7 @@
           "format": "short",
           "label": null,
           "logBase": 1,
-          "max": "5000",
+          "max": null,
           "min": "0",
           "show": true
         },

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -527,7 +527,7 @@
               "format": "short",
               "label": null,
               "logBase": 1,
-              "max": "5000",
+              "max": null,
               "min": "0",
               "show": true
             },
@@ -632,7 +632,7 @@
               "format": "short",
               "label": null,
               "logBase": 1,
-              "max": "5000",
+              "max": null,
               "min": "0",
               "show": true
             },
@@ -2639,7 +2639,7 @@
               "format": "short",
               "label": null,
               "logBase": 1,
-              "max": "5000",
+              "max": null,
               "min": "0",
               "show": true
             },
@@ -2740,7 +2740,7 @@
               "format": "short",
               "label": null,
               "logBase": 1,
-              "max": "5000",
+              "max": null,
               "min": "0",
               "show": true
             },
@@ -2841,7 +2841,7 @@
               "format": "short",
               "label": null,
               "logBase": 1,
-              "max": "5000",
+              "max": null,
               "min": "0",
               "show": true
             },


### PR DESCRIPTION
## Description

Using a static "max" value **forces** the graph to display the Y-axis from 0 to 5000 (the max value). This has 2 consequences:

* If the values are way below 5000, then all the lines in the graph are cramped at the bottom and it's difficult to see what's happening.
* If the values are above 5000, then we can't see the actual values are the lines in the graphs are going out of the canvas.

Grafana can manage itself the maximum value of the Y-axis, it's probably better to let it do the job itself.

## Related issues


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
