### PR TITLE
Disable setup-maven on macOS

### DIFF
--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -18,9 +18,9 @@ inputs:
     description: The JDK version to setup
     default: "17"
     required: false
-  maven-version:
-    description: The Maven version to setup
-    default: "3.8.5"
+  maven:
+    description: If true, will set up Maven; defaults to true
+    default: "true"
     required: false
 
 outputs: {}
@@ -33,10 +33,10 @@ runs:
       with:
         distribution: 'temurin'
         java-version: ${{ inputs.java-version }}
-    - if: ${{ inputs.java == 'true' }}
+    - if: ${{ inputs.java == 'true' && inputs.maven == 'true' }}
       uses: stCarolas/setup-maven@v4.4
       with:
-        maven-version: ${{ inputs.maven-version }}
+        maven-version: '3.8.5'
     - if: ${{ inputs.go == 'true' }}
       uses: actions/setup-go@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,6 +165,8 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
+          # setting up maven often times out on macOS
+          maven: ${{ matrix.os != 'macos-latest' }}
       - uses: ./.github/actions/build-zeebe
         with:
           go: false


### PR DESCRIPTION
## Description

Removes the `maven-version` input for the `setup-zeebe` action, and instead hard codes the version (since we want the same version everywhere, and there's no use case to customize it yet). Instead, adds a new input `maven`, which is a boolean param, controlling whether maven will be installed or not.

Hopefully this fixes the issues on macOS where setting up maven times out, or we run out of cache code space.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
