### PR TITLE
refactor: let `dist` build the actor scheduler for gateway

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
-import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
@@ -41,9 +40,6 @@ public interface BrokerStartupContext {
   SpringBrokerBridge getSpringBrokerBridge();
 
   ActorSchedulingService getActorSchedulingService();
-
-  @Deprecated // use getActorSchedulingService instead
-  ActorScheduler getActorScheduler();
 
   ConcurrencyControl getConcurrencyControl();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
-import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
@@ -37,7 +36,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final BrokerInfo brokerInfo;
   private final BrokerCfg configuration;
   private final SpringBrokerBridge springBrokerBridge;
-  private final ActorScheduler actorScheduler;
+  private final ActorSchedulingService actorScheduler;
   private final BrokerHealthCheckService healthCheckService;
   private final ExporterRepository exporterRepository;
 
@@ -58,7 +57,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final BrokerInfo brokerInfo,
       final BrokerCfg configuration,
       final SpringBrokerBridge springBrokerBridge,
-      final ActorScheduler actorScheduler,
+      final ActorSchedulingService actorScheduler,
       final BrokerHealthCheckService healthCheckService,
       final ExporterRepository exporterRepository,
       final List<PartitionListener> additionalPartitionListeners) {
@@ -89,11 +88,6 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
 
   @Override
   public ActorSchedulingService getActorSchedulingService() {
-    return actorScheduler;
-  }
-
-  @Override
-  public ActorScheduler getActorScheduler() {
     return actorScheduler;
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
@@ -27,10 +27,11 @@ class EmbeddedGatewayServiceStep extends AbstractBrokerStartupStep {
 
     final var clusterServices = brokerStartupContext.getClusterServices();
 
+    @SuppressWarnings("resource")
     final var embeddedGatewayService =
         new EmbeddedGatewayService(
             brokerStartupContext.getBrokerConfiguration(),
-            brokerStartupContext.getActorScheduler(),
+            brokerStartupContext.getActorSchedulingService(),
             clusterServices.getMessagingService(),
             clusterServices.getMembershipService(),
             clusterServices.getEventService());

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
@@ -31,7 +31,7 @@ public final class EmbeddedGatewayService implements AutoCloseable {
     final Function<GatewayCfg, BrokerClient> brokerClientFactory =
         cfg ->
             new BrokerClientImpl(
-                cfg, messagingService, membershipService, eventService, actorScheduler, false);
+                cfg, messagingService, membershipService, eventService, actorScheduler);
     gateway = new Gateway(configuration.getGateway(), brokerClientFactory, actorScheduler);
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.gateway.Gateway;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
-import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.util.function.Function;
 
@@ -24,7 +24,7 @@ public final class EmbeddedGatewayService implements AutoCloseable {
 
   public EmbeddedGatewayService(
       final BrokerCfg configuration,
-      final ActorScheduler actorScheduler,
+      final ActorSchedulingService actorScheduler,
       final MessagingService messagingService,
       final ClusterMembershipService membershipService,
       final ClusterEventService eventService) {

--- a/dist/src/main/java/io/camunda/zeebe/gateway/ActorSchedulerComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/ActorSchedulerComponent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway;
+
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.shared.ActorClockConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Component
+final class ActorSchedulerComponent {
+
+  private final GatewayCfg config;
+  private final ActorClockConfiguration clockConfiguration;
+
+  @Autowired
+  public ActorSchedulerComponent(
+      final GatewayCfg config, final ActorClockConfiguration clockConfiguration) {
+    this.config = config;
+    this.clockConfiguration = clockConfiguration;
+  }
+
+  @Bean("actorScheduler")
+  ActorScheduler createActorSchedulingService() {
+    return ActorScheduler.newActorScheduler()
+        .setCpuBoundActorThreadCount(config.getThreads().getManagementThreads())
+        .setIoBoundActorThreadCount(0)
+        .setSchedulerName("gateway-scheduler")
+        .setActorClock(clockConfiguration.getClock())
+        .build();
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
@@ -146,7 +146,6 @@ public class StandaloneGateway
         atomixCluster.getMessagingService(),
         atomixCluster.getMembershipService(),
         atomixCluster.getEventService(),
-        actorScheduler,
-        false);
+        actorScheduler);
   }
 }

--- a/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
@@ -130,11 +130,13 @@ final class StandaloneGatewaySecurityTest {
 
   private StandaloneGateway buildGateway(final GatewayCfg gatewayCfg) {
     final AtomixComponent clusterComponent = new AtomixComponent(gatewayCfg);
+    final ActorSchedulerComponent actorSchedulerComponent =
+        new ActorSchedulerComponent(gatewayCfg, new ActorClockConfiguration(false));
 
     return new StandaloneGateway(
         gatewayCfg,
         new SpringGatewayBridge(),
-        new ActorClockConfiguration(false),
+        actorSchedulerComponent.createActorSchedulingService(),
         clusterComponent.createAtomixCluster());
   }
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -73,7 +73,9 @@ public final class Gateway {
       final ActorSchedulingService actorSchedulingService) {
     this(
         gatewayCfg,
-        cfg -> new BrokerClientImpl(cfg, messagingService, membershipService, eventService),
+        cfg ->
+            new BrokerClientImpl(
+                cfg, messagingService, membershipService, eventService, actorSchedulingService),
         DEFAULT_SERVER_BUILDER_FACTORY,
         actorSchedulingService);
   }
@@ -95,7 +97,7 @@ public final class Gateway {
     this.serverBuilderFactory = serverBuilderFactory;
     this.actorSchedulingService = actorSchedulingService;
 
-    this.healthManager = new GatewayHealthManagerImpl();
+    healthManager = new GatewayHealthManagerImpl();
   }
 
   public GatewayCfg getGatewayCfg() {
@@ -149,7 +151,7 @@ public final class Gateway {
       final var server = buildServer(serverBuilder, gatewayGrpcService);
       server.start();
       return Either.right(server);
-    } catch (Exception e) {
+    } catch (final Exception e) {
       return Either.left(e);
     }
   }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.grpc.StatusRuntimeException;
 import io.netty.util.NetUtil;
-import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -75,7 +74,7 @@ final class InterceptorIT {
   }
 
   @Test
-  void shouldAbortDeploymentCalls() throws IOException {
+  void shouldAbortDeploymentCalls() {
     // given
     final var interceptorCfg = new InterceptorCfg();
     interceptorCfg.setId("test");
@@ -102,7 +101,7 @@ final class InterceptorIT {
   }
 
   @Test
-  void shouldInjectQueryApiViaContext() throws IOException {
+  void shouldInjectQueryApiViaContext() {
     // given
     final var interceptorCfg = new InterceptorCfg();
     interceptorCfg.setId("test");
@@ -129,8 +128,7 @@ final class InterceptorIT {
         cluster.getMessagingService(),
         cluster.getMembershipService(),
         cluster.getEventService(),
-        scheduler,
-        false);
+        scheduler);
   }
 
   private ZeebeClient createZeebeClient() {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -413,9 +413,9 @@ public final class ClusteringRule extends ExternalResource {
             atomixCluster.getMembershipService(),
             atomixCluster.getEventService(),
             actorScheduler);
+    closeables.manage(actorScheduler::stop);
     closeables.manage(gateway::stop);
     closeables.manage(atomixCluster::stop);
-    closeables.manage(actorScheduler::stop);
     return gateway;
   }
 


### PR DESCRIPTION
## Description

This moves the responsibility of creating an actor scheduler for the gateway to the `dist` module. As an added benefit, this allows us to remove some redundant constructors, simplify BrokerClient to never start the actor scheduler and a deprecated method from `BrokerStartupContext`.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #9996 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
