### PR TITLE
Add OCI & OpenShift labels to Docker image

### DIFF
--- a/.ci/scripts/distribution/ensure-naming-for-process.sh
+++ b/.ci/scripts/distribution/ensure-naming-for-process.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -eu
 
-FIND_OUTPUT=$(find . -iname '*workflow*' -not -path '.*/node_modules/*' -not -path '.*/target/*' -not -path '.*/.git/*'  -not -path '.*/.github/*' -not -path '.*/vendor/*')
+FIND_OUTPUT=$(find . -iname '*workflow*' -not -path '.*/node_modules/*' -not -path '.*/target/*' -not -path '.*/.git/*'  -not -path '.*/.github/*' -not -path '.*/vendor/*' -not -path '.*/docker/*')
 
 # if grep doesn't find a match it exits with 1, which we ignore as we check the output later
-GREP_OUTPUT=$(grep --exclude-dir={.git,node_modules,target,.ci,.github,vendor} -i -P 'workflow(?![-\s]+(?i)engine)' -r . || true)
+GREP_OUTPUT=$(grep --exclude-dir={.git,node_modules,target,.ci,.github,vendor,docker} --exclude="Dockerfile" -i -P 'workflow(?![-\s]+(?i)engine)' -r . || true)
 
 if [ -n "${FIND_OUTPUT}" ] || [ -n "${GREP_OUTPUT}" ]; then
 	echo "Found occurence of workflow in file names or content"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -79,3 +79,54 @@ jobs:
           java-version: '17'
       - run: mvn -B -D skipTests -D skipChecks install
       - run: mvn -T1C -B -D skipTests -P !autoFormat,checkFormat,spotbugs verify
+  docker-checks:
+    name: Docker checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hadolint/hadolint-action@v2.1.0
+        with:
+          config: ./.hadolint.yaml
+          dockerfile: ./Dockerfile
+          format: sarif
+          output-file: ./hadolint.sarif
+          no-color: true
+      - name: Upload Hadolint Results
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ./hadolint.sarif
+      - uses: actions/setup-java@v3.4.1
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - uses: stCarolas/setup-maven@v4.4
+        with:
+          maven-version: 3.8.5
+      - name: Package Zeebe
+        run: mvn -B -DskipTests -DskipChecks package -T1C
+      - name: Set project version
+        run: echo ::set-output name=result::$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+        id: get-version
+      - name: Get build timestamp
+        id: get-date
+        run: echo "::set-output name=result::$(date --iso-8601=seconds)"
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          # give it a fake registry to make sure we don't accidentally push it
+          tags: localhost:5000/camunda/zeebe:${{ steps.get-version.outputs.result }}
+          load: true
+          no-cache: true
+          build-args: |
+            DISTBALL=dist/target/camunda-zeebe-${{ steps.get-version.outputs.result }}.tar.gz
+            DATE=${{ steps.get-date.outputs.result }}
+            REVISION=${{ github.sha }}
+            VERSION=${{ steps.get-version.outputs.result }}
+          target: app
+      - name: Verify Docker image
+        env:
+          DATE: ${{ steps.get-date.outputs.result }}
+          REVISION: ${{ github.sha }}
+          VERSION: ${{ steps.get-version.outputs.result }}
+        run: ${PWD}/docker/test/verify.sh 'localhost:5000/camunda/zeebe:${{ steps.get-version.outputs.result }}'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,13 @@ jobs:
         run: ./build.sh
         working-directory: clients/go/cmd/zbctl
       - name: Package Zeebe
-        run: mvn -B -DskipTests -DskipChecks package
+        run: mvn -B -DskipTests -DskipChecks package -T1C
+      - name: Set project version
+        run: echo ::set-output name=result::$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+        id: get-version
+      - name: Get build timestamp
+        id: get-date
+        run: echo "::set-output name=result::$(date --iso-8601=seconds)"
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -90,7 +96,11 @@ jobs:
           tags: camunda/zeebe:SNAPSHOT
           push: true
           no-cache: true
-          build-args: DISTBALL=dist/target/camunda-zeebe-*-SNAPSHOT.tar.gz
+          build-args: |
+            DISTBALL=dist/target/camunda-zeebe-${{ steps.get-version.outputs.result }}.tar.gz
+            DATE=${{ steps.get-date.outputs.result }}
+            REVISION=${{ github.sha }}
+            VERSION=${{ steps.get-version.outputs.result }}
           target: app
 
   notify-if-failed:

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,3 @@
+failure-threshold: warning
+format: tty
+ignored: []

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 ARG APP_ENV=prod
+# Override this based on the architecture; this is currently pointing to amd64
+ARG BASE_SHA="fce37e5146419a158c2199c6089fa39b92445fb2e66dc0331f8591891239ea3b"
 
 # Building builder image
 FROM ubuntu:focal as builder
@@ -12,27 +14,57 @@ COPY ${DISTBALL} ${TMP_ARCHIVE}
 RUN mkdir -p ${TMP_DIR} && \
     tar xfvz ${TMP_ARCHIVE} --strip 1 -C ${TMP_DIR} && \
     # already create volume dir to later have correct rights
-    mkdir ${TMP_DIR}/data
-
-RUN apt-get update && \
-    apt-get install tini && \
+    mkdir ${TMP_DIR}/data && \
+    apt-get -qq update && \
+    apt-get install -y --no-install-recommends tini=0.18.0-1 && \
     cp /usr/bin/tini ${TMP_DIR}/bin/tini
 
 COPY docker/utils/startup.sh ${TMP_DIR}/bin/startup.sh
-RUN chmod +x -R ${TMP_DIR}/bin/
-RUN chmod 0775 ${TMP_DIR} ${TMP_DIR}/data
+RUN chmod +x -R ${TMP_DIR}/bin/ && \
+    chmod 0775 ${TMP_DIR} ${TMP_DIR}/data
 
 # Building prod image
-FROM eclipse-temurin:17-jre-focal as prod
+FROM eclipse-temurin:17-jre-focal@sha256:${BASE_SHA} as prod
+
+# leave unset to use the default value at the top of the file
+ARG BASE_SHA
+
+LABEL org.opencontainers.image.base.digest="${BASE_SHA}"
+LABEL org.opencontainers.image.base.name="docker.io/library/eclipse-temurin:17-jre-focal"
 
 # Building dev image
 FROM eclipse-temurin:17-jdk-focal as dev
-RUN echo "running DEV pre-install commands"
-RUN apt-get update
-RUN curl -sSL https://github.com/jvm-profiling-tools/async-profiler/releases/download/v1.7.1/async-profiler-1.7.1-linux-x64.tar.gz | tar xzv
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN echo "running DEV pre-install commands" && \
+    curl -sSL https://github.com/jvm-profiling-tools/async-profiler/releases/download/v1.7.1/async-profiler-1.7.1-linux-x64.tar.gz | tar xzv
 
 # Building application image
+# hadolint ignore=DL3006
 FROM ${APP_ENV} as app
+
+ARG VERSION=""
+ARG DATE=""
+ARG REVISION=""
+
+# OCI labels: https://github.com/opencontainers/image-spec/blob/main/annotations.md
+LABEL org.opencontainers.image.created="${DATE}"
+LABEL org.opencontainers.image.authors="zeebe@camunda.com"
+LABEL org.opencontainers.image.url="https://zeebe.io"
+LABEL org.opencontainers.image.documentation="https://docs.camunda.io/docs/self-managed/zeebe-deployment/"
+LABEL org.opencontainers.image.source="https://github.com/camunda/zeebe"
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.revision="${REVISION}"
+LABEL org.opencontainers.image.vendor="Camunda Services GmbH"
+LABEL org.opencontainers.image.licenses="(Apache-2.0 AND LicenseRef-Zeebe-Community-1.1)"
+LABEL org.opencontainers.image.title="Zeebe"
+LABEL org.opencontainers.image.description="Workflow engine for microservice orchestration"
+
+# OpenShift labels: https://docs.openshift.com/container-platform/4.10/openshift_images/create-images.html#defining-image-metadata
+LABEL io.openshift.tags="bpmn,orchestration,workflow"
+LABEL io.k8s.description="Workflow engine for microservice orchestration"
+LABEL io.openshift.non-scalable="false"
+LABEL io.openshift.min-memory="512Mi"
+LABEL io.openshift.min-cpu="1"
 
 ENV ZB_HOME=/usr/local/zeebe \
     ZEEBE_BROKER_GATEWAY_NETWORK_HOST=0.0.0.0 \

--- a/docker/test/docker-labels.golden.json
+++ b/docker/test/docker-labels.golden.json
@@ -1,0 +1,20 @@
+{
+  "io.k8s.description": "Workflow engine for microservice orchestration",
+  "io.openshift.min-cpu": "1",
+  "io.openshift.min-memory": "512Mi",
+  "io.openshift.non-scalable": "false",
+  "io.openshift.tags": "bpmn,orchestration,workflow",
+  "org.opencontainers.image.authors": "zeebe@camunda.com",
+  "org.opencontainers.image.base.digest": "fce37e5146419a158c2199c6089fa39b92445fb2e66dc0331f8591891239ea3b",
+  "org.opencontainers.image.base.name": "docker.io/library/eclipse-temurin:17-jre-focal",
+  "org.opencontainers.image.created": $DATE,
+  "org.opencontainers.image.description": "Workflow engine for microservice orchestration",
+  "org.opencontainers.image.documentation": "https://docs.camunda.io/docs/self-managed/zeebe-deployment/",
+  "org.opencontainers.image.licenses": "(Apache-2.0 AND LicenseRef-Zeebe-Community-1.1)",
+  "org.opencontainers.image.revision": $REVISION,
+  "org.opencontainers.image.source": "https://github.com/camunda/zeebe",
+  "org.opencontainers.image.title": "Zeebe",
+  "org.opencontainers.image.url": "https://zeebe.io",
+  "org.opencontainers.image.vendor": "Camunda Services GmbH",
+  "org.opencontainers.image.version": $VERSION
+}

--- a/docker/test/verify.sh
+++ b/docker/test/verify.sh
@@ -1,0 +1,76 @@
+#!/bin/bash -eu
+# Verifies certain properties of the Docker image, e.g. actualLabels are correct. This script relies
+# on `jq` as an external dependency.
+#
+# Example usage:
+#   $ ./verify.sh camunda/zeebe:8.1.0
+#
+# Globals:
+#   VERSION - required; the semantic version, e.g. 8.1.0 or 1.2.0-alpha1
+#   REVISION - required; the sha1 of the commit used to build the artifact
+#   DATE - required; the ISO 8601 date at which the image was built
+# Arguments:
+#   1 - Docker image name
+# Outputs:
+#   STDERR Error message if any of the properties are invalid
+# Returns:
+#   0 on success
+#   1 if one of the properties is invalid
+
+set -o pipefail
+
+VERSION="${VERSION:-}"
+REVISION="${REVISION:-}"
+DATE="${DATE:-}"
+
+# Make sure environment variables are set
+if [ -z "${VERSION}" ]; then
+  echo >&2 "No VERSION was given; make sure to pass a semantic version, e.g. VERSION=8.1.0"
+  exit 1
+fi
+
+if [ -z "${REVISION}" ]; then
+  echo >&2 "No REVISION was given; make sure to pass the Git commit sha, e.g. REVISION=2941d620f08d9729632b2b1222123edcbe3532c8"
+  exit 1
+fi
+
+if [ -z "${DATE}" ]; then
+  echo >&2 "No DATE was given; make sure to pass an ISO8601 date, e.g. DATE='2001-01-01T00:00:00Z'"
+  exit 1
+fi
+
+imageName="${1}"
+
+# Check that the image exists
+if ! imageInfo="$(docker inspect "${imageName}")"; then
+  echo >&2 "No known Docker image ${imageName} exists; did you pass the right name?"
+  exit 1
+fi
+
+# Extract the actual labels from the info - make sure to sort keys so we always have the same
+# ordering for maps to compare things properly
+actualLabels=$(echo "${imageInfo}" | jq --sort-keys '.[0].Config.Labels')
+
+if [[ -z "${actualLabels}" || "${actualLabels}" == "null" || "${actualLabels}" == "[]" ]]; then
+  echo >&2 "No labels found in the given image ${imageName}; raw inspect output to follow"
+  printf >&2 "\n====\n%s\n====\n" "${imageInfo}"
+  echo >&2 "Are there any labels in the above? If so, the JSON query may need to be changed."
+  exit 1
+fi
+
+# Generate the expected labels files with the dynamic properties substituted
+labelsGoldenFile="${BASH_SOURCE%/*}/docker-labels.golden.json"
+expectedLabels=$(
+  jq --sort-keys -n \
+    --arg VERSION "${VERSION}" \
+    --arg REVISION "${REVISION}" \
+    --arg DATE "${DATE}" \
+    "$(cat "${labelsGoldenFile}")"
+)
+
+# Compare and output
+echo "Comparing image label values..."
+if ! diff <(echo "${expectedLabels}") <(echo "${actualLabels}"); then
+  echo >&2 "Expected label values (marked by '<') do not match actual label values (marked by '>'); if you think this is wrong, update the golden file at ${labelsGoldenFile}"
+  exit 1
+fi


### PR DESCRIPTION
## Description

This PR adds labels to the Docker image following the OCI and OpenShift specs. This includes modifications to the build process to inject the few values which are dynamic, namely:
  - the created at ISO 8601 timestamp
  - the commit SHA (or revision) of the artifact
  - the semantic version of the artifact

You can find the specs here:

- https://github.com/opencontainers/image-spec/blob/main/annotations.md
- https://docs.openshift.com/container-platform/4.10/openshift_images/create-images.html#images-create-metadata_create-images

On top of adding labels, this modifies the `Dockerfile` a bit and pins the production image to specific sha of the base image, ensuring reproducible builds. In the future we should update this sha when need be, and update the golden file (`docker/test/docker-labels.golden.json`).

This also adds `hadolint` to lint our Dockerfile and applies some of the recommendations to it. A new code quality job is added, `Docker checks`, which runs hadolint and verifies that the labels are as expected. The verification is done via a bash script which grabs the labels from a `docker inspect`, and compares it with an interpolated golden file (since we have a few dynamic values). The comparison is done using `diff`, so the output should be familiar to most.

## Related issues

related to #9940 
blocks #10013 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
