### PR TITLE
Remove writers from interface

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -81,8 +81,6 @@ public class Engine implements RecordProcessor<EngineContext> {
 
     engineContext.setLifecycleListeners(typedRecordProcessors.getLifecycleListeners());
     recordProcessorMap = typedRecordProcessors.getRecordProcessorMap();
-
-    engineContext.setWriters(writers);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/EngineContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/EngineContext.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.StreamProcessorListene
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.LegacyTypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.LegacyTypedStreamWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import java.util.Collections;
@@ -34,7 +33,6 @@ public final class EngineContext {
   private final TypedRecordProcessorFactory typedRecordProcessorFactory;
   private List<StreamProcessorLifecycleAware> lifecycleListeners = Collections.EMPTY_LIST;
   private StreamProcessorListener streamProcessorListener;
-  private Writers writers;
 
   public EngineContext(
       final int partitionId,
@@ -101,13 +99,5 @@ public final class EngineContext {
 
   public void setStreamProcessorListener(final StreamProcessorListener streamProcessorListener) {
     this.streamProcessorListener = streamProcessorListener;
-  }
-
-  public Writers getWriters() {
-    return writers;
-  }
-
-  public void setWriters(final Writers writers) {
-    this.writers = writers;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ReadonlyStreamProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ReadonlyStreamProcessorContext.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.api;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.LegacyTypedStreamWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.logstreams.log.LogStream;
 
@@ -25,11 +24,6 @@ public interface ReadonlyStreamProcessorContext {
    * @return the actual log stream writer, used to write any record
    */
   LegacyTypedStreamWriter getLogStreamWriter();
-
-  /**
-   * @return the specific writers, like command, response, etc
-   */
-  Writers getWriters();
 
   /**
    * @return the state, where the data is stored during processing

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
@@ -346,7 +346,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     if (listener != null) {
       streamProcessorContext.listener(engineContext.getStreamProcessorListener());
     }
-    streamProcessorContext.writers(engineContext.getWriters());
   }
 
   private long recoverFromSnapshot() {

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.CommandRespons
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.LegacyTypedResponseWriterImpl;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.LegacyTypedStreamWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.NoopLegacyTypedStreamWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.KeyGeneratorControls;
 import io.camunda.zeebe.engine.state.ZeebeDbState;
@@ -55,7 +54,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private StreamProcessorMode streamProcessorMode = StreamProcessorMode.PROCESSING;
   private ProcessingScheduleService processingScheduleService;
   private MutableLastProcessedPositionState lastProcessedPositionState;
-  private Writers writers;
+
   private LogStreamBatchWriter logStreamBatchWriter;
   private CommandResponseWriter commandResponseWriter;
 
@@ -82,11 +81,6 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   @Override
   public LegacyTypedStreamWriter getLogStreamWriter() {
     return streamWriterProxy;
-  }
-
-  @Override
-  public Writers getWriters() {
-    return writers;
   }
 
   @Override
@@ -214,10 +208,6 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   public StreamProcessorMode getProcessorMode() {
     return streamProcessorMode;
-  }
-
-  public void writers(final Writers writers) {
-    this.writers = writers;
   }
 
   public void logStreamBatchWriter(final LogStreamBatchWriter batchWriter) {


### PR DESCRIPTION
## Description

This PR removes the writers fronm `ReadOnlyStreamProcessorContext`. This is important, because the writers are an engine-internal construct, only valid during calls to `process(...)` or `onError(...)` and must not be handed out to other classes.

## Related issues

relates to #9725
replaces #9872 

<!-- Cut-off marker
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
