### PR TITLE
Simplify ControlledActorClockEndpointIT

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -110,6 +110,7 @@
     <version.easy-random>5.0.0</version.easy-random>
     <version.jcip>1.0</version.jcip>
     <version.jnr-posix>3.1.15</version.jnr-posix>
+    <version.zpt>8.0.4</version.zpt>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.1.0</plugin.version.antrun>
@@ -340,6 +341,20 @@
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-atomix-utils</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <!-- sibling projects -->
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-process-test-assertions</artifactId>
+        <version>${version.zpt}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-process-test-filters</artifactId>
+        <version>${version.zpt}</version>
       </dependency>
 
       <!-- Third party dependencies -->
@@ -609,6 +624,12 @@
       <dependency>
         <groupId>io.zeebe</groupId>
         <artifactId>zeebe-test-container</artifactId>
+        <version>${version.zeebe-test-container}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.zeebe</groupId>
+        <artifactId>zeebe-test-container-engine</artifactId>
         <version>${version.zeebe-test-container}</version>
       </dependency>
 

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -112,6 +112,24 @@
     </dependency>
 
     <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-test-container-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-process-test-assertions</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-process-test-filters</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-atomix-cluster</artifactId>
       <scope>test</scope>
@@ -348,6 +366,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
@@ -8,202 +8,164 @@
 package io.camunda.zeebe.it.management;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
+import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordAssert;
 import io.camunda.zeebe.test.util.testcontainers.ZeebeTestContainerDefaults;
 import io.zeebe.containers.ZeebeContainer;
-import io.zeebe.containers.clock.ZeebeClock;
+import io.zeebe.containers.engine.ContainerEngine;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
-import java.net.http.HttpResponse.BodyHandlers;
+import java.net.http.HttpRequest.Builder;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.net.http.HttpResponse.BodySubscriber;
+import java.net.http.HttpResponse.ResponseInfo;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-import org.agrona.CloseHelper;
-import org.awaitility.Awaitility;
-import org.elasticsearch.client.RestClient;
-import org.junit.jupiter.api.AfterEach;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.Network;
-import org.testcontainers.elasticsearch.ElasticsearchContainer;
-import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
+// NOTE: once https://github.com/camunda-community-hub/zeebe-test-container/issues/318 is completed,
+// we can reduce execution time by sharing the same engine and resetting the clock in between
+@Testcontainers
 final class ControlledActorClockEndpointIT {
-  private static final String ELASTICSEARCH_HOST = "elasticsearch";
-  private static final String INDEX_PREFIX = "exporter-clock-test";
-  private Network network;
-  private ElasticsearchContainer elasticsearchContainer;
-  private ZeebeContainer zeebeContainer;
-  private ZeebeClient zeebeClient;
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper().registerModule(new JavaTimeModule());
+
+  private final ZeebeContainer container =
+      new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
+          .withEnv("ZEEBE_CLOCK_CONTROLLED", "true");
+
+  @Container
+  private final ContainerEngine engine =
+      ContainerEngine.builder()
+          .withContainer(container)
+          .withIdlePeriod(Duration.ofSeconds(2))
+          .build();
+
   private final HttpClient httpClient = HttpClient.newHttpClient();
-  private final ObjectMapper mapper = new ObjectMapper().registerModule(new ZeebeProtocolModule());
-  private ZeebeClock zeebeClock;
+  private ZeebeClient zeebeClient;
 
   @BeforeEach
-  void startContainers() {
-    network = Network.newNetwork();
-    startElasticsearch();
-    startZeebe();
-  }
-
-  @AfterEach
-  void stopContainers() {
-    CloseHelper.closeAll(zeebeClient, zeebeContainer, elasticsearchContainer, network);
+  void beforeEach() {
+    zeebeClient = engine.createClient();
   }
 
   @Test
-  void testPinningTime() throws IOException, InterruptedException {
+  void testPinningTime() throws IOException, InterruptedException, TimeoutException {
     // given - Zeebe actor clock is pinned
-    final var pinnedAt = zeebeClock.pinTime(Instant.now().minus(Duration.ofDays(3)));
+    final var now = System.currentTimeMillis();
+    final var request =
+        buildRequest("pin")
+            .POST(BodyPublishers.ofByteArray(MAPPER.writeValueAsBytes(Map.of("epochMilli", now))))
+            .build();
     final var process = Bpmn.createExecutableProcess().startEvent().endEvent().done();
+    final var response = httpClient.send(request, new ResponseHandler());
 
     // when - producing records
     zeebeClient.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
 
     // then - records are exported with a timestamp matching the pinned time
-    waitForExportedRecords();
-    final var records = searchExportedRecords();
-    assertThat(records)
-        .isNotEmpty() // double check that we have exported some records
-        .allSatisfy(record -> assertThat(record.getTimestamp()).isEqualTo(pinnedAt.toEpochMilli()));
+    engine.waitForIdleState(Duration.ofSeconds(5));
+    assertThat(response.statusCode()).as("/pin request was successful").isEqualTo(200);
+    assertThat(response.body().epochMilli()).as("response returned pinned time").isEqualTo(now);
+    assertThat(getExportedRecords())
+        .as("all exported records after /pin have the pinned timestamp")
+        .isNotEmpty()
+        .allSatisfy(record -> RecordAssert.assertThat(record).hasTimestamp(now));
   }
 
   @Test
-  void testOffsetTime() {
+  void testOffsetTime() throws IOException, InterruptedException {
     // given - Zeebe actor clock is offset
     final var process = Bpmn.createExecutableProcess().startEvent().endEvent().done();
     final var offset = Duration.ofHours(5);
+    final var request =
+        buildRequest("add")
+            .POST(
+                BodyPublishers.ofByteArray(
+                    MAPPER.writeValueAsBytes(Map.of("offsetMilli", offset.toMillis()))))
+            .build();
     final var beforeRecords = Instant.now();
-    zeebeClock.addTime(offset);
+    final var response = httpClient.send(request, new ResponseHandler());
 
     // when - producing records
     zeebeClient.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
 
     // then - records are exported with a timestamp matching the offset time
-    waitForExportedRecords();
-    Awaitility.await()
-        .untilAsserted(
-            () -> {
-              final var records = searchExportedRecords();
-              assertThat(records)
-                  .isNotEmpty() // double check that we have exported some records
-                  .allSatisfy(
-                      (record) -> {
-                        final var timestamp = Instant.ofEpochMilli(record.getTimestamp());
-                        final var afterRecords = Instant.now();
-                        assertThat(timestamp)
-                            .isBefore(afterRecords.plus(offset))
-                            .isAfter(beforeRecords.plus(offset));
-                      });
-            });
+    final var expectedUpperBound = Instant.now().plus(offset);
+    final var expectedLowerBound = beforeRecords.plus(offset);
+    assertThat(response.statusCode()).as("/add request was successful").isEqualTo(200);
+    assertThat(response.body().instant())
+        .as("returned instant is close to expected bound")
+        .isCloseTo(expectedUpperBound, within(30, ChronoUnit.SECONDS));
+    assertThat(getExportedRecords())
+        .as("all exported records after the /add request have an offset of 5 hours")
+        .isNotEmpty()
+        .allSatisfy(
+            record ->
+                assertThat(Instant.ofEpochMilli(record.getTimestamp()))
+                    .as("record has offset timestamp")
+                    .isBefore(expectedUpperBound)
+                    .isAfter(expectedLowerBound));
   }
 
-  private List<Record<?>> searchExportedRecords() throws IOException, InterruptedException {
-    final var uri =
-        URI.create(
-            String.format(
-                "http://%s/%s*/_search",
-                elasticsearchContainer.getHttpHostAddress(), INDEX_PREFIX));
-    final var request = HttpRequest.newBuilder(uri).method("POST", BodyPublishers.noBody()).build();
-    final var response = httpClient.send(request, BodyHandlers.ofInputStream());
-    final var result = mapper.readValue(response.body(), EsSearchResponseDto.class);
-    if (result.esDocumentsWrapper == null) {
-      return Collections.emptyList();
+  // it's necessary to make a copied stream out of this, as passing the iterable directly to AssertJ
+  // will cause it to close the underlying stream after the assertion
+  private Stream<Record<?>> getExportedRecords() {
+    final var exportedRecords = BpmnAssert.getRecordStream().records();
+    return StreamSupport.stream(exportedRecords.spliterator(), false);
+  }
+
+  private Builder buildRequest(final String operation) {
+    return HttpRequest.newBuilder(
+            URI.create(
+                "http://"
+                    + container.getExternalMonitoringAddress()
+                    + "/actuator/clock/"
+                    + operation))
+        .headers("Content-Type", "application/json", "Accept", "application/json");
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private record Response(
+      @JsonProperty("epochMilli") long epochMilli, @JsonProperty("instant") Instant instant) {}
+
+  private static final class ResponseHandler implements BodyHandler<Response> {
+
+    @Override
+    public BodySubscriber<Response> apply(final ResponseInfo responseInfo) {
+      return HttpResponse.BodySubscribers.mapping(
+          HttpResponse.BodySubscribers.ofInputStream(), this::unsafeRead);
     }
-    return result.esDocumentsWrapper.documents.stream()
-        .map(esDocumentDto -> esDocumentDto.record)
-        .collect(Collectors.toList());
-  }
 
-  private int getExportedRecordsCount() throws IOException, InterruptedException {
-    return searchExportedRecords().size();
-  }
-
-  void startElasticsearch() {
-    final var version = RestClient.class.getPackage().getImplementationVersion();
-    elasticsearchContainer =
-        new ElasticsearchContainer(
-                DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
-                    .withTag(version))
-            .withNetwork(network)
-            .withNetworkAliases(ELASTICSEARCH_HOST)
-            .withCreateContainerCmdModifier(
-                cmd ->
-                    Objects.requireNonNull(cmd.getHostConfig())
-                        .withMemory((long) (1024 * 1024 * 1024)));
-    elasticsearchContainer.start();
-  }
-
-  private void startZeebe() {
-    zeebeContainer =
-        new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
-            .withNetwork(network)
-            .withEnv(
-                "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME",
-                "io.camunda.zeebe.exporter.ElasticsearchExporter")
-            .withEnv(
-                "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL",
-                String.format("http://%s:9200", ELASTICSEARCH_HOST))
-            .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_DELAY", "1")
-            .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_SIZE", "1")
-            .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_PREFIX", INDEX_PREFIX)
-            .withEnv("ZEEBE_CLOCK_CONTROLLED", "true");
-    zeebeContainer.start();
-    zeebeClient =
-        ZeebeClient.newClientBuilder()
-            .usePlaintext()
-            .gatewayAddress(zeebeContainer.getExternalGatewayAddress())
-            .build();
-    zeebeClock = ZeebeClock.newDefaultClock(zeebeContainer);
-  }
-
-  /**
-   * Wait until all records are exported. We assume that all records are exported if the number of
-   * records is does not change for 5 seconds. Initialize the counter to one so that we expect at
-   * least one record and don't succeed if nothing is exported.
-   */
-  private void waitForExportedRecords() {
-    final AtomicInteger previouslySeenRecords = new AtomicInteger(1);
-    Awaitility.await("Waiting for a stable number of exported records")
-        .during(Duration.ofSeconds(5))
-        .timeout(Duration.ofSeconds(30))
-        .until(
-            this::getExportedRecordsCount,
-            (recordCount) -> {
-              final var previous = previouslySeenRecords.getAndSet(recordCount);
-              return recordCount == previous;
-            });
-  }
-
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  private static final class EsDocumentDto {
-    @JsonProperty(value = "_source", required = true)
-    Record<?> record;
-  }
-
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  private static final class EsSearchResponseDto {
-    @JsonProperty(value = "hits", required = true)
-    EsDocumentsWrapper esDocumentsWrapper;
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private static final class EsDocumentsWrapper {
-      @JsonProperty(value = "hits", required = true)
-      final List<EsDocumentDto> documents = Collections.emptyList();
+    private Response unsafeRead(final InputStream input) {
+      try {
+        return MAPPER.readValue(input, Response.class);
+      } catch (final IOException e) {
+        throw new UncheckedIOException(e);
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

This PR simplifies the `ControlledActorClockEndpointIT`, dropping the dependency on Elasticsearch and using `BpmnAssert` to verify the records produced.

I also opted to not use `ZeebeClock` directly, or even the `ZeebeTestEngine#increaseTime`, as we want to explicitly test the endpoint, and not the interfaces provided by other libraries.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
