### PR TITLE
[Backport stable/1.3] fix: don't replicate snapshot if member already has the latest snapshot

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -355,6 +355,12 @@ final class LeaderAppender extends AbstractAppender {
     if (persistedSnapshot == null) {
       return false;
     }
+    if (member.getSnapshotIndex() >= persistedSnapshot.getIndex()) {
+      // Member has the latest snapshot, replicating the snapshot again wouldn't help.
+      // WARNING! This is load-bearing and not just an optimization. See
+      // https://github.com/camunda/zeebe/issues/9820 for context.
+      return false;
+    }
     if (raft.getLog().getFirstIndex() > member.getCurrentIndex()) {
       // Necessary events are not available anymore, we have to use the snapshot
       return true;

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftReplicationTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftReplicationTest.java
@@ -128,7 +128,7 @@ public class RaftReplicationTest {
 
     raftRule.getServers().stream()
         .filter(s -> s.getRole() == Role.FOLLOWER)
-        .toList()
+        .collect(Collectors.toList())
         .forEach(
             (follower) -> {
               try {


### PR DESCRIPTION
# Description
Backport of #9824 to `stable/1.3`.

relates to #9820