### PR TITLE
Broker can handle admin request to pause exporting

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/AdminApiServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/AdminApiServiceStep.java
@@ -25,7 +25,8 @@ public class AdminApiServiceStep extends AbstractBrokerStartupStep {
       final ActorFuture<BrokerStartupContext> startupFuture) {
     final var schedulingService = brokerStartupContext.getActorSchedulingService();
     final var transport = brokerStartupContext.getGatewayBrokerTransport();
-    final var handler = new AdminApiRequestHandler(transport);
+    final var handler =
+        new AdminApiRequestHandler(transport, brokerStartupContext.getPartitionManager());
 
     concurrencyControl.runOnCompletion(
         schedulingService.submitActor(handler),

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -58,13 +58,14 @@ public final class BrokerStartupProcess {
     result.add(new ApiMessagingServiceStep());
     result.add(new GatewayBrokerTransportStep());
     result.add(new CommandApiServiceStep());
-    result.add(new AdminApiServiceStep());
 
     if (config.getGateway().isEnable()) {
       result.add(new EmbeddedGatewayServiceStep());
     }
 
     result.add(new PartitionManagerStep());
+
+    result.add(new AdminApiServiceStep());
 
     return result;
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -53,9 +53,6 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
                                   () ->
                                       forwardExceptions(
                                           () -> {
-                                            final var adminApi =
-                                                brokerStartupContext.getAdminApiService();
-                                            adminApi.injectPartitionManager(partitionManager);
                                             final var adminService =
                                                 brokerStartupContext.getBrokerAdminService();
                                             adminService.injectAdminAccess(

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/MultiPartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/MultiPartitionAdminAccess.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.ActorFutureCollector;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 
 final class MultiPartitionAdminAccess implements PartitionAdminAccess {
@@ -32,8 +33,8 @@ final class MultiPartitionAdminAccess implements PartitionAdminAccess {
    *     partitions
    */
   @Override
-  public PartitionAdminAccess forPartition(final int partitionId) {
-    return partitions.get(partitionId);
+  public Optional<PartitionAdminAccess> forPartition(final int partitionId) {
+    return Optional.ofNullable(partitions.get(partitionId));
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/MultiPartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/MultiPartitionAdminAccess.java
@@ -7,24 +7,33 @@
  */
 package io.camunda.zeebe.broker.partitioning;
 
-import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.ActorFutureCollector;
-import java.util.List;
+import java.util.Collections;
+import java.util.Map;
 import java.util.function.Function;
 
 final class MultiPartitionAdminAccess implements PartitionAdminAccess {
   private final ConcurrencyControl concurrencyControl;
-  private final List<? extends PartitionAdminAccess> partitions;
+  private final Map<Integer, ? extends PartitionAdminAccess> partitions;
 
   MultiPartitionAdminAccess(
       final ConcurrencyControl concurrencyControl,
-      final List<? extends PartitionAdminAccess> partitions) {
+      final Map<Integer, ? extends PartitionAdminAccess> partitions) {
     this.concurrencyControl = requireNonNull(concurrencyControl);
-    this.partitions = unmodifiableList(requireNonNull(partitions));
+    this.partitions = Collections.unmodifiableMap(requireNonNull(partitions));
+  }
+
+  /**
+   * @return A scoped-down admin access that that only act's on the given partition, not all
+   *     partitions
+   */
+  @Override
+  public PartitionAdminAccess forPartition(final int partitionId) {
+    return partitions.get(partitionId);
   }
 
   @Override
@@ -56,7 +65,7 @@ final class MultiPartitionAdminAccess implements PartitionAdminAccess {
       final Function<PartitionAdminAccess, ActorFuture<Void>> functionToCall) {
     final ActorFuture<Void> response = concurrencyControl.createFuture();
     final var aggregatedResult =
-        partitions.stream()
+        partitions.values().stream()
             .map(functionToCall)
             .collect(new ActorFutureCollector<>(concurrencyControl));
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/NoOpPartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/NoOpPartitionAdminAccess.java
@@ -17,6 +17,11 @@ public final class NoOpPartitionAdminAccess implements PartitionAdminAccess {
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
 
   @Override
+  public PartitionAdminAccess forPartition(final int partitionId) {
+    return this;
+  }
+
+  @Override
   public ActorFuture<Void> takeSnapshot() {
     logCall();
     return CompletableActorFuture.completed(null);

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/NoOpPartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/NoOpPartitionAdminAccess.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.partitioning;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Optional;
 import org.slf4j.Logger;
 
 public final class NoOpPartitionAdminAccess implements PartitionAdminAccess {
@@ -17,8 +18,8 @@ public final class NoOpPartitionAdminAccess implements PartitionAdminAccess {
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
 
   @Override
-  public PartitionAdminAccess forPartition(final int partitionId) {
-    return this;
+  public Optional<PartitionAdminAccess> forPartition(final int partitionId) {
+    return Optional.empty();
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
@@ -8,9 +8,10 @@
 package io.camunda.zeebe.broker.partitioning;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.util.Optional;
 
 public interface PartitionAdminAccess {
-  PartitionAdminAccess forPartition(int partitionId);
+  Optional<PartitionAdminAccess> forPartition(int partitionId);
 
   ActorFuture<Void> takeSnapshot();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.broker.partitioning;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 
 public interface PartitionAdminAccess {
+  PartitionAdminAccess forPartition(int partitionId);
+
   ActorFuture<Void> takeSnapshot();
 
   ActorFuture<Void> pauseExporting();

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -106,13 +106,12 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
   }
 
   public PartitionAdminAccess createAdminAccess(final ConcurrencyControl concurrencyControl) {
-    final var adminAccess =
-        new MultiPartitionAdminAccess(
-            concurrencyControl,
-            partitions.stream()
-                .map(ZeebePartition::createAdminAccess)
-                .collect(Collectors.toList()));
-    return adminAccess;
+    return new MultiPartitionAdminAccess(
+        concurrencyControl,
+        partitions.stream()
+            .collect(
+                Collectors.toMap(
+                    ZeebePartition::getPartitionId, ZeebePartition::createAdminAccess)));
   }
 
   public CompletableFuture<Void> start() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -90,7 +90,7 @@ public final class ZeebePartition extends Actor
   }
 
   public PartitionAdminAccess createAdminAccess() {
-    return new ZeebePartitionAdminAccess(actor, adminControl);
+    return new ZeebePartitionAdminAccess(actor, getPartitionId(), adminControl);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.io.IOException;
+import java.util.Optional;
 import org.slf4j.Logger;
 
 class ZeebePartitionAdminAccess implements PartitionAdminAccess {
@@ -34,13 +35,11 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
   }
 
   @Override
-  public PartitionAdminAccess forPartition(final int partitionId) {
+  public Optional<PartitionAdminAccess> forPartition(final int partitionId) {
     if (this.partitionId == partitionId) {
-      return this;
+      return Optional.of(this);
     } else {
-      throw new IllegalArgumentException(
-          "Requested PartitionAdminAccess for partition %s, this PartitionAdminAccess only manages partition %s"
-              .formatted(partitionId, this.partitionId));
+      return Optional.empty();
     }
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
@@ -21,12 +21,27 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
 
   private final ConcurrencyControl concurrencyControl;
+  private final int partitionId;
   private final PartitionAdminControl adminControl;
 
   ZeebePartitionAdminAccess(
-      final ConcurrencyControl concurrencyControl, final PartitionAdminControl adminControl) {
+      final ConcurrencyControl concurrencyControl,
+      final int partitionId,
+      final PartitionAdminControl adminControl) {
     this.concurrencyControl = requireNonNull(concurrencyControl);
+    this.partitionId = partitionId;
     this.adminControl = requireNonNull(adminControl);
+  }
+
+  @Override
+  public PartitionAdminAccess forPartition(final int partitionId) {
+    if (this.partitionId == partitionId) {
+      return this;
+    } else {
+      throw new IllegalArgumentException(
+          "Requested PartitionAdminAccess for partition %s, this PartitionAdminAccess only manages partition %s"
+              .formatted(partitionId, this.partitionId));
+    }
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/ApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/ApiRequestHandler.java
@@ -7,155 +7,38 @@
  */
 package io.camunda.zeebe.broker.transport;
 
-import io.camunda.zeebe.broker.Loggers;
-import io.camunda.zeebe.broker.transport.ApiRequestHandler.RequestReader;
-import io.camunda.zeebe.broker.transport.ApiRequestHandler.ResponseWriter;
-import io.camunda.zeebe.scheduler.Actor;
-import io.camunda.zeebe.transport.RequestHandler;
-import io.camunda.zeebe.transport.ServerOutput;
+import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.RequestReader;
+import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.ResponseWriter;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.Either;
-import io.camunda.zeebe.util.buffer.BufferReader;
-import io.camunda.zeebe.util.buffer.BufferWriter;
-import org.agrona.DirectBuffer;
-import org.agrona.sbe.MessageDecoderFlyweight;
-import org.slf4j.Logger;
 
 /**
- * A {@link RequestHandler} that automatically decodes requests and encodes successful and error
- * responses.
- *
- * @param <R> a {@link RequestReader} that reads the request
- * @param <W> a {@link ResponseWriter} that writes the response
+ * @param <R>
+ * @param <W>
  */
 public abstract class ApiRequestHandler<R extends RequestReader<?>, W extends ResponseWriter>
-    extends Actor implements RequestHandler {
-
-  public static final Logger LOG = Loggers.TRANSPORT_LOGGER;
-  private final ErrorResponseWriter errorResponseWriter = new ErrorResponseWriter();
-  private final R requestReader;
-  private final W responseWriter;
+    extends AsyncApiRequestHandler<R, W> {
 
   protected ApiRequestHandler(final R requestReader, final W responseWriter) {
-    this.requestReader = requestReader;
-    this.responseWriter = responseWriter;
+    super(requestReader, responseWriter);
   }
 
-  /**
-   * Handles a request. The {@param requestReader} is populated at this point.
-   *
-   * @param partitionId the current partition id
-   * @param requestId the current request id
-   * @param requestReader a {@link R reader} that is already populated with the request data
-   * @param responseWriter a {@link W writer} that can be used to write successful responses
-   * @param errorWriter a {@link ErrorResponseWriter} that can be used to write error responses
-   * @return a {@link ErrorResponseWriter} when the handling failed, or a {@link W ResponseWriter}
-   *     when the handling was successful. Writes to the other writer will be ignored and are not
-   *     sent as a response.
-   */
   protected abstract Either<ErrorResponseWriter, W> handle(
-      int partitionId,
-      long requestId,
-      R requestReader,
-      W responseWriter,
-      ErrorResponseWriter errorWriter);
+      final int partitionId,
+      final long requestId,
+      final R requestReader,
+      final W responseWriter,
+      final ErrorResponseWriter errorWriter);
 
   @Override
-  public final void onRequest(
-      final ServerOutput serverOutput,
+  protected final ActorFuture<Either<ErrorResponseWriter, W>> handleAsync(
       final int partitionId,
       final long requestId,
-      final DirectBuffer buffer,
-      final int offset,
-      final int length) {
-    actor.submit(() -> handleRequest(serverOutput, partitionId, requestId, buffer, offset, length));
-  }
-
-  private void handleRequest(
-      final ServerOutput serverOutput,
-      final int partitionId,
-      final long requestId,
-      final DirectBuffer buffer,
-      final int offset,
-      final int length) {
-    requestReader.reset();
-    responseWriter.reset();
-    errorResponseWriter.reset();
-
-    try {
-      requestReader.wrap(buffer, offset, length);
-    } catch (final RequestReaderException.InvalidTemplateException e) {
-      errorResponseWriter
-          .invalidMessageTemplate(e.actualTemplate, e.expectedTemplate)
-          .tryWriteResponseOrLogFailure(serverOutput, partitionId, requestId);
-      return;
-    } catch (final Exception e) {
-      LOG.error("Failed to deserialize message", e);
-      errorResponseWriter
-          .malformedRequest(e)
-          .tryWriteResponseOrLogFailure(serverOutput, partitionId, requestId);
-      return;
-    }
-
-    try {
-      final var result =
-          handle(partitionId, requestId, requestReader, responseWriter, errorResponseWriter);
-      if (result.isLeft()) {
-        result.getLeft().tryWriteResponse(serverOutput, partitionId, requestId);
-      } else {
-        result.get().tryWriteResponse(serverOutput, partitionId, requestId);
-      }
-    } catch (final Exception e) {
-      LOG.error("Error handling request on partition {}", partitionId, e);
-      errorResponseWriter
-          .internalError(
-              "Failed to handle request due to internal error; see the broker logs for more")
-          .tryWriteResponse(serverOutput, partitionId, requestId);
-    }
-  }
-
-  /**
-   * Extension of {@link BufferWriter} that provides extra methods used by {@link ApiRequestHandler}
-   * implementations
-   */
-  public interface ResponseWriter extends BufferWriter {
-
-    /**
-     * Writes a successful response to the {@link ServerOutput}
-     *
-     * @param output the underlying {@link ServerOutput} that can be written to.
-     * @param partitionId the current partition id
-     * @param requestId the current request id
-     */
-    void tryWriteResponse(final ServerOutput output, final int partitionId, final long requestId);
-
-    /** Resets all internal state to prepare for sending the next response */
-    void reset();
-  }
-
-  /**
-   * Extension of {@link BufferReader} that provides extra methods used by {@link ApiRequestHandler}
-   * implementations.
-   *
-   * @param <T> the type of the message decoder.
-   */
-  public interface RequestReader<T extends MessageDecoderFlyweight> extends BufferReader {
-
-    /** Reset all internal state to prepare for reading the next request. */
-    void reset();
-
-    /**
-     * @return The message decoder which can be used by {@link ApiRequestHandler} implementations to
-     *     get access to the request data.
-     */
-    T getMessageDecoder();
-
-    /**
-     * @param buffer the buffer to read from
-     * @param offset the offset at which to start reading
-     * @param length the length of the values to read
-     * @throws RequestReaderException if reading the request failed
-     */
-    @Override
-    void wrap(DirectBuffer buffer, int offset, int length);
+      final R requestReader,
+      final W responseWriter,
+      final ErrorResponseWriter errorWriter) {
+    return CompletableActorFuture.completed(
+        handle(partitionId, requestId, requestReader, responseWriter, errorWriter));
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/AsyncApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/AsyncApiRequestHandler.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.transport;
+
+import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.RequestReader;
+import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.ResponseWriter;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.transport.RequestHandler;
+import io.camunda.zeebe.transport.ServerOutput;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+import org.agrona.sbe.MessageDecoderFlyweight;
+import org.slf4j.Logger;
+
+/**
+ * A {@link RequestHandler} that automatically decodes requests and encodes successful and error
+ * responses. Handling requests is asynchronous, use {@link ApiRequestHandler} if handling can be
+ * synchronous.
+ *
+ * @param <R> a {@link RequestReader} that reads the request
+ * @param <W> a {@link ResponseWriter} that writes the response
+ */
+public abstract class AsyncApiRequestHandler<R extends RequestReader<?>, W extends ResponseWriter>
+    extends Actor implements RequestHandler {
+
+  public static final Logger LOG = Loggers.TRANSPORT_LOGGER;
+  private final ErrorResponseWriter errorResponseWriter = new ErrorResponseWriter();
+  private final R requestReader;
+  private final W responseWriter;
+
+  protected AsyncApiRequestHandler(final R requestReader, final W responseWriter) {
+    this.requestReader = requestReader;
+    this.responseWriter = responseWriter;
+  }
+
+  /**
+   * Handles a request. The {@param requestReader} is populated at this point.
+   *
+   * @param partitionId the current partition id
+   * @param requestId the current request id
+   * @param requestReader a {@link R reader} that is already populated with the request data
+   * @param responseWriter a {@link W writer} that can be used to write successful responses
+   * @param errorWriter a {@link ErrorResponseWriter} that can be used to write error responses
+   * @return a {@link ErrorResponseWriter} when the handling failed, or a {@link W ResponseWriter}
+   *     when the handling was successful. Writes to the other writer will be ignored and are not
+   *     sent as a response.
+   */
+  protected abstract ActorFuture<Either<ErrorResponseWriter, W>> handleAsync(
+      int partitionId,
+      long requestId,
+      R requestReader,
+      W responseWriter,
+      ErrorResponseWriter errorWriter);
+
+  @Override
+  public final void onRequest(
+      final ServerOutput serverOutput,
+      final int partitionId,
+      final long requestId,
+      final DirectBuffer buffer,
+      final int offset,
+      final int length) {
+    actor.submit(() -> handleRequest(serverOutput, partitionId, requestId, buffer, offset, length));
+  }
+
+  private void handleRequest(
+      final ServerOutput serverOutput,
+      final int partitionId,
+      final long requestId,
+      final DirectBuffer buffer,
+      final int offset,
+      final int length) {
+    requestReader.reset();
+    responseWriter.reset();
+    errorResponseWriter.reset();
+
+    try {
+      requestReader.wrap(buffer, offset, length);
+    } catch (final RequestReaderException.InvalidTemplateException e) {
+      errorResponseWriter
+          .invalidMessageTemplate(e.actualTemplate, e.expectedTemplate)
+          .tryWriteResponseOrLogFailure(serverOutput, partitionId, requestId);
+      return;
+    } catch (final Exception e) {
+      LOG.error("Failed to deserialize message", e);
+      errorResponseWriter
+          .malformedRequest(e)
+          .tryWriteResponseOrLogFailure(serverOutput, partitionId, requestId);
+      return;
+    }
+
+    try {
+      final var resultFuture =
+          handleAsync(partitionId, requestId, requestReader, responseWriter, errorResponseWriter);
+      resultFuture.onComplete(
+          (result, throwable) -> {
+            if (throwable != null) {
+              LOG.error("Error handling request on partition {}", partitionId, throwable);
+              errorResponseWriter
+                  .internalError(
+                      "Failed to handle request due to internal error; see the broker logs for more")
+                  .tryWriteResponse(serverOutput, partitionId, requestId);
+            }
+            if (result.isLeft()) {
+              result.getLeft().tryWriteResponse(serverOutput, partitionId, requestId);
+            } else {
+              result.get().tryWriteResponse(serverOutput, partitionId, requestId);
+            }
+          });
+    } catch (final Exception e) {
+      LOG.error("Error handling request on partition {}", partitionId, e);
+      errorResponseWriter
+          .internalError(
+              "Failed to handle request due to internal error; see the broker logs for more")
+          .tryWriteResponse(serverOutput, partitionId, requestId);
+    }
+  }
+
+  /**
+   * Extension of {@link BufferWriter} that provides extra methods used by {@link
+   * AsyncApiRequestHandler} implementations
+   */
+  public interface ResponseWriter extends BufferWriter {
+
+    /**
+     * Writes a successful response to the {@link ServerOutput}
+     *
+     * @param output the underlying {@link ServerOutput} that can be written to.
+     * @param partitionId the current partition id
+     * @param requestId the current request id
+     */
+    void tryWriteResponse(final ServerOutput output, final int partitionId, final long requestId);
+
+    /** Resets all internal state to prepare for sending the next response */
+    void reset();
+  }
+
+  /**
+   * Extension of {@link BufferReader} that provides extra methods used by {@link
+   * AsyncApiRequestHandler} implementations.
+   *
+   * @param <T> the type of the message decoder.
+   */
+  public interface RequestReader<T extends MessageDecoderFlyweight> extends BufferReader {
+
+    /** Reset all internal state to prepare for reading the next request. */
+    void reset();
+
+    /**
+     * @return The message decoder which can be used by {@link AsyncApiRequestHandler}
+     *     implementations to get access to the request data.
+     */
+    T getMessageDecoder();
+
+    /**
+     * @param buffer the buffer to read from
+     * @param offset the offset at which to start reading
+     * @param length the length of the values to read
+     * @throws RequestReaderException if reading the request failed
+     */
+    @Override
+    void wrap(DirectBuffer buffer, int offset, int length);
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.zeebe.broker.transport.adminapi;
 
-import io.atomix.primitive.partition.Partition;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
+import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler;
 import io.camunda.zeebe.broker.transport.ErrorResponseWriter;
 import io.camunda.zeebe.protocol.management.AdminRequestType;
@@ -37,9 +37,9 @@ public class AdminApiRequestHandler
 
   @Override
   protected void onActorStarting() {
-    partitionManager.getPartitionGroup().getPartitions().stream()
-        .map(Partition::id)
-        .forEach(partitionId -> transport.subscribe(partitionId.id(), RequestType.ADMIN, this));
+    partitionManager.getPartitions().stream()
+        .map(ZeebePartition::getPartitionId)
+        .forEach(partitionId -> transport.subscribe(partitionId, RequestType.ADMIN, this));
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
@@ -71,7 +71,9 @@ public class AdminApiRequestHandler
     if (partitionAdminAccess.isEmpty()) {
       return CompletableActorFuture.completed(
           Either.left(
-              errorWriter.internalError("Partition %s failed to pause exporting", partitionId)));
+              errorWriter.internalError(
+                  "Partition %s failed to pause exporting. Could not find the partition.",
+                  partitionId)));
     }
 
     final ActorFuture<Either<ErrorResponseWriter, ApiResponseWriter>> result = actor.createFuture();

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/ApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/ApiRequestReader.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.transport.adminapi;
 
-import io.camunda.zeebe.broker.transport.ApiRequestHandler.RequestReader;
+import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.RequestReader;
 import io.camunda.zeebe.protocol.management.AdminRequestDecoder;
 import io.camunda.zeebe.protocol.management.MessageHeaderDecoder;
 import org.agrona.DirectBuffer;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/ApiResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/ApiResponseWriter.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.transport.adminapi;
 
-import io.camunda.zeebe.broker.transport.ApiRequestHandler.ResponseWriter;
+import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.ResponseWriter;
 import io.camunda.zeebe.protocol.management.AdminResponseEncoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
 import io.camunda.zeebe.transport.ServerOutput;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestReader.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.transport.backupapi;
 
-import io.camunda.zeebe.broker.transport.ApiRequestHandler.RequestReader;
+import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.RequestReader;
 import io.camunda.zeebe.protocol.management.BackupRequestDecoder;
 import io.camunda.zeebe.protocol.management.BackupRequestType;
 import io.camunda.zeebe.protocol.management.MessageHeaderDecoder;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiResponseWriter.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.transport.backupapi;
 
-import io.camunda.zeebe.broker.transport.ApiRequestHandler.ResponseWriter;
+import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.ResponseWriter;
 import io.camunda.zeebe.protocol.management.BackupResponseEncoder;
 import io.camunda.zeebe.protocol.management.MessageHeaderEncoder;
 import io.camunda.zeebe.transport.ServerOutput;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.broker.transport.commandapi;
 
 import static io.camunda.zeebe.protocol.record.ExecuteCommandRequestDecoder.TEMPLATE_ID;
 
-import io.camunda.zeebe.broker.transport.ApiRequestHandler.RequestReader;
+import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.RequestReader;
 import io.camunda.zeebe.broker.transport.RequestReaderException;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiResponseWriter.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.transport.commandapi;
 
-import io.camunda.zeebe.broker.transport.ApiRequestHandler.ResponseWriter;
+import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.ResponseWriter;
 import io.camunda.zeebe.transport.ServerOutput;
 import org.agrona.MutableDirectBuffer;
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryRequestReader.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.transport.queryapi;
 
-import io.camunda.zeebe.broker.transport.ApiRequestHandler.RequestReader;
+import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.RequestReader;
 import io.camunda.zeebe.protocol.record.ExecuteQueryRequestDecoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import org.agrona.DirectBuffer;

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryResponseWriter.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.transport.queryapi;
 
-import io.camunda.zeebe.broker.transport.ApiRequestHandler.ResponseWriter;
+import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.ResponseWriter;
 import io.camunda.zeebe.protocol.record.ExecuteQueryResponseEncoder;
 import io.camunda.zeebe.protocol.record.MessageHeaderEncoder;
 import io.camunda.zeebe.transport.ServerOutput;

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/MultiPartitionAdminAccessTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/MultiPartitionAdminAccessTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.broker.partitioning;
 
-import static java.util.List.of;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -15,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +39,8 @@ class MultiPartitionAdminAccessTest {
     mockAdminAccess2 = mock(PartitionAdminAccess.class);
 
     sutMultiPartitionAdminAccess =
-        new MultiPartitionAdminAccess(concurrencyControl, of(mockAdminAccess1, mockAdminAccess2));
+        new MultiPartitionAdminAccess(
+            concurrencyControl, Map.of(1, mockAdminAccess1, 2, mockAdminAccess2));
   }
 
   @Test

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/ApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/ApiRequestHandlerTest.java
@@ -11,8 +11,8 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import io.camunda.zeebe.broker.transport.ApiRequestHandler.RequestReader;
-import io.camunda.zeebe.broker.transport.ApiRequestHandler.ResponseWriter;
+import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.RequestReader;
+import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.ResponseWriter;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerRule;
 import io.camunda.zeebe.transport.ServerOutput;

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
@@ -8,149 +8,55 @@
 package io.camunda.zeebe.broker.transport.adminapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.atomix.primitive.partition.ManagedPartitionGroup;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.atomix.raft.partition.RaftPartitionGroup;
+import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.protocol.impl.encoding.AdminRequest;
 import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
 import io.camunda.zeebe.protocol.impl.encoding.ErrorResponse;
 import io.camunda.zeebe.protocol.management.AdminRequestType;
 import io.camunda.zeebe.protocol.record.ErrorCode;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import io.camunda.zeebe.transport.ServerOutput;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.Either;
-import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-class AdminApiRequestHandlerTest {
-  @RegisterExtension
-  final ControlledActorSchedulerExtension scheduler = new ControlledActorSchedulerExtension();
-
-  final AtomixServerTransport transport = mock(AtomixServerTransport.class);
-
-  @Test
-  void shouldRejectRequestWithInvalidType() {
-    // given
-    final var handler = setupDefaultHandler();
-    final var request = new AdminRequest();
-    request.setType(AdminRequestType.NULL_VAL);
-
-    // when
-    final var responseFuture = handleRequest(request, handler);
-
-    // then
-    assertThat(responseFuture)
-        .succeedsWithin(Duration.ofMinutes(1))
-        .matches(Either::isLeft)
-        .matches(Either::isLeft)
-        .extracting(Either::getLeft)
-        .extracting(ErrorResponse::getErrorCode)
-        .isEqualTo(ErrorCode.UNSUPPORTED_MESSAGE);
-  }
-
-  @Test
-  void shouldInitiateStepdown() {
-    // given
-    final var handler = setupDefaultHandler();
-    final var request = new AdminRequest();
-    request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
-
-    // when
-    final var responseFuture = handleRequest(request, handler);
-
-    // then
-    assertThat(responseFuture).succeedsWithin(Duration.ofMinutes(1)).matches(Either::isRight);
-  }
-
-  @Test
-  void shouldRejectRequestWhenNoPartitionsAreKnown() {
-    // given
-    final var partitionManager = mock(PartitionManagerImpl.class);
-    final var partitionGroup = mock(RaftPartitionGroup.class);
-    when(partitionGroup.getPartitionIds()).thenReturn(List.of());
-    when(partitionManager.getPartitionGroup()).thenReturn(partitionGroup);
-    final var handler = new AdminApiRequestHandler(transport, partitionManager);
-    scheduler.submitActor(handler);
-    scheduler.workUntilDone();
-
-    final var request = new AdminRequest();
-    request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
-
-    // when
-    final var responseFuture = handleRequest(request, handler);
-
-    // then
-    assertThat(responseFuture)
-        .succeedsWithin(Duration.ofMinutes(1))
-        .matches(Either::isLeft)
-        .extracting(Either::getLeft)
-        .extracting(ErrorResponse::getErrorCode)
-        .isEqualTo(ErrorCode.PARTITION_LEADER_MISMATCH); // no partitions -> no handler subscribed
-  }
-
-  @Test
-  void shouldRejectRequestWhenNotLeader() {
-    // given
-    final var partitionManager = mock(PartitionManagerImpl.class);
-    final var partitionGroup = mock(RaftPartitionGroup.class);
-    final var partition = mock(RaftPartition.class);
-    when(partition.getRole()).thenReturn(Role.FOLLOWER);
-    when(partitionGroup.getPartition(anyInt())).thenReturn(partition);
-    when(partitionManager.getPartitionGroup()).thenReturn(partitionGroup);
-    final var handler = new AdminApiRequestHandler(transport, partitionManager);
-    scheduler.submitActor(handler);
-    scheduler.workUntilDone();
-
-    final var request = new AdminRequest();
-    request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
-
-    // when
-    final var responseFuture = handleRequest(request, handler);
-
-    // then
-    assertThat(responseFuture)
-        .succeedsWithin(Duration.ofMinutes(1))
-        .matches(Either::isLeft)
-        .extracting(Either::getLeft)
-        .extracting(ErrorResponse::getErrorCode)
-        .isEqualTo(ErrorCode.PARTITION_LEADER_MISMATCH); // no partitions -> no handler subscribed
-  }
-
-  private AdminApiRequestHandler setupDefaultHandler() {
-    final var partitionManager = mock(PartitionManagerImpl.class);
-    final var partitionGroup = mock(RaftPartitionGroup.class);
-    final var raftPartition = mock(RaftPartition.class);
-    when(raftPartition.getRole()).thenReturn(Role.LEADER);
-    when(raftPartition.stepDownIfNotPrimary()).thenReturn(CompletableFuture.completedFuture(null));
-    when(partitionGroup.name()).thenReturn("test");
-    when(partitionGroup.getPartition(anyInt())).thenReturn(raftPartition);
-    when(partitionManager.getPartitionGroup()).thenReturn(partitionGroup);
-    final var handler = new AdminApiRequestHandler(transport, partitionManager);
-    scheduler.submitActor(handler);
-    scheduler.workUntilDone();
-    return handler;
-  }
+@Execution(ExecutionMode.CONCURRENT)
+final class AdminApiRequestHandlerTest {
 
   private CompletableFuture<Either<ErrorResponse, AdminResponse>> handleRequest(
-      final BufferWriter request, final AdminApiRequestHandler handler) {
+      final AdminRequest request, final AdminApiRequestHandler handler) {
     final var future = new CompletableFuture<Either<ErrorResponse, AdminResponse>>();
     final ServerOutput serverOutput = createServerOutput(future);
     final var requestBuffer = new UnsafeBuffer(new byte[request.getLength()]);
     request.write(requestBuffer, 0);
-    handler.onRequest(serverOutput, 0, 0, requestBuffer, 0, request.getLength());
-    scheduler.workUntilDone();
+    handler.onRequest(
+        serverOutput, request.getPartitionId(), 0, requestBuffer, 0, request.getLength());
     return future;
   }
 
@@ -175,5 +81,209 @@ class AdminApiRequestHandlerTest {
         future.completeExceptionally(e);
       }
     };
+  }
+
+  @Nested
+  @ExtendWith(MockitoExtension.class)
+  final class OtherRequest {
+    @RegisterExtension
+    final ControlledActorSchedulerExtension scheduler = new ControlledActorSchedulerExtension();
+
+    private final AdminApiRequestHandler handler;
+
+    OtherRequest(
+        @Mock final AtomixServerTransport transport,
+        @Mock final PartitionManagerImpl partitionManager) {
+      when(partitionManager.getPartitionGroup()).thenReturn(mock(ManagedPartitionGroup.class));
+      when(partitionManager.getPartitions()).thenReturn(List.of());
+      handler = new AdminApiRequestHandler(transport, partitionManager);
+    }
+
+    @BeforeEach
+    void installHandler() {
+      scheduler.submitActor(handler);
+      scheduler.workUntilDone();
+    }
+
+    @Test
+    void shouldRejectRequestWithInvalidType() {
+      // given
+      final var request = new AdminRequest();
+      request.setType(AdminRequestType.NULL_VAL);
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertThat(responseFuture)
+          .succeedsWithin(Duration.ofMinutes(1))
+          .matches(Either::isLeft)
+          .matches(Either::isLeft)
+          .extracting(Either::getLeft)
+          .extracting(ErrorResponse::getErrorCode)
+          .isEqualTo(ErrorCode.UNSUPPORTED_MESSAGE);
+    }
+  }
+
+  @Nested
+  @ExtendWith(MockitoExtension.class)
+  final class PauseExportingRequest {
+    @RegisterExtension
+    final ControlledActorSchedulerExtension scheduler = new ControlledActorSchedulerExtension();
+
+    private final PartitionAdminAccess adminAccess;
+    private final AdminApiRequestHandler handler;
+
+    public PauseExportingRequest(
+        @Mock(answer = Answers.RETURNS_SELF) final PartitionAdminAccess adminAccess,
+        @Mock final PartitionManagerImpl partitionManager,
+        @Mock final AtomixServerTransport transport) {
+      this.adminAccess = adminAccess;
+      when(partitionManager.getPartitionGroup()).thenReturn(mock(ManagedPartitionGroup.class));
+      when(partitionManager.getPartitions()).thenReturn(List.of());
+      when(partitionManager.createAdminAccess(any())).thenReturn(adminAccess);
+      handler = new AdminApiRequestHandler(transport, partitionManager);
+    }
+
+    @BeforeEach
+    void startHandler() {
+      scheduler.submitActor(handler);
+      scheduler.workUntilDone();
+    }
+
+    @Test
+    void shouldPauseExportingForGivenPartition() {
+      when(adminAccess.pauseExporting()).thenReturn(CompletableActorFuture.completed(null));
+
+      final var request = new AdminRequest();
+      request.setPartitionId(1);
+      request.setType(AdminRequestType.PAUSE_EXPORTING);
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertThat(responseFuture).succeedsWithin(Duration.ofMinutes(1)).matches(Either::isRight);
+      verify(adminAccess).forPartition(request.getPartitionId());
+      verify(adminAccess).pauseExporting();
+    }
+
+    @Test
+    void shouldRespondWithFailureIfPausingFails() {
+      // given
+      when(adminAccess.pauseExporting())
+          .thenReturn(
+              CompletableActorFuture.completedExceptionally(
+                  new RuntimeException("Exporting fails")));
+
+      final var request = new AdminRequest();
+      request.setPartitionId(1);
+      request.setType(AdminRequestType.PAUSE_EXPORTING);
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertThat(responseFuture)
+          .succeedsWithin(Duration.ofMinutes(1))
+          .matches(Either::isLeft)
+          .extracting(Either::getLeft)
+          .extracting(ErrorResponse::getErrorCode)
+          .isEqualTo(ErrorCode.INTERNAL_ERROR);
+    }
+  }
+
+  @Nested
+  @ExtendWith(MockitoExtension.class)
+  final class StepdownRequest {
+    @RegisterExtension
+    final ControlledActorSchedulerExtension scheduler = new ControlledActorSchedulerExtension();
+
+    private final AdminApiRequestHandler handler;
+    private final PartitionManagerImpl partitionManager;
+
+    StepdownRequest(
+        @Mock final AtomixServerTransport transport,
+        @Mock final PartitionManagerImpl partitionManager) {
+      this.partitionManager = partitionManager;
+      when(partitionManager.getPartitionGroup()).thenReturn(mock(ManagedPartitionGroup.class));
+      when(partitionManager.getPartitions()).thenReturn(List.of());
+      handler = new AdminApiRequestHandler(transport, partitionManager);
+    }
+
+    @BeforeEach
+    void installHandler() {
+      scheduler.submitActor(handler);
+      scheduler.workUntilDone();
+    }
+
+    @Test
+    void shouldInitiateStepdown() {
+      // given
+      final var partition = mock(RaftPartition.class);
+      when(partition.getRole()).thenReturn(Role.LEADER);
+
+      final var partitionGroup = mock(ManagedPartitionGroup.class);
+      when(partitionGroup.getPartition(anyInt())).thenReturn(partition);
+      when(partitionManager.getPartitionGroup()).thenReturn(partitionGroup);
+
+      final var request = new AdminRequest();
+      request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertThat(responseFuture).succeedsWithin(Duration.ofMinutes(1)).matches(Either::isRight);
+    }
+
+    @Test
+    void shouldRejectRequestWhenNoPartitionsAreKnown() {
+      // given
+
+      final var request = new AdminRequest();
+      request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertThat(responseFuture)
+          .succeedsWithin(Duration.ofMinutes(1))
+          .matches(Either::isLeft)
+          .extracting(Either::getLeft)
+          .extracting(ErrorResponse::getErrorCode)
+          .isEqualTo(ErrorCode.PARTITION_LEADER_MISMATCH); // no partitions -> no handler subscribed
+    }
+
+    @Test
+    void shouldRejectRequestWhenNotLeader() {
+      // given
+      final var partitionGroup = mock(RaftPartitionGroup.class);
+      final var partition = mock(RaftPartition.class);
+      when(partition.getRole()).thenReturn(Role.FOLLOWER);
+      when(partitionGroup.getPartition(anyInt())).thenReturn(partition);
+      when(partitionManager.getPartitionGroup()).thenReturn(partitionGroup);
+
+      final var request = new AdminRequest();
+      request.setType(AdminRequestType.STEP_DOWN_IF_NOT_PRIMARY);
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertThat(responseFuture)
+          .succeedsWithin(Duration.ofMinutes(1))
+          .matches(Either::isLeft)
+          .extracting(Either::getLeft)
+          .extracting(ErrorResponse::getErrorCode)
+          .isEqualTo(ErrorCode.PARTITION_LEADER_MISMATCH); // no partitions -> no handler subscribed
+    }
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
@@ -83,6 +83,17 @@ final class AdminApiRequestHandlerTest {
     };
   }
 
+  private static void assertErrorCode(
+      final CompletableFuture<Either<ErrorResponse, AdminResponse>> response,
+      final ErrorCode expectedErrorCode) {
+    assertThat(response)
+        .succeedsWithin(Duration.ofMinutes(1))
+        .matches(Either::isLeft)
+        .extracting(Either::getLeft)
+        .extracting(ErrorResponse::getErrorCode)
+        .isEqualTo(expectedErrorCode);
+  }
+
   @Nested
   @ExtendWith(MockitoExtension.class)
   final class OtherRequest {
@@ -116,13 +127,7 @@ final class AdminApiRequestHandlerTest {
       scheduler.workUntilDone();
 
       // then
-      assertThat(responseFuture)
-          .succeedsWithin(Duration.ofMinutes(1))
-          .matches(Either::isLeft)
-          .matches(Either::isLeft)
-          .extracting(Either::getLeft)
-          .extracting(ErrorResponse::getErrorCode)
-          .isEqualTo(ErrorCode.UNSUPPORTED_MESSAGE);
+      assertErrorCode(responseFuture, ErrorCode.UNSUPPORTED_MESSAGE);
     }
   }
 
@@ -187,12 +192,7 @@ final class AdminApiRequestHandlerTest {
       scheduler.workUntilDone();
 
       // then
-      assertThat(responseFuture)
-          .succeedsWithin(Duration.ofMinutes(1))
-          .matches(Either::isLeft)
-          .extracting(Either::getLeft)
-          .extracting(ErrorResponse::getErrorCode)
-          .isEqualTo(ErrorCode.INTERNAL_ERROR);
+      assertErrorCode(responseFuture, ErrorCode.INTERNAL_ERROR);
     }
   }
 
@@ -253,12 +253,7 @@ final class AdminApiRequestHandlerTest {
       scheduler.workUntilDone();
 
       // then
-      assertThat(responseFuture)
-          .succeedsWithin(Duration.ofMinutes(1))
-          .matches(Either::isLeft)
-          .extracting(Either::getLeft)
-          .extracting(ErrorResponse::getErrorCode)
-          .isEqualTo(ErrorCode.PARTITION_LEADER_MISMATCH); // no partitions -> no handler subscribed
+      assertErrorCode(responseFuture, ErrorCode.PARTITION_LEADER_MISMATCH);
     }
 
     @Test
@@ -278,12 +273,7 @@ final class AdminApiRequestHandlerTest {
       scheduler.workUntilDone();
 
       // then
-      assertThat(responseFuture)
-          .succeedsWithin(Duration.ofMinutes(1))
-          .matches(Either::isLeft)
-          .extracting(Either::getLeft)
-          .extracting(ErrorResponse::getErrorCode)
-          .isEqualTo(ErrorCode.PARTITION_LEADER_MISMATCH); // no partitions -> no handler subscribed
+      assertErrorCode(responseFuture, ErrorCode.PARTITION_LEADER_MISMATCH);
     }
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
@@ -32,6 +32,7 @@ import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -42,7 +43,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -141,10 +141,11 @@ final class AdminApiRequestHandlerTest {
     private final AdminApiRequestHandler handler;
 
     public PauseExportingRequest(
-        @Mock(answer = Answers.RETURNS_SELF) final PartitionAdminAccess adminAccess,
+        @Mock final PartitionAdminAccess adminAccess,
         @Mock final PartitionManagerImpl partitionManager,
         @Mock final AtomixServerTransport transport) {
       this.adminAccess = adminAccess;
+      when(adminAccess.forPartition(anyInt())).thenReturn(Optional.of(adminAccess));
       when(partitionManager.getPartitionGroup()).thenReturn(mock(ManagedPartitionGroup.class));
       when(partitionManager.getPartitions()).thenReturn(List.of());
       when(partitionManager.createAdminAccess(any())).thenReturn(adminAccess);

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ErrorResponse.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ErrorResponse.java
@@ -133,4 +133,9 @@ public final class ErrorResponse implements BufferWriter, BufferReader {
     write(buffer, 0);
     return bytes;
   }
+
+  @Override
+  public String toString() {
+    return "ErrorResponse{" + "errorCode=" + errorCode + '}';
+  }
 }


### PR DESCRIPTION
## Description
This started as a small PR to just add support for `PAUSE_EXPORTING` in `AdminApiRequestHandler`.
However, there were a couple of changes necessary to implement this properly:
* Single partition admin access. `AdminAccess`'s scope can now be narrowed to a specific partition.
* `AdminApiService` is now started after the partition manager has started. This allows for the api service to immediately have access to `AdminAccess`.
* Api request handlers can be asynchronous.

I've also included a somewhat large refactoring of the existing admin api tests.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #9630

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
