### PR TITLE
Avoid timer cycle with start time triggering multiple times

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/time/Interval.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/time/Interval.java
@@ -75,7 +75,10 @@ public class Interval implements TemporalAmount {
   }
 
   public long toEpochMilli(final long fromEpochMilli) {
-    if (!start.isPresent()) {
+    final long epochMilli =
+        start.map(ZonedDateTime::toInstant).map(Instant::toEpochMilli).orElse(fromEpochMilli);
+
+    if (epochMilli <= fromEpochMilli) {
       if (!isCalendarBased()) {
         return fromEpochMilli + getDuration().toMillis();
       }
@@ -86,7 +89,7 @@ public class Interval implements TemporalAmount {
           .toEpochMilli();
     }
 
-    return start.get().toInstant().toEpochMilli();
+    return epochMilli;
   }
 
   /**

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/util/time/RepeatingIntervalTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/util/time/RepeatingIntervalTest.java
@@ -198,4 +198,21 @@ public class RepeatingIntervalTest {
     // then
     assertThat(newDueDate).isEqualTo(expected);
   }
+
+  @Test
+  public void shouldNotBeLessThanCurrentTime() {
+    // given
+    final Interval interval = new Interval(Period.ZERO, Duration.ofSeconds(10));
+    final Instant currentTime = Instant.now();
+    final long fromEpochMilli = currentTime.toEpochMilli();
+
+    // set start time to be less than current time
+    final Instant start = currentTime.minus(Duration.ofDays(1));
+
+    // when
+    final long dueDate = interval.withStart(start).toEpochMilli(fromEpochMilli);
+
+    // then
+    assertThat(dueDate).isEqualTo(currentTime.plusSeconds(10).toEpochMilli());
+  }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
@@ -1071,7 +1071,7 @@ public final class TimerStartEventTest {
     final long secondDeploymentProcessDefinitionKey = secondDeployment.getProcessDefinitionKey();
 
     // when
-    engine.increaseTime(Duration.ofSeconds(25));
+    engine.increaseTime(Duration.ofSeconds(15));
 
     // then
     assertThat(


### PR DESCRIPTION
## Description
If a repeating timer with a start time is defined, the engine is stopped for some time during which the timer is supposed to trigger multiple times, and the engine is restarted, then it should trigger only once and reschedule the next timer in the future. Also, if a past start time is defined, it triggers after one interval period. If a future start time is defined that is expected sooner than, at, or after one interval period, it triggers at the start time.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9680 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
