### PR TITLE
build(engine): explicitly depend on junit test engines

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -128,6 +128,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
@@ -136,6 +142,12 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Fixes an issue where IntelliJ was not able to discover/run tests apart from the architecture test in the engine module
