### PR TITLE
chore(ci): update GHA secrets to new Vault path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,8 +29,8 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/common/github.com/actions/camunda/zeebe ARTIFACTS_USR;
-            secret/data/common/github.com/actions/camunda/zeebe ARTIFACTS_PSW;
+            secret/data/products/zeebe/ci/zeebe ARTIFACTS_USR;
+            secret/data/products/zeebe/ci/zeebe ARTIFACTS_PSW;
       - uses: actions/setup-java@v3.4.1
         with:
           distribution: 'temurin'
@@ -62,8 +62,8 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/common/github.com/actions/camunda/zeebe REGISTRY_HUB_DOCKER_COM_USR;
-            secret/data/common/github.com/actions/camunda/zeebe REGISTRY_HUB_DOCKER_COM_PSW;
+            secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_USR;
+            secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW;
       - uses: actions/setup-java@v3.4.1
         with:
           distribution: 'temurin'

--- a/.github/workflows/qa-testbench.yaml
+++ b/.github/workflows/qa-testbench.yaml
@@ -71,9 +71,9 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/common/github.com/actions/camunda/zeebe ZEEBE_GCR_SERVICEACCOUNT_JSON;
-            secret/data/common/github.com/actions/camunda/zeebe TESTBENCH_PROD_CLIENT_SECRET;
-            secret/data/common/github.com/actions/camunda/zeebe TESTBENCH_PROD_CONTACT_POINT;
+            secret/data/products/zeebe/ci/zeebe ZEEBE_GCR_SERVICEACCOUNT_JSON;
+            secret/data/products/zeebe/ci/zeebe TESTBENCH_PROD_CLIENT_SECRET;
+            secret/data/products/zeebe/ci/zeebe TESTBENCH_PROD_CONTACT_POINT;
 
       - uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
## Description

related to a [recent announcement](https://camunda.slack.com/archives/C03AEFWGJ9K/p1657524606321389) of restructuring Vault.

Secrets have already been copied over to: https://vault.int.camunda.com/ui/vault/secrets/secret/list/products/zeebe/ci/


## Related issues

related to [INFRA-3336](https://jira.camunda.com/browse/INFRA-3336)

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
