### PR TITLE
Common reusable actions

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -1,7 +1,4 @@
 # This action expects the code to have been checked out beforehand, e.g. via actions/checkout@v3
-# It will set up Java and maven as dependencies. If requested to package Zeebe, it will also set up
-# Go, build zbctl, then build the Zeebe distribution.
-#
 # If no version is given, the version is set to the Maven project version.
 
 ---
@@ -16,10 +13,9 @@ inputs:
   version:
     description: 'The image version, e.g. SNAPSHOT, 8.1.0'
     required: false
-  package:
-    description: 'If true, will package Zeebe, otherwise uses the tar-ball under dist/target'
-    default: 'false'
-    required: false
+  distball:
+    description: 'The path to the Zeebe distribution TAR ball'
+    required: true
   push:
     description: 'If true, will push the image'
     required: false
@@ -51,29 +47,6 @@ runs:
         driver-opts: network=host
         endpoint: zeebe-context
         install: true
-    # We need maven and Java (indirectly) to get properties from the project
-    - uses: actions/setup-java@v3.4.1
-      with:
-        distribution: 'temurin'
-        java-version: '17'
-    - uses: stCarolas/setup-maven@v4.4
-      with:
-        maven-version: 3.8.5
-    - if: ${{ inputs.package == 'true' }}
-      uses: actions/setup-go@v3
-      with:
-        go-version-file: 'clients/go/go.mod'
-        cache: true
-        cache-dependency-path: 'clients/go/go.sum'
-    - if: ${{ inputs.package == 'true' }}
-      name: Build Go
-      shell: bash
-      run: ./build.sh
-      working-directory: clients/go/cmd/zbctl
-    - if: ${{ inputs.package == 'true' }}
-      name: Package Zeebe
-      shell: bash
-      run: mvn -B -DskipTests -DskipChecks package -T1C
     - name: Set semantic version from Maven project
       id: get-version
       shell: bash
@@ -86,6 +59,10 @@ runs:
       id: get-image
       shell: bash
       run: echo "::set-output name=result::${{ inputs.repository }}:${{ inputs.version || steps.get-version.outputs.result }}"
+    - name: Set DISTBALL path relative to the build context
+      id: get-distball
+      shell: bash
+      run: echo "::set-output name=result::$(realpath --relative-to="${PWD}" ${{ inputs.distball }})"
     - name: Build Docker image
       uses: docker/build-push-action@v3
       with:
@@ -95,7 +72,7 @@ runs:
         push: ${{ inputs.push }}
         no-cache: true
         build-args: |
-          DISTBALL=dist/target/camunda-zeebe-${{ steps.get-version.outputs.result }}.tar.gz
+          DISTBALL=${{ steps.get-distball.outputs.result }}
           DATE=${{ steps.get-date.outputs.result }}
           REVISION=${{ github.sha }}
           VERSION=${{ steps.get-version.outputs.result }}

--- a/.github/actions/build-zeebe/action.yml
+++ b/.github/actions/build-zeebe/action.yml
@@ -1,0 +1,45 @@
+# This action packages the complete Zeebe distribution artifacts. This includes the Go client,
+# zbctl, and the Zeebe distribution TAR ball. This excludes the Docker image. See the build-docker
+# for that.
+
+---
+name: Build Zeebe
+description: Builds & installs the complete Zeebe distribution
+
+inputs:
+  go:
+    description: If false, will not build zbctl; defaults to true
+    default: "true"
+    required: false
+  java:
+    description: If false, will not build the Java distribution; defaults to true
+    default: "true"
+    required: false
+  maven-extra-args:
+    description: Additional CLI arguments which will be passed to the maven install command as is, e.g. "-am -pl util/"
+    default: ""
+    required: false
+
+outputs:
+  distball:
+    description: "The path to the Zeebe distribution TAR ball"
+    value: ${{ steps.build-java.outputs.result }}
+
+runs:
+  using: composite
+  steps:
+    - if: ${{ inputs.go == 'true' }}
+      name: Build Go
+      shell: bash
+      id: build-go
+      working-directory: clients/go/cmd/zbctl
+      run: ./build.sh
+    - if: ${{ inputs.java == 'true' }}
+      name: Package Zeebe
+      shell: bash
+      id: build-java
+      run: |
+        mvn -B -DskipTests -DskipChecks -T1C install ${{ inputs.maven-extra-args }}
+        export BUILD_DIR=$(mvn -pl dist/ help:evaluate -Dexpression=project.build.directory -q -DforceStdout)
+        export ARTIFACT=$(mvn -pl dist/ help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
+        echo "::set-output name=result::${BUILD_DIR}/${ARTIFACT}.tar.gz"

--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -1,0 +1,45 @@
+# This action sets up the environment with the required tech stack in order to build, install, and
+# run Zeebe.
+
+---
+name: Setup Zeebe
+description: Sets up the required stack to build, install, and run Zeebe
+
+inputs:
+  go:
+    description: If true, will set up Golang; defaults to true
+    required: false
+    default: "true"
+  java:
+    description: If true, will set up Java; defaults to true
+    required: false
+    default: "true"
+  java-version:
+    description: The JDK version to setup
+    default: "17"
+    required: false
+  maven-version:
+    description: The Maven version to setup
+    default: "3.8.5"
+    required: false
+
+outputs: {}
+
+runs:
+  using: composite
+  steps:
+    - if: ${{ inputs.java == 'true' }}
+      uses: actions/setup-java@v3.4.1
+      with:
+        distribution: 'temurin'
+        java-version: ${{ inputs.java-version }}
+    - if: ${{ inputs.java == 'true' }}
+      uses: stCarolas/setup-maven@v4.4
+      with:
+        maven-version: ${{ inputs.maven-version }}
+    - if: ${{ inputs.go == 'true' }}
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: 'clients/go/go.mod'
+        cache: true
+        cache-dependency-path: 'clients/go/go.sum'

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -17,15 +17,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3.4.1
+      - uses: ./.github/actions/setup-zeebe
         with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Set up Maven
-        uses: stCarolas/setup-maven@v4.4
-        with:
-          maven-version: 3.8.5
+          go: false
       - name: Use CI Nexus cache
         uses: ./.github/actions/use-ci-nexus-cache
       - name: Initialize CodeQL
@@ -33,8 +27,7 @@ jobs:
         with:
           languages: java
           queries: +security-and-quality
-      - name: Build
-        run: mvn -B -T1C -DskipTests -DskipChecks install
+      - uses: ./.github/actions/build-zeebe
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
         with:
@@ -58,11 +51,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: ./.github/actions/setup-zeebe
         with:
-          go-version-file: 'clients/go/go.mod'
-          cache: true
-          cache-dependency-path: 'clients/go/go.sum'
+          java: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -73,11 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3.4.1
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - run: mvn -B -D skipTests -D skipChecks install
+      - uses: ./.github/actions/setup-zeebe
       - run: mvn -T1C -B -D skipTests -P !autoFormat,checkFormat,spotbugs verify
   docker-checks:
     name: Docker checks
@@ -95,12 +82,16 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ./hadolint.sarif
+      - uses: ./.github/actions/setup-zeebe
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
       - uses: ./.github/actions/build-docker
         id: build-docker
         with:
           # give it a fake name to ensure we never try pushing it
           repository: localhost:5000/camunda/zeebe
           package: true
+          distball: ${{ steps.build-zeebe.outputs.distball }}
       - name: Verify Docker image
         env:
           DATE: ${{ steps.build-docker.outputs.date }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,13 +69,16 @@ jobs:
         with:
           username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
           password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
+      - uses: ./.github/actions/setup-zeebe
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
       - uses: ./.github/actions/build-docker
         id: build-docker
         with:
           repository: camunda/zeebe
           version: SNAPSHOT
-          package: true
           push: true
+          distball: ${{ steps.build-zeebe.outputs.distball }}
 
   notify-if-failed:
     name: Send slack notification on build failure

--- a/.github/workflows/qa-testbench.yaml
+++ b/.github/workflows/qa-testbench.yaml
@@ -74,41 +74,27 @@ jobs:
             secret/data/products/zeebe/ci/zeebe ZEEBE_GCR_SERVICEACCOUNT_JSON;
             secret/data/products/zeebe/ci/zeebe TESTBENCH_PROD_CLIENT_SECRET;
             secret/data/products/zeebe/ci/zeebe TESTBENCH_PROD_CONTACT_POINT;
-
-      - uses: actions/setup-go@v3
+    - name: Login to GCR
+      uses: docker/login-action@v2
+      with:
+        registry: gcr.io
+        username: _json_key
+        password: ${{ steps.secrets.outputs.ZEEBE_GCR_SERVICEACCOUNT_JSON }}
+      - uses: ./.github/actions/setup-zeebe
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+      - uses: ./.github/actions/build-docker
         with:
-          go-version-file: 'clients/go/go.mod'
-          cache: true
-          cache-dependency-path: 'clients/go/go.sum'
-      - name: Build Go
-        run: ./build.sh
-        working-directory: clients/go/cmd/zbctl
-      - name: Package Zeebe
-        run: mvn -B -DskipTests -DskipChecks package
-
-      - name: Login to GCR
-        uses: docker/login-action@v2
-        with:
-          registry: gcr.io
-          username: _json_key
-          password: ${{ steps.secrets.outputs.ZEEBE_GCR_SERVICEACCOUNT_JSON }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          tags: "${{ env.IMAGE }}:${{ env.TAG }}"
+          repository: ${{ env.IMAGE }}
+          version: ${{ env.TAG }}
           push: true
-          no-cache: true
-          build-args: DISTBALL=dist/target/camunda-zeebe-*-SNAPSHOT.tar.gz
-          target: app
+          distball: ${{ steps.build-zeebe.outputs.distball }}
       # Executes the Testbench QA run and awaits the result
       - name: Run Testbench QA
         run: .ci/scripts/distribution/qa-testbench.sh
         env:
           ZEEBE_CLIENT_SECRET: ${{ steps.secrets.outputs.TESTBENCH_PROD_CLIENT_SECRET }}
           ZEEBE_ADDRESS: ${{ steps.secrets.outputs.TESTBENCH_PROD_CONTACT_POINT }}
-
 
   notify:
     name: Send slack notification

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,20 +27,16 @@ jobs:
           - 5000:5000
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3.4.1
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - uses: stCarolas/setup-maven@v4.4
-        with:
-          maven-version: 3.8.5
+      - uses: ./.github/actions/setup-zeebe
       - uses: ./.github/actions/use-ci-nexus-cache
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
       - uses: ./.github/actions/build-docker
         with:
           repository: localhost:5000/camunda/zeebe
           version: current-test
           push: true
-          package: true
+          distball: ${{ steps.build-zeebe.outputs.distball }}
       - name: Prepare Testcontainers Cloud agent
         if: env.TC_CLOUD_TOKEN != ''
         run: |
@@ -66,15 +62,13 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3.4.1
+      - uses: ./.github/actions/setup-zeebe
         with:
-          distribution: 'temurin'
-          java-version: '17'
-      - uses: stCarolas/setup-maven@v4.4
-        with:
-          maven-version: 3.8.5
+          go: false
       - uses: ./.github/actions/use-ci-nexus-cache
-      - run: mvn -B -DskipChecks -DskipTests install
+      - uses: ./.github/actions/build-zeebe
+        with:
+          go: false
       - run: >
           mvn -B --no-snapshot-updates
           -D skipUTs -D skipChecks -D failsafe.rerunFailingTestsCount=3
@@ -109,15 +103,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3.4.1
+      - uses: ./.github/actions/setup-zeebe
         with:
-          distribution: 'temurin'
-          java-version: '17'
-      - run: >
-          mvn -B
-          -D skipTests -D skipChecks
-          -am -pl ${{ matrix.project }}
-          install
+          go: false
+      - uses: ./.github/actions/build-zeebe
+        with:
+          go: false
+          maven-extra-args: -am -pl ${{ matrix.project }}
       - run: >
           mvn -B --no-snapshot-updates
           -D skipITs -D skipChecks
@@ -135,19 +127,14 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3.4.1
+      - uses: ./.github/actions/setup-zeebe
         with:
-          distribution: 'temurin'
-          java-version: '17'
-      - uses: stCarolas/setup-maven@v4.4
-        with:
-          maven-version: 3.8.5
+          go: false
       - uses: ./.github/actions/use-ci-nexus-cache
-      - run: >
-          mvn -B
-          -D skipTests -D skipChecks
-          -am -pl :zeebe-workflow-engine
-          install
+      - uses: ./.github/actions/build-zeebe
+        with:
+          go: false
+          maven-extra-args: -am -pl engine/
       - run: >
           mvn -B --no-snapshot-updates
           -D skipITs -D skipChecks
@@ -171,17 +158,13 @@ jobs:
       JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3.4.1
+      - uses: ./.github/actions/setup-zeebe
         with:
-          java-version: '17'
-          distribution: 'temurin'
-      - name: Build relevant modules
-        run: >
-          mvn -B
-          -D skipTests -D skipChecks "-D maven.javadoc.skip=true"
-          -am -pl qa/integration-tests
-          install
+          go: false
+      - uses: ./.github/actions/build-zeebe
+        with:
+          go: false
+          maven-extra-args: -am -pl qa/integration-tests
       - name: Run smoke test
         run: >
           mvn -B --no-snapshot-updates
@@ -199,11 +182,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3.4.1
+      - uses: ./.github/actions/setup-zeebe
         with:
-          distribution: 'temurin'
-          java-version: '17'
-      - run: mvn -B -D skipChecks -D skipTests install
+          go: false
+      - uses: ./.github/actions/build-zeebe
+        with:
+          go: false
       - run: mvn -T1C -B -D skipChecks -P parallel-tests,include-random-tests test
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
@@ -215,44 +199,46 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version-file: 'clients/go/go.mod'
-          cache: true
-          cache-dependency-path: 'clients/go/go.sum'
-      - name: Check gocompat
+      - uses: ./.github/actions/setup-zeebe
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+      # Once we're on Go 1.18, use the official gorelease to do this
+      - name: Check backwards compatibility
+        working-directory: clients/go/
         run: |
-          curl -sL https://github.com/smola/gocompat/releases/download/v0.3.0/gocompat_linux_amd64.tar.gz | tar xzvf - gocompat_linux_amd64
+          go install github.com/smola/gocompat/...@v0.3.0
           PREFIX=github.com/camunda/zeebe/clients/go/v8
           EXCLUDE=""
           for file in {internal,cmd/zbctl/internal}/*; do
             EXCLUDE="$EXCLUDE --exclude-package $PREFIX/$file"
           done
-          ./gocompat_linux_amd64 compare --go1compat ${EXCLUDE} ./...
-        working-directory: clients/go/
+          gocompat compare --go1compat ${EXCLUDE} ./...
       - uses: ./.github/actions/build-docker
         id: build-docker
         with:
           repository: camunda/zeebe
           version: current-test
-          package: true
-      - run: go test -mod=vendor -v ./...
+          distball: ${{ steps.build-zeebe.outputs.distball }}
+      - name: Run Go tests
         working-directory: clients/go
+        run: go test -mod=vendor -v ./...
   java-client:
     name: Java client tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
-      # First, install dependencies with JDK 17
-      - uses: actions/setup-java@v3.4.1
+      # First package the complete application
+      - uses: ./.github/actions/setup-zeebe
         with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: maven
-      - run: mvn -B -D skipChecks -D skipTests -am -pl clients/java install
+          go: false
+      - uses: ./.github/actions/build-zeebe
+        with:
+          go: false
+          maven-extra-args: -am -pl clients/java
+      # This is a workaround for java 8, which does not support the --add-exports options
+      - run: rm .mvn/jvm.config
       # Then run client tests with JDK 8
-      - run: rm .mvn/jvm.config # This is a workaround for java 8, which does not support the --add-exports options
       - uses: actions/setup-java@v3.4.1
         with:
           java-version: '8'


### PR DESCRIPTION
## Description

This PR aggregates the steps to set up the Zeebe environment for packaging, as well as packaging itself, into two reusable actions. By doing this, it removes the duplicate code in the `build-docker` action, and instead relies on the caller having set up and packaged Zeebe beforehand (much like we rely on the checkout step being invoked before).

`setup-zeebe` will prepare the environment to build the complete Zeebe distribution. The benefits here is that we centralize once the tech stack, how it's installed, and the versions we require, instead of spreading this everywhere. I've made it configurable so some parts can be ignored, primarily because of the `setup-go` action. If you use that, but do not do anything with Go, it will fail in its post-run when trying to clean a non-existent cache :shrug: The action requires the code to have been checked out beforehand.

`build-zeebe` will build the Go client (optional) and the Java distribution (optional). By default, it builds everything. It also requires the environment to be set up beforehand, and the code checked out. It uses the `clients/go/cmd/zbctl/build.sh` script to build the Go client, and will `install` the mvn modules, skipping checks and using `-T1C` to parallelize by default. You can customize the installation via a free-form field letting you set up additional properties to pass to the build. The benefits here is again centralization of the common set up, while allowing enough customization for the various steps.

I decided to split both set up and packaging because there are some places where we package the application differently, notably when deploying/releasing. As this will most likely be used in the future for releases, it made sense to me. So the packaging is really more of a "package for non-release cases". It could be changed to allow us to modify the command for packaging (right now you can only pass options, but cannot change the actual goals to execute), and then I suppose it could be reused. I think it might be misleading though to have a build Zeebe action which actually deploys, so I'd rather avoid that for now.

## Related issues

related to #10017 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
