### PR TITLE
Support PI modification in Java client

### DIFF
--- a/.idea/copyright/Apache_2_0.xml
+++ b/.idea/copyright/Apache_2_0.xml
@@ -1,6 +1,6 @@
 <component name="CopyrightManager">
   <copyright>
-    <option name="notice" value="Copyright © &amp;#36;today.year camunda services GmbH (info@camunda.com)&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
+    <option name="notice" value="Copyright © 2017 camunda services GmbH (info@camunda.com)&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
     <option name="myName" value="Apache 2.0" />
   </copyright>
 </component>

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -309,5 +309,24 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    */
   ActivateJobsCommandStep1 newActivateJobsCommand();
 
+  /**
+   * Command to modify a process instance.
+   *
+   * <pre>
+   *   zeebeClient
+   *    .newModifyProcessInstanceCommand(processInstanceKey)
+   *    .activateElement("element1")
+   *    .and()
+   *    .activateElement("element2")
+   *    .withVariables(globalScopedVariables)
+   *    .withVariables(localScopedVariables, "element2")
+   *    .and()
+   *    .terminateElement("element3")
+   *    .send();
+   * </pre>
+   *
+   * @param processInstanceKey
+   * @return a builder for the command
+   */
   ModifyProcessInstanceCommandStep1 newModifyProcessInstanceCommand(long processInstanceKey);
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -145,6 +145,27 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
   CreateProcessInstanceCommandStep1 newCreateInstanceCommand();
 
   /**
+   * Command to modify a process instance.
+   *
+   * <pre>
+   *   zeebeClient
+   *    .newModifyProcessInstanceCommand(processInstanceKey)
+   *    .activateElement("element1")
+   *    .and()
+   *    .activateElement("element2")
+   *    .withVariables(globalScopedVariables)
+   *    .withVariables(localScopedVariables, "element2")
+   *    .and()
+   *    .terminateElement("element3")
+   *    .send();
+   * </pre>
+   *
+   * @param processInstanceKey the key which identifies the corresponding process instance
+   * @return a builder for the command
+   */
+  ModifyProcessInstanceCommandStep1 newModifyProcessInstanceCommand(long processInstanceKey);
+
+  /**
    * Command to cancel a process instance.
    *
    * <pre>
@@ -308,25 +329,4 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   ActivateJobsCommandStep1 newActivateJobsCommand();
-
-  /**
-   * Command to modify a process instance.
-   *
-   * <pre>
-   *   zeebeClient
-   *    .newModifyProcessInstanceCommand(processInstanceKey)
-   *    .activateElement("element1")
-   *    .and()
-   *    .activateElement("element2")
-   *    .withVariables(globalScopedVariables)
-   *    .withVariables(localScopedVariables, "element2")
-   *    .and()
-   *    .terminateElement("element3")
-   *    .send();
-   * </pre>
-   *
-   * @param processInstanceKey
-   * @return a builder for the command
-   */
-  ModifyProcessInstanceCommandStep1 newModifyProcessInstanceCommand(long processInstanceKey);
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.client.api.command.CancelProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.CreateProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.DeployProcessCommandStep1;
 import io.camunda.zeebe.client.api.command.DeployResourceCommandStep1;
+import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.PublishMessageCommandStep1;
 import io.camunda.zeebe.client.api.command.ResolveIncidentCommandStep1;
 import io.camunda.zeebe.client.api.command.SetVariablesCommandStep1;
@@ -307,4 +308,6 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   ActivateJobsCommandStep1 newActivateJobsCommand();
+
+  ModifyProcessInstanceCommandStep1 newModifyProcessInstanceCommand(long processInstanceKey);
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java
@@ -21,9 +21,26 @@ import java.util.Map;
 
 public interface ModifyProcessInstanceCommandStep1 {
 
-  ModifyProcessInstanceCommandStep2 activateElement(final String elementId);
+  /**
+   * Create an activate instruction for the given element id. The element will be created within an
+   * existing element instance of the flow scope.
+   *
+   * @param elementId the id of the element to activate
+   * @return the builder for this command
+   */
+  ModifyProcessInstanceCommandStep3 activateElement(final String elementId);
 
-  ModifyProcessInstanceCommandStep2 activateElement(
+  /**
+   * Create an {@link
+   * io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.ActivateInstruction}
+   * for the given element id. The element will be created within the scope that is passed. This
+   * scope must be an ancestor of the element that's getting activated.
+   *
+   * @param elementId the id of the element to activate
+   * @param ancestorElementInstanceKey the element instance key in which the element will be created
+   * @return the builder for this command
+   */
+  ModifyProcessInstanceCommandStep3 activateElement(
       final String elementId, final long ancestorElementInstanceKey);
 
   /**
@@ -38,27 +55,109 @@ public interface ModifyProcessInstanceCommandStep1 {
 
   interface ModifyProcessInstanceCommandStep2
       extends FinalCommandStep<ModifyProcessInstanceResponse> {
-
-    ModifyProcessInstanceCommandStep2 withVariables(final InputStream variables);
-
-    ModifyProcessInstanceCommandStep2 withVariables(
-        final InputStream variables, final String scopeId);
-
-    ModifyProcessInstanceCommandStep2 withVariables(final String variables);
-
-    ModifyProcessInstanceCommandStep2 withVariables(final String variables, final String scopeId);
-
-    ModifyProcessInstanceCommandStep2 withVariables(final Map<String, Object> variables);
-
-    ModifyProcessInstanceCommandStep2 withVariables(
-        final Map<String, Object> variables, final String scopeId);
-
-    ModifyProcessInstanceCommandStep2 withVariables(final Object variables);
-
-    ModifyProcessInstanceCommandStep2 withVariables(final Object variables, final String scopeId);
+    /**
+     * Acts as a boundary between the different activate and terminate instructions. Use this if you
+     * want to activate or terminate another element. Otherwise, {@link #send()} the command.
+     *
+     * @return the builder for this command
+     */
+    ModifyProcessInstanceCommandStep1 and();
   }
 
-  interface ModifyProcessInstanceCommandStep3 {
-    ModifyProcessInstanceCommandStep1 and();
+  interface ModifyProcessInstanceCommandStep3 extends ModifyProcessInstanceCommandStep2 {
+
+    /**
+     * Create a {@link
+     * io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.VariableInstruction}
+     * for the element that's getting activated. These variables will be created in the global scope
+     * of the process instance.
+     *
+     * @param variables the variables JSON document as stream
+     * @return the builder for this command
+     */
+    ModifyProcessInstanceCommandStep3 withVariables(final InputStream variables);
+
+    /**
+     * Create a {@link
+     * io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.VariableInstruction}
+     * for the element that's getting activated. These variables will be created in the scope of the
+     * passed element.
+     *
+     * @param variables the variables JSON document as stream
+     * @param scopeId the id of the element in which scope the variables should be created
+     * @return the builder for this command
+     */
+    ModifyProcessInstanceCommandStep3 withVariables(
+        final InputStream variables, final String scopeId);
+
+    /**
+     * Create a {@link
+     * io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.VariableInstruction}
+     * for the element that's getting activated. These variables will be created in the global scope
+     * of the process instance.
+     *
+     * @param variables the variables JSON document as String
+     * @return the builder for this command
+     */
+    ModifyProcessInstanceCommandStep3 withVariables(final String variables);
+
+    /**
+     * Create a {@link
+     * io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.VariableInstruction}
+     * for the element that's getting activated. These variables will be created in the scope of the
+     * passed element.
+     *
+     * @param variables the variables JSON document as String
+     * @param scopeId the id of the element in which scope the variables should be created
+     * @return the builder for this command
+     */
+    ModifyProcessInstanceCommandStep3 withVariables(final String variables, final String scopeId);
+
+    /**
+     * Create a {@link
+     * io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.VariableInstruction}
+     * for the element that's getting activated. These variables will be created in the global scope
+     * of the process instance.
+     *
+     * @param variables the variables JSON document as map
+     * @return the builder for this command
+     */
+    ModifyProcessInstanceCommandStep3 withVariables(final Map<String, Object> variables);
+
+    /**
+     * Create a {@link
+     * io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.VariableInstruction}
+     * for the element that's getting activated. These variables will be created in the scope of the
+     * passed element.
+     *
+     * @param variables the variables JSON document as map
+     * @param scopeId the id of the element in which scope the variables should be created
+     * @return the builder for this command
+     */
+    ModifyProcessInstanceCommandStep3 withVariables(
+        final Map<String, Object> variables, final String scopeId);
+
+    /**
+     * Create a {@link
+     * io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.VariableInstruction}
+     * for the element that's getting activated. These variables will be created in the global scope
+     * of the process instance.
+     *
+     * @param variables the variables document as object to be serialized to JSON
+     * @return the builder for this command
+     */
+    ModifyProcessInstanceCommandStep3 withVariables(final Object variables);
+
+    /**
+     * Create a {@link
+     * io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.VariableInstruction}
+     * for the element that's getting activated. These variables will be created in the scope of the
+     * passed element.
+     *
+     * @param variables the variables document as object to be serialized to JSON
+     * @param scopeId the id of the element in which scope the variables should be created
+     * @return the builder for this command
+     */
+    ModifyProcessInstanceCommandStep3 withVariables(final Object variables, final String scopeId);
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 camunda services GmbH (info@camunda.com)
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2022 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.command;
+
+import io.camunda.zeebe.client.api.response.ModifyProcessInstanceResponse;
+import java.io.InputStream;
+import java.util.Map;
+
+public interface ModifyProcessInstanceCommandStep1 {
+
+  ModifyProcessInstanceCommandStep2 activateElement(final String elementId);
+
+  ModifyProcessInstanceCommandStep2 activateElement(
+      final String elementId, final long ancestorElementInstanceKey);
+
+  /**
+   * Create a {@link
+   * io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.TerminateInstruction}
+   * for the given element id.
+   *
+   * @param elementInstanceKey the element instance key of the element to termiante
+   * @return the builder for this command
+   */
+  ModifyProcessInstanceCommandStep2 terminateElement(final long elementInstanceKey);
+
+  interface ModifyProcessInstanceCommandStep2
+      extends FinalCommandStep<ModifyProcessInstanceResponse> {
+
+    ModifyProcessInstanceCommandStep2 withVariables(final InputStream variables);
+
+    ModifyProcessInstanceCommandStep2 withVariables(
+        final InputStream variables, final String scopeId);
+
+    ModifyProcessInstanceCommandStep2 withVariables(final String variables);
+
+    ModifyProcessInstanceCommandStep2 withVariables(final String variables, final String scopeId);
+
+    ModifyProcessInstanceCommandStep2 withVariables(final Map<String, Object> variables);
+
+    ModifyProcessInstanceCommandStep2 withVariables(
+        final Map<String, Object> variables, final String scopeId);
+
+    ModifyProcessInstanceCommandStep2 withVariables(final Object variables);
+
+    ModifyProcessInstanceCommandStep2 withVariables(final Object variables, final String scopeId);
+  }
+
+  interface ModifyProcessInstanceCommandStep3 {
+    ModifyProcessInstanceCommandStep1 and();
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java
@@ -22,8 +22,11 @@ import java.util.Map;
 public interface ModifyProcessInstanceCommandStep1 {
 
   /**
-   * Create an activate instruction for the given element id. The element will be created within an
-   * existing element instance of the flow scope.
+   * Create an {@link
+   * io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.ActivateInstruction}
+   * for the given element id. The element will be created within an existing element instance of
+   * the flow scope. When activating an element inside a multi-instance element the element instance
+   * key of the ancestor must be defined. For this use {@link #activateElement(String, long)}.
    *
    * @param elementId the id of the element to activate
    * @return the builder for this command

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ModifyProcessInstanceResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ModifyProcessInstanceResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2022 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+public interface ModifyProcessInstanceResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ModifyProcessInstanceResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ModifyProcessInstanceResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 camunda services GmbH (info@camunda.com)
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -259,6 +259,17 @@ public final class ZeebeClientImpl implements ZeebeClient {
   }
 
   @Override
+  public ModifyProcessInstanceCommandStep1 newModifyProcessInstanceCommand(
+      final long processInstanceKey) {
+    return new ModifyProcessInstanceCommandImpl(
+        processInstanceKey,
+        jsonMapper,
+        asyncStub,
+        config.getDefaultRequestTimeout(),
+        credentialsProvider::shouldRetryRequest);
+  }
+
+  @Override
   public CancelProcessInstanceCommandStep1 newCancelInstanceCommand(final long processInstanceKey) {
     return new CancelProcessInstanceCommandImpl(
         asyncStub,
@@ -322,17 +333,6 @@ public final class ZeebeClientImpl implements ZeebeClient {
   public ActivateJobsCommandStep1 newActivateJobsCommand() {
     return new ActivateJobsCommandImpl(
         asyncStub, config, jsonMapper, credentialsProvider::shouldRetryRequest);
-  }
-
-  @Override
-  public ModifyProcessInstanceCommandStep1 newModifyProcessInstanceCommand(
-      final long processInstanceKey) {
-    return new ModifyProcessInstanceCommandImpl(
-        processInstanceKey,
-        jsonMapper,
-        asyncStub,
-        config.getDefaultRequestTimeout(),
-        credentialsProvider::shouldRetryRequest);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.client.api.command.CreateProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.DeployProcessCommandStep1;
 import io.camunda.zeebe.client.api.command.DeployResourceCommandStep1;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
+import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.PublishMessageCommandStep1;
 import io.camunda.zeebe.client.api.command.ResolveIncidentCommandStep1;
 import io.camunda.zeebe.client.api.command.SetVariablesCommandStep1;
@@ -43,6 +44,7 @@ import io.camunda.zeebe.client.impl.command.CreateProcessInstanceCommandImpl;
 import io.camunda.zeebe.client.impl.command.DeployProcessCommandImpl;
 import io.camunda.zeebe.client.impl.command.DeployResourceCommandImpl;
 import io.camunda.zeebe.client.impl.command.JobUpdateRetriesCommandImpl;
+import io.camunda.zeebe.client.impl.command.ModifyProcessInstanceCommandImpl;
 import io.camunda.zeebe.client.impl.command.PublishMessageCommandImpl;
 import io.camunda.zeebe.client.impl.command.ResolveIncidentCommandImpl;
 import io.camunda.zeebe.client.impl.command.SetVariablesCommandImpl;
@@ -320,6 +322,17 @@ public final class ZeebeClientImpl implements ZeebeClient {
   public ActivateJobsCommandStep1 newActivateJobsCommand() {
     return new ActivateJobsCommandImpl(
         asyncStub, config, jsonMapper, credentialsProvider::shouldRetryRequest);
+  }
+
+  @Override
+  public ModifyProcessInstanceCommandStep1 newModifyProcessInstanceCommand(
+      final long processInstanceKey) {
+    return new ModifyProcessInstanceCommandImpl(
+        processInstanceKey,
+        jsonMapper,
+        asyncStub,
+        config.getDefaultRequestTimeout(),
+        credentialsProvider::shouldRetryRequest);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright © 2022 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.command;
+
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.FinalCommandStep;
+import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1;
+import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep2;
+import io.camunda.zeebe.client.api.response.ModifyProcessInstanceResponse;
+import io.camunda.zeebe.client.impl.RetriableClientFutureImpl;
+import io.camunda.zeebe.client.impl.response.ModifyProcessInstanceResponseImpl;
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.ActivateInstruction;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.TerminateInstruction;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.VariableInstruction;
+import io.grpc.stub.StreamObserver;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+public class ModifyProcessInstanceCommandImpl
+    implements ModifyProcessInstanceCommandStep1, ModifyProcessInstanceCommandStep2 {
+
+  private static final String EMPTY_SCOPE_ID = "";
+  private static final long EMPTY_ANCESTOR_KEY = -1L;
+  private final ModifyProcessInstanceRequest.Builder requestBuilder =
+      ModifyProcessInstanceRequest.newBuilder();
+  private final JsonMapper jsonMapper;
+  private final GatewayStub asyncStub;
+  private final Predicate<Throwable> retryPredicate;
+  private ActivateInstruction latestActivateInstruction;
+  private Duration requestTimeout;
+
+  public ModifyProcessInstanceCommandImpl(
+      final long processInstanceKey,
+      final JsonMapper jsonMapper,
+      final GatewayStub asyncStub,
+      final Duration requestTimeout,
+      final Predicate<Throwable> retryPredicate) {
+    requestBuilder.setProcessInstanceKey(processInstanceKey);
+    this.jsonMapper = jsonMapper;
+    this.asyncStub = asyncStub;
+    this.requestTimeout = requestTimeout;
+    this.retryPredicate = retryPredicate;
+  }
+
+  @Override
+  public ModifyProcessInstanceCommandStep2 activateElement(final String elementId) {
+    return activateElement(elementId, EMPTY_ANCESTOR_KEY);
+  }
+
+  @Override
+  public ModifyProcessInstanceCommandStep2 activateElement(
+      final String elementId, final long ancestorElementInstanceKey) {
+    return addActivateInstruction(elementId, ancestorElementInstanceKey);
+  }
+
+  @Override
+  public ModifyProcessInstanceCommandStep3 terminateElement(final long elementInstanceKey) {
+    requestBuilder.addTerminateInstructions(
+        TerminateInstruction.newBuilder().setElementInstanceKey(elementInstanceKey).build());
+    return this;
+  }
+
+  private ModifyProcessInstanceCommandStep2 addActivateInstruction(
+      final String elementId, final long ancestorElementInstanceKey) {
+    final ActivateInstruction activateInstruction =
+        ActivateInstruction.newBuilder()
+            .setElementId(elementId)
+            .setAncestorElementInstanceKey(ancestorElementInstanceKey)
+            .build();
+    latestActivateInstruction = activateInstruction;
+    requestBuilder.addActivateInstructions(activateInstruction);
+    return this;
+  }
+
+  @Override
+  public ModifyProcessInstanceCommandStep1 and() {
+    return this;
+  }
+
+  @Override
+  public ModifyProcessInstanceCommandStep2 withVariables(final InputStream variables) {
+    final VariableInstruction variableInstruction =
+        createVariableInstruction(variables, EMPTY_SCOPE_ID);
+    latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
+    return this;
+  }
+
+  @Override
+  public ModifyProcessInstanceCommandStep2 withVariables(
+      final InputStream variables, final String scopeId) {
+    final VariableInstruction variableInstruction = createVariableInstruction(variables, scopeId);
+    latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
+    return this;
+  }
+
+  @Override
+  public ModifyProcessInstanceCommandStep2 withVariables(final String variables) {
+    final VariableInstruction variableInstruction =
+        createVariableInstruction(variables, EMPTY_SCOPE_ID);
+    latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
+    return this;
+  }
+
+  @Override
+  public ModifyProcessInstanceCommandStep2 withVariables(
+      final String variables, final String scopeId) {
+    final VariableInstruction variableInstruction = createVariableInstruction(variables, scopeId);
+    latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
+    return this;
+  }
+
+  @Override
+  public ModifyProcessInstanceCommandStep2 withVariables(final Map<String, Object> variables) {
+    final VariableInstruction variableInstruction =
+        createVariableInstruction(variables, EMPTY_SCOPE_ID);
+    latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
+    return this;
+  }
+
+  @Override
+  public ModifyProcessInstanceCommandStep2 withVariables(
+      final Map<String, Object> variables, final String scopeId) {
+    final VariableInstruction variableInstruction = createVariableInstruction(variables, scopeId);
+    latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
+    return this;
+  }
+
+  @Override
+  public ModifyProcessInstanceCommandStep2 withVariables(final Object variables) {
+    final VariableInstruction variableInstruction =
+        createVariableInstruction(variables, EMPTY_SCOPE_ID);
+    latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
+    return this;
+  }
+
+  @Override
+  public ModifyProcessInstanceCommandStep2 withVariables(
+      final Object variables, final String scopeId) {
+    final VariableInstruction variableInstruction = createVariableInstruction(variables, scopeId);
+    latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
+    return this;
+  }
+
+  private VariableInstruction createVariableInstruction(
+      final InputStream variables, final String scopeId) {
+    ArgumentUtil.ensureNotNull("variables", variables);
+    final String variablesString = jsonMapper.validateJson("variables", variables);
+    return createVariableInstruction(variablesString, scopeId);
+  }
+
+  private VariableInstruction createVariableInstruction(
+      final Map<String, Object> variables, final String scopeId) {
+    return createVariableInstruction((Object) variables, scopeId);
+  }
+
+  private VariableInstruction createVariableInstruction(
+      final Object variables, final String scopeId) {
+    ArgumentUtil.ensureNotNull("variables", variables);
+    final String variablesString = jsonMapper.toJson(variables);
+    return createVariableInstruction(variablesString, scopeId);
+  }
+
+  private VariableInstruction createVariableInstruction(
+      final String variables, final String scopeId) {
+    return VariableInstruction.newBuilder()
+        .setVariables(jsonMapper.validateJson("variables", variables))
+        .setScopeId(scopeId)
+        .build();
+  }
+
+  @Override
+  public FinalCommandStep<ModifyProcessInstanceResponse> requestTimeout(
+      final Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
+    return this;
+  }
+
+  @Override
+  public ZeebeFuture<ModifyProcessInstanceResponse> send() {
+    final ModifyProcessInstanceRequest request = requestBuilder.build();
+
+    final RetriableClientFutureImpl<
+            ModifyProcessInstanceResponse, GatewayOuterClass.ModifyProcessInstanceResponse>
+        future =
+            new RetriableClientFutureImpl<>(
+                ModifyProcessInstanceResponseImpl::new,
+                retryPredicate,
+                streamObserver -> send(request, streamObserver));
+
+    send(request, future);
+
+    return future;
+  }
+
+  private void send(
+      final ModifyProcessInstanceRequest request, final StreamObserver streamObserver) {
+    asyncStub
+        .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
+        .modifyProcessInstance(request, streamObserver);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 camunda services GmbH (info@camunda.com)
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
@@ -99,10 +99,7 @@ public class ModifyProcessInstanceCommandImpl
 
   @Override
   public ModifyProcessInstanceCommandStep3 withVariables(final InputStream variables) {
-    final VariableInstruction variableInstruction =
-        createVariableInstruction(variables, EMPTY_SCOPE_ID);
-    addVariableInstructionToLatestActivateInstruction(variableInstruction);
-    return this;
+    return withVariables(variables, EMPTY_SCOPE_ID);
   }
 
   @Override
@@ -115,10 +112,7 @@ public class ModifyProcessInstanceCommandImpl
 
   @Override
   public ModifyProcessInstanceCommandStep3 withVariables(final String variables) {
-    final VariableInstruction variableInstruction =
-        createVariableInstruction(variables, EMPTY_SCOPE_ID);
-    addVariableInstructionToLatestActivateInstruction(variableInstruction);
-    return this;
+    return withVariables(variables, EMPTY_SCOPE_ID);
   }
 
   @Override
@@ -131,10 +125,7 @@ public class ModifyProcessInstanceCommandImpl
 
   @Override
   public ModifyProcessInstanceCommandStep3 withVariables(final Map<String, Object> variables) {
-    final VariableInstruction variableInstruction =
-        createVariableInstruction(variables, EMPTY_SCOPE_ID);
-    addVariableInstructionToLatestActivateInstruction(variableInstruction);
-    return this;
+    return withVariables(variables, EMPTY_SCOPE_ID);
   }
 
   @Override
@@ -147,10 +138,7 @@ public class ModifyProcessInstanceCommandImpl
 
   @Override
   public ModifyProcessInstanceCommandStep3 withVariables(final Object variables) {
-    final VariableInstruction variableInstruction =
-        createVariableInstruction(variables, EMPTY_SCOPE_ID);
-    addVariableInstructionToLatestActivateInstruction(variableInstruction);
-    return this;
+    return withVariables(variables, EMPTY_SCOPE_ID);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
@@ -101,7 +101,7 @@ public class ModifyProcessInstanceCommandImpl
   public ModifyProcessInstanceCommandStep3 withVariables(final InputStream variables) {
     final VariableInstruction variableInstruction =
         createVariableInstruction(variables, EMPTY_SCOPE_ID);
-    latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
+    addVariableInstructionToLatestActivateInstruction(variableInstruction);
     return this;
   }
 
@@ -109,7 +109,7 @@ public class ModifyProcessInstanceCommandImpl
   public ModifyProcessInstanceCommandStep3 withVariables(
       final InputStream variables, final String scopeId) {
     final VariableInstruction variableInstruction = createVariableInstruction(variables, scopeId);
-    latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
+    addVariableInstructionToLatestActivateInstruction(variableInstruction);
     return this;
   }
 
@@ -117,7 +117,7 @@ public class ModifyProcessInstanceCommandImpl
   public ModifyProcessInstanceCommandStep3 withVariables(final String variables) {
     final VariableInstruction variableInstruction =
         createVariableInstruction(variables, EMPTY_SCOPE_ID);
-    latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
+    addVariableInstructionToLatestActivateInstruction(variableInstruction);
     return this;
   }
 
@@ -125,7 +125,7 @@ public class ModifyProcessInstanceCommandImpl
   public ModifyProcessInstanceCommandStep3 withVariables(
       final String variables, final String scopeId) {
     final VariableInstruction variableInstruction = createVariableInstruction(variables, scopeId);
-    latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
+    addVariableInstructionToLatestActivateInstruction(variableInstruction);
     return this;
   }
 
@@ -133,7 +133,7 @@ public class ModifyProcessInstanceCommandImpl
   public ModifyProcessInstanceCommandStep3 withVariables(final Map<String, Object> variables) {
     final VariableInstruction variableInstruction =
         createVariableInstruction(variables, EMPTY_SCOPE_ID);
-    latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
+    addVariableInstructionToLatestActivateInstruction(variableInstruction);
     return this;
   }
 
@@ -141,7 +141,7 @@ public class ModifyProcessInstanceCommandImpl
   public ModifyProcessInstanceCommandStep3 withVariables(
       final Map<String, Object> variables, final String scopeId) {
     final VariableInstruction variableInstruction = createVariableInstruction(variables, scopeId);
-    latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
+    addVariableInstructionToLatestActivateInstruction(variableInstruction);
     return this;
   }
 
@@ -149,7 +149,7 @@ public class ModifyProcessInstanceCommandImpl
   public ModifyProcessInstanceCommandStep3 withVariables(final Object variables) {
     final VariableInstruction variableInstruction =
         createVariableInstruction(variables, EMPTY_SCOPE_ID);
-    latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
+    addVariableInstructionToLatestActivateInstruction(variableInstruction);
     return this;
   }
 
@@ -157,7 +157,7 @@ public class ModifyProcessInstanceCommandImpl
   public ModifyProcessInstanceCommandStep3 withVariables(
       final Object variables, final String scopeId) {
     final VariableInstruction variableInstruction = createVariableInstruction(variables, scopeId);
-    latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
+    addVariableInstructionToLatestActivateInstruction(variableInstruction);
     return this;
   }
 
@@ -186,6 +186,19 @@ public class ModifyProcessInstanceCommandImpl
         .setVariables(jsonMapper.validateJson("variables", variables))
         .setScopeId(scopeId)
         .build();
+  }
+
+  private void addVariableInstructionToLatestActivateInstruction(
+      final VariableInstruction variableInstruction) {
+    // Grpc created immutable objects. Since we have already build the activate instruction before
+    // (in case it has no variables), we will have to remove this instruction. We can then copy it
+    // using toBuilder() and add the variable instructions we need. Then we need to re-add the
+    // activate instruction.
+    requestBuilder.removeActivateInstructions(
+        requestBuilder.getActivateInstructionsList().indexOf(latestActivateInstruction));
+    latestActivateInstruction =
+        latestActivateInstruction.toBuilder().addVariableInstructions(variableInstruction).build();
+    requestBuilder.addActivateInstructions(latestActivateInstruction);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
-public class ModifyProcessInstanceCommandImpl
+public final class ModifyProcessInstanceCommandImpl
     implements ModifyProcessInstanceCommandStep1, ModifyProcessInstanceCommandStep3 {
 
   private static final String EMPTY_SCOPE_ID = "";
@@ -94,6 +94,7 @@ public class ModifyProcessInstanceCommandImpl
 
   @Override
   public ModifyProcessInstanceCommandStep1 and() {
+    latestActivateInstruction = null;
     return this;
   }
 
@@ -214,7 +215,8 @@ public class ModifyProcessInstanceCommandImpl
   }
 
   private void send(
-      final ModifyProcessInstanceRequest request, final StreamObserver streamObserver) {
+      final ModifyProcessInstanceRequest request,
+      final StreamObserver<GatewayOuterClass.ModifyProcessInstanceResponse> streamObserver) {
     asyncStub
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
         .modifyProcessInstance(request, streamObserver);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
 import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1;
-import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep2;
+import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep3;
 import io.camunda.zeebe.client.api.response.ModifyProcessInstanceResponse;
 import io.camunda.zeebe.client.impl.RetriableClientFutureImpl;
 import io.camunda.zeebe.client.impl.response.ModifyProcessInstanceResponseImpl;
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 public class ModifyProcessInstanceCommandImpl
-    implements ModifyProcessInstanceCommandStep1, ModifyProcessInstanceCommandStep2 {
+    implements ModifyProcessInstanceCommandStep1, ModifyProcessInstanceCommandStep3 {
 
   private static final String EMPTY_SCOPE_ID = "";
   private static final long EMPTY_ANCESTOR_KEY = -1L;
@@ -63,24 +63,24 @@ public class ModifyProcessInstanceCommandImpl
   }
 
   @Override
-  public ModifyProcessInstanceCommandStep2 activateElement(final String elementId) {
+  public ModifyProcessInstanceCommandStep3 activateElement(final String elementId) {
     return activateElement(elementId, EMPTY_ANCESTOR_KEY);
   }
 
   @Override
-  public ModifyProcessInstanceCommandStep2 activateElement(
+  public ModifyProcessInstanceCommandStep3 activateElement(
       final String elementId, final long ancestorElementInstanceKey) {
     return addActivateInstruction(elementId, ancestorElementInstanceKey);
   }
 
   @Override
-  public ModifyProcessInstanceCommandStep3 terminateElement(final long elementInstanceKey) {
+  public ModifyProcessInstanceCommandStep2 terminateElement(final long elementInstanceKey) {
     requestBuilder.addTerminateInstructions(
         TerminateInstruction.newBuilder().setElementInstanceKey(elementInstanceKey).build());
     return this;
   }
 
-  private ModifyProcessInstanceCommandStep2 addActivateInstruction(
+  private ModifyProcessInstanceCommandStep3 addActivateInstruction(
       final String elementId, final long ancestorElementInstanceKey) {
     final ActivateInstruction activateInstruction =
         ActivateInstruction.newBuilder()
@@ -98,7 +98,7 @@ public class ModifyProcessInstanceCommandImpl
   }
 
   @Override
-  public ModifyProcessInstanceCommandStep2 withVariables(final InputStream variables) {
+  public ModifyProcessInstanceCommandStep3 withVariables(final InputStream variables) {
     final VariableInstruction variableInstruction =
         createVariableInstruction(variables, EMPTY_SCOPE_ID);
     latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
@@ -106,7 +106,7 @@ public class ModifyProcessInstanceCommandImpl
   }
 
   @Override
-  public ModifyProcessInstanceCommandStep2 withVariables(
+  public ModifyProcessInstanceCommandStep3 withVariables(
       final InputStream variables, final String scopeId) {
     final VariableInstruction variableInstruction = createVariableInstruction(variables, scopeId);
     latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
@@ -114,7 +114,7 @@ public class ModifyProcessInstanceCommandImpl
   }
 
   @Override
-  public ModifyProcessInstanceCommandStep2 withVariables(final String variables) {
+  public ModifyProcessInstanceCommandStep3 withVariables(final String variables) {
     final VariableInstruction variableInstruction =
         createVariableInstruction(variables, EMPTY_SCOPE_ID);
     latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
@@ -122,7 +122,7 @@ public class ModifyProcessInstanceCommandImpl
   }
 
   @Override
-  public ModifyProcessInstanceCommandStep2 withVariables(
+  public ModifyProcessInstanceCommandStep3 withVariables(
       final String variables, final String scopeId) {
     final VariableInstruction variableInstruction = createVariableInstruction(variables, scopeId);
     latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
@@ -130,7 +130,7 @@ public class ModifyProcessInstanceCommandImpl
   }
 
   @Override
-  public ModifyProcessInstanceCommandStep2 withVariables(final Map<String, Object> variables) {
+  public ModifyProcessInstanceCommandStep3 withVariables(final Map<String, Object> variables) {
     final VariableInstruction variableInstruction =
         createVariableInstruction(variables, EMPTY_SCOPE_ID);
     latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
@@ -138,7 +138,7 @@ public class ModifyProcessInstanceCommandImpl
   }
 
   @Override
-  public ModifyProcessInstanceCommandStep2 withVariables(
+  public ModifyProcessInstanceCommandStep3 withVariables(
       final Map<String, Object> variables, final String scopeId) {
     final VariableInstruction variableInstruction = createVariableInstruction(variables, scopeId);
     latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
@@ -146,7 +146,7 @@ public class ModifyProcessInstanceCommandImpl
   }
 
   @Override
-  public ModifyProcessInstanceCommandStep2 withVariables(final Object variables) {
+  public ModifyProcessInstanceCommandStep3 withVariables(final Object variables) {
     final VariableInstruction variableInstruction =
         createVariableInstruction(variables, EMPTY_SCOPE_ID);
     latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);
@@ -154,7 +154,7 @@ public class ModifyProcessInstanceCommandImpl
   }
 
   @Override
-  public ModifyProcessInstanceCommandStep2 withVariables(
+  public ModifyProcessInstanceCommandStep3 withVariables(
       final Object variables, final String scopeId) {
     final VariableInstruction variableInstruction = createVariableInstruction(variables, scopeId);
     latestActivateInstruction.getVariableInstructionsList().add(variableInstruction);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ModifyProcessInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ModifyProcessInstanceResponseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 camunda services GmbH (info@camunda.com)
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ModifyProcessInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ModifyProcessInstanceResponseImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2022 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.response;
+
+import io.camunda.zeebe.client.api.response.ModifyProcessInstanceResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+
+public class ModifyProcessInstanceResponseImpl implements ModifyProcessInstanceResponse {
+
+  public ModifyProcessInstanceResponseImpl(
+      final GatewayOuterClass.ModifyProcessInstanceResponse response) {}
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/ModifyProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/ModifyProcessInstanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 camunda services GmbH (info@camunda.com)
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/ModifyProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/ModifyProcessInstanceTest.java
@@ -1,0 +1,425 @@
+/*
+ * Copyright © 2022 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.process;
+
+import static io.camunda.zeebe.client.util.JsonUtil.fromJsonAsMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.camunda.zeebe.client.util.ClientTest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.ActivateInstruction;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.TerminateInstruction;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest.VariableInstruction;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collections;
+import org.junit.Test;
+
+public class ModifyProcessInstanceTest extends ClientTest {
+
+  private static final Long PI_KEY = 1L;
+  private static final Long EMPTY_KEY = -1L;
+  private static final Long ELEMENT_KEY_A = 2L;
+  private static final Long ELEMENT_KEY_B = 3L;
+  private static final String EMPTY_ELEMENT_ID = "";
+  private static final String ELEMENT_ID_A = "elementId_A";
+  private static final String ELEMENT_ID_B = "elementId_B";
+
+  @Test
+  public void shouldActivateSingleElement() {
+    // when
+    client.newModifyProcessInstanceCommand(PI_KEY).activateElement(ELEMENT_ID_A).send().join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 1, 0);
+    final ActivateInstruction activateInstruction = request.getActivateInstructions(0);
+    assertActivateInstruction(activateInstruction, ELEMENT_ID_A, EMPTY_KEY, 0);
+  }
+
+  @Test
+  public void shouldActivateMultipleElements() {
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .activateElement(ELEMENT_ID_A)
+        .and()
+        .activateElement(ELEMENT_ID_B)
+        .send()
+        .join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 2, 0);
+    final ActivateInstruction activateInstructionA = request.getActivateInstructions(0);
+    assertActivateInstruction(activateInstructionA, ELEMENT_ID_A, EMPTY_KEY, 0);
+    final ActivateInstruction activateInstructionB = request.getActivateInstructions(1);
+    assertActivateInstruction(activateInstructionB, ELEMENT_ID_B, EMPTY_KEY, 0);
+  }
+
+  @Test
+  public void shouldActivateMultipleElementsWithVariables() {
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .activateElement(ELEMENT_ID_A)
+        .withVariables(new VariableDocument())
+        .and()
+        .activateElement(ELEMENT_ID_B)
+        .withVariables(new VariableDocument())
+        .send()
+        .join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 2, 0);
+    final ActivateInstruction activateInstructionA = request.getActivateInstructions(0);
+    assertActivateInstruction(activateInstructionA, ELEMENT_ID_A, EMPTY_KEY, 1);
+    final VariableInstruction variableInstructionA =
+        activateInstructionA.getVariableInstructions(0);
+    assertVariableInstruction(variableInstructionA, EMPTY_ELEMENT_ID);
+    final ActivateInstruction activateInstructionB = request.getActivateInstructions(1);
+    assertActivateInstruction(activateInstructionB, ELEMENT_ID_B, EMPTY_KEY, 1);
+    final VariableInstruction variableInstructionB =
+        activateInstructionB.getVariableInstructions(0);
+    assertVariableInstruction(variableInstructionB, EMPTY_ELEMENT_ID);
+  }
+
+  @Test
+  public void shouldTerminateSingleElement() {
+    // when
+    client.newModifyProcessInstanceCommand(PI_KEY).terminateElement(ELEMENT_KEY_A).send().join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 0, 1);
+    final TerminateInstruction terminateInstruction = request.getTerminateInstructions(0);
+    assertTerminateInstruction(terminateInstruction, ELEMENT_KEY_A);
+  }
+
+  @Test
+  public void shouldTerminateMultipleElements() {
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .terminateElement(ELEMENT_KEY_A)
+        .and()
+        .terminateElement(ELEMENT_KEY_B)
+        .send()
+        .join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 0, 2);
+    final TerminateInstruction terminateInstructionA = request.getTerminateInstructions(0);
+    assertTerminateInstruction(terminateInstructionA, ELEMENT_KEY_A);
+    final TerminateInstruction terminateInstructionB = request.getTerminateInstructions(1);
+    assertTerminateInstruction(terminateInstructionB, ELEMENT_KEY_B);
+  }
+
+  @Test
+  public void shouldActivateAndTerminateElement() {
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .activateElement(ELEMENT_ID_A)
+        .and()
+        .terminateElement(ELEMENT_KEY_A)
+        .send()
+        .join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 1, 1);
+    final ActivateInstruction activateInstruction = request.getActivateInstructions(0);
+    assertActivateInstruction(activateInstruction, ELEMENT_ID_A, EMPTY_KEY, 0);
+    final TerminateInstruction terminateInstruction = request.getTerminateInstructions(0);
+    assertTerminateInstruction(terminateInstruction, ELEMENT_KEY_A);
+  }
+
+  @Test
+  public void shouldActivateElementWithAncestor() {
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .activateElement(ELEMENT_ID_A, ELEMENT_KEY_A)
+        .send()
+        .join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 1, 0);
+    final ActivateInstruction activateInstruction = request.getActivateInstructions(0);
+    assertActivateInstruction(activateInstruction, ELEMENT_ID_A, ELEMENT_KEY_A, 0);
+  }
+
+  @Test
+  public void shouldActivateElementWithStringVariables() {
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .activateElement(ELEMENT_ID_A)
+        .withVariables("{\"foo\": \"bar\"}")
+        .send()
+        .join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 1, 0);
+    final ActivateInstruction activateInstruction = request.getActivateInstructions(0);
+    assertActivateInstruction(activateInstruction, ELEMENT_ID_A, EMPTY_KEY, 1);
+    final VariableInstruction variableInstruction = activateInstruction.getVariableInstructions(0);
+    assertVariableInstruction(variableInstruction, EMPTY_ELEMENT_ID);
+  }
+
+  @Test
+  public void shouldActivateElementWithInputStreamVariables() {
+    // given
+    final String variables = "{\"foo\": \"bar\"}";
+    final InputStream inputStream =
+        new ByteArrayInputStream(variables.getBytes(StandardCharsets.UTF_8));
+
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .activateElement(ELEMENT_ID_A)
+        .withVariables(inputStream)
+        .send()
+        .join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 1, 0);
+    final ActivateInstruction activateInstruction = request.getActivateInstructions(0);
+    assertActivateInstruction(activateInstruction, ELEMENT_ID_A, EMPTY_KEY, 1);
+    final VariableInstruction variableInstruction = activateInstruction.getVariableInstructions(0);
+    assertVariableInstruction(variableInstruction, EMPTY_ELEMENT_ID);
+  }
+
+  @Test
+  public void shouldActivateElementWithMapVariables() {
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .activateElement(ELEMENT_ID_A)
+        .withVariables(Collections.singletonMap("foo", "bar"))
+        .send()
+        .join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 1, 0);
+    final ActivateInstruction activateInstruction = request.getActivateInstructions(0);
+    assertActivateInstruction(activateInstruction, ELEMENT_ID_A, EMPTY_KEY, 1);
+    final VariableInstruction variableInstruction = activateInstruction.getVariableInstructions(0);
+    assertVariableInstruction(variableInstruction, EMPTY_ELEMENT_ID);
+  }
+
+  @Test
+  public void shouldActivateElementWithObjectVariables() {
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .activateElement(ELEMENT_ID_A)
+        .withVariables(new VariableDocument())
+        .send()
+        .join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 1, 0);
+    final ActivateInstruction activateInstruction = request.getActivateInstructions(0);
+    assertActivateInstruction(activateInstruction, ELEMENT_ID_A, EMPTY_KEY, 1);
+    final VariableInstruction variableInstruction = activateInstruction.getVariableInstructions(0);
+    assertVariableInstruction(variableInstruction, EMPTY_ELEMENT_ID);
+  }
+
+  @Test
+  public void shouldActivateElementWithStringVariablesAndScopeId() {
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .activateElement(ELEMENT_ID_A)
+        .withVariables("{\"foo\": \"bar\"}", ELEMENT_ID_B)
+        .send()
+        .join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 1, 0);
+    final ActivateInstruction activateInstruction = request.getActivateInstructions(0);
+    assertActivateInstruction(activateInstruction, ELEMENT_ID_A, EMPTY_KEY, 1);
+    final VariableInstruction variableInstruction = activateInstruction.getVariableInstructions(0);
+    assertVariableInstruction(variableInstruction, ELEMENT_ID_B);
+  }
+
+  @Test
+  public void shouldActivateElementWithInputStreamVariablesAndScopeId() {
+    // given
+    final String variables = "{\"foo\": \"bar\"}";
+    final InputStream inputStream =
+        new ByteArrayInputStream(variables.getBytes(StandardCharsets.UTF_8));
+
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .activateElement(ELEMENT_ID_A)
+        .withVariables(inputStream, ELEMENT_ID_B)
+        .send()
+        .join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 1, 0);
+    final ActivateInstruction activateInstruction = request.getActivateInstructions(0);
+    assertActivateInstruction(activateInstruction, ELEMENT_ID_A, EMPTY_KEY, 1);
+    final VariableInstruction variableInstruction = activateInstruction.getVariableInstructions(0);
+    assertVariableInstruction(variableInstruction, ELEMENT_ID_B);
+  }
+
+  @Test
+  public void shouldActivateElementWithMapVariablesAndScopeId() {
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .activateElement(ELEMENT_ID_A)
+        .withVariables(Collections.singletonMap("foo", "bar"), ELEMENT_ID_B)
+        .send()
+        .join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 1, 0);
+    final ActivateInstruction activateInstruction = request.getActivateInstructions(0);
+    assertActivateInstruction(activateInstruction, ELEMENT_ID_A, EMPTY_KEY, 1);
+    final VariableInstruction variableInstruction = activateInstruction.getVariableInstructions(0);
+    assertVariableInstruction(variableInstruction, ELEMENT_ID_B);
+  }
+
+  @Test
+  public void shouldActivateElementWithObjectVariablesAndScopeId() {
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .activateElement(ELEMENT_ID_A)
+        .withVariables(new VariableDocument(), ELEMENT_ID_B)
+        .send()
+        .join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 1, 0);
+    final ActivateInstruction activateInstruction = request.getActivateInstructions(0);
+    assertActivateInstruction(activateInstruction, ELEMENT_ID_A, EMPTY_KEY, 1);
+    final VariableInstruction variableInstruction = activateInstruction.getVariableInstructions(0);
+    assertVariableInstruction(variableInstruction, ELEMENT_ID_B);
+  }
+
+  @Test
+  public void shouldActivateElementWithMultipleVariables() {
+    // given
+    final String variables = "{\"foo\": \"bar\"}";
+    final InputStream inputStream =
+        new ByteArrayInputStream(variables.getBytes(StandardCharsets.UTF_8));
+
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .activateElement(ELEMENT_ID_A)
+        .withVariables(variables)
+        .withVariables(inputStream)
+        .withVariables(Collections.singletonMap("foo", "bar"))
+        .withVariables(new VariableDocument())
+        .send()
+        .join();
+
+    // then
+    final ModifyProcessInstanceRequest request = gatewayService.getLastRequest();
+    assertRequest(request, 1, 0);
+    final ActivateInstruction activateInstruction = request.getActivateInstructions(0);
+    assertActivateInstruction(activateInstruction, ELEMENT_ID_A, EMPTY_KEY, 4);
+    final VariableInstruction variableInstruction1 = activateInstruction.getVariableInstructions(0);
+    assertVariableInstruction(variableInstruction1, EMPTY_ELEMENT_ID);
+    final VariableInstruction variableInstruction2 = activateInstruction.getVariableInstructions(1);
+    assertVariableInstruction(variableInstruction2, EMPTY_ELEMENT_ID);
+    final VariableInstruction variableInstruction3 = activateInstruction.getVariableInstructions(2);
+    assertVariableInstruction(variableInstruction3, EMPTY_ELEMENT_ID);
+    final VariableInstruction variableInstruction4 = activateInstruction.getVariableInstructions(3);
+    assertVariableInstruction(variableInstruction4, EMPTY_ELEMENT_ID);
+  }
+
+  private void assertRequest(
+      final ModifyProcessInstanceRequest request,
+      final int expectedStartInstructions,
+      final int expectedTerminateInstructions) {
+    assertThat(request.getProcessInstanceKey()).isEqualTo(PI_KEY);
+    assertThat(request.getActivateInstructionsCount()).isEqualTo(expectedStartInstructions);
+    assertThat(request.getTerminateInstructionsCount()).isEqualTo(expectedTerminateInstructions);
+  }
+
+  private void assertActivateInstruction(
+      final ActivateInstruction activateInstruction,
+      final String expectedElementId,
+      final long expectedAncestorKey,
+      final int expectedVariableInstructions) {
+    assertThat(activateInstruction.getElementId()).isEqualTo(expectedElementId);
+    assertThat(activateInstruction.getAncestorElementInstanceKey()).isEqualTo(expectedAncestorKey);
+    assertThat(activateInstruction.getVariableInstructionsCount())
+        .isEqualTo(expectedVariableInstructions);
+  }
+
+  private void assertTerminateInstruction(
+      final TerminateInstruction terminateInstruction, final long expectedElementKey) {
+    assertThat(terminateInstruction.getElementInstanceKey()).isEqualTo(expectedElementKey);
+  }
+
+  private void assertVariableInstruction(
+      final VariableInstruction variableInstruction, final String expectedScopeId) {
+    assertThat(fromJsonAsMap(variableInstruction.getVariables())).containsOnly(entry("foo", "bar"));
+    assertThat(variableInstruction.getScopeId()).isEqualTo(expectedScopeId);
+  }
+
+  @Test
+  public void shouldSetRequestTimeout() {
+    // given
+    final Duration requestTimeout = Duration.ofHours(124);
+
+    // when
+    client
+        .newModifyProcessInstanceCommand(PI_KEY)
+        .activateElement(ELEMENT_ID_A)
+        .requestTimeout(requestTimeout)
+        .send()
+        .join();
+
+    // then
+    rule.verifyRequestTimeout(requestTimeout);
+  }
+
+  private static class VariableDocument {
+
+    private final String foo = "bar";
+
+    VariableDocument() {}
+
+    public String getFoo() {
+      return foo;
+    }
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/util/RecordingGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/util/RecordingGatewayService.java
@@ -38,6 +38,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRespons
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Deployment;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ModifyProcessInstanceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Partition;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Partition.PartitionBrokerHealth;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Partition.PartitionBrokerRole;
@@ -99,6 +101,9 @@ public final class RecordingGatewayService extends GatewayImplBase {
     addRequestHandler(ActivateJobsRequest.class, r -> ActivateJobsResponse.getDefaultInstance());
     addRequestHandler(
         ResolveIncidentRequest.class, r -> ResolveIncidentResponse.getDefaultInstance());
+    addRequestHandler(
+        ModifyProcessInstanceRequest.class,
+        r -> ModifyProcessInstanceResponse.getDefaultInstance());
   }
 
   public static Partition partition(
@@ -286,6 +291,13 @@ public final class RecordingGatewayService extends GatewayImplBase {
   public void updateJobRetries(
       final UpdateJobRetriesRequest request,
       final StreamObserver<UpdateJobRetriesResponse> responseObserver) {
+    handle(request, responseObserver);
+  }
+
+  @Override
+  public void modifyProcessInstance(
+      final ModifyProcessInstanceRequest request,
+      final StreamObserver<ModifyProcessInstanceResponse> responseObserver) {
     handle(request, responseObserver);
   }
 

--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -431,7 +431,7 @@ message ModifyProcessInstanceRequest {
     // valid argument, as the root of the JSON document is an array and not an object.
     string variables = 1;
     // the id of the element in which scope the variables should be created;
-    // set to -1 to create the variables in the global scope of the process instance
+    // leave empty to create the variables in the global scope of the process instance
     string scopeId = 2;
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR adds support for sending PI modification command through the Java API. The interface lets you add activate/terminate instructions for elements. When activating an element it also provides the option to add variables.

To keep a clear distinction between the element that is currently being activated / terminated it is required to call the and() method when switching to a new element.

E.g.:
```java
    client
        .newModifyProcessInstanceCommand(piKey)
        .activateElement(elementId)
        .withVariables(variables)
        .and()
        .activateElement(elementId, ancestorKey)
        .withVariables(variables)
        .withVariables(variables, scopeId)
        .and()
        .terminateElement(elementId)
        .send()
        .join();
```

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9660

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
