### PR TITLE
Support logging partition id in compact record logger

### DIFF
--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -87,7 +87,7 @@ public class CompactRecordLogger {
   private final int keyDigits;
   private final int valueTypeChars;
   private final int intentChars;
-  private final boolean singlePartition;
+  private final boolean multiPartition;
   private final Map<Long, String> substitutions = new HashMap<>();
   private final ArrayList<Record<?>> records;
 
@@ -118,15 +118,8 @@ public class CompactRecordLogger {
 
   public CompactRecordLogger(final Collection<Record<?>> records) {
     this.records = new ArrayList<>(records);
+    multiPartition = isMultiPartition();
 
-    singlePartition =
-        this.records.stream()
-                .mapToLong(Record::getKey)
-                .filter(key -> key != -1)
-                .map(Protocol::decodePartitionId)
-                .distinct()
-                .count()
-            < 2;
     final var highestPosition = this.records.get(this.records.size() - 1).getPosition();
 
     int digits = 0;
@@ -169,11 +162,21 @@ public class CompactRecordLogger {
     LOG.info(bulkMessage.toString());
   }
 
+  private boolean isMultiPartition() {
+    final long numberOfPartitions =
+        records.stream()
+            .map(r -> Math.max(Protocol.decodePartitionId(r.getKey()), r.getPartitionId()))
+            .filter(x -> x != -1)
+            .distinct()
+            .count();
+    return numberOfPartitions > 1;
+  }
+
   private void addSummarizedRecords(final StringBuilder bulkMessage) {
     bulkMessage
         .append("--------\n")
         .append(
-            "\t['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position]  P[partitionId]K[key] - [summary of value]\n")
+            "\t[Partition] ['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position]  P[partitionId]K[key] - [summary of value]\n")
         .append(
             "\tP9K999 - key; #999 - record position; \"ID\" element/process id; @\"elementid\"/[P9K999] - element with ID and key\n")
         .append(
@@ -182,10 +185,7 @@ public class CompactRecordLogger {
             "\tLong IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'\n")
         .append("--------\n");
 
-    records.forEach(
-        record -> {
-          bulkMessage.append(summarizeRecord(record)).append("\n");
-        });
+    records.forEach(record -> bulkMessage.append(summarizeRecord(record)).append("\n"));
   }
 
   private void addDeployedProcesses(final StringBuilder bulkMessage) {
@@ -218,6 +218,7 @@ public class CompactRecordLogger {
   private StringBuilder summarizeRecord(final Record<?> record) {
     final StringBuilder message = new StringBuilder();
 
+    message.append(summarizePartition(record));
     message.append(summarizeIntent(record));
     message.append(summarizePositionFields(record));
     message.append(summarizeValue(record));
@@ -228,6 +229,13 @@ public class CompactRecordLogger {
     }
 
     return message;
+  }
+
+  private String summarizePartition(final Record<?> record) {
+    if (!multiPartition) {
+      return "";
+    }
+    return record.getPartitionId() + " ";
   }
 
   private StringBuilder summarizePositionFields(final Record<?> record) {
@@ -621,7 +629,7 @@ public class CompactRecordLogger {
   private String formatKey(final long key) {
     final var result = new StringBuilder();
 
-    if (!singlePartition) {
+    if (multiPartition) {
       if (key > 0) {
         result.append("P").append(Protocol.decodePartitionId(key));
       } else {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The compact record logger could already log the encoded partition id of keys when multiple partitions were used, but sometimes we write records on other partitions without a key (-1), or we write records on other partitions with a key that encodes a different partition.

This PR adds support for printing the partition id at the start of each log line. The partition id is omitted if the records don't contain any reference to other partitions (neither `partitionId` nor encoded in the `key`). 

I ran into this while working on a test case for #9877.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates #9877 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
