### PR TITLE
Notify checkpoint listeners after init and replay

### DIFF
--- a/backup/src/main/java/io/camunda/zeebe/backup/api/CheckpointListener.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/CheckpointListener.java
@@ -17,6 +17,7 @@ public interface CheckpointListener {
    * <li>When the processor is initialized with the latest checkpoint
    * <li>When CHECKPOINT:CREATE record is processed and if it results in a new checkpoint.
    * <li>When CHECKPOINT:CREATED record is replayed
+   * <li>If there is a valid checkpoint, when the listener is registered
    */
   void onNewCheckpointCreated(long checkpointId);
 }

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/CheckpointListener.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/CheckpointListener.java
@@ -13,8 +13,10 @@ public interface CheckpointListener {
   /**
    * Called when ever a new checkpoint is created.
    *
-   * <p>Will be called immediately after CHECKPOINT:CREATE record is processed if it results in a
-   * new checkpoint.
+   * <p>This will be called
+   * <li>When the processor is initialized with the latest checkpoint
+   * <li>When CHECKPOINT:CREATE record is processed and if it results in a new checkpoint.
+   * <li>When CHECKPOINT:CREATED record is replayed
    */
   void onNewCheckpointCreated(long checkpointId);
 }

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
@@ -7,19 +7,26 @@
  */
 package io.camunda.zeebe.backup.processing;
 
+import io.camunda.zeebe.backup.api.CheckpointListener;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import java.util.Set;
 
 public final class CheckpointCreatedEventApplier {
 
-  final CheckpointState checkpointState;
+  private final CheckpointState checkpointState;
+  private final Set<CheckpointListener> checkpointListeners;
 
-  public CheckpointCreatedEventApplier(final CheckpointState checkpointState) {
+  public CheckpointCreatedEventApplier(
+      final CheckpointState checkpointState, final Set<CheckpointListener> checkpointListeners) {
     this.checkpointState = checkpointState;
+    this.checkpointListeners = checkpointListeners;
   }
 
   public void apply(final CheckpointRecord checkpointRecord) {
     checkpointState.setCheckpointInfo(
         checkpointRecord.getCheckpointId(), checkpointRecord.getCheckpointPosition());
+    checkpointListeners.forEach(
+        listener -> listener.onNewCheckpointCreated(checkpointState.getCheckpointId()));
   }
 }

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/Context.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/Context.java
@@ -9,9 +9,11 @@ package io.camunda.zeebe.backup.processing;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 
 /**
  * There is a good chance that we will get rid of this context, and use a "ProcessingContext"
  * defined by the StreamProcessor. *
  */
-public record Context(ZeebeDb zeebeDb, TransactionContext transactionContext) {}
+public record Context(
+    ZeebeDb zeebeDb, TransactionContext transactionContext, ProcessingScheduleService executor) {}

--- a/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.backup.processing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -23,6 +25,7 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
+import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
@@ -36,15 +39,13 @@ import org.junit.jupiter.api.io.TempDir;
 final class CheckpointRecordsProcessorTest {
 
   @TempDir Path database;
-
-  CheckpointRecordsProcessor processor;
-
-  ProcessingResultBuilder resultBuilder;
-
-  // Used for verifying state in the tests
-  CheckpointState state;
-
   final BackupManager backupManager = mock(BackupManager.class);
+  private final ProcessingScheduleService executor = mock(ProcessingScheduleService.class);
+
+  private CheckpointRecordsProcessor processor;
+  private ProcessingResultBuilder resultBuilder;
+  // Used for verifying state in the tests
+  private CheckpointState state;
   private ZeebeDb zeebedb;
 
   @BeforeEach
@@ -53,7 +54,7 @@ final class CheckpointRecordsProcessorTest {
         new ZeebeRocksDbFactory<>(
                 new RocksDbConfiguration(), new ConsistencyChecksSettings(true, true))
             .createDb(database.toFile());
-    final var context = new Context(zeebedb, zeebedb.createContext());
+    final var context = new Context(zeebedb, zeebedb.createContext(), executor);
 
     resultBuilder = new MockProcessingResultBuilder();
     processor = new CheckpointRecordsProcessor(backupManager);
@@ -227,7 +228,7 @@ final class CheckpointRecordsProcessorTest {
   @Test
   void shouldNotifyListenerOnInit() {
     // given
-    final var context = new Context(zeebedb, zeebedb.createContext());
+    final var context = new Context(zeebedb, zeebedb.createContext(), null);
     processor = new CheckpointRecordsProcessor(backupManager);
     final long checkpointId = 3;
     final long checkpointPosition = 30;
@@ -237,6 +238,30 @@ final class CheckpointRecordsProcessorTest {
     final AtomicLong checkpoint = new AtomicLong();
     processor.addCheckpointListener(checkpoint::set);
     processor.init(context);
+
+    // then
+    assertThat(checkpoint).hasValue(checkpointId);
+  }
+
+  @Test
+  void shouldNotifyWhenListenerIsRegistered() {
+    // given
+    final long checkpointId = 3;
+    final long checkpointPosition = 30;
+    state.setCheckpointInfo(checkpointId, checkpointPosition);
+
+    doAnswer(
+            invocation -> {
+              final Runnable callback = (Runnable) invocation.getArguments()[1];
+              callback.run();
+              return null;
+            })
+        .when(executor)
+        .runDelayed(any(), any(Runnable.class));
+
+    // when
+    final AtomicLong checkpoint = new AtomicLong();
+    processor.addCheckpointListener(checkpoint::set);
 
     // then
     assertThat(checkpoint).hasValue(checkpointId);


### PR DESCRIPTION
## Description

The listeners must be upddated with the current checkpointId after init and replay. Otherwise if there are no new checkpoint created, after a restart or failover the listeners cannot know about the latest checkpoint. It is important for `InterPartitionCommandSencer` and `InterPartitionCommandReceiver` to keep track of the latest checkpointId to guarantee that the checkpoints are consistent.

## Related issues

closes #9916 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
