### PR TITLE
[Backport stable/8.0] Don't overwrite local multi-instance variables

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractMultiInstanceLoopCharacteristicsBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractMultiInstanceLoopCharacteristicsBuilder.java
@@ -115,6 +115,11 @@ public class AbstractMultiInstanceLoopCharacteristicsBuilder<
     return myself;
   }
 
+  /**
+   * Warn: the Output Element must be an expression.
+   *
+   * <p>Please use {@link #zeebeOutputElementExpression(String)} instead.
+   */
   public B zeebeOutputElement(final String outputElement) {
     final ZeebeLoopCharacteristics characteristics =
         getCreateSingleExtensionElement(ZeebeLoopCharacteristics.class);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -305,13 +305,21 @@ public final class MultiInstanceBodyProcessor
                 stateBehavior.setLocalVariable(childContext, variableName, inputElement));
 
     // Output multiInstanceBody expressions that are just a variable or nested property of a
-    // variable need to
-    // be initialised with a nil-value. This makes sure that they are not written at a non-local
-    // scope.
+    // variable need to be initialised with a nil-value. This makes sure that the variable exists at
+    // the local scope.
+    //
+    // We can make an exception for output expressions that refer to the same variable as the input
+    // element, because the input variable is already created at the local scope.
     loopCharacteristics
         .getOutputElement()
         .flatMap(Expression::getVariableName)
         .map(BufferUtil::wrapString)
+        .filter(
+            output ->
+                loopCharacteristics
+                    .getInputElement()
+                    .map(input -> !BufferUtil.equals(input, output))
+                    .orElse(true))
         .ifPresent(
             variableName -> stateBehavior.setLocalVariable(childContext, variableName, NIL_VALUE));
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -310,6 +310,8 @@ public final class MultiInstanceBodyProcessor
     //
     // We can make an exception for output expressions that refer to the same variable as the input
     // element, because the input variable is already created at the local scope.
+    //
+    // Likewise, we can make the same exception for the `loopCounter` variable.
     loopCharacteristics
         .getOutputElement()
         .flatMap(Expression::getVariableName)
@@ -320,6 +322,7 @@ public final class MultiInstanceBodyProcessor
                     .getInputElement()
                     .map(input -> !BufferUtil.equals(input, output))
                     .orElse(true))
+        .filter(output -> !BufferUtil.equals(output, LOOP_COUNTER_VARIABLE))
         .ifPresent(
             variableName -> stateBehavior.setLocalVariable(childContext, variableName, NIL_VALUE));
 


### PR DESCRIPTION
# Description
Backport of #9947 to `stable/8.0`.

relates to #4687