### PR TITLE
Separate `StreamProcessorContext` and `TypedRecordProcessorContext`

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -54,10 +54,14 @@ public class Engine implements RecordProcessor {
             .getTypedRecordProcessorFactory()
             .createProcessors(typedProcessorContext);
 
+    recordProcessorContext.setStreamProcessorListener(
+        typedProcessorContext.getStreamProcessorListener());
+
     recordProcessorContext.setLifecycleListeners(typedRecordProcessors.getLifecycleListeners());
     final RecordProcessorMap recordProcessorMap = typedRecordProcessors.getRecordProcessorMap();
 
     recordProcessorContext.setRecordProcessorMap(recordProcessorMap);
+    recordProcessorContext.setWriters(typedProcessorContext.getWriters());
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -15,6 +15,9 @@ import io.camunda.zeebe.engine.api.ProcessingResult;
 import io.camunda.zeebe.engine.api.RecordProcessor;
 import io.camunda.zeebe.engine.api.RecordProcessorContext;
 import io.camunda.zeebe.engine.api.TypedRecord;
+import io.camunda.zeebe.engine.processing.streamprocessor.RecordProcessorMap;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorContextImpl;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.ZeebeDbState;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
@@ -36,7 +39,25 @@ public class Engine implements RecordProcessor {
 
   @Override
   public void init(final RecordProcessorContext recordProcessorContext) {
-    throw new IllegalStateException("Not yet implemented");
+    final var typedProcessorContext =
+        new TypedRecordProcessorContextImpl(
+            recordProcessorContext.getPartitionId(),
+            recordProcessorContext.getScheduleService(),
+            recordProcessorContext.getZeebeDb(),
+            recordProcessorContext.getTransactionContext(),
+            recordProcessorContext.getStreamWriterProxy(),
+            recordProcessorContext.getEventApplierFactory(),
+            recordProcessorContext.getTypedResponseWriter());
+
+    final TypedRecordProcessors typedRecordProcessors =
+        recordProcessorContext
+            .getTypedRecordProcessorFactory()
+            .createProcessors(typedProcessorContext);
+
+    recordProcessorContext.setLifecycleListeners(typedRecordProcessors.getLifecycleListeners());
+    final RecordProcessorMap recordProcessorMap = typedRecordProcessors.getRecordProcessorMap();
+
+    recordProcessorContext.setRecordProcessorMap(recordProcessorMap);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessorContext.java
@@ -7,4 +7,40 @@
  */
 package io.camunda.zeebe.engine.api;
 
-public interface RecordProcessorContext {}
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.processing.streamprocessor.RecordProcessorMap;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.camunda.zeebe.engine.state.EventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import java.util.List;
+import java.util.function.Function;
+
+public interface RecordProcessorContext {
+
+  int getPartitionId();
+
+  ProcessingScheduleService getScheduleService();
+
+  ZeebeDb getZeebeDb();
+
+  TransactionContext getTransactionContext();
+
+  @Deprecated // will be removed soon
+  TypedStreamWriter getStreamWriterProxy();
+
+  @Deprecated // will be removed soon
+  TypedResponseWriter getTypedResponseWriter();
+
+  Function<MutableZeebeState, EventApplier> getEventApplierFactory();
+
+  TypedRecordProcessorFactory getTypedRecordProcessorFactory();
+
+  @Deprecated // will most likely be moved into engine
+  void setLifecycleListeners(List<StreamProcessorLifecycleAware> lifecycleListeners);
+
+  @Deprecated // will be moved into engine
+  void setRecordProcessorMap(RecordProcessorMap recordProcessorMap);
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessorContext.java
@@ -10,9 +10,11 @@ package io.camunda.zeebe.engine.api;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.processing.streamprocessor.RecordProcessorMap;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorListener;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import java.util.List;
@@ -43,4 +45,9 @@ public interface RecordProcessorContext {
 
   @Deprecated // will be moved into engine
   void setRecordProcessorMap(RecordProcessorMap recordProcessorMap);
+
+  void setStreamProcessorListener(StreamProcessorListener streamProcessorListener);
+
+  @Deprecated // will most likely be moved into engine
+  void setWriters(Writers writers);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
@@ -21,5 +21,7 @@ public interface TypedRecordProcessorContext {
 
   Writers getWriters();
 
+  @Deprecated // will be moved to stream processor
+  @Deprecated // only used in test
   TypedRecordProcessorContext listener(StreamProcessorListener streamProcessorListener);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
@@ -21,7 +21,6 @@ public interface TypedRecordProcessorContext {
 
   Writers getWriters();
 
-  @Deprecated // will be moved to stream processor
   @Deprecated // only used in test
   TypedRecordProcessorContext listener(StreamProcessorListener streamProcessorListener);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.api.ProcessingScheduleService;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.EventApplyingStateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.EventApplier;
+import io.camunda.zeebe.engine.state.ZeebeDbState;
+import io.camunda.zeebe.engine.state.immutable.LastProcessedPositionState;
+import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import java.util.function.Function;
+
+public class TypedRecordProcessorContextImpl implements TypedRecordProcessorContext {
+
+  private final int partitionId;
+  private final ProcessingScheduleService scheduleService;
+  private StreamProcessorListener streamProcessorListener;
+  private final ZeebeDbState zeebeState;
+  private final Writers writers;
+
+  public TypedRecordProcessorContextImpl(
+      final int partitionId,
+      final ProcessingScheduleService scheduleService,
+      final ZeebeDb zeebeDb,
+      final TransactionContext transactionContext,
+      final TypedStreamWriter streamWriterProxy,
+      final Function<MutableZeebeState, EventApplier> eventApplierFactory,
+      final TypedResponseWriter typedResponseWriter) {
+    this.partitionId = partitionId;
+    this.scheduleService = scheduleService;
+
+    zeebeState = new ZeebeDbState(partitionId, zeebeDb, transactionContext);
+
+    final var stateWriter =
+        new EventApplyingStateWriter(streamWriterProxy, eventApplierFactory.apply(zeebeState));
+    writers = new Writers(streamWriterProxy, stateWriter, typedResponseWriter);
+  }
+
+  @Override
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  @Override
+  public ProcessingScheduleService getScheduleService() {
+    return scheduleService;
+  }
+
+  @Override
+  public MutableZeebeState getZeebeState() {
+    return zeebeState;
+  }
+
+  @Override
+  public Writers getWriters() {
+    return writers;
+  }
+
+  @Override
+  public LastProcessedPositionState getLastProcessedPositionState() {
+    return getZeebeState().getLastProcessedPositionState();
+  }
+
+  @Override
+  public TypedRecordProcessorContext listener(
+      final StreamProcessorListener streamProcessorListener) {
+    this.streamProcessorListener = streamProcessorListener;
+    return this;
+  }
+
+  public StreamProcessorListener getStreamProcessorListener() {
+    return streamProcessorListener;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWri
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.ZeebeDbState;
-import io.camunda.zeebe.engine.state.immutable.LastProcessedPositionState;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import java.util.function.Function;
 
@@ -64,11 +63,6 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   @Override
   public Writers getWriters() {
     return writers;
-  }
-
-  @Override
-  public LastProcessedPositionState getLastProcessedPositionState() {
-    return getZeebeState().getLastProcessedPositionState();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/RecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/RecordProcessorContextImpl.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.streamprocessor;
+
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.api.ProcessingScheduleService;
+import io.camunda.zeebe.engine.api.RecordProcessorContext;
+import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.engine.processing.streamprocessor.RecordProcessorMap;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.camunda.zeebe.engine.state.EventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+public class RecordProcessorContextImpl implements RecordProcessorContext {
+
+  private final int partitionId;
+  private final ProcessingScheduleService scheduleService;
+  private final ZeebeDb zeebeDb;
+  private final TransactionContext transactionContext;
+  private final TypedStreamWriter streamWriter;
+  private final TypedResponseWriter responseWriter;
+  private final Function<MutableZeebeState, EventApplier> eventApplierFactory;
+  private final TypedRecordProcessorFactory typedRecordProcessorFactory;
+  private List<StreamProcessorLifecycleAware> lifecycleListeners = Collections.EMPTY_LIST;
+  private RecordProcessorMap recordProcessorMap;
+
+  public RecordProcessorContextImpl(
+      final int partitionId,
+      final ProcessingScheduleService scheduleService,
+      final ZeebeDb zeebeDb,
+      final TransactionContext transactionContext,
+      final TypedStreamWriter streamWriter,
+      final TypedResponseWriter responseWriter,
+      final Function<MutableZeebeState, EventApplier> eventApplierFactory,
+      final TypedRecordProcessorFactory typedRecordProcessorFactory) {
+    this.partitionId = partitionId;
+    this.scheduleService = scheduleService;
+    this.zeebeDb = zeebeDb;
+    this.transactionContext = transactionContext;
+    this.streamWriter = streamWriter;
+    this.responseWriter = responseWriter;
+    this.eventApplierFactory = eventApplierFactory;
+    this.typedRecordProcessorFactory = typedRecordProcessorFactory;
+  }
+
+  @Override
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  @Override
+  public ProcessingScheduleService getScheduleService() {
+    return scheduleService;
+  }
+
+  @Override
+  public ZeebeDb getZeebeDb() {
+    return zeebeDb;
+  }
+
+  @Override
+  public TransactionContext getTransactionContext() {
+    return transactionContext;
+  }
+
+  @Override
+  public TypedStreamWriter getStreamWriterProxy() {
+    return streamWriter;
+  }
+
+  @Override
+  public TypedResponseWriter getTypedResponseWriter() {
+    return responseWriter;
+  }
+
+  @Override
+  public Function<MutableZeebeState, EventApplier> getEventApplierFactory() {
+    return eventApplierFactory;
+  }
+
+  @Override
+  public TypedRecordProcessorFactory getTypedRecordProcessorFactory() {
+    return typedRecordProcessorFactory;
+  }
+
+  @Deprecated // will likely be moved to engine
+  public List<StreamProcessorLifecycleAware> getLifecycleListeners() {
+    return lifecycleListeners;
+  }
+
+  @Override
+  public void setLifecycleListeners(final List<StreamProcessorLifecycleAware> lifecycleListeners) {
+    this.lifecycleListeners = lifecycleListeners;
+  }
+
+  @Deprecated // will be moved to engine
+  public RecordProcessorMap getRecordProcessorMap() {
+    return recordProcessorMap;
+  }
+
+  @Override
+  public void setRecordProcessorMap(final RecordProcessorMap recordProcessorMap) {
+    this.recordProcessorMap = recordProcessorMap;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/RecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/RecordProcessorContextImpl.java
@@ -13,16 +13,18 @@ import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.api.RecordProcessorContext;
 import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.RecordProcessorMap;
+import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorListener;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
-public class RecordProcessorContextImpl implements RecordProcessorContext {
+public final class RecordProcessorContextImpl implements RecordProcessorContext {
 
   private final int partitionId;
   private final ProcessingScheduleService scheduleService;
@@ -34,6 +36,8 @@ public class RecordProcessorContextImpl implements RecordProcessorContext {
   private final TypedRecordProcessorFactory typedRecordProcessorFactory;
   private List<StreamProcessorLifecycleAware> lifecycleListeners = Collections.EMPTY_LIST;
   private RecordProcessorMap recordProcessorMap;
+  private StreamProcessorListener streamProcessorListener;
+  private Writers writers;
 
   public RecordProcessorContextImpl(
       final int partitionId,
@@ -112,5 +116,23 @@ public class RecordProcessorContextImpl implements RecordProcessorContext {
   @Override
   public void setRecordProcessorMap(final RecordProcessorMap recordProcessorMap) {
     this.recordProcessorMap = recordProcessorMap;
+  }
+
+  public StreamProcessorListener getStreamProcessorListener() {
+    return streamProcessorListener;
+  }
+
+  @Override
+  public void setStreamProcessorListener(final StreamProcessorListener streamProcessorListener) {
+    this.streamProcessorListener = streamProcessorListener;
+  }
+
+  public Writers getWriters() {
+    return writers;
+  }
+
+  @Override
+  public void setWriters(final Writers writers) {
+    this.writers = writers;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorBuilder.java
@@ -128,8 +128,6 @@ public final class StreamProcessorBuilder {
     Objects.requireNonNull(typedRecordProcessorFactory, "No stream processor factory provided.");
     Objects.requireNonNull(actorSchedulingService, "No task scheduler provided.");
     Objects.requireNonNull(streamProcessorContext.getLogStream(), "No log stream provided.");
-    Objects.requireNonNull(
-        streamProcessorContext.getWriters().response(), "No command response writer provided.");
     Objects.requireNonNull(zeebeDb, "No database provided.");
     Objects.requireNonNull(eventApplierFactory, "No factory for the event supplier provided.");
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -25,7 +25,6 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.streamprocessor.StreamProcessor;
-import io.camunda.zeebe.streamprocessor.StreamProcessorContext;
 import io.camunda.zeebe.streamprocessor.state.MutableLastProcessedPositionState;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
@@ -68,8 +67,6 @@ public class StreamProcessingComposite {
       final TypedRecordProcessorContext typedRecordProcessorContext) {
     zeebeState = typedRecordProcessorContext.getZeebeState();
 
-    lastProcessedPositionState =
-        ((StreamProcessorContext) typedRecordProcessorContext).getLastProcessedPositionState();
     return factory.build(
         TypedRecordProcessors.processors(
             zeebeState.getKeyGenerator(), typedRecordProcessorContext.getWriters()),


### PR DESCRIPTION
## Description

- This separates the context objects needed by the stream processor vs. the engine. 
- They still are used to exchange information back and forth (i.e. `setWriters()`), which is a bit of a smell. Some of the information flows will be removed by further refactoring.

## Related issues

closes #9725

<!-- Cut-off marker

## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
