### PR TITLE
Modify process instance by activating elements inside existing flow scopes

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -56,16 +56,13 @@ public final class ProcessInstanceModificationProcessor
 
     final var processInstance =
         elementInstanceState.getInstance(value.getProcessInstanceKey()).getValue();
-
     // todo: reject if process instance could not be found
+    final var process = processState.getProcessByKey(processInstance.getProcessDefinitionKey());
 
     value
         .getActivateInstructions()
         .forEach(
             instruction -> {
-              // todo: consider moving this out of the foreach loop
-              final var process =
-                  processState.getProcessByKey(processInstance.getProcessDefinitionKey());
               final var elementToActivate =
                   process.getProcess().getElementById(instruction.getElementId());
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -17,11 +17,15 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationActivateInstructionValue;
+import java.util.List;
+import java.util.Optional;
+import org.agrona.DirectBuffer;
 
 public final class ProcessInstanceModificationProcessor
     implements TypedRecordProcessor<ProcessInstanceModificationRecord> {
@@ -83,15 +87,45 @@ public final class ProcessInstanceModificationProcessor
       final AbstractFlowElement elementToActivate) {
     final var elementInstanceRecord = new ProcessInstanceRecord();
     elementInstanceRecord.wrap(processInstance);
+    // todo: deal with non-existing flow scope (#9643)
+    final Optional<Long> flowScopeKey = getFlowScopeKey(processInstance, elementToActivate);
     commandWriter.appendFollowUpCommand(
         keyGenerator.nextKey(),
         ProcessInstanceIntent.ACTIVATE_ELEMENT,
         elementInstanceRecord
-            // todo: allow non-process instance element's as flowscope
-            .setFlowScopeKey(processInstance.getProcessInstanceKey())
+            .setFlowScopeKey(flowScopeKey.get())
             .setBpmnElementType(elementToActivate.getElementType())
             .setElementId(instruction.getElementId())
             .setParentProcessInstanceKey(-1)
             .setParentElementInstanceKey(-1));
+  }
+
+  private Optional<Long> getFlowScopeKey(
+      final ProcessInstanceRecord processInstance, final AbstractFlowElement elementToActivate) {
+    final var flowScope = elementToActivate.getFlowScope();
+    if (flowScope.getId().equals(processInstance.getElementIdBuffer())) {
+      return Optional.of(processInstance.getProcessInstanceKey());
+    } else {
+      return getFlowScopeKey(processInstance.getProcessInstanceKey(), flowScope.getId());
+    }
+  }
+
+  private Optional<Long> getFlowScopeKey(
+      final long ancestorKey, final DirectBuffer targetElementId) {
+    final List<ElementInstance> children = elementInstanceState.getChildren(ancestorKey);
+
+    for (final ElementInstance child : children) {
+      if (child.getValue().getElementIdBuffer().equals(targetElementId)) {
+        // todo: instead of early return we should reject the command when multiple matching
+        //  children are found
+        return Optional.of(child.getKey());
+      } else {
+        final var optionalFlowScopeKey = getFlowScopeKey(child.getKey(), targetElementId);
+        if (optionalFlowScopeKey.isPresent()) {
+          return optionalFlowScopeKey;
+        }
+      }
+    }
+    return Optional.empty();
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -88,7 +88,7 @@ public final class ProcessInstanceModificationProcessor
     final var elementInstanceRecord = new ProcessInstanceRecord();
     elementInstanceRecord.wrap(processInstance);
     // todo: deal with non-existing flow scope (#9643)
-    final Optional<Long> flowScopeKey = getFlowScopeKey(processInstance, elementToActivate);
+    final Optional<Long> flowScopeKey = findFlowScopeKey(processInstance, elementToActivate);
     commandWriter.appendFollowUpCommand(
         keyGenerator.nextKey(),
         ProcessInstanceIntent.ACTIVATE_ELEMENT,
@@ -100,17 +100,17 @@ public final class ProcessInstanceModificationProcessor
             .setParentElementInstanceKey(-1));
   }
 
-  private Optional<Long> getFlowScopeKey(
+  private Optional<Long> findFlowScopeKey(
       final ProcessInstanceRecord processInstance, final AbstractFlowElement elementToActivate) {
     final var flowScope = elementToActivate.getFlowScope();
     if (flowScope.getId().equals(processInstance.getElementIdBuffer())) {
       return Optional.of(processInstance.getProcessInstanceKey());
     } else {
-      return getFlowScopeKey(processInstance.getProcessInstanceKey(), flowScope.getId());
+      return findFlowScopeKey(processInstance.getProcessInstanceKey(), flowScope.getId());
     }
   }
 
-  private Optional<Long> getFlowScopeKey(
+  private Optional<Long> findFlowScopeKey(
       final long ancestorKey, final DirectBuffer targetElementId) {
     final List<ElementInstance> children = elementInstanceState.getChildren(ancestorKey);
 
@@ -120,7 +120,7 @@ public final class ProcessInstanceModificationProcessor
         //  children are found
         return Optional.of(child.getKey());
       } else {
-        final var optionalFlowScopeKey = getFlowScopeKey(child.getKey(), targetElementId);
+        final var optionalFlowScopeKey = findFlowScopeKey(child.getKey(), targetElementId);
         if (optionalFlowScopeKey.isPresent()) {
           return optionalFlowScopeKey;
         }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -413,20 +413,28 @@ public class ModifyProcessInstanceTest {
     Assertions.assertThat(
             RecordingExporter.processInstanceRecords()
                 .onlyEvents()
-                .withElementIdIn("B", "C")
+                .withElementId("B")
+                .withProcessInstanceKey(processInstanceKey)
+                .limit("B", ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .toList())
+        .extracting(Record::getIntent, r -> r.getValue().getFlowScopeKey())
+        .describedAs("Expect the tasks to have been activated in the correct scope")
+        .containsExactly(
+            Tuple.tuple(ProcessInstanceIntent.ELEMENT_ACTIVATING, subprocessScopeKey),
+            Tuple.tuple(ProcessInstanceIntent.ELEMENT_ACTIVATED, subprocessScopeKey));
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords()
+                .onlyEvents()
+                .withElementId("C")
                 .withProcessInstanceKey(processInstanceKey)
                 .limit("C", ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .toList())
-        .extracting(
-            r -> r.getValue().getElementId(),
-            Record::getIntent,
-            r -> r.getValue().getFlowScopeKey())
+        .extracting(Record::getIntent, r -> r.getValue().getFlowScopeKey())
         .describedAs("Expect the tasks to have been activated in the correct scope")
         .containsExactly(
-            Tuple.tuple("B", ProcessInstanceIntent.ELEMENT_ACTIVATING, subprocessScopeKey),
-            Tuple.tuple("B", ProcessInstanceIntent.ELEMENT_ACTIVATED, subprocessScopeKey),
-            Tuple.tuple("C", ProcessInstanceIntent.ELEMENT_ACTIVATING, subprocessScopeKey),
-            Tuple.tuple("C", ProcessInstanceIntent.ELEMENT_ACTIVATED, subprocessScopeKey));
+            Tuple.tuple(ProcessInstanceIntent.ELEMENT_ACTIVATING, subprocessScopeKey),
+            Tuple.tuple(ProcessInstanceIntent.ELEMENT_ACTIVATED, subprocessScopeKey));
   }
 
   @Test

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceRecordStream.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
-import java.util.Arrays;
 import java.util.stream.Stream;
 
 public final class ProcessInstanceRecordStream
@@ -45,10 +44,6 @@ public final class ProcessInstanceRecordStream
 
   public ProcessInstanceRecordStream withElementId(final String elementId) {
     return valueFilter(v -> elementId.equals(v.getElementId()));
-  }
-
-  public ProcessInstanceRecordStream withElementIdIn(final String... elementIds) {
-    return valueFilter(v -> Arrays.asList(elementIds).contains(v.getElementId()));
   }
 
   public ProcessInstanceRecordStream withFlowScopeKey(final long flowScopeKey) {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceRecordStream.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.util.Arrays;
 import java.util.stream.Stream;
 
 public final class ProcessInstanceRecordStream
@@ -44,6 +45,10 @@ public final class ProcessInstanceRecordStream
 
   public ProcessInstanceRecordStream withElementId(final String elementId) {
     return valueFilter(v -> elementId.equals(v.getElementId()));
+  }
+
+  public ProcessInstanceRecordStream withElementIdIn(final String... elementIds) {
+    return valueFilter(v -> Arrays.asList(elementIds).contains(v.getElementId()));
   }
 
   public ProcessInstanceRecordStream withFlowScopeKey(final long flowScopeKey) {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Allows the activation of nested elements, as long as they are activated inside of an existing flow scope. Using the flowscope element id we can search for an element instance matching this id. When found we can return the key of this element instance and use it as the flow scope when activating the element from the activate instruction.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9642 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
