### PR TITLE
fix: build event appliers on engine init

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
@@ -141,7 +141,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     actorName = buildActorName(processorBuilder.getNodeId(), "StreamProcessor", partitionId);
     metrics = new StreamProcessorMetrics(partitionId);
 
-    engine = new Engine(partitionId, zeebeDb, processorBuilder.getEventApplierFactory());
+    engine = new Engine();
   }
 
   public static StreamProcessorBuilder builder() {


### PR DESCRIPTION
The event appliers can only be built when `init` is called. The constructor is called before snapshot recovery finishes so we must not construct the state and event appliers at that time.

I've tried to keep changes minimal since a lot of this is getting refactored anyway.

@pihme This is a bit different to what we discussed since I missed that `ReplayStateMachine` *does* get constructed if and only if snapshot recovery finished (constructor is called only after `recoverFromSnapshot` was called: [code](https://github.com/camunda/zeebe/blob/9abee8fe97b2c89c90ebcba803bb2d09c9bc3079/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java#L179-L186)) . It still fixes the issue that the event appliers get built too early/on pre-recovery state.
