### PR TITLE
chore(ci): adjust direct Vault usage in Jenkins to new path

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -273,7 +273,7 @@ pipeline {
 
                                     withVault(
                                         [vaultSecrets: [
-                                            [path: 'secret/common/ci-zeebe/jenkins', secretValues: [
+                                            [path: 'secret/products/zeebe/ci/jenkins', secretValues: [
                                                 [envVar: 'TC_CLOUD_TOKEN', vaultKey: 'TC_CLOUD_TOKEN'],
                                             ]],
                                     ]]) {
@@ -375,7 +375,7 @@ pipeline {
                     withVault(
                         [vaultSecrets:
                              [
-                                 [path        : 'secret/common/ci-zeebe/testbench-secrets-1.x-prod',
+                                 [path        : 'secret/products/zeebe/ci/testbench-secrets-1.x-prod',
                                   secretValues:
                                       [
                                           [envVar: 'ZEEBE_CLIENT_SECRET', vaultKey: 'clientSecret'],


### PR DESCRIPTION
## Description

Infra is restructuring Vault paths to ease the self-service.
See announcement on [slack](https://camunda.slack.com/archives/C03AEFWGJ9K/p1657524606321389).

GitHub paths will also be adjusted later this week in a different PR.
Goal is to combine everything under a product space, which makes reusing of secrets also easier as you don't have to duplicate them between GitHub Actions and Jenkins.

## Related issues

On the Infra side --> [INFRA-3326](https://jira.camunda.com/browse/INFRA-3326)

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
