### PR TITLE
refactor: let `dist` build gateways broker client

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
@@ -37,7 +37,9 @@ import org.springframework.core.env.Profiles;
  *
  * <p>See {@link #main(String[])} for more.
  */
-@SpringBootApplication(scanBasePackages = {"io.camunda.zeebe.broker", "io.camunda.zeebe.shared"})
+@SpringBootApplication(
+    proxyBeanMethods = false,
+    scanBasePackages = {"io.camunda.zeebe.broker", "io.camunda.zeebe.shared"})
 @ConfigurationPropertiesScan(basePackages = {"io.camunda.zeebe.broker", "io.camunda.zeebe.shared"})
 public class StandaloneBroker
     implements CommandLineRunner, ApplicationListener<ContextClosedEvent> {

--- a/dist/src/main/java/io/camunda/zeebe/gateway/BrokerClientComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/BrokerClientComponent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway;
+
+import io.atomix.cluster.AtomixCluster;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Component
+final class BrokerClientComponent {
+  final GatewayCfg config;
+  final AtomixCluster atomixCluster;
+  final ActorScheduler actorScheduler;
+
+  @Autowired
+  BrokerClientComponent(
+      final GatewayCfg config,
+      final AtomixCluster atomixCluster,
+      final ActorScheduler actorScheduler) {
+    this.config = config;
+    this.atomixCluster = atomixCluster;
+    this.actorScheduler = actorScheduler;
+  }
+
+  @Bean("brokerClient")
+  BrokerClient createBrokerClient() {
+    return new BrokerClientImpl(
+        config,
+        atomixCluster.getMessagingService(),
+        atomixCluster.getMembershipService(),
+        atomixCluster.getEventService(),
+        actorScheduler);
+  }
+}

--- a/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
@@ -132,11 +132,13 @@ final class StandaloneGatewaySecurityTest {
     final AtomixComponent clusterComponent = new AtomixComponent(gatewayCfg);
     final ActorSchedulerComponent actorSchedulerComponent =
         new ActorSchedulerComponent(gatewayCfg, new ActorClockConfiguration(false));
+    final var atomixCluster = clusterComponent.createAtomixCluster();
+    final var actorScheduler = actorSchedulerComponent.createActorSchedulingService();
+    final BrokerClientComponent brokerClientComponent =
+        new BrokerClientComponent(gatewayCfg, atomixCluster, actorScheduler);
+    final var brokerClient = brokerClientComponent.createBrokerClient();
 
     return new StandaloneGateway(
-        gatewayCfg,
-        new SpringGatewayBridge(),
-        actorSchedulerComponent.createActorSchedulingService(),
-        clusterComponent.createAtomixCluster());
+        gatewayCfg, new SpringGatewayBridge(), actorScheduler, atomixCluster, brokerClient);
   }
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/BrokerClient.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/BrokerClient.java
@@ -16,6 +16,9 @@ import java.util.function.Consumer;
 
 public interface BrokerClient extends AutoCloseable {
 
+  void start();
+
+  @Override
   void close();
 
   /**

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.ClientStatusException;
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
 import io.camunda.zeebe.gateway.Gateway;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.gateway.impl.configuration.NetworkCfg;
 import io.camunda.zeebe.scheduler.ActorScheduler;
@@ -54,13 +55,16 @@ class UnavailableBrokersTest {
     actorScheduler = ActorScheduler.newActorScheduler().build();
     actorScheduler.start();
 
-    gateway =
-        new Gateway(
-            new GatewayCfg().setNetwork(networkCfg),
+    final var brokerClient =
+        new BrokerClientImpl(
+            config,
             cluster.getMessagingService(),
             cluster.getMembershipService(),
             cluster.getEventService(),
             actorScheduler);
+    brokerClient.start();
+
+    gateway = new Gateway(config, brokerClient, actorScheduler);
     gateway.start().join();
 
     final String gatewayAddress = NetUtil.toSocketAddressString(networkCfg.toSocketAddress());

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
@@ -40,6 +40,9 @@ public final class StubbedBrokerClient implements BrokerClient {
   public StubbedBrokerClient() {}
 
   @Override
+  public void start() {}
+
+  @Override
   public void close() {}
 
   @Override

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/broker/BrokerClientTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/broker/BrokerClientTest.java
@@ -99,6 +99,8 @@ public final class BrokerClientTest {
             atomixCluster.getEventService(),
             actorScheduler.get());
 
+    client.start();
+
     final BrokerClusterStateImpl topology = new BrokerClusterStateImpl();
     topology.addPartitionIfAbsent(START_PARTITION_ID);
     topology.setPartitionLeader(START_PARTITION_ID, 0, 1);

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.utils.net.Address;
 import io.camunda.zeebe.gateway.Gateway;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.gateway.impl.configuration.NetworkCfg;
 import io.camunda.zeebe.gateway.impl.configuration.SecurityCfg;
@@ -145,12 +146,14 @@ final class SecurityTest {
             .build();
     final var actorScheduler = ActorScheduler.newActorScheduler().build();
     actorScheduler.start();
-
-    return new Gateway(
-        gatewayCfg,
-        atomix.getMessagingService(),
-        atomix.getMembershipService(),
-        atomix.getEventService(),
-        actorScheduler);
+    final var brokerClient =
+        new BrokerClientImpl(
+            gatewayCfg,
+            atomix.getMessagingService(),
+            atomix.getMembershipService(),
+            atomix.getEventService(),
+            actorScheduler);
+    brokerClient.start();
+    return new Gateway(gatewayCfg, brokerClient, actorScheduler);
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayIntegrationTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayIntegrationTest.java
@@ -59,6 +59,7 @@ public final class GatewayIntegrationTest {
             clusterServices.getMembershipService(),
             clusterServices.getEventService(),
             actorScheduler);
+    client.start();
   }
 
   @After


### PR DESCRIPTION
## Description

Builds the broker client in dist, making it available for injection. Because `BrokerClient` needs to schedule actors, the actor scheduler must be started before. To achieve this, `BrokerClient` gets a `start` method that does the scheduling.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #9996 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
