### PR TITLE
[Backport stable/1.3] Remove ActorControl#runUntilDone

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/management/deployment/PushDeploymentRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/management/deployment/PushDeploymentRequestHandler.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.sched.ActorControl;
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
@@ -131,29 +132,39 @@ public final class PushDeploymentRequestHandler
     final DeploymentRecord deploymentRecord = new DeploymentRecord();
     deploymentRecord.wrap(deployment);
 
-    actor.runUntilDone(
-        () -> {
-          final LogStreamRecordWriter logStream = leaderPartitions.get(partitionId);
-          if (logStream == null) {
-            LOG.debug("Leader change on partition {}, ignore push deployment request", partitionId);
-            actor.done();
-            return;
-          }
+    actor.submit(
+        () ->
+            tryWriteDistributeDeployment(
+                responseFuture, deploymentKey, partitionId, deploymentRecord));
+  }
 
-          final boolean success =
-              writeDistributeDeployment(logStream, deploymentKey, deploymentRecord);
-          if (success) {
-            LOG.debug(
-                "Deployment DISTRIBUTE command for deployment {} was written on partition {}",
-                deploymentKey,
-                partitionId);
-            actor.done();
+  private void tryWriteDistributeDeployment(
+      final CompletableFuture<byte[]> responseFuture,
+      final long deploymentKey,
+      final int partitionId,
+      final DeploymentRecord deploymentRecord) {
+    final LogStreamRecordWriter logStream = leaderPartitions.get(partitionId);
+    if (logStream == null) {
+      LOG.debug("Leader change on partition {}, ignore push deployment request", partitionId);
+      return;
+    }
 
-            sendResponse(responseFuture, deploymentKey, partitionId);
-          } else {
-            actor.yieldThread();
-          }
-        });
+    final boolean success = writeDistributeDeployment(logStream, deploymentKey, deploymentRecord);
+    if (!success) {
+      actor.runDelayed(
+          Duration.ofMillis(100),
+          () ->
+              tryWriteDistributeDeployment(
+                  responseFuture, deploymentKey, partitionId, deploymentRecord));
+      return;
+    }
+
+    LOG.debug(
+        "Deployment DISTRIBUTE command for deployment {} was written on partition {}",
+        deploymentKey,
+        partitionId);
+
+    sendResponse(responseFuture, deploymentKey, partitionId);
   }
 
   private void sendResponse(

--- a/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/ActorFrameworkIntegrationTest.java
+++ b/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/ActorFrameworkIntegrationTest.java
@@ -164,7 +164,7 @@ public final class ActorFrameworkIntegrationTest {
     }
   }
 
-  class ClaimingProducer extends Actor {
+  final class ClaimingProducer extends Actor {
     final CountDownLatch latch = new CountDownLatch(1);
 
     final int totalWork = 10_000;
@@ -172,13 +172,14 @@ public final class ActorFrameworkIntegrationTest {
     final Dispatcher dispatcher;
     final ClaimedFragment claim = new ClaimedFragment();
     int counter = 1;
+
     ClaimingProducer(final Dispatcher dispatcher) {
       this.dispatcher = dispatcher;
-    }    final Runnable produce = this::produce;
+    }
 
     @Override
     protected void onActorStarted() {
-      actor.run(produce);
+      actor.run(this::produce);
     }
 
     void produce() {
@@ -189,12 +190,10 @@ public final class ActorFrameworkIntegrationTest {
 
       if (counter < totalWork) {
         actor.yieldThread();
-        actor.run(produce);
+        actor.run(this::produce);
       } else {
         latch.countDown();
       }
     }
-
-
   }
 }

--- a/util/src/main/java/io/camunda/zeebe/util/retry/ActorRetryMechanism.java
+++ b/util/src/main/java/io/camunda/zeebe/util/retry/ActorRetryMechanism.java
@@ -32,15 +32,20 @@ public final class ActorRetryMechanism {
     currentFuture = resultFuture;
   }
 
-  void run() throws Exception {
+  Control run() throws Exception {
     if (currentCallable.run()) {
       currentFuture.complete(true);
-      actor.done();
+      return Control.DONE;
     } else if (currentTerminateCondition.getAsBoolean()) {
       currentFuture.complete(false);
-      actor.done();
+      return Control.DONE;
     } else {
-      actor.yieldThread();
+      return Control.RETRY;
     }
+  }
+
+  enum Control {
+    RETRY,
+    DONE;
   }
 }

--- a/util/src/main/java/io/camunda/zeebe/util/retry/RecoverableRetryStrategy.java
+++ b/util/src/main/java/io/camunda/zeebe/util/retry/RecoverableRetryStrategy.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.util.retry;
 
 import io.camunda.zeebe.util.exception.RecoverableException;
+import io.camunda.zeebe.util.retry.ActorRetryMechanism.Control;
 import io.camunda.zeebe.util.sched.ActorControl;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
@@ -37,23 +38,23 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
     terminateCondition = condition;
     retryMechanism.wrap(callable, terminateCondition, currentFuture);
 
-    actor.runUntilDone(this::run);
+    actor.run(this::run);
 
     return currentFuture;
   }
 
   private void run() {
     try {
-      retryMechanism.run();
+      final var control = retryMechanism.run();
+      if (control == Control.RETRY) {
+        actor.submit(this::run);
+      }
     } catch (final RecoverableException ex) {
-      if (terminateCondition.getAsBoolean()) {
-        actor.done();
-      } else {
-        actor.yieldThread();
+      if (!terminateCondition.getAsBoolean()) {
+        actor.submit(this::run);
       }
     } catch (final Exception exception) {
       currentFuture.completeExceptionally(exception);
-      actor.done();
     }
   }
 }

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorControl.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorControl.java
@@ -67,7 +67,6 @@ public class ActorControl implements ConcurrencyControl {
 
     final ActorJob job = new ActorJob();
     job.setRunnable(consumer);
-    job.setAutoCompleting(false);
     job.onJobAddedToTask(task);
 
     final ChannelConsumerCondition subscription = new ChannelConsumerCondition(job, channel);
@@ -117,7 +116,6 @@ public class ActorControl implements ConcurrencyControl {
     final ActorJob job = new ActorJob();
     final ActorFuture<T> future = job.setCallable(callable);
     job.onJobAddedToTask(task);
-    job.setAutoCompleting(true);
     task.submit(job);
 
     return future;
@@ -246,7 +244,6 @@ public class ActorControl implements ConcurrencyControl {
     }
 
     job.setRunnable(action);
-    job.setAutoCompleting(true);
     job.onJobAddedToTask(task);
     task.submit(job);
 
@@ -291,7 +288,6 @@ public class ActorControl implements ConcurrencyControl {
       final Function<ActorJob, ActorFutureSubscription> futureSubscriptionSupplier) {
     final ActorJob continuationJob = new ActorJob();
     continuationJob.setRunnable(new FutureContinuationRunnable<>(future, callback));
-    continuationJob.setAutoCompleting(true);
     continuationJob.onJobAddedToTask(task);
 
     final ActorFutureSubscription subscription = futureSubscriptionSupplier.apply(continuationJob);
@@ -335,7 +331,6 @@ public class ActorControl implements ConcurrencyControl {
     final ActorJob closeJob = new ActorJob();
 
     closeJob.onJobAddedToTask(task);
-    closeJob.setAutoCompleting(true);
     closeJob.setRunnable(task::requestClose);
 
     task.submit(closeJob);
@@ -349,13 +344,11 @@ public class ActorControl implements ConcurrencyControl {
     if (currentActorThread != null && currentActorThread.getCurrentTask() == task) {
       final ActorJob newJob = currentActorThread.newJob();
       newJob.setRunnable(runnable);
-      newJob.setAutoCompleting(true);
       newJob.onJobAddedToTask(task);
       task.insertJob(newJob);
     } else {
       final ActorJob job = new ActorJob();
       job.setRunnable(runnable);
-      job.setAutoCompleting(true);
       job.onJobAddedToTask(task);
       task.submit(job);
     }

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorJob.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorJob.java
@@ -28,7 +28,6 @@ public final class ActorJob {
   private Runnable runnable;
   private Object invocationResult;
   private boolean isAutoCompleting;
-  private boolean isDoneCalled;
   private ActorFuture resultFuture;
   private ActorSubscription subscription;
 
@@ -55,7 +54,7 @@ public final class ActorJob {
       actorThread = null;
 
       // in any case, success or exception, decide if the job should be resubmitted
-      if (isTriggeredBySubscription() || (isAutoCompleting && runnable == null) || isDoneCalled) {
+      if (isTriggeredBySubscription() || (isAutoCompleting && runnable == null)) {
         schedulingState = TaskSchedulingState.TERMINATED;
       } else {
         schedulingState = TaskSchedulingState.QUEUED;
@@ -67,17 +66,11 @@ public final class ActorJob {
     if (callable != null) {
       invocationResult = callable.call();
     } else {
+      // only tasks triggered by a subscription can "yield"; everything else just executes once
       if (!isTriggeredBySubscription()) {
-        // TODO: preempt after fixed number of iterations
-        while (runnable != null && !task.shouldYield && !isDoneCalled) {
-          final Runnable r = runnable;
-
-          if (isAutoCompleting) {
-            runnable = null;
-          }
-
-          r.run();
-        }
+        final Runnable r = runnable;
+        runnable = null;
+        r.run();
       } else {
         runnable.run();
       }
@@ -107,19 +100,9 @@ public final class ActorJob {
     runnable = null;
     invocationResult = null;
     isAutoCompleting = true;
-    isDoneCalled = false;
 
     resultFuture = null;
     subscription = null;
-  }
-
-  public void markDone() {
-    if (isAutoCompleting) {
-      throw new UnsupportedOperationException(
-          "Incorrect use of actor.done(). Can only be called in methods submitted using actor.runUntilDone(Runnable r)");
-    }
-
-    isDoneCalled = true;
   }
 
   public void setAutoCompleting(final boolean isAutoCompleting) {

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorJob.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorJob.java
@@ -27,7 +27,6 @@ public final class ActorJob {
   private Callable<?> callable;
   private Runnable runnable;
   private Object invocationResult;
-  private boolean isAutoCompleting;
   private ActorFuture resultFuture;
   private ActorSubscription subscription;
 
@@ -54,7 +53,7 @@ public final class ActorJob {
       actorThread = null;
 
       // in any case, success or exception, decide if the job should be resubmitted
-      if (isTriggeredBySubscription() || (isAutoCompleting && runnable == null)) {
+      if (isTriggeredBySubscription() || runnable == null) {
         schedulingState = TaskSchedulingState.TERMINATED;
       } else {
         schedulingState = TaskSchedulingState.QUEUED;
@@ -99,14 +98,9 @@ public final class ActorJob {
     callable = null;
     runnable = null;
     invocationResult = null;
-    isAutoCompleting = true;
 
     resultFuture = null;
     subscription = null;
-  }
-
-  public void setAutoCompleting(final boolean isAutoCompleting) {
-    this.isAutoCompleting = isAutoCompleting;
   }
 
   @Override

--- a/util/src/main/java/io/camunda/zeebe/util/sched/ActorTask.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/ActorTask.java
@@ -90,7 +90,6 @@ public class ActorTask {
     final ActorJob j = new ActorJob();
     j.setRunnable(actor::onActorStarting);
     j.setResultFuture(jobStartingTaskFuture);
-    j.setAutoCompleting(true);
     j.onJobAddedToTask(this);
 
     currentJob = j;
@@ -224,7 +223,6 @@ public class ActorTask {
   private void submitStartedJob() {
     final ActorJob startedJob = ActorThread.current().newJob();
     startedJob.onJobAddedToTask(this);
-    startedJob.setAutoCompleting(true);
     startedJob.setRunnable(actor::onActorStarted);
     currentJob = startedJob;
   }
@@ -232,7 +230,6 @@ public class ActorTask {
   private void submitClosedJob() {
     final ActorJob closedJob = ActorThread.current().newJob();
     closedJob.onJobAddedToTask(this);
-    closedJob.setAutoCompleting(true);
     closedJob.setRunnable(actor::onActorClosed);
     currentJob = closedJob;
   }
@@ -240,7 +237,6 @@ public class ActorTask {
   private void submitClosingJob() {
     final ActorJob closeJob = ActorThread.current().newJob();
     closeJob.onJobAddedToTask(this);
-    closeJob.setAutoCompleting(true);
     closeJob.setRunnable(actor::onActorClosing);
     closeJob.setResultFuture(jobClosingTaskFuture);
     currentJob = closeJob;

--- a/util/src/test/java/io/camunda/zeebe/util/sched/functional/RunnableActionsTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/sched/functional/RunnableActionsTest.java
@@ -149,13 +149,13 @@ public final class RunnableActionsTest {
     assertThat(exceptionOnSubmit).isFalse();
   }
 
-  class Submitter extends Actor {
+  private static final class Submitter extends Actor {
     public void submit(final Runnable r) {
       actor.submit(r);
     }
   }
 
-  class Runner extends Actor {
+  private static class Runner extends Actor {
     int runs = 0;
     final Runnable onExecution;
 

--- a/util/src/test/java/io/camunda/zeebe/util/sched/lifecycle/ActorLifecyclePhasesTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/sched/lifecycle/ActorLifecyclePhasesTest.java
@@ -226,17 +226,19 @@ public final class ActorLifecyclePhasesTest {
           @Override
           public void onActorStarted() {
             super.onActorStarted();
+            actor.submit(this::triggerFailure);
+          }
 
-            actor.runUntilDone(
-                () -> {
-                  final int inv = invocations.getAndIncrement();
+          @Override
+          protected void handleFailure(final Throwable failure) {
+            final int inv = invocations.getAndIncrement();
+            if (inv < 10) {
+              actor.submit(this::triggerFailure);
+            }
+          }
 
-                  if (inv == 0) {
-                    throw new RuntimeException("foo");
-                  } else if (inv == 10) {
-                    actor.done();
-                  }
-                });
+          private void triggerFailure() {
+            throw new RuntimeException("fail");
           }
         };
 

--- a/util/src/test/java/io/camunda/zeebe/util/sched/ordering/RunnableOrderingTests.java
+++ b/util/src/test/java/io/camunda/zeebe/util/sched/ordering/RunnableOrderingTests.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import io.camunda.zeebe.util.sched.testing.ControlledActorSchedulerRule;
 import java.time.Duration;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -170,84 +169,6 @@ public final class RunnableOrderingTests {
     assertThat(actor.actions).containsSubsequence(newArrayList(ONE, TWO));
     assertThat(actor.actions).containsSubsequence(newArrayList(THREE, TWO));
     assertThat(actor.actions).containsSubsequence(newArrayList(ONE, FOUR));
-    assertThat(actor.actions).containsSubsequence(newArrayList(THREE, FOUR));
-  }
-
-  @Test
-  public void runUntilDoneTest() {
-    // given
-    final CompletableActorFuture<Void> future = CompletableActorFuture.completed(null);
-    final ActionRecordingActor actor =
-        new ActionRecordingActor() {
-          @Override
-          protected void onActorStarted() {
-            actor.run(runnable(TWO));
-            final AtomicInteger count = new AtomicInteger();
-            actor.runUntilDone(
-                () -> {
-                  final int couter = count.incrementAndGet();
-                  if (couter > 2) {
-                    actor.done();
-                  } else {
-                    actor.runOnCompletion(future, futureConsumer(FOUR));
-                  }
-
-                  actions.add(ONE);
-                });
-            actor.run(runnable(THREE));
-          }
-        };
-
-    // when
-    schedulerRule.submitActor(actor);
-    schedulerRule.workUntilDone();
-
-    // then
-    assertThat(actor.actions).containsSequence(newArrayList(ONE, ONE, ONE));
-    assertThat(actor.actions).containsSequence(newArrayList(FOUR, FOUR));
-    assertThat(actor.actions)
-        .containsSubsequence(
-            newArrayList(ONE, FOUR)); // futures are executed after runUntilDone finishes
-    assertThat(actor.actions).containsSubsequence(newArrayList(TWO, FOUR));
-    assertThat(actor.actions).containsSubsequence(newArrayList(THREE, FOUR));
-  }
-
-  @Test
-  public void runUntilDoneWithBlockingPhaseTest() {
-    // given
-    final CompletableActorFuture<Void> future = CompletableActorFuture.completed(null);
-    final ActionRecordingActor actor =
-        new ActionRecordingActor() {
-          @Override
-          protected void onActorStarted() {
-            actor.run(runnable(TWO));
-            final AtomicInteger count = new AtomicInteger();
-            actor.runUntilDone(
-                () -> {
-                  final int couter = count.incrementAndGet();
-                  if (couter > 2) {
-                    actor.done();
-                  } else {
-                    actor.runOnCompletionBlockingCurrentPhase(future, futureConsumer(FOUR));
-                  }
-
-                  actions.add(ONE);
-                });
-            actor.run(runnable(THREE));
-          }
-        };
-
-    // when
-    schedulerRule.submitActor(actor);
-    schedulerRule.workUntilDone();
-
-    // then
-    assertThat(actor.actions).containsSequence(newArrayList(ONE, ONE, ONE));
-    assertThat(actor.actions).containsSequence(newArrayList(FOUR, FOUR));
-    assertThat(actor.actions)
-        .containsSubsequence(
-            newArrayList(ONE, FOUR)); // futures are executed after runUntilDone finishes
-    assertThat(actor.actions).containsSubsequence(newArrayList(TWO, FOUR));
     assertThat(actor.actions).containsSubsequence(newArrayList(THREE, FOUR));
   }
 


### PR DESCRIPTION
## Description

This PR backports #9850 to stable/8.0. There was one additional commit not in the PR which had to be backported/adapted, b05271207. This is the last commit of the PR.

## Related issues

backports #9850 
related to #8302 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
