### PR TITLE
[Backport stable/8.0] Allow relaxed instantiation of exporter configuration

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -29,10 +29,6 @@
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfiguration.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfiguration.java
@@ -7,7 +7,8 @@
  */
 package io.camunda.zeebe.broker.exporter.context;
 
-import com.fasterxml.jackson.core.JsonParser.Feature;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -26,7 +27,8 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
           .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
           .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
           .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES)
-          .enable(Feature.IGNORE_UNDEFINED, Feature.ALLOW_SINGLE_QUOTES)
+          .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
           .build();
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfiguration.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfiguration.java
@@ -7,25 +7,27 @@
  */
 package io.camunda.zeebe.broker.exporter.context;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
-import io.camunda.zeebe.exporter.api.ExporterException;
+import com.fasterxml.jackson.core.JsonParser.Feature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.camunda.zeebe.exporter.api.context.Configuration;
+import io.camunda.zeebe.util.ReflectUtil;
 import java.util.Map;
 
-public final class ExporterConfiguration implements Configuration {
-  private static final Gson CONFIG_INSTANTIATOR = new GsonBuilder().create();
+public record ExporterConfiguration(String id, Map<String, Object> arguments)
+    implements Configuration {
 
-  private final String id;
-  private final Map<String, Object> arguments;
-
-  private JsonElement intermediateConfiguration;
-
-  public ExporterConfiguration(final String id, final Map<String, Object> arguments) {
-    this.id = id;
-    this.arguments = arguments;
-  }
+  // Accepts more lenient cases, such that the property "something" would match a field "someThing"
+  // Note however that if a field "something" and "someThing" are present, only one of them will be
+  // instantiated (the last declared one), using the last matching value.
+  private static final ObjectMapper MAPPER =
+      JsonMapper.builder()
+          .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+          .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
+          .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES)
+          .enable(Feature.IGNORE_UNDEFINED, Feature.ALLOW_SINGLE_QUOTES)
+          .build();
 
   @Override
   public String getId() {
@@ -40,25 +42,9 @@ public final class ExporterConfiguration implements Configuration {
   @Override
   public <T> T instantiate(final Class<T> configClass) {
     if (arguments != null) {
-      return CONFIG_INSTANTIATOR.fromJson(getIntermediateConfiguration(), configClass);
+      return MAPPER.convertValue(arguments, configClass);
     } else {
-      try {
-        return configClass.newInstance();
-      } catch (final Exception e) {
-        throw new ExporterException(
-            "Unable to instantiate config class "
-                + configClass.getName()
-                + " with default constructor",
-            e);
-      }
+      return ReflectUtil.newInstance(configClass);
     }
-  }
-
-  private JsonElement getIntermediateConfiguration() {
-    if (intermediateConfiguration == null) {
-      intermediateConfiguration = CONFIG_INSTANTIATOR.toJsonTree(arguments);
-    }
-
-    return intermediateConfiguration;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterDescriptor.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterDescriptor.java
@@ -37,6 +37,6 @@ public class ExporterDescriptor {
   }
 
   public String getId() {
-    return configuration.getId();
+    return configuration.id();
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/context/ExporterConfigurationTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/context/ExporterConfigurationTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.exporter.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@Execution(ExecutionMode.CONCURRENT)
+final class ExporterConfigurationTest {
+  @ParameterizedTest
+  @ValueSource(strings = {"numberofshards", "numberOfShards", "NUMBEROFSHARDS"})
+  void shouldInstantiateConfigWithCaseInsensitiveProperties(final String property) {
+    // given
+    final var args = Map.<String, Object>of(property, 1);
+    final var expected = new Config(1);
+    final var config = new ExporterConfiguration("id", args);
+
+    // when
+    final var instance = config.instantiate(Config.class);
+
+    // then
+    assertThat(instance).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"numberofshards", "numberOfShards", "NUMBEROFSHARDS"})
+  void shouldInstantiateNestedConfigWithCaseInsensitiveProperties(final String property) {
+    // given
+    final var args = Map.<String, Object>of("nested", Map.of(property, 1));
+    final var expected = new ContainerConfig(new Config(1));
+    final var config = new ExporterConfiguration("id", args);
+
+    // when
+    final var instance = config.instantiate(ContainerConfig.class);
+
+    // then
+    assertThat(instance).isEqualTo(expected);
+  }
+
+  private record Config(int numberOfShards) {}
+
+  private record ContainerConfig(Config nested) {}
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/repo/ExporterRepositoryTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/repo/ExporterRepositoryTest.java
@@ -94,8 +94,8 @@ final class ExporterRepositoryTest {
 
     // then
     assertThat(config.isExternal()).isTrue();
-    assertThat(descriptor.getConfiguration().getArguments()).isEqualTo(config.getArgs());
-    assertThat(descriptor.getConfiguration().getId()).isEqualTo("exported");
+    assertThat(descriptor.getConfiguration().arguments()).isEqualTo(config.getArgs());
+    assertThat(descriptor.getConfiguration().id()).isEqualTo("exported");
     assertThat(descriptor.newInstance().getClass().getCanonicalName())
         .isEqualTo(ExternalExporter.EXPORTER_CLASS_NAME);
   }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -664,12 +664,6 @@
       </dependency>
 
       <dependency>
-        <groupId>com.google.code.gson</groupId>
-        <artifactId>gson</artifactId>
-        <version>${version.gson}</version>
-      </dependency>
-
-      <dependency>
         <groupId>io.zeebe</groupId>
         <artifactId>zeebe-test-container</artifactId>
         <version>${version.zeebe-test-container}</version>
@@ -1036,6 +1030,13 @@
         <groupId>com.github.jnr</groupId>
         <artifactId>jnr-posix</artifactId>
         <version>${version.jnr-posix}</version>
+      </dependency>
+
+      <!-- grpc-core & protobuf-java-util require different versions of gson -->
+      <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>${version.gson}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Description

This PR backports #9854 to stable/8.0.

## Related issues

backports #9854 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
