### PR TITLE
Fix NPE on sendCorrelateCommand() side-effect

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -177,19 +177,15 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
   }
 
   private boolean sendCorrelateCommand() {
-
-    final var success =
-        correlatingSubscriptions.visitSubscriptions(
-            subscription ->
-                commandSender.correlateProcessMessageSubscription(
-                    subscription.getProcessInstanceKey(),
-                    subscription.getElementInstanceKey(),
-                    subscription.getBpmnProcessId(),
-                    messageRecord.getNameBuffer(),
-                    messageKey,
-                    messageRecord.getVariablesBuffer(),
-                    messageRecord.getCorrelationKeyBuffer()));
-
-    return success && responseWriter.flush();
+    return correlatingSubscriptions.visitSubscriptions(
+        subscription ->
+            commandSender.correlateProcessMessageSubscription(
+                subscription.getProcessInstanceKey(),
+                subscription.getElementInstanceKey(),
+                subscription.getBpmnProcessId(),
+                messageRecord.getNameBuffer(),
+                messageKey,
+                messageRecord.getVariablesBuffer(),
+                messageRecord.getCorrelationKeyBuffer()));
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
With the engine abstraction topic the response writer is already getting flushed in the `executeSideEffects()` method of the `ProcessingStateMachine`. Flushing a second time here causes NullPointerExceptions.


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9860

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
