### PR TITLE
Define state for storing checkpoint info

### DIFF
--- a/backup/pom.xml
+++ b/backup/pom.xml
@@ -25,6 +25,35 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-scheduler</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-workflow-engine</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-impl</artifactId>
+      <version>8.1.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+      <version>8.1.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-msgpack-value</artifactId>
+      <version>8.1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-db</artifactId>
+      <version>8.1.0-SNAPSHOT</version>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/backup/pom.xml
+++ b/backup/pom.xml
@@ -33,25 +33,24 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-protocol-impl</artifactId>
-      <version>8.1.0-SNAPSHOT</version>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-protocol</artifactId>
-      <version>8.1.0-SNAPSHOT</version>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>zeebe-msgpack-value</artifactId>
-      <version>8.1.0-SNAPSHOT</version>
     </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-db</artifactId>
-      <version>8.1.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointInfo.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointInfo.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.processing.state;
+
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+
+/** Checkpoint info stored in db in msgpack format. */
+public class CheckpointInfo extends UnpackedObject implements DbValue {
+  private final LongProperty idProperty = new LongProperty("id");
+  private final LongProperty positionProperty = new LongProperty("position");
+
+  public CheckpointInfo() {
+    declareProperty(idProperty).declareProperty(positionProperty);
+  }
+
+  public long getId() {
+    return idProperty.getValue();
+  }
+
+  public CheckpointInfo setId(final long id) {
+    idProperty.setValue(id);
+    return this;
+  }
+
+  public long getPosition() {
+    return positionProperty.getValue();
+  }
+
+  public CheckpointInfo setPosition(final long position) {
+    positionProperty.setValue(position);
+    return this;
+  }
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.processing.state;
+
+public interface CheckpointState {
+
+  long NO_CHECKPOINT = 0L;
+
+  /**
+   * Returns the id of the last created checkpoint
+   *
+   * @return checkpointId
+   */
+  long getCheckpointId();
+
+  /**
+   * Returns the position of the last created checkpoint
+   *
+   * @return checkpointPosition
+   */
+  long getCheckpointPosition();
+
+  /**
+   * Set checkpointId and checkpointPosition
+   *
+   * @param checkpointId id of the checkpoint
+   * @param checkpointPosition position of the checkpoint
+   */
+  void setCheckpointInfo(final long checkpointId, final long checkpointPosition);
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointState.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.backup.processing.state;
 
 public interface CheckpointState {
 
-  long NO_CHECKPOINT = 0L;
+  long NO_CHECKPOINT = -1L;
 
   /**
    * Returns the id of the last created checkpoint

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.processing.state;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.engine.state.ZbColumnFamilies;
+
+public class DbCheckpointState implements CheckpointState {
+  private static final String CHECKPOINT_KEY = "checkpoint";
+
+  private final CheckpointInfo checkpointInfo = new CheckpointInfo();
+  private final ColumnFamily<DbString, CheckpointInfo> checkpointColumnFamily;
+  private final DbString checkpointInfoKey;
+
+  public DbCheckpointState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    checkpointInfoKey = new DbString();
+    checkpointInfoKey.wrapString(CHECKPOINT_KEY);
+    checkpointColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.DEFAULT, transactionContext, checkpointInfoKey, checkpointInfo);
+  }
+
+  @Override
+  public long getCheckpointId() {
+    final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
+    return info != null ? info.getId() : NO_CHECKPOINT;
+  }
+
+  @Override
+  public long getCheckpointPosition() {
+    final CheckpointInfo info = checkpointColumnFamily.get(checkpointInfoKey);
+    return info != null ? info.getPosition() : NO_CHECKPOINT;
+  }
+
+  @Override
+  public void setCheckpointInfo(final long checkpointId, final long checkpointPosition) {
+    checkpointInfo.setId(checkpointId).setPosition(checkpointPosition);
+    checkpointColumnFamily.upsert(checkpointInfoKey, checkpointInfo);
+  }
+}

--- a/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointStateTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointStateTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.processing.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.db.ConsistencyChecksSettings;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+final class DbCheckpointStateTest {
+
+  @TempDir Path database;
+  private DbCheckpointState state;
+  private ZeebeDb zeebedb;
+
+  @AfterEach
+  void closeDb() throws Exception {
+    zeebedb.close();
+  }
+
+  @BeforeEach
+  void before() {
+    zeebedb =
+        new ZeebeRocksDbFactory<>(
+                new RocksDbConfiguration(), new ConsistencyChecksSettings(true, true))
+            .createDb(database.toFile());
+    state = new DbCheckpointState(zeebedb, zeebedb.createContext());
+  }
+
+  @Test
+  void shouldInitializeToZero() {
+    // given
+
+    // when-then
+    assertThat(state.getCheckpointId()).isZero();
+    assertThat(state.getCheckpointPosition()).isZero();
+  }
+
+  @Test
+  void shouldSetAndGetCheckpointIdAndPosition() {
+    // when
+    state.setCheckpointInfo(5L, 10L);
+
+    // then
+    assertThat(state.getCheckpointId()).isEqualTo(5L);
+    assertThat(state.getCheckpointPosition()).isEqualTo(10L);
+  }
+
+  @Test
+  void shouldOverwriteCheckpointIdAndPosition() {
+    // given
+    state.setCheckpointInfo(5L, 10L);
+
+    // when
+    state.setCheckpointInfo(15L, 20L);
+
+    // then
+    assertThat(state.getCheckpointId()).isEqualTo(15L);
+    assertThat(state.getCheckpointPosition()).isEqualTo(20L);
+  }
+}

--- a/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointStateTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointStateTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.processing.state;
 
+import static io.camunda.zeebe.backup.processing.state.CheckpointState.NO_CHECKPOINT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.db.ConsistencyChecksSettings;
@@ -40,12 +41,12 @@ final class DbCheckpointStateTest {
   }
 
   @Test
-  void shouldInitializeToZero() {
+  void shouldInitializeWhenNoCheckpoint() {
     // given
 
     // when-then
-    assertThat(state.getCheckpointId()).isZero();
-    assertThat(state.getCheckpointPosition()).isZero();
+    assertThat(state.getCheckpointId()).isEqualTo(NO_CHECKPOINT);
+    assertThat(state.getCheckpointPosition()).isEqualTo(NO_CHECKPOINT);
   }
 
   @Test


### PR DESCRIPTION
## Description

When processing checkpoint records, the processor have to store the latest checkpoint info in the state. This PR adds the necessary classes for accessing checkpoint info in ZeebeDb.

## Related issue

realted #9720 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
