### PR TITLE
Rollback transaction when resetting result builder

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResultBuilder.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import org.rocksdb.RocksDBException;
 
 /** Builder to compose the processing result */
 public interface ProcessingResultBuilder {
@@ -56,11 +57,11 @@ public interface ProcessingResultBuilder {
 
   /**
    * Resets the processing result build to its initial states (removes all follow-up records, the
-   * response and post-commit tasks.
+   * response, post-commit tasks and rolls back the transaction).
    *
    * @return returns itself for method chaining
    */
-  ProcessingResultBuilder reset();
+  ProcessingResultBuilder reset() throws RocksDBException, Exception;
 
   /**
    * Resets itself with the post commit tasks reset

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/Writers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/Writers.java
@@ -64,8 +64,11 @@ public final class Writers {
     return responseWriter;
   }
 
-  /** Resets written records, response and post commit tasks */
-  public void reset() {
+  /**
+   * Resets written records, response, post commit tasks/side effects and rolls back current
+   * transaction
+   */
+  public void reset() throws Exception {
     resultBuilderSupplier.get().reset();
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -256,12 +256,14 @@ public final class ProcessingStateMachine {
       typedCommand.wrap(command, metadata, value);
 
       final long position = typedCommand.getPosition();
-      final ProcessingResultBuilder processingResultBuilder =
-          new DirectProcessingResultBuilder(context, position);
 
       metrics.processingLatency(command.getTimestamp(), processingStartTime);
 
       zeebeDbTransaction = transactionContext.getCurrentTransaction();
+
+      final ProcessingResultBuilder processingResultBuilder =
+          new DirectProcessingResultBuilder(context, zeebeDbTransaction, position);
+
       zeebeDbTransaction.run(
           () -> {
             processingResultBuilder.reset();
@@ -330,7 +332,7 @@ public final class ProcessingStateMachine {
         () -> {
           final long position = typedCommand.getPosition();
           final ProcessingResultBuilder processingResultBuilder =
-              new DirectProcessingResultBuilder(context, position);
+              new DirectProcessingResultBuilder(context, zeebeDbTransaction, position);
 
           logStreamWriter.configureSourceContext(position);
 


### PR DESCRIPTION
## Description

- Adds transaction to result builder so that transaction can be rolled back when resetting the result builder
- The `throws Exception` part is not very elegant

## Related issues

closes #9420

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
