### PR TITLE
Remove writes from typed record processor part1

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -88,8 +88,8 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
   @Override
   public void processRecord(
       final TypedRecord<ProcessInstanceRecord> record,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter,
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2,
       final Consumer<SideEffectProducer> sideEffect) {
 
     // initialize

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -22,8 +22,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectQueue;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
@@ -88,8 +86,6 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
   @Override
   public void processRecord(
       final TypedRecord<ProcessInstanceRecord> record,
-      final TypedResponseWriter deprecated1,
-      final TypedStreamWriter deprecated2,
       final Consumer<SideEffectProducer> sideEffect) {
 
     // initialize

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
@@ -65,23 +65,23 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
   @Override
   public void processRecord(
       final TypedRecord<IncidentRecord> command,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter,
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2,
       final Consumer<SideEffectProducer> sideEffect) {
     final long key = command.getKey();
 
     final var incident = incidentState.getIncidentRecord(key);
     if (incident == null) {
       final var errorMessage = String.format(NO_INCIDENT_FOUND_MSG, key);
-      rejectResolveCommand(command, responseWriter, errorMessage, RejectionType.NOT_FOUND);
+      rejectResolveCommand(command, deprecated1, errorMessage, RejectionType.NOT_FOUND);
       return;
     }
 
     stateWriter.appendFollowUpEvent(key, IncidentIntent.RESOLVED, incident);
-    responseWriter.writeEventOnCommand(key, IncidentIntent.RESOLVED, incident, command);
+    deprecated1.writeEventOnCommand(key, IncidentIntent.RESOLVED, incident, command);
 
     // if it fails, a new incident is raised
-    attemptToContinueProcessProcessing(command, streamWriter, sideEffect, incident);
+    attemptToContinueProcessProcessing(command, deprecated2, sideEffect, incident);
   }
 
   private void rejectResolveCommand(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -60,8 +60,8 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   @Override
   public void processRecord(
       final TypedRecord<JobBatchRecord> record,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter) {
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2) {
     final JobBatchRecord value = record.getValue();
     if (isValid(value)) {
       activateJobs(record);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageExpireProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageExpireProcessor.java
@@ -26,8 +26,8 @@ public final class MessageExpireProcessor implements TypedRecordProcessor<Messag
   @Override
   public void processRecord(
       final TypedRecord<MessageRecord> record,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter) {
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2) {
 
     stateWriter.appendFollowUpEvent(record.getKey(), MessageIntent.EXPIRED, record.getValue());
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -74,10 +74,10 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
   @Override
   public void processRecord(
       final TypedRecord<MessageRecord> command,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter,
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2,
       final Consumer<SideEffectProducer> sideEffect) {
-    this.responseWriter = responseWriter;
+    responseWriter = deprecated1;
     messageRecord = command.getValue();
 
     correlatingSubscriptions.clear();
@@ -91,11 +91,10 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
           String.format(
               ALREADY_PUBLISHED_MESSAGE, bufferAsString(messageRecord.getMessageIdBuffer()));
 
-      streamWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, rejectionReason);
-      responseWriter.writeRejectionOnCommand(
-          command, RejectionType.ALREADY_EXISTS, rejectionReason);
+      deprecated2.appendRejection(command, RejectionType.ALREADY_EXISTS, rejectionReason);
+      deprecated1.writeRejectionOnCommand(command, RejectionType.ALREADY_EXISTS, rejectionReason);
     } else {
-      handleNewMessage(command, responseWriter, sideEffect);
+      handleNewMessage(command, deprecated1, sideEffect);
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
@@ -13,8 +13,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.MessageSubscriptionState;
@@ -51,8 +49,6 @@ public final class MessageSubscriptionCorrelateProcessor
   @Override
   public void processRecord(
       final TypedRecord<MessageSubscriptionRecord> record,
-      final TypedResponseWriter deprecated1,
-      final TypedStreamWriter deprecated2,
       final Consumer<SideEffectProducer> sideEffect) {
 
     final MessageSubscriptionRecord command = record.getValue();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
@@ -51,8 +51,8 @@ public final class MessageSubscriptionCorrelateProcessor
   @Override
   public void processRecord(
       final TypedRecord<MessageSubscriptionRecord> record,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter,
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2,
       final Consumer<SideEffectProducer> sideEffect) {
 
     final MessageSubscriptionRecord command = record.getValue();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
@@ -55,8 +55,8 @@ public final class MessageSubscriptionCreateProcessor
   @Override
   public void processRecord(
       final TypedRecord<MessageSubscriptionRecord> record,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter,
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2,
       final Consumer<SideEffectProducer> sideEffect) {
     subscriptionRecord = record.getValue();
 
@@ -64,7 +64,7 @@ public final class MessageSubscriptionCreateProcessor
         subscriptionRecord.getElementInstanceKey(), subscriptionRecord.getMessageNameBuffer())) {
       sideEffect.accept(this::sendAcknowledgeCommand);
 
-      streamWriter.appendRejection(
+      deprecated2.appendRejection(
           record,
           RejectionType.INVALID_STATE,
           String.format(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
@@ -12,8 +12,7 @@ import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSen
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
@@ -38,6 +37,7 @@ public final class MessageSubscriptionCreateProcessor
   private final KeyGenerator keyGenerator;
 
   private MessageSubscriptionRecord subscriptionRecord;
+  private final TypedRejectionWriter rejectionWriter;
 
   public MessageSubscriptionCreateProcessor(
       final MessageState messageState,
@@ -48,6 +48,7 @@ public final class MessageSubscriptionCreateProcessor
     this.subscriptionState = subscriptionState;
     this.commandSender = commandSender;
     stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
     this.keyGenerator = keyGenerator;
     messageCorrelator = new MessageCorrelator(messageState, commandSender, stateWriter);
   }
@@ -55,8 +56,6 @@ public final class MessageSubscriptionCreateProcessor
   @Override
   public void processRecord(
       final TypedRecord<MessageSubscriptionRecord> record,
-      final TypedResponseWriter deprecated1,
-      final TypedStreamWriter deprecated2,
       final Consumer<SideEffectProducer> sideEffect) {
     subscriptionRecord = record.getValue();
 
@@ -64,7 +63,7 @@ public final class MessageSubscriptionCreateProcessor
         subscriptionRecord.getElementInstanceKey(), subscriptionRecord.getMessageNameBuffer())) {
       sideEffect.accept(this::sendAcknowledgeCommand);
 
-      deprecated2.appendRejection(
+      rejectionWriter.appendRejection(
           record,
           RejectionType.INVALID_STATE,
           String.format(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
@@ -50,8 +50,8 @@ public final class MessageSubscriptionDeleteProcessor
   @Override
   public void processRecord(
       final TypedRecord<MessageSubscriptionRecord> record,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter,
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2,
       final Consumer<SideEffectProducer> sideEffect) {
     subscriptionRecord = record.getValue();
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
@@ -13,8 +13,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.MessageSubscriptionState;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
@@ -50,8 +48,6 @@ public final class MessageSubscriptionDeleteProcessor
   @Override
   public void processRecord(
       final TypedRecord<MessageSubscriptionRecord> record,
-      final TypedResponseWriter deprecated1,
-      final TypedStreamWriter deprecated2,
       final Consumer<SideEffectProducer> sideEffect) {
     subscriptionRecord = record.getValue();
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
@@ -48,8 +48,8 @@ public final class MessageSubscriptionRejectProcessor
   @Override
   public void processRecord(
       final TypedRecord<MessageSubscriptionRecord> record,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter,
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2,
       final Consumer<SideEffectProducer> sideEffect) {
 
     final MessageSubscriptionRecord subscriptionRecord = record.getValue();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
@@ -13,8 +13,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.MessageSubscriptionState;
@@ -48,8 +46,6 @@ public final class MessageSubscriptionRejectProcessor
   @Override
   public void processRecord(
       final TypedRecord<MessageSubscriptionRecord> record,
-      final TypedResponseWriter deprecated1,
-      final TypedStreamWriter deprecated2,
       final Consumer<SideEffectProducer> sideEffect) {
 
     final MessageSubscriptionRecord subscriptionRecord = record.getValue();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -77,8 +77,8 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
   @Override
   public void processRecord(
       final TypedRecord<ProcessMessageSubscriptionRecord> command,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter) {
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2) {
 
     final var record = command.getValue();
     final var elementInstanceKey = record.getElementInstanceKey();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCreateProcessor.java
@@ -45,8 +45,8 @@ public final class ProcessMessageSubscriptionCreateProcessor
   @Override
   public void processRecord(
       final TypedRecord<ProcessMessageSubscriptionRecord> command,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter) {
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2) {
 
     final ProcessMessageSubscriptionRecord subscriptionRecord = command.getValue();
     final ProcessMessageSubscription subscription =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionDeleteProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionDeleteProcessor.java
@@ -41,8 +41,8 @@ public final class ProcessMessageSubscriptionDeleteProcessor
   @Override
   public void processRecord(
       final TypedRecord<ProcessMessageSubscriptionRecord> command,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter) {
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2) {
 
     final ProcessMessageSubscriptionRecord subscriptionRecord = command.getValue();
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCommandProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCommandProcessor.java
@@ -32,9 +32,9 @@ public final class ProcessInstanceCommandProcessor
   @Override
   public void processRecord(
       final TypedRecord<ProcessInstanceRecord> record,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter) {
-    populateCommandContext(record, responseWriter, streamWriter);
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2) {
+    populateCommandContext(record, deprecated1, deprecated2);
     commandHandlers.handle(context);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
@@ -69,8 +69,8 @@ public final class CommandProcessorImpl<T extends UnifiedRecordValue>
   @Override
   public void processRecord(
       final TypedRecord<T> command,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter,
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2,
       final Consumer<SideEffectProducer> sideEffect) {
 
     entityKey = command.getKey();
@@ -86,12 +86,12 @@ public final class CommandProcessorImpl<T extends UnifiedRecordValue>
       stateWriter.appendFollowUpEvent(entityKey, newState, updatedValue);
       wrappedProcessor.afterAccept(commandWriter, stateWriter, entityKey, newState, updatedValue);
       if (respond) {
-        responseWriter.writeEventOnCommand(entityKey, newState, updatedValue, command);
+        deprecated1.writeEventOnCommand(entityKey, newState, updatedValue, command);
       }
     } else {
       rejectionWriter.appendRejection(command, rejectionType, rejectionReason);
       if (respond) {
-        responseWriter.writeRejectionOnCommand(command, rejectionType, rejectionReason);
+        deprecated1.writeRejectionOnCommand(command, rejectionType, rejectionReason);
       }
     }
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
@@ -22,6 +22,11 @@ public interface TypedRecordProcessor<T extends UnifiedRecordValue> {
 
   default void processRecord(final TypedRecord<T> record) {}
 
+  default void processRecord(
+      final TypedRecord<T> record, final Consumer<SideEffectProducer> sideEffect) {
+    processRecord(record);
+  }
+
   /**
    * @see #processRecord(TypedRecord, TypedResponseWriter, TypedStreamWriter, Consumer)
    */

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
@@ -27,8 +27,8 @@ public interface TypedRecordProcessor<T extends UnifiedRecordValue> {
    */
   default void processRecord(
       final TypedRecord<T> record,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter) {
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2) {
     processRecord(record);
   }
 
@@ -37,18 +37,18 @@ public interface TypedRecordProcessor<T extends UnifiedRecordValue> {
    */
   default void processRecord(
       final TypedRecord<T> record,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter,
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2,
       final Consumer<SideEffectProducer> sideEffect) {
-    processRecord(record, responseWriter, streamWriter);
+    processRecord(record, deprecated1, deprecated2);
   }
 
   /**
    * @param position the position of the current record to process
    * @param record the record to process
-   * @param responseWriter the default side effect that can be used for sending responses. {@link
+   * @param deprecated1 the default side effect that can be used for sending responses. {@link
    *     TypedResponseWriter#flush()} must not be called in this method.
-   * @param streamWriter
+   * @param deprectaed2
    * @param sideEffect consumer to replace the default side effect (response writer). Can be used to
    *     implement other types of side effects or composite side effects. If a composite side effect
    *     involving the response writer is used, {@link TypedResponseWriter#flush()} must be called
@@ -57,9 +57,9 @@ public interface TypedRecordProcessor<T extends UnifiedRecordValue> {
   default void processRecord(
       final long position,
       final TypedRecord<T> record,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter,
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprectaed2,
       final Consumer<SideEffectProducer> sideEffect) {
-    processRecord(record, responseWriter, streamWriter, sideEffect);
+    processRecord(record, deprecated1, deprectaed2, sideEffect);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/CancelTimerProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/CancelTimerProcessor.java
@@ -39,8 +39,8 @@ public final class CancelTimerProcessor implements TypedRecordProcessor<TimerRec
   @Override
   public void processRecord(
       final TypedRecord<TimerRecord> record,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter) {
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2) {
     final TimerRecord timer = record.getValue();
     final TimerInstance timerInstance =
         timerInstanceState.get(timer.getElementInstanceKey(), record.getKey());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
@@ -122,7 +122,7 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
     }
 
     if (shouldReschedule(timer)) {
-      rescheduleTimer(timer, catchEvent, streamWriter, sideEffects);
+      rescheduleTimer(timer, catchEvent, deprecated2, sideEffects);
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
@@ -88,8 +88,8 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
   @Override
   public void processRecord(
       final TypedRecord<TimerRecord> record,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter,
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2,
       final Consumer<SideEffectProducer> sideEffects) {
     final var timer = record.getValue();
     final var elementInstanceKey = timer.getElementInstanceKey();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/UpdateVariableDocumentProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/UpdateVariableDocumentProcessor.java
@@ -44,8 +44,8 @@ public final class UpdateVariableDocumentProcessor
   @Override
   public void processRecord(
       final TypedRecord<VariableDocumentRecord> record,
-      final TypedResponseWriter responseWriter,
-      final TypedStreamWriter streamWriter) {
+      final TypedResponseWriter deprecated1,
+      final TypedStreamWriter deprecated2) {
     final VariableDocumentRecord value = record.getValue();
 
     final ElementInstance scope = elementInstanceState.getInstance(value.getScopeKey());
@@ -54,8 +54,8 @@ public final class UpdateVariableDocumentProcessor
           String.format(
               "Expected to update variables for element with key '%d', but no such element was found",
               value.getScopeKey());
-      streamWriter.appendRejection(record, RejectionType.NOT_FOUND, reason);
-      responseWriter.writeRejectionOnCommand(record, RejectionType.NOT_FOUND, reason);
+      deprecated2.appendRejection(record, RejectionType.NOT_FOUND, reason);
+      deprecated1.writeRejectionOnCommand(record, RejectionType.NOT_FOUND, reason);
       return;
     }
 
@@ -83,14 +83,14 @@ public final class UpdateVariableDocumentProcessor
           String.format(
               "Expected document to be valid msgpack, but it could not be read: '%s'",
               e.getMessage());
-      streamWriter.appendRejection(record, RejectionType.INVALID_ARGUMENT, reason);
-      responseWriter.writeRejectionOnCommand(record, RejectionType.INVALID_ARGUMENT, reason);
+      deprecated2.appendRejection(record, RejectionType.INVALID_ARGUMENT, reason);
+      deprecated1.writeRejectionOnCommand(record, RejectionType.INVALID_ARGUMENT, reason);
       return;
     }
 
     final long key = keyGenerator.nextKey();
 
     stateWriter.appendFollowUpEvent(key, VariableDocumentIntent.UPDATED, value);
-    responseWriter.writeEventOnCommand(key, VariableDocumentIntent.UPDATED, value, record);
+    deprecated1.writeEventOnCommand(key, VariableDocumentIntent.UPDATED, value, record);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/SkipFailingEventsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/SkipFailingEventsTest.java
@@ -162,8 +162,8 @@ public final class SkipFailingEventsTest {
                     @Override
                     public void processRecord(
                         final TypedRecord<UnifiedRecordValue> record,
-                        final TypedResponseWriter responseWriter,
-                        final TypedStreamWriter streamWriter) {
+                        final TypedResponseWriter deprecated1,
+                        final TypedStreamWriter deprecated2) {
                       throw new NullPointerException();
                     }
                   });
@@ -320,11 +320,11 @@ public final class SkipFailingEventsTest {
               @Override
               public void processRecord(
                   final TypedRecord<JobRecord> record,
-                  final TypedResponseWriter responseWriter,
-                  final TypedStreamWriter streamWriter) {
+                  final TypedResponseWriter deprecated1,
+                  final TypedStreamWriter deprecated2) {
                 processedInstances.add(record.getValue().getProcessInstanceKey());
                 final var processInstanceKey = (int) record.getValue().getProcessInstanceKey();
-                streamWriter.appendFollowUpCommand(
+                deprecated2.appendFollowUpCommand(
                     record.getKey(),
                     ProcessInstanceIntent.COMPLETE_ELEMENT,
                     Records.processInstance(processInstanceKey));
@@ -335,8 +335,8 @@ public final class SkipFailingEventsTest {
           @Override
           public void processRecord(
               final TypedRecord<JobRecord> record,
-              final TypedResponseWriter responseWriter,
-              final TypedStreamWriter streamWriter) {
+              final TypedResponseWriter deprecated1,
+              final TypedStreamWriter deprecated2) {
             throw new RuntimeException("expected");
           }
         };
@@ -403,13 +403,13 @@ public final class SkipFailingEventsTest {
           @Override
           public void processRecord(
               final TypedRecord<DeploymentRecord> record,
-              final TypedResponseWriter responseWriter,
-              final TypedStreamWriter streamWriter) {
+              final TypedResponseWriter deprecated1,
+              final TypedStreamWriter deprecated2) {
             if (record.getKey() == 0) {
               throw new RuntimeException("expected");
             }
             processedInstances.add(TimerInstance.NO_ELEMENT_INSTANCE);
-            streamWriter.appendFollowUpEvent(
+            deprecated2.appendFollowUpEvent(
                 record.getKey(),
                 TimerIntent.CREATED,
                 Records.timer(TimerInstance.NO_ELEMENT_INSTANCE));
@@ -479,8 +479,8 @@ public final class SkipFailingEventsTest {
     @Override
     public void processRecord(
         final TypedRecord<ProcessInstanceRecord> record,
-        final TypedResponseWriter responseWriter,
-        final TypedStreamWriter streamWriter) {
+        final TypedResponseWriter deprecated1,
+        final TypedStreamWriter deprecated2) {
       processCount.incrementAndGet();
       throw new RuntimeException("expected");
     }
@@ -496,10 +496,10 @@ public final class SkipFailingEventsTest {
     @Override
     public void processRecord(
         final TypedRecord<ProcessInstanceRecord> record,
-        final TypedResponseWriter responseWriter,
-        final TypedStreamWriter streamWriter) {
+        final TypedResponseWriter deprecated1,
+        final TypedStreamWriter deprecated2) {
       processedInstances.add(record.getValue().getProcessInstanceKey());
-      streamWriter.appendFollowUpEvent(
+      deprecated2.appendFollowUpEvent(
           record.getKey(), ProcessInstanceIntent.ELEMENT_COMPLETED, record.getValue());
     }
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
@@ -272,10 +272,10 @@ public final class StreamProcessorTest {
                       @Override
                       public void processRecord(
                           final TypedRecord<UnifiedRecordValue> record,
-                          final TypedResponseWriter responseWriter,
-                          final TypedStreamWriter streamWriter) {
+                          final TypedResponseWriter deprecated1,
+                          final TypedStreamWriter deprecated2) {
 
-                        streamWriter.appendFollowUpEvent(
+                        deprecated2.appendFollowUpEvent(
                             record.getKey(),
                             ProcessInstanceIntent.ELEMENT_ACTIVATING,
                             record.getValue());
@@ -310,8 +310,8 @@ public final class StreamProcessorTest {
                   @Override
                   public void processRecord(
                       final TypedRecord<UnifiedRecordValue> record,
-                      final TypedResponseWriter responseWriter,
-                      final TypedStreamWriter streamWriter,
+                      final TypedResponseWriter deprecated1,
+                      final TypedStreamWriter deprecated2,
                       final Consumer<SideEffectProducer> sideEffect) {
 
                     sideEffect.accept(
@@ -343,8 +343,8 @@ public final class StreamProcessorTest {
                   @Override
                   public void processRecord(
                       final TypedRecord<UnifiedRecordValue> record,
-                      final TypedResponseWriter responseWriter,
-                      final TypedStreamWriter streamWriter,
+                      final TypedResponseWriter deprecated1,
+                      final TypedStreamWriter deprecated2,
                       final Consumer<SideEffectProducer> sideEffect) {
                     sideEffect.accept(
                         () -> {
@@ -375,8 +375,8 @@ public final class StreamProcessorTest {
                   @Override
                   public void processRecord(
                       final TypedRecord<UnifiedRecordValue> record,
-                      final TypedResponseWriter responseWriter,
-                      final TypedStreamWriter streamWriter,
+                      final TypedResponseWriter deprecated1,
+                      final TypedStreamWriter deprecated2,
                       final Consumer<SideEffectProducer> sideEffect) {
 
                     sideEffect.accept(
@@ -492,10 +492,10 @@ public final class StreamProcessorTest {
                   @Override
                   public void processRecord(
                       final TypedRecord<UnifiedRecordValue> record,
-                      final TypedResponseWriter responseWriter,
-                      final TypedStreamWriter streamWriter) {
+                      final TypedResponseWriter deprecated1,
+                      final TypedStreamWriter deprecated2) {
 
-                    responseWriter.writeEventOnCommand(
+                    deprecated1.writeEventOnCommand(
                         3, ProcessInstanceIntent.ELEMENT_ACTIVATING, record.getValue(), record);
                   }
                 }));
@@ -531,10 +531,10 @@ public final class StreamProcessorTest {
                   @Override
                   public void processRecord(
                       final TypedRecord<UnifiedRecordValue> record,
-                      final TypedResponseWriter responseWriter,
-                      final TypedStreamWriter streamWriter) {
+                      final TypedResponseWriter deprecated1,
+                      final TypedStreamWriter deprecated2) {
 
-                    responseWriter.writeEventOnCommand(
+                    deprecated1.writeEventOnCommand(
                         3, ProcessInstanceIntent.ELEMENT_ACTIVATING, record.getValue(), record);
 
                     throw new RuntimeException("expected");
@@ -687,10 +687,10 @@ public final class StreamProcessorTest {
                       @Override
                       public void processRecord(
                           final TypedRecord<UnifiedRecordValue> record,
-                          final TypedResponseWriter responseWriter,
-                          final TypedStreamWriter streamWriter) {
+                          final TypedResponseWriter deprecated1,
+                          final TypedStreamWriter deprecated2) {
 
-                        streamWriter.appendFollowUpEvent(
+                        deprecated2.appendFollowUpEvent(
                             record.getKey(),
                             ProcessInstanceIntent.ELEMENT_ACTIVATING,
                             record.getValue());

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedStreamProcessorTest.java
@@ -192,14 +192,13 @@ public final class TypedStreamProcessorTest {
     @Override
     public void processRecord(
         final TypedRecord<DeploymentRecord> record,
-        final TypedResponseWriter responseWriter,
-        final TypedStreamWriter streamWriter) {
+        final TypedResponseWriter deprecated1,
+        final TypedStreamWriter deprecated2) {
       if (record.getKey() == 0) {
         throw new RuntimeException("expected");
       }
-      streamWriter.appendFollowUpEvent(
-          record.getKey(), DeploymentIntent.CREATED, record.getValue());
-      streamWriter.flush();
+      deprecated2.appendFollowUpEvent(record.getKey(), DeploymentIntent.CREATED, record.getValue());
+      deprecated2.flush();
     }
   }
 
@@ -208,11 +207,11 @@ public final class TypedStreamProcessorTest {
     @Override
     public void processRecord(
         final TypedRecord<DeploymentRecord> record,
-        final TypedResponseWriter responseWriter,
-        final TypedStreamWriter streamWriter) {
-      streamWriter.appendFollowUpEvent(
+        final TypedResponseWriter deprecated1,
+        final TypedStreamWriter deprecated2) {
+      deprecated2.appendFollowUpEvent(
           keyGenerator.nextKey(), DeploymentIntent.CREATED, record.getValue());
-      streamWriter.flush();
+      deprecated2.flush();
     }
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to #8002

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
