### PR TITLE
Disable building in parallel

### DIFF
--- a/.github/actions/build-zeebe/action.yml
+++ b/.github/actions/build-zeebe/action.yml
@@ -39,7 +39,7 @@ runs:
       shell: bash
       id: build-java
       run: |
-        mvn -B -DskipTests -DskipChecks -T1C install ${{ inputs.maven-extra-args }}
+        mvn -B -DskipTests -DskipChecks install ${{ inputs.maven-extra-args }}
         export BUILD_DIR=$(mvn -pl dist/ help:evaluate -Dexpression=project.build.directory -q -DforceStdout)
         export ARTIFACT=$(mvn -pl dist/ help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
         echo "::set-output name=result::${BUILD_DIR}/${ARTIFACT}.tar.gz"

--- a/.github/actions/build-zeebe/action.yml
+++ b/.github/actions/build-zeebe/action.yml
@@ -38,6 +38,8 @@ runs:
       name: Package Zeebe
       shell: bash
       id: build-java
+      # we do not build in parallel to avoid memory and cache corruption issues, notably observed
+      # on macOS and Windows
       run: |
         mvn -B -DskipTests -DskipChecks install ${{ inputs.maven-extra-args }}
         export BUILD_DIR=$(mvn -pl dist/ help:evaluate -Dexpression=project.build.directory -q -DforceStdout)

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -90,7 +90,6 @@ jobs:
         with:
           # give it a fake name to ensure we never try pushing it
           repository: localhost:5000/camunda/zeebe
-          package: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
       - name: Verify Docker image
         env:


### PR DESCRIPTION
## Description

This PR disables building in parallel, as this sometimes causes issues on certain systems (especially non-Linux systems). As we mostly care about testing in parallel (as testing is where we spend the bulk of our time), I think it's safe to disable this for now.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
