### PR TITLE
deps: remove override of awaitility version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -92,7 +92,6 @@
     <version.spring-boot>2.7.2</version.spring-boot>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.3.0</version.kryo>
-    <version.awaitility>4.0.3</version.awaitility>
     <version.failsafe>2.4.4</version.failsafe>
     <version.jqwik>1.6.5</version.jqwik>
     <version.jmock>2.12.0</version.jmock>


### PR DESCRIPTION
The version for awaitility was defined twice. This removes the second definition so that we actually use awaitility 4.2.0.