### PR TITLE
`TypedStreamWriter` that writes to buffer

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResultBuilder.java
@@ -24,6 +24,7 @@ public interface ProcessingResultBuilder {
    */
   ProcessingResultBuilder appendRecord(
       final long key,
+      int sourceIndex,
       final RecordType type,
       final Intent intent,
       final RejectionType rejectionType,

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResultBuilder.java
@@ -24,7 +24,6 @@ public interface ProcessingResultBuilder {
    */
   ProcessingResultBuilder appendRecord(
       final long key,
-      int sourceIndex,
       final RecordType type,
       final Intent intent,
       final RejectionType rejectionType,

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedProcessingResultBuilder.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.UnaryOperator;
+import java.util.function.BinaryOperator;
 
 /** Implementation of {@code ProcessingResultBuilder} that writes all data into a buffer */
 final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
@@ -34,7 +34,7 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
   private final int sourceIndex;
 
   BufferedProcessingResultBuilder(
-      final UnaryOperator<Integer> capacityCalculator, final int sourceIndex) {
+      final BinaryOperator<Integer> capacityCalculator, final int sourceIndex) {
     bufferedStreamWriter = new BufferedStreamWriter(capacityCalculator);
     this.sourceIndex = sourceIndex;
 

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedProcessingResultBuilder.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.streamprocessor;
+
+import io.camunda.zeebe.engine.api.ProcessingResult;
+import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Implementation of {@code ProcessingResultBuilder} that writes all data into a buffer */
+final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
+
+  private final BufferedStreamWriter bufferedStreamWriter;
+  private final List<Runnable> postCommitTasks = new ArrayList<>();
+
+  BufferedProcessingResultBuilder(final int maxFragmentSize) {
+    bufferedStreamWriter = new BufferedStreamWriter(maxFragmentSize);
+  }
+
+  @Override
+  public ProcessingResultBuilder appendRecord(
+      final long key,
+      final int sourceIndex,
+      final RecordType type,
+      final Intent intent,
+      final RejectionType rejectionType,
+      final String rejectionReason,
+      final RecordValue value) {
+    bufferedStreamWriter.appendRecord(
+        key, sourceIndex, type, intent, rejectionType, rejectionReason, value);
+    return this;
+  }
+
+  @Override
+  public ProcessingResultBuilder withResponse(
+      final long eventKey,
+      final Intent eventState,
+      final UnpackedObject eventValue,
+      final ValueType valueType,
+      final long requestId,
+      final int requestStreamId) {
+    throw new RuntimeException("Not yet implemented");
+  }
+
+  @Override
+  public ProcessingResultBuilder appendPostCommitTask(final Runnable r) {
+    postCommitTasks.add(r);
+    return this;
+  }
+
+  @Override
+  public ProcessingResultBuilder reset() {
+    bufferedStreamWriter.reset();
+    postCommitTasks.clear();
+    return this;
+  }
+
+  @Override
+  public ProcessingResult build() {
+    throw new RuntimeException("Not yet implemented");
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedProcessingResultBuilder.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.streamprocessor;
 
+import static io.camunda.zeebe.engine.processing.streamprocessor.TypedEventRegistry.EVENT_REGISTRY;
+
 import io.camunda.zeebe.engine.api.ProcessingResult;
 import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
 import io.camunda.zeebe.msgpack.UnpackedObject;
@@ -16,16 +18,23 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /** Implementation of {@code ProcessingResultBuilder} that writes all data into a buffer */
 final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
+
+  private final Map<Class<? extends UnpackedObject>, ValueType> typeRegistry;
 
   private final BufferedStreamWriter bufferedStreamWriter;
   private final List<Runnable> postCommitTasks = new ArrayList<>();
 
   BufferedProcessingResultBuilder(final int maxFragmentSize) {
     bufferedStreamWriter = new BufferedStreamWriter(maxFragmentSize);
+
+    typeRegistry = new HashMap<>();
+    EVENT_REGISTRY.forEach((e, c) -> typeRegistry.put(c, e));
   }
 
   @Override
@@ -37,8 +46,15 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
       final RejectionType rejectionType,
       final String rejectionReason,
       final RecordValue value) {
+
+    final ValueType valueType = typeRegistry.get(value.getClass());
+    if (valueType == null) {
+      // usually happens when the record is not registered at the TypedStreamEnvironment
+      throw new RuntimeException("Missing value type mapping for record: " + value.getClass());
+    }
+
     bufferedStreamWriter.appendRecord(
-        key, sourceIndex, type, intent, rejectionType, rejectionReason, value);
+        key, sourceIndex, type, intent, rejectionType, rejectionReason, valueType, value);
     return this;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedProcessingResultBuilder.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.streamprocessor;
 
 import static io.camunda.zeebe.engine.processing.streamprocessor.TypedEventRegistry.EVENT_REGISTRY;
 
+import io.camunda.zeebe.engine.api.PostCommitTask;
 import io.camunda.zeebe.engine.api.ProcessingResult;
 import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
 import io.camunda.zeebe.msgpack.UnpackedObject;
@@ -30,7 +31,7 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
   private final Map<Class<? extends UnpackedObject>, ValueType> typeRegistry;
 
   private final BufferedStreamWriter bufferedStreamWriter;
-  private final List<Runnable> postCommitTasks = new ArrayList<>();
+  private final List<PostCommitTask> postCommitTasks = new ArrayList<>();
   private final int sourceIndex;
 
   BufferedProcessingResultBuilder(
@@ -71,7 +72,7 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
   }
 
   @Override
-  public ProcessingResultBuilder appendPostCommitTask(final Runnable r) {
+  public ProcessingResultBuilder appendPostCommitTask(final PostCommitTask r) {
     postCommitTasks.add(r);
     return this;
   }
@@ -79,6 +80,12 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
   @Override
   public ProcessingResultBuilder reset() {
     bufferedStreamWriter.reset();
+    postCommitTasks.clear();
+    return this;
+  }
+
+  @Override
+  public ProcessingResultBuilder resetPostCommitTasks() {
     postCommitTasks.clear();
     return this;
   }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedProcessingResultBuilder.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 
 /** Implementation of {@code ProcessingResultBuilder} that writes all data into a buffer */
 final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
@@ -32,8 +33,9 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
   private final List<Runnable> postCommitTasks = new ArrayList<>();
   private final int sourceIndex;
 
-  BufferedProcessingResultBuilder(final int maxFragmentSize, final int sourceIndex) {
-    bufferedStreamWriter = new BufferedStreamWriter(maxFragmentSize);
+  BufferedProcessingResultBuilder(
+      final UnaryOperator<Integer> capacityCalculator, final int sourceIndex) {
+    bufferedStreamWriter = new BufferedStreamWriter(capacityCalculator);
     this.sourceIndex = sourceIndex;
 
     typeRegistry = new HashMap<>();

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedProcessingResultBuilder.java
@@ -26,8 +26,6 @@ import java.util.Map;
 /** Implementation of {@code ProcessingResultBuilder} that writes all data into a buffer */
 final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
 
-  private final Map<Class<?>, Boolean> SUITABLE_TYPES = new HashMap<>();
-
   private final Map<Class<? extends UnpackedObject>, ValueType> typeRegistry;
 
   private final BufferedStreamWriter bufferedStreamWriter;
@@ -97,11 +95,8 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
   }
 
   private BufferWriter initValueWriter(final RecordValue value) {
-    final var suitableType =
-        SUITABLE_TYPES.computeIfAbsent(value.getClass(), BufferWriter.class::isAssignableFrom);
-
     // validation
-    if (!suitableType) {
+    if (!(value instanceof BufferWriter)) {
       throw new RuntimeException(String.format("The record value %s is not a BufferWriter", value));
     }
 

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedProcessingResultBuilder.java
@@ -30,9 +30,11 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
 
   private final BufferedStreamWriter bufferedStreamWriter;
   private final List<Runnable> postCommitTasks = new ArrayList<>();
+  private final int sourceIndex;
 
-  BufferedProcessingResultBuilder(final int maxFragmentSize) {
+  BufferedProcessingResultBuilder(final int maxFragmentSize, final int sourceIndex) {
     bufferedStreamWriter = new BufferedStreamWriter(maxFragmentSize);
+    this.sourceIndex = sourceIndex;
 
     typeRegistry = new HashMap<>();
     EVENT_REGISTRY.forEach((e, c) -> typeRegistry.put(c, e));
@@ -41,7 +43,6 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
   @Override
   public ProcessingResultBuilder appendRecord(
       final long key,
-      final int sourceIndex,
       final RecordType type,
       final Intent intent,
       final RejectionType rejectionType,

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedProcessingResultBuilder.java
@@ -90,15 +90,19 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
     final ValueType valueType = typeRegistry.get(value.getClass());
     if (valueType == null) {
       // usually happens when the record is not registered at the TypedStreamEnvironment
-      throw new RuntimeException("Missing value type mapping for record: " + value.getClass());
+      throw new IllegalArgumentException(
+          "Missing value type mapping for record: " + value.getClass());
     }
     return valueType;
   }
 
   private BufferWriter initValueWriter(final RecordValue value) {
+    // TODO evaluate whether the interface should be changed to UnifiedRecordValue or <T extends
+    // RecordValue & BufferWriter> BufferWriter initValueWriter(final T value) {}
     // validation
     if (!(value instanceof BufferWriter)) {
-      throw new RuntimeException(String.format("The record value %s is not a BufferWriter", value));
+      throw new IllegalArgumentException(
+          String.format("The record value %s is not a BufferWriter", value));
     }
 
     return (BufferWriter) value;

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedStreamWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedStreamWriter.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.streamprocessor;
+
+import static io.camunda.zeebe.engine.processing.streamprocessor.TypedEventRegistry.EVENT_REGISTRY;
+import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.HEADER_BLOCK_LENGTH;
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+
+import io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.HashMap;
+import java.util.Map;
+import org.agrona.ExpandableDirectByteBuffer;
+import org.agrona.MutableDirectBuffer;
+
+/** Stream writer that writes into a byte buffer instead of writing directly to the stream */
+final class BufferedStreamWriter {
+
+  private static final Map<Class, Boolean> SUITABLE_TYPES = new HashMap<>();
+  private static final int INITIAL_BUFFER_CAPACITY = 1024 * 32;
+  private final Map<Class<? extends UnpackedObject>, ValueType> typeRegistry;
+  // todo we can allocate one buffer with max message size here and then it would simplify this -
+  // and limit checking
+  private final MutableDirectBuffer eventBuffer =
+      new ExpandableDirectByteBuffer(INITIAL_BUFFER_CAPACITY);
+
+  private final RecordMetadata metadata = new RecordMetadata();
+
+  private final int maxFragmentSize;
+
+  private int eventBufferOffset;
+  private int eventLength;
+  private int eventCount;
+
+  protected BufferedStreamWriter(final int maxFragmentSize) {
+    reset();
+
+    this.maxFragmentSize = maxFragmentSize;
+    typeRegistry = new HashMap<>();
+    EVENT_REGISTRY.forEach((e, c) -> typeRegistry.put(c, e));
+  }
+
+  protected MutableDirectBuffer getEventBuffer() {
+    return eventBuffer;
+  }
+
+  protected int getEventLength() {
+    return eventLength;
+  }
+
+  protected int getEventCount() {
+    return eventCount;
+  }
+
+  protected void appendRecord(
+      final long key,
+      final int sourceIndex,
+      final RecordType type,
+      final Intent intent,
+      final RejectionType rejectionType,
+      final String rejectionReason,
+      final RecordValue value) {
+
+    // copy record to buffer
+    writeKey(key);
+    writeSourceIndex(sourceIndex);
+
+    initMetadata(type, intent, rejectionType, rejectionReason, value);
+    final var metadataLength = metadata.getLength();
+    writeMetadataLength(metadataLength);
+
+    final BufferWriter valueWriter = initValueWriter(value);
+    final var valueLength = valueWriter.getLength();
+    writeValueLength(valueLength);
+
+    writeMetadata(metadataLength);
+    writeValue(valueWriter, valueLength);
+
+    eventLength += metadataLength + valueLength;
+    eventCount += 1;
+  }
+
+  protected boolean canWriteAdditionalEvent(final int length) {
+    final var count = eventCount + 1;
+    final var batchLength = eventLength + length + (count * HEADER_BLOCK_LENGTH);
+    return batchLength < maxFragmentSize;
+  }
+
+  private void writeKey(long key) {
+    if (key < 0) {
+      key = LogEntryDescriptor.KEY_NULL_VALUE;
+    }
+    eventBuffer.putLong(eventBufferOffset, key, Protocol.ENDIANNESS);
+    eventBufferOffset += SIZE_OF_LONG;
+  }
+
+  private void writeSourceIndex(final int sourceIndex) {
+    eventBuffer.putInt(eventBufferOffset, sourceIndex, Protocol.ENDIANNESS);
+    eventBufferOffset += SIZE_OF_INT;
+  }
+
+  private void initMetadata(
+      final RecordType type,
+      final Intent intent,
+      final RejectionType rejectionType,
+      final String rejectionReason,
+      final RecordValue value) {
+    metadata.reset();
+    final ValueType valueType = typeRegistry.get(value.getClass());
+    if (valueType == null) {
+      // usually happens when the record is not registered at the TypedStreamEnvironment
+      throw new RuntimeException("Missing value type mapping for record: " + value.getClass());
+    }
+
+    metadata
+        .recordType(type)
+        .valueType(valueType)
+        .intent(intent)
+        .rejectionType(rejectionType)
+        .rejectionReason(rejectionReason);
+  }
+
+  private void writeMetadataLength(final int metadataLength) {
+    eventBuffer.putInt(eventBufferOffset, metadataLength, Protocol.ENDIANNESS);
+    eventBufferOffset += SIZE_OF_INT;
+  }
+
+  private BufferWriter initValueWriter(final RecordValue value) {
+    final var suitableType =
+        SUITABLE_TYPES.computeIfAbsent(value.getClass(), BufferWriter.class::isAssignableFrom);
+
+    // validation
+    if (!suitableType) {
+      throw new RuntimeException(String.format("The record value %s is not a BufferWriter", value));
+    }
+
+    final var valueWriter = (BufferWriter) value;
+    return valueWriter;
+  }
+
+  private void writeValueLength(final int valueLength) {
+    eventBuffer.putInt(eventBufferOffset, valueLength, Protocol.ENDIANNESS);
+    eventBufferOffset += SIZE_OF_INT;
+  }
+
+  private void writeMetadata(final int metadataLength) {
+    if (metadataLength > 0) {
+      metadata.write(eventBuffer, eventBufferOffset);
+      eventBufferOffset += metadataLength;
+    }
+  }
+
+  private void writeValue(final BufferWriter valueWriter, final int valueLength) {
+    valueWriter.write(eventBuffer, eventBufferOffset);
+    eventBufferOffset += valueLength;
+  }
+
+  protected void reset() {
+    eventBufferOffset = 0;
+    eventLength = 0;
+    eventCount = 0;
+    metadata.reset();
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedStreamWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/BufferedStreamWriter.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.util.buffer.BufferWriter;
-import java.util.function.UnaryOperator;
+import java.util.function.BinaryOperator;
 import org.agrona.ExpandableDirectByteBuffer;
 import org.agrona.MutableDirectBuffer;
 
@@ -36,13 +36,9 @@ final class BufferedStreamWriter {
 
   private int recordBufferOffset;
   private int recordCount;
-  private final UnaryOperator<Integer> capacityCalculator;
+  private final BinaryOperator<Integer> capacityCalculator;
 
-  /**
-   * @param capacityCalculator function that takes current buffer size as input and returns free
-   *     capacity
-   */
-  BufferedStreamWriter(final UnaryOperator<Integer> capacityCalculator) {
+  BufferedStreamWriter(final BinaryOperator<Integer> capacityCalculator) {
     reset();
 
     this.capacityCalculator = capacityCalculator;
@@ -88,7 +84,7 @@ final class BufferedStreamWriter {
   }
 
   boolean canWriteAdditionalEvent(final int length) {
-    return length < capacityCalculator.apply(recordBufferOffset);
+    return length < capacityCalculator.apply(recordCount, recordBufferOffset);
   }
 
   private void writeKey(long key) {


### PR DESCRIPTION
## Description

- Implements `TypedStreamWriter` that writes to buffer
- Implements processing result builder to use the buffered stream writer
- does not add tests. I started it, but it would take too much time. Hope I can revisit it after my holidays. For now there is just a follow up issue: https://github.com/camunda/zeebe/issues/9838

## Related issues

closes #9780 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
