### PR TITLE
[Backport stable/8.0] test(qa): wait until message is published before restarting the broker

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/CompleteProcessInstanceAfterLeaderChangeTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/CompleteProcessInstanceAfterLeaderChangeTest.java
@@ -76,7 +76,8 @@ public class CompleteProcessInstanceAfterLeaderChangeTest {
                     .newPublishMessageCommand()
                     .messageName("msg")
                     .correlationKey("123")
-                    .send(),
+                    .send()
+                    .join(),
         (BiConsumer<ClusteringRule, GrpcClientRule>)
             (clusteringRule, clientRule) -> {
               final var processDefinitionKey =


### PR DESCRIPTION
# Description
Backport of #9886 to `stable/8.0`.

relates to #9813