### PR TITLE
feat(backup): define interface for backup store

### DIFF
--- a/backup/src/main/java/io/camunda/zeebe/backup/api/Backup.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/Backup.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.api;
+
+import java.nio.file.Path;
+import java.util.Set;
+
+/** Represents a backup * */
+public interface Backup {
+
+  /**
+   * @return Returns backup identifier
+   */
+  BackupIdentifier id();
+
+  /**
+   * The number of partitions configured in the system at the time the backup is taken. This is
+   * useful when the system supports dynamic configuration and the system restores from a backup at
+   * a time when the number of partitions was different.
+   *
+   * @return number of partitions at the time backup is taken.
+   */
+  int numberOfPartitions();
+
+  /**
+   * @return id of the snapshot included in the backup
+   */
+  String snapshotId();
+
+  /**
+   * @return the set of snapshot files
+   */
+  Set<Path> snapshot();
+
+  /**
+   * @return the checkpoint position of the checkpoint included in the backup
+   */
+  long checkpointPosition();
+
+  /**
+   * @return the set of segment files
+   */
+  Set<Path> segments();
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIdentifier.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIdentifier.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.api;
+
+/** BackupMetadata must uniquely identify a backup stored in the BackupStore. */
+public interface BackupIdentifier {
+
+  /**
+   * @return Id of the broker which took this backup
+   */
+  int nodeId();
+
+  /**
+   * @return id of the partition of which the backup is taken
+   */
+  int partitionId();
+
+  /**
+   * @return id of the checkpoint included in the backup
+   */
+  long checkpointId();
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.api;
+
+import java.util.concurrent.CompletableFuture;
+
+/** A store where the backup is stored * */
+public interface BackupStore {
+
+  /** Saves the backup to the backup storage. */
+  CompletableFuture<Void> save(Backup backup);
+
+  /** Returns the status of the backup */
+  CompletableFuture<BackupStatus> getStatus(BackupIdentifier id);
+
+  /** Delete all state related to the backup from the storage */
+  CompletableFuture<Void> delete(BackupIdentifier id);
+
+  /** Restores the backup */
+  CompletableFuture<Backup> restore(BackupIdentifier id);
+
+  /**
+   * Marks the backup as failed. If saving a backup failed, the backups store must mark it as
+   * failed. This method can be used if we want to explicitly mark a partial backup as failed.
+   */
+  CompletableFuture<Void> markFailed(BackupIdentifier id);
+}


### PR DESCRIPTION
## Description

This interface will be used by the BackupManager to manage backups. The implementation of this interface manages the physical resources of a backup - such as storing the files to an external storage.

## Related issues

closes #9978 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
