### PR TITLE
[stable/8.0] Allow retried DMN resource distribution

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -146,11 +146,11 @@ public final class DbDecisionState implements MutableDecisionState {
   public void storeDecisionRecord(final DecisionRecord record) {
     dbDecisionKey.wrapLong(record.getDecisionKey());
     dbPersistedDecision.wrap(record);
-    decisionsByKey.insert(dbDecisionKey, dbPersistedDecision);
+    decisionsByKey.upsert(dbDecisionKey, dbPersistedDecision);
 
     dbDecisionKey.wrapLong(record.getDecisionKey());
     dbDecisionRequirementsKey.wrapLong(record.getDecisionRequirementsKey());
-    decisionKeyByDecisionRequirementsKey.insert(
+    decisionKeyByDecisionRequirementsKey.upsert(
         dbDecisionRequirementsKeyAndDecisionKey, DbNil.INSTANCE);
 
     updateLatestDecisionVersion(record);
@@ -160,7 +160,7 @@ public final class DbDecisionState implements MutableDecisionState {
   public void storeDecisionRequirements(final DecisionRequirementsRecord record) {
     dbDecisionRequirementsKey.wrapLong(record.getDecisionRequirementsKey());
     dbPersistedDecisionRequirements.wrap(record);
-    decisionRequirementsByKey.insert(dbDecisionRequirementsKey, dbPersistedDecisionRequirements);
+    decisionRequirementsByKey.upsert(dbDecisionRequirementsKey, dbPersistedDecisionRequirements);
 
     updateLatestDecisionRequirementsVersion(record);
   }
@@ -185,7 +185,7 @@ public final class DbDecisionState implements MutableDecisionState {
   private void insertDecisionAsLatestVersion(final DecisionRecord record) {
     dbDecisionId.wrapBuffer(record.getDecisionIdBuffer());
     dbDecisionKey.wrapLong(record.getDecisionKey());
-    latestDecisionKeysByDecisionId.insert(dbDecisionId, fkDecision);
+    latestDecisionKeysByDecisionId.upsert(dbDecisionId, fkDecision);
   }
 
   private void updateLatestDecisionRequirementsVersion(final DecisionRequirementsRecord record) {
@@ -209,6 +209,6 @@ public final class DbDecisionState implements MutableDecisionState {
   private void insertDecisionRequirementsAsLatestVersion(final DecisionRequirementsRecord record) {
     dbDecisionRequirementsId.wrapBuffer(record.getDecisionRequirementsIdBuffer());
     dbDecisionRequirementsKey.wrapLong(record.getDecisionRequirementsKey());
-    latestDecisionRequirementsKeysById.insert(dbDecisionRequirementsId, fkDecisionRequirements);
+    latestDecisionRequirementsKeysById.upsert(dbDecisionRequirementsId, fkDecisionRequirements);
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/DeploymentClusteredTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/DeploymentClusteredTest.java
@@ -14,10 +14,14 @@ import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.it.util.GrpcClientRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
 import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -29,7 +33,13 @@ public final class DeploymentClusteredTest {
       Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
 
   public final Timeout testTimeout = Timeout.seconds(120);
-  public final ClusteringRule clusteringRule = new ClusteringRule(3, 1, 3);
+  public final ClusteringRule clusteringRule =
+      new ClusteringRule(
+          3,
+          1,
+          3,
+          brokerCfg ->
+              brokerCfg.getExperimental().getConsistencyChecks().setEnablePreconditions(true));
   public final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
 
   @Rule
@@ -89,5 +99,63 @@ public final class DeploymentClusteredTest {
 
     // then
     clientRule.waitUntilDeploymentIsDone(processDefinitionKey);
+  }
+
+  /**
+   * Regression test against https://github.com/camunda/zeebe/issues/9877
+   *
+   * <p>We expect that the DISTRIBUTE command is written a second time, after restart of the leader
+   * of the deployment partition. Both DISTRIBUTE commands should be processed and resulting in
+   * DISTRIBUTED events. These should be idempotently applied, for example using `upsert`.
+   */
+  @Test
+  public void shouldDistributeDmnResourceOnRetry() {
+    final var leaderForDeploymentPartition =
+        clusteringRule.getLeaderForPartition(Protocol.DEPLOYMENT_PARTITION).getNodeId();
+    final var leaderForPartitionTwo = clusteringRule.getLeaderForPartition(2).getNodeId();
+    final var adminServiceLeaderTwo =
+        clusteringRule.getBroker(leaderForPartitionTwo).getBrokerContext().getBrokerAdminService();
+
+    // given
+    adminServiceLeaderTwo.pauseStreamProcessing();
+
+    clientRule
+        .getClient()
+        .newDeployResourceCommand()
+        .addResourceFromClasspath("dmn/decision-table.dmn")
+        .send()
+        .join();
+
+    Awaitility.await("until deployment distribution is send once to partition 2")
+        .atMost(Duration.ofMinutes(1))
+        .pollInterval(Duration.ofMillis(200))
+        .until(
+            () ->
+                RecordingExporter.deploymentRecords(DeploymentIntent.DISTRIBUTE)
+                    .withPartitionId(2)
+                    .withResourceName("dmn/decision-table.dmn")
+                    .findAny()
+                    .isPresent());
+
+    RecordingExporter.reset();
+
+    // when
+    clusteringRule.stopBroker(leaderForDeploymentPartition);
+    adminServiceLeaderTwo.resumeStreamProcessing();
+    clusteringRule.startBroker(leaderForDeploymentPartition);
+
+    // then
+    Awaitility.await("until partition 2 has processed distribute command twice")
+        .atMost(Duration.ofMinutes(1))
+        .pollInterval(Duration.ofMillis(200))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        RecordingExporter.deploymentRecords(DeploymentIntent.DISTRIBUTED)
+                            .withPartitionId(2)
+                            .withResourceName("dmn/decision-table.dmn")
+                            .limit(2))
+                    .describedAs("expect that deployment is distributed twice")
+                    .hasSize(2));
   }
 }

--- a/qa/integration-tests/src/test/resources/dmn/decision-table.dmn
+++ b/qa/integration-tests/src/test/resources/dmn/decision-table.dmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="force_users" name="Force Users" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+  <decision id="jedi_or_sith" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_14n3bxx">
+      <input id="Input_1" label="Lightsaber color" biodi:width="192">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaberColor</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="Jedi or Sith" name="jedi_or_sith" typeRef="string" biodi:width="192">
+        <outputValues id="UnaryTests_0hj346a">
+          <text>"Jedi","Sith"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_0zumznl">
+        <inputEntry id="UnaryTests_0leuxqi">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c9vpz8">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utwb1e">
+        <inputEntry id="UnaryTests_1v3sd4m">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0tgh8k1">
+          <text>"Jedi"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1bwgcym">
+        <inputEntry id="UnaryTests_0n1ewm3">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19xnlkw">
+          <text>"Sith"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/DeploymentRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/DeploymentRecordStream.java
@@ -42,4 +42,12 @@ public final class DeploymentRecordStream
   public DeploymentRecordStream withDeployedProcess(final Process process) {
     return valueFilter(v -> v.getProcessesMetadata().contains(process));
   }
+
+  public DeploymentRecordStream withResourceName(final String resourceName) {
+    return valueFilter(
+        v ->
+            v.getResources().stream()
+                .map(DeploymentResource::getResourceName)
+                .anyMatch(resourceName::equals));
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This patches a critical bug related to the retry mechanism of deployment distribution. If the retried deployment distribution contains a DMN resource, then this would trigger the consistency checks.

This patch is only available for `stable/8.0`, as we want to provide a different solution on `main`. See https://github.com/camunda/zeebe/issues/9877#issuecomment-1194279127.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9877

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
