### PR TITLE
StreamProcessor can choose between engine and non-engine records

### DIFF
--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
@@ -65,6 +65,11 @@ public final class CheckpointRecordsProcessor implements RecordProcessor {
   }
 
   @Override
+  public boolean canProcess(final ValueType valueType) {
+    return valueType == ValueType.CHECKPOINT;
+  }
+
+  @Override
   public void replay(final TypedRecord record) {
     if (record.getValueType() != ValueType.CHECKPOINT) {
       // Should never reach here. StreamProcessor must choose the right processor always.

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessor.java
@@ -65,7 +65,7 @@ public final class CheckpointRecordsProcessor implements RecordProcessor {
   }
 
   @Override
-  public boolean canProcess(final ValueType valueType) {
+  public boolean accepts(final ValueType valueType) {
     return valueType == ValueType.CHECKPOINT;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.engine.state.processing.DbBlackListState;
 import io.camunda.zeebe.logstreams.impl.Loggers;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
 import java.util.Objects;
@@ -80,6 +81,11 @@ public class Engine implements RecordProcessor {
 
     recordProcessorContext.addLifecycleListeners(typedRecordProcessors.getLifecycleListeners());
     recordProcessorMap = typedRecordProcessors.getRecordProcessorMap();
+  }
+
+  @Override
+  public boolean canProcess(final ValueType valueType) {
+    return recordProcessorMap.hasValueType(valueType);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
+import java.util.EnumSet;
 import java.util.Objects;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -40,6 +41,10 @@ public class Engine implements RecordProcessor {
       "Expected to find processor for record '{}', but caught an exception. Skip this record.";
   private static final String ERROR_MESSAGE_PROCESSING_EXCEPTION_OCCURRED =
       "Expected to process record '%s' without errors, but exception occurred with message '%s'.";
+
+  private static final EnumSet<ValueType> SUPPORTED_VALUETYPES =
+      EnumSet.range(ValueType.JOB, ValueType.PROCESS_INSTANCE_MODIFICATION);
+
   private EventApplier eventApplier;
   private RecordProcessorMap recordProcessorMap;
   private ZeebeDbState zeebeState;
@@ -85,7 +90,7 @@ public class Engine implements RecordProcessor {
 
   @Override
   public boolean canProcess(final ValueType valueType) {
-    return recordProcessorMap.hasValueType(valueType);
+    return SUPPORTED_VALUETYPES.contains(valueType);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -89,7 +89,7 @@ public class Engine implements RecordProcessor {
   }
 
   @Override
-  public boolean canProcess(final ValueType valueType) {
+  public boolean accepts(final ValueType valueType) {
     return SUPPORTED_VALUETYPES.contains(valueType);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessor.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.api;
 
+import io.camunda.zeebe.protocol.record.ValueType;
+
 /**
  * Interface for record processors. A record processor is responsible for handling a single record.
  * (The class {@code StreamProcessor} in turn is responsible for handling a stream of records.
@@ -19,6 +21,21 @@ public interface RecordProcessor {
    * @param recordProcessorContext context object to initialize the processor
    */
   void init(RecordProcessorContext recordProcessorContext);
+
+  /**
+   * Returns true if the processor is responsible for processing a record with the given valueType.
+   * If it returns true, then {@link RecordProcessor#process(TypedRecord, ProcessingResultBuilder)}
+   * and {@link RecordProcessor#replay(TypedRecord)} must successfully process or replay the record
+   * with the given valueType. The processor can also choose to skip the record depending on the
+   * intent of the record.
+   *
+   * <p>If it returns false, {@link RecordProcessor#process(TypedRecord, ProcessingResultBuilder)} *
+   * and {@link RecordProcessor#replay(TypedRecord)} with the given valueType will not be called.
+   *
+   * @param valueType valueType of a record
+   * @return true or false
+   */
+  boolean canProcess(ValueType valueType);
 
   /**
    * Called by platform in order to replay a single record

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessor.java
@@ -35,7 +35,7 @@ public interface RecordProcessor {
    * @param valueType valueType of a record
    * @return true or false
    */
-  boolean canProcess(ValueType valueType);
+  boolean accepts(ValueType valueType);
 
   /**
    * Called by platform in order to replay a single record

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/RecordProcessorMap.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/RecordProcessorMap.java
@@ -10,11 +10,14 @@ package io.camunda.zeebe.engine.processing.streamprocessor;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.util.EnumSet;
 import java.util.Iterator;
 
 @SuppressWarnings({"rawtypes"})
 public final class RecordProcessorMap {
   private final TypedRecordProcessor[] elements;
+
+  private final EnumSet<ValueType> supportedValueTypes;
 
   private final int valueTypeCardinality;
   private final int intentCardinality;
@@ -28,6 +31,7 @@ public final class RecordProcessorMap {
 
     final int cardinality = recordTypeCardinality * valueTypeCardinality * intentCardinality;
     elements = new TypedRecordProcessor[cardinality];
+    supportedValueTypes = EnumSet.noneOf(ValueType.class);
   }
 
   public TypedRecordProcessor get(final RecordType key1, final ValueType key2, final int key3) {
@@ -64,6 +68,7 @@ public final class RecordProcessorMap {
     }
 
     elements[index] = value;
+    supportedValueTypes.add(key2);
   }
 
   private int mapToIndex(final RecordType key1, final ValueType key2, final int key3) {
@@ -74,6 +79,10 @@ public final class RecordProcessorMap {
     return (key1.ordinal() * valueTypeCardinality * intentCardinality)
         + (key2.ordinal() * intentCardinality)
         + key3;
+  }
+
+  public boolean hasValueType(final ValueType valueType) {
+    return supportedValueTypes.contains(valueType);
   }
 
   /** BEWARE: does not detect concurrent modifications and behaves incorrectly in this case */

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/RecordProcessorMap.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/RecordProcessorMap.java
@@ -10,14 +10,11 @@ package io.camunda.zeebe.engine.processing.streamprocessor;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
-import java.util.EnumSet;
 import java.util.Iterator;
 
 @SuppressWarnings({"rawtypes"})
 public final class RecordProcessorMap {
   private final TypedRecordProcessor[] elements;
-
-  private final EnumSet<ValueType> supportedValueTypes;
 
   private final int valueTypeCardinality;
   private final int intentCardinality;
@@ -31,7 +28,6 @@ public final class RecordProcessorMap {
 
     final int cardinality = recordTypeCardinality * valueTypeCardinality * intentCardinality;
     elements = new TypedRecordProcessor[cardinality];
-    supportedValueTypes = EnumSet.noneOf(ValueType.class);
   }
 
   public TypedRecordProcessor get(final RecordType key1, final ValueType key2, final int key3) {
@@ -68,7 +64,6 @@ public final class RecordProcessorMap {
     }
 
     elements[index] = value;
-    supportedValueTypes.add(key2);
   }
 
   private int mapToIndex(final RecordType key1, final ValueType key2, final int key3) {
@@ -79,10 +74,6 @@ public final class RecordProcessorMap {
     return (key1.ordinal() * valueTypeCardinality * intentCardinality)
         + (key2.ordinal() * intentCardinality)
         + key3;
-  }
-
-  public boolean hasValueType(final ValueType valueType) {
-    return supportedValueTypes.contains(valueType);
   }
 
   /** BEWARE: does not detect concurrent modifications and behaves incorrectly in this case */

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -179,6 +179,7 @@ public final class ProcessingStateMachine {
 
   private void skipRecord() {
     notifySkippedListener(currentRecord);
+    inProcessing = false;
     actor.submit(this::readNextRecord);
     metrics.eventSkipped();
   }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -258,16 +258,17 @@ public final class ProcessingStateMachine {
 
       metrics.processingLatency(command.getTimestamp(), processingStartTime);
 
+      currentProcessor =
+          recordProcessors.stream()
+              .filter(p -> p.accepts(typedCommand.getValueType()))
+              .findFirst()
+              .orElse(null);
+
       zeebeDbTransaction = transactionContext.getCurrentTransaction();
       zeebeDbTransaction.run(
           () -> {
             processingResultBuilder.reset();
 
-            currentProcessor =
-                recordProcessors.stream()
-                    .filter(p -> p.canProcess(typedCommand.getValueType()))
-                    .findFirst()
-                    .orElse(null);
             if (currentProcessor != null) {
               currentProcessingResult =
                   currentProcessor.process(typedCommand, processingResultBuilder);

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.util.exception.RecoverableException;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.prometheus.client.Histogram;
 import java.time.Duration;
+import java.util.List;
 import java.util.function.BooleanSupplier;
 import org.slf4j.Logger;
 
@@ -144,15 +145,16 @@ public final class ProcessingStateMachine {
   private boolean reachedEnd = true;
   private boolean inProcessing;
   private final StreamProcessorContext context;
-  private final RecordProcessor engine;
+  private final List<RecordProcessor> recordProcessors;
   private ProcessingResult currentProcessingResult;
+  private RecordProcessor currentProcessor;
 
   public ProcessingStateMachine(
       final StreamProcessorContext context,
       final BooleanSupplier shouldProcessNext,
-      final RecordProcessor engine) {
+      final List<RecordProcessor> recordProcessors) {
     this.context = context;
-    this.engine = engine;
+    this.recordProcessors = recordProcessors;
     actor = context.getActor();
     recordValues = context.getRecordValues();
     logStreamReader = context.getLogStreamReader();
@@ -260,7 +262,15 @@ public final class ProcessingStateMachine {
           () -> {
             processingResultBuilder.reset();
 
-            currentProcessingResult = engine.process(typedCommand, processingResultBuilder);
+            currentProcessor =
+                recordProcessors.stream()
+                    .filter(p -> p.canProcess(typedCommand.getValueType()))
+                    .findFirst()
+                    .orElse(null);
+            if (currentProcessor != null) {
+              currentProcessingResult =
+                  currentProcessor.process(typedCommand, processingResultBuilder);
+            }
 
             lastProcessedPositionState.markAsProcessed(position);
           });
@@ -330,7 +340,8 @@ public final class ProcessingStateMachine {
           logStreamWriter.configureSourceContext(position);
 
           currentProcessingResult =
-              engine.onProcessingError(processingException, typedCommand, processingResultBuilder);
+              currentProcessor.onProcessingError(
+                  processingException, typedCommand, processingResultBuilder);
         });
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ReplayStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ReplayStateMachine.java
@@ -222,11 +222,10 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
       readMetadata(currentEvent);
       final var currentTypedEvent = readRecordValue(currentEvent);
 
-      final var processor =
-          recordProcessors.stream()
-              .filter(p -> p.canProcess(currentTypedEvent.getValueType()))
-              .findFirst();
-      processor.ifPresent(recordProcessor -> recordProcessor.replay(currentTypedEvent));
+      recordProcessors.stream()
+          .filter(p -> p.accepts(currentTypedEvent.getValueType()))
+          .findFirst()
+          .ifPresent(recordProcessor -> recordProcessor.replay(currentTypedEvent));
 
       lastReplayedEventPosition = currentTypedEvent.getPosition();
     }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
@@ -134,7 +134,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     partitionId = logStream.getPartitionId();
     actorName = buildActorName(processorBuilder.getNodeId(), "StreamProcessor", partitionId);
     metrics = new StreamProcessorMetrics(partitionId);
-    recordProcessors.add(processorBuilder.getRecordProcessor());
+    recordProcessors.addAll(processorBuilder.getRecordProcessors());
   }
 
   public static StreamProcessorBuilder builder() {

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -112,7 +113,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private ActorFuture<LastProcessingPositions> replayCompletedFuture;
   private final Function<LogStreamBatchWriter, LegacyTypedStreamWriter> typedStreamWriterFactory;
 
-  private final RecordProcessor recordProcessor;
+  private final List<RecordProcessor> recordProcessors = new ArrayList<>();
   private StreamProcessorDbState streamProcessorDbState;
 
   protected StreamProcessor(final StreamProcessorBuilder processorBuilder) {
@@ -133,7 +134,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     partitionId = logStream.getPartitionId();
     actorName = buildActorName(processorBuilder.getNodeId(), "StreamProcessor", partitionId);
     metrics = new StreamProcessorMetrics(partitionId);
-    recordProcessor = processorBuilder.getRecordProcessor();
+    recordProcessors.add(processorBuilder.getRecordProcessor());
   }
 
   public static StreamProcessorBuilder builder() {
@@ -170,12 +171,12 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
       final var startRecoveryTimer = metrics.startRecoveryTimer();
       final long snapshotPosition = recoverFromSnapshot();
 
-      initEngine();
+      initRecordProcessors();
 
       healthCheckTick();
 
       replayStateMachine =
-          new ReplayStateMachine(recordProcessor, streamProcessorContext, this::shouldProcessNext);
+          new ReplayStateMachine(recordProcessors, streamProcessorContext, this::shouldProcessNext);
 
       openFuture.complete(null);
       replayCompletedFuture = replayStateMachine.startRecover(snapshotPosition);
@@ -281,7 +282,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
       processingStateMachine =
           new ProcessingStateMachine(
-              streamProcessorContext, this::shouldProcessNext, recordProcessor);
+              streamProcessorContext, this::shouldProcessNext, recordProcessors);
 
       logStream.registerRecordAvailableListener(this);
 
@@ -316,17 +317,18 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     return openFuture;
   }
 
-  private void initEngine() {
-    final var engineContext =
+  private void initRecordProcessors() {
+    final var processorContext =
         new RecordProcessorContextImpl(
             partitionId,
             streamProcessorContext.getScheduleService(),
             zeebeDb,
             streamProcessorContext.getTransactionContext(),
             eventApplierFactory);
-    recordProcessor.init(engineContext);
 
-    lifecycleAwareListeners.addAll(engineContext.getLifecycleListeners());
+    recordProcessors.forEach(processor -> processor.init(processorContext));
+
+    lifecycleAwareListeners.addAll(processorContext.getLifecycleListeners());
   }
 
   private long recoverFromSnapshot() {

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorBuilder.java
@@ -34,14 +34,14 @@ public final class StreamProcessorBuilder {
   private Function<LogStreamBatchWriter, LegacyTypedStreamWriter> typedStreamWriterFactory =
       LegacyTypedStreamWriterImpl::new;
 
-  private List<RecordProcessor> recordProcessor;
+  private List<RecordProcessor> recordProcessors;
 
   public StreamProcessorBuilder() {
     streamProcessorContext = new StreamProcessorContext();
   }
 
-  public StreamProcessorBuilder recordProcessors(final List<RecordProcessor> recordProcessor) {
-    this.recordProcessor = recordProcessor;
+  public StreamProcessorBuilder recordProcessors(final List<RecordProcessor> recordProcessors) {
+    this.recordProcessors = recordProcessors;
     return this;
   }
 
@@ -109,7 +109,7 @@ public final class StreamProcessorBuilder {
   }
 
   public List<RecordProcessor> getRecordProcessors() {
-    return recordProcessor;
+    return recordProcessors;
   }
 
   public Function<MutableZeebeState, EventApplier> getEventApplierFactory() {

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorBuilder.java
@@ -34,13 +34,13 @@ public final class StreamProcessorBuilder {
   private Function<LogStreamBatchWriter, LegacyTypedStreamWriter> typedStreamWriterFactory =
       LegacyTypedStreamWriterImpl::new;
 
-  private RecordProcessor recordProcessor;
+  private List<RecordProcessor> recordProcessor;
 
   public StreamProcessorBuilder() {
     streamProcessorContext = new StreamProcessorContext();
   }
 
-  public StreamProcessorBuilder recordProcessor(final RecordProcessor recordProcessor) {
+  public StreamProcessorBuilder recordProcessors(final List<RecordProcessor> recordProcessor) {
     this.recordProcessor = recordProcessor;
     return this;
   }
@@ -108,7 +108,7 @@ public final class StreamProcessorBuilder {
     return nodeId;
   }
 
-  public RecordProcessor getRecordProcessor() {
+  public List<RecordProcessor> getRecordProcessors() {
     return recordProcessor;
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/NewStreamProcessorReplayModeTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/NewStreamProcessorReplayModeTest.java
@@ -15,6 +15,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.timeout;
 
+import io.camunda.zeebe.engine.api.RecordProcessor;
 import io.camunda.zeebe.engine.util.Records;
 import io.camunda.zeebe.engine.util.StreamPlatform;
 import io.camunda.zeebe.engine.util.StreamPlatformExtension;
@@ -50,7 +51,7 @@ public final class NewStreamProcessorReplayModeTest {
         event().processInstance(ELEMENT_ACTIVATING, RECORD).causedBy(0));
 
     // then
-    final var recordProcessor = streamPlatform.getRecordProcessor();
+    final RecordProcessor recordProcessor = streamPlatform.getDefaultRecordProcessor();
     final InOrder inOrder = inOrder(recordProcessor);
     inOrder.verify(recordProcessor, TIMEOUT).replay(any());
     inOrder.verify(recordProcessor, TIMEOUT).process(any(), any());

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorMultipleProcessorsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorMultipleProcessorsTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+import static io.camunda.zeebe.engine.util.RecordToWrite.command;
+import static io.camunda.zeebe.engine.util.RecordToWrite.event;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.api.EmptyProcessingResult;
+import io.camunda.zeebe.engine.api.RecordProcessor;
+import io.camunda.zeebe.engine.util.Records;
+import io.camunda.zeebe.engine.util.StreamPlatform;
+import io.camunda.zeebe.engine.util.StreamPlatformExtension;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.verification.VerificationWithTimeout;
+
+@ExtendWith(StreamPlatformExtension.class)
+final class StreamProcessorMultipleProcessorsTest {
+
+  private static final long TIMEOUT_MILLIS = 2_000L;
+  private static final VerificationWithTimeout TIMEOUT = timeout(TIMEOUT_MILLIS);
+
+  private static final ProcessInstanceRecord RECORD = Records.processInstance(1);
+  private static final JobRecord JOB_RECORD = Records.job(1);
+
+  @SuppressWarnings("unused") // injected by the extension
+  private StreamPlatform streamPlatform;
+
+  @Test
+  void shouldChooseTheRightProcessorToProcess() {
+    // given
+    streamPlatform.writeBatch(command().processInstance(ACTIVATE_ELEMENT, RECORD).causedBy(0));
+    streamPlatform.writeBatch(command().job(JobIntent.COMPLETE, JOB_RECORD).causedBy(0));
+
+    final var processInstanceProcessor = createRecordProcessorFor(ValueType.PROCESS_INSTANCE);
+    final var jobProcessor = createRecordProcessorFor(ValueType.JOB);
+
+    // when
+    streamPlatform
+        .withRecordProcessors(List.of(processInstanceProcessor, jobProcessor))
+        .startStreamProcessor();
+
+    // then
+    final InOrder inOrder = inOrder(processInstanceProcessor, jobProcessor);
+    inOrder.verify(processInstanceProcessor, TIMEOUT).process(any(), any());
+    inOrder.verify(jobProcessor, TIMEOUT).process(any(), any());
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  void shouldChooseTheRightProcessorToReplay() {
+    // given
+    streamPlatform.writeBatch(
+        command().processInstance(ACTIVATE_ELEMENT, RECORD),
+        event().processInstance(ELEMENT_ACTIVATING, RECORD).causedBy(0));
+    streamPlatform.writeBatch(
+        command().job(JobIntent.COMPLETE, JOB_RECORD),
+        event().job(JobIntent.COMPLETED, JOB_RECORD).causedBy(0));
+
+    final var processInstanceProcessor = createRecordProcessorFor(ValueType.PROCESS_INSTANCE);
+    final var jobProcessor = createRecordProcessorFor(ValueType.JOB);
+
+    // when
+    streamPlatform
+        .withRecordProcessors(List.of(processInstanceProcessor, jobProcessor))
+        .startStreamProcessor();
+
+    // then
+    final InOrder inOrder = inOrder(processInstanceProcessor, jobProcessor);
+    inOrder.verify(processInstanceProcessor, TIMEOUT).replay(any());
+    inOrder.verify(jobProcessor, TIMEOUT).replay(any());
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  private RecordProcessor createRecordProcessorFor(final ValueType valueType) {
+    final RecordProcessor recordProcessor = mock(RecordProcessor.class);
+    when(recordProcessor.process(any(), any())).thenReturn(EmptyProcessingResult.INSTANCE);
+    when(recordProcessor.onProcessingError(any(), any(), any()))
+        .thenReturn(EmptyProcessingResult.INSTANCE);
+    when(recordProcessor.canProcess(valueType)).thenReturn(true);
+    return recordProcessor;
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
@@ -201,7 +201,7 @@ public final class StreamPlatform {
             .zeebeDb(zeebeDb)
             .actorSchedulingService(actorScheduler)
             .commandResponseWriter(mockCommandResponseWriter)
-            .recordProcessor(recordProcessor)
+            .recordProcessors(List.of(recordProcessor))
             .eventApplierFactory(EventAppliers::new) // todo remove this soon
             .streamProcessorMode(streamProcessorMode);
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
@@ -104,7 +104,7 @@ public final class StreamPlatform {
     when(defaultRecordProcessor.process(any(), any())).thenReturn(EmptyProcessingResult.INSTANCE);
     when(defaultRecordProcessor.onProcessingError(any(), any(), any()))
         .thenReturn(EmptyProcessingResult.INSTANCE);
-    when(defaultRecordProcessor.canProcess(any())).thenReturn(true);
+    when(defaultRecordProcessor.accepts(any())).thenReturn(true);
     recordProcessors = List.of(defaultRecordProcessor);
   }
 
@@ -172,11 +172,6 @@ public final class StreamPlatform {
 
   public StreamPlatform withRecordProcessors(final List<RecordProcessor> recordProcessors) {
     this.recordProcessors = recordProcessors;
-    return this;
-  }
-
-  public StreamPlatform withDefaultRecordProcessor() {
-    recordProcessors = List.of(defaultRecordProcessor);
     return this;
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
@@ -194,6 +194,7 @@ public final class StreamPlatform {
     when(recordProcessor.process(any(), any())).thenReturn(EmptyProcessingResult.INSTANCE);
     when(recordProcessor.onProcessingError(any(), any(), any()))
         .thenReturn(EmptyProcessingResult.INSTANCE);
+    when(recordProcessor.canProcess(any())).thenReturn(true);
 
     final var builder =
         StreamProcessor.builder()

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -55,6 +55,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -312,7 +313,7 @@ public final class TestStreams {
             .actorSchedulingService(actorScheduler)
             .commandResponseWriter(mockCommandResponseWriter)
             .listener(new StreamProcessorListenerRelay(streamProcessorListeners))
-            .recordProcessor(new Engine(wrappedFactory))
+            .recordProcessors(List.of(new Engine(wrappedFactory)))
             .eventApplierFactory(eventApplierFactory)
             .streamProcessorMode(streamProcessorMode);
 


### PR DESCRIPTION
## Description

This PR allows us to add more than one RecordProcessor in the StreamProcessor. Currently there is only one processor which is the `Engine`. After this PR, we can add checkpoint processor to the StreamProcessor. 

## Related issues

closes #9613 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
