### PR TITLE
refactor(backup): encapsulate additional backup information

### DIFF
--- a/backup/src/main/java/io/camunda/zeebe/backup/api/Backup.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/Backup.java
@@ -7,43 +7,26 @@
  */
 package io.camunda.zeebe.backup.api;
 
-import java.nio.file.Path;
-import java.util.Set;
-
-/** Represents a backup * */
+/** Represents a backup */
 public interface Backup {
 
   /**
-   * @return Returns backup identifier
+   * @return the backup identifier
    */
   BackupIdentifier id();
 
   /**
-   * The number of partitions configured in the system at the time the backup is taken. This is
-   * useful when the system supports dynamic configuration and the system restores from a backup at
-   * a time when the number of partitions was different.
-   *
-   * @return number of partitions at the time backup is taken.
+   * @return the backup descriptor which contains additional information about the backup
    */
-  int numberOfPartitions();
-
-  /**
-   * @return id of the snapshot included in the backup
-   */
-  String snapshotId();
+  BackupDescriptor descriptor();
 
   /**
    * @return the set of snapshot files
    */
-  Set<Path> snapshot();
-
-  /**
-   * @return the checkpoint position of the checkpoint included in the backup
-   */
-  long checkpointPosition();
+  NamedFileSet snapshot();
 
   /**
    * @return the set of segment files
    */
-  Set<Path> segments();
+  NamedFileSet segments();
 }

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupDescriptor.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupDescriptor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.api;
+
+/**
+ * Additional information about the backup that might be required for restoring or querying the
+ * status
+ */
+public interface BackupDescriptor {
+  /**
+   * @return id of the snapshot included in the backup
+   */
+  String snapshotId();
+
+  /**
+   * @return the checkpoint position of the checkpoint included in the backup
+   */
+  long checkpointPosition();
+
+  /**
+   * The number of partitions configured in the system at the time the backup is taken. This is
+   * useful when the system supports dynamic configuration and the system restores from a backup at
+   * a time when the number of partitions was different.
+   *
+   * @return number of partitions at the time backup is taken.
+   */
+  int numberOfPartitions();
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIdentifier.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIdentifier.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.zeebe.backup.api;
 
-/** BackupMetadata must uniquely identify a backup stored in the BackupStore. */
+/** Uniquely identifies a backup stored in the BackupStore. */
 public interface BackupIdentifier {
 
   /**
-   * @return Id of the broker which took this backup
+   * @return id of the broker which took this backup
    */
   int nodeId();
 

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/NamedFileSet.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/NamedFileSet.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.api;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A set of files with names. Files are represented by their paths and names can be arbitrary
+ * strings, for example the actual file name (last part of the path) or a pre-defined name that is
+ * unrelated to the path.
+ */
+public interface NamedFileSet {
+
+  /**
+   * @return the names of files contained in this set
+   */
+  Set<String> names();
+
+  /**
+   * @return the paths to files contained in this set
+   */
+  Set<Path> files();
+
+  /**
+   * @return a map from file names to file paths
+   */
+  Map<String, Path> namedFiles();
+}


### PR DESCRIPTION
This introduces two new interfaces:
* `BackupDescriptor` which contains additional information that is required for restoring and querying the backup status.
* `NamedFileSet` which is map of file names to paths. This replaces the flat set of paths to support nested file layouts and others.