### PR TITLE
Try to handle expected error in record processor

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -34,9 +34,9 @@ import org.slf4j.Logger;
 public class Engine implements RecordProcessor<EngineContext> {
 
   private static final Logger LOG = Loggers.PROCESSOR_LOGGER;
-  private static final String ERROR_MESSAGE_ON_EVENT_FAILED_SKIP_EVENT =
+  private static final String ERROR_MESSAGE_PROCESSOR_NOT_FOUND =
       "Expected to find processor for record '{}', but caught an exception. Skip this record.";
-  private static final String PROCESSING_ERROR_MESSAGE =
+  private static final String ERROR_MESSAGE_PROCESSING_EXCEPTION_OCCURRED =
       "Expected to process record '%s' without errors, but exception occurred with message '%s'.";
   private EventApplier eventApplier;
   private RecordProcessorMap recordProcessorMap;
@@ -102,7 +102,7 @@ public class Engine implements RecordProcessor<EngineContext> {
                 typedCommand.getValueType(),
                 typedCommand.getIntent().value());
       } catch (final Exception e) {
-        LOG.error(ERROR_MESSAGE_ON_EVENT_FAILED_SKIP_EVENT, typedCommand, e);
+        LOG.error(ERROR_MESSAGE_PROCESSOR_NOT_FOUND, typedCommand, e);
       }
 
       if (currentProcessor == null) {
@@ -128,7 +128,8 @@ public class Engine implements RecordProcessor<EngineContext> {
       final TypedRecord record,
       final ProcessingResultBuilder processingResultBuilder) {
     final String errorMessage =
-        String.format(PROCESSING_ERROR_MESSAGE, record, processingException.getMessage());
+        String.format(
+            ERROR_MESSAGE_PROCESSING_EXCEPTION_OCCURRED, record, processingException.getMessage());
     LOG.error(errorMessage, processingException);
 
     try (final var scope = new ProcessingResultBuilderScope(processingResultBuilder)) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessor.java
@@ -39,15 +39,14 @@ public interface RecordProcessor<CONTEXT> {
   void replay(TypedRecord record);
 
   /**
-   * Called by platform to process a single record
+   * Called by platform to process a single record.
    *
-   * <p><em>Contract</em> * *
+   * <p><em>Contract</em>
    *
    * <ul>
-   *   *
    *   <li>Record will be a command
    *   <li>Will be called after replay is called
-   *   <li>Implementors can write to the database. Transaction is provided by platform, which also *
+   *   <li>Implementors can write to the database. Transaction is provided by platform, which also
    *       takes care of lifecycle of the transaction
    *   <li>Implementors must ensure that if they generate follow up events, these are applied to the
    *       database while this method is called

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessor.java
@@ -63,7 +63,23 @@ public interface RecordProcessor<CONTEXT> {
   ProcessingResult process(TypedRecord record, ProcessingResultBuilder processingResultBuilder);
 
   /**
-   * Called by platform when a processing error occurred
+   * Called by platform when a processing error occurred.
+   *
+   * <p><em>Contract</em>
+   *
+   * <ul>
+   *   <li>Record will be a command
+   *   <li>Will be called if an uncaught exception is thrown in {@link #process(TypedRecord,
+   *       ProcessingResultBuilder)}, or when an uncaught exception is thrown by the
+   *       ProcessingStateMachine while committing the transaction
+   *   <li>Implementors can write to the database. Transaction is provided by platform, which also
+   *       takes care of lifecycle of the transaction
+   *   <li>Implementors must ensure that if they generate follow up events, these are applied to the
+   *       database while this method is called
+   *   <li>Implementors can produce follow up commands, events and rejections, client responses and
+   *       on commit tasks via {@code processingResultBuilder}
+   *   <li>Implementors are responsible for error logging when needed
+   * </ul>
    *
    * @return the result of the processing; must be generated via {@code ProcessingResultBuilder
    *     processingResultBuilder }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -125,6 +125,7 @@ public final class CreateProcessInstanceProcessor
   public ProcessingError tryHandleError(
       final TypedRecord<ProcessInstanceCreationRecord> typedCommand, final Throwable error) {
     if (error instanceof EventSubscriptionException exception) {
+      // This exception is only thrown for ProcessInstanceCreationRecord with start instructions
       rejectionWriter.appendRejection(
           typedCommand, RejectionType.INVALID_ARGUMENT, exception.getMessage());
       return ProcessingError.EXPECTED_ERROR;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import io.camunda.zeebe.engine.api.TypedRecord;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor.ProcessingError;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -41,6 +42,17 @@ public interface CommandProcessor<T extends UnifiedRecordValue> {
       final long key,
       final Intent intent,
       final T value) {}
+
+  /**
+   * Try to handle an error that occurred during processing.
+   *
+   * @param command The command that was being processed when the error occurred
+   * @param error The error that occurred, and the processor should attempt to handle
+   * @return The type of the processing error. Default: {@link ProcessingError#UNEXPECTED_ERROR}.
+   */
+  default ProcessingError tryHandleError(final TypedRecord<T> command, final Throwable error) {
+    return ProcessingError.UNEXPECTED_ERROR;
+  }
 
   interface CommandControl<T> {
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
@@ -95,6 +95,11 @@ public final class CommandProcessorImpl<T extends UnifiedRecordValue>
   }
 
   @Override
+  public ProcessingError tryHandleError(final TypedRecord<T> command, final Throwable error) {
+    return wrappedProcessor.tryHandleError(command, error);
+  }
+
+  @Override
   public long accept(final Intent newState, final T updatedValue) {
     if (entityKey < 0) {
       entityKey = keyGenerator.nextKey();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
@@ -23,4 +23,9 @@ public interface TypedRecordProcessor<T extends UnifiedRecordValue> {
       final TypedRecord<T> record, final Consumer<SideEffectProducer> sideEffect) {
     processRecord(record);
   }
+
+  enum ProcessingError {
+    EXPECTED_ERROR,
+    UNEXPECTED_ERROR
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
@@ -24,6 +24,17 @@ public interface TypedRecordProcessor<T extends UnifiedRecordValue> {
     processRecord(record);
   }
 
+  /**
+   * Try to handle an error that occurred during processing.
+   *
+   * @param command The command that was being processed when the error occurred
+   * @param error The error that occurred, and the processor should attempt to handle
+   * @return The type of the processing error. Default: {@link ProcessingError#UNEXPECTED_ERROR}.
+   */
+  default ProcessingError tryHandleError(final TypedRecord<T> command, final Throwable error) {
+    return ProcessingError.UNEXPECTED_ERROR;
+  }
+
   enum ProcessingError {
     EXPECTED_ERROR,
     UNEXPECTED_ERROR

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -325,6 +325,7 @@ public final class ProcessingStateMachine {
           final long position = typedCommand.getPosition();
           final ProcessingResultBuilder processingResultBuilder =
               new DirectProcessingResultBuilder(context, position);
+          // todo(#10047): replace this reset method by using Buffered Writers
           processingResultBuilder.reset();
 
           logStreamWriter.configureSourceContext(position);

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -285,7 +285,6 @@ public final class ProcessingStateMachine {
     } catch (final UnrecoverableException unrecoverableException) {
       throw unrecoverableException;
     } catch (final Exception e) {
-      LOG.error(ERROR_MESSAGE_PROCESSING_FAILED_SKIP_EVENT, command, metadata, e);
       onError(e, this::writeRecords);
     }
   }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -326,6 +326,7 @@ public final class ProcessingStateMachine {
           final long position = typedCommand.getPosition();
           final ProcessingResultBuilder processingResultBuilder =
               new DirectProcessingResultBuilder(context, position);
+          processingResultBuilder.reset();
 
           logStreamWriter.configureSourceContext(position);
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR offers a solution for
- #9420 

The idea is to pass the error to the specific `TypedRecordProcessor`, which can decide whether the error is `EXPECTED` or `UNEXPECTED`. 
- If the error is `UNEXPECTED`, we handle it as before by writing an Error event, etc.
- If the error is `EXPECTED`, we let the processor control how we reject the command and what else has to happen.

This PR shows how this could work by also providing a solution for
- #9644 

A test is added to verify the correct behavior: custom rejection + transaction rolled back. The test showed that a hidden bug was introduced (I managed to bisect this to 463366f4e9901aa6c001d37c022b75b774f4a009): the output was reset on error, but no longer when encapsulated by the ProcessingResultBuilder. A fix for this bug is also part of this PR.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9420
closes #9644

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
