### PR TITLE
Throw specific exception when accessing result builder out of scope

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
+import java.util.Objects;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 
@@ -162,17 +163,18 @@ public class Engine implements RecordProcessor<EngineContext> {
     private ProcessingResultBuilder resultBuilder;
 
     private void setResultBuilder(final ProcessingResultBuilder resultBuilder) {
-      this.resultBuilder = resultBuilder;
+      this.resultBuilder = Objects.requireNonNull(resultBuilder);
     }
 
     private void unsetResultBuilder() {
-      /* TODO think about what we want to do here. Right now it is rest to null, which means NPEs
-      if accessed outside scope. We could also set a NOOP implementation, or one that logs warnings, etc.*/
       resultBuilder = null;
     }
 
     @Override
     public ProcessingResultBuilder get() {
+      if (resultBuilder == null) {
+        throw new IllegalStateException("Attempt to retrieve resultBuilder out of scope.");
+      }
       return resultBuilder;
     }
   }


### PR DESCRIPTION
## Description
Throw specific exception when accessing result builder out of scope

<!-- Cut-off marker
## Definition of Ready

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
