### PR TITLE
Add processor to process checkpoint records

### DIFF
--- a/backup/pom.xml
+++ b/backup/pom.xml
@@ -42,6 +42,20 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/backup/pom.xml
+++ b/backup/pom.xml
@@ -67,6 +67,19 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Should not depend on logstreams. But we have some dependencies in the test -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-logstreams</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
@@ -69,7 +69,12 @@ public final class CheckpointCreateProcessor {
       final CheckpointRecord checkpointRecord,
       final ProcessingResultBuilder resultBuilder) {
     resultBuilder.appendRecord(
-        command.getKey(), RecordType.EVENT, resultIntent, null, null, checkpointRecord);
+        command.getKey(),
+        RecordType.EVENT,
+        resultIntent,
+        RejectionType.NULL_VAL,
+        "",
+        checkpointRecord);
 
     if (command.hasRequestMetadata()) {
       resultBuilder.withResponse(
@@ -79,7 +84,7 @@ public final class CheckpointCreateProcessor {
           checkpointRecord,
           ValueType.CHECKPOINT,
           RejectionType.NULL_VAL,
-          null,
+          "",
           command.getRequestId(),
           command.getRequestStreamId());
     }

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import java.util.Set;
 
-public class CheckpointCreateProcessor {
+public final class CheckpointCreateProcessor {
   private final CheckpointState checkpointState;
   private final BackupManager backupManager;
 

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.processing;
+
+import io.camunda.zeebe.backup.api.BackupManager;
+import io.camunda.zeebe.backup.api.CheckpointListener;
+import io.camunda.zeebe.backup.processing.state.CheckpointState;
+import io.camunda.zeebe.engine.api.ProcessingResult;
+import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
+import io.camunda.zeebe.engine.api.TypedRecord;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import java.util.Set;
+
+public class CheckpointCreateProcessor {
+  private final CheckpointState checkpointState;
+  private final BackupManager backupManager;
+
+  private final Set<CheckpointListener> listeners;
+
+  public CheckpointCreateProcessor(
+      final CheckpointState checkpointState,
+      final BackupManager backupManager,
+      final Set<CheckpointListener> listeners) {
+    this.checkpointState = checkpointState;
+    this.backupManager = backupManager;
+    this.listeners = listeners;
+  }
+
+  public ProcessingResult process(
+      final TypedRecord<CheckpointRecord> record, final ProcessingResultBuilder resultBuilder) {
+
+    final var checkpointRecord = record.getValue();
+    final long checkpointId = checkpointRecord.getCheckpointId();
+    if (checkpointState.getCheckpointId() < checkpointId) {
+      // Only take a checkpoint if it is newer
+      final var checkpointPosition = record.getPosition();
+      backupManager.takeBackup(checkpointId, checkpointPosition);
+      checkpointState.setCheckpointInfo(checkpointId, checkpointPosition);
+
+      // Notify listeners immediately
+      listeners.forEach(l -> l.onNewCheckpointCreated(checkpointId));
+
+      final var followupRecord =
+          new CheckpointRecord()
+              .setCheckpointId(checkpointId)
+              .setCheckpointPosition(checkpointPosition);
+      return createFollowUpAndResponse(
+          record, CheckpointIntent.CREATED, followupRecord, resultBuilder);
+    } else {
+      // A checkpoint already exists. Hence ignore the command. Note:- this is not an error, so not
+      // considered as a "rejection"
+      return createFollowUpAndResponse(
+          record, CheckpointIntent.IGNORED, checkpointRecord, resultBuilder);
+    }
+  }
+
+  private ProcessingResult createFollowUpAndResponse(
+      final TypedRecord<CheckpointRecord> command,
+      final CheckpointIntent resultIntent,
+      final CheckpointRecord checkpointRecord,
+      final ProcessingResultBuilder resultBuilder) {
+    resultBuilder.appendRecord(
+        command.getKey(), RecordType.EVENT, resultIntent, null, null, checkpointRecord);
+
+    if (command.hasRequestMetadata()) {
+      resultBuilder.withResponse(
+          RecordType.EVENT,
+          command.getKey(),
+          resultIntent,
+          checkpointRecord,
+          ValueType.CHECKPOINT,
+          RejectionType.NULL_VAL,
+          null,
+          command.getRequestId(),
+          command.getRequestStreamId());
+    }
+    return resultBuilder.build();
+  }
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.processing;
+
+import io.camunda.zeebe.backup.processing.state.CheckpointState;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+
+public class CheckpointCreatedEventApplier {
+
+  final CheckpointState checkpointState;
+
+  public CheckpointCreatedEventApplier(final CheckpointState checkpointState) {
+    this.checkpointState = checkpointState;
+  }
+
+  public void apply(final CheckpointRecord checkpointRecord) {
+    checkpointState.setCheckpointInfo(
+        checkpointRecord.getCheckpointId(), checkpointRecord.getCheckpointPosition());
+  }
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.backup.processing;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 
-public class CheckpointCreatedEventApplier {
+public final class CheckpointCreatedEventApplier {
 
   final CheckpointState checkpointState;
 

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.processing;
+
+import io.camunda.zeebe.backup.api.BackupManager;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointState;
+import io.camunda.zeebe.engine.api.ProcessingResult;
+import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
+import io.camunda.zeebe.engine.api.RecordProcessor;
+import io.camunda.zeebe.engine.api.TypedRecord;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Process and replays records related to Checkpoint. */
+public class CheckpointRecordsProcessor implements RecordProcessor<Context> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CheckpointRecordsProcessor.class);
+
+  private final BackupManager backupManager;
+  private CheckpointCreateProcessor checkpointCreateProcessor;
+  private CheckpointCreatedEventApplier checkpointCreatedEventApplier;
+
+  public CheckpointRecordsProcessor(final BackupManager backupManager) {
+    this.backupManager = backupManager;
+  }
+
+  @Override
+  public void init(final Context recordProcessorContext) {
+    final var checkpointState =
+        new DbCheckpointState(
+            recordProcessorContext.zeebeDb(), recordProcessorContext.transactionContext());
+
+    checkpointCreateProcessor =
+        new CheckpointCreateProcessor(checkpointState, backupManager, Set.of());
+    checkpointCreatedEventApplier = new CheckpointCreatedEventApplier(checkpointState);
+  }
+
+  @Override
+  public void replay(final TypedRecord record) {
+    if (record.getValueType() != ValueType.CHECKPOINT) {
+      // Should never reach here. StreamProcessor must choose the right processor always.
+      throw new IllegalArgumentException("Unknown record");
+    }
+    final CheckpointIntent intent = (CheckpointIntent) record.getIntent();
+    if (intent == CheckpointIntent.CREATED) {
+      checkpointCreatedEventApplier.apply((CheckpointRecord) record.getValue());
+    }
+    // Don't apply intents CREATE and IGNORED
+  }
+
+  @Override
+  public ProcessingResult process(
+      final TypedRecord record, final ProcessingResultBuilder resultBuilder) {
+    if (record.getValueType() == ValueType.CHECKPOINT
+        && record.getIntent() == CheckpointIntent.CREATE) {
+      return checkpointCreateProcessor.process(record, resultBuilder);
+    }
+    // Should never reach here. StreamProcessor must choose the right processor always.
+    throw new IllegalArgumentException("Unknown record");
+  }
+
+  @Override
+  public ProcessingResult onProcessingError(
+      final Throwable processingException,
+      final TypedRecord record,
+      final ProcessingResultBuilder processingResultBuilder) {
+    LOG.error("Could not process checkpoint record {}.", record.getValue(), processingException);
+    // There is no correct way to handle this error. If processing checkpoint create failed, and we
+    // continue with processing, it can violate the consistency guarantees provided by the
+    // checkpointing algorithm. The only way to guarantee correctness is preventing StreamProcessor
+    // from making progress.
+    throw new RuntimeException(processingException);
+  }
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
@@ -21,7 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Process and replays records related to Checkpoint. */
-public class CheckpointRecordsProcessor implements RecordProcessor<Context> {
+public final class CheckpointRecordsProcessor implements RecordProcessor<Context> {
 
   private static final Logger LOG = LoggerFactory.getLogger(CheckpointRecordsProcessor.class);
 

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/Context.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/Context.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.processing;
+
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+
+/** There is a good chance that we will get rid of this context, and use a "ProcessingContext" defined by the StreamProcessor. **/
+public record Context(ZeebeDb zeebeDb, TransactionContext transactionContext) {}

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/Context.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/Context.java
@@ -10,5 +10,8 @@ package io.camunda.zeebe.backup.processing;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 
-/** There is a good chance that we will get rid of this context, and use a "ProcessingContext" defined by the StreamProcessor. **/
+/**
+ * There is a good chance that we will get rid of this context, and use a "ProcessingContext"
+ * defined by the StreamProcessor. *
+ */
 public record Context(ZeebeDb zeebeDb, TransactionContext transactionContext) {}

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointInfo.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointInfo.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 
 /** Checkpoint info stored in db in msgpack format. */
-public class CheckpointInfo extends UnpackedObject implements DbValue {
+public final class CheckpointInfo extends UnpackedObject implements DbValue {
   private final LongProperty idProperty = new LongProperty("id");
   private final LongProperty positionProperty = new LongProperty("position");
 

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/state/DbCheckpointState.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
 
-public class DbCheckpointState implements CheckpointState {
+public final class DbCheckpointState implements CheckpointState {
   private static final String CHECKPOINT_KEY = "checkpoint";
 
   private final CheckpointInfo checkpointInfo = new CheckpointInfo();

--- a/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.processing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.zeebe.backup.api.BackupManager;
+import io.camunda.zeebe.backup.processing.MockProcessingResult.Event;
+import io.camunda.zeebe.backup.processing.MockProcessingResult.MockProcessingResultBuilder;
+import io.camunda.zeebe.backup.processing.state.CheckpointState;
+import io.camunda.zeebe.backup.processing.state.DbCheckpointState;
+import io.camunda.zeebe.db.ConsistencyChecksSettings;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+final class CheckpointRecordsProcessorTest {
+
+  @TempDir Path database;
+
+  CheckpointRecordsProcessor processor;
+
+  ProcessingResultBuilder resultBuilder;
+
+  // Used for verifying state in the tests
+  CheckpointState state;
+
+  final BackupManager backupManager = mock(BackupManager.class);
+  private ZeebeDb zeebedb;
+
+  @BeforeEach
+  void setup() {
+    zeebedb =
+        new ZeebeRocksDbFactory<>(
+                new RocksDbConfiguration(), new ConsistencyChecksSettings(true, true))
+            .createDb(database.toFile());
+    final var context = new Context(zeebedb, zeebedb.createContext());
+
+    resultBuilder = new MockProcessingResultBuilder();
+    processor = new CheckpointRecordsProcessor(backupManager);
+    processor.init(context);
+
+    state = new DbCheckpointState(zeebedb, zeebedb.createContext());
+  }
+
+  @AfterEach
+  void after() throws Exception {
+    zeebedb.close();
+  }
+
+  @Test
+  void shouldCreateCheckpointOnCreateRecord() {
+    // given
+    final long checkpointId = 1;
+    final long checkpointPosition = 10;
+    final CheckpointRecord value = new CheckpointRecord().setCheckpointId(checkpointId);
+    final MockTypedCheckpointRecord record =
+        new MockTypedCheckpointRecord(
+            checkpointPosition, 0, CheckpointIntent.CREATE, RecordType.COMMAND, value);
+
+    // when
+    final var result = (MockProcessingResult) processor.process(record, resultBuilder);
+
+    // then
+
+    // backup is triggered
+    verify(backupManager, times(1)).takeBackup(checkpointId, checkpointPosition);
+
+    // followup event is written
+    assertThat(result.records()).hasSize(1);
+    final Event followupEvent = result.records().get(0);
+    assertThat(followupEvent.intent()).isEqualTo(CheckpointIntent.CREATED);
+    assertThat(followupEvent.type()).isEqualTo(RecordType.EVENT);
+    assertThat(followupEvent.value()).isNotNull();
+
+    final CheckpointRecord followupRecord = (CheckpointRecord) followupEvent.value();
+    assertThat(followupRecord.getCheckpointId()).isEqualTo(checkpointId);
+    assertThat(followupRecord.getCheckpointPosition()).isEqualTo(checkpointPosition);
+
+    // state is updated
+    assertThat(state.getCheckpointId()).isEqualTo(checkpointId);
+    assertThat(state.getCheckpointPosition()).isEqualTo(checkpointPosition);
+  }
+
+  @Test
+  void shouldNotCreateCheckpointIfAlreadyExists() {
+    // given
+    final long checkpointId = 1;
+    final long checkpointPosition = 10;
+    state.setCheckpointInfo(checkpointId, checkpointPosition);
+
+    final CheckpointRecord value = new CheckpointRecord().setCheckpointId(checkpointId);
+    final MockTypedCheckpointRecord record =
+        new MockTypedCheckpointRecord(
+            checkpointPosition + 10, 0, CheckpointIntent.CREATE, RecordType.COMMAND, value);
+
+    // when
+    final var result = (MockProcessingResult) processor.process(record, resultBuilder);
+
+    // then
+
+    // backup is not triggered
+    verify(backupManager, never()).takeBackup(checkpointId, checkpointPosition);
+
+    // followup event is written
+    assertThat(result.records()).hasSize(1);
+    final Event followupEvent = result.records().get(0);
+    assertThat(followupEvent.intent()).isEqualTo(CheckpointIntent.IGNORED);
+    assertThat(followupEvent.type()).isEqualTo(RecordType.EVENT);
+
+    // state not changed
+    assertThat(state.getCheckpointId()).isEqualTo(checkpointId);
+    assertThat(state.getCheckpointPosition()).isEqualTo(checkpointPosition);
+  }
+
+  @Test
+  void shouldReplayCreatedRecord() {
+    // given
+    final long checkpointId = 1;
+    final long checkpointPosition = 10;
+    final CheckpointRecord value =
+        new CheckpointRecord()
+            .setCheckpointId(checkpointId)
+            .setCheckpointPosition(checkpointPosition);
+    final MockTypedCheckpointRecord record =
+        new MockTypedCheckpointRecord(
+            checkpointPosition + 1,
+            checkpointPosition,
+            CheckpointIntent.CREATED,
+            RecordType.EVENT,
+            value);
+
+    // when
+    processor.replay(record);
+
+    // then
+    // state is updated
+    assertThat(state.getCheckpointId()).isEqualTo(checkpointId);
+    assertThat(state.getCheckpointPosition()).isEqualTo(checkpointPosition);
+  }
+
+  @Test
+  void shouldReplayIgnoredRecord() {
+    // given
+    final long checkpointId = 2;
+    final long checkpointPosition = 10;
+    state.setCheckpointInfo(checkpointId, checkpointPosition);
+    final CheckpointRecord value = new CheckpointRecord().setCheckpointId(1);
+    final MockTypedCheckpointRecord record =
+        new MockTypedCheckpointRecord(21, 20, CheckpointIntent.IGNORED, RecordType.EVENT, value);
+
+    // when
+    processor.replay(record);
+
+    // then
+    // state is not changed
+    assertThat(state.getCheckpointId()).isEqualTo(checkpointId);
+    assertThat(state.getCheckpointPosition()).isEqualTo(checkpointPosition);
+  }
+}

--- a/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.processing;
+
+import io.camunda.zeebe.engine.api.PostCommitTask;
+import io.camunda.zeebe.engine.api.ProcessingResult;
+import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
+import io.camunda.zeebe.logstreams.log.LogStreamBatchWriter;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.util.ArrayList;
+import java.util.List;
+
+record MockProcessingResult(List<Event> records) implements ProcessingResult {
+
+  @Override
+  public long writeRecordsToStream(final LogStreamBatchWriter logStreamBatchWriter) {
+    return 0;
+  }
+
+  @Override
+  public boolean writeResponse(final CommandResponseWriter commandResponseWriter) {
+    return false;
+  }
+
+  @Override
+  public boolean executePostCommitTasks() {
+    return false;
+  }
+
+  record Event(
+      Intent intent,
+      RecordType type,
+      RejectionType rejectionType,
+      String rejectionReason,
+      long key,
+      RecordValue value) {}
+
+  static class MockProcessingResultBuilder implements ProcessingResultBuilder {
+
+    final List<Event> followupRecords = new ArrayList<>();
+
+    @Override
+    public ProcessingResultBuilder appendRecord(
+        final long key,
+        final RecordType type,
+        final Intent intent,
+        final RejectionType rejectionType,
+        final String rejectionReason,
+        final RecordValue value) {
+
+      final var record = new Event(intent, type, rejectionType, rejectionReason, key, value);
+      followupRecords.add(record);
+      return null;
+    }
+
+    @Override
+    public ProcessingResultBuilder withResponse(
+        final RecordType type,
+        final long key,
+        final Intent intent,
+        final UnpackedObject value,
+        final ValueType valueType,
+        final RejectionType rejectionType,
+        final String rejectionReason,
+        final long requestId,
+        final int requestStreamId) {
+      return null;
+    }
+
+    @Override
+    public ProcessingResultBuilder appendPostCommitTask(final PostCommitTask task) {
+      return null;
+    }
+
+    @Override
+    public ProcessingResultBuilder reset() {
+      return null;
+    }
+
+    @Override
+    public ProcessingResultBuilder resetPostCommitTasks() {
+      return null;
+    }
+
+    @Override
+    public ProcessingResult build() {
+      return new MockProcessingResult(followupRecords);
+    }
+
+    @Override
+    public boolean canWriteEventOfLength(final int eventLength) {
+      return false;
+    }
+
+    @Override
+    public int getMaxEventLength() {
+      return 0;
+    }
+  }
+}

--- a/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.processing;
+
+import io.camunda.zeebe.engine.api.TypedRecord;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+
+record MockTypedCheckpointRecord(
+    long position,
+    long sourceRecordPosition,
+    Intent intent,
+    RecordType recordType,
+    CheckpointRecord value)
+    implements TypedRecord<CheckpointRecord> {
+
+  @Override
+  public long getPosition() {
+    return position;
+  }
+
+  @Override
+  public long getSourceRecordPosition() {
+    return sourceRecordPosition;
+  }
+
+  @Override
+  public long getTimestamp() {
+    return 0;
+  }
+
+  @Override
+  public Intent getIntent() {
+    return intent;
+  }
+
+  @Override
+  public int getPartitionId() {
+    return 1;
+  }
+
+  @Override
+  public RecordType getRecordType() {
+    return recordType;
+  }
+
+  @Override
+  public RejectionType getRejectionType() {
+    return null;
+  }
+
+  @Override
+  public String getRejectionReason() {
+    return null;
+  }
+
+  @Override
+  public String getBrokerVersion() {
+    return null;
+  }
+
+  @Override
+  public ValueType getValueType() {
+    return ValueType.CHECKPOINT;
+  }
+
+  @Override
+  public long getKey() {
+    return 0;
+  }
+
+  @Override
+  public CheckpointRecord getValue() {
+    return value;
+  }
+
+  @Override
+  public int getRequestStreamId() {
+    return -1;
+  }
+
+  @Override
+  public long getRequestId() {
+    return -1L;
+  }
+
+  @Override
+  public int getLength() {
+    return 0;
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9720 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
