### PR TITLE
Increase topology changes timers

### DIFF
--- a/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -46,8 +46,8 @@ import org.testcontainers.utility.DockerImageName;
  * These tests are here to detect when rolling update between one version to the next are not
  * possible. If we decide that they aren't between versions, we can disable or adjust assumptions.
  *
- * <p>The important part is that we should be aware whether or not rolling update is possible
- * between versions.
+ * <p>The important part is that we should be aware whether rolling update is possible between
+ * versions.
  */
 final class RollingUpdateTest {
 
@@ -104,7 +104,7 @@ final class RollingUpdateTest {
       broker.start();
 
       Awaitility.await()
-          .atMost(Duration.ofSeconds(5))
+          .atMost(Duration.ofSeconds(120))
           .pollInterval(Duration.ofMillis(100))
           .untilAsserted(() -> assertTopologyContainsUpdatedBroker(client, index));
     }
@@ -121,7 +121,7 @@ final class RollingUpdateTest {
 
       // potentially retry in case we're faster than the deployment distribution
       Awaitility.await("process instance creation")
-          .atMost(Duration.ofSeconds(5))
+          .atMost(Duration.ofSeconds(30))
           .pollInterval(Duration.ofMillis(100))
           .ignoreExceptions()
           .until(() -> createProcessInstance(client), Objects::nonNull)
@@ -134,13 +134,13 @@ final class RollingUpdateTest {
 
     try (final var client = cluster.newClientBuilder().build()) {
       Awaitility.await("broker is removed from topology")
-          .atMost(Duration.ofSeconds(20))
+          .atMost(Duration.ofSeconds(120))
           .pollInterval(Duration.ofMillis(100))
           .untilAsserted(() -> assertTopologyDoesNotContainerBroker(client, brokerId));
 
       for (int i = 0; i < 100; i++) {
         Awaitility.await("process instance creation")
-            .atMost(Duration.ofSeconds(5))
+            .atMost(Duration.ofSeconds(30))
             .pollInterval(Duration.ofMillis(100))
             .ignoreExceptions()
             .until(() -> createProcessInstance(client), Objects::nonNull)
@@ -163,7 +163,7 @@ final class RollingUpdateTest {
       updateBroker(broker);
       broker.start();
       Awaitility.await("updated broker is added to topology")
-          .atMost(Duration.ofSeconds(10))
+          .atMost(Duration.ofSeconds(120))
           .pollInterval(Duration.ofMillis(100))
           .untilAsserted(() -> assertTopologyContainsUpdatedBroker(client, brokerId));
     }
@@ -185,7 +185,7 @@ final class RollingUpdateTest {
       // potentially retry in case we're faster than the deployment distribution
       firstProcessInstanceKey =
           Awaitility.await("process instance creation")
-              .atMost(Duration.ofSeconds(5))
+              .atMost(Duration.ofSeconds(30))
               .pollInterval(Duration.ofMillis(100))
               .ignoreExceptions()
               .until(() -> createProcessInstance(client), Objects::nonNull)
@@ -199,14 +199,14 @@ final class RollingUpdateTest {
         broker.stop();
 
         Awaitility.await("broker is removed from topology")
-            .atMost(Duration.ofSeconds(10))
+            .atMost(Duration.ofSeconds(120))
             .pollInterval(Duration.ofMillis(100))
             .untilAsserted(() -> assertTopologyDoesNotContainerBroker(client, brokerId));
 
         updateBroker(broker);
         broker.start();
         Awaitility.await("updated broker is added to topology")
-            .atMost(Duration.ofSeconds(10))
+            .atMost(Duration.ofSeconds(120))
             .pollInterval(Duration.ofMillis(100))
             .untilAsserted(() -> assertTopologyContainsUpdatedBroker(client, brokerId));
 


### PR DESCRIPTION
## Description

This PR tentatively fixes #10030 by increasing the timeout everywhere we expect topology changes. This takes into account two things:

1. Topology changes may take a while to get propagated, and not always at the same rate
1. Leader election in Raft isn't strictly bounded I think, meaning while it should not take too long, you could be unlucky and it may take more than one round of votes to elect a leader. 10 seconds is a little too tight in this sense, so we give a generous timeout.

Since we're not going for performance here, I think it's OK to wait longer. It means if the test fails you also wait longer, but that is only a big issue when reproducing locally, and you can always change it then.

## Related issues

closes #10030 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
