### PR TITLE
Inter-partition command receiver writes checkpoint create record

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -291,6 +291,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverActor.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverActor.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.broker.transport.partitionapi.InterPartitionComma
 
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.camunda.zeebe.backup.api.CheckpointListener;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
@@ -25,7 +26,7 @@ import org.slf4j.Logger;
  * failure, are ignored. The sender is responsible for recognizing failures and retrying.
  */
 public final class InterPartitionCommandReceiverActor extends Actor
-    implements DiskSpaceUsageListener {
+    implements DiskSpaceUsageListener, CheckpointListener {
   private static final Logger LOG = Loggers.TRANSPORT_LOGGER;
   private final String actorName;
   private final ClusterCommunicationService communicationService;
@@ -73,6 +74,11 @@ public final class InterPartitionCommandReceiverActor extends Actor
   @Override
   public void onDiskSpaceAvailable() {
     actor.run(() -> receiver.setDiskSpaceAvailable(true));
+  }
+
+  @Override
+  public void onNewCheckpointCreated(final long checkpointId) {
+    actor.run(() -> receiver.setCheckpointId(checkpointId));
   }
 
   private void tryHandleMessage(final MemberId memberId, final byte[] message) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
@@ -82,6 +82,7 @@ public final class InterPartitionCommandReceiverImpl {
       messageBuffer.wrap(message);
       messageDecoder.wrapAndApplyHeader(messageBuffer, 0, headerDecoder);
 
+      final var checkpointId = messageDecoder.checkpointId();
       Optional<Long> recordKey = Optional.empty();
       if (messageDecoder.recordKey() != InterPartitionMessageDecoder.recordKeyNullValue()) {
         recordKey = Optional.of(messageDecoder.recordKey());
@@ -101,10 +102,13 @@ public final class InterPartitionCommandReceiverImpl {
       final var commandLength = messageDecoder.commandLength();
       commandBuffer.wrap(messageBuffer, commandOffset, commandLength);
 
-      return new Decoder.DecodedMessage(recordKey, recordMetadata, commandBuffer);
+      return new Decoder.DecodedMessage(checkpointId, recordKey, recordMetadata, commandBuffer);
     }
 
     record DecodedMessage(
-        Optional<Long> recordKey, RecordMetadata metadata, BufferWriter command) {}
+        long checkpointId,
+        Optional<Long> recordKey,
+        RecordMetadata metadata,
+        BufferWriter command) {}
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
@@ -43,10 +43,11 @@ public final class InterPartitionCommandReceiverImpl {
 
     if (!diskSpaceAvailable) {
       LOG.warn(
-          "Ignoring command {} {} from {}, no disk space available",
+          "Ignoring command {} {} from {}, checkpoint {}, no disk space available",
           decoded.metadata.getValueType(),
           decoded.metadata.getIntent(),
-          memberId);
+          memberId,
+          decoded.checkpointId);
       return;
     }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.transport.partitionapi;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.clustering.management.InterPartitionMessageDecoder;
 import io.camunda.zeebe.clustering.management.MessageHeaderDecoder;
@@ -27,6 +28,7 @@ public final class InterPartitionCommandReceiverImpl {
   private final Decoder decoder = new Decoder();
   private final LogStreamRecordWriter logStreamWriter;
   private boolean diskSpaceAvailable = true;
+  private long checkpointId = CheckpointState.NO_CHECKPOINT;
 
   public InterPartitionCommandReceiverImpl(final LogStreamRecordWriter logStreamWriter) {
     this.logStreamWriter = logStreamWriter;
@@ -63,6 +65,10 @@ public final class InterPartitionCommandReceiverImpl {
 
   public void setDiskSpaceAvailable(final boolean available) {
     diskSpaceAvailable = available;
+  }
+
+  public void setCheckpointId(final long checkpointId) {
+    this.checkpointId = checkpointId;
   }
 
   private static final class Decoder {

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
@@ -59,8 +59,8 @@ public final class InterPartitionCommandSenderImpl
     if (!partitionLeaders.containsKey(receiverPartitionId)) {
       LOG.warn(
           "Not sending command {} {} to {}, no known leader for this partition",
-          intent,
           valueType,
+          intent,
           receiverPartitionId);
       return;
     }

--- a/broker/src/main/resources/management-schema.xml
+++ b/broker/src/main/resources/management-schema.xml
@@ -34,7 +34,7 @@
     <field name="valueType" id="1" type="uint8"/>
     <field name="intent" id="2" type="uint8"/>
     <field name="recordKey" id="3" type="uint64" presence="optional"/>
-    <field name="checkpointId" id="4" type="uint64"/>
+    <field name="checkpointId" id="4" type="int64"/>
 
     <data name="command" id="32" type="blob"/>
   </sbe:message>

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.partitionapi;
+
+import static io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandSenderImpl.TOPIC_PREFIX;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.camunda.zeebe.broker.partitioning.topology.TopologyPartitionListenerImpl;
+import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import io.camunda.zeebe.util.buffer.DirectBufferWriter;
+import org.agrona.collections.Int2IntHashMap;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class InterPartitionCommandCheckpointTest {
+
+  private final ClusterCommunicationService communicationService;
+  private final LogStreamRecordWriter logStreamRecordWriter;
+  private final InterPartitionCommandSenderImpl sender;
+  private final InterPartitionCommandReceiverImpl receiver;
+
+  InterPartitionCommandCheckpointTest(
+      @Mock final ClusterCommunicationService communicationService,
+      @Mock(answer = Answers.RETURNS_SELF) final LogStreamRecordWriter logStreamRecordWriter) {
+    this.communicationService = communicationService;
+    this.logStreamRecordWriter = logStreamRecordWriter;
+
+    final var topology = new Int2IntHashMap(-1);
+    topology.put(1, 2);
+    final var topologyListener = mock(TopologyPartitionListenerImpl.class);
+    when(topologyListener.getPartitionLeaders()).thenReturn(topology);
+
+    sender = new InterPartitionCommandSenderImpl(communicationService, topologyListener);
+    receiver = new InterPartitionCommandReceiverImpl(logStreamRecordWriter);
+  }
+
+  @Test
+  void shouldHandleMissingCheckpoints() {
+    // given
+    when(logStreamRecordWriter.tryWrite()).thenReturn(1L);
+
+    // when
+    sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
+
+    // then
+
+    final var io = inOrder(logStreamRecordWriter);
+    io.verify(logStreamRecordWriter)
+        .metadataWriter(matchMetadata(ValueType.DEPLOYMENT, DeploymentIntent.CREATE));
+    io.verify(logStreamRecordWriter).tryWrite();
+    io.verifyNoMoreInteractions();
+  }
+
+  @Test
+  void shouldCreateFirstCheckpoint() {
+    // given
+    when(logStreamRecordWriter.tryWrite()).thenReturn(1L);
+    sender.onNewCheckpointCreated(1);
+
+    // when
+    sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
+
+    // then
+    final var io = inOrder(logStreamRecordWriter);
+    io.verify(logStreamRecordWriter)
+        .metadataWriter(matchMetadata(ValueType.CHECKPOINT, CheckpointIntent.CREATE));
+    io.verify(logStreamRecordWriter).valueWriter(matchCheckpoint(1));
+    io.verify(logStreamRecordWriter).tryWrite();
+
+    io.verify(logStreamRecordWriter)
+        .metadataWriter(matchMetadata(ValueType.DEPLOYMENT, DeploymentIntent.CREATE));
+    io.verify(logStreamRecordWriter).tryWrite();
+    io.verifyNoMoreInteractions();
+  }
+
+  @Test
+  void shouldUpdateExistingCheckpoint() {
+    // given
+    when(logStreamRecordWriter.tryWrite()).thenReturn(1L);
+    receiver.setCheckpointId(5);
+    sender.onNewCheckpointCreated(17);
+
+    // when
+    sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
+
+    // then
+    final var io = inOrder(logStreamRecordWriter);
+    io.verify(logStreamRecordWriter)
+        .metadataWriter(matchMetadata(ValueType.CHECKPOINT, CheckpointIntent.CREATE));
+    io.verify(logStreamRecordWriter).valueWriter(matchCheckpoint(17));
+    io.verify(logStreamRecordWriter).tryWrite();
+    io.verify(logStreamRecordWriter)
+        .metadataWriter(matchMetadata(ValueType.DEPLOYMENT, DeploymentIntent.CREATE));
+    io.verify(logStreamRecordWriter).tryWrite();
+  }
+
+  @Test
+  void shouldNotRecreateExistingCheckpoint() {
+    // given
+    when(logStreamRecordWriter.tryWrite()).thenReturn(1L);
+    receiver.setCheckpointId(5);
+    sender.onNewCheckpointCreated(5);
+
+    // when
+    sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
+
+    // then
+    final var io = inOrder(logStreamRecordWriter);
+    io.verify(logStreamRecordWriter)
+        .metadataWriter(matchMetadata(ValueType.DEPLOYMENT, DeploymentIntent.CREATE));
+    io.verify(logStreamRecordWriter).tryWrite();
+    io.verifyNoMoreInteractions();
+  }
+
+  @Test
+  void shouldNotOverwriteNewerCheckpoint() {
+    // given
+    when(logStreamRecordWriter.tryWrite()).thenReturn(1L);
+    receiver.setCheckpointId(6);
+    sender.onNewCheckpointCreated(5);
+
+    // when
+    sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
+
+    // then
+    final var io = inOrder(logStreamRecordWriter);
+    io.verify(logStreamRecordWriter)
+        .metadataWriter(matchMetadata(ValueType.DEPLOYMENT, DeploymentIntent.CREATE));
+    io.verify(logStreamRecordWriter).tryWrite();
+    io.verifyNoMoreInteractions();
+  }
+
+  @Test
+  void shouldNotWriteCommandIfCheckpointCreateFailed() {
+    // given
+    when(logStreamRecordWriter.tryWrite()).thenReturn(-1L, 1L);
+    receiver.setCheckpointId(5);
+    sender.onNewCheckpointCreated(17);
+
+    // when
+    sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
+
+    // then
+    final var io = inOrder(logStreamRecordWriter);
+    io.verify(logStreamRecordWriter)
+        .metadataWriter(matchMetadata(ValueType.CHECKPOINT, CheckpointIntent.CREATE));
+    io.verify(logStreamRecordWriter).tryWrite();
+    io.verifyNoMoreInteractions();
+  }
+
+  @Test
+  void shouldNotWriteCommandIfNoDiskAvailable() {
+    // given
+    receiver.setDiskSpaceAvailable(false);
+    receiver.setCheckpointId(5);
+    sender.onNewCheckpointCreated(17);
+
+    // when
+    sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
+
+    // then
+    verifyNoInteractions(logStreamRecordWriter);
+  }
+
+  private BufferWriter matchMetadata(final ValueType valueType, final Intent intent) {
+    return Mockito.argThat(
+        metadataWriter -> {
+          final var metadata = (RecordMetadata) metadataWriter;
+          return metadata.getValueType() == valueType && metadata.getIntent() == intent;
+        });
+  }
+
+  private BufferWriter matchCheckpoint(final long checkpointId) {
+    return Mockito.argThat(
+        valueWriter -> {
+          if (valueWriter instanceof CheckpointRecord checkpoint) {
+            return checkpoint.getCheckpointId() == checkpointId;
+          } else {
+            return false;
+          }
+        });
+  }
+
+  private void sendAndReceive(final ValueType valueType, final Intent intent) {
+    final var bufferWriter = new DirectBufferWriter();
+    bufferWriter.wrap(new UnsafeBuffer(new byte[100]));
+    sender.sendCommand(1, valueType, intent, bufferWriter);
+
+    final var messageCaptor = ArgumentCaptor.forClass(byte[].class);
+    verify(communicationService).unicast(eq(TOPIC_PREFIX + 1), messageCaptor.capture(), any());
+    receiver.handleMessage(new MemberId("0"), messageCaptor.getValue());
+  }
+}


### PR DESCRIPTION
## Description

The inter-partition command receiver writes new checkpoint create commands when receiving messages that carry a newer checkpoint.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9809 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
