### PR TITLE
Modify a process instance by activating elements inside a non-existing flow scope

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnStreamProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
+import io.camunda.zeebe.engine.processing.common.ElementActivationBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.message.PendingProcessMessageSubscriptionChecker;
@@ -65,8 +66,13 @@ public final class ProcessEventProcessors {
     final MutableProcessMessageSubscriptionState subscriptionState =
         zeebeState.getProcessMessageSubscriptionState();
     final var keyGenerator = zeebeState.getKeyGenerator();
+
     final VariableBehavior variableBehavior =
         new VariableBehavior(zeebeState.getVariableState(), writers.state(), keyGenerator);
+
+    final var elementActivationBehavior =
+        new ElementActivationBehavior(
+            keyGenerator, writers, catchEventBehavior, zeebeState.getElementInstanceState());
 
     final var processEngineMetrics = new ProcessEngineMetrics(zeebeState.getPartitionId());
 
@@ -111,7 +117,7 @@ public final class ProcessEventProcessors {
         zeebeState,
         writers,
         variableBehavior,
-        catchEventBehavior,
+        elementActivationBehavior,
         processEngineMetrics);
     addProcessInstanceModificationStreamProcessors(
         typedRecordProcessors,
@@ -224,7 +230,7 @@ public final class ProcessEventProcessors {
       final MutableZeebeState zeebeState,
       final Writers writers,
       final VariableBehavior variableBehavior,
-      final CatchEventBehavior catchEventBehavior,
+      final ElementActivationBehavior elementActivationBehavior,
       final ProcessEngineMetrics metrics) {
     final MutableElementInstanceState elementInstanceState = zeebeState.getElementInstanceState();
     final KeyGenerator keyGenerator = zeebeState.getKeyGenerator();
@@ -235,7 +241,7 @@ public final class ProcessEventProcessors {
             keyGenerator,
             writers,
             variableBehavior,
-            catchEventBehavior,
+            elementActivationBehavior,
             metrics);
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationIntent.CREATE, createProcessor);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
@@ -123,10 +123,10 @@ public final class ProcessEventProcessors {
         typedRecordProcessors,
         zeebeState,
         writers,
-        keyGenerator,
         jobBehavior,
         incidentBehavior,
-        catchEventBehavior);
+        catchEventBehavior,
+        elementActivationBehavior);
 
     return bpmnStreamProcessor;
   }
@@ -256,19 +256,19 @@ public final class ProcessEventProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final ZeebeState zeebeState,
       final Writers writers,
-      final KeyGenerator keyGenerator,
       final BpmnJobBehavior jobBehavior,
       final BpmnIncidentBehavior incidentBehavior,
-      final CatchEventBehavior catchEventBehavior) {
+      final CatchEventBehavior catchEventBehavior,
+      final ElementActivationBehavior elementActivationBehavior) {
     final ProcessInstanceModificationProcessor modificationProcessor =
         new ProcessInstanceModificationProcessor(
             writers,
-            keyGenerator,
             zeebeState.getElementInstanceState(),
             zeebeState.getProcessState(),
             jobBehavior,
             incidentBehavior,
-            catchEventBehavior);
+            catchEventBehavior,
+            elementActivationBehavior);
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE_MODIFICATION,
         ProcessInstanceModificationIntent.MODIFY,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -109,12 +109,15 @@ public final class ElementActivationBehavior {
         findElementInstances(flowScope, flowScopeKey);
 
     if (elementInstancesOfScope.isEmpty()) {
-
+      // there is no active instance of this flow scope
+      // - create/activate a new instance and continue with the remaining flow scopes
       final long elementInstanceKey =
           activateFlowScope(processInstanceRecord, flowScopeKey, flowScope);
       return activateFlowScopes(processInstanceRecord, elementInstanceKey, flowScopes);
 
     } else if (elementInstancesOfScope.size() == 1) {
+      // there is an active instance of this flow scope
+      // - no need to create a new instance; continue with the remaining flow scopes
       final var elementInstance = elementInstancesOfScope.get(0);
       return activateFlowScopes(processInstanceRecord, elementInstance.getKey(), flowScopes);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -52,8 +52,9 @@ public final class ElementActivationBehavior {
   }
 
   /**
-   * Activates the flow scopes of a given element. This is used when modifying a process instance or
-   * starting a process instance at a different place than the start event.
+   * Activates the given element. If the element is nested inside a flow scope and there is no
+   * active instance of the flow scope then it creates a new instance. This is used when modifying a
+   * process instance or starting a process instance at a different place than the start event.
    *
    * @param processInstanceRecord the record of the process instance
    * @param elementToActivate The element to activate

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -23,8 +23,9 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.util.ArrayList;
+import java.util.ArrayDeque;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
 
@@ -79,31 +80,30 @@ public final class ElementActivationBehavior {
     return elementInstanceKey;
   }
 
-  private List<ExecutableFlowElement> collectFlowScopesOfElement(
+  private Deque<ExecutableFlowElement> collectFlowScopesOfElement(
       final ExecutableFlowElement element) {
-    final List<ExecutableFlowElement> flowScopes = new ArrayList<>();
+    final Deque<ExecutableFlowElement> flowScopes = new ArrayDeque<>();
 
     ExecutableFlowElement currentElement = element.getFlowScope();
 
     while (currentElement != null) {
-      flowScopes.add(currentElement);
+      flowScopes.addFirst(currentElement);
 
       currentElement = currentElement.getFlowScope();
     }
 
-    Collections.reverse(flowScopes);
     return flowScopes;
   }
 
   private long activateFlowScopes(
       final ProcessInstanceRecord processInstanceRecord,
       final long flowScopeKey,
-      final List<ExecutableFlowElement> flowScopes) {
+      final Deque<ExecutableFlowElement> flowScopes) {
 
     if (flowScopes.isEmpty()) {
       return flowScopeKey;
     }
-    final var flowScope = flowScopes.remove(0);
+    final var flowScope = flowScopes.poll();
 
     final List<ElementInstance> elementInstancesOfScope =
         findElementInstances(flowScope, flowScopeKey);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.common;
+
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContextImpl;
+import io.camunda.zeebe.engine.processing.deployment.model.element.AbstractFlowElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventSupplier;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectQueue;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.KeyGenerator;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public final class ElementActivationBehavior {
+
+  private final SideEffectQueue sideEffectQueue = new SideEffectQueue();
+
+  private final KeyGenerator keyGenerator;
+  private final TypedCommandWriter commandWriter;
+  private final StateWriter stateWriter;
+  private final CatchEventBehavior catchEventBehavior;
+
+  private final ElementInstanceState elementInstanceState;
+
+  public ElementActivationBehavior(
+      final KeyGenerator keyGenerator,
+      final Writers writers,
+      final CatchEventBehavior catchEventBehavior,
+      final ElementInstanceState elementInstanceState) {
+    this.keyGenerator = keyGenerator;
+    this.catchEventBehavior = catchEventBehavior;
+    this.elementInstanceState = elementInstanceState;
+    commandWriter = writers.command();
+    stateWriter = writers.state();
+  }
+
+  /**
+   * Activates the flow scopes of a given element. This is used when modifying a process instance or
+   * starting a process instance at a different place than the start event.
+   *
+   * @param processInstanceRecord the record of the process instance
+   * @param elementToActivate The element to activate
+   * @return The key of the activated element instance
+   */
+  public long activateElement(
+      final ProcessInstanceRecord processInstanceRecord,
+      final AbstractFlowElement elementToActivate) {
+
+    final var flowScopes = collectFlowScopesOfElement(elementToActivate);
+
+    final var flowScopeKey =
+        activateFlowScopes(
+            processInstanceRecord, processInstanceRecord.getProcessInstanceKey(), flowScopes);
+
+    final long elementInstanceKey =
+        activateElementByCommand(processInstanceRecord, elementToActivate, flowScopeKey);
+
+    // applying the side effects is part of creating the event subscriptions
+    sideEffectQueue.flush();
+
+    return elementInstanceKey;
+  }
+
+  private List<ExecutableFlowElement> collectFlowScopesOfElement(
+      final ExecutableFlowElement element) {
+    final List<ExecutableFlowElement> flowScopes = new ArrayList<>();
+
+    ExecutableFlowElement currentElement = element.getFlowScope();
+
+    while (currentElement != null) {
+      flowScopes.add(currentElement);
+
+      currentElement = currentElement.getFlowScope();
+    }
+
+    Collections.reverse(flowScopes);
+    return flowScopes;
+  }
+
+  private long activateFlowScopes(
+      final ProcessInstanceRecord processInstanceRecord,
+      final long flowScopeKey,
+      final List<ExecutableFlowElement> flowScopes) {
+
+    if (flowScopes.isEmpty()) {
+      return flowScopeKey;
+    }
+    final var flowScope = flowScopes.remove(0);
+
+    final List<ElementInstance> elementInstancesOfScope =
+        findElementInstances(flowScope, flowScopeKey);
+
+    if (elementInstancesOfScope.isEmpty()) {
+
+      final long elementInstanceKey =
+          activateFlowScope(processInstanceRecord, flowScopeKey, flowScope);
+      return activateFlowScopes(processInstanceRecord, elementInstanceKey, flowScopes);
+
+    } else if (elementInstancesOfScope.size() == 1) {
+      final var elementInstance = elementInstancesOfScope.get(0);
+      return activateFlowScopes(processInstanceRecord, elementInstance.getKey(), flowScopes);
+
+    } else {
+      // todo: deal with multiple flow scopes found without ancestor selection (#10008)
+      final var flowScopeId = BufferUtil.bufferAsString(flowScope.getId());
+      throw new UnsupportedOperationException(
+          "Found more than one flow scope instance with id '%s'.".formatted(flowScopeId));
+    }
+  }
+
+  private List<ElementInstance> findElementInstances(
+      final ExecutableFlowElement element, final long flowScopeKey) {
+
+    if (isProcess(element)) {
+      return Optional.ofNullable(elementInstanceState.getInstance(flowScopeKey))
+          .map(List::of)
+          .orElse(Collections.emptyList());
+
+    } else {
+      return elementInstanceState.getChildren(flowScopeKey).stream()
+          .filter(instance -> instance.getValue().getElementIdBuffer().equals(element.getId()))
+          .toList();
+    }
+  }
+
+  private static boolean isProcess(final ExecutableFlowElement element) {
+    return element.getElementType() == BpmnElementType.PROCESS;
+  }
+
+  private long activateFlowScope(
+      final ProcessInstanceRecord processInstanceRecord,
+      final long flowScopeKey,
+      final ExecutableFlowElement flowScope) {
+    final long elementInstanceKey;
+    final long elementInstanceFlowScopeKey;
+
+    if (isProcess(flowScope)) {
+      elementInstanceKey = processInstanceRecord.getProcessInstanceKey();
+      elementInstanceFlowScopeKey = -1L;
+
+    } else {
+      elementInstanceKey = keyGenerator.nextKey();
+      elementInstanceFlowScopeKey = flowScopeKey;
+    }
+
+    activateFlowScopeByEvents(
+        processInstanceRecord, flowScope, elementInstanceKey, elementInstanceFlowScopeKey);
+
+    return elementInstanceKey;
+  }
+
+  private void activateFlowScopeByEvents(
+      final ProcessInstanceRecord processInstanceRecord,
+      final ExecutableFlowElement element,
+      final long elementInstanceKey,
+      final long flowScopeKey) {
+
+    final var elementRecord = createElementRecord(processInstanceRecord, element, flowScopeKey);
+
+    stateWriter.appendFollowUpEvent(
+        elementInstanceKey, ProcessInstanceIntent.ELEMENT_ACTIVATING, elementRecord);
+    stateWriter.appendFollowUpEvent(
+        elementInstanceKey, ProcessInstanceIntent.ELEMENT_ACTIVATED, elementRecord);
+
+    createEventSubscriptions(element, elementRecord, elementInstanceKey);
+  }
+
+  private long activateElementByCommand(
+      final ProcessInstanceRecord processInstanceRecord,
+      final AbstractFlowElement elementToActivate,
+      final long flowScopeKey) {
+
+    final var elementInstanceKey = keyGenerator.nextKey();
+    final var elementRecord =
+        createElementRecord(processInstanceRecord, elementToActivate, flowScopeKey);
+    commandWriter.appendFollowUpCommand(
+        elementInstanceKey, ProcessInstanceIntent.ACTIVATE_ELEMENT, elementRecord);
+
+    return elementInstanceKey;
+  }
+
+  private ProcessInstanceRecord createElementRecord(
+      final ProcessInstanceRecord processInstanceRecord,
+      final ExecutableFlowElement elementToActivate,
+      final long flowScopeKey) {
+    final var elementInstanceRecord = new ProcessInstanceRecord();
+    // take the properties from the process instance
+    elementInstanceRecord.wrap(processInstanceRecord);
+    // override the properties for the specific element
+    elementInstanceRecord
+        .setElementId(elementToActivate.getId())
+        .setBpmnElementType(elementToActivate.getElementType())
+        .setFlowScopeKey(flowScopeKey)
+        .setParentProcessInstanceKey(-1L)
+        .setParentElementInstanceKey(-1L);
+
+    return elementInstanceRecord;
+  }
+
+  /**
+   * Create the event subscriptions of the given element. Assuming that the element instance is in
+   * state ACTIVATED.
+   */
+  private void createEventSubscriptions(
+      final ExecutableFlowElement element,
+      final ProcessInstanceRecord elementRecord,
+      final long elementInstanceKey) {
+
+    if (element instanceof ExecutableCatchEventSupplier catchEventSupplier) {
+      final var bpmnElementContext = new BpmnElementContextImpl();
+      bpmnElementContext.init(
+          elementInstanceKey, elementRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+
+      final Either<Failure, ?> subscribedOrFailure =
+          catchEventBehavior.subscribeToEvents(
+              bpmnElementContext, catchEventSupplier, sideEffectQueue);
+
+      if (subscribedOrFailure.isLeft()) {
+        final var message =
+            "expected to subscribe to catch event(s) of '%s' but %s"
+                .formatted(
+                    BufferUtil.bufferAsString(element.getId()),
+                    subscribedOrFailure.getLeft().getMessage());
+        throw new EventSubscriptionException(message);
+      }
+    }
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventSubscriptionException.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventSubscriptionException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.common;
+
+import io.camunda.zeebe.engine.api.TypedRecord;
+
+/**
+ * Exception that can be thrown during processing of a command, in case the engine could not
+ * subscribe to an event. This exception can be handled by the processor in {@link
+ * io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor#tryHandleError(TypedRecord,
+ * Throwable)}.
+ */
+public class EventSubscriptionException extends RuntimeException {
+
+  EventSubscriptionException(final String message) {
+    super(message);
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -159,11 +159,7 @@ public class ModifyProcessInstanceTest {
         .modify();
 
     // when
-    RecordingExporter.jobRecords(JobIntent.CREATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .limit(3)
-        .map(Record::getKey)
-        .forEach(jobKey -> ENGINE.job().withKey(jobKey).complete());
+    completeJobs(processInstanceKey, 3);
 
     // then
     verifyThatElementIsCompleted(processInstanceKey, "B");
@@ -291,11 +287,8 @@ public class ModifyProcessInstanceTest {
         .modify();
 
     // when
-    RecordingExporter.jobRecords(JobIntent.CREATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .limit(3) // 3 jobs as A creates another B
-        .map(Record::getKey)
-        .forEach(jobKey -> ENGINE.job().withKey(jobKey).complete());
+    // 3 jobs as A creates another B
+    completeJobs(processInstanceKey, 3);
 
     // then
     verifyThatElementIsCompleted(processInstanceKey, "B");
@@ -390,5 +383,13 @@ public class ModifyProcessInstanceTest {
                 .findAny())
         .describedAs("Expect the process instance to have been completed")
         .isPresent();
+  }
+
+  private static void completeJobs(final long processInstanceKey, final int numberOfJobs) {
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .limit(numberOfJobs)
+        .map(Record::getKey)
+        .forEach(jobKey -> ENGINE.job().withKey(jobKey).complete());
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -244,7 +244,7 @@ public class ModifyProcessInstanceTest {
   }
 
   @Test
-  public void shouldBeAbleToCompleteModfiedProcessInstance() {
+  public void shouldBeAbleToCompleteModifiedProcessInstance() {
     // given
     ENGINE
         .deployment()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -342,6 +342,12 @@ public class ModifyProcessInstanceTest {
         .modify();
 
     // then
+    verifyThatElementIsActivated(
+        processInstanceKey,
+        "event-subprocess",
+        BpmnElementType.EVENT_SUB_PROCESS,
+        processInstanceKey);
+
     final var eventSubprocessKey =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
             .withProcessInstanceKey(processInstanceKey)
@@ -354,17 +360,12 @@ public class ModifyProcessInstanceTest {
     verifyThatElementIsActivated(
         processInstanceKey, "C", BpmnElementType.USER_TASK, eventSubprocessKey);
 
-    verifyThatElementIsActivated(
-        processInstanceKey,
-        "event-subprocess",
-        BpmnElementType.EVENT_SUB_PROCESS,
-        processInstanceKey);
-
     // and
     completeJobs(processInstanceKey, 3);
 
     verifyThatElementIsCompleted(processInstanceKey, "B");
     verifyThatElementIsCompleted(processInstanceKey, "C");
+    verifyThatElementIsCompleted(processInstanceKey, "event-subprocess");
     verifyThatProcessInstanceIsCompleted(processInstanceKey);
   }
 
@@ -411,6 +412,17 @@ public class ModifyProcessInstanceTest {
         .modify();
 
     // then
+    verifyThatElementIsActivated(
+        processInstanceKey,
+        "event-subprocess-1",
+        BpmnElementType.EVENT_SUB_PROCESS,
+        processInstanceKey);
+    verifyThatElementIsActivated(
+        processInstanceKey,
+        "event-subprocess-2",
+        BpmnElementType.EVENT_SUB_PROCESS,
+        processInstanceKey);
+
     final var eventSubprocessKeysByElementId =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
             .withProcessInstanceKey(processInstanceKey)
@@ -429,22 +441,13 @@ public class ModifyProcessInstanceTest {
         BpmnElementType.USER_TASK,
         eventSubprocessKeysByElementId.get("event-subprocess-2"));
 
-    verifyThatElementIsActivated(
-        processInstanceKey,
-        "event-subprocess-1",
-        BpmnElementType.EVENT_SUB_PROCESS,
-        processInstanceKey);
-    verifyThatElementIsActivated(
-        processInstanceKey,
-        "event-subprocess-2",
-        BpmnElementType.EVENT_SUB_PROCESS,
-        processInstanceKey);
-
     // and
     completeJobs(processInstanceKey, 3);
 
     verifyThatElementIsCompleted(processInstanceKey, "B");
     verifyThatElementIsCompleted(processInstanceKey, "C");
+    verifyThatElementIsCompleted(processInstanceKey, "event-subprocess-1");
+    verifyThatElementIsCompleted(processInstanceKey, "event-subprocess-2");
     verifyThatProcessInstanceIsCompleted(processInstanceKey);
   }
 
@@ -495,12 +498,18 @@ public class ModifyProcessInstanceTest {
         .modify();
 
     // then
+    verifyThatElementIsActivated(
+        processInstanceKey, "subprocess", BpmnElementType.SUB_PROCESS, processInstanceKey);
+
     final var subprocessKey =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
             .withProcessInstanceKey(processInstanceKey)
             .withElementType(BpmnElementType.SUB_PROCESS)
             .getFirst()
             .getKey();
+
+    verifyThatElementIsActivated(
+        processInstanceKey, "event-subprocess", BpmnElementType.EVENT_SUB_PROCESS, subprocessKey);
 
     final var eventSubprocessKey =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
@@ -513,16 +522,13 @@ public class ModifyProcessInstanceTest {
         processInstanceKey, "B", BpmnElementType.SERVICE_TASK, eventSubprocessKey);
     verifyThatElementIsActivated(processInstanceKey, "C", BpmnElementType.USER_TASK, subprocessKey);
 
-    verifyThatElementIsActivated(
-        processInstanceKey, "subprocess", BpmnElementType.SUB_PROCESS, processInstanceKey);
-    verifyThatElementIsActivated(
-        processInstanceKey, "event-subprocess", BpmnElementType.EVENT_SUB_PROCESS, subprocessKey);
-
     // and
     completeJobs(processInstanceKey, 4);
 
     verifyThatElementIsCompleted(processInstanceKey, "B");
     verifyThatElementIsCompleted(processInstanceKey, "C");
+    verifyThatElementIsCompleted(processInstanceKey, "subprocess");
+    verifyThatElementIsCompleted(processInstanceKey, "event-subprocess");
     verifyThatProcessInstanceIsCompleted(processInstanceKey);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -162,16 +162,7 @@ public class ModifyProcessInstanceTest {
     ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
 
     // then
-    Assertions.assertThat(
-            RecordingExporter.processInstanceRecords()
-                .onlyEvents()
-                .withElementId("B")
-                .withProcessInstanceKey(processInstanceKey)
-                .limit("B", ProcessInstanceIntent.ELEMENT_COMPLETED))
-        .describedAs("Expect the element instance to have been completed")
-        .extracting(Record::getIntent)
-        .containsSequence(
-            ProcessInstanceIntent.ELEMENT_COMPLETING, ProcessInstanceIntent.ELEMENT_COMPLETED);
+    verifyThatElementIsCompleted(processInstanceKey, "B");
   }
 
   @Test
@@ -209,14 +200,7 @@ public class ModifyProcessInstanceTest {
         .forEach(jobKey -> ENGINE.job().withKey(jobKey).complete());
 
     // then
-    Assertions.assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementType(BpmnElementType.PROCESS)
-                .limitToProcessInstanceCompleted()
-                .findAny())
-        .describedAs("Expect the process instance to have been completed")
-        .isPresent();
+    verifyThatProcessInstanceIsCompleted(processInstanceKey);
   }
 
   @Test
@@ -347,14 +331,8 @@ public class ModifyProcessInstanceTest {
         .forEach(jobKey -> ENGINE.job().withKey(jobKey).complete());
 
     // then
-    Assertions.assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementType(BpmnElementType.PROCESS)
-                .limitToProcessInstanceCompleted()
-                .findAny())
-        .describedAs("Expect the process instance to have been completed")
-        .isPresent();
+    verifyThatElementIsCompleted(processInstanceKey, "B");
+    verifyThatProcessInstanceIsCompleted(processInstanceKey);
   }
 
   private static void verifyThatRootElementIsActivated(
@@ -418,5 +396,32 @@ public class ModifyProcessInstanceTest {
                 flowScopeKey,
                 -1L,
                 -1L));
+  }
+
+  private static void verifyThatElementIsCompleted(
+      final long processInstanceKey, final String elementId) {
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords()
+                .onlyEvents()
+                .withElementId(elementId)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(elementId, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .describedAs("Expect the element instance to have been completed")
+        .extracting(Record::getIntent)
+        .containsSequence(
+            ProcessInstanceIntent.ELEMENT_COMPLETING, ProcessInstanceIntent.ELEMENT_COMPLETED);
+  }
+
+  private static void verifyThatProcessInstanceIsCompleted(final long processInstanceKey) {
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .limitToProcessInstanceCompleted()
+                .findAny())
+        .describedAs("Expect the process instance to have been completed")
+        .isPresent();
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -8,18 +8,25 @@
 package io.camunda.zeebe.engine.processing.processinstance;
 
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.SubProcessBuilder;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.groups.Tuple;
 import org.junit.ClassRule;
@@ -293,6 +300,320 @@ public class ModifyProcessInstanceTest {
     // then
     verifyThatElementIsCompleted(processInstanceKey, "B");
     verifyThatProcessInstanceIsCompleted(processInstanceKey);
+  }
+
+  @Test
+  public void shouldActivateElementsInsideSameNonExistingFlowScope() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .eventSubProcess(
+                    "event-subprocess",
+                    s ->
+                        s.startEvent()
+                            .message(m -> m.name("start").zeebeCorrelationKeyExpression("key"))
+                            .parallelGateway("fork")
+                            .serviceTask("B", t -> t.zeebeJobType("B"))
+                            .moveToNode("fork")
+                            .userTask("C"))
+                .startEvent()
+                .userTask("A")
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("key", "1").create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .activateElement("B")
+        .activateElement("C")
+        .modify();
+
+    // then
+    final var eventSubprocessKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.EVENT_SUB_PROCESS)
+            .getFirst()
+            .getKey();
+
+    verifyThatElementIsActivated(
+        processInstanceKey, "B", BpmnElementType.SERVICE_TASK, eventSubprocessKey);
+    verifyThatElementIsActivated(
+        processInstanceKey, "C", BpmnElementType.USER_TASK, eventSubprocessKey);
+
+    verifyThatElementIsActivated(
+        processInstanceKey,
+        "event-subprocess",
+        BpmnElementType.EVENT_SUB_PROCESS,
+        processInstanceKey);
+
+    // and
+    completeJobs(processInstanceKey, 3);
+
+    verifyThatElementIsCompleted(processInstanceKey, "B");
+    verifyThatElementIsCompleted(processInstanceKey, "C");
+    verifyThatProcessInstanceIsCompleted(processInstanceKey);
+  }
+
+  @Test
+  public void shouldActivateElementsInsideDifferentNonExistingFlowScopes() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .eventSubProcess(
+                    "event-subprocess-1",
+                    s ->
+                        s.startEvent()
+                            .message(m -> m.name("start-1").zeebeCorrelationKeyExpression("key"))
+                            .serviceTask("B", t -> t.zeebeJobType("B")))
+                .eventSubProcess(
+                    "event-subprocess-2",
+                    s ->
+                        s.startEvent()
+                            .message(m -> m.name("start-2").zeebeCorrelationKeyExpression("key"))
+                            .userTask("C"))
+                .startEvent()
+                .userTask("A")
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("key", "1").create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .activateElement("B")
+        .activateElement("C")
+        .modify();
+
+    // then
+    final var eventSubprocessKeysByElementId =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.EVENT_SUB_PROCESS)
+            .limit(2)
+            .collect(Collectors.toMap(r -> r.getValue().getElementId(), Record::getKey));
+
+    verifyThatElementIsActivated(
+        processInstanceKey,
+        "B",
+        BpmnElementType.SERVICE_TASK,
+        eventSubprocessKeysByElementId.get("event-subprocess-1"));
+    verifyThatElementIsActivated(
+        processInstanceKey,
+        "C",
+        BpmnElementType.USER_TASK,
+        eventSubprocessKeysByElementId.get("event-subprocess-2"));
+
+    verifyThatElementIsActivated(
+        processInstanceKey,
+        "event-subprocess-1",
+        BpmnElementType.EVENT_SUB_PROCESS,
+        processInstanceKey);
+    verifyThatElementIsActivated(
+        processInstanceKey,
+        "event-subprocess-2",
+        BpmnElementType.EVENT_SUB_PROCESS,
+        processInstanceKey);
+
+    // and
+    completeJobs(processInstanceKey, 3);
+
+    verifyThatElementIsCompleted(processInstanceKey, "B");
+    verifyThatElementIsCompleted(processInstanceKey, "C");
+    verifyThatProcessInstanceIsCompleted(processInstanceKey);
+  }
+
+  @Test
+  public void shouldActivateElementsInsideNestedNonExistingFlowScopes() {
+    // given
+    final Consumer<SubProcessBuilder> subprocessBuilder =
+        subprocess ->
+            subprocess
+                .embeddedSubProcess()
+                .eventSubProcess(
+                    "event-subprocess",
+                    eventSubprocess ->
+                        eventSubprocess
+                            .startEvent()
+                            .message(m -> m.name("start").zeebeCorrelationKeyExpression("key"))
+                            .serviceTask("B", t -> t.zeebeJobType("B")))
+                .startEvent()
+                .userTask("C")
+                .endEvent();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask("A")
+                .subProcess("subprocess", subprocessBuilder)
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("key", "1").create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .activateElement("B")
+        .activateElement("C")
+        .modify();
+
+    // then
+    final var subprocessKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SUB_PROCESS)
+            .getFirst()
+            .getKey();
+
+    final var eventSubprocessKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.EVENT_SUB_PROCESS)
+            .getFirst()
+            .getKey();
+
+    verifyThatElementIsActivated(
+        processInstanceKey, "B", BpmnElementType.SERVICE_TASK, eventSubprocessKey);
+    verifyThatElementIsActivated(processInstanceKey, "C", BpmnElementType.USER_TASK, subprocessKey);
+
+    verifyThatElementIsActivated(
+        processInstanceKey, "subprocess", BpmnElementType.SUB_PROCESS, processInstanceKey);
+    verifyThatElementIsActivated(
+        processInstanceKey, "event-subprocess", BpmnElementType.EVENT_SUB_PROCESS, subprocessKey);
+
+    // and
+    completeJobs(processInstanceKey, 4);
+
+    verifyThatElementIsCompleted(processInstanceKey, "B");
+    verifyThatElementIsCompleted(processInstanceKey, "C");
+    verifyThatProcessInstanceIsCompleted(processInstanceKey);
+  }
+
+  @Test
+  public void shouldCreateEventSubscriptionsWhenActivatingElementsInsideNonExistingFlowScopes() {
+    // given
+    final Consumer<SubProcessBuilder> subprocessBuilder1 =
+        subprocess ->
+            subprocess
+                .embeddedSubProcess()
+                .eventSubProcess(
+                    "event-subprocess-1",
+                    eventSubprocess ->
+                        eventSubprocess
+                            .startEvent()
+                            .message(m -> m.name("start-1").zeebeCorrelationKeyExpression("key"))
+                            .endEvent())
+                .startEvent()
+                .serviceTask("B", t -> t.zeebeJobType("B"));
+
+    final Consumer<SubProcessBuilder> subprocessBuilder2 =
+        subprocess ->
+            subprocess
+                .embeddedSubProcess()
+                .eventSubProcess(
+                    "event-subprocess-2",
+                    eventSubprocess ->
+                        eventSubprocess
+                            .startEvent()
+                            .message(m -> m.name("start-2").zeebeCorrelationKeyExpression("key"))
+                            .endEvent())
+                .startEvent()
+                .userTask("C");
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask("A")
+                .subProcess("subprocess-1", subprocessBuilder1)
+                .subProcess("subprocess-2", subprocessBuilder2)
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("key", "1").create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .activateElement("B")
+        .activateElement("C")
+        .modify();
+
+    // then
+    final var subprocessKeysByElementId =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SUB_PROCESS)
+            .limit(2)
+            .collect(Collectors.toMap(r -> r.getValue().getElementId(), Record::getKey));
+
+    assertThat(
+            RecordingExporter.processMessageSubscriptionRecords(
+                    ProcessMessageSubscriptionIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(2))
+        .extracting(Record::getValue)
+        .extracting(
+            ProcessMessageSubscriptionRecordValue::getMessageName,
+            ProcessMessageSubscriptionRecordValue::getElementInstanceKey)
+        .describedAs("Expect one message subscription for each subprocess to be created")
+        .contains(
+            tuple("start-1", subprocessKeysByElementId.get("subprocess-1")),
+            tuple("start-2", subprocessKeysByElementId.get("subprocess-2")));
+
+    // and
+    ENGINE.message().withName("start-1").withCorrelationKey("1").publish();
+    ENGINE.message().withName("start-2").withCorrelationKey("1").publish();
+
+    verifyThatElementIsCompleted(processInstanceKey, "event-subprocess-1");
+    verifyThatElementIsCompleted(processInstanceKey, "event-subprocess-2");
   }
 
   private static void verifyThatRootElementIsActivated(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -132,41 +132,7 @@ public class ModifyProcessInstanceTest {
   }
 
   @Test
-  public void shouldBeAbleToCompleteActivatedRootElement() {
-    // given
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .serviceTask("A", a -> a.zeebeJobType("A"))
-                .serviceTask("B", b -> b.zeebeJobType("B"))
-                .endEvent()
-                .done())
-        .deploy();
-
-    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withElementType(BpmnElementType.PROCESS)
-        .await();
-
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .modification()
-        .activateElement("B")
-        .modify();
-
-    // when
-    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
-
-    // then
-    verifyThatElementIsCompleted(processInstanceKey, "B");
-  }
-
-  @Test
-  public void shouldBeAbleToCompleteModifiedProcessInstance() {
+  public void shouldCompleteModifiedProcessInstanceWithActivatedRootElements() {
     // given
     ENGINE
         .deployment()
@@ -200,6 +166,7 @@ public class ModifyProcessInstanceTest {
         .forEach(jobKey -> ENGINE.job().withKey(jobKey).complete());
 
     // then
+    verifyThatElementIsCompleted(processInstanceKey, "B");
     verifyThatProcessInstanceIsCompleted(processInstanceKey);
   }
 
@@ -291,7 +258,7 @@ public class ModifyProcessInstanceTest {
   }
 
   @Test
-  public void shouldCompletedProcessInstanceWhenElementsInsideExistingFlowScopesAreCompleted() {
+  public void shouldCompleteModifiedProcessInstanceWithActivatedElementsInExistingFlowScope() {
     // given
     ENGINE
         .deployment()


### PR DESCRIPTION
## Description

* support modifying a process instance with activating elements inside non-existing flow scopes
* reuse the logic from the `CreateProcessInstance` processor to activate the elements. but also restructure/rewrite the logic a bit to handle non-existing and existing instances of flow scopes 

## Related issues

closes #9643 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
