### PR TITLE
[Backport stable/8.0] Only check that the topology reports all replicas

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -249,6 +249,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
               .usePlaintext()
               .build()) {
         Awaitility.await("until we have a complete topology")
+            .ignoreExceptions()
             .untilAsserted(
                 () -> {
                   final var topology = client.newTopologyRequest().send().join();

--- a/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -255,8 +255,8 @@ public final class EmbeddedBrokerRule extends ExternalResource {
                   TopologyAssert.assertThat(topology)
                       .isComplete(
                           brokerCfg.getCluster().getClusterSize(),
-                          brokerCfg.getCluster().getPartitionsCount())
-                      .isHealthy();
+                          brokerCfg.getCluster().getPartitionsCount(),
+                          brokerCfg.getCluster().getReplicationFactor());
                 });
       }
     }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/topology/TopologyFaultToleranceTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/topology/TopologyFaultToleranceTest.java
@@ -96,7 +96,10 @@ public final class TopologyFaultToleranceTest {
         .untilAsserted(
             () ->
                 TopologyAssert.assertThat(clusterRule.getTopologyFromClient())
-                    .isComplete(clusterRule.getClusterSize(), clusterRule.getPartitionCount()));
+                    .isComplete(
+                        clusterRule.getClusterSize(),
+                        clusterRule.getPartitionCount(),
+                        clusterRule.getReplicationFactor()));
   }
 
   private void awaitBrokerIsRemovedFromTopology(final int nodeId) {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/AdvertisedAddressTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/AdvertisedAddressTest.java
@@ -20,7 +20,6 @@ import io.zeebe.containers.cluster.ZeebeCluster;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import org.agrona.CloseHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -107,9 +106,11 @@ final class AdvertisedAddressTest {
               .map(ZeebeNode::getInternalHost)
               .map(host -> toxiproxy.getProxy(host, ZeebePort.COMMAND.getPort()))
               .map(ContainerProxy::getOriginalProxyPort)
-              .collect(Collectors.toList());
+              .toList();
       TopologyAssert.assertThat(topology)
-          .isComplete(3, 1)
+          .hasClusterSize(3)
+          .hasExpectedReplicasCount(1, 3)
+          .hasLeaderForEachPartition(1)
           .hasBrokerSatisfying(
               b ->
                   assertThat(b.getAddress())

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/Ipv6IntegrationTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/Ipv6IntegrationTest.java
@@ -89,7 +89,7 @@ final class Ipv6IntegrationTest {
     try (final var client = cluster.newClientBuilder().build()) {
       final Topology topology = client.newTopologyRequest().send().join(5, TimeUnit.SECONDS);
       // then - can find each other
-      TopologyAssert.assertThat(topology).isComplete(1, 1);
+      TopologyAssert.assertThat(topology).isComplete(1, 1, 1);
     }
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/SecureClusteredMessagingIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/SecureClusteredMessagingIT.java
@@ -74,7 +74,7 @@ final class SecureClusteredMessagingIT {
 
     // then - ensure the cluster is formed correctly and all inter-cluster communication endpoints
     // are secured using the expected certificate
-    TopologyAssert.assertThat(topology).hasBrokersCount(2).isComplete(2, 1);
+    TopologyAssert.assertThat(topology).hasBrokersCount(2).isComplete(2, 1, 2);
     cluster
         .getBrokers()
         .forEach(

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/StandaloneBrokerIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/StandaloneBrokerIT.java
@@ -117,7 +117,7 @@ final class StandaloneBrokerIT {
   }
 
   private void assertTopologyIsComplete(final ZeebeClient client) {
-    TopologyAssert.assertThat(client.newTopologyRequest().send().join()).isComplete(1, 1);
+    TopologyAssert.assertThat(client.newTopologyRequest().send().join()).isComplete(1, 1, 1);
   }
 
   private ZeebeClient createClient() {

--- a/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -288,7 +288,10 @@ final class RollingUpdateTest {
     final var topology = zeebeClient.newTopologyRequest().send().join();
     TopologyAssert.assertThat(topology)
         .as("the topology contains all the brokers")
-        .isComplete(cluster.getBrokers().size(), 1)
+        .isComplete(
+            cluster.getBrokers().size(),
+            cluster.getPartitionsCount(),
+            cluster.getReplicationFactor())
         .as("the topology contains the updated broker")
         .hasBrokerSatisfying(
             brokerInfo -> {
@@ -302,7 +305,8 @@ final class RollingUpdateTest {
     TopologyAssert.assertThat(topology)
         .as("the topology does not contain broker %d", brokerId)
         .doesNotContainBroker(brokerId)
-        .isComplete(cluster.getBrokers().size() - 1, 1);
+        .hasLeaderForEachPartition(cluster.getPartitionsCount())
+        .hasExpectedReplicasCount(cluster.getPartitionsCount(), cluster.getBrokers().size() - 1);
   }
 
   private ZeebeClient newZeebeClient(final ZeebeGatewayNode<?> gateway) {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/TopologyAssert.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/TopologyAssert.java
@@ -8,98 +8,314 @@
 package io.camunda.zeebe.test.util.asserts;
 
 import io.camunda.zeebe.client.api.response.BrokerInfo;
+import io.camunda.zeebe.client.api.response.PartitionBrokerHealth;
 import io.camunda.zeebe.client.api.response.PartitionInfo;
 import io.camunda.zeebe.client.api.response.Topology;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractObjectAssert;
 
+/** Convenience class to assert certain properties of a Zeebe cluster {@link Topology}. */
+@SuppressWarnings("UnusedReturnValue")
 public final class TopologyAssert extends AbstractObjectAssert<TopologyAssert, Topology> {
 
+  /** @param topology the actual topology to assert against */
   public TopologyAssert(final Topology topology) {
     super(topology, TopologyAssert.class);
   }
 
+  /**
+   * A convenience factory method that's consistent with AssertJ conventions.
+   *
+   * @param actual the actual topology to assert against
+   * @return an instance of {@link TopologyAssert} to assert properties of the given topology
+   */
   public static TopologyAssert assertThat(final Topology actual) {
     return new TopologyAssert(actual);
   }
 
-  public final TopologyAssert isComplete(final int clusterSize, final int partitionCount) {
+  /**
+   * Asserts that the actual topology is complete. A complete topology is one which has the expected
+   * number of brokers, the expected number of partitions, the expected number of replicas per
+   * partition, one leader per partition, and all partitions are healthy.
+   *
+   * <p>This is a convenience method that combines all other assertions from this class.
+   *
+   * @param clusterSize the expected number of brokers in the cluster
+   * @param partitionCount the expected number of partitions in the cluster
+   * @param replicationFactor the expected number of replicas per partition
+   * @return itself for chaining
+   */
+  public TopologyAssert isComplete(
+      final int clusterSize, final int partitionCount, final int replicationFactor) {
+    isNotNull()
+        .hasClusterSize(clusterSize)
+        .hasPartitionsCount(partitionCount)
+        .hasReplicationFactor(replicationFactor)
+        .hasBrokersCount(clusterSize)
+        .hasExpectedReplicasCount(partitionCount, replicationFactor)
+        .hasLeaderForEachPartition(partitionCount)
+        .isHealthy();
+
+    return myself;
+  }
+
+  /**
+   * Verifies that all partitions are healthy for all brokers.
+   *
+   * @return a new map assert for all partitions
+   */
+  public TopologyAssert isHealthy() {
     isNotNull();
 
-    final List<BrokerInfo> brokers = actual.getBrokers();
-
-    if (brokers.size() != clusterSize) {
-      throw failure("Expected broker count to be <%s> but was <%s>", clusterSize, brokers.size());
+    for (final BrokerInfo broker : actual.getBrokers()) {
+      for (final PartitionInfo partition : broker.getPartitions()) {
+        if (partition.getHealth() != PartitionBrokerHealth.HEALTHY) {
+          throw failure(
+              "Expected all partitions to be healthy, but partition <%d> of broker <%d> is <%s>",
+              partition.getPartitionId(), broker.getNodeId(), partition.getHealth());
+        }
+      }
     }
 
-    final List<BrokerInfo> brokersWithUnexpectedPartitionCount =
-        brokers.stream()
-            .filter(b -> b.getPartitions().size() != partitionCount)
-            .collect(Collectors.toList());
+    return this;
+  }
 
-    if (!brokersWithUnexpectedPartitionCount.isEmpty()) {
+  /**
+   * Asserts that the topology reports the correct cluster size. Does not check whether the number
+   * of brokers is as expected, only the topology metadata.
+   *
+   * @param clusterSize the expected cluster size
+   * @return itself for chaining
+   */
+  public TopologyAssert hasClusterSize(final int clusterSize) {
+    isNotNull();
+
+    if (actual.getClusterSize() != clusterSize) {
       throw failure(
-          "Expected <%s> partitions at each broker, but found brokers with different partition count <%s>",
-          partitionCount, brokersWithUnexpectedPartitionCount);
-    }
-
-    final Set<Integer> partitions =
-        brokers.stream()
-            .flatMap(b -> b.getPartitions().stream())
-            .map(PartitionInfo::getPartitionId)
-            .collect(Collectors.toSet());
-    final Set<Integer> partitionsWithLeader =
-        brokers.stream()
-            .flatMap(b -> b.getPartitions().stream())
-            .filter(PartitionInfo::isLeader)
-            .map(PartitionInfo::getPartitionId)
-            .collect(Collectors.toUnmodifiableSet());
-
-    partitions.removeAll(partitionsWithLeader);
-    if (!partitions.isEmpty()) {
-      throw failure(
-          "Expected every partition to have a leader, but found the following have none: <%s>",
-          partitions);
+          "Expected cluster size to be <%d> but was <%d>", clusterSize, actual.getClusterSize());
     }
 
     return myself;
   }
 
-  public final TopologyAssert doesNotContainBroker(final int nodeId) {
+  /**
+   * Asserts that the topology reports the right number of partitions. Does not verify that each
+   * partition is present via the brokers list, only check the topology metadata.
+   *
+   * @param partitionCount the expected partitions count
+   * @return itself for chaining
+   */
+  public TopologyAssert hasPartitionsCount(final int partitionCount) {
     isNotNull();
 
-    final List<Integer> brokers =
-        actual.getBrokers().stream().map(BrokerInfo::getNodeId).collect(Collectors.toList());
-    if (brokers.contains(nodeId)) {
+    if (actual.getPartitionsCount() != partitionCount) {
       throw failure(
-          "Expected topology not to contain broker with ID %d, but found the following: [%s]",
+          "Expected partitions count to be <%d> but was <%d>",
+          partitionCount, actual.getPartitionsCount());
+    }
+
+    return myself;
+  }
+
+  /**
+   * Asserts that the topology reports the expected replication factor. Does not actually check that
+   * each reported partition contains the expected number of replicas, but simply the topology's
+   * metadata.
+   *
+   * @param replicationFactor the expected replication factor
+   * @return itself for chaining
+   */
+  public TopologyAssert hasReplicationFactor(final int replicationFactor) {
+    isNotNull();
+
+    if (actual.getReplicationFactor() != replicationFactor) {
+      throw failure(
+          "Expected replication factor to be <%d> but was <%d>",
+          replicationFactor, actual.getReplicationFactor());
+    }
+
+    return myself;
+  }
+
+  /**
+   * Asserts that the brokers list contains the expected number of brokers.
+   *
+   * @param count the expected brokers count
+   * @return itself for chaining
+   */
+  public TopologyAssert hasBrokersCount(final int count) {
+    isNotNull();
+
+    if (actual.getBrokers().size() != count) {
+      throw failure(
+          "Expected topology to contain <%d> brokers, but it contains <%s>",
+          count, actual.getBrokers());
+    }
+
+    return myself;
+  }
+
+  /**
+   * Asserts that each partition has the expected number of replicas.
+   *
+   * <p>NOTE: this will not work with the fixed partitioning scheme.
+   *
+   * @param partitionCount the partition count in the cluster
+   * @param replicationFactor the replication factor
+   * @return itself for chaining
+   */
+  public TopologyAssert hasExpectedReplicasCount(
+      final int partitionCount, final int replicationFactor) {
+    isNotNull();
+
+    final Map<Integer, List<PartitionBroker>> partitionMap = buildPartitionsMap();
+
+    if (partitionMap.size() != partitionCount) {
+      throw failure(
+          "Expected <%d> partitions to have <%d> replicas, but there are <%d> partitions in the topology: partitions <%s>",
+          partitionCount, replicationFactor, partitionMap.size(), partitionMap.keySet());
+    }
+
+    for (final Entry<Integer, List<PartitionBroker>> partitionBrokers : partitionMap.entrySet()) {
+      final int partitionId = partitionBrokers.getKey();
+      final List<PartitionBroker> brokers = partitionBrokers.getValue();
+
+      if (brokers.size() != replicationFactor) {
+        throw failure(
+            "Expected partition <%d> to have <%d> replicas, but it has <%d>: brokers <%s>",
+            partitionId,
+            replicationFactor,
+            brokers.size(),
+            brokers.stream().map(PartitionBroker::brokerInfo).toList());
+      }
+    }
+
+    return myself;
+  }
+
+  /**
+   * Asserts that each partition has exactly one leader.
+   *
+   * @param partitionCount the expected number of partitions
+   * @return itself for chaining
+   */
+  public TopologyAssert hasLeaderForEachPartition(final int partitionCount) {
+    isNotNull();
+
+    final Map<Integer, List<PartitionBroker>> partitionMap = buildPartitionsMap();
+
+    if (partitionMap.size() != partitionCount) {
+      throw failure(
+          "Expected <%d> partitions to have one leader, but there are <%d> partitions in the topology: partitions <%s>",
+          partitionCount, partitionMap.size(), partitionMap.keySet());
+    }
+
+    for (final Entry<Integer, List<PartitionBroker>> partitionBrokers : partitionMap.entrySet()) {
+      final int partitionId = partitionBrokers.getKey();
+      final List<PartitionBroker> brokers = partitionBrokers.getValue();
+      final List<PartitionBroker> leaders =
+          partitionBrokers.getValue().stream().filter(p -> p.partitionInfo.isLeader()).toList();
+
+      if (leaders.isEmpty()) {
+        throw failure(
+            "Expected partition <%d> to have a healthy leader, but it only has the following brokers: <%s>",
+            partitionId, brokers.stream().map(PartitionBroker::brokerInfo).toList());
+      }
+
+      if (leaders.size() > 1) {
+        throw failure(
+            "Expected partition <%d> to have a healthy leader, but it has the following leaders: <%s>",
+            partitionId, leaders.stream().map(PartitionBroker::brokerInfo).toList());
+      }
+    }
+
+    return myself;
+  }
+
+  /**
+   * Fails if the topology contains one or more brokers with the given node ID. For more general
+   * broker assertions, use {@link #hasBrokerSatisfying(Consumer)}.
+   *
+   * @param nodeId the node ID none of the brokers should have
+   * @return itself for chaining
+   */
+  public TopologyAssert doesNotContainBroker(final int nodeId) {
+    isNotNull();
+
+    final Set<Integer> brokerIds =
+        actual.getBrokers().stream().map(BrokerInfo::getNodeId).collect(Collectors.toSet());
+    if (brokerIds.contains(nodeId)) {
+      throw failure(
+          "Expected topology not to contain broker with ID <%d>, but found the following: <%s>",
+          nodeId, brokerIds);
+    }
+
+    return myself;
+  }
+
+  /**
+   * Fails if the topology does NOT contain exactly one broker with the given node ID. For more
+   * general broker assertions, use {@link #hasBrokerSatisfying(Consumer)}.
+   *
+   * @param nodeId the node ID of exactly one broker in the topology
+   * @return itself for chaining
+   */
+  public TopologyAssert containsBroker(final int nodeId) {
+    isNotNull();
+
+    final Set<Integer> brokers =
+        actual.getBrokers().stream().map(BrokerInfo::getNodeId).collect(Collectors.toSet());
+    if (!brokers.contains(nodeId)) {
+      throw failure(
+          "Expected topology to contain broker with ID <%d>, but found only the following: <%s>",
           nodeId, brokers);
     }
 
     return myself;
   }
 
-  public final TopologyAssert hasBrokerSatisfying(final Consumer<BrokerInfo> condition) {
+  /**
+   * Verifies that at least one element satisfies the given requirements expressed as a {@link
+   * Consumer}. This is useful to check that a group of assertions is verified by (at least) one
+   * element. If the group of elements to assert is empty, the assertion will fail.
+   *
+   * @param condition should throw an exception on failure
+   * @return itself for chaining
+   */
+  public TopologyAssert hasBrokerSatisfying(final Consumer<BrokerInfo> condition) {
     isNotNull();
 
     final List<BrokerInfo> brokers = actual.getBrokers();
-    newListAssertInstance(brokers).anySatisfy(condition);
-
-    return myself;
-  }
-
-  public final TopologyAssert hasBrokersCount(final int count) {
-    isNotNull();
-
-    if (actual.getBrokers().size() != count) {
+    if (brokers.isEmpty()) {
       throw failure(
-          "Expected topology to contain %d brokers, but it contains %s",
-          count, actual.getBrokers());
+          "Expected topology to contain broker satisfying a condition, but there are "
+              + "no brokers in the topology");
     }
 
+    newListAssertInstance(brokers).as(info.description()).anySatisfy(condition);
     return myself;
   }
+
+  private Map<Integer, List<PartitionBroker>> buildPartitionsMap() {
+    final Map<Integer, List<PartitionBroker>> partitionMap = new HashMap<>();
+
+    for (final BrokerInfo broker : actual.getBrokers()) {
+      for (final PartitionInfo partition : broker.getPartitions()) {
+        final List<PartitionBroker> partitionBrokers =
+            partitionMap.computeIfAbsent(partition.getPartitionId(), ignored -> new ArrayList<>());
+        partitionBrokers.add(new PartitionBroker(partition, broker));
+      }
+    }
+
+    return partitionMap;
+  }
+
+  private record PartitionBroker(PartitionInfo partitionInfo, BrokerInfo brokerInfo) {}
 }

--- a/test-util/src/test/java/io/camunda/zeebe/test/util/asserts/TestTopology.java
+++ b/test-util/src/test/java/io/camunda/zeebe/test/util/asserts/TestTopology.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.asserts;
+
+import io.camunda.zeebe.client.api.response.BrokerInfo;
+import io.camunda.zeebe.client.api.response.PartitionBrokerHealth;
+import io.camunda.zeebe.client.api.response.PartitionBrokerRole;
+import io.camunda.zeebe.client.api.response.PartitionInfo;
+import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.zeebe.util.VersionUtil;
+import java.util.List;
+
+/**
+ * Topology implementation used in tests to avoid coupling tests to the implementation of the client
+ * and its protocol.
+ */
+record TestTopology(
+    int clusterSize, int partitionsCount, int replicationFactor, List<BrokerInfo> brokers)
+    implements Topology {
+
+  private static final String HARDCODED_VERSION = VersionUtil.getVersion();
+
+  @Override
+  public List<BrokerInfo> getBrokers() {
+    return brokers;
+  }
+
+  @Override
+  public int getClusterSize() {
+    return clusterSize;
+  }
+
+  @Override
+  public int getPartitionsCount() {
+    return partitionsCount;
+  }
+
+  @Override
+  public int getReplicationFactor() {
+    return replicationFactor;
+  }
+
+  @Override
+  public String getGatewayVersion() {
+    return HARDCODED_VERSION;
+  }
+
+  record TestPartition(int partitionId, PartitionBrokerRole role, PartitionBrokerHealth health)
+      implements PartitionInfo {
+
+    @Override
+    public int getPartitionId() {
+      return partitionId;
+    }
+
+    @Override
+    public PartitionBrokerRole getRole() {
+      return role;
+    }
+
+    @Override
+    public boolean isLeader() {
+      return role == PartitionBrokerRole.LEADER;
+    }
+
+    @Override
+    public PartitionBrokerHealth getHealth() {
+      return health;
+    }
+  }
+
+  record TestBroker(int nodeId, List<PartitionInfo> partitions) implements BrokerInfo {
+
+    @Override
+    public int getNodeId() {
+      return nodeId;
+    }
+
+    @Override
+    public String getHost() {
+      return "foo";
+    }
+
+    @Override
+    public int getPort() {
+      return 26502;
+    }
+
+    @Override
+    public String getAddress() {
+      return getHost() + ":" + getPort();
+    }
+
+    @Override
+    public String getVersion() {
+      return HARDCODED_VERSION;
+    }
+
+    @Override
+    public List<PartitionInfo> getPartitions() {
+      return partitions;
+    }
+  }
+}

--- a/test-util/src/test/java/io/camunda/zeebe/test/util/asserts/TopologyAssertTest.java
+++ b/test-util/src/test/java/io/camunda/zeebe/test/util/asserts/TopologyAssertTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.asserts;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.zeebe.client.api.response.PartitionBrokerHealth;
+import io.camunda.zeebe.client.api.response.PartitionBrokerRole;
+import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.zeebe.test.util.asserts.TestTopology.TestBroker;
+import io.camunda.zeebe.test.util.asserts.TestTopology.TestPartition;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+final class TopologyAssertTest {
+  @Nested
+  final class IsCompleteTest {
+    @Test
+    void shouldFailWithWrongBrokersCount() {
+      // given
+      final Topology topology = new TestTopology(1, 1, 1, List.of());
+
+      // when
+      final var topologyAssert = TopologyAssert.assertThat(topology);
+
+      // then
+      assertThatCode(() -> topologyAssert.isComplete(1, 1, 1)).isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void shouldFailWithWrongReplicasCount() {
+      // given
+      final var partition =
+          new TestPartition(1, PartitionBrokerRole.LEADER, PartitionBrokerHealth.HEALTHY);
+      final var broker = new TestBroker(1, List.of(partition));
+      final Topology topology = new TestTopology(1, 1, 1, List.of(broker));
+
+      // when
+      final var topologyAssert = TopologyAssert.assertThat(topology);
+
+      // then
+      assertThatCode(() -> topologyAssert.isComplete(1, 1, 2)).isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void shouldFailIfPartitionHasNoLeader() {
+      // given
+      final var partition =
+          new TestPartition(1, PartitionBrokerRole.FOLLOWER, PartitionBrokerHealth.HEALTHY);
+      final var broker = new TestBroker(1, List.of(partition));
+      final Topology topology = new TestTopology(1, 1, 1, List.of(broker));
+
+      // when
+      final var topologyAssert = TopologyAssert.assertThat(topology);
+
+      // then
+      assertThatCode(() -> topologyAssert.isComplete(1, 1, 1)).isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void shouldFailIfPartitionIsUnhealthy() {
+      // given
+      final var partition =
+          new TestPartition(1, PartitionBrokerRole.LEADER, PartitionBrokerHealth.UNHEALTHY);
+      final var broker = new TestBroker(1, List.of(partition));
+      final Topology topology = new TestTopology(1, 1, 1, List.of(broker));
+
+      // when
+      final var topologyAssert = TopologyAssert.assertThat(topology);
+
+      // then
+      assertThatCode(() -> topologyAssert.isComplete(1, 1, 1)).isInstanceOf(AssertionError.class);
+    }
+  }
+
+  @Nested
+  final class HasLeaderForEachPartitionTest {
+    @Test
+    void shouldFailWhenNotEnoughPartitionsWithLeader() {
+      // given
+      final var partition =
+          new TestPartition(1, PartitionBrokerRole.LEADER, PartitionBrokerHealth.HEALTHY);
+      final var broker = new TestBroker(1, List.of(partition));
+      final Topology topology = new TestTopology(1, 1, 1, List.of(broker));
+
+      // when
+      final var topologyAssert = TopologyAssert.assertThat(topology);
+
+      // then
+      assertThatCode(() -> topologyAssert.hasLeaderForEachPartition(2))
+          .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void shouldFailWhenPartitionHasTwoLeaders() {
+      // given
+      final var partition =
+          new TestPartition(1, PartitionBrokerRole.LEADER, PartitionBrokerHealth.HEALTHY);
+      final Topology topology =
+          new TestTopology(
+              2,
+              1,
+              2,
+              List.of(
+                  new TestBroker(2, List.of(partition)), new TestBroker(2, List.of(partition))));
+
+      // when
+      final var topologyAssert = TopologyAssert.assertThat(topology);
+
+      // then
+      assertThatCode(() -> topologyAssert.hasLeaderForEachPartition(1))
+          .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void shouldFailWhenPartitionHasNoLeader() {
+      // given
+      final var partition =
+          new TestPartition(1, PartitionBrokerRole.FOLLOWER, PartitionBrokerHealth.HEALTHY);
+      final var broker = new TestBroker(1, List.of(partition));
+      final Topology topology = new TestTopology(1, 1, 1, List.of(broker));
+
+      // when
+      final var topologyAssert = TopologyAssert.assertThat(topology);
+
+      // then
+      assertThatCode(() -> topologyAssert.hasLeaderForEachPartition(1))
+          .isInstanceOf(AssertionError.class);
+    }
+  }
+
+  @Nested
+  final class HasExpectedReplicasCountTest {
+    @Test
+    void shouldFailWhenNotEnoughReplicas() {
+      // given
+      final var partition =
+          new TestPartition(1, PartitionBrokerRole.FOLLOWER, PartitionBrokerHealth.HEALTHY);
+      final var broker = new TestBroker(1, List.of(partition));
+      final Topology topology = new TestTopology(1, 1, 1, List.of(broker));
+
+      // when
+      final var topologyAssert = TopologyAssert.assertThat(topology);
+
+      // then
+      assertThatCode(() -> topologyAssert.hasExpectedReplicasCount(1, 2))
+          .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void shouldFailWhenTooManyReplicas() {
+      // given
+      final var partition =
+          new TestPartition(1, PartitionBrokerRole.FOLLOWER, PartitionBrokerHealth.HEALTHY);
+      final Topology topology =
+          new TestTopology(
+              1,
+              1,
+              2,
+              List.of(
+                  new TestBroker(1, List.of(partition)), new TestBroker(2, List.of(partition))));
+
+      // when
+      final var topologyAssert = TopologyAssert.assertThat(topology);
+
+      // then
+      assertThatCode(() -> topologyAssert.hasExpectedReplicasCount(1, 1))
+          .isInstanceOf(AssertionError.class);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR backports #10082 to stable/8.0. At the same time, I backported two other flaky test fixes, since one included the `TopologyAssert` helpers used here (and possibly in further flaky test fixes).

There were no conflicts by the way.

## Related issues

backports #10082, #9596, #9502

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
