### PR TITLE
Shape legacy code into new interfaces good bits part 2

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -106,7 +106,7 @@ public class Engine implements RecordProcessor {
           responseWriter,
           streamWriter,
           (sep) -> {
-            // TODO clear post commit tasks
+            processingResultBuilder.resetPostCommitTasks();
             processingResultBuilder.appendPostCommitTask(sep::flush);
           });
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -20,9 +20,13 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorCo
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.logstreams.impl.Loggers;
+import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import org.slf4j.Logger;
 
 public class Engine implements RecordProcessor {
@@ -30,11 +34,17 @@ public class Engine implements RecordProcessor {
   private static final Logger LOG = Loggers.PROCESSOR_LOGGER;
   private static final String ERROR_MESSAGE_ON_EVENT_FAILED_SKIP_EVENT =
       "Expected to find processor for record '{}', but caught an exception. Skip this record.";
+  private static final String PROCESSING_ERROR_MESSAGE =
+      "Expected to process record '%s' without errors, but exception occurred with message '%s'.";
   private EventApplier eventApplier;
   private RecordProcessorMap recordProcessorMap;
   private MutableZeebeState zeebeState;
   private TypedStreamWriter streamWriter;
   private TypedResponseWriter responseWriter;
+
+  private final ErrorRecord errorRecord = new ErrorRecord();
+
+  private Writers writers;
 
   public Engine() {}
 
@@ -64,8 +74,8 @@ public class Engine implements RecordProcessor {
     recordProcessorContext.setLifecycleListeners(typedRecordProcessors.getLifecycleListeners());
     recordProcessorMap = typedRecordProcessors.getRecordProcessorMap();
 
-    recordProcessorContext.setWriters(typedProcessorContext.getWriters());
-
+    writers = typedProcessorContext.getWriters();
+    recordProcessorContext.setWriters(writers);
     zeebeState = typedProcessorContext.getZeebeState();
     eventApplier = recordProcessorContext.getEventApplierFactory().apply(zeebeState);
   }
@@ -119,6 +129,20 @@ public class Engine implements RecordProcessor {
       final Throwable processingException,
       final TypedRecord record,
       final ErrorHandlingContext errorHandlingContext) {
-    throw new IllegalStateException("Not yet implemented");
+
+    final String errorMessage =
+        String.format(PROCESSING_ERROR_MESSAGE, record, processingException.getMessage());
+    LOG.error(errorMessage, processingException);
+
+    final var processingResultBuilder = errorHandlingContext.getProcessingResultBuilder();
+
+    writers.rejection().appendRejection(record, RejectionType.PROCESSING_ERROR, errorMessage);
+    writers
+        .response()
+        .writeRejectionOnCommand(record, RejectionType.PROCESSING_ERROR, errorMessage);
+    errorRecord.initErrorRecord(processingException, record.getPosition());
+
+    writers.state().appendFollowUpEvent(record.getKey(), ErrorIntent.CREATED, errorRecord);
+    return processingResultBuilder.build();
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -64,7 +64,6 @@ public class Engine implements RecordProcessor {
     recordProcessorContext.setLifecycleListeners(typedRecordProcessors.getLifecycleListeners());
     recordProcessorMap = typedRecordProcessors.getRecordProcessorMap();
 
-    recordProcessorContext.setRecordProcessorMap(recordProcessorMap);
     recordProcessorContext.setWriters(typedProcessorContext.getWriters());
 
     zeebeState = typedProcessorContext.getZeebeState();
@@ -106,7 +105,10 @@ public class Engine implements RecordProcessor {
           record,
           responseWriter,
           streamWriter,
-          (sep) -> processingResultBuilder.appendPostCommitTask(sep::flush));
+          (sep) -> {
+            // TODO clear post commit tasks
+            processingResultBuilder.appendPostCommitTask(sep::flush);
+          });
     }
 
     return processingResultBuilder.build();

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/EmptyProcessingResult.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/EmptyProcessingResult.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.api;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
+import io.camunda.zeebe.logstreams.log.LogStreamBatchWriter;
+
+public final class EmptyProcessingResult implements ProcessingResult {
+
+  public static final ProcessingResult INSTANCE = new EmptyProcessingResult();
+
+  private EmptyProcessingResult() {}
+
+  @Override
+  public long writeRecordsToStream(final LogStreamBatchWriter logStreamBatchWriter) {
+    return 0;
+  }
+
+  @Override
+  public boolean writeResponse(final CommandResponseWriter commandResponseWriter) {
+    return true;
+  }
+
+  @Override
+  public boolean executePostCommitTasks() {
+    return true;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResultBuilder.java
@@ -59,5 +59,12 @@ public interface ProcessingResultBuilder {
    */
   ProcessingResultBuilder reset();
 
+  /**
+   * Resets itself with the post commit tasks reset
+   *
+   * @return itself for method chaining
+   */
+  ProcessingResultBuilder resetPostCommitTasks();
+
   ProcessingResult build();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessorContext.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.api;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
-import io.camunda.zeebe.engine.processing.streamprocessor.RecordProcessorMap;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorListener;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -42,9 +41,6 @@ public interface RecordProcessorContext {
 
   @Deprecated // will most likely be moved into engine
   void setLifecycleListeners(List<StreamProcessorLifecycleAware> lifecycleListeners);
-
-  @Deprecated // will be moved into engine
-  void setRecordProcessorMap(RecordProcessorMap recordProcessorMap);
 
   void setStreamProcessorListener(StreamProcessorListener streamProcessorListener);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessResultSenderBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessResultSenderBehavior.java
@@ -74,8 +74,6 @@ public final class BpmnProcessResultSenderBehavior {
         ValueType.PROCESS_INSTANCE_RESULT,
         requestMetadata.getRequestId(),
         requestMetadata.getRequestStreamId());
-
-    responseWriter.flush();
   }
 
   private DirectBuffer collectVariables(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -92,8 +92,6 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
       final TypedStreamWriter streamWriter,
       final Consumer<SideEffectProducer> sideEffect) {
 
-    // need to add multiple side-effects for sending a response and scheduling timers
-    sideEffects.add(responseWriter);
     sideEffect.accept(sideEffects);
 
     final DeploymentRecord deploymentEvent = command.getValue();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
@@ -111,7 +111,6 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
         .ifRightOrLeft(
             failedCommand -> {
               sideEffects.clear();
-              sideEffects.add(responseWriter::flush);
 
               bpmnStreamProcessor.processRecord(
                   failedCommand, noopResponseWriter, streamWriter, sideEffects::add);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
@@ -81,7 +81,7 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
     responseWriter.writeEventOnCommand(key, IncidentIntent.RESOLVED, incident, command);
 
     // if it fails, a new incident is raised
-    attemptToContinueProcessProcessing(command, responseWriter, streamWriter, sideEffect, incident);
+    attemptToContinueProcessProcessing(command, streamWriter, sideEffect, incident);
   }
 
   private void rejectResolveCommand(
@@ -96,7 +96,6 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
 
   private void attemptToContinueProcessProcessing(
       final TypedRecord<IncidentRecord> command,
-      final TypedResponseWriter responseWriter,
       final TypedStreamWriter streamWriter,
       final Consumer<SideEffectProducer> sideEffect,
       final IncidentRecord incident) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
@@ -77,7 +77,6 @@ public final class CommandProcessorImpl<T extends UnifiedRecordValue>
 
     sideEffect.accept(sideEffectQueue);
     sideEffectQueue.clear();
-    sideEffectQueue.add(responseWriter::flush);
 
     final boolean shouldRespond = wrappedProcessor.onCommand(command, this, sideEffectQueue::add);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBlackListState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBlackListState.java
@@ -93,7 +93,7 @@ public final class DbBlackListState implements MutableBlackListState {
     blacklist(processInstanceKey);
   }
 
-  private boolean shouldBeBlacklisted(final Intent intent) {
+  public static boolean shouldBeBlacklisted(final Intent intent) {
 
     if (intent instanceof ProcessInstanceRelatedIntent) {
       final ProcessInstanceRelatedIntent processInstanceRelatedIntent =

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResult.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResult.java
@@ -28,7 +28,7 @@ final class DirectProcessingResult implements ProcessingResult {
 
   private final TypedStreamWriter streamWriter;
   private final TypedResponseWriter responseWriter;
-  private final boolean hasResponse;
+  private boolean hasResponse;
 
   DirectProcessingResult(
       final StreamProcessorContext context,
@@ -51,6 +51,7 @@ final class DirectProcessingResult implements ProcessingResult {
     // here we must assume that response writer is backed up by command response writer internally
 
     if (hasResponse) {
+      hasResponse = false;
       return responseWriter.flush();
     } else {
       return true;

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResultBuilder.java
@@ -84,6 +84,12 @@ final class DirectProcessingResultBuilder implements ProcessingResultBuilder {
   }
 
   @Override
+  public ProcessingResultBuilder resetPostCommitTasks() {
+    postCommitTasks.clear();
+    return this;
+  }
+
+  @Override
   public ProcessingResult build() {
     return new DirectProcessingResult(context, postCommitTasks, hasResponse);
   }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResultBuilder.java
@@ -35,7 +35,8 @@ final class DirectProcessingResultBuilder implements ProcessingResultBuilder {
   private final TypedStreamWriter streamWriter;
   private final TypedResponseWriter responseWriter;
 
-  private boolean hasResponse = false;
+  private boolean hasResponse =
+      true; // TODO set to false after the process builder class is used by the engine
 
   DirectProcessingResultBuilder(final StreamProcessorContext context) {
     this.context = context;

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ErrorHandlingContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ErrorHandlingContextImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.streamprocessor;
+
+import io.camunda.zeebe.engine.api.ErrorHandlingContext;
+import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
+
+final class ErrorHandlingContextImpl implements ErrorHandlingContext {
+
+  private final ProcessingResultBuilder processingResultBuilder;
+
+  ErrorHandlingContextImpl(final ProcessingResultBuilder processingResultBuilder) {
+    this.processingResultBuilder = processingResultBuilder;
+  }
+
+  @Override
+  public ProcessingResultBuilder getProcessingResultBuilder() {
+    return processingResultBuilder;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingContextImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.streamprocessor;
+
+import io.camunda.zeebe.engine.api.ProcessingContext;
+import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
+
+final class ProcessingContextImpl implements ProcessingContext {
+
+  private final ProcessingResultBuilder processingResultBuilder;
+
+  ProcessingContextImpl(final ProcessingResultBuilder processingResultBuilder) {
+    this.processingResultBuilder = processingResultBuilder;
+  }
+
+  @Override
+  public ProcessingResultBuilder getProcessingResultBuilder() {
+    return processingResultBuilder;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -46,7 +46,6 @@ import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.prometheus.client.Histogram;
 import java.time.Duration;
 import java.util.function.BooleanSupplier;
-import org.agrona.collections.MutableReference;
 import org.slf4j.Logger;
 
 /**

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/RecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/RecordProcessorContextImpl.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.api.RecordProcessorContext;
 import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
-import io.camunda.zeebe.engine.processing.streamprocessor.RecordProcessorMap;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorListener;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -35,7 +34,6 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   private final Function<MutableZeebeState, EventApplier> eventApplierFactory;
   private final TypedRecordProcessorFactory typedRecordProcessorFactory;
   private List<StreamProcessorLifecycleAware> lifecycleListeners = Collections.EMPTY_LIST;
-  private RecordProcessorMap recordProcessorMap;
   private StreamProcessorListener streamProcessorListener;
   private Writers writers;
 
@@ -106,16 +104,6 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   @Override
   public void setLifecycleListeners(final List<StreamProcessorLifecycleAware> lifecycleListeners) {
     this.lifecycleListeners = lifecycleListeners;
-  }
-
-  @Deprecated // will be moved to engine
-  public RecordProcessorMap getRecordProcessorMap() {
-    return recordProcessorMap;
-  }
-
-  @Override
-  public void setRecordProcessorMap(final RecordProcessorMap recordProcessorMap) {
-    this.recordProcessorMap = recordProcessorMap;
   }
 
   public StreamProcessorListener getStreamProcessorListener() {

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
@@ -344,7 +344,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     engine.init(recordProcessorContext);
 
     lifecycleAwareListeners.addAll(recordProcessorContext.getLifecycleListeners());
-    streamProcessorContext.recordProcessorMap(recordProcessorContext.getRecordProcessorMap());
     final var listener = recordProcessorContext.getStreamProcessorListener();
     if (listener != null) {
       streamProcessorContext.listener(recordProcessorContext.getStreamProcessorListener());

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
@@ -295,7 +295,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
       streamProcessorContext.enableLogStreamWriter();
 
       processingStateMachine =
-          new ProcessingStateMachine(streamProcessorContext, this::shouldProcessNext);
+          new ProcessingStateMachine(streamProcessorContext, this::shouldProcessNext, engine);
 
       logStream.registerRecordAvailableListener(this);
 

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
@@ -57,6 +57,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private MutableLastProcessedPositionState lastProcessedPositionState;
   private Writers writers;
   private LogStreamBatchWriter logStreamBatchWriter;
+  private CommandResponseWriter commandResponseWriter;
 
   public StreamProcessorContext() {
     streamWriterProxy.wrap(logStreamWriter);
@@ -150,6 +151,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   public StreamProcessorContext commandResponseWriter(
       final CommandResponseWriter commandResponseWriter) {
+    this.commandResponseWriter = commandResponseWriter;
     typedResponseWriter =
         new TypedResponseWriterImpl(commandResponseWriter, getLogStream().getPartitionId());
     return this;
@@ -224,5 +226,9 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   public LogStreamBatchWriter getLogStreamBatchWriter() {
     return logStreamBatchWriter;
+  }
+
+  public CommandResponseWriter getCommandResponseWriter() {
+    return commandResponseWriter;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.TypedStreamWriterProxy;
-import io.camunda.zeebe.engine.processing.streamprocessor.RecordProcessorMap;
 import io.camunda.zeebe.engine.processing.streamprocessor.RecordValues;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorListener;
 import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorMode;
@@ -45,7 +44,6 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private TypedResponseWriterImpl typedResponseWriter;
 
   private RecordValues recordValues;
-  private RecordProcessorMap recordProcessorMap;
   private ZeebeDbState zeebeState;
   private TransactionContext transactionContext;
   private EventApplier eventApplier;
@@ -124,11 +122,6 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
     return this;
   }
 
-  public StreamProcessorContext recordProcessorMap(final RecordProcessorMap recordProcessorMap) {
-    this.recordProcessorMap = recordProcessorMap;
-    return this;
-  }
-
   public StreamProcessorContext zeebeState(final ZeebeDbState zeebeState) {
     this.zeebeState = zeebeState;
     return this;
@@ -195,10 +188,6 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   public RecordValues getRecordValues() {
     return recordValues;
-  }
-
-  public RecordProcessorMap getRecordProcessorMap() {
-    return recordProcessorMap;
   }
 
   public TransactionContext getTransactionContext() {


### PR DESCRIPTION
## Description

- Move logic to select processor into engine
- Move processing logic into engine
- Use `ProcessingResult` to return response and execute side effects
- Move error handling logic into engine
- Fix tests

## Review Hints
- most of the commits have some failing tests
- this was unavoidable, because substeps in the modification were invalid/incomplete
- In the end, all tests are now passing again. This was quite satisfying acutally - adding more changes and seeing the test failure count go down again
- Overall I would say we are through the valley of pain. Was quite volatile recently, but I am confident we can bring some calmness back to development
- This achieves that most of the engine abstraction classes are in play; and the division of labor is largely as intended. 
- Still lots of stuff to do on either side, though

## Related issues

related to #9725

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
