### PR TITLE
Add new process instance modification record

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.protocol.record.ExecuteCommandRequestDecoder;
@@ -40,6 +41,8 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
     RECORDS_BY_TYPE.put(ValueType.INCIDENT, new IncidentRecord());
     RECORDS_BY_TYPE.put(ValueType.VARIABLE_DOCUMENT, new VariableDocumentRecord());
     RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE_CREATION, new ProcessInstanceCreationRecord());
+    RECORDS_BY_TYPE.put(
+        ValueType.PROCESS_INSTANCE_MODIFICATION, new ProcessInstanceModificationRecord());
   }
 
   private UnpackedObject event;

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -555,6 +555,7 @@
         #     process: true
         #     processInstance: true
         #     processInstanceCreation: false
+        #     processInstanceModification: false
         #     processMessageSubscription: true
         #     variable: true
         #     variableDocument: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -492,6 +492,7 @@
         #     process: true
         #     processInstance: true
         #     processInstanceCreation: false
+        #     processInstanceModification: false
         #     processMessageSubscription: true
         #     variable: true
         #     variableDocument: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -479,19 +479,22 @@
         #     event: true
         #     rejection: false
         #
-        #     deployment: false
-        #     process: true
+        #     decisionRequirements: true
+        #     decision: true
+        #     decisionEvaluation: true
+        #     deployment: true
         #     error: true
         #     incident: true
         #     job: true
         #     jobBatch: false
-        #     message: false
-        #     messageSubscription: false
-        #     variable: true
-        #     variableDocument: true
+        #     message: true
+        #     messageSubscription: true
+        #     process: true
         #     processInstance: true
         #     processInstanceCreation: false
-        #     processMessageSubscription: false
+        #     processMessageSubscription: true
+        #     variable: true
+        #     variableDocument: true
 
     # experimental
       # Be aware that all configuration's which are part of the experimental section

--- a/docs/developer_handbook.md
+++ b/docs/developer_handbook.md
@@ -20,3 +20,63 @@ This document contains instructions for developers who want to contribute to thi
 * If changes are deliberate it is necessary to regenerate this file for the build to pass
 * This is achieved by running ``cd clients/go && gocompat save ./...` and comitting the changes
 
+## How to create a new record?
+
+Generally, you'll need to do 3 things:
+1. [Expand our `protocol` with a new `RecordValue` interface (incl. a new `ValueType` value)](#expanding-our-protocol-with-a-new-recordvalue).
+2. [Implement this `RecordValue` in the `protocol-impl` module](#implement-a-new-recordvalue-in-protocol-impl).
+3. [Support this `RecordValue` in the Elasticsearch exporter](#support-a-recordvalue-in-the-elasticsearch-exporter).
+
+### Expanding our protocol with a new RecordValue
+
+The protocol consists of Java code and [SBE message definitions](../protocol/src/main/resources/). When compiled, Java code is generated that allows us to serialize our records into the SBE format and deserialize them back into Java.
+
+Please have a look at [Message Versioning](https://github.com/real-logic/simple-binary-encoding/wiki/Message-Versioning) to learn about extending SBE messages.
+
+1. Add a new `<validValue>` to the `ValueType` enum in [`protocol.xml`](../protocol/src/main/resources/protocol.xml).
+
+2. Create an enum implementing [`Intent`](../protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java) to reflect the possible commands and events:
+
+- It should also be added to the `INTENT_CLASSES` defined in Intent
+- Make sure to add the new intent as a case to `Intent.fromProtocolValue`
+
+3. Create an interface for the record value itself.
+
+- It should extend the [`RecordValue`](../protocol/src/main/java/io/camunda/zeebe/protocol/record/RecordValue.java) interface
+- Add methods for each of the properties that you want to expose
+- If you need to create additional data types, then you can create new interfaces to represent these
+- Annotate the interfaces with:
+  * `@Value.Immutable`
+  * `@ImmutableProtocol(builder = Immutable...RecordValue.Builder.class)`, replacing `...` with the name of the interface
+
+    > Note, that the Immutable class is only available after building (i.e. it is generated from these annotations), so you may see a compile error when you add this annotation. To resolve the compile error, just build the protocol.
+
+4. Build the protocol: `mvn clean install -pl :zeebe-protocol` to generate the Immutable classes and to generate the new `ValueType` enum value.
+
+5. Add a mapping to [`ValueTypeMapping`](../protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java) connecting the `ValueType`, `RecordValue` and `Intent` together.
+
+### Implement a new RecordValue in protocol-impl
+
+1. Implement your new `RecordValue` interface in [protocol-impl](../protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/).
+
+- Make sure to add annotations for properties (or getter methods) that shouldn't be serialized to JSON.
+
+2. Add new cases to [JsonSerializableToJsonTest](../protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java):
+
+- one case that provides a value for each property (as far nested as possible)
+- one case that has as few properties as possible (i.e. an empty record)
+
+3. Add the new `Record` to the broker's [CommandApiRequestReader](../broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java)'s `RECORDS_BY_TYPE` mapping.
+
+### Support a RecordValue in the Elasticsearch exporter
+
+You'll always need to add support for new records in the ES exporter. Even if you don't yet want to export a new record, our tests will fail if you don't provide this support. Note that in step 3 below, you can choose whether or not the record is exported to ES by default.
+
+1. Add a record template to the elastic search exporter's [resources](../exporters/elasticsearch-exporter/src/main/resources/).
+
+- Tip: start by copying an existing template and change the relevant properties.
+
+2. Add a call to `createValueIndexTemplate` for the `ValueType` in [ElasticsearchExporter](../exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java).
+3. Allow the record to be filtered through the [configuration](../exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java).
+4. Add a mapping for the ValueType to the [TestSupport](../exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java).
+

--- a/docs/developer_handbook.md
+++ b/docs/developer_handbook.md
@@ -78,5 +78,7 @@ You'll always need to add support for new records in the ES exporter. Even if yo
 
 2. Add a call to `createValueIndexTemplate` for the `ValueType` in [ElasticsearchExporter](../exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java).
 3. Allow the record to be filtered through the [configuration](../exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java).
-4. Add a mapping for the ValueType to the [TestSupport](../exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java).
+4. Document this new filter option in the dist folder's [broker config templates](../dist/src/main/config/).
+5. Document this new filter option in the elasticsearch exporter's [README](../exporters/elasticsearch-exporter/README.md).
+6. Add a mapping for the ValueType to the [TestSupport](../exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java).
 

--- a/exporters/elasticsearch-exporter/README.md
+++ b/exporters/elasticsearch-exporter/README.md
@@ -97,6 +97,7 @@ exporters:
         process: false
         processInstance: false
         processInstanceCreation: false
+        processInstanceModification: false
         processMessageSubscription: false
         variable: false
         variableDocument: false
@@ -135,6 +136,8 @@ More specifically, each option configures the following:
 * `processInstance` (`boolean`): if true, records related to process instances will be exported; if
   false, ignored.
 * `processInstanceCreation` (`boolean`): if true, records related to process instance creations will
+  be exported; if false, ignored.
+* `processInstanceModification` (`boolean`): if true, records related to process instance modifications will
   be exported; if false, ignored.
 * `processMessageSubscription` (`boolean`): if true, records related to process message
   subscriptions will be exported; if false, ignored.
@@ -192,6 +195,7 @@ exporters:
         process: true
         processInstance: true
         processInstanceCreation: false
+        processInstanceModification: false
         processMessageSubscription: true
         variable: true
         variableDocument: true

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -182,6 +182,9 @@ public class ElasticsearchExporter implements Exporter {
       if (index.processInstanceCreation) {
         createValueIndexTemplate(ValueType.PROCESS_INSTANCE_CREATION);
       }
+      if (index.processInstanceModification) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MODIFICATION);
+      }
       if (index.processMessageSubscription) {
         createValueIndexTemplate(ValueType.PROCESS_MESSAGE_SUBSCRIPTION);
       }

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -77,6 +77,8 @@ public class ElasticsearchExporterConfiguration {
         return index.processInstance;
       case PROCESS_INSTANCE_CREATION:
         return index.processInstanceCreation;
+      case PROCESS_INSTANCE_MODIFICATION:
+        return index.processInstanceModification;
       case PROCESS_MESSAGE_SUBSCRIPTION:
         return index.processMessageSubscription;
       case DECISION_REQUIREMENTS:
@@ -131,6 +133,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean process = true;
     public boolean processInstance = true;
     public boolean processInstanceCreation = false;
+    public boolean processInstanceModification = false;
     public boolean processMessageSubscription = true;
     public boolean variable = true;
     public boolean variableDocument = true;
@@ -193,6 +196,8 @@ public class ElasticsearchExporterConfiguration {
           + processInstance
           + ", processInstanceCreation="
           + processInstanceCreation
+          + ", processInstanceModification="
+          + processInstanceModification
           + ", processMessageSubscription="
           + processMessageSubscription
           + ", decisionRequirements="

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
@@ -1,0 +1,57 @@
+{
+  "index_patterns": [
+    "zeebe-record_process-instance-modification_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-process-instance-modification": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "processInstanceKey": {
+              "type": "long"
+            },
+            "terminateInstructions": {
+              "properties": {
+                "elementInstanceKey": {
+                  "type": "long"
+                }
+              }
+            },
+            "activateInstructions": {
+              "properties": {
+                "elementId": {
+                  "type": "keyword"
+                },
+                "ancestorScopeKey": {
+                  "type": "long"
+                },
+                "variableInstructions": {
+                  "properties": {
+                    "variables": {
+                      "enabled": false
+                    },
+                    "elementId": {
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -60,6 +60,7 @@ final class TestSupport {
       case VARIABLE -> config.variable = value;
       case VARIABLE_DOCUMENT -> config.variableDocument = value;
       case PROCESS_INSTANCE_CREATION -> config.processInstanceCreation = value;
+      case PROCESS_INSTANCE_MODIFICATION -> config.processInstanceModification = value;
       case ERROR -> config.error = value;
       case PROCESS -> config.process = value;
       case DECISION -> config.decision = value;

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -157,11 +157,19 @@ public class ObjectValue extends BaseValue {
     }
   }
 
+  /**
+   * Hashcode of an ObjectValue object is generated based on the properties (declared, undeclared,
+   * recycled).
+   */
   @Override
   public int hashCode() {
     return Objects.hash(declaredProperties, undeclaredProperties, recycledProperties);
   }
 
+  /**
+   * Equality of ObjectValue objects is based on equality of properties (declared, undeclared,
+   * recycled).
+   */
   @Override
   public boolean equals(final Object o) {
     if (this == o) {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationActivateInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationActivateInstruction.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.processinstance;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationActivateInstructionValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationVariableInstructionValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import org.agrona.DirectBuffer;
+
+@JsonIgnoreProperties({
+  /* 'encodedLength' is a technical field needed for MsgPack and inherited from ObjectValue; it has
+  no purpose in exported JSON records*/
+  "encodedLength"
+})
+public final class ProcessInstanceModificationActivateInstruction extends ObjectValue
+    implements ProcessInstanceModificationActivateInstructionValue {
+
+  private final StringProperty elementIdProperty = new StringProperty("elementId");
+  private final LongProperty ancestorScopeKeyProperty = new LongProperty("ancestorScopeKey", -1);
+  private final ArrayProperty<ProcessInstanceModificationVariableInstruction>
+      variableInstructionsProperty =
+          new ArrayProperty<>(
+              "variableInstructions", new ProcessInstanceModificationVariableInstruction());
+
+  public ProcessInstanceModificationActivateInstruction() {
+    declareProperty(elementIdProperty)
+        .declareProperty(ancestorScopeKeyProperty)
+        .declareProperty(variableInstructionsProperty);
+  }
+
+  @Override
+  public String getElementId() {
+    return BufferUtil.bufferAsString(getElementIdBuffer());
+  }
+
+  @Override
+  public long getAncestorScopeKey() {
+    return ancestorScopeKeyProperty.getValue();
+  }
+
+  /**
+   * This method is expensive because it copies each element before returning it. It is recommended
+   * to use {@link #hasVariableInstructions()} before calling this.
+   *
+   * <p>{@inheritDoc}
+   */
+  @Override
+  public List<ProcessInstanceModificationVariableInstructionValue> getVariableInstructions() {
+    return variableInstructionsProperty.stream()
+        .map(
+            instruction -> {
+              final var copy = new ProcessInstanceModificationVariableInstruction();
+              copy.copy(instruction);
+              return (ProcessInstanceModificationVariableInstructionValue) copy;
+            })
+        .toList();
+  }
+
+  public ProcessInstanceModificationActivateInstruction setAncestorScopeKey(
+      final long ancestorScopeKey) {
+    ancestorScopeKeyProperty.setValue(ancestorScopeKey);
+    return this;
+  }
+
+  public ProcessInstanceModificationActivateInstruction setElementId(final String elementId) {
+    elementIdProperty.setValue(elementId);
+    return this;
+  }
+
+  /** Returns true if this record has variable instructions, otherwise false. */
+  @JsonIgnore
+  public boolean hasVariableInstructions() {
+    return !variableInstructionsProperty.isEmpty();
+  }
+
+  public ProcessInstanceModificationActivateInstruction addVariableInstruction(
+      final ProcessInstanceModificationVariableInstruction variableInstruction) {
+    variableInstructionsProperty.add().copy(variableInstruction);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getElementIdBuffer() {
+    return elementIdProperty.getValue();
+  }
+
+  public void copy(final ProcessInstanceModificationActivateInstruction object) {
+    setElementId(object.getElementId());
+    setAncestorScopeKey(object.getAncestorScopeKey());
+    object.getVariableInstructions().stream()
+        .map(ProcessInstanceModificationVariableInstruction.class::cast)
+        .forEach(this::addVariableInstruction);
+  }
+
+  /** hashCode relies on implementation provided by {@link ObjectValue#hashCode()} */
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  /** equals relies on implementation provided by {@link ObjectValue#equals(Object)} */
+  @Override
+  public boolean equals(final Object o) {
+    return super.equals(o);
+  }
+}

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.processinstance;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
+import java.util.List;
+
+public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
+    implements ProcessInstanceModificationRecordValue {
+
+  private final LongProperty processInstanceKeyProperty = new LongProperty("processInstanceKey");
+  private final ArrayProperty<ProcessInstanceModificationTerminateInstruction>
+      terminateInstructionsProperty =
+          new ArrayProperty<>(
+              "terminateInstructions", new ProcessInstanceModificationTerminateInstruction());
+  private final ArrayProperty<ProcessInstanceModificationActivateInstruction>
+      activateInstructionsProperty =
+          new ArrayProperty<>(
+              "activateInstructions", new ProcessInstanceModificationActivateInstruction());
+
+  public ProcessInstanceModificationRecord() {
+    declareProperty(processInstanceKeyProperty)
+        .declareProperty(terminateInstructionsProperty)
+        .declareProperty(activateInstructionsProperty);
+  }
+
+  /**
+   * This method is expensive because it copies each element before returning it. It is recommended
+   * to use {@link #hasTerminateInstructions()} before calling this.
+   *
+   * <p>{@inheritDoc}
+   */
+  @Override
+  public List<ProcessInstanceModificationTerminateInstructionValue> getTerminateInstructions() {
+    // we need to make a copy of each element in the ArrayProperty while iterating it because the
+    // inner values are updated during the iteration
+    return terminateInstructionsProperty.stream()
+        .map(
+            element -> {
+              final var elementCopy = new ProcessInstanceModificationTerminateInstruction();
+              elementCopy.copy(element);
+              return (ProcessInstanceModificationTerminateInstructionValue) elementCopy;
+            })
+        .toList();
+  }
+
+  /**
+   * This method is expensive because it copies each element before returning it. It is recommended
+   * to use {@link #hasActivateInstructions()} before calling this.
+   *
+   * <p>{@inheritDoc}
+   */
+  @Override
+  public List<ProcessInstanceModificationActivateInstructionValue> getActivateInstructions() {
+    // we need to make a copy of each element in the ArrayProperty while iterating it because the
+    // inner values are updated during the iteration
+    return activateInstructionsProperty.stream()
+        .map(
+            element -> {
+              final var elementCopy = new ProcessInstanceModificationActivateInstruction();
+              elementCopy.copy(element);
+              return (ProcessInstanceModificationActivateInstructionValue) elementCopy;
+            })
+        .toList();
+  }
+
+  /** Returns true if this record has terminate instructions, otherwise false. */
+  @JsonIgnore
+  public boolean hasTerminateInstructions() {
+    return !terminateInstructionsProperty.isEmpty();
+  }
+
+  public ProcessInstanceModificationRecord addTerminateInstruction(
+      final ProcessInstanceModificationTerminateInstructionValue terminateInstruction) {
+    terminateInstructionsProperty.add().copy(terminateInstruction);
+    return this;
+  }
+
+  /** Returns true if this record has activate instructions, otherwise false. */
+  @JsonIgnore
+  public boolean hasActivateInstructions() {
+    return !activateInstructionsProperty.isEmpty();
+  }
+
+  public ProcessInstanceModificationRecord addActivateInstruction(
+      final ProcessInstanceModificationActivateInstruction activateInstruction) {
+    activateInstructionsProperty.add().copy(activateInstruction);
+    return this;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceModificationRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProperty.setValue(processInstanceKey);
+    return this;
+  }
+
+  /** hashCode relies on implementation provided by {@link ObjectValue#hashCode()} */
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  /** equals relies on implementation provided by {@link ObjectValue#equals(Object)} */
+  @Override
+  public boolean equals(final Object o) {
+    return super.equals(o);
+  }
+}

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationTerminateInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationTerminateInstruction.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.processinstance;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationTerminateInstructionValue;
+
+@JsonIgnoreProperties({
+  /* 'encodedLength' is a technical field needed for MsgPack and inherited from ObjectValue; it has
+  no purpose in exported JSON records*/
+  "encodedLength"
+})
+public final class ProcessInstanceModificationTerminateInstruction extends ObjectValue
+    implements ProcessInstanceModificationTerminateInstructionValue {
+
+  private final LongProperty elementInstanceKeyProperty = new LongProperty("elementInstanceKey");
+
+  @Override
+  public long getElementInstanceKey() {
+    return elementInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceModificationTerminateInstruction setElementInstanceKey(
+      final long elementInstanceKey) {
+    elementInstanceKeyProperty.setValue(elementInstanceKey);
+    return this;
+  }
+
+  public void copy(final ProcessInstanceModificationTerminateInstructionValue object) {
+    setElementInstanceKey(object.getElementInstanceKey());
+  }
+
+  /** hashCode relies on implementation provided by {@link ObjectValue#hashCode()} */
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  /** equals relies on implementation provided by {@link ObjectValue#equals(Object)} */
+  @Override
+  public boolean equals(final Object o) {
+    return super.equals(o);
+  }
+}

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationVariableInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationVariableInstruction.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.processinstance;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationVariableInstructionValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+
+@JsonIgnoreProperties({
+  /* 'encodedLength' is a technical field needed for MsgPack and inherited from ObjectValue; it has
+  no purpose in exported JSON records*/
+  "encodedLength"
+})
+public final class ProcessInstanceModificationVariableInstruction extends ObjectValue
+    implements ProcessInstanceModificationVariableInstructionValue {
+
+  private final DocumentProperty variablesProp = new DocumentProperty("variables");
+  private final StringProperty elementIdProp = new StringProperty("elementId", "");
+
+  public ProcessInstanceModificationVariableInstruction() {
+    declareProperty(variablesProp).declareProperty(elementIdProp);
+  }
+
+  @Override
+  public Map<String, Object> getVariables() {
+    return MsgPackConverter.convertToMap(getVariablesBuffer());
+  }
+
+  @Override
+  public String getElementId() {
+    return BufferUtil.bufferAsString(getElementIdBuffer());
+  }
+
+  public ProcessInstanceModificationVariableInstruction setElementId(final String elementId) {
+    elementIdProp.setValue(elementId);
+    return this;
+  }
+
+  public ProcessInstanceModificationVariableInstruction setVariables(final DirectBuffer variables) {
+    variablesProp.setValue(variables);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getElementIdBuffer() {
+    return elementIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getVariablesBuffer() {
+    return variablesProp.getValue();
+  }
+
+  public void copy(final ProcessInstanceModificationVariableInstruction object) {
+    setVariables(object.getVariablesBuffer());
+    setElementId(object.getElementId());
+  }
+
+  /** hashCode relies on implementation provided by {@link ObjectValue#hashCode()} */
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  /** equals relies on implementation provided by {@link ObjectValue#equals(Object)} */
+  @Override
+  public boolean equals(final Object o) {
+    return super.equals(o);
+  }
+}

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -34,6 +34,10 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRe
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationActivateInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationTerminateInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationVariableInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
@@ -739,6 +743,69 @@ final class JsonSerializableToJsonTest {
         "Empty ProcessInstanceCreationRecord",
         (Supplier<UnifiedRecordValue>) ProcessInstanceCreationRecord::new,
         "{'variables':{},'bpmnProcessId':'','processDefinitionKey':-1,'version':-1,'processInstanceKey':-1, 'startInstructions':[]}"
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// ProcessInstanceModificationRecord /////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "ProcessInstanceModificationRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final long key = 1L;
+              final var elementInstanceKeyToTerminate = 2L;
+              final var elementIdToActivate = "activity";
+              final var ancestorScopeKey = 3L;
+              final var variableInstructionElementId = "sub-process";
+
+              return new ProcessInstanceModificationRecord()
+                  .setProcessInstanceKey(key)
+                  .addTerminateInstruction(
+                      new ProcessInstanceModificationTerminateInstruction()
+                          .setElementInstanceKey(elementInstanceKeyToTerminate))
+                  .addActivateInstruction(
+                      new ProcessInstanceModificationActivateInstruction()
+                          .setElementId(elementIdToActivate)
+                          .setAncestorScopeKey(ancestorScopeKey)
+                          .addVariableInstruction(
+                              new ProcessInstanceModificationVariableInstruction()
+                                  .setVariables(VARIABLES_MSGPACK)
+                                  .setElementId(variableInstructionElementId)));
+            },
+        """
+        {
+          "processInstanceKey": 1,
+          "terminateInstructions": [{
+            "elementInstanceKey": 2
+          }],
+          "activateInstructions": [{
+            "ancestorScopeKey": 3,
+            "variableInstructions": [{
+              "elementId": "sub-process",
+              "variables": {
+                "foo": "bar"
+              }
+            }],
+            "elementId": "activity"
+          }]
+        }
+        """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// Empty ProcessInstanceModificationRecord ///////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty ProcessInstanceModificationRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> new ProcessInstanceModificationRecord().setProcessInstanceKey(1L),
+        """
+        {
+          "processInstanceKey": 1,
+          "terminateInstructions": [],
+          "activateInstructions": []
+        }
+        """
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
@@ -50,6 +51,7 @@ import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecor
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessEventRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
@@ -152,6 +154,10 @@ public final class ValueTypeMapping {
         ValueType.PROCESS_INSTANCE_CREATION,
         new Mapping<>(
             ProcessInstanceCreationRecordValue.class, ProcessInstanceCreationIntent.class));
+    mapping.put(
+        ValueType.PROCESS_INSTANCE_MODIFICATION,
+        new Mapping<>(
+            ProcessInstanceModificationRecordValue.class, ProcessInstanceModificationIntent.class));
     mapping.put(
         ValueType.PROCESS_INSTANCE_RESULT,
         new Mapping<>(ProcessInstanceResultRecordValue.class, ProcessInstanceResultIntent.class));

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -64,6 +64,7 @@ public interface Intent {
 
   String name();
 
+  @SuppressWarnings("checkstyle:MissingSwitchDefault")
   static Intent fromProtocolValue(final ValueType valueType, final short intent) {
     switch (valueType) {
       case DEPLOYMENT:
@@ -115,12 +116,12 @@ public interface Intent {
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
-      default:
-        throw new RuntimeException(
-            String.format(
-                "Expected to map value type %s to intent type, but did not recognize the value type",
-                valueType.name()));
     }
+
+    throw new RuntimeException(
+        String.format(
+            "Expected to map value type %s to intent type, but did not recognize the value type",
+            valueType.name()));
   }
 
   static Intent fromProtocolValue(final ValueType valueType, final String intent) {

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -44,7 +44,8 @@ public interface Intent {
           DecisionEvaluationIntent.class,
           MessageStartEventSubscriptionIntent.class,
           ProcessInstanceResultIntent.class,
-          CheckpointIntent.class);
+          CheckpointIntent.class,
+          ProcessInstanceModificationIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN =
       new Intent() {
@@ -109,6 +110,8 @@ public interface Intent {
         return DecisionEvaluationIntent.from(intent);
       case CHECKPOINT:
         return CheckpointIntent.from(intent);
+      case PROCESS_INSTANCE_MODIFICATION:
+        return ProcessInstanceModificationIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceModificationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceModificationIntent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum ProcessInstanceModificationIntent implements Intent, ProcessInstanceRelatedIntent {
+  MODIFY((short) 0),
+  MODIFIED((short) 1);
+
+  private final short value;
+
+  ProcessInstanceModificationIntent(final short value) {
+    this.value = value;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean shouldBlacklistInstanceOnError() {
+    return true;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return MODIFY;
+      case 1:
+        return MODIFIED;
+      default:
+        return UNKNOWN;
+    }
+  }
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceModificationRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceModificationRecordValue.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import java.util.List;
+import java.util.Map;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableProcessInstanceModificationRecordValue.Builder.class)
+public interface ProcessInstanceModificationRecordValue
+    extends RecordValue, ProcessInstanceRelated {
+
+  /** Returns a list of terminate instructions (if available), or an empty list. */
+  List<ProcessInstanceModificationTerminateInstructionValue> getTerminateInstructions();
+
+  /** Returns a list of activate instructions (if available), or an empty list. */
+  List<ProcessInstanceModificationActivateInstructionValue> getActivateInstructions();
+
+  @Value.Immutable
+  @ImmutableProtocol(
+      builder = ImmutableProcessInstanceModificationTerminateInstructionValue.Builder.class)
+  interface ProcessInstanceModificationTerminateInstructionValue {
+
+    /** Returns the key of element instance to terminate. */
+    long getElementInstanceKey();
+  }
+
+  @Value.Immutable
+  @ImmutableProtocol(
+      builder = ImmutableProcessInstanceModificationActivateInstructionValue.Builder.class)
+  interface ProcessInstanceModificationActivateInstructionValue {
+
+    /** Returns the id of the element to create a new element instance at. */
+    String getElementId();
+
+    /**
+     * Returns the key of the ancestor scope to create the new element instance in, or -1 if no
+     * specific ancestor is selected.
+     *
+     * <p>This key is used for ancestor selection:
+     *
+     * <p>By default, the new element instance is created within an existing element instance of the
+     * flow scope. For example, when activating an element inside an embedded subprocess and the
+     * subprocess is already active.
+     *
+     * <p>If there is more than one element instance of the flow scope active then the engine can't
+     * decide which element instance to create the new element instance in. Instead, the element
+     * instance must be selected by its element instance key. The new element instance is created
+     * within the selected element instance.
+     *
+     * <p>If the selected element instance is not of the flow scope but from a higher scope (e.g.
+     * the process instance key instead of the element instance key of the subprocess) then the
+     * engine creates a new element instance of the flow scope first and then creates the new
+     * element instance within this scope.
+     */
+    long getAncestorScopeKey();
+
+    /** Returns a list of variable instructions (if available), or an empty list. */
+    List<ProcessInstanceModificationVariableInstructionValue> getVariableInstructions();
+  }
+
+  @Value.Immutable
+  @ImmutableProtocol(
+      builder = ImmutableProcessInstanceModificationVariableInstructionValue.Builder.class)
+  interface ProcessInstanceModificationVariableInstructionValue {
+
+    /** Returns the variables of this instruction. Can be empty. */
+    Map<String, Object> getVariables();
+
+    /**
+     * Returns the element id of the scope where the variables should be created in, or an empty
+     * string if the variables are global for the process instance.
+     */
+    String getElementId();
+  }
+}

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -42,6 +42,7 @@
       <validValue name="DECISION">25</validValue>
       <validValue name="DECISION_REQUIREMENTS">26</validValue>
       <validValue name="DECISION_EVALUATION">27</validValue>
+      <validValue name="PROCESS_INSTANCE_MODIFICATION">28</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="CHECKPOINT">254</validValue>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Introduces a new record with:
- value type `PROCESS_INSTANCE_MODIFICATION` 
- intents: `MODIFY`, `MODIFIED`
- a value that supports expressing activate instructions, and terminate instructions

Due to failing tests, we're nowadays forced to immediately implement support for exporting new records to Elasticsearch. So this PR also adds this.

Finally, this PR documents the process of creating a new record.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9638 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
