### PR TITLE
Shape legacy code into new interfaces good bits part 1

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/api/PostCommitTask.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/PostCommitTask.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.api;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
+
+public interface PostCommitTask extends SideEffectProducer {}

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResult.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResult.java
@@ -9,15 +9,19 @@ package io.camunda.zeebe.engine.api;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 
 /**
  * Here the interface is just a suggestion. Can be whatever PDT teams thinks is best to work with
  */
 public interface ProcessingResult {
 
-  long writeRecordsToStream(LogStreamRecordWriter logStreamRecordWriter);
+  ActorFuture<Boolean> writeRecordsToStream(LogStreamRecordWriter logStreamRecordWriter);
 
   boolean writeResponse(CommandResponseWriter commandResponseWriter);
 
-  void executePostCommitTasks();
+  /**
+   * @return <code>false</code> to indicate that the side effect could not be applied successfully
+   */
+  boolean executePostCommitTasks();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResult.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResult.java
@@ -9,14 +9,13 @@ package io.camunda.zeebe.engine.api;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamBatchWriter;
-import io.camunda.zeebe.scheduler.future.ActorFuture;
 
 /**
  * Here the interface is just a suggestion. Can be whatever PDT teams thinks is best to work with
  */
 public interface ProcessingResult {
 
-  ActorFuture<Boolean> writeRecordsToStream(LogStreamBatchWriter logStreamBatchWriter);
+  long writeRecordsToStream(LogStreamBatchWriter logStreamBatchWriter);
 
   boolean writeResponse(CommandResponseWriter commandResponseWriter);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResult.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResult.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.engine.api;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
-import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
+import io.camunda.zeebe.logstreams.log.LogStreamBatchWriter;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 
 /**
@@ -16,7 +16,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
  */
 public interface ProcessingResult {
 
-  ActorFuture<Boolean> writeRecordsToStream(LogStreamRecordWriter logStreamRecordWriter);
+  ActorFuture<Boolean> writeRecordsToStream(LogStreamBatchWriter logStreamBatchWriter);
 
   boolean writeResponse(CommandResponseWriter commandResponseWriter);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResultBuilder.java
@@ -49,7 +49,7 @@ public interface ProcessingResultBuilder {
    *
    * @return returns itself for method chaining
    */
-  ProcessingResultBuilder appendPostCommitTask(Runnable r);
+  ProcessingResultBuilder appendPostCommitTask(PostCommitTask task);
 
   /**
    * Resets the processing result build to its initial states (removes all follow-up records, the

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/TypedStreamWriterProxy.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/TypedStreamWriterProxy.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import io.camunda.zeebe.engine.api.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -27,6 +28,17 @@ public final class TypedStreamWriterProxy implements TypedStreamWriter {
       final RejectionType type,
       final String reason) {
     writer.appendRejection(command, type, reason);
+  }
+
+  @Override
+  public void appendRecord(
+      final long key,
+      final RecordType type,
+      final Intent intent,
+      final RejectionType rejectionType,
+      final String rejectionReason,
+      final RecordValue value) {
+    writer.appendRecord(key, type, intent, rejectionType, rejectionReason, value);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/CompleteDeploymentDistributionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/CompleteDeploymentDistributionProcessor.java
@@ -9,11 +9,8 @@ package io.camunda.zeebe.engine.processing.deployment.distribute;
 
 import io.camunda.zeebe.engine.api.TypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
-import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.DeploymentState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentDistributionRecord;
@@ -21,7 +18,6 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
-import java.util.function.Consumer;
 
 public class CompleteDeploymentDistributionProcessor
     implements TypedRecordProcessor<DeploymentDistributionRecord> {
@@ -42,12 +38,7 @@ public class CompleteDeploymentDistributionProcessor
   }
 
   @Override
-  public void processRecord(
-      final long position,
-      final TypedRecord<DeploymentDistributionRecord> record,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter,
-      final Consumer<SideEffectProducer> sideEffect) {
+  public void processRecord(final TypedRecord<DeploymentDistributionRecord> record) {
 
     final var deploymentKey = record.getKey();
     if (!deploymentState.hasPendingDeploymentDistribution(deploymentKey)) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentDistributeProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentDistributeProcessor.java
@@ -11,17 +11,13 @@ import io.camunda.zeebe.engine.api.TypedRecord;
 import io.camunda.zeebe.engine.processing.deployment.DeploymentResponder;
 import io.camunda.zeebe.engine.processing.deployment.MessageStartEventSubscriptionManager;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
-import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.MessageStartEventSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
-import java.util.function.Consumer;
 
 public final class DeploymentDistributeProcessor implements TypedRecordProcessor<DeploymentRecord> {
 
@@ -46,12 +42,7 @@ public final class DeploymentDistributeProcessor implements TypedRecordProcessor
   }
 
   @Override
-  public void processRecord(
-      final long position,
-      final TypedRecord<DeploymentRecord> event,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter,
-      final Consumer<SideEffectProducer> sideEffect) {
+  public void processRecord(final TypedRecord<DeploymentRecord> event) {
     final var deploymentEvent = event.getValue();
     final var deploymentKey = event.getKey();
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
-import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -30,7 +29,6 @@ import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscri
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
-import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
 
 public final class ProcessMessageSubscriptionCorrelateProcessor
@@ -80,8 +78,7 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
   public void processRecord(
       final TypedRecord<ProcessMessageSubscriptionRecord> command,
       final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter,
-      final Consumer<SideEffectProducer> sideEffect) {
+      final TypedStreamWriter streamWriter) {
 
     final var record = command.getValue();
     final var elementInstanceKey = record.getElementInstanceKey();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
@@ -16,8 +16,11 @@ import java.util.function.Consumer;
 
 // todo (#8002): remove TypedStreamWriter from this interface's method signatures
 // After the migration, none of these should be in use anymore and replaced by the CommandWriter and
-// StateWriter passed along to the constructors of the concrete processors.
+// StateWriter passed along to the constructors of the concrete processors. The only method that
+// should remain in use is {@code processRecord(final TypedRecord<T> record)}
 public interface TypedRecordProcessor<T extends UnifiedRecordValue> {
+
+  default void processRecord(final TypedRecord<T> record) {}
 
   /**
    * @see #processRecord(TypedRecord, TypedResponseWriter, TypedStreamWriter, Consumer)
@@ -25,7 +28,9 @@ public interface TypedRecordProcessor<T extends UnifiedRecordValue> {
   default void processRecord(
       final TypedRecord<T> record,
       final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter) {}
+      final TypedStreamWriter streamWriter) {
+    processRecord(record);
+  }
 
   /**
    * @see #processRecord(TypedRecord, TypedResponseWriter, TypedStreamWriter, Consumer)

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/NoopTypedStreamWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/NoopTypedStreamWriter.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
 import io.camunda.zeebe.engine.api.TypedRecord;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -19,6 +20,17 @@ public final class NoopTypedStreamWriter implements TypedStreamWriter {
       final TypedRecord<? extends RecordValue> command,
       final RejectionType type,
       final String reason) {
+    // no op implementation
+  }
+
+  @Override
+  public void appendRecord(
+      final long key,
+      final RecordType type,
+      final Intent intent,
+      final RejectionType rejectionType,
+      final String rejectionReason,
+      final RecordValue value) {
     // no op implementation
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedStreamWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedStreamWriter.java
@@ -7,9 +7,22 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+
 /** Things that only a stream processor should write to the log stream (+ commands) */
 public interface TypedStreamWriter
     extends TypedCommandWriter, TypedEventWriter, TypedRejectionWriter {
+
+  void appendRecord(
+      long key,
+      RecordType type,
+      Intent intent,
+      RejectionType rejectionType,
+      String rejectionReason,
+      RecordValue value);
 
   void configureSourceContext(long sourceRecordPosition);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedStreamWriterImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedStreamWriterImpl.java
@@ -53,7 +53,8 @@ public class TypedStreamWriterImpl implements TypedStreamWriter {
     appendRecord(key, type, intent, RejectionType.NULL_VAL, "", value);
   }
 
-  protected void appendRecord(
+  @Override
+  public void appendRecord(
       final long key,
       final RecordType type,
       final Intent intent,
@@ -82,6 +83,11 @@ public class TypedStreamWriterImpl implements TypedStreamWriter {
     } else {
       throw new RuntimeException(String.format("The record value %s is not a BufferWriter", value));
     }
+  }
+
+  @Override
+  public void configureSourceContext(final long sourceRecordPosition) {
+    this.sourceRecordPosition = sourceRecordPosition;
   }
 
   @Override
@@ -118,11 +124,6 @@ public class TypedStreamWriterImpl implements TypedStreamWriter {
         rejectionType,
         reason,
         command.getValue());
-  }
-
-  @Override
-  public void configureSourceContext(final long sourceRecordPosition) {
-    this.sourceRecordPosition = sourceRecordPosition;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResult.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResult.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.streamprocessor;
+
+import io.camunda.zeebe.engine.api.PostCommitTask;
+import io.camunda.zeebe.engine.api.ProcessingResult;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.retry.AbortableRetryStrategy;
+import io.camunda.zeebe.scheduler.retry.RetryStrategy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+
+/**
+ * Implementation of {@code ProcessingResult} that uses direct access to the stream and to response
+ * writer. This implementation is here to support a bridge for legacy code. Legacy code can first be
+ * shaped into the interfaces defined in engine abstraction, and subseqeently the interfaces can be
+ * re-implemented to allow for buffered writing to stream and response writer
+ */
+final class DirectProcessingResult implements ProcessingResult {
+
+  private final List<PostCommitTask> postCommitTasks;
+
+  private final RetryStrategy writeRetryStrategy;
+  private final BooleanSupplier abortCondition;
+  private final TypedStreamWriter streamWriter;
+  private final TypedResponseWriter responseWriter;
+
+  DirectProcessingResult(
+      final StreamProcessorContext context, final List<PostCommitTask> postCommitTasks) {
+    this.postCommitTasks = new ArrayList<>(postCommitTasks);
+    writeRetryStrategy = new AbortableRetryStrategy(context.getActor());
+    abortCondition = context.getAbortCondition();
+    streamWriter = context.getLogStreamWriter();
+    responseWriter = context.getTypedResponseWriter();
+  }
+
+  @Override
+  public ActorFuture<Boolean> writeRecordsToStream(
+      final LogStreamRecordWriter logStreamRecordWriter) {
+    // here we must assume that stream writer is backed by log stream record writer internally
+    return writeRetryStrategy.runWithRetry(
+        () -> {
+          final long position = streamWriter.flush();
+          return position >= 0;
+        },
+        abortCondition);
+  }
+
+  @Override
+  public boolean writeResponse(final CommandResponseWriter commandResponseWriter) {
+    // here we must assume that response writer is backed up by command response writer internally
+    return responseWriter.flush();
+  }
+
+  @Override
+  public boolean executePostCommitTasks() {
+    boolean aggregatedResult = true;
+
+    for (final PostCommitTask task : postCommitTasks) {
+      try {
+        aggregatedResult = aggregatedResult && task.flush();
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    return aggregatedResult;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResult.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResult.java
@@ -34,14 +34,19 @@ final class DirectProcessingResult implements ProcessingResult {
   private final BooleanSupplier abortCondition;
   private final TypedStreamWriter streamWriter;
   private final TypedResponseWriter responseWriter;
+  private final boolean hasResponse;
 
   DirectProcessingResult(
-      final StreamProcessorContext context, final List<PostCommitTask> postCommitTasks) {
+      final StreamProcessorContext context,
+      final List<PostCommitTask> postCommitTasks,
+      final boolean hasResponse) {
     this.postCommitTasks = new ArrayList<>(postCommitTasks);
     writeRetryStrategy = new AbortableRetryStrategy(context.getActor());
     abortCondition = context.getAbortCondition();
     streamWriter = context.getLogStreamWriter();
     responseWriter = context.getTypedResponseWriter();
+
+    this.hasResponse = hasResponse;
   }
 
   @Override
@@ -59,7 +64,12 @@ final class DirectProcessingResult implements ProcessingResult {
   @Override
   public boolean writeResponse(final CommandResponseWriter commandResponseWriter) {
     // here we must assume that response writer is backed up by command response writer internally
-    return responseWriter.flush();
+
+    if (hasResponse) {
+      return responseWriter.flush();
+    } else {
+      return true;
+    }
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResult.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResult.java
@@ -13,12 +13,8 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandRespons
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamBatchWriter;
-import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.scheduler.retry.AbortableRetryStrategy;
-import io.camunda.zeebe.scheduler.retry.RetryStrategy;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BooleanSupplier;
 
 /**
  * Implementation of {@code ProcessingResult} that uses direct access to the stream and to response
@@ -30,8 +26,6 @@ final class DirectProcessingResult implements ProcessingResult {
 
   private final List<PostCommitTask> postCommitTasks;
 
-  private final RetryStrategy writeRetryStrategy;
-  private final BooleanSupplier abortCondition;
   private final TypedStreamWriter streamWriter;
   private final TypedResponseWriter responseWriter;
   private final boolean hasResponse;
@@ -41,8 +35,6 @@ final class DirectProcessingResult implements ProcessingResult {
       final List<PostCommitTask> postCommitTasks,
       final boolean hasResponse) {
     this.postCommitTasks = new ArrayList<>(postCommitTasks);
-    writeRetryStrategy = new AbortableRetryStrategy(context.getActor());
-    abortCondition = context.getAbortCondition();
     streamWriter = context.getLogStreamWriter();
     responseWriter = context.getTypedResponseWriter();
 
@@ -50,16 +42,8 @@ final class DirectProcessingResult implements ProcessingResult {
   }
 
   @Override
-  public ActorFuture<Boolean> writeRecordsToStream(
-      final LogStreamBatchWriter logStreamBatchWriter) {
-    // here we must assume that stream writer is backed by log stream record writer internally
-    return writeRetryStrategy.runWithRetry(
-        () -> {
-          final long position = streamWriter.flush();
-          logStreamBatchWriter.tryWrite();
-          return position >= 0;
-        },
-        abortCondition);
+  public long writeRecordsToStream(final LogStreamBatchWriter logStreamBatchWriter) {
+    return streamWriter.flush();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResult.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResult.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.engine.api.ProcessingResult;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
-import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
+import io.camunda.zeebe.logstreams.log.LogStreamBatchWriter;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.retry.AbortableRetryStrategy;
 import io.camunda.zeebe.scheduler.retry.RetryStrategy;
@@ -51,11 +51,12 @@ final class DirectProcessingResult implements ProcessingResult {
 
   @Override
   public ActorFuture<Boolean> writeRecordsToStream(
-      final LogStreamRecordWriter logStreamRecordWriter) {
+      final LogStreamBatchWriter logStreamBatchWriter) {
     // here we must assume that stream writer is backed by log stream record writer internally
     return writeRetryStrategy.runWithRetry(
         () -> {
           final long position = streamWriter.flush();
+          logStreamBatchWriter.tryWrite();
           return position >= 0;
         },
         abortCondition);

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResultBuilder.java
@@ -21,6 +21,12 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Implementation of {@code ProcessingResultBuilder} that uses direct access to the stream and to
+ * response writer. This implementation is here to support a bridge for legacy code. Legacy code can
+ * first be shaped into the interfaces defined in engine abstraction, and subseqeently the
+ * interfaces can be re-implemented to allow for buffered writing to stream and response writer
+ */
 final class DirectProcessingResultBuilder implements ProcessingResultBuilder {
 
   private final List<PostCommitTask> postCommitTasks = new ArrayList<>();

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResultBuilder.java
@@ -29,6 +29,8 @@ final class DirectProcessingResultBuilder implements ProcessingResultBuilder {
   private final TypedStreamWriter streamWriter;
   private final TypedResponseWriter responseWriter;
 
+  private boolean hasResponse = false;
+
   DirectProcessingResultBuilder(final StreamProcessorContext context) {
     this.context = context;
     streamWriter = context.getLogStreamWriter();
@@ -55,6 +57,7 @@ final class DirectProcessingResultBuilder implements ProcessingResultBuilder {
       final ValueType valueType,
       final long requestId,
       final int requestStreamId) {
+    hasResponse = true;
     responseWriter.writeResponse(
         eventKey, eventState, eventValue, valueType, requestId, requestStreamId);
     return this;
@@ -76,6 +79,6 @@ final class DirectProcessingResultBuilder implements ProcessingResultBuilder {
 
   @Override
   public ProcessingResult build() {
-    return new DirectProcessingResult(context, postCommitTasks);
+    return new DirectProcessingResult(context, postCommitTasks, hasResponse);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResultBuilder.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.streamprocessor;
+
+import io.camunda.zeebe.engine.api.PostCommitTask;
+import io.camunda.zeebe.engine.api.ProcessingResult;
+import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.util.ArrayList;
+import java.util.List;
+
+final class DirectProcessingResultBuilder implements ProcessingResultBuilder {
+
+  private final List<PostCommitTask> postCommitTasks = new ArrayList<>();
+
+  private final StreamProcessorContext context;
+  private final TypedStreamWriter streamWriter;
+  private final TypedResponseWriter responseWriter;
+
+  DirectProcessingResultBuilder(final StreamProcessorContext context) {
+    this.context = context;
+    streamWriter = context.getLogStreamWriter();
+    responseWriter = context.getTypedResponseWriter();
+  }
+
+  @Override
+  public ProcessingResultBuilder appendRecord(
+      final long key,
+      final RecordType type,
+      final Intent intent,
+      final RejectionType rejectionType,
+      final String rejectionReason,
+      final RecordValue value) {
+    streamWriter.appendRecord(key, type, intent, rejectionType, rejectionReason, value);
+    return this;
+  }
+
+  @Override
+  public ProcessingResultBuilder withResponse(
+      final long eventKey,
+      final Intent eventState,
+      final UnpackedObject eventValue,
+      final ValueType valueType,
+      final long requestId,
+      final int requestStreamId) {
+    responseWriter.writeResponse(
+        eventKey, eventState, eventValue, valueType, requestId, requestStreamId);
+    return this;
+  }
+
+  @Override
+  public ProcessingResultBuilder appendPostCommitTask(final PostCommitTask task) {
+    postCommitTasks.add(task);
+    return this;
+  }
+
+  @Override
+  public ProcessingResultBuilder reset() {
+    streamWriter.reset();
+    responseWriter.reset();
+    postCommitTasks.clear();
+    return this;
+  }
+
+  @Override
+  public ProcessingResult build() {
+    return new DirectProcessingResult(context, postCommitTasks);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -406,7 +406,7 @@ public final class ProcessingStateMachine {
 
   private void writeRecords(final ProcessingResult result) {
     final ActorFuture<Boolean> retryFuture =
-        result.writeRecordsToStream(null); // TODO get hold of writer
+        result.writeRecordsToStream(context.getLogStreamBatchWriter());
 
     actor.runOnCompletion(
         retryFuture,

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -47,8 +47,8 @@ import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.prometheus.client.Histogram;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
+import org.agrona.collections.MutableReference;
 import org.slf4j.Logger;
 
 /**
@@ -264,7 +264,7 @@ public final class ProcessingStateMachine {
     final var processingStartTime = ActorClock.currentTimeMillis();
     processingTimer = metrics.startProcessingDurationTimer(metadata.getRecordType());
 
-    final AtomicReference<ProcessingResult> processingResultRef = new AtomicReference<>();
+    final MutableReference<ProcessingResult> processingResultRef = new MutableReference<>();
 
     try {
       final var value = recordValues.readRecordValue(command, metadata.getValueType());

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
@@ -287,6 +287,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
           .maxFragmentSize(batchWriter.getMaxFragmentLength())
           .logStreamWriter(typedStreamWriterFactory.apply(batchWriter));
 
+      streamProcessorContext.logStreamBatchWriter(batchWriter);
+
       phase = Phase.PROCESSING;
 
       // enable writing records to the stream

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.engine.state.KeyGeneratorControls;
 import io.camunda.zeebe.engine.state.ZeebeDbState;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.logstreams.log.LogStreamBatchWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.streamprocessor.state.MutableLastProcessedPositionState;
@@ -57,6 +58,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private ProcessingScheduleService processingScheduleService;
   private MutableLastProcessedPositionState lastProcessedPositionState;
   private Writers writers;
+  private LogStreamBatchWriter logStreamBatchWriter;
 
   public StreamProcessorContext() {
     streamWriterProxy.wrap(logStreamWriter);
@@ -225,5 +227,13 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   public void writers(final Writers writers) {
     this.writers = writers;
+  }
+
+  public void logStreamBatchWriter(final LogStreamBatchWriter batchWriter) {
+    logStreamBatchWriter = batchWriter;
+  }
+
+  public LogStreamBatchWriter getLogStreamBatchWriter() {
+    return logStreamBatchWriter;
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.util.Records;
 import io.camunda.zeebe.engine.util.StreamProcessorRule;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -208,6 +209,15 @@ public class StreamProcessorHealthTest {
         final TypedRecord<? extends RecordValue> command,
         final RejectionType type,
         final String reason) {}
+
+    @Override
+    public void appendRecord(
+        final long key,
+        final RecordType type,
+        final Intent intent,
+        final RejectionType rejectionType,
+        final String rejectionReason,
+        final RecordValue value) {}
 
     @Override
     public void configureSourceContext(final long sourceRecordPosition) {}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
@@ -13,8 +13,6 @@ import static io.camunda.zeebe.test.util.TestUtil.waitUntil;
 import static org.mockito.Mockito.mock;
 
 import io.camunda.zeebe.engine.api.TypedRecord;
-import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.engine.util.Records;
@@ -33,7 +31,6 @@ import io.camunda.zeebe.util.health.HealthStatus;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,7 +43,6 @@ public class StreamProcessorHealthTest {
   @Rule public final StreamProcessorRule streamProcessorRule = new StreamProcessorRule();
 
   private StreamProcessor streamProcessor;
-  private TypedStreamWriter mockedLogStreamWriter;
   private AtomicBoolean shouldFlushThrowException;
   private AtomicInteger invocation;
   private AtomicBoolean shouldFailErrorHandlingInTransaction;
@@ -165,13 +161,7 @@ public class StreamProcessorHealthTest {
                       ACTIVATE_ELEMENT,
                       new TypedRecordProcessor<>() {
                         @Override
-                        public void processRecord(
-                            final long position,
-                            final TypedRecord<UnifiedRecordValue> record,
-                            final TypedResponseWriter responseWriter,
-                            final TypedStreamWriter streamWriter,
-                            final Consumer<SideEffectProducer> sideEffect) {
-
+                        public void processRecord(final TypedRecord<UnifiedRecordValue> record) {
                           invocation.getAndIncrement();
                           if (shouldProcessingThrowException.get()) {
                             throw new RuntimeException("Expected failure on processing");

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorReprocessingTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorReprocessingTest.java
@@ -22,9 +22,6 @@ import static org.mockito.Mockito.verify;
 import io.camunda.zeebe.engine.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.api.TypedRecord;
-import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.engine.util.Records;
@@ -36,7 +33,6 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.test.util.stream.StreamWrapper;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
 import org.junit.Before;
@@ -253,12 +249,7 @@ public final class StreamProcessorReprocessingTest {
                 ACTIVATE_ELEMENT,
                 new TypedRecordProcessor<>() {
                   @Override
-                  public void processRecord(
-                      final long position,
-                      final TypedRecord<UnifiedRecordValue> record,
-                      final TypedResponseWriter responseWriter,
-                      final TypedStreamWriter streamWriter,
-                      final Consumer<SideEffectProducer> sideEffect) {}
+                  public void processRecord(final TypedRecord<UnifiedRecordValue> record) {}
                 }));
 
     streamProcessorRule.writeCommand(ACTIVATE_ELEMENT, PROCESS_INSTANCE_RECORD);
@@ -282,12 +273,7 @@ public final class StreamProcessorReprocessingTest {
                 ACTIVATE_ELEMENT,
                 new TypedRecordProcessor<>() {
                   @Override
-                  public void processRecord(
-                      final long position,
-                      final TypedRecord<UnifiedRecordValue> record,
-                      final TypedResponseWriter responseWriter,
-                      final TypedStreamWriter streamWriter,
-                      final Consumer<SideEffectProducer> sideEffect) {}
+                  public void processRecord(final TypedRecord<UnifiedRecordValue> record) {}
                 }));
 
     final long position =
@@ -396,12 +382,7 @@ public final class StreamProcessorReprocessingTest {
                 ACTIVATE_ELEMENT,
                 new TypedRecordProcessor<>() {
                   @Override
-                  public void processRecord(
-                      final long position,
-                      final TypedRecord<UnifiedRecordValue> record,
-                      final TypedResponseWriter responseWriter,
-                      final TypedStreamWriter streamWriter,
-                      final Consumer<SideEffectProducer> sideEffect) {}
+                  public void processRecord(final TypedRecord<UnifiedRecordValue> record) {}
                 }));
 
     streamProcessorRule.writeCommand(ACTIVATE_ELEMENT, PROCESS_INSTANCE_RECORD);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
@@ -271,11 +271,9 @@ public final class StreamProcessorTest {
                     new TypedRecordProcessor<>() {
                       @Override
                       public void processRecord(
-                          final long position,
                           final TypedRecord<UnifiedRecordValue> record,
                           final TypedResponseWriter responseWriter,
-                          final TypedStreamWriter streamWriter,
-                          final Consumer<SideEffectProducer> sideEffect) {
+                          final TypedStreamWriter streamWriter) {
 
                         streamWriter.appendFollowUpEvent(
                             record.getKey(),
@@ -311,7 +309,6 @@ public final class StreamProcessorTest {
                 new TypedRecordProcessor<>() {
                   @Override
                   public void processRecord(
-                      final long position,
                       final TypedRecord<UnifiedRecordValue> record,
                       final TypedResponseWriter responseWriter,
                       final TypedStreamWriter streamWriter,
@@ -345,7 +342,6 @@ public final class StreamProcessorTest {
                 new TypedRecordProcessor<>() {
                   @Override
                   public void processRecord(
-                      final long position,
                       final TypedRecord<UnifiedRecordValue> record,
                       final TypedResponseWriter responseWriter,
                       final TypedStreamWriter streamWriter,
@@ -378,7 +374,6 @@ public final class StreamProcessorTest {
                 new TypedRecordProcessor<>() {
                   @Override
                   public void processRecord(
-                      final long position,
                       final TypedRecord<UnifiedRecordValue> record,
                       final TypedResponseWriter responseWriter,
                       final TypedStreamWriter streamWriter,
@@ -416,12 +411,7 @@ public final class StreamProcessorTest {
               ProcessInstanceIntent.ACTIVATE_ELEMENT,
               new TypedRecordProcessor<>() {
                 @Override
-                public void processRecord(
-                    final long position,
-                    final TypedRecord<UnifiedRecordValue> record,
-                    final TypedResponseWriter responseWriter,
-                    final TypedStreamWriter streamWriter,
-                    final Consumer<SideEffectProducer> sideEffect) {
+                public void processRecord(final TypedRecord<UnifiedRecordValue> record) {
 
                   state.getJobState().create(jobKey, JOB_RECORD);
 
@@ -465,12 +455,7 @@ public final class StreamProcessorTest {
               ProcessInstanceIntent.ACTIVATE_ELEMENT,
               new TypedRecordProcessor<>() {
                 @Override
-                public void processRecord(
-                    final long position,
-                    final TypedRecord<UnifiedRecordValue> record,
-                    final TypedResponseWriter responseWriter,
-                    final TypedStreamWriter streamWriter,
-                    final Consumer<SideEffectProducer> sideEffect) {
+                public void processRecord(final TypedRecord<UnifiedRecordValue> record) {
 
                   state.getJobState().create(jobKey, JOB_RECORD);
                 }
@@ -506,11 +491,9 @@ public final class StreamProcessorTest {
                 new TypedRecordProcessor<>() {
                   @Override
                   public void processRecord(
-                      final long position,
                       final TypedRecord<UnifiedRecordValue> record,
                       final TypedResponseWriter responseWriter,
-                      final TypedStreamWriter streamWriter,
-                      final Consumer<SideEffectProducer> sideEffect) {
+                      final TypedStreamWriter streamWriter) {
 
                     responseWriter.writeEventOnCommand(
                         3, ProcessInstanceIntent.ELEMENT_ACTIVATING, record.getValue(), record);
@@ -547,11 +530,9 @@ public final class StreamProcessorTest {
                 new TypedRecordProcessor<>() {
                   @Override
                   public void processRecord(
-                      final long position,
                       final TypedRecord<UnifiedRecordValue> record,
                       final TypedResponseWriter responseWriter,
-                      final TypedStreamWriter streamWriter,
-                      final Consumer<SideEffectProducer> sideEffect) {
+                      final TypedStreamWriter streamWriter) {
 
                     responseWriter.writeEventOnCommand(
                         3, ProcessInstanceIntent.ELEMENT_ACTIVATING, record.getValue(), record);
@@ -705,11 +686,9 @@ public final class StreamProcessorTest {
                     new TypedRecordProcessor<>() {
                       @Override
                       public void processRecord(
-                          final long position,
                           final TypedRecord<UnifiedRecordValue> record,
                           final TypedResponseWriter responseWriter,
-                          final TypedStreamWriter streamWriter,
-                          final Consumer<SideEffectProducer> sideEffect) {
+                          final TypedStreamWriter streamWriter) {
 
                         streamWriter.appendFollowUpEvent(
                             record.getKey(),


### PR DESCRIPTION
## Description

The overall trajectory of these PRs is as follows:
- Use new interfaces and implement them with classes that use mostly legacy code
- Switch engine and platform to use more and more of the new interfaces and less and less of direct legacy code
- Refine interfaces according to what is needed
- Once the existing code is using mostly the new interfaces, we can implement the new interfaces with new code (e.g. code that uses buffers instead of writing directly to a stream)

This process has many baby steps, but should be good to follow.

In this PR `ProcessingResult` and `ProcessingResultBuilder` are implemented based on legacy code, and it is in the process of using these interfaces more and more in `ProcessingStateMachine`. The cut for part 1 was everything I did today which didn't break the tests.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to #9725

<!-- Cut-off marker
## Definition of Ready

* [ ] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
