### PR TITLE
Reusable build docker action

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -1,0 +1,92 @@
+# This action expects the code to have been checked out beforehand, e.g. via actions/checkout@v3
+# It will set up Java and maven as dependencies. If requested to package Zeebe, it will also set up
+# Go, build zbctl, then build the Zeebe distribution.
+#
+# If no version is given, the version is set to the Maven project version.
+#
+# This action does NOT work on self-hosted runners unless they have buildx already set up. See
+# https://github.com/docker/setup-buildx-action for more
+
+---
+name: Build Docker Image
+description: Builds the Zeebe Docker image
+
+inputs:
+  repository:
+    description: 'The image repository, e.g. camunda/zeebe'
+    default: 'camunda/zeebe'
+    required: true
+  version:
+    description: 'The image version, e.g. SNAPSHOT, 8.1.0'
+    required: false
+  package:
+    description: 'If true, will package Zeebe, otherwise uses the tar-ball under dist/target'
+    default: 'false'
+    required: false
+  push:
+    description: 'If true, will push the image'
+    required: false
+    default: 'false'
+
+outputs:
+  image:
+    description: "Fully qualified image name available in your local Docker daemon"
+    value: ${{ steps.get-image.outputs.result }}
+  date:
+    description: "The ISO 8601 date at which the image was created"
+    value: ${{ steps.get-date.outputs.result }}
+  version:
+    description: "The semantic version of the packaged artifact"
+    value: ${{ steps.get-version.outputs.result }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-java@v3.4.1
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+    - uses: stCarolas/setup-maven@v4.4
+      with:
+        maven-version: 3.8.5
+    - if: ${{ inputs.package == 'true' }}
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: 'clients/go/go.mod'
+        cache: true
+        cache-dependency-path: 'clients/go/go.sum'
+    - if: ${{ inputs.package == 'true' }}
+      name: Build Go
+      shell: bash
+      run: ./build.sh
+      working-directory: clients/go/cmd/zbctl
+    - if: ${{ inputs.package == 'true' }}
+      name: Package Zeebe
+      shell: bash
+      run: mvn -B -DskipTests -DskipChecks package -T1C
+    - name: Set semantic version from Maven project
+      id: get-version
+      shell: bash
+      run: echo ::set-output name=result::$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+    - name: Set image build label from ISO 8601 DATE
+      id: get-date
+      shell: bash
+      run: echo "::set-output name=result::$(date --iso-8601=seconds)"
+    - name: Set image name from params or project version
+      id: get-image
+      shell: bash
+      run: echo "::set-output name=result::${{ inputs.repository }}:${{ inputs.version || steps.get-version.outputs.result }}"
+    - name: Build Docker image
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        tags: ${{ steps.get-image.outputs.result }}
+        load: true
+        push: ${{ inputs.push }}
+        no-cache: true
+        build-args: |
+          DISTBALL=dist/target/camunda-zeebe-${{ steps.get-version.outputs.result }}.tar.gz
+          DATE=${{ steps.get-date.outputs.result }}
+          REVISION=${{ github.sha }}
+          VERSION=${{ steps.get-version.outputs.result }}
+        target: app

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -42,6 +42,19 @@ outputs:
 runs:
   using: composite
   steps:
+    # Creating a context is required when installing buildx on self-hosted runners
+    - name: Create context
+      shell: bash
+      run: |
+        docker context create zeebe-context
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        # to be able to push to local registry, which we use in our tests, we need to use host network
+        driver-opts: network=host
+        endpoint: zeebe-context
+        install: true
+    # We need maven and Java (indirectly) to get properties from the project
     - uses: actions/setup-java@v3.4.1
       with:
         distribution: 'temurin'
@@ -81,7 +94,7 @@ runs:
       with:
         context: .
         tags: ${{ steps.get-image.outputs.result }}
-        load: true
+        load: ${{ inputs.push != 'true' }}
         push: ${{ inputs.push }}
         no-cache: true
         build-args: |

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -3,9 +3,6 @@
 # Go, build zbctl, then build the Zeebe distribution.
 #
 # If no version is given, the version is set to the Maven project version.
-#
-# This action does NOT work on self-hosted runners unless they have buildx already set up. See
-# https://github.com/docker/setup-buildx-action for more
 
 ---
 name: Build Docker Image

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -95,38 +95,15 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ./hadolint.sarif
-      - uses: actions/setup-java@v3.4.1
+      - uses: ./.github/actions/build-docker
+        id: build-docker
         with:
-          distribution: 'temurin'
-          java-version: '17'
-      - uses: stCarolas/setup-maven@v4.4
-        with:
-          maven-version: 3.8.5
-      - name: Package Zeebe
-        run: mvn -B -DskipTests -DskipChecks package -T1C
-      - name: Set project version
-        run: echo ::set-output name=result::$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-        id: get-version
-      - name: Get build timestamp
-        id: get-date
-        run: echo "::set-output name=result::$(date --iso-8601=seconds)"
-      - name: Build Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          # give it a fake registry to make sure we don't accidentally push it
-          tags: localhost:5000/camunda/zeebe:${{ steps.get-version.outputs.result }}
-          load: true
-          no-cache: true
-          build-args: |
-            DISTBALL=dist/target/camunda-zeebe-${{ steps.get-version.outputs.result }}.tar.gz
-            DATE=${{ steps.get-date.outputs.result }}
-            REVISION=${{ github.sha }}
-            VERSION=${{ steps.get-version.outputs.result }}
-          target: app
+          # give it a fake name to ensure we never try pushing it
+          repository: localhost:5000/camunda/zeebe
+          package: true
       - name: Verify Docker image
         env:
-          DATE: ${{ steps.get-date.outputs.result }}
+          DATE: ${{ steps.build-docker.outputs.date }}
           REVISION: ${{ github.sha }}
-          VERSION: ${{ steps.get-version.outputs.result }}
-        run: ${PWD}/docker/test/verify.sh 'localhost:5000/camunda/zeebe:${{ steps.get-version.outputs.result }}'
+          VERSION: ${{ steps.build-docker.outputs.version }}
+        run: ${PWD}/docker/test/verify.sh '${{ steps.build-docker.outputs.image }}'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,44 +64,18 @@ jobs:
           secrets: |
             secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_USR;
             secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW;
-      - uses: actions/setup-java@v3.4.1
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - uses: actions/setup-go@v3
-        with:
-          go-version-file: 'clients/go/go.mod'
-          cache: true
-          cache-dependency-path: 'clients/go/go.sum'
-      - name: Build Go
-        run: ./build.sh
-        working-directory: clients/go/cmd/zbctl
-      - name: Package Zeebe
-        run: mvn -B -DskipTests -DskipChecks package -T1C
-      - name: Set project version
-        run: echo ::set-output name=result::$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-        id: get-version
-      - name: Get build timestamp
-        id: get-date
-        run: echo "::set-output name=result::$(date --iso-8601=seconds)"
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
           username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
           password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+      - uses: ./.github/actions/build-docker
+        id: build-docker
         with:
-          context: .
-          tags: camunda/zeebe:SNAPSHOT
+          repository: camunda/zeebe
+          version: SNAPSHOT
+          package: true
           push: true
-          no-cache: true
-          build-args: |
-            DISTBALL=dist/target/camunda-zeebe-${{ steps.get-version.outputs.result }}.tar.gz
-            DATE=${{ steps.get-date.outputs.result }}
-            REVISION=${{ github.sha }}
-            VERSION=${{ steps.get-version.outputs.result }}
-          target: app
 
   notify-if-failed:
     name: Send slack notification on build failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,6 @@ jobs:
           maven-version: 3.8.5
       - uses: ./.github/actions/use-ci-nexus-cache
       - run: mvn -B -DskipChecks -DskipTests install
-      - run: docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t camunda/zeebe:current-test .
       - run: >
           mvn -B --no-snapshot-updates
           -D skipUTs -D skipChecks -D failsafe.rerunFailingTestsCount=3
@@ -249,10 +248,6 @@ jobs:
           go-version-file: 'clients/go/go.mod'
           cache: true
           cache-dependency-path: 'clients/go/go.sum'
-      - uses: actions/setup-java@v3.4.1
-        with:
-          java-version: '17'
-          distribution: 'temurin'
       - name: Check gocompat
         run: |
           curl -sL https://github.com/smola/gocompat/releases/download/v0.3.0/gocompat_linux_amd64.tar.gz | tar xzvf - gocompat_linux_amd64
@@ -263,8 +258,12 @@ jobs:
           done
           ./gocompat_linux_amd64 compare --go1compat ${EXCLUDE} ./...
         working-directory: clients/go/
-      - run: mvn -B -DskipChecks -DskipTests install
-      - run: docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t camunda/zeebe:current-test .
+      - uses: ./.github/actions/build-docker
+        id: build-docker
+        with:
+          repository: camunda/zeebe
+          version: current-test
+          package: true
       - run: go test -mod=vendor -v ./...
         working-directory: clients/go
   java-client:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,12 @@ jobs:
         with:
           maven-version: 3.8.5
       - uses: ./.github/actions/use-ci-nexus-cache
-      - run: mvn -B -DskipChecks -DskipTests install
-      - run: docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t "${ZEEBE_TEST_DOCKER_IMAGE}" .
-      - run: docker push "${ZEEBE_TEST_DOCKER_IMAGE}"
+      - uses: ./.github/actions/build-docker
+        with:
+          repository: localhost:5000/camunda/zeebe
+          version: current-test
+          push: true
+          package: true
       - name: Prepare Testcontainers Cloud agent
         if: env.TC_CLOUD_TOKEN != ''
         run: |


### PR DESCRIPTION
## Description

This PR aggregates the steps required to build the Docker image into a reusable action called `build-docker`. The action can build and push the Docker image, as well as package the artifacts for it if need be.

Further iterations may want to split packaging out into its own action.

Its usage is as:

```yaml
- uses: ./.github/actions/build-docker
  with:
    repository: localhost:5000/camunda/zeebe
    version: current-test
    push: true
    package: true
```

The action will set up Docker & Buildx, Java, and Maven. If `package` is true, it will also setup `Go` in order to build `zbctl`.

When `push` is true, the image is pushed to the given repository, with the tag being made of the `repository` and `version`. In the above, this would be equivalent to `docker push localhost:5000/camunda/zeebe:current-test`. If `push` is false, then the image is built and loaded into the local Docker registry only.

If `package` is true, then `zbctl` is compiled, and all the modules are built and installed to the local maven repository. Additionally, the distribution TAR ball is built. If it's false, then the distribution TAR ball is expected to already be present under `dist/target/camunda-zeebe-<VERSION>-tar.gz`.

If the `version` is omitted, it will be read from the Maven project.

## Related issues

related to #10013 (as a follow up)

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
