### PR TITLE
fix: create new readers and writer for every async request

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
@@ -29,7 +29,7 @@ public class AdminApiRequestHandler
 
   public AdminApiRequestHandler(
       final AtomixServerTransport transport, final PartitionManagerImpl partitionManager) {
-    super(new ApiRequestReader(), new ApiResponseWriter());
+    super(ApiRequestReader::new, ApiResponseWriter::new);
     this.transport = transport;
     this.partitionManager = partitionManager;
     adminAccess = partitionManager.createAdminAccess(this);

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/ApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/ApiRequestHandlerTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.RequestReader;
 import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.ResponseWriter;
-import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerRule;
 import io.camunda.zeebe.transport.ServerOutput;
 import io.camunda.zeebe.util.Either;
@@ -91,10 +90,6 @@ public class ApiRequestHandlerTest {
     TestApiRequestHandler(
         final RequestReader<?> requestReader, final ResponseWriter responseWriter) {
       super(requestReader, responseWriter);
-    }
-
-    public ActorControl actor() {
-      return actor;
     }
 
     @Override


### PR DESCRIPTION
## Description

This allows async api handlers to get new instances of request readers and writers on every request, while synchronous handlers can re-use their writers and readers.

## Related issues

closes #10014 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
