### PR TITLE
Add code coverage to test workflow 

### DIFF
--- a/.github/actions/collect-test-artifacts/action.yml
+++ b/.github/actions/collect-test-artifacts/action.yml
@@ -1,0 +1,45 @@
+---
+name: Collect test artifacts
+
+description: Collects test outputs and uploads them as artifact
+
+inputs:
+  name:
+    description: 'Name of the test artifact.'
+    required: true
+  sed-bin:
+    description: 'GNU sed binary name.'
+    required: false
+    default: 'sed'
+
+runs:
+  using: composite
+  steps:
+
+    # MacOS sed is not compatible with the remove script, we need gnu sed instead
+  - name: Install GNU sed
+    if: runner.os == 'macOS'
+    shell: bash
+    run: |
+      brew install gnu-sed
+      echo "SED_BIN=gsed" >> $GITHUB_ENV
+
+    # Mitigate to large test output files by deleting the system-out element using sed
+    # Note: we cannot use XML tools like xmlstarlet as they all suffer the same libxml2 limitation
+    # Related to https://github.com/camunda/zeebe/issues/9959
+  - name: Remove system-out from test xml files
+    shell: bash
+    run: |
+      find . -iname TEST-*.xml -print0 | xargs -0 -r ${SED_BIN:-sed} '/<system-out>/,/<\/system-out>/d' -i
+
+  - name: Archive Test Results
+    uses: actions/upload-artifact@v3
+    if: always()
+    with:
+      name: Test results for ${{ inputs.name  }}
+      path: |
+        **/target/failsafe-reports/
+        **/target/surefire-reports/
+        **/hs_err_*.log
+      retention-days: 7
+      if-no-files-found: ignore

--- a/.github/actions/collect-test-artifacts/action.yml
+++ b/.github/actions/collect-test-artifacts/action.yml
@@ -40,6 +40,7 @@ runs:
       path: |
         **/target/failsafe-reports/
         **/target/surefire-reports/
+        **/target/site/jacoco/jacoco.xml
         **/hs_err_*.log
       retention-days: 7
       if-no-files-found: ignore

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -28,13 +28,6 @@ jobs:
             unzip -d "$name" "$name.zip"
           done
 
-        # Mitigate to large test output files by deleting the system-out element using sed
-        # Note: we cannot use XML tools like xmlstarlet as they all suffer the same libxml2 limitation
-        # Related to https://github.com/camunda/zeebe/issues/9959
-      - name: Remove system-out from test xml files
-        run: |
-          find . -iname TEST-*.xml -print0 | xargs -0 sed '/<system-out>/,/<\/system-out>/d' -i
-
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -37,3 +37,35 @@ jobs:
           junit_files: |
             artifacts/**/surefire-reports/*.xml
             artifacts/**/failsafe-reports/TEST-*.xml
+
+      - name: Read Event File
+        id: read-event-file
+        run: |
+          cd 'artifacts/Event File/'
+          echo "::set-output name=pr_id::$(jq -r '.pull_request.number' < event.json)"
+          echo "::set-output name=repository::$(jq -r '.pull_request.head.repo.full_name' < event.json)"
+          echo "::set-output name=commit_sha::$(jq -r '.pull_request.head.sha' < event.json)"
+          echo "::set-output name=branch_ref::$(jq -r '.pull_request.head.ref' < event.json)"
+
+      - name: Checkout source code for code coverage upload
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ steps.read-event-file.outputs.repository }}
+          ref: ${{ steps.read-event-file.outputs.commit_sha }}
+          path: src
+
+      - name: Collect Code Coverage Reports
+        id: code-coverage-reports
+        run: |
+          echo "::set-output name=files::$(find . -name jacoco.xml -print0 | tr '\0' , | head -c -1)"
+
+      - name: Upload CodeCoverage
+        if: ${{ steps.code-coverage-reports.outputs.files }}
+        uses: codecov/codecov-action@v3
+        with:
+          files: ${{ steps.code-coverage-reports.outputs.files }}
+          override_branch: ${{ steps.read-event-file.outputs.branch_ref }}
+          override_commit: ${{ steps.read-event-file.outputs.commit_sha }}
+          override_pr: ${{ steps.read-event-file.outputs.pr_id }}
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,15 +53,10 @@ jobs:
           -P parallel-tests,extract-flaky-tests
           -pl !:zeebe-elasticsearch-exporter
           verify
-      - name: Archive Test Results
-        uses: actions/upload-artifact@v3
-        if: always()
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
         with:
-          name: Integration test results
-          path: |
-            **/target/failsafe-reports/
-            **/hs_err_*.log
-          retention-days: 7
+          name: Integration Tests
   exporter-tests:
     name: Exporter tests
     runs-on: "n1-standard-8-netssd-preempt"
@@ -83,15 +78,10 @@ jobs:
           -D skipUTs -D skipChecks -D failsafe.rerunFailingTestsCount=3
           -pl :zeebe-elasticsearch-exporter
           verify
-      - name: Archive Test Results
-        uses: actions/upload-artifact@v3
-        if: always()
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
         with:
-          name: Exporter test results
-          path: |
-            **/target/failsafe-reports/
-            **/hs_err_*.log
-          retention-days: 7
+          name: Exporter Tests
   project-list:
     # Builds a list of projects where unit tests can be run on hosted runners
     name: List projects
@@ -133,16 +123,10 @@ jobs:
           verify
       - name: Normalize artifact name
         run: echo "ARTIFACT_NAME=$(echo ${{ matrix.project }} | sed 's/\//-/g')" >> $GITHUB_ENV
-      - name: Archive Test Results
-        uses: actions/upload-artifact@v3
-        if: always()
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
         with:
-          name: Unit test results for ${{ env.ARTIFACT_NAME }}
-          path: |
-            **/target/surefire-reports/
-            **/hs_err_*.log
-          retention-days: 7
-          if-no-files-found: ignore
+          name: ${{ env.ARTIFACT_NAME }}
   slow-unit-tests:
     name: Slow unit tests
     runs-on: "n1-standard-8-netssd-preempt"
@@ -167,15 +151,10 @@ jobs:
           -D skipITs -D skipChecks
           -pl :zeebe-workflow-engine
           verify
-      - name: Archive Test Results
-        uses: actions/upload-artifact@v3
-        if: always()
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
         with:
-          name: Slow unit test results
-          path: |
-            **/target/surefire-reports/
-            **/hs_err_*.log
-          retention-days: 7
+          name: Slow Unit Tests
   smoke-tests:
     # This name is hard-referenced from bors.toml
     # Remember to update that if this name, or the matrix.os changes
@@ -208,15 +187,10 @@ jobs:
           -pl qa/integration-tests
           -P smoke-test
           verify
-      - name: Archive Test Results
-        uses: actions/upload-artifact@v3
-        if: always()
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
         with:
-          name: Smoke test results for ${{ matrix.os }}
-          path: |
-            **/target/failsafe-reports/
-            **/hs_err_*.log
-          retention-days: 7
+          name: Smoke Tests ${{ matrix.os }}
   java-randomized-tests:
     name: Java randomized tests
     runs-on: ubuntu-latest
@@ -229,15 +203,10 @@ jobs:
           java-version: '17'
       - run: mvn -B -D skipChecks -D skipTests install
       - run: mvn -T1C -B -D skipChecks -P parallel-tests,include-random-tests test
-      - name: Archive Test Results
-        uses: actions/upload-artifact@v3
-        if: always()
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
         with:
-          name: Java randomized test results
-          path: |
-            **/target/surefire-reports/
-            **/hs_err_*.log
-          retention-days: 7
+          name: Java Randomized Tests
   go-client:
     name: Go client tests
     runs-on: ubuntu-latest
@@ -294,15 +263,10 @@ jobs:
           -D surefire.rerunFailingTestsCount=3
           -pl clients/java
           verify
-      - name: Archive Test Results
-        uses: actions/upload-artifact@v3
-        if: always()
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
         with:
-          name: Java 8 client test results
-          path: |
-            **/target/surefire-reports/
-            **/hs_err_*.log
-          retention-days: 7
+          name: Java 8 Client
 
   # Used by bors to check all tests, including the unit test matrix.
   # New test jobs must be added to the `needs` lists!

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1457,6 +1457,9 @@
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>${plugin.version.jacoco}</version>
+          <configuration>
+            <formats>XML</formats>
+          </configuration>
           <executions>
             <execution>
               <id>coverage-initialize</id>


### PR DESCRIPTION
## Description

This change limits the jacoco report format to XML, as I assume nobody is using the other formats. The jacoco reports are included in the uploaded artifacts at the end of the test run. 

In the publish test result action the PR event details are read to extract the github properties to use in codecov upload. Also the source code of the commit is checked out to as it is needed for the code coverage upload.

## Related issues

closes #9130 
based on #10045 