### PR TITLE
Remove ActorControl#runUntilDone

### DIFF
--- a/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/ActorFrameworkIntegrationTest.java
+++ b/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/ActorFrameworkIntegrationTest.java
@@ -164,7 +164,7 @@ public final class ActorFrameworkIntegrationTest {
     }
   }
 
-  class ClaimingProducer extends Actor {
+  final class ClaimingProducer extends Actor {
     final CountDownLatch latch = new CountDownLatch(1);
 
     final int totalWork = 10_000;
@@ -172,13 +172,14 @@ public final class ActorFrameworkIntegrationTest {
     final Dispatcher dispatcher;
     final ClaimedFragment claim = new ClaimedFragment();
     int counter = 1;
+
     ClaimingProducer(final Dispatcher dispatcher) {
       this.dispatcher = dispatcher;
-    }    final Runnable produce = this::produce;
+    }
 
     @Override
     protected void onActorStarted() {
-      actor.run(produce);
+      actor.run(this::produce);
     }
 
     void produce() {
@@ -189,12 +190,10 @@ public final class ActorFrameworkIntegrationTest {
 
       if (counter < totalWork) {
         actor.yieldThread();
-        actor.run(produce);
+        actor.run(this::produce);
       } else {
         latch.countDown();
       }
     }
-
-
   }
 }

--- a/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/ActorFrameworkIntegrationTest.java
+++ b/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/ActorFrameworkIntegrationTest.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.util.ByteValue;
-import java.util.Iterator;
 import java.util.concurrent.CountDownLatch;
 import org.agrona.DirectBuffer;
 import org.junit.Rule;
@@ -58,7 +57,40 @@ public final class ActorFrameworkIntegrationTest {
     dispatcher.close();
   }
 
-  class Consumer extends Actor implements FragmentHandler {
+  static final class ClaimingProducer extends Actor {
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    final int totalWork = 10_000;
+
+    final Dispatcher dispatcher;
+    final ClaimedFragment claim = new ClaimedFragment();
+    int counter = 1;
+
+    ClaimingProducer(final Dispatcher dispatcher) {
+      this.dispatcher = dispatcher;
+    }
+
+    @Override
+    protected void onActorStarted() {
+      actor.run(this::produce);
+    }
+
+    void produce() {
+      if (dispatcher.claimSingleFragment(claim, 4534) >= 0) {
+        claim.getBuffer().putInt(claim.getOffset(), counter++);
+        claim.commit();
+      }
+
+      if (counter < totalWork) {
+        actor.yieldThread();
+        actor.run(this::produce);
+      } else {
+        latch.countDown();
+      }
+    }
+  }
+
+  static final class Consumer extends Actor implements FragmentHandler {
     final Dispatcher dispatcher;
     Subscription subscription;
     int counter = 0;
@@ -99,7 +131,7 @@ public final class ActorFrameworkIntegrationTest {
     }
   }
 
-  class PeekingConsumer extends Actor implements FragmentHandler {
+  static final class PeekingConsumer extends Actor implements FragmentHandler {
     final Dispatcher dispatcher;
     final BlockPeek peek = new BlockPeek();
     Subscription subscription;
@@ -136,9 +168,7 @@ public final class ActorFrameworkIntegrationTest {
     }
 
     void processPeek() {
-      final Iterator<DirectBuffer> iterator = peek.iterator();
-      while (iterator.hasNext()) {
-        final DirectBuffer directBuffer = iterator.next();
+      for (final DirectBuffer directBuffer : peek) {
         final int newCounter = directBuffer.getInt(0);
         if (newCounter - 1 != counter) {
           throw new RuntimeException(newCounter + " " + counter);
@@ -161,39 +191,6 @@ public final class ActorFrameworkIntegrationTest {
       }
       counter = newCounter;
       return FragmentHandler.CONSUME_FRAGMENT_RESULT;
-    }
-  }
-
-  final class ClaimingProducer extends Actor {
-    final CountDownLatch latch = new CountDownLatch(1);
-
-    final int totalWork = 10_000;
-
-    final Dispatcher dispatcher;
-    final ClaimedFragment claim = new ClaimedFragment();
-    int counter = 1;
-
-    ClaimingProducer(final Dispatcher dispatcher) {
-      this.dispatcher = dispatcher;
-    }
-
-    @Override
-    protected void onActorStarted() {
-      actor.run(this::produce);
-    }
-
-    void produce() {
-      if (dispatcher.claimSingleFragment(claim, 4534) >= 0) {
-        claim.getBuffer().putInt(claim.getOffset(), counter++);
-        claim.commit();
-      }
-
-      if (counter < totalWork) {
-        actor.yieldThread();
-        actor.run(this::produce);
-      } else {
-        latch.countDown();
-      }
     }
   }
 }

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
@@ -56,7 +56,6 @@ public class ActorControl implements ConcurrencyControl {
 
     final ActorJob job = new ActorJob();
     job.setRunnable(consumer);
-    job.setAutoCompleting(false);
     job.onJobAddedToTask(task);
 
     final ChannelConsumerCondition subscription = new ChannelConsumerCondition(job, channel);
@@ -106,7 +105,6 @@ public class ActorControl implements ConcurrencyControl {
     final ActorJob job = new ActorJob();
     final ActorFuture<T> future = job.setCallable(callable);
     job.onJobAddedToTask(task);
-    job.setAutoCompleting(true);
     task.submit(job);
 
     return future;
@@ -235,7 +233,6 @@ public class ActorControl implements ConcurrencyControl {
     }
 
     job.setRunnable(action);
-    job.setAutoCompleting(true);
     job.onJobAddedToTask(task);
     task.submit(job);
 
@@ -280,7 +277,6 @@ public class ActorControl implements ConcurrencyControl {
       final Function<ActorJob, ActorFutureSubscription> futureSubscriptionSupplier) {
     final ActorJob continuationJob = new ActorJob();
     continuationJob.setRunnable(new FutureContinuationRunnable<>(future, callback));
-    continuationJob.setAutoCompleting(true);
     continuationJob.onJobAddedToTask(task);
 
     final ActorFutureSubscription subscription = futureSubscriptionSupplier.apply(continuationJob);
@@ -324,7 +320,6 @@ public class ActorControl implements ConcurrencyControl {
     final ActorJob closeJob = new ActorJob();
 
     closeJob.onJobAddedToTask(task);
-    closeJob.setAutoCompleting(true);
     closeJob.setRunnable(task::requestClose);
 
     task.submit(closeJob);
@@ -338,13 +333,11 @@ public class ActorControl implements ConcurrencyControl {
     if (currentActorThread != null && currentActorThread.getCurrentTask() == task) {
       final ActorJob newJob = currentActorThread.newJob();
       newJob.setRunnable(runnable);
-      newJob.setAutoCompleting(true);
       newJob.onJobAddedToTask(task);
       task.insertJob(newJob);
     } else {
       final ActorJob job = new ActorJob();
       job.setRunnable(runnable);
-      job.setAutoCompleting(true);
       job.onJobAddedToTask(task);
       task.submit(job);
     }

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
@@ -130,15 +130,6 @@ public class ActorControl implements ConcurrencyControl {
   }
 
   /**
-   * Run the provided runnable repeatedly until it calls {@link #done()}. To be used for jobs which
-   * may experience backpressure.
-   */
-  public void runUntilDone(final Runnable runnable) {
-    ensureCalledFromWithinActor("runUntilDone(...)");
-    scheduleRunnable(runnable, false);
-  }
-
-  /**
    * The runnable is is executed while the actor is in the following actor lifecycle phases: {@link
    * ActorLifecyclePhase#STARTED}
    *
@@ -219,7 +210,7 @@ public class ActorControl implements ConcurrencyControl {
    */
   @Override
   public void run(final Runnable action) {
-    scheduleRunnable(action, true);
+    scheduleRunnable(action);
   }
 
   /**
@@ -341,27 +332,22 @@ public class ActorControl implements ConcurrencyControl {
     return task.closeFuture;
   }
 
-  private void scheduleRunnable(final Runnable runnable, final boolean autocompleting) {
+  private void scheduleRunnable(final Runnable runnable) {
     final ActorThread currentActorThread = ActorThread.current();
 
     if (currentActorThread != null && currentActorThread.getCurrentTask() == task) {
       final ActorJob newJob = currentActorThread.newJob();
       newJob.setRunnable(runnable);
-      newJob.setAutoCompleting(autocompleting);
+      newJob.setAutoCompleting(true);
       newJob.onJobAddedToTask(task);
       task.insertJob(newJob);
     } else {
       final ActorJob job = new ActorJob();
       job.setRunnable(runnable);
-      job.setAutoCompleting(autocompleting);
+      job.setAutoCompleting(true);
       job.onJobAddedToTask(task);
       task.submit(job);
     }
-  }
-
-  public void done() {
-    final ActorJob job = ensureCalledFromWithinActor("done()");
-    job.markDone();
   }
 
   public boolean isClosing() {

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorJob.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorJob.java
@@ -28,7 +28,6 @@ public final class ActorJob {
   private Runnable runnable;
   private Object invocationResult;
   private boolean isAutoCompleting;
-  private boolean isDoneCalled;
   private ActorFuture resultFuture;
   private ActorSubscription subscription;
   private long scheduledAt = -1;
@@ -58,7 +57,7 @@ public final class ActorJob {
       actorThread = null;
 
       // in any case, success or exception, decide if the job should be resubmitted
-      if (isTriggeredBySubscription() || (isAutoCompleting && runnable == null) || isDoneCalled) {
+      if (isTriggeredBySubscription() || (isAutoCompleting && runnable == null)) {
         schedulingState = TaskSchedulingState.TERMINATED;
       } else {
         schedulingState = TaskSchedulingState.QUEUED;
@@ -87,17 +86,11 @@ public final class ActorJob {
     if (callable != null) {
       invocationResult = callable.call();
     } else {
+      // only tasks triggered by a subscription can "yield"; everything else just executes once
       if (!isTriggeredBySubscription()) {
-        // TODO: preempt after fixed number of iterations
-        while (runnable != null && !task.shouldYield && !isDoneCalled) {
-          final Runnable r = runnable;
-
-          if (isAutoCompleting) {
-            runnable = null;
-          }
-
-          r.run();
-        }
+        final Runnable r = runnable;
+        runnable = null;
+        r.run();
       } else {
         runnable.run();
       }
@@ -128,19 +121,9 @@ public final class ActorJob {
     runnable = null;
     invocationResult = null;
     isAutoCompleting = true;
-    isDoneCalled = false;
 
     resultFuture = null;
     subscription = null;
-  }
-
-  public void markDone() {
-    if (isAutoCompleting) {
-      throw new UnsupportedOperationException(
-          "Incorrect use of actor.done(). Can only be called in methods submitted using actor.runUntilDone(Runnable r)");
-    }
-
-    isDoneCalled = true;
   }
 
   public void setAutoCompleting(final boolean isAutoCompleting) {

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorJob.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorJob.java
@@ -27,7 +27,6 @@ public final class ActorJob {
   private Callable<?> callable;
   private Runnable runnable;
   private Object invocationResult;
-  private boolean isAutoCompleting;
   private ActorFuture resultFuture;
   private ActorSubscription subscription;
   private long scheduledAt = -1;
@@ -57,7 +56,7 @@ public final class ActorJob {
       actorThread = null;
 
       // in any case, success or exception, decide if the job should be resubmitted
-      if (isTriggeredBySubscription() || (isAutoCompleting && runnable == null)) {
+      if (isTriggeredBySubscription() || runnable == null) {
         schedulingState = TaskSchedulingState.TERMINATED;
       } else {
         schedulingState = TaskSchedulingState.QUEUED;
@@ -120,14 +119,9 @@ public final class ActorJob {
     callable = null;
     runnable = null;
     invocationResult = null;
-    isAutoCompleting = true;
 
     resultFuture = null;
     subscription = null;
-  }
-
-  public void setAutoCompleting(final boolean isAutoCompleting) {
-    this.isAutoCompleting = isAutoCompleting;
   }
 
   @Override

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTask.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTask.java
@@ -84,7 +84,6 @@ public class ActorTask {
     final ActorJob j = new ActorJob();
     j.setRunnable(actor::onActorStarting);
     j.setResultFuture(jobStartingTaskFuture);
-    j.setAutoCompleting(true);
     j.onJobAddedToTask(this);
 
     currentJob = j;
@@ -218,7 +217,6 @@ public class ActorTask {
   private void submitStartedJob() {
     final ActorJob startedJob = ActorThread.current().newJob();
     startedJob.onJobAddedToTask(this);
-    startedJob.setAutoCompleting(true);
     startedJob.setRunnable(actor::onActorStarted);
     currentJob = startedJob;
   }
@@ -226,7 +224,6 @@ public class ActorTask {
   private void submitClosedJob() {
     final ActorJob closedJob = ActorThread.current().newJob();
     closedJob.onJobAddedToTask(this);
-    closedJob.setAutoCompleting(true);
     closedJob.setRunnable(actor::onActorClosed);
     currentJob = closedJob;
   }
@@ -234,7 +231,6 @@ public class ActorTask {
   private void submitClosingJob() {
     final ActorJob closeJob = ActorThread.current().newJob();
     closeJob.onJobAddedToTask(this);
-    closeJob.setAutoCompleting(true);
     closeJob.setRunnable(actor::onActorClosing);
     closeJob.setResultFuture(jobClosingTaskFuture);
     currentJob = closeJob;

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/ActorRetryMechanism.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/ActorRetryMechanism.java
@@ -32,15 +32,20 @@ public final class ActorRetryMechanism {
     currentFuture = resultFuture;
   }
 
-  void run() throws Exception {
+  Control run() throws Exception {
     if (currentCallable.run()) {
       currentFuture.complete(true);
-      actor.done();
+      return Control.DONE;
     } else if (currentTerminateCondition.getAsBoolean()) {
       currentFuture.complete(false);
-      actor.done();
+      return Control.DONE;
     } else {
-      actor.yieldThread();
+      return Control.RETRY;
     }
+  }
+
+  enum Control {
+    RETRY,
+    DONE;
   }
 }

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/RunnableActionsTest.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/RunnableActionsTest.java
@@ -149,13 +149,13 @@ public final class RunnableActionsTest {
     assertThat(exceptionOnSubmit).isFalse();
   }
 
-  class Submitter extends Actor {
+  private static final class Submitter extends Actor {
     public void submit(final Runnable r) {
       actor.submit(r);
     }
   }
 
-  class Runner extends Actor {
+  private static class Runner extends Actor {
     int runs = 0;
     final Runnable onExecution;
 

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/RunnableActionsTest.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/RunnableActionsTest.java
@@ -8,25 +8,16 @@
 package io.camunda.zeebe.scheduler.functional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 
 import io.camunda.zeebe.scheduler.Actor;
-import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.ActorThread;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerRule;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.InOrder;
 
 public final class RunnableActionsTest {
   @Rule public final ControlledActorSchedulerRule scheduler = new ControlledActorSchedulerRule();
@@ -128,61 +119,6 @@ public final class RunnableActionsTest {
   }
 
   @Test
-  public void shouldRunUntilDoneCalled() {
-    // given
-    final Runner actor = new Runner();
-    final Consumer<ActorControl> runnable =
-        (ctr) -> {
-          if (actor.runs == 5) {
-            ctr.done();
-          } else {
-            ctr.yieldThread();
-          }
-        };
-
-    // when
-    scheduler.submitActor(actor);
-    actor.doRunUntilDone(runnable);
-    scheduler.workUntilDone();
-
-    // then
-    assertThat(actor.runs).isEqualTo(5);
-  }
-
-  @Test
-  public void shouldNotInterruptRunUntilDone() {
-    // given
-    final Runnable otherAction = mock(Runnable.class);
-    final Runner actor = new Runner();
-    final Consumer<ActorControl> runUntilDoneAction =
-        spy(
-            new Consumer<ActorControl>() {
-              @Override
-              public void accept(final ActorControl ctr) {
-                ctr.run(otherAction); // does not interrupt this action
-
-                if (actor.runs == 5) {
-                  ctr.done();
-                } else {
-                  ctr.yieldThread();
-                }
-              }
-            });
-    doCallRealMethod().when(runUntilDoneAction).accept(any());
-
-    // when
-    scheduler.submitActor(actor);
-    actor.doRunUntilDone(runUntilDoneAction);
-    scheduler.workUntilDone();
-
-    // then
-    final InOrder inOrder = inOrder(runUntilDoneAction, otherAction);
-    inOrder.verify(runUntilDoneAction, times(5)).accept(any());
-    inOrder.verify(otherAction, times(5)).run();
-    inOrder.verifyNoMoreInteractions();
-  }
-
-  @Test
   public void shouldSubmitFromAnotherActor() {
     // given
     final AtomicInteger invocations = new AtomicInteger();
@@ -238,17 +174,6 @@ public final class RunnableActionsTest {
               onExecution.run();
             }
             runs++;
-          });
-    }
-
-    public void doRunUntilDone(final Consumer<ActorControl> runnable) {
-      actor.run(
-          () -> {
-            actor.runUntilDone(
-                () -> {
-                  runs++;
-                  runnable.accept(actor);
-                });
           });
     }
   }

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/lifecycle/ActorLifecyclePhasesTest.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/lifecycle/ActorLifecyclePhasesTest.java
@@ -235,17 +235,19 @@ public final class ActorLifecyclePhasesTest {
           @Override
           public void onActorStarted() {
             super.onActorStarted();
+            actor.submit(this::triggerFailure);
+          }
 
-            actor.runUntilDone(
-                () -> {
-                  final int inv = invocations.getAndIncrement();
+          @Override
+          protected void handleFailure(final Throwable failure) {
+            final int inv = invocations.getAndIncrement();
+            if (inv < 10) {
+              actor.submit(this::triggerFailure);
+            }
+          }
 
-                  if (inv == 0) {
-                    throw new RuntimeException("foo");
-                  } else if (inv == 10) {
-                    actor.done();
-                  }
-                });
+          private void triggerFailure() {
+            throw new RuntimeException("fail");
           }
         };
 

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/ordering/RunnableOrderingTests.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/ordering/RunnableOrderingTests.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerRule;
 import java.time.Duration;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -170,84 +169,6 @@ public final class RunnableOrderingTests {
     assertThat(actor.actions).containsSubsequence(newArrayList(ONE, TWO));
     assertThat(actor.actions).containsSubsequence(newArrayList(THREE, TWO));
     assertThat(actor.actions).containsSubsequence(newArrayList(ONE, FOUR));
-    assertThat(actor.actions).containsSubsequence(newArrayList(THREE, FOUR));
-  }
-
-  @Test
-  public void runUntilDoneTest() {
-    // given
-    final CompletableActorFuture<Void> future = CompletableActorFuture.completed(null);
-    final ActionRecordingActor actor =
-        new ActionRecordingActor() {
-          @Override
-          protected void onActorStarted() {
-            actor.run(runnable(TWO));
-            final AtomicInteger count = new AtomicInteger();
-            actor.runUntilDone(
-                () -> {
-                  final int couter = count.incrementAndGet();
-                  if (couter > 2) {
-                    actor.done();
-                  } else {
-                    actor.runOnCompletion(future, futureConsumer(FOUR));
-                  }
-
-                  actions.add(ONE);
-                });
-            actor.run(runnable(THREE));
-          }
-        };
-
-    // when
-    schedulerRule.submitActor(actor);
-    schedulerRule.workUntilDone();
-
-    // then
-    assertThat(actor.actions).containsSequence(newArrayList(ONE, ONE, ONE));
-    assertThat(actor.actions).containsSequence(newArrayList(FOUR, FOUR));
-    assertThat(actor.actions)
-        .containsSubsequence(
-            newArrayList(ONE, FOUR)); // futures are executed after runUntilDone finishes
-    assertThat(actor.actions).containsSubsequence(newArrayList(TWO, FOUR));
-    assertThat(actor.actions).containsSubsequence(newArrayList(THREE, FOUR));
-  }
-
-  @Test
-  public void runUntilDoneWithBlockingPhaseTest() {
-    // given
-    final CompletableActorFuture<Void> future = CompletableActorFuture.completed(null);
-    final ActionRecordingActor actor =
-        new ActionRecordingActor() {
-          @Override
-          protected void onActorStarted() {
-            actor.run(runnable(TWO));
-            final AtomicInteger count = new AtomicInteger();
-            actor.runUntilDone(
-                () -> {
-                  final int couter = count.incrementAndGet();
-                  if (couter > 2) {
-                    actor.done();
-                  } else {
-                    actor.runOnCompletionBlockingCurrentPhase(future, futureConsumer(FOUR));
-                  }
-
-                  actions.add(ONE);
-                });
-            actor.run(runnable(THREE));
-          }
-        };
-
-    // when
-    schedulerRule.submitActor(actor);
-    schedulerRule.workUntilDone();
-
-    // then
-    assertThat(actor.actions).containsSequence(newArrayList(ONE, ONE, ONE));
-    assertThat(actor.actions).containsSequence(newArrayList(FOUR, FOUR));
-    assertThat(actor.actions)
-        .containsSubsequence(
-            newArrayList(ONE, FOUR)); // futures are executed after runUntilDone finishes
-    assertThat(actor.actions).containsSubsequence(newArrayList(TWO, FOUR));
     assertThat(actor.actions).containsSubsequence(newArrayList(THREE, FOUR));
   }
 


### PR DESCRIPTION
## Description

This PR removes the dangerous `ActorControl#runUntilDone` and replaces its usage with simple re-scheduling via `run` or `submit` or `runDelayed` where appropriate. At the same time, since we don't need it anymore, it also removes `ActorControl#done`. We keep `ActorControl#yieldThread` for jobs triggered by subscriptions/conditions (e.g. dispatcher subscriptions). This means only such jobs are not auto completing anymore (but they never had to call done).

## Related issues

related to #8302

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
