### PR TITLE
Add note about community channels to general issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/general_issue.md
+++ b/.github/ISSUE_TEMPLATE/general_issue.md
@@ -8,6 +8,16 @@ assignees: ''
 
 ---
 
+<!--
+In case you have questions about our software we encourage everyone to participate in our community via the
+- Camunda Platform community forum https://forum.camunda.io/ or 
+- Slack https://camunda-cloud.slack.com/ (For invite: https://camunda-slack-invite.herokuapp.com/)
+
+There you can exchange ideas with other Zeebe and Camunda Platform 8 users, as well as the product developers, and use the search to find answer to similar questions.
+
+This issue template is used by the Zeebe engineers to create general tasks.
+-->
+
 **Description**
 
 A clear and concise description of what this issue is about.


### PR DESCRIPTION
## Description

Try to guide people for general questions to the community channel, to reduce the amount of questions in github issues.
