### PR TITLE
Rename CommandApiServerTransport

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/AdminApiServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/AdminApiServiceStep.java
@@ -24,7 +24,7 @@ public class AdminApiServiceStep extends AbstractBrokerStartupStep {
       final ConcurrencyControl concurrencyControl,
       final ActorFuture<BrokerStartupContext> startupFuture) {
     final var schedulingService = brokerStartupContext.getActorSchedulingService();
-    final var transport = brokerStartupContext.getCommandApiServerTransport();
+    final var transport = brokerStartupContext.getGatewayBrokerTransport();
     final var handler = new AdminApiRequestHandler(transport);
 
     concurrencyControl.runOnCompletion(

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -67,9 +67,9 @@ public interface BrokerStartupContext {
 
   void setAdminApiService(AdminApiRequestHandler adminApiService);
 
-  AtomixServerTransport getCommandApiServerTransport();
+  AtomixServerTransport getGatewayBrokerTransport();
 
-  void setCommandApiServerTransport(AtomixServerTransport commandApiServerTransport);
+  void setGatewayBrokerTransport(AtomixServerTransport gatewayBrokerTransport);
 
   ManagedMessagingService getApiMessagingService();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -46,7 +46,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private ConcurrencyControl concurrencyControl;
   private DiskSpaceUsageMonitor diskSpaceUsageMonitor;
   private ClusterServicesImpl clusterServices;
-  private AtomixServerTransport commandApiServerTransport;
+  private AtomixServerTransport gatewayBrokerTransport;
   private ManagedMessagingService commandApiMessagingService;
   private CommandApiServiceImpl commandApiService;
   private AdminApiRequestHandler adminApiService;
@@ -157,13 +157,13 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   }
 
   @Override
-  public AtomixServerTransport getCommandApiServerTransport() {
-    return commandApiServerTransport;
+  public AtomixServerTransport getGatewayBrokerTransport() {
+    return gatewayBrokerTransport;
   }
 
   @Override
-  public void setCommandApiServerTransport(final AtomixServerTransport commandApiServerTransport) {
-    this.commandApiServerTransport = commandApiServerTransport;
+  public void setGatewayBrokerTransport(final AtomixServerTransport gatewayBrokerTransport) {
+    this.gatewayBrokerTransport = gatewayBrokerTransport;
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -56,6 +56,7 @@ public final class BrokerStartupProcess {
     result.add(new ClusterServicesStep());
 
     result.add(new ApiMessagingServiceStep());
+    result.add(new GatewayBrokerTransportStep());
     result.add(new CommandApiServiceStep());
     result.add(new AdminApiServiceStep());
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStep.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+
+/** Starts the server transport which can receive commands from the gateway * */
+final class GatewayBrokerTransportStep extends AbstractBrokerStartupStep {
+
+  @Override
+  public String getName() {
+    return "Broker Transport";
+  }
+
+  @Override
+  void startupInternal(
+      final BrokerStartupContext brokerStartupContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> startupFuture) {
+    concurrencyControl.run(() -> startServerTransport(brokerStartupContext, startupFuture));
+  }
+
+  @Override
+  void shutdownInternal(
+      final BrokerStartupContext brokerShutdownContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> shutdownFuture) {
+    closeServerTransport(brokerShutdownContext, concurrencyControl, shutdownFuture);
+  }
+
+  private void startServerTransport(
+      final BrokerStartupContext brokerStartupContext,
+      final ActorFuture<BrokerStartupContext> startupFuture) {
+
+    final var concurrencyControl = brokerStartupContext.getConcurrencyControl();
+    final var brokerInfo = brokerStartupContext.getBrokerInfo();
+    final var schedulingService = brokerStartupContext.getActorSchedulingService();
+    final var messagingService = brokerStartupContext.getApiMessagingService();
+
+    final var atomixServerTransport =
+        new AtomixServerTransport(brokerInfo.getNodeId(), messagingService);
+
+    concurrencyControl.runOnCompletion(
+        schedulingService.submitActor(atomixServerTransport),
+        proceed(
+            () -> {
+              brokerStartupContext.setGatewayBrokerTransport(atomixServerTransport);
+              startupFuture.complete(brokerStartupContext);
+            },
+            startupFuture));
+  }
+
+  private void closeServerTransport(
+      final BrokerStartupContext brokerShutdownContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> shutdownFuture) {
+    final var serverTransport = brokerShutdownContext.getGatewayBrokerTransport();
+
+    if (serverTransport == null) {
+      return;
+    }
+
+    concurrencyControl.runOnCompletion(
+        serverTransport.closeAsync(),
+        proceed(
+            () -> {
+              brokerShutdownContext.setGatewayBrokerTransport(null);
+              shutdownFuture.complete(brokerShutdownContext);
+            },
+            shutdownFuture));
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -34,7 +34,7 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
             brokerStartupContext.getPartitionListeners(),
             brokerStartupContext.getCommandApiService(),
             brokerStartupContext.getExporterRepository(),
-            brokerStartupContext.getCommandApiServerTransport());
+            brokerStartupContext.getGatewayBrokerTransport());
 
     CompletableFuture.runAsync(
         () ->

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
@@ -66,6 +66,7 @@ class CommandApiServiceStepTest {
             Collections.emptyList());
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
     testBrokerStartupContext.setDiskSpaceUsageMonitor(mock(DiskSpaceUsageMonitor.class));
+    testBrokerStartupContext.setGatewayBrokerTransport(mock(AtomixServerTransport.class));
   }
 
   @Test
@@ -100,19 +101,6 @@ class CommandApiServiceStepTest {
       // then
       assertThat(startupFuture).succeedsWithin(TIME_OUT);
       assertThat(startupFuture.join()).isNotNull();
-    }
-
-    @Test
-    void shouldStartAndInstallServerTransport() {
-      // when
-      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
-      await().until(startupFuture::isDone);
-
-      // then
-      final var serverTransport = testBrokerStartupContext.getGatewayBrokerTransport();
-
-      assertThat(serverTransport).isNotNull();
-      verify(mockActorSchedulingService).submitActor(serverTransport);
     }
 
     @Test
@@ -223,18 +211,6 @@ class CommandApiServiceStepTest {
       verify(mockCommandApiService).closeAsync();
       final var commandApiService = testBrokerStartupContext.getCommandApiService();
       assertThat(commandApiService).isNull();
-    }
-
-    @Test
-    void shouldStopAndUninstallServerTransport() {
-      // when
-      sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);
-      await().until(shutdownFuture::isDone);
-
-      // then
-      verify(mockAtomixServerTransport).closeAsync();
-      final var serverTransport = testBrokerStartupContext.getGatewayBrokerTransport();
-      assertThat(serverTransport).isNull();
     }
 
     @Test

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
@@ -109,7 +109,7 @@ class CommandApiServiceStepTest {
       await().until(startupFuture::isDone);
 
       // then
-      final var serverTransport = testBrokerStartupContext.getCommandApiServerTransport();
+      final var serverTransport = testBrokerStartupContext.getGatewayBrokerTransport();
 
       assertThat(serverTransport).isNotNull();
       verify(mockActorSchedulingService).submitActor(serverTransport);
@@ -177,7 +177,7 @@ class CommandApiServiceStepTest {
       when(mockAtomixServerTransport.closeAsync())
           .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
 
-      testBrokerStartupContext.setCommandApiServerTransport(mockAtomixServerTransport);
+      testBrokerStartupContext.setGatewayBrokerTransport(mockAtomixServerTransport);
       testBrokerStartupContext.setCommandApiService(mockCommandApiService);
       testBrokerStartupContext.addPartitionListener(mockCommandApiService);
       testBrokerStartupContext.setDiskSpaceUsageMonitor(mock(DiskSpaceUsageMonitor.class));
@@ -233,7 +233,7 @@ class CommandApiServiceStepTest {
 
       // then
       verify(mockAtomixServerTransport).closeAsync();
-      final var serverTransport = testBrokerStartupContext.getCommandApiServerTransport();
+      final var serverTransport = testBrokerStartupContext.getGatewayBrokerTransport();
       assertThat(serverTransport).isNull();
     }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStepTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.broker.SpringBrokerBridge;
+import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import java.time.Duration;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class GatewayBrokerTransportStepTest {
+  private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
+  private static final BrokerCfg TEST_BROKER_CONFIG = new BrokerCfg();
+  private static final BrokerInfo TEST_BROKER_INFO = new BrokerInfo(0, "localhost");
+  private static final Duration TIME_OUT = Duration.ofSeconds(10);
+
+  private final ActorScheduler mockActorSchedulingService = mock(ActorScheduler.class);
+
+  private BrokerStartupContextImpl testBrokerStartupContext;
+
+  private final GatewayBrokerTransportStep sut = new GatewayBrokerTransportStep();
+
+  @BeforeEach
+  void setUp() {
+    when(mockActorSchedulingService.submitActor(any()))
+        .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
+
+    testBrokerStartupContext =
+        new BrokerStartupContextImpl(
+            TEST_BROKER_INFO,
+            TEST_BROKER_CONFIG,
+            mock(SpringBrokerBridge.class),
+            mockActorSchedulingService,
+            mock(BrokerHealthCheckService.class),
+            mock(ExporterRepository.class),
+            Collections.emptyList());
+    testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
+  }
+
+  @Test
+  void shouldHaveDescriptiveName() {
+    // when
+    final var actual = sut.getName();
+
+    // then
+    assertThat(actual).isSameAs("Broker Transport");
+  }
+
+  @Nested
+  class StartupBehavior {
+
+    private ActorFuture<BrokerStartupContext> startupFuture;
+
+    @BeforeEach
+    void setUp() {
+      startupFuture = CONCURRENCY_CONTROL.createFuture();
+    }
+
+    @Test
+    void shouldCompleteFuture() {
+      // when
+      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+
+      // then
+      assertThat(startupFuture).succeedsWithin(TIME_OUT);
+      assertThat(startupFuture.join()).isNotNull();
+    }
+
+    @Test
+    void shouldStartAndInstallTransport() {
+      // when
+      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+      await().until(startupFuture::isDone);
+
+      // then
+      final var transport = testBrokerStartupContext.getGatewayBrokerTransport();
+
+      assertThat(transport).isNotNull();
+      verify(mockActorSchedulingService).submitActor(transport);
+    }
+  }
+
+  @Nested
+  class ShutdownBehavior {
+
+    private AtomixServerTransport mockTransport;
+
+    private ActorFuture<BrokerStartupContext> shutdownFuture;
+
+    @BeforeEach
+    void setUp() {
+
+      mockTransport = mock(AtomixServerTransport.class);
+      when(mockTransport.closeAsync()).thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
+
+      testBrokerStartupContext.setGatewayBrokerTransport(mockTransport);
+
+      shutdownFuture = CONCURRENCY_CONTROL.createFuture();
+    }
+
+    @Test
+    void shouldStopAndUninstallServerTransport() {
+      // when
+      sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);
+      await().until(shutdownFuture::isDone);
+
+      // then
+      verify(mockTransport).closeAsync();
+      final var serverTransport = testBrokerStartupContext.getGatewayBrokerTransport();
+      assertThat(serverTransport).isNull();
+    }
+
+    @Test
+    void shouldCompleteFuture() {
+      // when
+      sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);
+
+      // then
+      assertThat(shutdownFuture).succeedsWithin(TIME_OUT);
+      assertThat(shutdownFuture.join()).isNotNull();
+    }
+  }
+}


### PR DESCRIPTION
## Description

`CommandApiServerTransport` is used not only by the `commandApi` but also to handle other requests processed by `AdminApi` and `BackupApi`. So it is better to rename it to make it clear that it is a shared resource.

Also split the installation of the transport out of `CommandApiServiceStep`.

## Related issues

Related to https://github.com/camunda/zeebe/pull/9936#discussion_r934675962

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
