### PR TITLE
Document ProcessingScheduleService.runAtFixedRate

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingScheduleService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingScheduleService.java
@@ -17,6 +17,18 @@ public interface ProcessingScheduleService {
 
   <T> void runOnCompletion(ActorFuture<T> precedingTask, BiConsumer<T, Throwable> followUpTask);
 
+  /**
+   * Schedule a task to execute at a fixed rate. After an initial delay, the task is executed. Once
+   * the task is executed, it is rescheduled with the same delay again.
+   *
+   * <p>Note that time-traveling in tests only affects the delay of the currently scheduled next
+   * task and not any of the iterations after. This is because the next task is scheduled with the
+   * delay counted from the new time (i.e. the time after time traveling + task execution duration +
+   * delay duration = scheduled time of the next task).
+   *
+   * @param delay The delay to wait initially and between each run
+   * @param task The task to execute at the fixed rate
+   */
   default void runAtFixedRate(final Duration delay, final Runnable task) {
     runDelayed(
         delay,


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The ProcessingScheduleService has a runAtFixedRate which is implemented in a simple way: run the task after a delay and then schedule itself. But there are some quirks around this that should be clear to the caller.

Specifically, that there is an initial delay before the task is run, **and** that due to the way it reschedules the task, time traveling only affects the currently scheduled delay.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to #10064 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
