### PR TITLE
Refactor LongPollingIT to have a narrower/stricter scope

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Loggers.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Loggers.java
@@ -13,6 +13,8 @@ import org.slf4j.LoggerFactory;
 public final class Loggers {
 
   public static final Logger GATEWAY_LOGGER = LoggerFactory.getLogger("io.camunda.zeebe.gateway");
+  public static final Logger LONG_POLLING =
+      LoggerFactory.getLogger("io.camunda.zeebe.gateway.longPolling");
   public static final Logger GATEWAY_CFG_LOGGER =
       LoggerFactory.getLogger("io.camunda.zeebe.gateway.impl.configuration");
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InflightActivateJobsRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/InflightActivateJobsRequest.java
@@ -21,7 +21,7 @@ import org.slf4j.Logger;
 
 public class InflightActivateJobsRequest {
 
-  private static final Logger LOG = Loggers.GATEWAY_LOGGER;
+  private static final Logger LOG = Loggers.LONG_POLLING;
   private final long requestId;
   private final BrokerActivateJobsRequest request;
   private final ServerStreamObserver<ActivateJobsResponse> responseObserver;
@@ -197,7 +197,7 @@ public class InflightActivateJobsRequest {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(final Object obj) {
     if (this == obj) {
       return true;
     }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -36,7 +36,7 @@ import org.slf4j.Logger;
 public final class LongPollingActivateJobsHandler implements ActivateJobsHandler {
 
   private static final String JOBS_AVAILABLE_TOPIC = "jobsAvailable";
-  private static final Logger LOG = Loggers.GATEWAY_LOGGER;
+  private static final Logger LOG = Loggers.LONG_POLLING;
   private static final String ERROR_MSG_ACTIVATED_EXHAUSTED =
       "Expected to activate jobs of type '%s', but no jobs available and at least one broker returned 'RESOURCE_EXHAUSTED'. Please try again later.";
 
@@ -68,7 +68,7 @@ public final class LongPollingActivateJobsHandler implements ActivateJobsHandler
   }
 
   @Override
-  public void accept(ActorControl actor) {
+  public void accept(final ActorControl actor) {
     this.actor = actor;
     activateJobsHandler.accept(actor);
     onActorStarted();

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
@@ -7,98 +7,144 @@
  */
 package io.camunda.zeebe.it.clustering;
 
-import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
+import io.camunda.zeebe.gateway.Loggers;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.process.test.assertions.BpmnAssert;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.qa.util.actuator.LoggersActuator;
 import io.camunda.zeebe.qa.util.testcontainers.ContainerLogsDumper;
 import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.test.util.record.RecordStream;
+import io.zeebe.containers.ZeebeGatewayNode;
+import io.zeebe.containers.ZeebePort;
 import io.zeebe.containers.cluster.ZeebeCluster;
+import io.zeebe.containers.engine.ContainerEngine;
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.StreamSupport;
 import org.agrona.CloseHelper;
-import org.assertj.core.api.Assertions;
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Testcontainers
 final class LongPollingIT {
-  private static final Logger LOGGER = LoggerFactory.getLogger(LongPollingIT.class);
-  private static final BpmnModelInstance PROCESS =
-      Bpmn.createExecutableProcess("process")
-          .startEvent()
-          .serviceTask("task", t -> t.zeebeJobType("foo"))
-          .endEvent()
-          .done();
-
-  private Network network;
-  private ZeebeCluster cluster;
-
-  @SuppressWarnings("unused")
-  @RegisterExtension
-  final ContainerLogsDumper gatewayLogsWatcher =
-      new ContainerLogsDumper(() -> cluster.getGateways(), LOGGER);
+  private final Network network = Network.newNetwork();
+  private final ZeebeCluster cluster =
+      ZeebeCluster.builder()
+          .withBrokersCount(1)
+          .withGatewaysCount(1)
+          .withPartitionsCount(1)
+          .withEmbeddedGateway(false)
+          .withImage(ZeebeTestContainerDefaults.defaultTestImage())
+          .withGatewayConfig(this::configureGateway)
+          .build();
 
   @SuppressWarnings("unused")
   @RegisterExtension
-  final ContainerLogsDumper brokerLogsWatcher =
-      new ContainerLogsDumper(() -> cluster.getBrokers(), LOGGER);
+  final ContainerLogsDumper logsWatcher = new ContainerLogsDumper(cluster::getNodes);
+
+  @Container
+  private final ContainerEngine engine =
+      ContainerEngine.builder().withCluster(cluster).withIdlePeriod(Duration.ofSeconds(5)).build();
 
   @BeforeEach
   void beforeEach() {
-    network = Network.newNetwork();
+    // set log level for long polling to trace to have more debugging info when the test fails
+    for (final var gateway : cluster.getGateways().values()) {
+      LoggersActuator.of(gateway).set(Loggers.LONG_POLLING.getName(), Level.TRACE);
+    }
   }
 
   @AfterEach
   void afterEach() {
-    CloseHelper.quietCloseAll(cluster, network);
+    CloseHelper.quietCloseAll(network);
   }
 
   // regression test of https://github.com/camunda/zeebe/issues/9658
   @Test
-  void shouldActivateAndCompleteJobsInTime() {
+  void shouldActivateAndCompleteJobsInTime() throws InterruptedException, TimeoutException {
     // given
-    cluster =
-        ZeebeCluster.builder()
-            .withBrokersCount(1)
-            .withGatewaysCount(1)
-            .withEmbeddedGateway(false)
-            .withPartitionsCount(3)
-            .withReplicationFactor(1)
-            .withImage(ZeebeTestContainerDefaults.defaultTestImage())
-            .build();
-    cluster.start();
-    final var zeebeClient = cluster.newClientBuilder().build();
-    final var deploymentEvent =
-        zeebeClient
-            .newDeployResourceCommand()
-            .addProcessModel(PROCESS, "process.bpmn")
-            .send()
-            .join();
-    // open the worker first and cause so to run into long polling mode
-    zeebeClient
-        .newWorker()
-        .jobType("foo")
-        .handler((c, j) -> c.newCompleteCommand(j).send())
-        .timeout(Duration.ofSeconds(10))
-        .pollInterval(Duration.ofMillis(10))
-        .open();
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("foo"))
+            .endEvent()
+            .done();
 
-    // when
-    final var resultZeebeFuture =
-        zeebeClient
-            .newCreateInstanceCommand()
-            .processDefinitionKey(deploymentEvent.getProcesses().get(0).getProcessDefinitionKey())
-            .withResult()
-            .send();
+    try (final var client = engine.createClient()) {
+      final var deploymentEvent =
+          client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
 
-    // then
-    Assertions.assertThat((CompletionStage<ProcessInstanceResult>) resultZeebeFuture)
-        .succeedsWithin(2, TimeUnit.SECONDS)
-        .isNotNull();
+      // when - send the ActivateJobs request first, before the process instance is created
+      final var jobs =
+          client
+              .newActivateJobsCommand()
+              .jobType("foo")
+              .maxJobsToActivate(1)
+              .requestTimeout(Duration.ofSeconds(30))
+              .send();
+
+      // wait until the first activate command before starting the process instance to ensure long
+      // polling will come in effect
+      engine.waitForIdleState(Duration.ofSeconds(30));
+      records()
+          .withIntent(JobBatchIntent.ACTIVATE)
+          .findFirst()
+          .orElseThrow(
+              () ->
+                  new IllegalStateException(
+                      "Expected at least one job batch ACTIVATE command, but none found"));
+      client
+          .newCreateInstanceCommand()
+          .processDefinitionKey(deploymentEvent.getProcesses().get(0).getProcessDefinitionKey())
+          .requestTimeout(Duration.ofMinutes(1))
+          .send()
+          .join();
+
+      // then - ensure that we tried to activate before the job was created, and that we activated
+      // it AGAIN after it was created, without the client sending a new request
+      engine.waitForIdleState(Duration.ofSeconds(30));
+      assertThat(records())
+          .extracting(Record::getValueType, Record::getIntent)
+          .containsSubsequence(
+              Tuple.tuple(ValueType.JOB_BATCH, JobBatchIntent.ACTIVATE),
+              Tuple.tuple(ValueType.JOB, JobIntent.CREATED),
+              Tuple.tuple(ValueType.JOB_BATCH, JobBatchIntent.ACTIVATE));
+      assertThat((CompletionStage<ActivateJobsResponse>) jobs)
+          .succeedsWithin(30, TimeUnit.SECONDS)
+          .extracting(ActivateJobsResponse::getJobs)
+          .asList()
+          .hasSize(1);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private RecordStream records() {
+    return new RecordStream(
+        StreamSupport.stream(BpmnAssert.getRecordStream().records().spliterator(), false)
+            .map(r -> (Record<RecordValue>) r));
+  }
+
+  private void configureGateway(final ZeebeGatewayNode<?> gateway) {
+    gateway
+        .withEnv("ZEEBE_GATEWAY_LONGPOLLING_ENABLED", "true")
+        // https://github.com/camunda-community-hub/zeebe-test-container/issues/332
+        .addExposedPort(ZeebePort.MONITORING.getPort());
   }
 }

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/LoggersActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/LoggersActuator.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.actuator;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import feign.Feign;
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import feign.Retryer;
+import feign.Target.HardCodedTarget;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import io.zeebe.containers.ZeebeNode;
+import org.slf4j.event.Level;
+
+/**
+ * Java interface for any node's loggers actuator. To instantiate this interface, you can use {@link
+ * Feign}; see {@link #of(String)} as an example.
+ *
+ * <p>You can use one of {@link #of(String)} or {@link #of(ZeebeNode)} to create a new client to use
+ * for yourself.
+ *
+ * <p>Adding a new method is simple: simply define the input/output here as you normally would, and
+ * make sure to add the correct JSON encoding headers (`Accept` for the response type,
+ * `Content-Type` if there's a body to send).
+ */
+@SuppressWarnings({"unused", "UnusedReturnValue"})
+public interface LoggersActuator {
+
+  /**
+   * Returns a {@link LoggersActuator} instance using the given node as upstream.
+   *
+   * @param node the node to connect to
+   * @return a new instance of {@link LoggersActuator}
+   */
+  static LoggersActuator of(final ZeebeNode<?> node) {
+    final var endpoint =
+        String.format("http://%s/actuator/loggers", node.getExternalMonitoringAddress());
+    return of(endpoint);
+  }
+
+  /**
+   * Returns a {@link LoggersActuator} instance using the given endpoint as upstream. The endpoint
+   * is expected to be a complete absolute URL, e.g. "http://localhost:9600/actuator/loggers".
+   *
+   * @param endpoint the actuator URL to connect to
+   * @return a new instance of {@link LoggersActuator}
+   */
+  @SuppressWarnings("JavadocLinkAsPlainText")
+  static LoggersActuator of(final String endpoint) {
+    final var target = new HardCodedTarget<>(LoggersActuator.class, endpoint);
+    return Feign.builder()
+        .encoder(new JacksonEncoder())
+        .decoder(new JacksonDecoder())
+        .retryer(Retryer.NEVER_RETRY)
+        .target(target);
+  }
+
+  /**
+   * A convenience method to set the level of a logger remotely via the Spring Boot actuator, using
+   * SLF4J levels as input to avoid any errors (e.g. typos).
+   *
+   * @param id the logger ID, e.g. io.camunda.zeebe.gateway
+   * @param level the level you wish to set
+   */
+  default void set(final String id, final Level level) {
+    set(id, new LoggerInfo(level.toString(), null));
+  }
+
+  @RequestLine("POST /{id}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  void set(@Param final String id, final LoggerInfo level);
+
+  @RequestLine("POST /{id}")
+  @Headers("Accept: application/json")
+  LoggerInfo get(@Param final String id);
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonInclude(Include.NON_EMPTY)
+  record LoggerInfo(String configuredLevel, String effectiveLevel) {}
+}

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
@@ -28,8 +28,8 @@ import java.util.Map;
  *
  * <p>Adding a new method is simple: simply define the input/output here as you normally would, and
  * make sure to add the correct JSON encoding headers (`Accept` for the response type,
- * `Content-Type` if there's a body to send). See {@link io.zeebe.containers.clock.ZeebeClockClient}
- * for a more complete example.
+ * `Content-Type` if there's a body to send). See {@link LoggersActuator} for a more complete
+ * example.
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public interface PartitionsActuator {


### PR DESCRIPTION
## Description

Refactors the LongPollingIT to be of narrower scope. The main idea is that the test now does the following:

- The first activate command is processed before the create process instance command
- Once the job created event is applied, a new job activate command should be sent again without the client having done so
- The client receives the job

To do that, we send the activate requests manually (to avoid the worker re-polling and thus getting the job without going through long polling). This ensures the client only sent a single request, and that if there are two ACTIVATE commands on the logs, it must have come from long polling.

Refactoring also includes:

- Simplification of set up (e.g. dumping logs of all nodes in a single extension, only using a single partition, etc.)
- Setting the long polling logger to trace for more information on failure
- Using `ContainerEngine` to be able to assert the ordering of the commands on the log, as well as getting the log printed out on failure

## Related issues

closes #9740 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
