### PR TITLE
[Backport stable/1.3] test(qa): increase timeout

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/CompleteProcessInstanceAfterLeaderChangeTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/CompleteProcessInstanceAfterLeaderChangeTest.java
@@ -94,6 +94,8 @@ public class CompleteProcessInstanceAfterLeaderChangeTest {
                   .processDefinitionKey(processDefinitionKey)
                   .variables(Map.of("key", "123"))
                   .withResult()
+                  // retry delay for message subscription commands is 10s. Set a higher timeout.
+                  .requestTimeout(Duration.ofSeconds(20))
                   .send()
                   .join();
             },


### PR DESCRIPTION
# Description
Backport of #9905 to `stable/1.3`.

relates to #9813