### PR TITLE
Abort snapshot concurrent to a backup

### DIFF
--- a/backup/src/main/java/io/camunda/zeebe/backup/api/CheckpointListener.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/CheckpointListener.java
@@ -19,5 +19,5 @@ public interface CheckpointListener {
    * <li>When CHECKPOINT:CREATED record is replayed
    * <li>If there is a valid checkpoint, when the listener is registered
    */
-  void onNewCheckpointCreated(long checkpointId);
+  void onNewCheckpointCreated(long checkpointId, final long checkpointPosition);
 }

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
@@ -47,7 +47,7 @@ public final class CheckpointCreateProcessor {
       checkpointState.setCheckpointInfo(checkpointId, checkpointPosition);
 
       // Notify listeners immediately
-      listeners.forEach(l -> l.onNewCheckpointCreated(checkpointId));
+      listeners.forEach(l -> l.onNewCheckpointCreated(checkpointId, checkpointPosition));
 
       final var followupRecord =
           new CheckpointRecord()

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
@@ -27,6 +27,8 @@ public final class CheckpointCreatedEventApplier {
     checkpointState.setCheckpointInfo(
         checkpointRecord.getCheckpointId(), checkpointRecord.getCheckpointPosition());
     checkpointListeners.forEach(
-        listener -> listener.onNewCheckpointCreated(checkpointState.getCheckpointId()));
+        listener ->
+            listener.onNewCheckpointCreated(
+                checkpointState.getCheckpointId(), checkpointState.getCheckpointPosition()));
   }
 }

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
@@ -60,7 +60,9 @@ public final class CheckpointRecordsProcessor implements RecordProcessor {
 
     if (checkpointState.getCheckpointId() != CheckpointState.NO_CHECKPOINT) {
       checkpointListeners.forEach(
-          listener -> listener.onNewCheckpointCreated(checkpointState.getCheckpointId()));
+          listener ->
+              listener.onNewCheckpointCreated(
+                  checkpointState.getCheckpointId(), checkpointState.getCheckpointPosition()));
     }
   }
 
@@ -116,7 +118,8 @@ public final class CheckpointRecordsProcessor implements RecordProcessor {
           () -> {
             final var checkpointId = checkpointState.getCheckpointId();
             if (checkpointId != CheckpointState.NO_CHECKPOINT) {
-              checkpointListener.onNewCheckpointCreated(checkpointState.getCheckpointId());
+              checkpointListener.onNewCheckpointCreated(
+                  checkpointState.getCheckpointId(), checkpointState.getCheckpointPosition());
             }
           });
     }

--- a/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -188,7 +188,7 @@ final class CheckpointRecordsProcessorTest {
   void shouldNotifyListenerWhenNewCheckpointCreated() {
     // given
     final AtomicLong checkpoint = new AtomicLong();
-    processor.addCheckpointListener(checkpoint::set);
+    processor.addCheckpointListener((id, checkpointPosition) -> checkpoint.set(id));
 
     final long checkpointId = 2;
     final long checkpointPosition = 20;
@@ -208,7 +208,7 @@ final class CheckpointRecordsProcessorTest {
   void shouldNotifyListenerWhenReplayed() {
     // given
     final AtomicLong checkpoint = new AtomicLong();
-    processor.addCheckpointListener(checkpoint::set);
+    processor.addCheckpointListener((id, checkpointPosition) -> checkpoint.set(id));
 
     final long checkpointId = 3;
     final long checkpointPosition = 10;
@@ -242,7 +242,7 @@ final class CheckpointRecordsProcessorTest {
 
     // when
     final AtomicLong checkpoint = new AtomicLong();
-    processor.addCheckpointListener(checkpoint::set);
+    processor.addCheckpointListener((id, position) -> checkpoint.set(id));
     processor.init(context);
 
     // then
@@ -267,7 +267,7 @@ final class CheckpointRecordsProcessorTest {
 
     // when
     final AtomicLong checkpoint = new AtomicLong();
-    processor.addCheckpointListener(checkpoint::set);
+    processor.addCheckpointListener((id, position) -> checkpoint.set(id));
 
     // then
     assertThat(checkpoint).hasValue(checkpointId);

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverActor.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverActor.java
@@ -77,7 +77,7 @@ public final class InterPartitionCommandReceiverActor extends Actor
   }
 
   @Override
-  public void onNewCheckpointCreated(final long checkpointId) {
+  public void onNewCheckpointCreated(final long checkpointId, final long checkpointPosition) {
     actor.run(() -> receiver.setCheckpointId(checkpointId));
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
@@ -81,7 +81,7 @@ public final class InterPartitionCommandSenderImpl
   }
 
   @Override
-  public void onNewCheckpointCreated(final long checkpointId) {
+  public void onNewCheckpointCreated(final long checkpointId, final long checkpointPosition) {
     this.checkpointId = checkpointId;
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
@@ -82,7 +82,7 @@ final class InterPartitionCommandCheckpointTest {
   void shouldCreateFirstCheckpoint() {
     // given
     when(logStreamRecordWriter.tryWrite()).thenReturn(1L);
-    sender.onNewCheckpointCreated(1, );
+    sender.onNewCheckpointCreated(1, 10);
 
     // when
     sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
@@ -105,7 +105,7 @@ final class InterPartitionCommandCheckpointTest {
     // given
     when(logStreamRecordWriter.tryWrite()).thenReturn(1L);
     receiver.setCheckpointId(5);
-    sender.onNewCheckpointCreated(17, );
+    sender.onNewCheckpointCreated(17, 10);
 
     // when
     sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
@@ -126,7 +126,7 @@ final class InterPartitionCommandCheckpointTest {
     // given
     when(logStreamRecordWriter.tryWrite()).thenReturn(1L);
     receiver.setCheckpointId(5);
-    sender.onNewCheckpointCreated(5, );
+    sender.onNewCheckpointCreated(5, 10);
 
     // when
     sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
@@ -144,7 +144,7 @@ final class InterPartitionCommandCheckpointTest {
     // given
     when(logStreamRecordWriter.tryWrite()).thenReturn(1L);
     receiver.setCheckpointId(6);
-    sender.onNewCheckpointCreated(5, );
+    sender.onNewCheckpointCreated(5, 10);
 
     // when
     sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
@@ -162,7 +162,7 @@ final class InterPartitionCommandCheckpointTest {
     // given
     when(logStreamRecordWriter.tryWrite()).thenReturn(-1L, 1L);
     receiver.setCheckpointId(5);
-    sender.onNewCheckpointCreated(17, );
+    sender.onNewCheckpointCreated(17, 10);
 
     // when
     sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
@@ -180,7 +180,7 @@ final class InterPartitionCommandCheckpointTest {
     // given
     receiver.setDiskSpaceAvailable(false);
     receiver.setCheckpointId(5);
-    sender.onNewCheckpointCreated(17, );
+    sender.onNewCheckpointCreated(17, 10);
 
     // when
     sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
@@ -82,7 +82,7 @@ final class InterPartitionCommandCheckpointTest {
   void shouldCreateFirstCheckpoint() {
     // given
     when(logStreamRecordWriter.tryWrite()).thenReturn(1L);
-    sender.onNewCheckpointCreated(1);
+    sender.onNewCheckpointCreated(1, );
 
     // when
     sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
@@ -105,7 +105,7 @@ final class InterPartitionCommandCheckpointTest {
     // given
     when(logStreamRecordWriter.tryWrite()).thenReturn(1L);
     receiver.setCheckpointId(5);
-    sender.onNewCheckpointCreated(17);
+    sender.onNewCheckpointCreated(17, );
 
     // when
     sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
@@ -126,7 +126,7 @@ final class InterPartitionCommandCheckpointTest {
     // given
     when(logStreamRecordWriter.tryWrite()).thenReturn(1L);
     receiver.setCheckpointId(5);
-    sender.onNewCheckpointCreated(5);
+    sender.onNewCheckpointCreated(5, );
 
     // when
     sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
@@ -144,7 +144,7 @@ final class InterPartitionCommandCheckpointTest {
     // given
     when(logStreamRecordWriter.tryWrite()).thenReturn(1L);
     receiver.setCheckpointId(6);
-    sender.onNewCheckpointCreated(5);
+    sender.onNewCheckpointCreated(5, );
 
     // when
     sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
@@ -162,7 +162,7 @@ final class InterPartitionCommandCheckpointTest {
     // given
     when(logStreamRecordWriter.tryWrite()).thenReturn(-1L, 1L);
     receiver.setCheckpointId(5);
-    sender.onNewCheckpointCreated(17);
+    sender.onNewCheckpointCreated(17, );
 
     // when
     sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
@@ -180,7 +180,7 @@ final class InterPartitionCommandCheckpointTest {
     // given
     receiver.setDiskSpaceAvailable(false);
     receiver.setCheckpointId(5);
-    sender.onNewCheckpointCreated(17);
+    sender.onNewCheckpointCreated(17, );
 
     // when
     sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);


### PR DESCRIPTION
## Description

This is required to prevent inconsistencies in the backup that is triggered by the checkpoint. A backup must always include a snapshot at position before the checkpoint position. If the checkpoint is taken while the snapshot is also taken, then it is possible that the actual snapshot position in the snapshot is greater than the checkpoint position because the snapshots are taken asynchrously. If we include this snapshot in the backup, the backup is not consistent anymore. To be safe, we abort the snapshot. This is not an ideal solution, but it is a simple solution to prevent the inconsistency.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9906 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
