### PR TITLE
Generate and verify labels of Docker image during release

### DIFF
--- a/.ci/jobs/docker_zeebe.dsl
+++ b/.ci/jobs/docker_zeebe.dsl
@@ -12,7 +12,10 @@ pipelineJob('zeebe-docker') {
     parameters {
         stringParam('BRANCH', 'main', 'Which branch to build and push?')
         stringParam('VERSION', '', 'Zeebe version to build the image for')
+        stringParam('REVISION', '', 'The Git commit used to build the image; can be omitted except for releases')
+        stringParam('DATE', '', 'The ISO-8601 date when the packaged artifact was built; can be omitted except for releases')
         booleanParam('IS_LATEST', false, 'Should the docker image be tagged as camunda/zeebe:latest?')
         booleanParam('PUSH', false, 'Should the docker image be pushed to docker hub?')
+        booleanParam('VERIFY', false', 'Should we verify the Docker image before pushing it?')
     }
 }

--- a/.ci/pipelines/docker_zeebe.groovy
+++ b/.ci/pipelines/docker_zeebe.groovy
@@ -66,6 +66,9 @@ spec:
         PUSH = "${params.PUSH}"
         IMAGE = "camunda/zeebe"
         TAG = docker_tag("${params.VERSION}")
+        REVISION = "${params.REVISION}"
+        DATE = "${param.DATE}"
+        VERIFY = "${param.VERIFY}"
     }
 
     stages {
@@ -79,6 +82,12 @@ spec:
                 container('maven') {
                     sh '.ci/scripts/docker/prepare.sh'
                 }
+
+                // extract to a script if we need to do more here; these are necessary for the
+                // verify script
+                container('docker') {
+                    sh 'apk add -q bash jq'
+                }
             }
         }
 
@@ -86,6 +95,15 @@ spec:
             steps {
                 container('docker') {
                     sh '.ci/scripts/docker/build.sh'
+                }
+            }
+        }
+
+        stage('Verify') {
+            when { environment name: 'VERIFY', value: 'true' }
+            steps {
+                container('docker') {
+                    sh "./docker/test/verify.sh '${env.IMAGE}:${env.TAG}'"
                 }
             }
         }

--- a/.ci/pipelines/release_zeebe.groovy
+++ b/.ci/pipelines/release_zeebe.groovy
@@ -146,13 +146,15 @@ spec:
         }
 
         stage('Docker Image') {
-            when { expression { return params.PUSH_DOCKER } }
             steps {
                 build job: 'zeebe-docker', parameters: [
                         string(name: 'BRANCH', value: env.RELEASE_BRANCH),
                         string(name: 'VERSION', value: params.RELEASE_VERSION),
+                        string(name: 'REVISION', value: env.GIT_COMMIT),
+                        string(name: 'DATE', value: java.time.Instant.now().toString()),
                         booleanParam(name: 'IS_LATEST', value: params.IS_LATEST),
-                        booleanParam(name: 'PUSH', value: true)
+                        booleanParam(name: 'PUSH', value: params.PUSH_DOCKER),
+                        booleanParam(name: 'VERIFY', value: true)
                 ]
             }
         }

--- a/.ci/scripts/docker/build.sh
+++ b/.ci/scripts/docker/build.sh
@@ -1,4 +1,9 @@
 #!/bin/sh -eux
 
 echo "Building Zeebe Docker image ${IMAGE}:${TAG}"
-docker build --no-cache --build-arg DISTBALL=camunda-zeebe.tar.gz -t ${IMAGE}:${TAG} --target app .
+docker build --no-cache \
+  --build-arg DISTBALL=camunda-zeebe.tar.gz \
+  --build-arg DATE="${DATE}" \
+  --build-arg REVISION="${REVISION}" \
+  --build-arg VERSION="${VERSION}" \
+  -t "${IMAGE}:${TAG}" --target app .

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,6 +119,9 @@ pipeline {
                 DOCKER_BUILDKIT = "1"
                 IMAGE = "camunda/zeebe"
                 TAG = 'current-test'
+                VERSION = readMavenPom(file: 'bom/pom.xml').getVersion()
+                REVISION = "${env.GIT_COMMIT}"
+                DATE = java.time.Instant.now().toString()
             }
 
             steps {


### PR DESCRIPTION
## Description

This PR updates the release process to generate the correct labels for the Docker image, and verify them, failing the release process (and not pushing the image) if they are wrong.

Ideally, this would be done before the Maven release to avoid wasting time if the image would produce the wrong labels. Doing this is quite a bit of refactoring of the CI pipeline unfortunately, and producing the wrong labels is most likely an issue with the CI pipeline itself, which should not happen very often. Errors in the Dockerfile itself would be checked by the GHA pipeline, which should cover the important cases and runs on each pull.

I opted to do the verification during the release process as it's very easy to miss that the labels are wrong, and it would somewhat unprofessional if a customer were to report it to us down the road.

## Related issues

closes #9940 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
