### PR TITLE
[Backport stable/8.0] Don't log JsonParseExceptions as errors

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.grpc;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.google.protobuf.Any;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
@@ -72,6 +73,9 @@ public final class GrpcErrorMapper {
       builder.setCode(Code.INVALID_ARGUMENT_VALUE).setMessage(error.getMessage());
       logger.debug(
           "Expected to handle gRPC request, but messagepack property was invalid", rootError);
+    } else if (error instanceof JsonParseException) {
+      builder.setCode(Code.INVALID_ARGUMENT_VALUE).setMessage(error.getMessage());
+      logger.debug("Expected to handle gRPC request, but JSON property was invalid", rootError);
     } else if (error instanceof PartitionNotFoundException) {
       builder.setCode(Code.UNAVAILABLE_VALUE).setMessage(error.getMessage());
       logger.debug(


### PR DESCRIPTION
# Description
Backport of #9934 to `stable/8.0`.

relates to #9933