### PR TITLE
fix: more precise and reliable way to force new leaders in tests

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/BrokerLeaderChangeTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/BrokerLeaderChangeTest.java
@@ -63,7 +63,7 @@ public final class BrokerLeaderChangeTest {
     final var firstLeaderNodeId = firstLeaderInfo.getNodeId();
 
     // when
-    clusteringRule.forceClusterToHaveNewLeader(1, firstLeaderNodeId);
+    clusteringRule.forceNewLeaderForPartition(firstLeaderNodeId, 1);
 
     // then
     assertThat(clusteringRule.getCurrentLeaderForPartition(1).getNodeId())

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/BrokerLeaderChangeTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/BrokerLeaderChangeTest.java
@@ -63,7 +63,7 @@ public final class BrokerLeaderChangeTest {
     final var firstLeaderNodeId = firstLeaderInfo.getNodeId();
 
     // when
-    clusteringRule.forceClusterToHaveNewLeader(firstLeaderNodeId);
+    clusteringRule.forceClusterToHaveNewLeader(1, firstLeaderNodeId);
 
     // then
     assertThat(clusteringRule.getCurrentLeaderForPartition(1).getNodeId())

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -603,7 +603,7 @@ public final class ClusteringRule extends ExternalResource {
     }
   }
 
-  public void forceClusterToHaveNewLeader(final int partitionId, final int expectedLeaderId) {
+  public void forceNewLeaderForPartition(final int expectedLeaderId, final int partitionId) {
     final var previousLeader = getCurrentLeaderForPartition(partitionId);
     final var expectedLeader = brokers.get(expectedLeaderId);
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/InstallRequestHandlingTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/InstallRequestHandlingTest.java
@@ -52,7 +52,7 @@ public class InstallRequestHandlingTest {
 
     // then
     clusteringRule.waitForSnapshotAtBroker(followerId);
-    clusteringRule.forceClusterToHaveNewLeader(followerId);
+    clusteringRule.forceClusterToHaveNewLeader(1, followerId);
 
     clientRule.getClient().newCompleteCommand(jobKey).send().join();
     ZeebeAssertHelper.assertProcessInstanceCompleted("process");
@@ -79,7 +79,7 @@ public class InstallRequestHandlingTest {
     clientRule.createProcessInstance(processDefinitionKey);
 
     // then
-    clusteringRule.forceClusterToHaveNewLeader(followerId);
+    clusteringRule.forceClusterToHaveNewLeader(1, followerId);
 
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/InstallRequestHandlingTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/InstallRequestHandlingTest.java
@@ -52,7 +52,7 @@ public class InstallRequestHandlingTest {
 
     // then
     clusteringRule.waitForSnapshotAtBroker(followerId);
-    clusteringRule.forceClusterToHaveNewLeader(1, followerId);
+    clusteringRule.forceNewLeaderForPartition(followerId, 1);
 
     clientRule.getClient().newCompleteCommand(jobKey).send().join();
     ZeebeAssertHelper.assertProcessInstanceCompleted("process");
@@ -79,7 +79,7 @@ public class InstallRequestHandlingTest {
     clientRule.createProcessInstance(processDefinitionKey);
 
     // then
-    clusteringRule.forceClusterToHaveNewLeader(1, followerId);
+    clusteringRule.forceNewLeaderForPartition(followerId, 1);
 
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
@@ -68,7 +68,7 @@ public class ReaderCloseTest {
             .getConfig()
             .getCluster()
             .getNodeId();
-    clusteringRule.forceClusterToHaveNewLeader(1, followerId);
+    clusteringRule.forceNewLeaderForPartition(followerId, 1);
     // because of https://github.com/camunda/zeebe/issues/8329
     // we need to add another record so we can do a snapshot
     clientRule

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
@@ -68,7 +68,7 @@ public class ReaderCloseTest {
             .getConfig()
             .getCluster()
             .getNodeId();
-    clusteringRule.forceClusterToHaveNewLeader(followerId);
+    clusteringRule.forceClusterToHaveNewLeader(1, followerId);
     // because of https://github.com/camunda/zeebe/issues/8329
     // we need to add another record so we can do a snapshot
     clientRule


### PR DESCRIPTION

## Description

This PR changes two things:
1. after promoting a new leader, we assert that the new leader is as expected
2. retries the promote request to allow for temporary failures, for example unavailable receivers


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9921 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
