### PR TITLE
New `AdminRequest` type to pause exporting

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerRequest;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.camunda.zeebe.protocol.impl.encoding.AdminRequest;
 import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
+import io.camunda.zeebe.protocol.record.AdminRequestEncoder;
 import io.camunda.zeebe.protocol.record.AdminRequestType;
 import io.camunda.zeebe.protocol.record.AdminResponseEncoder;
 import io.camunda.zeebe.transport.RequestType;
@@ -29,6 +30,16 @@ public class BrokerAdminRequest extends BrokerRequest<Void> {
 
   public void stepDownIfNotPrimary() {
     request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
+  }
+
+  @Override
+  public Optional<Integer> getBrokerId() {
+    final var brokerId = request.getBrokerId();
+    if (brokerId != AdminRequestEncoder.brokerIdNullValue()) {
+      return Optional.of(brokerId);
+    } else {
+      return Optional.empty();
+    }
   }
 
   @Override
@@ -87,11 +98,6 @@ public class BrokerAdminRequest extends BrokerRequest<Void> {
   @Override
   public RequestType getRequestType() {
     return RequestType.ADMIN;
-  }
-
-  @Override
-  public Optional<Integer> getBrokerId() {
-    return Optional.empty();
   }
 
   @Override

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
@@ -46,6 +46,10 @@ public class BrokerAdminRequest extends BrokerRequest<Void> {
     }
   }
 
+  public void setBrokerId(final int brokerId) {
+    request.setBrokerId(brokerId);
+  }
+
   @Override
   public int getPartitionId() {
     return request.getPartitionId();

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
@@ -32,6 +32,10 @@ public class BrokerAdminRequest extends BrokerRequest<Void> {
     request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
   }
 
+  public void pauseExporting() {
+    request.setType(AdminRequestType.PAUSE_EXPORTING);
+  }
+
   @Override
   public Optional<Integer> getBrokerId() {
     final var brokerId = request.getBrokerId();

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
@@ -23,10 +23,12 @@ public class AdminRequest implements BufferReader, BufferWriter {
   private final AdminRequestEncoder bodyEncoder = new AdminRequestEncoder();
   private final AdminRequestDecoder bodyDecoder = new AdminRequestDecoder();
 
+  private int brokerId;
   private int partitionId;
   private AdminRequestType type;
 
   public AdminRequest reset() {
+    brokerId = AdminRequestEncoder.brokerIdNullValue();
     partitionId = AdminRequestEncoder.partitionIdNullValue();
     type = AdminRequestType.NULL_VAL;
     return this;
@@ -35,6 +37,7 @@ public class AdminRequest implements BufferReader, BufferWriter {
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
     bodyDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
+    brokerId = bodyDecoder.brokerId();
     partitionId = bodyDecoder.partitionId();
     type = bodyDecoder.type();
   }
@@ -48,8 +51,17 @@ public class AdminRequest implements BufferReader, BufferWriter {
   public void write(final MutableDirectBuffer buffer, final int offset) {
     bodyEncoder
         .wrapAndApplyHeader(buffer, offset, headerEncoder)
+        .brokerId(brokerId)
         .partitionId(partitionId)
         .type(type);
+  }
+
+  public int getBrokerId() {
+    return brokerId;
+  }
+
+  public void setBrokerId(final int brokerId) {
+    this.brokerId = brokerId;
   }
 
   public int getPartitionId() {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AdminRequest.java
@@ -23,16 +23,9 @@ public class AdminRequest implements BufferReader, BufferWriter {
   private final AdminRequestEncoder bodyEncoder = new AdminRequestEncoder();
   private final AdminRequestDecoder bodyDecoder = new AdminRequestDecoder();
 
-  private int brokerId;
-  private int partitionId;
-  private AdminRequestType type;
-
-  public AdminRequest reset() {
-    brokerId = AdminRequestEncoder.brokerIdNullValue();
-    partitionId = AdminRequestEncoder.partitionIdNullValue();
-    type = AdminRequestType.NULL_VAL;
-    return this;
-  }
+  private int brokerId = AdminRequestEncoder.brokerIdNullValue();
+  private int partitionId = AdminRequestEncoder.partitionIdNullValue();
+  private AdminRequestType type = AdminRequestType.NULL_VAL;
 
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -25,7 +25,7 @@
   <properties>
     <version.java>8</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
-    <protocol.version>3</protocol.version>
+    <protocol.version>4</protocol.version>
   </properties>
 
   <dependencies>

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -15,6 +15,17 @@
     "configuration": {
       "differences": [
         {
+          "justification": "Upgrading the protocol version should be backwards compatible",
+          "code": "java.field.constantValueChanged",
+          "classQualifiedName": "io.camunda.zeebe.protocol.Protocol",
+          "fieldName": "PROTOCOL_VERSION"
+        },
+        {
+          "justification": "Upgrading the schema version should be backwards compatible",
+          "code": "java.field.constantValueChanged",
+          "fieldName": "SCHEMA_VERSION"
+        },
+        {
           "justification": "Ignore Enum order for BpmnElementType as ordinal() is not used and the elements are grouped in the enum.",
           "code": "java.field.enumConstantOrderChanged",
           "classQualifiedName": "io.camunda.zeebe.protocol.record.value.BpmnElementType"
@@ -37,6 +48,20 @@
           "code": "java.field.removed",
           "classQualifiedName": "io.camunda.zeebe.protocol.record.value.BpmnElementType",
           "fieldName": "TESTING_ONLY"
+        },
+        {
+          "justification": "Ignore Enum order for AdminRequestType as ordinal() is not used",
+          "code": "java.field.enumConstantOrderChanged",
+          "classQualifiedName": "io.camunda.zeebe.protocol.record.AdminRequestType"
+        },
+        {
+          "justification": "Adding optional fields to the end of the root block is backwards compatible",
+          "code": "java.field.constantValueChanged",
+          "regex": true,
+          "classQualifiedName": "io.camunda.zeebe.protocol.record.AdminRequest(Decoder|Encoder)",
+          "fieldName": "BLOCK_LENGTH",
+          "oldValue": 3,
+          "newValue": 5
         }
       ]
     }

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -126,7 +126,7 @@
   </sbe:message>
 
   <sbe:message name="AdminRequest" id="40">
-    <field name="brokerId" id="3" type="uint16" presence="optional"/>
+    <field name="brokerId" id="3" type="uint16" presence="optional" sinceVersion="4"/>
     <field name="partitionId" id="1" type="uint16"/>
     <field name="type" id="2" type="AdminRequestType"/>
   </sbe:message>

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -126,9 +126,9 @@
   </sbe:message>
 
   <sbe:message name="AdminRequest" id="40">
-    <field name="brokerId" id="3" type="uint16" presence="optional" sinceVersion="4"/>
     <field name="partitionId" id="1" type="uint16"/>
     <field name="type" id="2" type="AdminRequestType"/>
+    <field name="brokerId" id="3" type="uint16" presence="optional" sinceVersion="4"/>
   </sbe:message>
 
   <sbe:message name="AdminResponse" id="41">

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -125,6 +125,7 @@
   </sbe:message>
 
   <sbe:message name="AdminRequest" id="40">
+    <field name="brokerId" id="3" type="uint16" presence="optional"/>
     <field name="partitionId" id="1" type="uint16"/>
     <field name="type" id="2" type="AdminRequestType"/>
   </sbe:message>

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -82,6 +82,7 @@
 
     <enum name="AdminRequestType" encodingType="uint8">
       <validValue name="STEP_DOWN_IF_NOT_PRIMARY">0</validValue>
+      <validValue name="PAUSE_EXPORTING">1</validValue>
     </enum>
 
   </types>


### PR DESCRIPTION
## Description

Adds a new request type, `PAUSE_EXPORTING` and adds an optional broker id for all admin requests.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #9630 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
