### PR TITLE
Run scheduled Task only in Processing Phase

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/api/EmptyTaskResult.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/EmptyTaskResult.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.api;
+
+import io.camunda.zeebe.logstreams.log.LogStreamBatchWriter;
+
+public final class EmptyTaskResult implements TaskResult {
+
+  public static final TaskResult INSTANCE = new EmptyTaskResult();
+
+  private EmptyTaskResult() {}
+
+  @Override
+  public long writeRecordsToStream(final LogStreamBatchWriter logStreamBatchWriter) {
+    return 0;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
@@ -56,7 +56,16 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService 
      * this only works because this class is scheduled on the same actor as the
      * stream processor.
      */
-    runAtFixedRate(delay, toRunnable(task));
+    runDelayed(
+        delay,
+        toRunnable(
+            builder -> {
+              try {
+                return task.execute(builder);
+              } finally {
+                runAtFixedRate(delay, task);
+              }
+            }));
   }
 
   private void scheduleOnActor(final Runnable task) {

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
@@ -26,6 +26,7 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService 
   private final StreamProcessorContext streamProcessorContext;
   private final AbortableRetryStrategy writeRetryStrategy;
 
+  // todo remove context from CTOR; will be cleaned up after engine abstraction is done
   public ProcessingScheduleServiceImpl(final StreamProcessorContext streamProcessorContext) {
     actorControl = streamProcessorContext.getActor();
     this.streamProcessorContext = streamProcessorContext;

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
@@ -83,7 +83,8 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService 
         //  * we are not running during suspending
         //  * we are not interfering with the current ongoing processing,
         //    such that all transaction changes are available during our task execution
-        Loggers.PROCESS_PROCESSOR_LOGGER.trace("Not able to execute scheduled task right now. [streamProcessorPhase: {}, inProcessing: {}]",
+        Loggers.PROCESS_PROCESSOR_LOGGER.trace(
+            "Not able to execute scheduled task right now. [streamProcessorPhase: {}, inProcessing: {}]",
             currentStreamProcessorPhase,
             streamProcessorContext.isInProcessing());
         actorControl.submit(toRunnable(task));

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
@@ -103,8 +103,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private ProcessingStateMachine processingStateMachine;
   private ReplayStateMachine replayStateMachine;
 
-  private volatile Phase phase = Phase.INITIAL;
-
   private CompletableActorFuture<Void> openFuture;
   private final CompletableActorFuture<Void> closeFuture = new CompletableActorFuture<>();
   private volatile long lastTickTime;
@@ -183,7 +181,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
       if (!shouldProcess) {
         setStateToPausedAndNotifyListeners();
       } else {
-        phase = Phase.REPLAY;
+        streamProcessorContext.phase(Phase.REPLAY);
       }
 
       if (isInReplayOnlyMode()) {
@@ -245,7 +243,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   @Override
   public void onActorFailed() {
-    phase = Phase.FAILED;
+    streamProcessorContext.phase(Phase.FAILED);
     isOpened.set(false);
     lifecycleAwareListeners.forEach(StreamProcessorLifecycleAware::onFailed);
     tearDown();
@@ -277,7 +275,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
       streamProcessorContext.logStreamBatchWriter(batchWriter);
 
-      phase = Phase.PROCESSING;
+      streamProcessorContext.phase(Phase.PROCESSING);
 
       processingStateMachine =
           new ProcessingStateMachine(
@@ -399,7 +397,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   }
 
   public boolean isFailed() {
-    return phase == Phase.FAILED;
+    return streamProcessorContext.getPhase() == Phase.FAILED;
   }
 
   public ActorFuture<Long> getLastProcessedPositionAsync() {
@@ -447,7 +445,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     // If healthCheckTick was not invoked it indicates the actor is blocked in a runUntilDone loop.
     if (ActorClock.currentTimeMillis() - lastTickTime > HEALTH_CHECK_TICK_DURATION.toMillis() * 2) {
       return HealthReport.unhealthy(this).withMessage("actor appears blocked");
-    } else if (phase == Phase.FAILED) {
+    } else if (streamProcessorContext.getPhase() == Phase.FAILED) {
       return HealthReport.unhealthy(this).withMessage("in failed phase");
     } else {
       return HealthReport.healthy(this);
@@ -465,7 +463,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   }
 
   public ActorFuture<Phase> getCurrentPhase() {
-    return actor.call(() -> phase);
+    return actor.call(streamProcessorContext::getPhase);
   }
 
   public ActorFuture<Void> pauseProcessing() {
@@ -494,7 +492,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     }
 
     shouldProcess = false;
-    phase = Phase.PAUSED;
+    streamProcessorContext.phase(Phase.PAUSED);
   }
 
   public void resumeProcessing() {
@@ -504,14 +502,14 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
             shouldProcess = true;
 
             if (isInReplayOnlyMode() || !replayCompletedFuture.isDone()) {
-              phase = Phase.REPLAY;
+              streamProcessorContext.phase(Phase.REPLAY);
               actor.submit(replayStateMachine::replayNextEvent);
               LOG.debug("Resumed replay for partition {}", partitionId);
             } else {
               // we only want to call the lifecycle listeners on processing resume
               // since the listeners are not recovered yet
               lifecycleAwareListeners.forEach(StreamProcessorLifecycleAware::onResumed);
-              phase = Phase.PROCESSING;
+              streamProcessorContext.phase(Phase.PROCESSING);
               if (processingStateMachine != null) {
                 actor.submit(processingStateMachine::readNextRecord);
               }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.logstreams.log.LogStreamBatchWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.scheduler.ActorControl;
+import io.camunda.zeebe.streamprocessor.StreamProcessor.Phase;
 import io.camunda.zeebe.streamprocessor.state.MutableLastProcessedPositionState;
 import java.util.function.BooleanSupplier;
 
@@ -60,6 +61,9 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   // this is always accessed by the same actor; which means we don't need to use a concurrent/thread
   // safe structure here
   private boolean inProcessing;
+
+  // this is accessed outside, which is why we need to make sure that it is thread-safe
+  private volatile StreamProcessor.Phase phase = Phase.INITIAL;
 
   public StreamProcessorContext actor(final ActorControl actor) {
     this.actor = actor;
@@ -225,5 +229,13 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   public void partitionCommandSender(final InterPartitionCommandSender partitionCommandSender) {
     this.partitionCommandSender = partitionCommandSender;
+  }
+
+  public Phase getPhase() {
+    return phase;
+  }
+
+  public void phase(final Phase phase) {
+    this.phase = phase;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
@@ -231,11 +231,11 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
     this.partitionCommandSender = partitionCommandSender;
   }
 
-  public Phase getPhase() {
+  public Phase getStreamProcessorPhase() {
     return phase;
   }
 
-  public void phase(final Phase phase) {
+  public void streamProcessorPhase(final Phase phase) {
     this.phase = phase;
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
@@ -200,6 +200,22 @@ public class ProcessingScheduleServiceTest {
         .process(Mockito.argThat(record -> record.getKey() == 1), any());
   }
 
+  @Test
+  public void shouldScheduleOnFixedRate() {
+    // given
+    final var dummyProcessorSpy = spy(dummyProcessor);
+    streamPlatform.withRecordProcessors(List.of(dummyProcessorSpy)).startStreamProcessor();
+
+    // when
+    dummyProcessorSpy.scheduleService.runAtFixedRate(
+        Duration.ofMillis(100),
+        (builder) -> builder.appendCommandRecord(1, ACTIVATE_ELEMENT, RECORD).build());
+
+    // then
+    verify(dummyProcessorSpy, TIMEOUT.times(5))
+        .process(Mockito.argThat(record -> record.getKey() == 1), any());
+  }
+
   private static final class DummyTask implements Task {
     @Override
     public TaskResult execute(final TaskResultBuilder taskResultBuilder) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
@@ -8,21 +8,26 @@
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import static io.camunda.zeebe.engine.util.RecordToWrite.command;
+import static io.camunda.zeebe.engine.util.RecordToWrite.event;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.zeebe.engine.api.EmptyProcessingResult;
+import io.camunda.zeebe.engine.api.EmptyTaskResult;
 import io.camunda.zeebe.engine.api.ProcessingResult;
 import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
 import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.api.RecordProcessor;
 import io.camunda.zeebe.engine.api.RecordProcessorContext;
 import io.camunda.zeebe.engine.api.Task;
+import io.camunda.zeebe.engine.api.TaskResult;
+import io.camunda.zeebe.engine.api.TaskResultBuilder;
 import io.camunda.zeebe.engine.api.TypedRecord;
 import io.camunda.zeebe.engine.util.Records;
 import io.camunda.zeebe.engine.util.StreamPlatform;
@@ -59,6 +64,7 @@ public class ProcessingScheduleServiceTest {
 
   @AfterEach
   public void clean() {
+    dummyProcessor.continueReplay();
     dummyProcessor.continueProcessing();
   }
 
@@ -66,7 +72,7 @@ public class ProcessingScheduleServiceTest {
   public void shouldExecuteScheduledTask() {
     // given
     streamPlatform.withRecordProcessors(List.of(dummyProcessor)).startStreamProcessor();
-    final var mockedTask = mock(Task.class);
+    final var mockedTask = spy(new DummyTask());
 
     // when
     dummyProcessor.scheduleService.runDelayed(Duration.ZERO, mockedTask);
@@ -81,7 +87,7 @@ public class ProcessingScheduleServiceTest {
     dummyProcessor.blockProcessing();
     streamPlatform.writeBatch(command().processInstance(ACTIVATE_ELEMENT, RECORD));
     streamPlatform.withRecordProcessors(List.of(dummyProcessor)).startStreamProcessor();
-    final var mockedTask = mock(Task.class);
+    final var mockedTask = spy(new DummyTask());
 
     // when
     dummyProcessor.scheduleService.runDelayed(Duration.ZERO, mockedTask);
@@ -96,7 +102,7 @@ public class ProcessingScheduleServiceTest {
     dummyProcessor.blockProcessing();
     streamPlatform.writeBatch(command().processInstance(ACTIVATE_ELEMENT, RECORD));
     streamPlatform.withRecordProcessors(List.of(dummyProcessor)).startStreamProcessor();
-    final var mockedTask = mock(Task.class);
+    final var mockedTask = spy(new DummyTask());
 
     // when
     dummyProcessor.scheduleService.runDelayed(Duration.ZERO, mockedTask);
@@ -107,6 +113,74 @@ public class ProcessingScheduleServiceTest {
     verify(mockedTask, TIMEOUT).execute(any());
   }
 
+  @Test
+  public void shouldNotExecuteScheduledTaskIfOnReplay() {
+    // given
+    dummyProcessor.blockReplay();
+    streamPlatform.writeBatch(
+        command().processInstance(ACTIVATE_ELEMENT, RECORD),
+        event().processInstance(ELEMENT_ACTIVATING, RECORD).causedBy(0));
+    streamPlatform.withRecordProcessors(List.of(dummyProcessor)).startStreamProcessorNotAwaitOpening();
+    final var mockedTask = spy(new DummyTask());
+
+    // when
+    dummyProcessor.scheduleService.runDelayed(Duration.ZERO, mockedTask);
+
+    // then
+    verify(mockedTask, never()).execute(any());
+  }
+
+  @Test
+  public void shouldExecuteScheduledTaskAfterReplay() {
+    // given
+    final var processor = spy(dummyProcessor);
+    processor.blockReplay();
+    streamPlatform.writeBatch(
+        command().processInstance(ACTIVATE_ELEMENT, RECORD),
+        event().processInstance(ELEMENT_ACTIVATING, RECORD).causedBy(0));
+    streamPlatform.withRecordProcessors(List.of(processor)).startStreamProcessorNotAwaitOpening();
+    final var mockedTask = spy(new DummyTask());
+
+    // when
+    processor.scheduleService.runDelayed(Duration.ZERO, mockedTask);
+    processor.continueReplay();
+
+    // then
+    final var inOrder = inOrder(processor, mockedTask);
+    inOrder.verify(processor, TIMEOUT).init(any());
+    inOrder.verify(processor, TIMEOUT).replay(any());
+    inOrder.verify(mockedTask, TIMEOUT).execute(any());
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldNotExecuteScheduledTaskIfSuspended() {
+    // given
+    streamPlatform.withRecordProcessors(List.of(dummyProcessor)).startStreamProcessor();
+    streamPlatform.pauseProcessing();
+    final var mockedTask = spy(new DummyTask());
+
+    // when
+    dummyProcessor.scheduleService.runDelayed(Duration.ZERO, mockedTask);
+
+    // then
+    verify(mockedTask, never()).execute(any());
+  }
+
+  @Test
+  public void shouldExecuteScheduledTaskAfterResumed() {
+    // given
+    streamPlatform.withRecordProcessors(List.of(dummyProcessor)).startStreamProcessor();
+    streamPlatform.pauseProcessing();
+    final var mockedTask = spy(new DummyTask());
+
+    // when
+    dummyProcessor.scheduleService.runDelayed(Duration.ZERO, mockedTask);
+    streamPlatform.resumeProcessing();
+
+    // then
+    verify(mockedTask, TIMEOUT).execute(any());
+  }
   @Test
   public void shouldWriteRecordAfterTaskWasExecuted() {
     // given
@@ -123,10 +197,18 @@ public class ProcessingScheduleServiceTest {
         .process(Mockito.argThat(record -> record.getKey() == 1), any());
   }
 
+  private static final class DummyTask implements Task {
+    @Override
+    public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
+      return EmptyTaskResult.INSTANCE;
+    }
+  }
+
   private static final class DummyProcessor implements RecordProcessor {
 
     private ProcessingScheduleService scheduleService;
-    private CountDownLatch latch;
+    private CountDownLatch processingLatch;
+    private CountDownLatch replayLatch;
 
     @Override
     public void init(final RecordProcessorContext recordProcessorContext) {
@@ -140,15 +222,21 @@ public class ProcessingScheduleServiceTest {
 
     @Override
     public void replay(final TypedRecord record) {
-      // do nothing
+      if (replayLatch != null) {
+        try {
+          replayLatch.await();
+        } catch (final InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }
     }
 
     @Override
     public ProcessingResult process(
         final TypedRecord record, final ProcessingResultBuilder processingResultBuilder) {
-      if (latch != null) {
+      if (processingLatch != null) {
         try {
-          latch.await();
+          processingLatch.await();
         } catch (final InterruptedException e) {
           throw new RuntimeException(e);
         }
@@ -165,12 +253,22 @@ public class ProcessingScheduleServiceTest {
     }
 
     public void blockProcessing() {
-      latch = new CountDownLatch(1);
+      processingLatch = new CountDownLatch(1);
     }
 
     public void continueProcessing() {
-      if (latch != null) {
-        latch.countDown();
+      if (processingLatch != null) {
+        processingLatch.countDown();
+      }
+    }
+
+    public void blockReplay() {
+      replayLatch = new CountDownLatch(1);
+    }
+
+    public void continueReplay() {
+      if (replayLatch != null) {
+        replayLatch.countDown();
       }
     }
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
@@ -120,7 +120,9 @@ public class ProcessingScheduleServiceTest {
     streamPlatform.writeBatch(
         command().processInstance(ACTIVATE_ELEMENT, RECORD),
         event().processInstance(ELEMENT_ACTIVATING, RECORD).causedBy(0));
-    streamPlatform.withRecordProcessors(List.of(dummyProcessor)).startStreamProcessorNotAwaitOpening();
+    streamPlatform
+        .withRecordProcessors(List.of(dummyProcessor))
+        .startStreamProcessorNotAwaitOpening();
     final var mockedTask = spy(new DummyTask());
 
     // when
@@ -181,6 +183,7 @@ public class ProcessingScheduleServiceTest {
     // then
     verify(mockedTask, TIMEOUT).execute(any());
   }
+
   @Test
   public void shouldWriteRecordAfterTaskWasExecuted() {
     // given

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
@@ -182,6 +182,12 @@ public final class StreamPlatform {
     return buildStreamProcessor(stream, null, true);
   }
 
+  public StreamProcessor startStreamProcessorNotAwaitOpening() {
+    final var logName = getLogName(DEFAULT_PARTITION);
+    final SynchronousLogStream stream = getLogStream(logName);
+    return buildStreamProcessor(stream, null, false);
+  }
+
   public StreamProcessor buildStreamProcessor(
       final SynchronousLogStream stream,
       final Function<LogStreamBatchWriter, LegacyTypedStreamWriter> streamWriterFactory,
@@ -242,11 +248,22 @@ public final class StreamPlatform {
     return streamProcessor;
   }
 
+  public void pauseProcessing() {
+    pauseProcessing(getLogName(DEFAULT_PARTITION));
+  }
+
+  // todo remove multi partition support - is not necessary for the StreamProcessor tests
+  @Deprecated
   public void pauseProcessing(final String streamName) {
     streamContextMap.get(streamName).streamProcessor.pauseProcessing().join();
     LOG.info("Paused processing for stream {}", streamName);
   }
 
+  public void resumeProcessing() {
+    resumeProcessing(getLogName(DEFAULT_PARTITION));
+  }
+  // todo remove multi partition support - is not necessary for the StreamProcessor tests
+  @Deprecated
   public void resumeProcessing(final String streamName) {
     streamContextMap.get(streamName).streamProcessor.resumeProcessing();
     LOG.info("Resume processing for stream {}", streamName);


### PR DESCRIPTION
## Description
This PR makes sure that we no longer run Tasks in other phases than in Processing. 


>     We want to execute the scheduled tasks only if the StreamProcessor is in the PROCESSING
>     PHASE, but no processing is currently happening.
>     
>     To make sure that:
>     
>      * we are not running during replay/init phase (the state might not be up-to-date yet)
>      * we are not running during suspending
>      * we are not interfering with the current ongoing processing,
>        such that all transaction changes are available during our task execution
> 


This means when the StreamProcessor is suspended scheduled Tasks are not executed they are put back to the queue this was the simplest solution for now, since we have no Actor suspend feature for now #10006. Furthermore, we no longer run scheduled tasks on replay since this might also lead to issues (because the state is not yet fully rebuild etc.)

Added tests for certain aspects of this feature.
    

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/9962
closes https://github.com/camunda/zeebe/issues/9999
closes https://github.com/camunda/zeebe/issues/8642 (this will no longer happen since the abort condition is also verified in the SchedulingService)

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
