### PR TITLE
Activate root elements for activate instructions of PI modification

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
@@ -241,7 +241,11 @@ public final class ProcessEventProcessors {
       final Writers writers,
       final KeyGenerator keyGenerator) {
     final ProcessInstanceModificationProcessor modificationProcessor =
-        new ProcessInstanceModificationProcessor(writers, keyGenerator);
+        new ProcessInstanceModificationProcessor(
+            writers,
+            keyGenerator,
+            zeebeState.getElementInstanceState(),
+            zeebeState.getProcessState());
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE_MODIFICATION,
         ProcessInstanceModificationIntent.MODIFY,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.engine.processing.variable.UpdateVariableDocumentProcess
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
@@ -60,9 +61,9 @@ public final class ProcessEventProcessors {
       final JobMetrics jobMetrics) {
     final MutableProcessMessageSubscriptionState subscriptionState =
         zeebeState.getProcessMessageSubscriptionState();
+    final var keyGenerator = zeebeState.getKeyGenerator();
     final VariableBehavior variableBehavior =
-        new VariableBehavior(
-            zeebeState.getVariableState(), writers.state(), zeebeState.getKeyGenerator());
+        new VariableBehavior(zeebeState.getVariableState(), writers.state(), keyGenerator);
 
     final var processEngineMetrics = new ProcessEngineMetrics(zeebeState.getPartitionId());
 
@@ -99,7 +100,7 @@ public final class ProcessEventProcessors {
         typedRecordProcessors,
         variableBehavior,
         zeebeState.getElementInstanceState(),
-        zeebeState.getKeyGenerator(),
+        keyGenerator,
         writers.state());
     addProcessInstanceCreationStreamProcessors(
         typedRecordProcessors,
@@ -108,7 +109,8 @@ public final class ProcessEventProcessors {
         variableBehavior,
         catchEventBehavior,
         processEngineMetrics);
-    addProcessInstanceModificationStreamProcessors(typedRecordProcessors, zeebeState, writers);
+    addProcessInstanceModificationStreamProcessors(
+        typedRecordProcessors, zeebeState, writers, keyGenerator);
 
     return bpmnStreamProcessor;
   }
@@ -235,10 +237,11 @@ public final class ProcessEventProcessors {
 
   private static void addProcessInstanceModificationStreamProcessors(
       final TypedRecordProcessors typedRecordProcessors,
-      final MutableZeebeState zeebeState,
-      final Writers writers) {
+      final ZeebeState zeebeState,
+      final Writers writers,
+      final KeyGenerator keyGenerator) {
     final ProcessInstanceModificationProcessor modificationProcessor =
-        new ProcessInstanceModificationProcessor(writers, zeebeState.getKeyGenerator());
+        new ProcessInstanceModificationProcessor(writers, keyGenerator);
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE_MODIFICATION,
         ProcessInstanceModificationIntent.MODIFY,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -33,14 +33,14 @@ public final class ProcessInstanceModificationProcessor
   @Override
   public void processRecord(final TypedRecord<ProcessInstanceModificationRecord> command) {
     final long commandKey = command.getKey();
-    final ProcessInstanceModificationRecord record = command.getValue();
+    final var value = command.getValue();
 
     // if set, the command's key should take precedence over the processInstanceKey
-    final long eventKey = commandKey > -1 ? commandKey : record.getProcessInstanceKey();
+    final long eventKey = commandKey > -1 ? commandKey : value.getProcessInstanceKey();
 
-    stateWriter.appendFollowUpEvent(eventKey, ProcessInstanceModificationIntent.MODIFIED, record);
+    stateWriter.appendFollowUpEvent(eventKey, ProcessInstanceModificationIntent.MODIFIED, value);
 
     responseWriter.writeEventOnCommand(
-        eventKey, ProcessInstanceModificationIntent.MODIFIED, record, command);
+        eventKey, ProcessInstanceModificationIntent.MODIFIED, value, command);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -32,8 +32,11 @@ public final class ProcessInstanceModificationProcessor
 
   @Override
   public void processRecord(final TypedRecord<ProcessInstanceModificationRecord> command) {
+    final long commandKey = command.getKey();
     final ProcessInstanceModificationRecord record = command.getValue();
-    final long eventKey = keyGenerator.nextKey();
+
+    // if set, the command's key should take precedence over the processInstanceKey
+    final long eventKey = commandKey > -1 ? commandKey : record.getProcessInstanceKey();
 
     stateWriter.appendFollowUpEvent(eventKey, ProcessInstanceModificationIntent.MODIFIED, record);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -8,26 +8,42 @@
 package io.camunda.zeebe.engine.processing.processinstance;
 
 import io.camunda.zeebe.engine.api.TypedRecord;
+import io.camunda.zeebe.engine.processing.deployment.model.element.AbstractFlowElement;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.KeyGenerator;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationActivateInstructionValue;
 
 public final class ProcessInstanceModificationProcessor
     implements TypedRecordProcessor<ProcessInstanceModificationRecord> {
 
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
+  private final TypedCommandWriter commandWriter;
   private final KeyGenerator keyGenerator;
+  private final ElementInstanceState elementInstanceState;
+  private final ProcessState processState;
 
   public ProcessInstanceModificationProcessor(
-      final Writers writers, final KeyGenerator keyGenerator) {
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final ElementInstanceState elementInstanceState,
+      final ProcessState processState) {
     stateWriter = writers.state();
     responseWriter = writers.response();
+    commandWriter = writers.command();
     this.keyGenerator = keyGenerator;
+    this.elementInstanceState = elementInstanceState;
+    this.processState = processState;
   }
 
   @Override
@@ -38,9 +54,47 @@ public final class ProcessInstanceModificationProcessor
     // if set, the command's key should take precedence over the processInstanceKey
     final long eventKey = commandKey > -1 ? commandKey : value.getProcessInstanceKey();
 
+    final var processInstance =
+        elementInstanceState.getInstance(value.getProcessInstanceKey()).getValue();
+
+    // todo: reject if process instance could not be found
+
+    value
+        .getActivateInstructions()
+        .forEach(
+            instruction -> {
+              // todo: consider moving this out of the foreach loop
+              final var process =
+                  processState.getProcessByKey(processInstance.getProcessDefinitionKey());
+              final var elementToActivate =
+                  process.getProcess().getElementById(instruction.getElementId());
+
+              // todo: reject if elementToActivate could not be found
+
+              activateElement(processInstance, instruction, elementToActivate);
+            });
+
     stateWriter.appendFollowUpEvent(eventKey, ProcessInstanceModificationIntent.MODIFIED, value);
 
     responseWriter.writeEventOnCommand(
         eventKey, ProcessInstanceModificationIntent.MODIFIED, value, command);
+  }
+
+  private void activateElement(
+      final ProcessInstanceRecord processInstance,
+      final ProcessInstanceModificationActivateInstructionValue instruction,
+      final AbstractFlowElement elementToActivate) {
+    final var elementInstanceRecord = new ProcessInstanceRecord();
+    elementInstanceRecord.wrap(processInstance);
+    commandWriter.appendFollowUpCommand(
+        keyGenerator.nextKey(),
+        ProcessInstanceIntent.ACTIVATE_ELEMENT,
+        elementInstanceRecord
+            // todo: allow non-process instance element's as flowscope
+            .setFlowScopeKey(processInstance.getProcessInstanceKey())
+            .setBpmnElementType(elementToActivate.getElementType())
+            .setElementId(instruction.getElementId())
+            .setParentProcessInstanceKey(-1)
+            .setParentElementInstanceKey(-1));
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedEventRegistry.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedEventRegistry.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRe
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
@@ -55,6 +56,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.VARIABLE, VariableRecord.class);
     registry.put(ValueType.VARIABLE_DOCUMENT, VariableDocumentRecord.class);
     registry.put(ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationRecord.class);
+    registry.put(ValueType.PROCESS_INSTANCE_MODIFICATION, ProcessInstanceModificationRecord.class);
     registry.put(ValueType.ERROR, ErrorRecord.class);
     registry.put(ValueType.PROCESS_INSTANCE_RESULT, ProcessInstanceResultRecord.class);
     registry.put(ValueType.PROCESS, ProcessRecord.class);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class ModifyProcessInstanceTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  private static final String PROCESS_ID = "process";
+
+  @Test
+  public void shouldWriteModifiedEventForProcessInstance() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask("A", a -> a.zeebeJobType("A"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    final var event =
+        ENGINE.processInstance().withInstanceKey(processInstanceKey).modification().modify();
+
+    // then
+    assertThat(event)
+        .hasKey(processInstanceKey)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(ProcessInstanceModificationIntent.MODIFIED);
+
+    assertThat(event.getValue())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasNoActivateInstructions()
+        .hasNoTerminateInstructions();
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -11,15 +11,27 @@ import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.groups.Tuple;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestWatcher;
 
 public class ModifyProcessInstanceTest {
 
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
   private static final String PROCESS_ID = "process";
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
 
   @Test
   public void shouldWriteModifiedEventForProcessInstance() {
@@ -50,5 +62,81 @@ public class ModifyProcessInstanceTest {
         .hasProcessInstanceKey(processInstanceKey)
         .hasNoActivateInstructions()
         .hasNoTerminateInstructions();
+  }
+
+  @Test
+  public void shouldActivateRootElement() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask("A", a -> a.zeebeJobType("A"))
+                .serviceTask("B", b -> b.zeebeJobType("B"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var processInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst()
+            .getValue();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .activateElement("B")
+        .modify();
+
+    // then
+    final var elementInstanceEvents =
+        RecordingExporter.processInstanceRecords()
+            .onlyEvents()
+            .withElementId("B")
+            .withProcessInstanceKey(processInstanceKey)
+            .limit("B", ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .toList();
+
+    Assertions.assertThat(elementInstanceEvents)
+        .extracting(Record::getIntent)
+        .describedAs("Expect the element instance to have been activated")
+        .containsExactly(
+            ProcessInstanceIntent.ELEMENT_ACTIVATING, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+
+    Assertions.assertThat(elementInstanceEvents)
+        .extracting(Record::getKey)
+        .describedAs("Expect each element instance event to refer to the same entity")
+        .containsOnly(elementInstanceEvents.get(0).getKey());
+
+    Assertions.assertThat(elementInstanceEvents)
+        .extracting(Record::getValue)
+        .describedAs("Expect each element instance event to contain the complete record value")
+        .extracting(
+            ProcessInstanceRecordValue::getBpmnProcessId,
+            ProcessInstanceRecordValue::getProcessDefinitionKey,
+            ProcessInstanceRecordValue::getProcessInstanceKey,
+            ProcessInstanceRecordValue::getBpmnElementType,
+            ProcessInstanceRecordValue::getElementId,
+            ProcessInstanceRecordValue::getFlowScopeKey,
+            ProcessInstanceRecordValue::getVersion,
+            ProcessInstanceRecordValue::getParentProcessInstanceKey,
+            ProcessInstanceRecordValue::getParentElementInstanceKey)
+        .containsOnly(
+            Tuple.tuple(
+                PROCESS_ID,
+                processInstance.getProcessDefinitionKey(),
+                processInstanceKey,
+                BpmnElementType.SERVICE_TASK,
+                "B",
+                processInstanceKey,
+                processInstance.getVersion(),
+                -1L,
+                -1L));
   }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceModificationRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceModificationRecordStream.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
+import java.util.stream.Stream;
+
+public final class ProcessInstanceModificationRecordStream
+    extends ExporterRecordStream<
+        ProcessInstanceModificationRecordValue, ProcessInstanceModificationRecordStream> {
+
+  public ProcessInstanceModificationRecordStream(
+      final Stream<Record<ProcessInstanceModificationRecordValue>> records) {
+    super(records);
+  }
+
+  @Override
+  protected ProcessInstanceModificationRecordStream supply(
+      final Stream<Record<ProcessInstanceModificationRecordValue>> wrappedStream) {
+    return new ProcessInstanceModificationRecordStream(wrappedStream);
+  }
+
+  public ProcessInstanceModificationRecordStream withProcessInstanceKey(
+      final long processInstanceKey) {
+    return valueFilter(v -> v.getProcessInstanceKey() == processInstanceKey);
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
@@ -34,6 +35,7 @@ import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
@@ -242,6 +244,17 @@ public final class RecordingExporter implements Exporter {
   public static ProcessInstanceCreationRecordStream processInstanceCreationRecords() {
     return new ProcessInstanceCreationRecordStream(
         records(ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationRecordValue.class));
+  }
+
+  public static ProcessInstanceModificationRecordStream processInstanceModificationRecords() {
+    return new ProcessInstanceModificationRecordStream(
+        records(
+            ValueType.PROCESS_INSTANCE_MODIFICATION, ProcessInstanceModificationRecordValue.class));
+  }
+
+  public static ProcessInstanceModificationRecordStream processInstanceModificationRecords(
+      final ProcessInstanceModificationIntent intent) {
+    return processInstanceModificationRecords().withIntent(intent);
   }
 
   public static ProcessInstanceResultRecordStream processInstanceResultRecords() {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This adds the ability to the process instance modification `MODIFY` command processor to activate root process elements when these are specified in the activate instructions.

It also provides the basic test harness required to test this, and that is also needed for the upcoming issues.

Lastly, this PR rectifies some details about the process instance modification `MODIFIED` event that is written as a result of processing the `MODIFY` command.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9640 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
