### PR TITLE
Reject modify command when process instance is unknown

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class ModifyProcessInstanceRejectionTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRejectCommandWhenProcessInstanceIsUnknown() {
+    // given
+    final long unknownKey = 12345L;
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(unknownKey)
+        .modification()
+        .activateElement("A")
+        .expectRejection()
+        .modify();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceModificationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceModificationIntent.MODIFY)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            String.format(
+                "Expected to modify process instance but no process instance found with key '%d'",
+                unknownKey))
+        .hasKey(unknownKey);
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
-import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
@@ -487,33 +486,5 @@ public class ModifyProcessInstanceTest {
                 .findAny())
         .describedAs("Expect the process instance to have been completed")
         .isPresent();
-  }
-
-  @Test
-  public void shouldRejectCommandWhenProcessInstanceIsUnknown() {
-    // given
-    final long unknownKey = 12345L;
-
-    // when
-    ENGINE
-        .processInstance()
-        .withInstanceKey(unknownKey)
-        .modification()
-        .activateElement("A")
-        .expectRejection()
-        .modify();
-
-    // then
-    final var rejectionRecord =
-        RecordingExporter.processInstanceModificationRecords().onlyCommandRejections().getFirst();
-
-    assertThat(rejectionRecord)
-        .hasIntent(ProcessInstanceModificationIntent.MODIFY)
-        .hasRejectionType(RejectionType.NOT_FOUND)
-        .hasRejectionReason(
-            String.format(
-                "Expected to modify process instance but no process instance found with key '%d'",
-                unknownKey))
-        .hasKey(unknownKey);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
@@ -486,5 +487,32 @@ public class ModifyProcessInstanceTest {
                 .findAny())
         .describedAs("Expect the process instance to have been completed")
         .isPresent();
+  }
+
+  @Test
+  public void shouldRejectCommandWhenProcessInstanceIsUnknown() {
+    // given
+    final long unknownKey = 12345L;
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(unknownKey)
+        .modification()
+        .activateElement("A")
+        .expectRejection()
+        .modify();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceModificationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceModificationIntent.MODIFY)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            String.format(
+                "Expected to modify process instance but no process instance found with key '%d'",
+                unknownKey));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -513,6 +513,7 @@ public class ModifyProcessInstanceTest {
         .hasRejectionReason(
             String.format(
                 "Expected to modify process instance but no process instance found with key '%d'",
-                unknownKey));
+                unknownKey))
+        .hasKey(unknownKey);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -290,7 +290,11 @@ public final class ProcessInstanceClient {
           environmentRule.writeCommand(
               processInstanceKey, ProcessInstanceModificationIntent.MODIFY, record);
 
-      return expectation.apply(position);
+      if (expectation == REJECTION_EXPECTATION) {
+        return expectation.apply(processInstanceKey);
+      } else {
+        return expectation.apply(position);
+      }
     }
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ModifyProcessInstanceTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ModifyProcessInstanceTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
+import io.camunda.zeebe.client.api.command.ClientStatusException;
+import io.camunda.zeebe.it.util.GrpcClientRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class ModifyProcessInstanceTest {
+
+  private static final EmbeddedBrokerRule BROKER_RULE = new EmbeddedBrokerRule();
+  private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(BROKER_RULE);
+
+  @ClassRule
+  public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+  private String processId;
+  private long processDefinitionKey;
+
+  @Before
+  public void deploy() {
+    processId = helper.getBpmnProcessId();
+    processDefinitionKey =
+        CLIENT_RULE.deployProcess(
+            Bpmn.createExecutableProcess(processId).startEvent().endEvent().done());
+  }
+
+  @Test
+  public void shouldRejectCommandWhenProcessInstanceUnknown() {
+    // when
+    final var command =
+        CLIENT_RULE
+            .getClient()
+            .newModifyProcessInstanceCommand(
+                processDefinitionKey) // needs to be a valid key since we extract the partition from
+            // it
+            .activateElement("element")
+            .send();
+
+    // then
+    assertThatThrownBy(() -> command.join())
+        .isInstanceOf(ClientStatusException.class)
+        .hasMessageContaining(
+            String.format(
+                "Expected to modify process instance but no process instance found with key '%d'",
+                processDefinitionKey));
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR rejects the command if we cannot find the element instance belonging to the given key.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10078 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
