### PR TITLE
Reject duplicate DeploymentDistribution Complete command

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/CompleteDeploymentDistributionProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/CompleteDeploymentDistributionProcessor.java
@@ -41,7 +41,8 @@ public class CompleteDeploymentDistributionProcessor
   public void processRecord(final TypedRecord<DeploymentDistributionRecord> record) {
 
     final var deploymentKey = record.getKey();
-    if (!deploymentState.hasPendingDeploymentDistribution(deploymentKey)) {
+    final var partitionId = record.getValue().getPartitionId();
+    if (!deploymentState.hasPendingDeploymentDistribution(deploymentKey, partitionId)) {
       rejectionWriter.appendRejection(
           record,
           RejectionType.NOT_FOUND,

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
@@ -99,6 +99,13 @@ public final class DbDeploymentState implements MutableDeploymentState {
   }
 
   @Override
+  public boolean hasPendingDeploymentDistribution(final long deploymentKey, final int partitionId) {
+    this.deploymentKey.wrapLong(deploymentKey);
+    partitionKey.wrapInt(partitionId);
+    return pendingDeploymentColumnFamily.exists(deploymentPartitionKey);
+  }
+
+  @Override
   public DeploymentRecord getStoredDeploymentRecord(final long key) {
     deploymentKey.wrapLong(key);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DeploymentState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DeploymentState.java
@@ -12,7 +12,23 @@ import org.agrona.DirectBuffer;
 
 public interface DeploymentState {
 
+  /**
+   * Returns whether there are any deployment distributions pending for a deployment.
+   *
+   * @param deploymentKey the key of the deployment that may have a pending distribution
+   * @return {@code true} if a pending deployment for the deployment key exists, otherwise {@code
+   *     false}.
+   */
   boolean hasPendingDeploymentDistribution(long deploymentKey);
+
+  /**
+   * Returns whether a specific deployment distribution for a specific partition is pending.
+   *
+   * @param deploymentKey the key of the deployment that may have a pending distribution
+   * @param partitionId the id of the partition to which the distribution might be pending
+   * @return {@code true} if the specific pending deployment exists, otherwise {@code false}.
+   */
+  boolean hasPendingDeploymentDistribution(long deploymentKey, int partitionId);
 
   DeploymentRecord getStoredDeploymentRecord(long deploymentKey);
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
There existed a special case that could lead to a ZeebeDbInconsistentException:
- a pending deployment is distributed multiple times to another partition by the [DeploymentRedistributor](https://github.com/camunda/zeebe/blob/main/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentRedistributor.java).
- the other partition processes the distribution twice and both times sends a `DeploymentDistribution:Complete` command to the deployment partition (i.e. `partitionId: 1`).
- the deployment partition processes the first complete command, and writes `DeploymentDistribution:Completed` event, which is applied to the state.
- applying the completed event results in deleting the Pending Deployment for that partition.
- when it processes the second complete command, there could still be a pending deployment for another partition open for the same deployment, if so, the error happens.
- the second command is not rejected, because there is still a pending deployment for the deployment key, so another completed event is written and applied.
- applying fails this time, because the pending deployment no longer exists.

This PR changes the behavior. It makes sure the second command is rejected because the specific pending deployment no longer exists. In that case, we don't write the completed event a second time.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10064

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
