### PR TITLE
[Backport stable/8.0] deps(maven): bump dmn-engine from 1.7.1 to 1.7.2

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -94,7 +94,7 @@
     <version.netflix.concurrency>0.3.6</version.netflix.concurrency>
     <version.zeebe-test-container>3.3.0</version.zeebe-test-container>
     <version.feel-scala>1.14.2</version.feel-scala>
-    <version.dmn-scala>1.7.1</version.dmn-scala>
+    <version.dmn-scala>1.7.2</version.dmn-scala>
     <version.rest-assured>4.5.1</version.rest-assured>
     <version.spring>5.3.18</version.spring>
     <version.spring-boot>2.6.6</version.spring-boot>


### PR DESCRIPTION
## Description

Backport of #9361 to `stable/8.0`.

relates to https://github.com/camunda/zeebe/issues/9269

---

We had an issue in the DMN engine which was the cause of NPE. This was resolved in #9269 but it wasn't backported to the 8.0 branch.
