### PR TITLE
Await until no more marked-for-deletion segments are present

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
@@ -11,10 +11,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.it.util.GrpcClientRule;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Map;
+import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -43,7 +42,7 @@ public class ReaderCloseTest {
 
   // Regression test for https://github.com/camunda/zeebe/issues/7767
   @Test
-  public void shouldDeleteCompactedSegmentsFiles() throws IOException {
+  public void shouldDeleteCompactedSegmentsFiles() {
     // given
     fillSegments();
 
@@ -52,13 +51,13 @@ public class ReaderCloseTest {
 
     // then
     for (final Broker broker : clusteringRule.getBrokers()) {
-      assertThatFilesOfDeletedSegmentsDoesNotExist(broker);
+      awaitNoDanglingReaders(broker);
     }
   }
 
   // Regression test for https://github.com/camunda/zeebe/issues/7767
   @Test
-  public void shouldDeleteCompactedSegmentsFilesAfterLeaderChange() throws IOException {
+  public void shouldDeleteCompactedSegmentsFilesAfterLeaderChange() {
     // given
     fillSegments();
     final var leaderId = clusteringRule.getLeaderForPartition(1).getNodeId();
@@ -84,35 +83,28 @@ public class ReaderCloseTest {
 
     // then
     for (final Broker broker : clusteringRule.getBrokers()) {
-      assertThatFilesOfDeletedSegmentsDoesNotExist(broker);
+      awaitNoDanglingReaders(broker);
     }
+
     assertThat(leaderId).isNotEqualTo(clusteringRule.getLeaderForPartition(1).getNodeId());
   }
 
-  private void assertThatFilesOfDeletedSegmentsDoesNotExist(final Broker leader)
-      throws IOException {
+  private void awaitNoDanglingReaders(final Broker broker) {
+    Awaitility.await("until all readers are closed, observed via segment deletion")
+        .atMost(Duration.ofSeconds(20))
+        .untilAsserted(() -> assertThatFilesOfDeletedSegmentsDoesNotExist(broker));
+  }
+
+  private void assertThatFilesOfDeletedSegmentsDoesNotExist(final Broker leader) {
     final var segmentDirectory = clusteringRule.getSegmentsDirectory(leader);
-    try (final var stream =
-        Files.newDirectoryStream(segmentDirectory, path -> !path.toFile().isDirectory())) {
-      stream.forEach(
-          path ->
-              assertThat(isEitherLogOrRaftMetaFiles(path))
-                  .as(
-                      "The files in the segment directory should be either valid log segments or raft config and metadata. %s",
-                      path)
-                  .isTrue());
-    }
+    assertThat(segmentDirectory)
+        .as(
+            "broker <%s> closed all readers as it doesn't contain any marked-for-deletion segments",
+            leader.getConfig().getCluster().getNodeId())
+        .isDirectoryNotContaining("regex:.*-deleted");
   }
 
-  private boolean isEitherLogOrRaftMetaFiles(final Path path) {
-    final var filename = path.getFileName().toString();
-    return filename.endsWith(".log")
-        || filename.endsWith(".conf")
-        || filename.endsWith(".meta")
-        || filename.endsWith(".lock");
-  }
-
-  public void fillSegments() {
+  private void fillSegments() {
     clusteringRule.runUntilSegmentsFilled(
         clusteringRule.getBrokers(),
         2,


### PR DESCRIPTION
## Description

This PR allows for a slight delay for segment deletion to occur. The test checks that we close all readers by waiting for segments to be truly deleted; if a reader is left opened, then a "*-deleted" file will be present.

Since deletion is asynchronous, we should be a bit lenient and wait for a bit of time. I also took the opportunity to simplify a bit the verification of the test, improving the error message on failure I think.

## Related issues

closes #9685 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
