### PR TITLE
Add request handler to process take backup command 

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -286,6 +286,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
@@ -40,6 +40,8 @@ public final class ErrorResponseWriter implements BufferWriter {
   private static final String PROCESS_NOT_FOUND_FORMAT =
       "Expected to get process with %s, but no such process found";
   private static final String RESOURCE_EXHAUSTED = "Reached maximum capacity of requests handled";
+  private static final String OUT_OF_DISK_SPACE =
+      "Cannot accept requests. Broker is out of disk space";
 
   private final MessageHeaderEncoder messageHeaderEncoder = new MessageHeaderEncoder();
   private final ErrorResponseEncoder errorResponseEncoder = new ErrorResponseEncoder();
@@ -83,6 +85,10 @@ public final class ErrorResponseWriter implements BufferWriter {
 
   public ErrorResponseWriter resourceExhausted(final String message) {
     return errorCode(ErrorCode.RESOURCE_EXHAUSTED).errorMessage(message);
+  }
+
+  public ErrorResponseWriter outOfDiskSpace() {
+    return errorCode(ErrorCode.RESOURCE_EXHAUSTED).errorMessage(OUT_OF_DISK_SPACE);
   }
 
   public ErrorResponseWriter malformedRequest(Throwable e) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
@@ -41,7 +41,7 @@ public final class ErrorResponseWriter implements BufferWriter {
       "Expected to get process with %s, but no such process found";
   private static final String RESOURCE_EXHAUSTED = "Reached maximum capacity of requests handled";
   private static final String OUT_OF_DISK_SPACE =
-      "Cannot accept requests. Broker is out of disk space";
+      "Cannot accept requests for partition %d. Broker is out of disk space";
 
   private final MessageHeaderEncoder messageHeaderEncoder = new MessageHeaderEncoder();
   private final ErrorResponseEncoder errorResponseEncoder = new ErrorResponseEncoder();
@@ -87,8 +87,9 @@ public final class ErrorResponseWriter implements BufferWriter {
     return errorCode(ErrorCode.RESOURCE_EXHAUSTED).errorMessage(message);
   }
 
-  public ErrorResponseWriter outOfDiskSpace() {
-    return errorCode(ErrorCode.RESOURCE_EXHAUSTED).errorMessage(OUT_OF_DISK_SPACE);
+  public ErrorResponseWriter outOfDiskSpace(final int partitionId) {
+    return errorCode(ErrorCode.RESOURCE_EXHAUSTED)
+        .errorMessage(String.format(OUT_OF_DISK_SPACE, partitionId));
   }
 
   public ErrorResponseWriter malformedRequest(Throwable e) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -25,7 +25,7 @@ import io.camunda.zeebe.util.Either;
 /**
  * Request handler to handle commands and queries related to the backup ({@link RequestType#BACKUP})
  */
-public class BackupApiRequestHandler
+public final class BackupApiRequestHandler
     extends ApiRequestHandler<BackupApiRequestReader, BackupApiResponseWriter>
     implements DiskSpaceUsageListener {
   private boolean isDiskSpaceAvailable = true;
@@ -63,7 +63,7 @@ public class BackupApiRequestHandler
 
     if (requestReader.type() == BackupRequestType.TAKE_BACKUP) {
       if (!isDiskSpaceAvailable) {
-        return Either.left(errorWriter.outOfDiskSpace());
+        return Either.left(errorWriter.outOfDiskSpace(partitionId));
       }
       return handleTakeBackupRequest(requestReader, responseWriter, errorWriter);
     }

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -81,7 +81,7 @@ public class BackupApiRequestHandler
             .valueType(ValueType.CHECKPOINT)
             .intent(CheckpointIntent.CREATE);
     final CheckpointRecord checkpointRecord =
-        new CheckpointRecord().setCheckpointId(requestReader.checkpointId());
+        new CheckpointRecord().setCheckpointId(requestReader.backupId());
 
     final var written =
         logStreamRecordWriter.metadataWriter(metadata).valueWriter(checkpointRecord).tryWrite();

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -49,7 +49,7 @@ public final class BackupApiRequestHandler
   public void close() {
     transport.unsubscribe(partitionId, RequestType.BACKUP);
     // The broker is not the leader any more.
-    transport.subscribe(partitionId, RequestType.BACKUP, new NoPartitionLeaderHandler());
+    transport.subscribe(partitionId, RequestType.BACKUP, new NotPartitionLeaderHandler());
     super.close();
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.backupapi;
+
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
+import io.camunda.zeebe.broker.transport.ApiRequestHandler;
+import io.camunda.zeebe.broker.transport.ErrorResponseWriter;
+import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.record.AdminRequestType;
+import io.camunda.zeebe.protocol.record.BackupRequestType;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import io.camunda.zeebe.transport.RequestType;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.camunda.zeebe.util.Either;
+
+/**
+ * Request handler to handle commands and queries related to the backup ({@link RequestType#BACKUP})
+ */
+public class BackupApiRequestHandler
+    extends ApiRequestHandler<BackupApiRequestReader, BackupApiResponseWriter>
+    implements DiskSpaceUsageListener {
+  private boolean isDiskSpaceAvailable = true;
+  private final LogStreamRecordWriter logStreamRecordWriter;
+
+  public BackupApiRequestHandler(
+      final AtomixServerTransport transport,
+      final LogStreamRecordWriter logStreamRecordWriter,
+      final int partitionId) {
+    super(new BackupApiRequestReader(), new BackupApiResponseWriter());
+    this.logStreamRecordWriter = logStreamRecordWriter;
+    transport.subscribe(partitionId, RequestType.BACKUP, this);
+  }
+
+  @Override
+  protected Either<ErrorResponseWriter, BackupApiResponseWriter> handle(
+      final int partitionId,
+      final long requestId,
+      final BackupApiRequestReader requestReader,
+      final BackupApiResponseWriter responseWriter,
+      final ErrorResponseWriter errorWriter) {
+
+    if (requestReader.type() == BackupRequestType.TAKE_BACKUP) {
+      if (!isDiskSpaceAvailable) {
+        return Either.left(errorWriter.outOfDiskSpace());
+      }
+      return handleTakeBackupRequest(requestReader, responseWriter, errorWriter);
+    }
+
+    return unknownRequest(errorWriter, requestReader.getMessageDecoder().type());
+  }
+
+  private Either<ErrorResponseWriter, BackupApiResponseWriter> handleTakeBackupRequest(
+      final BackupApiRequestReader requestReader,
+      final BackupApiResponseWriter responseWriter,
+      final ErrorResponseWriter errorWriter) {
+    final RecordMetadata metadata =
+        new RecordMetadata()
+            .recordType(RecordType.COMMAND)
+            .valueType(ValueType.CHECKPOINT)
+            .intent(CheckpointIntent.CREATE);
+    final CheckpointRecord checkpointRecord =
+        new CheckpointRecord().setCheckpointId(requestReader.checkpointId());
+
+    final var written =
+        logStreamRecordWriter.metadataWriter(metadata).valueWriter(checkpointRecord).tryWrite();
+
+    if (written > 0) {
+      // Response will be sent by the processor
+      return Either.right(responseWriter.noResponse());
+    } else {
+      return Either.left(errorWriter.internalError("Failed to write command to logstream."));
+    }
+  }
+
+  private Either<ErrorResponseWriter, BackupApiResponseWriter> unknownRequest(
+      final ErrorResponseWriter errorWriter, final BackupRequestType type) {
+    errorWriter.unsupportedMessage(type, AdminRequestType.values());
+    return Either.left(errorWriter);
+  }
+
+  @Override
+  public void onDiskSpaceNotAvailable() {
+    actor.submit(() -> isDiskSpaceAvailable = false);
+  }
+
+  @Override
+  public void onDiskSpaceAvailable() {
+    actor.submit(() -> isDiskSpaceAvailable = true);
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestReader.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.protocol.record.BackupRequestType;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import org.agrona.DirectBuffer;
 
-public class BackupApiRequestReader implements RequestReader<BackupRequestDecoder> {
+public final class BackupApiRequestReader implements RequestReader<BackupRequestDecoder> {
 
   private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
   private final BackupRequestDecoder messageDecoder = new BackupRequestDecoder();

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestReader.java
@@ -19,7 +19,9 @@ public class BackupApiRequestReader implements RequestReader<BackupRequestDecode
   private final BackupRequestDecoder messageDecoder = new BackupRequestDecoder();
 
   @Override
-  public void reset() {}
+  public void reset() {
+    // No internal state to reset
+  }
 
   @Override
   public BackupRequestDecoder getMessageDecoder() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestReader.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.backupapi;
+
+import io.camunda.zeebe.broker.transport.ApiRequestHandler.RequestReader;
+import io.camunda.zeebe.protocol.record.BackupRequestDecoder;
+import io.camunda.zeebe.protocol.record.BackupRequestType;
+import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
+import org.agrona.DirectBuffer;
+
+public class BackupApiRequestReader implements RequestReader<BackupRequestDecoder> {
+
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+  private final BackupRequestDecoder messageDecoder = new BackupRequestDecoder();
+
+  @Override
+  public void reset() {}
+
+  @Override
+  public BackupRequestDecoder getMessageDecoder() {
+    return messageDecoder;
+  }
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    messageDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
+  }
+
+  public long checkpointId() {
+    return messageDecoder.checkpointId();
+  }
+
+  public long partitionId() {
+    return messageDecoder.partitionId();
+  }
+
+  public BackupRequestType type() {
+    return messageDecoder.type();
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestReader.java
@@ -33,8 +33,8 @@ public class BackupApiRequestReader implements RequestReader<BackupRequestDecode
     messageDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
   }
 
-  public long checkpointId() {
-    return messageDecoder.checkpointId();
+  public long backupId() {
+    return messageDecoder.backupId();
   }
 
   public long partitionId() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiResponseWriter.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.transport.ServerOutput;
 import io.camunda.zeebe.transport.impl.ServerResponseImpl;
 import org.agrona.MutableDirectBuffer;
 
-public class BackupApiResponseWriter implements ResponseWriter {
+public final class BackupApiResponseWriter implements ResponseWriter {
   private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
   private final BackupResponseEncoder responseEncoder = new BackupResponseEncoder();
   private final ServerResponseImpl response = new ServerResponseImpl();

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiResponseWriter.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.backupapi;
+
+import io.camunda.zeebe.broker.transport.ApiRequestHandler.ResponseWriter;
+import io.camunda.zeebe.protocol.record.BackupResponseEncoder;
+import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
+import io.camunda.zeebe.transport.ServerOutput;
+import io.camunda.zeebe.transport.impl.ServerResponseImpl;
+import org.agrona.MutableDirectBuffer;
+
+public class BackupApiResponseWriter implements ResponseWriter {
+  private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final BackupResponseEncoder responseEncoder = new BackupResponseEncoder();
+  private final ServerResponseImpl response = new ServerResponseImpl();
+
+  private boolean hasResponse = true;
+
+  public BackupApiResponseWriter noResponse() {
+    hasResponse = false;
+    return this;
+  }
+
+  @Override
+  public void tryWriteResponse(
+      final ServerOutput output, final int partitionId, final long requestId) {
+    if (hasResponse) {
+      try {
+        response.reset().writer(this).setPartitionId(partitionId).setRequestId(requestId);
+        output.sendResponse(response);
+      } finally {
+        reset();
+      }
+    }
+  }
+
+  @Override
+  public void reset() {
+    response.reset();
+    hasResponse = true;
+  }
+
+  @Override
+  public int getLength() {
+    return MessageHeaderEncoder.ENCODED_LENGTH + BackupResponseEncoder.BLOCK_LENGTH;
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    headerEncoder.wrap(buffer, offset);
+
+    headerEncoder
+        .blockLength(responseEncoder.sbeBlockLength())
+        .templateId(responseEncoder.sbeTemplateId())
+        .schemaId(responseEncoder.sbeSchemaId())
+        .version(responseEncoder.sbeSchemaVersion());
+
+    responseEncoder.wrap(buffer, offset + headerEncoder.encodedLength());
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/NoPartitionLeaderHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/NoPartitionLeaderHandler.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.backupapi;
+
+import io.camunda.zeebe.broker.transport.ErrorResponseWriter;
+import io.camunda.zeebe.transport.RequestHandler;
+import io.camunda.zeebe.transport.ServerOutput;
+import org.agrona.DirectBuffer;
+
+/**
+ * This can be used when the actual handler is removed because the broker is not the leader anymore.
+ */
+public class NoPartitionLeaderHandler implements RequestHandler {
+
+  @Override
+  public void onRequest(
+      final ServerOutput serverOutput,
+      final int partitionId,
+      final long requestId,
+      final DirectBuffer buffer,
+      final int offset,
+      final int length) {
+    final ErrorResponseWriter errorResponseWriter = new ErrorResponseWriter();
+    errorResponseWriter
+        .partitionLeaderMismatch(partitionId)
+        .tryWriteResponseOrLogFailure(serverOutput, partitionId, requestId);
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/NotPartitionLeaderHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/NotPartitionLeaderHandler.java
@@ -15,7 +15,7 @@ import org.agrona.DirectBuffer;
 /**
  * This can be used when the actual handler is removed because the broker is not the leader anymore.
  */
-public class NoPartitionLeaderHandler implements RequestHandler {
+public class NotPartitionLeaderHandler implements RequestHandler {
 
   @Override
   public void onRequest(

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -55,10 +55,7 @@ final class CommandApiRequestHandler
       final ErrorResponseWriter errorWriter) {
 
     if (!isDiskSpaceAvailable) {
-      errorWriter.resourceExhausted(
-          String.format(
-              "Cannot accept requests for partition %d. Broker is out of disk space", partitionId));
-      return Either.left(errorWriter);
+      return Either.left(errorWriter.outOfDiskSpace(partitionId));
     }
 
     final var command = reader.getMessageDecoder();

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -62,10 +62,7 @@ class BackupApiRequestHandlerTest {
   void shouldRejectRequestWithInvalidType() {
     // given
     final var request =
-        new BackupRequest()
-            .setType(BackupRequestType.NULL_VAL)
-            .setPartitionId(1)
-            .setCheckpointId(10);
+        new BackupRequest().setType(BackupRequestType.NULL_VAL).setPartitionId(1).setBackupId(10);
 
     // when
     final var requestBuffer = new UnsafeBuffer(new byte[request.getLength()]);
@@ -91,7 +88,7 @@ class BackupApiRequestHandlerTest {
         new BackupRequest()
             .setType(BackupRequestType.TAKE_BACKUP)
             .setPartitionId(1)
-            .setCheckpointId(10);
+            .setBackupId(10);
 
     // when
     final var requestBuffer = new UnsafeBuffer(new byte[request.getLength()]);
@@ -110,7 +107,7 @@ class BackupApiRequestHandlerTest {
         new BackupRequest()
             .setType(BackupRequestType.TAKE_BACKUP)
             .setPartitionId(1)
-            .setCheckpointId(10);
+            .setBackupId(10);
 
     handler.onDiskSpaceNotAvailable();
     scheduler.workUntilDone();
@@ -139,7 +136,7 @@ class BackupApiRequestHandlerTest {
         new BackupRequest()
             .setType(BackupRequestType.TAKE_BACKUP)
             .setPartitionId(1)
-            .setCheckpointId(10);
+            .setBackupId(10);
 
     handler.onDiskSpaceNotAvailable();
     scheduler.workUntilDone();

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport.backupapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
+import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
+import io.camunda.zeebe.protocol.impl.encoding.BackupRequest;
+import io.camunda.zeebe.protocol.impl.encoding.ErrorResponse;
+import io.camunda.zeebe.protocol.record.BackupRequestType;
+import io.camunda.zeebe.protocol.record.ErrorCode;
+import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
+import io.camunda.zeebe.transport.ServerOutput;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.camunda.zeebe.util.Either;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class BackupApiRequestHandlerTest {
+
+  @RegisterExtension
+  ControlledActorSchedulerExtension scheduler = new ControlledActorSchedulerExtension();
+
+  final AtomixServerTransport transport = mock(AtomixServerTransport.class);
+  BackupApiRequestHandler handler;
+  private final LogStreamRecordWriter logStreamRecordWriter = mock(LogStreamRecordWriter.class);
+  private ServerOutput serverOutput;
+
+  private CompletableFuture<Either<ErrorResponse, AdminResponse>> responseFuture;
+
+  @BeforeEach
+  void setup() {
+    when(logStreamRecordWriter.metadataWriter(any())).thenReturn(logStreamRecordWriter);
+    when(logStreamRecordWriter.valueWriter(any())).thenReturn(logStreamRecordWriter);
+
+    handler = new BackupApiRequestHandler(transport, logStreamRecordWriter, 1);
+    scheduler.submitActor(handler);
+    scheduler.workUntilDone();
+
+    serverOutput = createServerOutput();
+    responseFuture = new CompletableFuture<>();
+  }
+
+  @Test
+  void shouldRejectRequestWithInvalidType() {
+    // given
+    final var request =
+        new BackupRequest()
+            .setType(BackupRequestType.NULL_VAL)
+            .setPartitionId(1)
+            .setCheckpointId(10);
+
+    // when
+    final var requestBuffer = new UnsafeBuffer(new byte[request.getLength()]);
+    request.write(requestBuffer, 0);
+
+    handler.onRequest(serverOutput, 1, 1, requestBuffer, 0, request.getLength());
+    scheduler.workUntilDone();
+
+    // then
+    assertThat(responseFuture)
+        .succeedsWithin(Duration.ofMinutes(1))
+        .matches(Either::isLeft)
+        .extracting(Either::getLeft)
+        .extracting(ErrorResponse::getErrorCode)
+        .isEqualTo(ErrorCode.UNSUPPORTED_MESSAGE);
+  }
+
+  @Test
+  void shouldWriteToLogstreamOnTakeBackupRequest() {
+
+    // given
+    final var request =
+        new BackupRequest()
+            .setType(BackupRequestType.TAKE_BACKUP)
+            .setPartitionId(1)
+            .setCheckpointId(10);
+
+    // when
+    final var requestBuffer = new UnsafeBuffer(new byte[request.getLength()]);
+    request.write(requestBuffer, 0);
+    handler.onRequest(serverOutput, 1, 1, requestBuffer, 0, request.getLength());
+    scheduler.workUntilDone();
+
+    // then
+    verify(logStreamRecordWriter, times(1)).tryWrite();
+  }
+
+  @Test
+  void shouldNotWriteWhenNoDiskSpace() {
+    // given
+    final var request =
+        new BackupRequest()
+            .setType(BackupRequestType.TAKE_BACKUP)
+            .setPartitionId(1)
+            .setCheckpointId(10);
+
+    handler.onDiskSpaceNotAvailable();
+    scheduler.workUntilDone();
+
+    // when
+    final var requestBuffer = new UnsafeBuffer(new byte[request.getLength()]);
+    request.write(requestBuffer, 0);
+
+    handler.onRequest(serverOutput, 1, 1, requestBuffer, 0, request.getLength());
+    scheduler.workUntilDone();
+
+    // then
+    assertThat(responseFuture)
+        .succeedsWithin(Duration.ofMinutes(1))
+        .matches(Either::isLeft)
+        .extracting(Either::getLeft)
+        .extracting(ErrorResponse::getErrorCode)
+        .isEqualTo(ErrorCode.RESOURCE_EXHAUSTED);
+    verify(logStreamRecordWriter, never()).tryWrite();
+  }
+
+  @Test
+  void shouldWriteWhenDiskSpaceAvailableAgain() {
+    // given
+    final var request =
+        new BackupRequest()
+            .setType(BackupRequestType.TAKE_BACKUP)
+            .setPartitionId(1)
+            .setCheckpointId(10);
+
+    handler.onDiskSpaceNotAvailable();
+    scheduler.workUntilDone();
+    handler.onDiskSpaceAvailable();
+    scheduler.workUntilDone();
+
+    // when
+    final var requestBuffer = new UnsafeBuffer(new byte[request.getLength()]);
+    request.write(requestBuffer, 0);
+
+    handler.onRequest(serverOutput, 1, 1, requestBuffer, 0, request.getLength());
+    scheduler.workUntilDone();
+
+    // then
+    verify(logStreamRecordWriter, times(1)).tryWrite();
+  }
+
+  private ServerOutput createServerOutput() {
+    return serverResponse -> {
+      final var buffer = new ExpandableArrayBuffer();
+      serverResponse.write(buffer, 0);
+
+      final var error = new ErrorResponse();
+      if (error.tryWrap(buffer)) {
+        error.wrap(buffer, 0, serverResponse.getLength());
+        responseFuture.complete(Either.left(error));
+        return;
+      }
+
+      final var response = new AdminResponse();
+      try {
+        response.wrap(buffer, 0, serverResponse.getLength());
+        responseFuture.complete(Either.right(response));
+      } catch (final Exception e) {
+        responseFuture.completeExceptionally(e);
+      }
+    };
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -8,12 +8,9 @@
 package io.camunda.zeebe.broker.transport.backupapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
@@ -31,25 +28,29 @@ import org.agrona.ExpandableArrayBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-class BackupApiRequestHandlerTest {
+@ExtendWith(MockitoExtension.class)
+final class BackupApiRequestHandlerTest {
 
   @RegisterExtension
   ControlledActorSchedulerExtension scheduler = new ControlledActorSchedulerExtension();
 
-  final AtomixServerTransport transport = mock(AtomixServerTransport.class);
-  BackupApiRequestHandler handler;
-  private final LogStreamRecordWriter logStreamRecordWriter = mock(LogStreamRecordWriter.class);
-  private ServerOutput serverOutput;
+  @Mock AtomixServerTransport transport;
 
+  @Mock(answer = Answers.RETURNS_SELF)
+  LogStreamRecordWriter logStreamRecordWriter;
+
+  BackupApiRequestHandler handler;
+  private ServerOutput serverOutput;
   private CompletableFuture<Either<ErrorResponse, AdminResponse>> responseFuture;
 
   @BeforeEach
   void setup() {
-    when(logStreamRecordWriter.metadataWriter(any())).thenReturn(logStreamRecordWriter);
-    when(logStreamRecordWriter.valueWriter(any())).thenReturn(logStreamRecordWriter);
-
     handler = new BackupApiRequestHandler(transport, logStreamRecordWriter, 1);
     scheduler.submitActor(handler);
     scheduler.workUntilDone();

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupRequest.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupRequest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.encoding;
+
+import io.camunda.zeebe.protocol.record.BackupRequestDecoder;
+import io.camunda.zeebe.protocol.record.BackupRequestEncoder;
+import io.camunda.zeebe.protocol.record.BackupRequestType;
+import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
+import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public class BackupRequest implements BufferReader, BufferWriter {
+
+  private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+  private final BackupRequestEncoder bodyEncoder = new BackupRequestEncoder();
+  private final BackupRequestDecoder bodyDecoder = new BackupRequestDecoder();
+  private BackupRequestType type;
+  private int partitionId;
+  private long checkpointId;
+
+  public BackupRequest reset() {
+    type = BackupRequestType.NULL_VAL;
+    partitionId = BackupRequestEncoder.partitionIdNullValue();
+    checkpointId = BackupRequestEncoder.checkpointIdNullValue();
+    return this;
+  }
+
+  public BackupRequestType getType() {
+    return type;
+  }
+
+  public BackupRequest setType(final BackupRequestType type) {
+    this.type = type;
+    return this;
+  }
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  public BackupRequest setPartitionId(final int partitionId) {
+    this.partitionId = partitionId;
+    return this;
+  }
+
+  public long getCheckpointId() {
+    return checkpointId;
+  }
+
+  public BackupRequest setCheckpointId(final long checkpointId) {
+    this.checkpointId = checkpointId;
+    return this;
+  }
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    bodyDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
+    partitionId = bodyDecoder.partitionId();
+    type = bodyDecoder.type();
+    checkpointId = bodyDecoder.checkpointId();
+  }
+
+  @Override
+  public int getLength() {
+    return headerEncoder.encodedLength() + bodyEncoder.sbeBlockLength();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    bodyEncoder
+        .wrapAndApplyHeader(buffer, offset, headerEncoder)
+        .partitionId(partitionId)
+        .type(type)
+        .checkpointId(checkpointId);
+  }
+}

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupRequest.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupRequest.java
@@ -25,12 +25,12 @@ public class BackupRequest implements BufferReader, BufferWriter {
   private final BackupRequestDecoder bodyDecoder = new BackupRequestDecoder();
   private BackupRequestType type;
   private int partitionId;
-  private long checkpointId;
+  private long backupId;
 
   public BackupRequest reset() {
     type = BackupRequestType.NULL_VAL;
     partitionId = BackupRequestEncoder.partitionIdNullValue();
-    checkpointId = BackupRequestEncoder.checkpointIdNullValue();
+    backupId = BackupRequestEncoder.backupIdNullValue();
     return this;
   }
 
@@ -52,12 +52,12 @@ public class BackupRequest implements BufferReader, BufferWriter {
     return this;
   }
 
-  public long getCheckpointId() {
-    return checkpointId;
+  public long getBackupId() {
+    return backupId;
   }
 
-  public BackupRequest setCheckpointId(final long checkpointId) {
-    this.checkpointId = checkpointId;
+  public BackupRequest setBackupId(final long backupId) {
+    this.backupId = backupId;
     return this;
   }
 
@@ -66,7 +66,7 @@ public class BackupRequest implements BufferReader, BufferWriter {
     bodyDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
     partitionId = bodyDecoder.partitionId();
     type = bodyDecoder.type();
-    checkpointId = bodyDecoder.checkpointId();
+    backupId = bodyDecoder.backupId();
   }
 
   @Override
@@ -80,6 +80,6 @@ public class BackupRequest implements BufferReader, BufferWriter {
         .wrapAndApplyHeader(buffer, offset, headerEncoder)
         .partitionId(partitionId)
         .type(type)
-        .checkpointId(checkpointId);
+        .backupId(backupId);
   }
 }

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -139,7 +139,7 @@
   <sbe:message name="BackupRequest" id="42">
     <field name="partitionId" id="1" type="uint16"/>
     <field name="type" id="2" type="BackupRequestType"/>
-    <field name="checkpointId" id = "3" type="int64"/>
+    <field name="backupId" id = "3" type="int64"/>
   </sbe:message>
 
   <sbe:message name="BackupResponse" id="43">

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -84,6 +84,10 @@
       <validValue name="STEP_DOWN_IF_NOT_PRIMARY">0</validValue>
     </enum>
 
+    <enum name="BackupRequestType" encodingType="uint8">
+      <validValue name="TAKE_BACKUP">0</validValue>
+    </enum>
+
   </types>
 
   <!-- L1 General Messages 0 - 99 -->
@@ -130,6 +134,15 @@
   </sbe:message>
 
   <sbe:message name="AdminResponse" id="41">
+  </sbe:message>
+
+  <sbe:message name="BackupRequest" id="42">
+    <field name="partitionId" id="1" type="uint16"/>
+    <field name="type" id="2" type="BackupRequestType"/>
+    <field name="checkpointId" id = "3" type="int64"/>
+  </sbe:message>
+
+  <sbe:message name="BackupResponse" id="43">
   </sbe:message>
 
   <!-- L2 Common Messages 200 - 399 -->

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerExtension.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerExtension.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.scheduler.testing;
+
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.ActorScheduler.ActorSchedulerBuilder;
+import io.camunda.zeebe.scheduler.ActorScheduler.ActorThreadFactory;
+import io.camunda.zeebe.scheduler.ActorThread;
+import io.camunda.zeebe.scheduler.ActorThreadGroup;
+import io.camunda.zeebe.scheduler.ActorTimerQueue;
+import io.camunda.zeebe.scheduler.TaskScheduler;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
+import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class ControlledActorSchedulerExtension implements BeforeEachCallback, AfterEachCallback {
+
+  private ActorScheduler actorScheduler;
+  private ControlledActorThread controlledActorTaskRunner;
+
+  @Override
+  public void afterEach(final ExtensionContext extensionContext) throws Exception {
+    actorScheduler.stop();
+  }
+
+  @Override
+  public void beforeEach(final ExtensionContext extensionContext) throws Exception {
+    final ControlledActorThreadFactory actorTaskRunnerFactory = new ControlledActorThreadFactory();
+    final ControlledActorClock clock = new ControlledActorClock();
+    final ActorTimerQueue timerQueue = new ActorTimerQueue(clock, 1);
+    final ActorSchedulerBuilder builder =
+        ActorScheduler.newActorScheduler()
+            .setActorClock(clock)
+            .setCpuBoundActorThreadCount(1)
+            .setIoBoundActorThreadCount(0)
+            .setActorThreadFactory(actorTaskRunnerFactory)
+            .setActorTimerQueue(timerQueue);
+
+    actorScheduler = builder.build();
+    controlledActorTaskRunner = actorTaskRunnerFactory.controlledThread;
+    actorScheduler.start();
+  }
+
+  public ActorFuture<Void> submitActor(final Actor actor) {
+    return actorScheduler.submitActor(actor);
+  }
+
+  public void workUntilDone() {
+    controlledActorTaskRunner.workUntilDone();
+  }
+
+  static final class ControlledActorThreadFactory implements ActorThreadFactory {
+    private ControlledActorThread controlledThread;
+
+    @Override
+    public ActorThread newThread(
+        final String name,
+        final int id,
+        final ActorThreadGroup threadGroup,
+        final TaskScheduler taskScheduler,
+        final ActorClock clock,
+        final ActorTimerQueue timerQueue,
+        final boolean metricsEnabled) {
+      controlledThread =
+          new ControlledActorThread(name, id, threadGroup, taskScheduler, clock, timerQueue);
+      return controlledThread;
+    }
+  }
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/RequestType.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/RequestType.java
@@ -22,6 +22,8 @@ public enum RequestType {
   QUERY("query"),
   ADMIN("admin"),
 
+  BACKUP("backup"),
+
   // All other request types are considered unknown
   // This value exists mainly for testing purposes
   UNKNOWN("unknown");


### PR DESCRIPTION
## Description

- Adds `BackupApiRequestHandler`
- Handles TAKE_BACKUP command
 
The handler receives TAKE_BACKUP request, writes and new record to the logstream. The handler will not sent the response back to the gateway. The response will be sent by the processor after processing this record. This way the gateway knows that the request was processed and there is no need to retry.

We have also added a BackupResponse which is unused now. This will used by the other backup related commands which will be added later. For those requests, the response will be sent by this handler. For that BackupApiResponseWriter must be extended to allow returning a response. 

Adding a PartitionTransitionStep to install the new handler will be done in a follow up PR.

## Related issues

related #9726

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
