### PR TITLE
Add transition step to install BackupApiRequestHandler

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -33,7 +33,8 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
             brokerStartupContext.getDiskSpaceUsageMonitor(),
             brokerStartupContext.getPartitionListeners(),
             brokerStartupContext.getCommandApiService(),
-            brokerStartupContext.getExporterRepository());
+            brokerStartupContext.getExporterRepository(),
+            brokerStartupContext.getCommandApiServerTransport());
 
     CompletableFuture.runAsync(
         () ->

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.broker.system.partitions.impl.AtomixRecordEntrySupplierI
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionProcessingState;
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionTransitionImpl;
 import io.camunda.zeebe.broker.system.partitions.impl.StateControllerImpl;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.BackupApiRequestHandlerStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.ExporterDirectorPartitionTransitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.InterPartitionCommandReceiverStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.LogDeletionPartitionStartupStep;
@@ -78,7 +79,8 @@ final class PartitionFactory {
           new QueryServicePartitionTransitionStep(),
           new StreamProcessorTransitionStep(),
           new SnapshotDirectorPartitionTransitionStep(),
-          new ExporterDirectorPartitionTransitionStep());
+          new ExporterDirectorPartitionTransitionStep(),
+          new BackupApiRequestHandlerStep());
 
   private final ActorSchedulingService actorSchedulingService;
   private final BrokerCfg brokerCfg;

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -57,6 +57,7 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.startup.StartupStep;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.FeatureFlags;
 import java.util.ArrayList;
 import java.util.List;
@@ -88,6 +89,7 @@ final class PartitionFactory {
   private final ExporterRepository exporterRepository;
   private final BrokerHealthCheckService healthCheckService;
   private final DiskSpaceUsageMonitor diskSpaceUsageMonitor;
+  private final AtomixServerTransport gatewayBrokerTransport;
 
   PartitionFactory(
       final ActorSchedulingService actorSchedulingService,
@@ -98,7 +100,8 @@ final class PartitionFactory {
       final ClusterServices clusterServices,
       final ExporterRepository exporterRepository,
       final BrokerHealthCheckService healthCheckService,
-      final DiskSpaceUsageMonitor diskSpaceUsageMonitor) {
+      final DiskSpaceUsageMonitor diskSpaceUsageMonitor,
+      final AtomixServerTransport gatewayBrokerTransport) {
     this.actorSchedulingService = actorSchedulingService;
     this.brokerCfg = brokerCfg;
     this.localBroker = localBroker;
@@ -108,6 +111,7 @@ final class PartitionFactory {
     this.exporterRepository = exporterRepository;
     this.healthCheckService = healthCheckService;
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
+    this.gatewayBrokerTransport = gatewayBrokerTransport;
   }
 
   List<ZeebePartition> constructPartitions(
@@ -159,7 +163,8 @@ final class PartitionFactory {
               typedRecordProcessorsFactory,
               exporterRepository,
               new PartitionProcessingState(owningPartition),
-              diskSpaceUsageMonitor);
+              diskSpaceUsageMonitor,
+              gatewayBrokerTransport);
 
       final PartitionTransition newTransitionBehavior =
           new PartitionTransitionImpl(TRANSITION_STEPS);

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthStatus;
 import java.util.ArrayList;
 import java.util.List;
@@ -58,6 +59,7 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
   private final ClusterServices clusterServices;
   private final CommandApiService commandApiService;
   private final ExporterRepository exporterRepository;
+  private final AtomixServerTransport gatewayBrokerTransport;
 
   public PartitionManagerImpl(
       final ActorSchedulingService actorSchedulingService,
@@ -68,7 +70,9 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
       final DiskSpaceUsageMonitor diskSpaceUsageMonitor,
       final List<PartitionListener> partitionListeners,
       final CommandApiService commandApiService,
-      final ExporterRepository exporterRepository) {
+      final ExporterRepository exporterRepository,
+      final AtomixServerTransport gatewayBrokerTransport) {
+    this.gatewayBrokerTransport = gatewayBrokerTransport;
 
     snapshotStoreFactory =
         new FileBasedSnapshotStoreFactory(actorSchedulingService, localBroker.getNodeId());
@@ -140,7 +144,8 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
                       clusterServices,
                       exporterRepository,
                       healthCheckService,
-                      diskSpaceUsageMonitor);
+                      diskSpaceUsageMonitor,
+                      gatewayBrokerTransport);
 
               partitions.addAll(
                   partitionFactory.constructPartitions(

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionProcessingState;
+import io.camunda.zeebe.broker.transport.backupapi.BackupApiRequestHandler;
 import io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandReceiverActor;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.api.TypedRecord;
@@ -87,6 +88,7 @@ public class PartitionStartupAndTransitionContextImpl
   private ConcurrencyControl concurrencyControl;
   private InterPartitionCommandReceiverActor interPartitionCommandReceiver;
   private final AtomixServerTransport gatewayBrokerTransport;
+  private BackupApiRequestHandler backupApiRequestHandler;
 
   public PartitionStartupAndTransitionContextImpl(
       final int nodeId,
@@ -269,6 +271,16 @@ public class PartitionStartupAndTransitionContextImpl
   @Override
   public AtomixServerTransport getGatewayBrokerTransport() {
     return gatewayBrokerTransport;
+  }
+
+  @Override
+  public BackupApiRequestHandler getBackupApiRequestHandler() {
+    return backupApiRequestHandler;
+  }
+
+  @Override
+  public void setBackupApiRequestHandler(final BackupApiRequestHandler backupApiRequestHandler) {
+    this.backupApiRequestHandler = backupApiRequestHandler;
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.streamprocessor.StreamProcessor;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import java.util.Collection;
 import java.util.Collections;
@@ -85,6 +86,7 @@ public class PartitionStartupAndTransitionContextImpl
   private Role currentRole;
   private ConcurrencyControl concurrencyControl;
   private InterPartitionCommandReceiverActor interPartitionCommandReceiver;
+  private final AtomixServerTransport gatewayBrokerTransport;
 
   public PartitionStartupAndTransitionContextImpl(
       final int nodeId,
@@ -101,7 +103,8 @@ public class PartitionStartupAndTransitionContextImpl
       final TypedRecordProcessorsFactory typedRecordProcessorsFactory,
       final ExporterRepository exporterRepository,
       final PartitionProcessingState partitionProcessingState,
-      final DiskSpaceUsageMonitor diskSpaceUsageMonitor) {
+      final DiskSpaceUsageMonitor diskSpaceUsageMonitor,
+      final AtomixServerTransport gatewayBrokerTransport) {
     this.nodeId = nodeId;
     this.clusterCommunicationService = clusterCommunicationService;
     this.raftPartition = raftPartition;
@@ -119,6 +122,7 @@ public class PartitionStartupAndTransitionContextImpl
     this.exporterRepository = exporterRepository;
     this.partitionProcessingState = partitionProcessingState;
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
+    this.gatewayBrokerTransport = gatewayBrokerTransport;
   }
 
   public PartitionAdminControl getPartitionAdminControl() {
@@ -260,6 +264,11 @@ public class PartitionStartupAndTransitionContextImpl
   @Override
   public DiskSpaceUsageMonitor getDiskSpaceUsageMonitor() {
     return diskSpaceUsageMonitor;
+  }
+
+  @Override
+  public AtomixServerTransport getGatewayBrokerTransport() {
+    return gatewayBrokerTransport;
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.streamprocessor.StreamProcessor;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
@@ -97,4 +98,6 @@ public interface PartitionTransitionContext extends PartitionContext {
   void setQueryService(QueryService queryService);
 
   DiskSpaceUsageMonitor getDiskSpaceUsageMonitor();
+
+  AtomixServerTransport getGatewayBrokerTransport();
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.broker.logstreams.AtomixLogStorage;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
+import io.camunda.zeebe.broker.transport.backupapi.BackupApiRequestHandler;
 import io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandReceiverActor;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.api.TypedRecord;
@@ -100,4 +101,8 @@ public interface PartitionTransitionContext extends PartitionContext {
   DiskSpaceUsageMonitor getDiskSpaceUsageMonitor();
 
   AtomixServerTransport getGatewayBrokerTransport();
+
+  BackupApiRequestHandler getBackupApiRequestHandler();
+
+  void setBackupApiRequestHandler(BackupApiRequestHandler backupApiRequestHandler);
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStep.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
+import io.camunda.zeebe.broker.transport.backupapi.BackupApiRequestHandler;
+import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+
+public final class BackupApiRequestHandlerStep implements PartitionTransitionStep {
+
+  @Override
+  public ActorFuture<Void> prepareTransition(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    final BackupApiRequestHandler backupApiRequestHandler = context.getBackupApiRequestHandler();
+    if (backupApiRequestHandler != null) {
+      context.getDiskSpaceUsageMonitor().removeDiskUsageListener(backupApiRequestHandler);
+      final var closeFuture = backupApiRequestHandler.closeAsync();
+      context.setBackupApiRequestHandler(null);
+      return closeFuture;
+    }
+    return CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  public ActorFuture<Void> transitionTo(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    // Only installed during the leader
+    if (targetRole == Role.LEADER) {
+      return installRequestHandler(context);
+    }
+    return CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  public String getName() {
+    return "BackupApiRequestHandlerStep";
+  }
+
+  private ActorFuture<Void> installRequestHandler(final PartitionTransitionContext context) {
+    final ActorFuture<Void> installed = context.getConcurrencyControl().createFuture();
+    final var writerFuture = context.getLogStream().newLogStreamRecordWriter();
+    writerFuture.onComplete(
+        (logStreamRecordWriter, error) -> {
+          if (error == null) {
+            createBackupApiRequestHandler(context, installed, logStreamRecordWriter);
+          } else {
+            installed.completeExceptionally(error);
+          }
+        });
+
+    return installed;
+  }
+
+  private void createBackupApiRequestHandler(
+      final PartitionTransitionContext context,
+      final ActorFuture<Void> installed,
+      final LogStreamRecordWriter logStreamRecordWriter) {
+    final var requestHandler =
+        new BackupApiRequestHandler(
+            context.getGatewayBrokerTransport(), logStreamRecordWriter, context.getPartitionId());
+    context.getActorSchedulingService().submitActor(requestHandler).onComplete(installed);
+    installed.onComplete(
+        (ignore, error) -> {
+          if (error == null) {
+            context.setBackupApiRequestHandler(requestHandler);
+            context.getDiskSpaceUsageMonitor().addDiskUsageListener(requestHandler);
+          }
+        });
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStep.java
@@ -42,7 +42,7 @@ public final class BackupApiRequestHandlerStep implements PartitionTransitionSte
 
   @Override
   public String getName() {
-    return "BackupApiRequestHandlerStep";
+    return "BackupApiRequestHandler";
   }
 
   private ActorFuture<Void> installRequestHandler(final PartitionTransitionContext context) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImplTest.java
@@ -63,7 +63,8 @@ public final class PartitionManagerImplTest {
             null,
             new ArrayList<>(),
             null,
-            mock(ExporterRepository.class));
+            mock(ExporterRepository.class),
+            null);
 
     // then
     final var config = getPartitionGroupConfig(partitionManager);
@@ -87,7 +88,8 @@ public final class PartitionManagerImplTest {
             null,
             new ArrayList<>(),
             null,
-            mock(ExporterRepository.class));
+            mock(ExporterRepository.class),
+            null);
     // then
     final var config = getPartitionGroupConfig(partitionManager);
     assertThat(config.getStorageConfig().shouldFlushExplicitly()).isTrue();

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.broker.logstreams.AtomixLogStorage;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
+import io.camunda.zeebe.broker.transport.backupapi.BackupApiRequestHandler;
 import io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandReceiverActor;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.api.TypedRecord;
@@ -58,6 +59,8 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private ConcurrencyControl concurrencyControl;
   private InterPartitionCommandReceiverActor interPartitionCommandReceiver;
   private DiskSpaceUsageMonitor diskSpaceUsageMonitor;
+  private AtomixServerTransport gatewayBrokerTransport;
+  private BackupApiRequestHandler backupApiRequestHandler;
 
   @Override
   public int getPartitionId() {
@@ -187,7 +190,21 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
 
   @Override
   public AtomixServerTransport getGatewayBrokerTransport() {
-    return null;
+    return gatewayBrokerTransport;
+  }
+
+  @Override
+  public BackupApiRequestHandler getBackupApiRequestHandler() {
+    return backupApiRequestHandler;
+  }
+
+  @Override
+  public void setBackupApiRequestHandler(final BackupApiRequestHandler backupApiRequestHandler) {
+    this.backupApiRequestHandler = backupApiRequestHandler;
+  }
+
+  public void setGatewayBrokerTransport(final AtomixServerTransport gatewayBrokerTransport) {
+    this.gatewayBrokerTransport = gatewayBrokerTransport;
   }
 
   public void setDiskSpaceUsageMonitor(final DiskSpaceUsageMonitor diskSpaceUsageMonitor) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.streamprocessor.StreamProcessor;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import java.util.Collection;
 import java.util.List;
@@ -182,6 +183,11 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public DiskSpaceUsageMonitor getDiskSpaceUsageMonitor() {
     return diskSpaceUsageMonitor;
+  }
+
+  @Override
+  public AtomixServerTransport getGatewayBrokerTransport() {
+    return null;
   }
 
   public void setDiskSpaceUsageMonitor(final DiskSpaceUsageMonitor diskSpaceUsageMonitor) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStepTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
+import io.camunda.zeebe.broker.system.partitions.TestPartitionTransitionContext;
+import io.camunda.zeebe.broker.transport.backupapi.BackupApiRequestHandler;
+import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
+import io.camunda.zeebe.scheduler.ActorSchedulingService;
+import io.camunda.zeebe.scheduler.testing.TestActorFuture;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class BackupApiRequestHandlerStepTest {
+
+  @Mock AtomixServerTransport serverTransport;
+
+  @Mock LogStream logStream;
+  @Mock LogStreamRecordWriter logStreamRecordWriter;
+
+  @Mock DiskSpaceUsageMonitor diskSpaceUsageMonitor;
+
+  @Mock ActorSchedulingService actorSchedulingService;
+
+  private final TestPartitionTransitionContext transitionContext =
+      new TestPartitionTransitionContext();
+  private BackupApiRequestHandlerStep step;
+
+  @BeforeEach
+  void setup() {
+    transitionContext.setLogStream(logStream);
+    transitionContext.setGatewayBrokerTransport(serverTransport);
+    transitionContext.setConcurrencyControl(new TestConcurrencyControl());
+    transitionContext.setDiskSpaceUsageMonitor(diskSpaceUsageMonitor);
+    transitionContext.setActorSchedulingService(actorSchedulingService);
+
+    step = new BackupApiRequestHandlerStep();
+  }
+
+  @Test
+  void shouldInstallBackupRequestHandler() {
+    // given
+    when(logStream.newLogStreamRecordWriter())
+        .thenReturn(TestActorFuture.completedFuture(logStreamRecordWriter));
+    when(actorSchedulingService.submitActor(any()))
+        .thenReturn(TestActorFuture.completedFuture(null));
+
+    // when
+    transitionTo(Role.LEADER);
+
+    // then
+    assertThat(transitionContext.getBackupApiRequestHandler()).isNotNull();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = Role.class,
+      names = {"FOLLOWER", "CANDIDATE", "INACTIVE"})
+  void shouldCloseBackupRequestHandler(
+      final Role targetRole, @Mock final BackupApiRequestHandler requestHandlerFromPrevRole) {
+    // given
+    when(requestHandlerFromPrevRole.closeAsync()).thenReturn(TestActorFuture.completedFuture(null));
+    // current role is leader
+    transitionContext.setBackupApiRequestHandler(requestHandlerFromPrevRole);
+
+    // when
+    transitionTo(targetRole);
+
+    // then
+    assertThat(transitionContext.getBackupApiRequestHandler()).isNull();
+    verify(requestHandlerFromPrevRole).closeAsync();
+  }
+
+  private void transitionTo(final Role role) {
+    step.prepareTransition(transitionContext, 1, role).join();
+    step.transitionTo(transitionContext, 1, role).join();
+    transitionContext.setCurrentRole(role);
+  }
+}


### PR DESCRIPTION
## Description

- Added partition transition step to install and remove BackupApiRequestHandler. The service is installed only for leader role.

## Related issues

closes #9726 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
