### PR TITLE
feat: allow inter-partition commands with given record key

### DIFF
--- a/broker/src/main/resources/management-schema.xml
+++ b/broker/src/main/resources/management-schema.xml
@@ -44,7 +44,9 @@
     <field name="receiverPartitionId" id="0" type="uint16"/>
     <field name="valueType" id="1" type="uint8"/>
     <field name="intent" id="2" type="uint8"/>
-    <data name="command" id="3" type="blob"/>
+    <field name="recordKey" id="3" type="uint64" presence="optional"/>
+
+    <data name="command" id="32" type="blob"/>
   </sbe:message>
 
 </sbe:messageSchema>

--- a/engine/src/main/java/io/camunda/zeebe/engine/transport/InterPartitionCommandSender.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/transport/InterPartitionCommandSender.java
@@ -21,4 +21,19 @@ public interface InterPartitionCommandSender {
       final ValueType valueType,
       final Intent intent,
       final BufferWriter command);
+
+  /**
+   * Uses the given record key when writing the command. Otherwise, behaves like {@link
+   * InterPartitionCommandSender#sendCommand}
+   *
+   * @deprecated This is only available for compatability with deployment distribution.
+   * @param recordKey Record key to use when writing the command. Ignored if null.
+   */
+  @Deprecated(forRemoval = true)
+  void sendCommand(
+      final int receiverPartitionId,
+      final ValueType valueType,
+      final Intent intent,
+      final Long recordKey,
+      final BufferWriter command);
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -505,11 +505,24 @@ public final class EngineRule extends ExternalResource {
         final ValueType valueType,
         final Intent intent,
         final BufferWriter command) {
+      sendCommand(receiverPartitionId, valueType, intent, null, command);
+    }
+
+    @Override
+    public void sendCommand(
+        final int receiverPartitionId,
+        final ValueType valueType,
+        final Intent intent,
+        final Long recordKey,
+        final BufferWriter command) {
       final var metadata =
           new RecordMetadata().recordType(RecordType.COMMAND).intent(intent).valueType(valueType);
 
       final var writer = environmentRule.getLogStreamRecordWriter(receiverPartitionId);
       writer.reset();
+      if (recordKey != null) {
+        writer.key(recordKey);
+      }
       writer.metadataWriter(metadata).valueWriter(command).tryWrite();
     }
   }


### PR DESCRIPTION
## Description

To use inter-partition command sending for deployment distribution without refactoring deployment distribution, commands need to be written with a provided record key. This is somewhat unfortunate, and we'd prefer not supporting this natively in the inter-partition command sender and receiver, but we had to make a practical choice.

The method is marked as deprecated and contains a hint that this is only necessary to support deployment distribution. We should remove it again as soon as possible. The field in the sbe message is marked as optional and set to the canonical null value when the sender does not provide a record key.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #9625

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
