### PR TITLE
ci: set reasonable timeouts for test jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
   integration-tests:
     name: Integration tests
     runs-on: "n1-standard-32-netssd-preempt"
+    timeout-minutes: 45
     env:
       TC_CLOUD_TOKEN: ${{ secrets.TC_CLOUD_TOKEN }}
       TC_CLOUD_CONCURRENCY: 4
@@ -64,6 +65,7 @@ jobs:
   exporter-tests:
     name: Exporter tests
     runs-on: "n1-standard-8-netssd-preempt"
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3.4.1
@@ -112,6 +114,7 @@ jobs:
       matrix:
         project: ${{ fromJson(needs.project-list.outputs.projects) }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3.4.1
@@ -143,6 +146,7 @@ jobs:
   slow-unit-tests:
     name: Slow unit tests
     runs-on: "n1-standard-8-netssd-preempt"
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3.4.1
@@ -216,6 +220,7 @@ jobs:
   java-randomized-tests:
     name: Java randomized tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3.4.1
@@ -236,6 +241,7 @@ jobs:
   go-client:
     name: Go client tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -264,6 +270,7 @@ jobs:
   java-client:
     name: Java client tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
       # First, install dependencies with JDK 17


### PR DESCRIPTION
This sets the timeout for test jobs to a reasonable value, lower than the default of 6 hours. This improves the situation somewhat if jobs are failing too slowly or become stuck.
