### PR TITLE
Fix flaky MultiPartitionDeploymentLifecycleTest

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiPartitionDeploymentLifecycleTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiPartitionDeploymentLifecycleTest.java
@@ -51,41 +51,49 @@ public class MultiPartitionDeploymentLifecycleTest {
     engine.deployment().withXmlResource("process.bpmn", modelInstance).deploy();
 
     // then
-    final var deploymentPartitionRecords =
-        RecordingExporter.records().withPartitionId(1).limit(10).collect(Collectors.toList());
-
-    assertThat(deploymentPartitionRecords).hasSize(10);
-
-    assertThat(deploymentPartitionRecords.subList(0, 5))
-        .extracting(Record::getIntent, Record::getRecordType)
-        .containsExactly(
-            tuple(DeploymentIntent.CREATE, RecordType.COMMAND),
-            tuple(ProcessIntent.CREATED, RecordType.EVENT),
-            tuple(DeploymentIntent.CREATED, RecordType.EVENT),
-            tuple(DeploymentDistributionIntent.DISTRIBUTING, RecordType.EVENT),
-            tuple(DeploymentDistributionIntent.DISTRIBUTING, RecordType.EVENT));
-
-    assertThat(deploymentPartitionRecords.subList(5, 9))
+    assertThat(
+            RecordingExporter.records()
+                .withPartitionId(1)
+                .limit(r -> r.getIntent().equals(DeploymentIntent.FULLY_DISTRIBUTED)))
         .extracting(
             Record::getIntent,
             Record::getRecordType,
-            r -> ((DeploymentDistributionRecordValue) r.getValue()).getPartitionId())
+            r ->
+                // We want to verify the partition id where the deployment was distributing to and
+                // where it was completed. Since only the DeploymentDistribution records have a
+                // value that contains the partition id, we use the partition id the record was
+                // written on for the other records. It should be noted that the
+                // DeploymentDistribution records are also written on partition 1!
+                r.getValue() instanceof DeploymentDistributionRecordValue
+                    ? ((DeploymentDistributionRecordValue) r.getValue()).getPartitionId()
+                    : r.getPartitionId())
+        .startsWith(
+            tuple(DeploymentIntent.CREATE, RecordType.COMMAND, 1),
+            tuple(ProcessIntent.CREATED, RecordType.EVENT, 1),
+            tuple(DeploymentIntent.CREATED, RecordType.EVENT, 1))
         .containsSubsequence(
+            tuple(DeploymentDistributionIntent.DISTRIBUTING, RecordType.EVENT, 2),
             tuple(DeploymentDistributionIntent.COMPLETE, RecordType.COMMAND, 2),
             tuple(DeploymentDistributionIntent.COMPLETED, RecordType.EVENT, 2))
         .containsSubsequence(
+            tuple(DeploymentDistributionIntent.DISTRIBUTING, RecordType.EVENT, 3),
             tuple(DeploymentDistributionIntent.COMPLETE, RecordType.COMMAND, 3),
-            tuple(DeploymentDistributionIntent.COMPLETED, RecordType.EVENT, 3));
+            tuple(DeploymentDistributionIntent.COMPLETED, RecordType.EVENT, 3))
+        .endsWith(tuple(DeploymentIntent.FULLY_DISTRIBUTED, RecordType.EVENT, 1));
 
-    assertThat(deploymentPartitionRecords.subList(9, deploymentPartitionRecords.size()))
-        .extracting(Record::getIntent, Record::getRecordType)
-        .containsExactly(tuple(DeploymentIntent.FULLY_DISTRIBUTED, RecordType.EVENT));
-
-    assertThat(RecordingExporter.records().withPartitionId(2).limit(2).collect(Collectors.toList()))
+    assertThat(
+            RecordingExporter.records()
+                .withPartitionId(2)
+                .limit(r -> r.getIntent().equals(DeploymentIntent.DISTRIBUTED))
+                .collect(Collectors.toList()))
         .extracting(Record::getIntent)
         .containsExactly(DeploymentIntent.DISTRIBUTE, DeploymentIntent.DISTRIBUTED);
 
-    assertThat(RecordingExporter.records().withPartitionId(3).limit(2).collect(Collectors.toList()))
+    assertThat(
+            RecordingExporter.records()
+                .withPartitionId(3)
+                .limit(r -> r.getIntent().equals(DeploymentIntent.DISTRIBUTED))
+                .collect(Collectors.toList()))
         .extracting(Record::getIntent)
         .containsExactly(DeploymentIntent.DISTRIBUTE, DeploymentIntent.DISTRIBUTED);
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Test was flaky because it was asserted that the COMPLETE commands and COMPLETED events were written in order.
This is not always as the case. The COMPLETE commands are a result of partition 2 and 3 sending the command to partition 1. There is no guarantee that partition 1 will first receive both commands before it starts processing them.
As long as we assert that we receive the COMPLETE command of partition X before the COMPLETED event of partition X the test should be accurate without being flaky.


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9964 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
