### PR TITLE
Refactor BpmnBehaviors

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -99,8 +99,7 @@ public final class EngineProcessors {
             typedRecordProcessors,
             subscriptionCommandSender,
             writers,
-            timerChecker,
-            jobMetrics);
+            timerChecker);
 
     JobEventProcessors.addJobProcessors(
         typedRecordProcessors,
@@ -165,20 +164,14 @@ public final class EngineProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final SubscriptionCommandSender subscriptionCommandSender,
       final Writers writers,
-      final DueDateTimerChecker timerChecker,
-      final JobMetrics jobMetrics) {
+      final DueDateTimerChecker timerChecker) {
     return ProcessEventProcessors.addProcessProcessors(
         zeebeState,
-        bpmnBehaviors.expressionBehavior(),
+        bpmnBehaviors,
         typedRecordProcessors,
         subscriptionCommandSender,
-        bpmnBehaviors.catchEventBehavior(),
         timerChecker,
-        bpmnBehaviors.eventTriggerBehavior(),
-        writers,
-        jobMetrics,
-        bpmnBehaviors.jobBehavior(),
-        bpmnBehaviors.incidentBehavior());
+        writers);
   }
 
   private static void addDeploymentRelatedProcessorAndServices(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -188,8 +188,7 @@ public final class EngineProcessors {
     final var processor =
         new DeploymentCreateProcessor(
             zeebeState,
-            bpmnBehaviors.catchEventBehavior(),
-            bpmnBehaviors.expressionBehavior(),
+            bpmnBehaviors,
             partitionsCount,
             writers,
             deploymentDistributionCommandSender,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -157,7 +157,6 @@ public final class EngineProcessors {
         catchEventBehavior,
         variableBehavior,
         eventTriggerBehavior,
-        null, // TODO processor lookup
         writers,
         jobMetrics,
         processEngineMetrics);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
@@ -72,7 +72,8 @@ public final class ProcessEventProcessors {
         writers, typedRecordProcessors, zeebeState.getElementInstanceState());
 
     final var bpmnStreamProcessor =
-        new BpmnStreamProcessor(bpmnBehaviors, zeebeState, writers, sideEffectQueue);
+        new BpmnStreamProcessor(
+            bpmnBehaviors, zeebeState, writers, sideEffectQueue, processEngineMetrics);
     addBpmnStepProcessor(typedRecordProcessors, bpmnStreamProcessor);
 
     addMessageStreamProcessors(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCommand
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceModificationProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
+import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectQueue;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.CancelTimerProcessor;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
@@ -51,7 +52,8 @@ public final class ProcessEventProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final SubscriptionCommandSender subscriptionCommandSender,
       final DueDateTimerChecker timerChecker,
-      final Writers writers) {
+      final Writers writers,
+      final SideEffectQueue sideEffectQueue) {
     final MutableProcessMessageSubscriptionState subscriptionState =
         zeebeState.getProcessMessageSubscriptionState();
     final var keyGenerator = zeebeState.getKeyGenerator();
@@ -69,7 +71,8 @@ public final class ProcessEventProcessors {
     addProcessInstanceCommandProcessor(
         writers, typedRecordProcessors, zeebeState.getElementInstanceState());
 
-    final var bpmnStreamProcessor = new BpmnStreamProcessor(bpmnBehaviors, zeebeState, writers);
+    final var bpmnStreamProcessor =
+        new BpmnStreamProcessor(bpmnBehaviors, zeebeState, writers, sideEffectQueue);
     addBpmnStepProcessor(typedRecordProcessors, bpmnStreamProcessor);
 
     addMessageStreamProcessors(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/ProcessEventProcessors.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.engine.processing.timer.CancelTimerProcessor;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
 import io.camunda.zeebe.engine.processing.timer.TriggerTimerProcessor;
 import io.camunda.zeebe.engine.processing.variable.UpdateVariableDocumentProcessor;
-import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ZeebeState;
@@ -58,10 +57,6 @@ public final class ProcessEventProcessors {
     final var keyGenerator = zeebeState.getKeyGenerator();
 
     // TODO put this inside the bpmnBehaviors
-    final VariableBehavior variableBehavior =
-        new VariableBehavior(zeebeState.getVariableState(), writers.state(), keyGenerator);
-
-    // TODO put this inside the bpmnBehaviors
     final var elementActivationBehavior =
         new ElementActivationBehavior(
             keyGenerator,
@@ -88,7 +83,7 @@ public final class ProcessEventProcessors {
         typedRecordProcessors, timerChecker, zeebeState, bpmnBehaviors, writers);
     addVariableDocumentStreamProcessors(
         typedRecordProcessors,
-        variableBehavior,
+        bpmnBehaviors,
         zeebeState.getElementInstanceState(),
         keyGenerator,
         writers);
@@ -96,7 +91,7 @@ public final class ProcessEventProcessors {
         typedRecordProcessors,
         zeebeState,
         writers,
-       variableBehavior, bpmnBehaviors,
+        bpmnBehaviors,
         elementActivationBehavior,
         processEngineMetrics);
     addProcessInstanceModificationStreamProcessors(
@@ -190,7 +185,7 @@ public final class ProcessEventProcessors {
 
   private static void addVariableDocumentStreamProcessors(
       final TypedRecordProcessors typedRecordProcessors,
-      final VariableBehavior variableBehavior,
+      final BpmnBehaviors bpmnBehaviors,
       final ElementInstanceState elementInstanceState,
       final KeyGenerator keyGenerator,
       final Writers writers) {
@@ -198,14 +193,13 @@ public final class ProcessEventProcessors {
         ValueType.VARIABLE_DOCUMENT,
         VariableDocumentIntent.UPDATE,
         new UpdateVariableDocumentProcessor(
-            elementInstanceState, keyGenerator, variableBehavior, writers));
+            elementInstanceState, keyGenerator, bpmnBehaviors.variableBehavior(), writers));
   }
 
   private static void addProcessInstanceCreationStreamProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final MutableZeebeState zeebeState,
       final Writers writers,
-      final VariableBehavior variableBehavior,
       final BpmnBehaviors bpmnBehaviors,
       final ElementActivationBehavior elementActivationBehavior,
       final ProcessEngineMetrics metrics) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.bpmn;
 
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.container.CallActivityProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.container.EventSubProcessProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.container.MultiInstanceBodyProcessor;
@@ -36,42 +37,77 @@ public final class BpmnElementProcessors {
   private final Map<BpmnElementType, BpmnElementProcessor<?>> processors =
       new EnumMap<>(BpmnElementType.class);
 
-  public BpmnElementProcessors(final BpmnBehaviors bpmnBehaviors) {
+  public BpmnElementProcessors(
+      final BpmnBehaviors bpmnBehaviors,
+      final BpmnStateTransitionBehavior stateTransitionBehavior) {
     // tasks
-    processors.put(BpmnElementType.SERVICE_TASK, new JobWorkerTaskProcessor(bpmnBehaviors));
     processors.put(
-        BpmnElementType.BUSINESS_RULE_TASK, new BusinessRuleTaskProcessor(bpmnBehaviors));
-    processors.put(BpmnElementType.SCRIPT_TASK, new JobWorkerTaskProcessor(bpmnBehaviors));
-    processors.put(BpmnElementType.SEND_TASK, new JobWorkerTaskProcessor(bpmnBehaviors));
-    processors.put(BpmnElementType.USER_TASK, new JobWorkerTaskProcessor(bpmnBehaviors));
-    processors.put(BpmnElementType.RECEIVE_TASK, new ReceiveTaskProcessor(bpmnBehaviors));
-    processors.put(BpmnElementType.MANUAL_TASK, new ManualTaskProcessor(bpmnBehaviors));
+        BpmnElementType.SERVICE_TASK,
+        new JobWorkerTaskProcessor(bpmnBehaviors, stateTransitionBehavior));
+    processors.put(
+        BpmnElementType.BUSINESS_RULE_TASK,
+        new BusinessRuleTaskProcessor(bpmnBehaviors, stateTransitionBehavior));
+    processors.put(
+        BpmnElementType.SCRIPT_TASK,
+        new JobWorkerTaskProcessor(bpmnBehaviors, stateTransitionBehavior));
+    processors.put(
+        BpmnElementType.SEND_TASK,
+        new JobWorkerTaskProcessor(bpmnBehaviors, stateTransitionBehavior));
+    processors.put(
+        BpmnElementType.USER_TASK,
+        new JobWorkerTaskProcessor(bpmnBehaviors, stateTransitionBehavior));
+    processors.put(
+        BpmnElementType.RECEIVE_TASK,
+        new ReceiveTaskProcessor(bpmnBehaviors, stateTransitionBehavior));
+    processors.put(
+        BpmnElementType.MANUAL_TASK,
+        new ManualTaskProcessor(bpmnBehaviors, stateTransitionBehavior));
 
     // gateways
-    processors.put(BpmnElementType.EXCLUSIVE_GATEWAY, new ExclusiveGatewayProcessor(bpmnBehaviors));
-    processors.put(BpmnElementType.PARALLEL_GATEWAY, new ParallelGatewayProcessor(bpmnBehaviors));
     processors.put(
-        BpmnElementType.EVENT_BASED_GATEWAY, new EventBasedGatewayProcessor(bpmnBehaviors));
-    processors.put(BpmnElementType.INCLUSIVE_GATEWAY, new InclusiveGatewayProcessor(bpmnBehaviors));
+        BpmnElementType.EXCLUSIVE_GATEWAY,
+        new ExclusiveGatewayProcessor(bpmnBehaviors, stateTransitionBehavior));
+    processors.put(
+        BpmnElementType.PARALLEL_GATEWAY,
+        new ParallelGatewayProcessor(bpmnBehaviors, stateTransitionBehavior));
+    processors.put(
+        BpmnElementType.EVENT_BASED_GATEWAY,
+        new EventBasedGatewayProcessor(bpmnBehaviors, stateTransitionBehavior));
+    processors.put(
+        BpmnElementType.INCLUSIVE_GATEWAY,
+        new InclusiveGatewayProcessor(bpmnBehaviors, stateTransitionBehavior));
 
     // containers
-    processors.put(BpmnElementType.PROCESS, new ProcessProcessor(bpmnBehaviors));
-    processors.put(BpmnElementType.SUB_PROCESS, new SubProcessProcessor(bpmnBehaviors));
-    processors.put(BpmnElementType.EVENT_SUB_PROCESS, new EventSubProcessProcessor(bpmnBehaviors));
     processors.put(
-        BpmnElementType.MULTI_INSTANCE_BODY, new MultiInstanceBodyProcessor(bpmnBehaviors));
-    processors.put(BpmnElementType.CALL_ACTIVITY, new CallActivityProcessor(bpmnBehaviors));
+        BpmnElementType.PROCESS, new ProcessProcessor(bpmnBehaviors, stateTransitionBehavior));
+    processors.put(
+        BpmnElementType.SUB_PROCESS,
+        new SubProcessProcessor(bpmnBehaviors, stateTransitionBehavior));
+    processors.put(
+        BpmnElementType.EVENT_SUB_PROCESS,
+        new EventSubProcessProcessor(bpmnBehaviors, stateTransitionBehavior));
+    processors.put(
+        BpmnElementType.MULTI_INSTANCE_BODY,
+        new MultiInstanceBodyProcessor(bpmnBehaviors, stateTransitionBehavior));
+    processors.put(
+        BpmnElementType.CALL_ACTIVITY,
+        new CallActivityProcessor(bpmnBehaviors, stateTransitionBehavior));
 
     // events
-    processors.put(BpmnElementType.START_EVENT, new StartEventProcessor(bpmnBehaviors));
+    processors.put(
+        BpmnElementType.START_EVENT,
+        new StartEventProcessor(bpmnBehaviors, stateTransitionBehavior));
     processors.put(
         BpmnElementType.INTERMEDIATE_CATCH_EVENT,
-        new IntermediateCatchEventProcessor(bpmnBehaviors));
+        new IntermediateCatchEventProcessor(bpmnBehaviors, stateTransitionBehavior));
     processors.put(
         BpmnElementType.INTERMEDIATE_THROW_EVENT,
-        new IntermediateThrowEventProcessor(bpmnBehaviors));
-    processors.put(BpmnElementType.END_EVENT, new EndEventProcessor(bpmnBehaviors));
-    processors.put(BpmnElementType.BOUNDARY_EVENT, new BoundaryEventProcessor(bpmnBehaviors));
+        new IntermediateThrowEventProcessor(bpmnBehaviors, stateTransitionBehavior));
+    processors.put(
+        BpmnElementType.END_EVENT, new EndEventProcessor(bpmnBehaviors, stateTransitionBehavior));
+    processors.put(
+        BpmnElementType.BOUNDARY_EVENT,
+        new BoundaryEventProcessor(bpmnBehaviors, stateTransitionBehavior));
   }
 
   public <T extends ExecutableFlowElement> BpmnElementProcessor<T> getProcessor(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -31,9 +31,9 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
 
   private static final Logger LOGGER = Loggers.PROCESS_PROCESSOR_LOGGER;
 
-  private final SideEffectQueue sideEffectQueue = new SideEffectQueue();
   private final BpmnElementContextImpl context = new BpmnElementContextImpl();
 
+  private final SideEffectQueue sideEffectQueue;
   private final ProcessState processState;
   private final BpmnElementProcessors processors;
   private final ProcessInstanceStateTransitionGuard stateTransitionGuard;
@@ -44,7 +44,8 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
   public BpmnStreamProcessor(
       final BpmnBehaviors bpmnBehaviors,
       final MutableZeebeState zeebeState,
-      final Writers writers) {
+      final Writers writers,
+      final SideEffectQueue sideEffectQueue) {
     processState = zeebeState.getProcessState();
 
     rejectionWriter = writers.rejection();
@@ -53,6 +54,7 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
 
     stateTransitionGuard = bpmnBehaviors.stateTransitionGuard();
     stateTransitionBehavior = bpmnBehaviors.stateTransitionBehavior();
+    this.sideEffectQueue = sideEffectQueue;
   }
 
   // TODO figure out how to get this in the bpmn behaviors

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -52,7 +52,6 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
 
     rejectionWriter = writers.rejection();
     incidentBehavior = bpmnBehaviors.incidentBehavior();
-    processors = new BpmnElementProcessors(bpmnBehaviors);
     stateTransitionGuard = bpmnBehaviors.stateTransitionGuard();
     stateTransitionBehavior =
         new BpmnStateTransitionBehavior(
@@ -61,10 +60,10 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
             processEngineMetrics,
             this::getContainerProcessor,
             writers);
+    processors = new BpmnElementProcessors(bpmnBehaviors, stateTransitionBehavior);
     this.sideEffectQueue = sideEffectQueue;
   }
 
-  // TODO figure out how to get this in the bpmn behaviors
   private BpmnElementContainerProcessor<ExecutableFlowElement> getContainerProcessor(
       final BpmnElementType elementType) {
     return processors.getContainerProcessor(elementType);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.processing.bpmn.ProcessInstanceStateTransitionGua
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
+import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 
 public interface BpmnBehaviors {
 
@@ -43,4 +44,6 @@ public interface BpmnBehaviors {
   CatchEventBehavior catchEventBehavior();
 
   EventTriggerBehavior eventTriggerBehavior();
+
+  VariableBehavior variableBehavior();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import io.camunda.zeebe.engine.processing.bpmn.ProcessInstanceStateTransitionGuard;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
+import io.camunda.zeebe.engine.processing.common.ElementActivationBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
@@ -44,4 +45,6 @@ public interface BpmnBehaviors {
   EventTriggerBehavior eventTriggerBehavior();
 
   VariableBehavior variableBehavior();
+
+  ElementActivationBehavior elementActivationBehavior();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
@@ -29,8 +29,6 @@ public interface BpmnBehaviors {
 
   BpmnStateBehavior stateBehavior();
 
-  BpmnStateTransitionBehavior stateTransitionBehavior();
-
   ProcessInstanceStateTransitionGuard stateTransitionGuard();
 
   BpmnProcessResultSenderBehavior processResultSenderBehavior();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import io.camunda.zeebe.engine.processing.bpmn.ProcessInstanceStateTransitionGuard;
+import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
+import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 
 public interface BpmnBehaviors {
@@ -37,4 +39,8 @@ public interface BpmnBehaviors {
   BpmnJobBehavior jobBehavior();
 
   MultiInstanceOutputCollectionBehavior outputCollectionBehavior();
+
+  CatchEventBehavior catchEventBehavior();
+
+  EventTriggerBehavior eventTriggerBehavior();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.ProcessInstanceStateTransitionGuard;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
+import io.camunda.zeebe.engine.processing.common.ElementActivationBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffects;
@@ -38,6 +39,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   private final CatchEventBehavior catchEventBehavior;
   private final EventTriggerBehavior eventTriggerBehavior;
   private final VariableBehavior variableBehavior;
+  private final ElementActivationBehavior elementActivationBehavior;
 
   public BpmnBehaviorsImpl(
       final ExpressionProcessor expressionBehavior,
@@ -96,6 +98,12 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
     this.variableBehavior =
         new VariableBehavior(
             zeebeState.getVariableState(), writers.state(), zeebeState.getKeyGenerator());
+    elementActivationBehavior =
+        new ElementActivationBehavior(
+            zeebeState.getKeyGenerator(),
+            writers,
+            catchEventBehavior,
+            zeebeState.getElementInstanceState());
   }
 
   @Override
@@ -171,5 +179,10 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   @Override
   public VariableBehavior variableBehavior() {
     return variableBehavior;
+  }
+
+  @Override
+  public ElementActivationBehavior elementActivationBehavior() {
+    return elementActivationBehavior;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -42,6 +42,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   private final MultiInstanceOutputCollectionBehavior multiInstanceOutputCollectionBehavior;
   private final CatchEventBehavior catchEventBehavior;
   private final EventTriggerBehavior eventTriggerBehavior;
+  private final VariableBehavior variableBehavior;
 
   public BpmnBehaviorsImpl(
       final ExpressionProcessor expressionBehavior,
@@ -106,6 +107,9 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
         new MultiInstanceOutputCollectionBehavior(stateBehavior, expressionBehavior());
     this.catchEventBehavior = catchEventBehavior;
     this.eventTriggerBehavior = eventTriggerBehavior;
+    this.variableBehavior =
+        new VariableBehavior(
+            zeebeState.getVariableState(), writers.state(), zeebeState.getKeyGenerator());
   }
 
   @Override
@@ -181,5 +185,10 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   @Override
   public EventTriggerBehavior eventTriggerBehavior() {
     return eventTriggerBehavior;
+  }
+
+  @Override
+  public VariableBehavior variableBehavior() {
+    return variableBehavior;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -40,6 +40,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   private final BpmnJobBehavior jobBehavior;
 
   private final MultiInstanceOutputCollectionBehavior multiInstanceOutputCollectionBehavior;
+  private final CatchEventBehavior catchEventBehavior;
+  private final EventTriggerBehavior eventTriggerBehavior;
 
   public BpmnBehaviorsImpl(
       final ExpressionProcessor expressionBehavior,
@@ -100,9 +102,10 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             stateBehavior,
             incidentBehavior,
             jobMetrics);
-
     multiInstanceOutputCollectionBehavior =
         new MultiInstanceOutputCollectionBehavior(stateBehavior, expressionBehavior());
+    this.catchEventBehavior = catchEventBehavior;
+    this.eventTriggerBehavior = eventTriggerBehavior;
   }
 
   @Override
@@ -168,5 +171,15 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   @Override
   public MultiInstanceOutputCollectionBehavior outputCollectionBehavior() {
     return multiInstanceOutputCollectionBehavior;
+  }
+
+  @Override
+  public CatchEventBehavior catchEventBehavior() {
+    return catchEventBehavior;
+  }
+
+  @Override
+  public EventTriggerBehavior eventTriggerBehavior() {
+    return eventTriggerBehavior;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -10,19 +10,15 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 import io.camunda.zeebe.dmn.DecisionEngineFactory;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
-import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContainerProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.ProcessInstanceStateTransitionGuard;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
-import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.streamprocessor.sideeffect.SideEffects;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
-import io.camunda.zeebe.protocol.record.value.BpmnElementType;
-import java.util.function.Function;
 
 public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
@@ -33,7 +29,6 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   private final BpmnEventSubscriptionBehavior eventSubscriptionBehavior;
   private final BpmnIncidentBehavior incidentBehavior;
   private final BpmnStateBehavior stateBehavior;
-  private final BpmnStateTransitionBehavior stateTransitionBehavior;
   private final ProcessInstanceStateTransitionGuard stateTransitionGuard;
   private final BpmnProcessResultSenderBehavior processResultSenderBehavior;
   private final BpmnBufferedMessageStartEventBehavior bufferedMessageStartEventBehavior;
@@ -51,8 +46,6 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final CatchEventBehavior catchEventBehavior,
       final VariableBehavior variableBehavior,
       final EventTriggerBehavior eventTriggerBehavior,
-      final Function<BpmnElementType, BpmnElementContainerProcessor<ExecutableFlowElement>>
-          processorLookup,
       final Writers writers,
       final JobMetrics jobMetrics,
       final ProcessEngineMetrics processEngineMetrics) {
@@ -74,13 +67,6 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
     stateTransitionGuard = new ProcessInstanceStateTransitionGuard(stateBehavior);
     variableMappingBehavior =
         new BpmnVariableMappingBehavior(expressionBehavior, zeebeState, variableBehavior);
-    stateTransitionBehavior =
-        new BpmnStateTransitionBehavior(
-            zeebeState.getKeyGenerator(),
-            stateBehavior,
-            processEngineMetrics,
-            processorLookup,
-            writers);
     eventSubscriptionBehavior =
         new BpmnEventSubscriptionBehavior(
             catchEventBehavior, eventTriggerBehavior, sideEffects, zeebeState);
@@ -145,11 +131,6 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   @Override
   public BpmnStateBehavior stateBehavior() {
     return stateBehavior;
-  }
-
-  @Override
-  public BpmnStateTransitionBehavior stateTransitionBehavior() {
-    return stateTransitionBehavior;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -41,9 +41,11 @@ public final class CallActivityProcessor
   private final BpmnEventSubscriptionBehavior eventSubscriptionBehavior;
   private final BpmnVariableMappingBehavior variableMappingBehavior;
 
-  public CallActivityProcessor(final BpmnBehaviors bpmnBehaviors) {
+  public CallActivityProcessor(
+      final BpmnBehaviors bpmnBehaviors,
+      final BpmnStateTransitionBehavior stateTransitionBehavior) {
     expressionProcessor = bpmnBehaviors.expressionBehavior();
-    stateTransitionBehavior = bpmnBehaviors.stateTransitionBehavior();
+    this.stateTransitionBehavior = stateTransitionBehavior;
     stateBehavior = bpmnBehaviors.stateBehavior();
     incidentBehavior = bpmnBehaviors.incidentBehavior();
     eventSubscriptionBehavior = bpmnBehaviors.eventSubscriptionBehavior();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
@@ -25,9 +25,11 @@ public final class EventSubProcessProcessor
   private final BpmnVariableMappingBehavior variableMappingBehavior;
   private final BpmnIncidentBehavior incidentBehavior;
 
-  public EventSubProcessProcessor(final BpmnBehaviors bpmnBehaviors) {
+  public EventSubProcessProcessor(
+      final BpmnBehaviors bpmnBehaviors,
+      final BpmnStateTransitionBehavior stateTransitionBehavior) {
     stateBehavior = bpmnBehaviors.stateBehavior();
-    stateTransitionBehavior = bpmnBehaviors.stateTransitionBehavior();
+    this.stateTransitionBehavior = stateTransitionBehavior;
     variableMappingBehavior = bpmnBehaviors.variableMappingBehavior();
     incidentBehavior = bpmnBehaviors.incidentBehavior();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -63,8 +63,10 @@ public final class MultiInstanceBodyProcessor
   private final BpmnIncidentBehavior incidentBehavior;
   private final MultiInstanceOutputCollectionBehavior multiInstanceOutputCollectionBehavior;
 
-  public MultiInstanceBodyProcessor(final BpmnBehaviors bpmnBehaviors) {
-    stateTransitionBehavior = bpmnBehaviors.stateTransitionBehavior();
+  public MultiInstanceBodyProcessor(
+      final BpmnBehaviors bpmnBehaviors,
+      final BpmnStateTransitionBehavior stateTransitionBehavior) {
+    this.stateTransitionBehavior = stateTransitionBehavior;
     eventSubscriptionBehavior = bpmnBehaviors.eventSubscriptionBehavior();
     stateBehavior = bpmnBehaviors.stateBehavior();
     expressionBehavior = bpmnBehaviors.expressionBehavior();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -36,9 +36,11 @@ public final class ProcessProcessor
   private final BpmnProcessResultSenderBehavior processResultSenderBehavior;
   private final BpmnBufferedMessageStartEventBehavior bufferedMessageStartEventBehavior;
 
-  public ProcessProcessor(final BpmnBehaviors bpmnBehaviors) {
+  public ProcessProcessor(
+      final BpmnBehaviors bpmnBehaviors,
+      final BpmnStateTransitionBehavior stateTransitionBehavior) {
     stateBehavior = bpmnBehaviors.stateBehavior();
-    stateTransitionBehavior = bpmnBehaviors.stateTransitionBehavior();
+    this.stateTransitionBehavior = stateTransitionBehavior;
     eventSubscriptionBehavior = bpmnBehaviors.eventSubscriptionBehavior();
     incidentBehavior = bpmnBehaviors.incidentBehavior();
     processResultSenderBehavior = bpmnBehaviors.processResultSenderBehavior();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -31,9 +31,11 @@ public final class SubProcessProcessor
   private final BpmnVariableMappingBehavior variableMappingBehavior;
   private final BpmnIncidentBehavior incidentBehavior;
 
-  public SubProcessProcessor(final BpmnBehaviors bpmnBehaviors) {
+  public SubProcessProcessor(
+      final BpmnBehaviors bpmnBehaviors,
+      final BpmnStateTransitionBehavior stateTransitionBehavior) {
     stateBehavior = bpmnBehaviors.stateBehavior();
-    stateTransitionBehavior = bpmnBehaviors.stateTransitionBehavior();
+    this.stateTransitionBehavior = stateTransitionBehavior;
     eventSubscriptionBehavior = bpmnBehaviors.eventSubscriptionBehavior();
     variableMappingBehavior = bpmnBehaviors.variableMappingBehavior();
     incidentBehavior = bpmnBehaviors.incidentBehavior();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/BoundaryEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/BoundaryEventProcessor.java
@@ -22,8 +22,10 @@ public final class BoundaryEventProcessor implements BpmnElementProcessor<Execut
   private final BpmnVariableMappingBehavior variableMappingBehavior;
   private final BpmnIncidentBehavior incidentBehavior;
 
-  public BoundaryEventProcessor(final BpmnBehaviors bpmnBehaviors) {
-    stateTransitionBehavior = bpmnBehaviors.stateTransitionBehavior();
+  public BoundaryEventProcessor(
+      final BpmnBehaviors bpmnBehaviors,
+      final BpmnStateTransitionBehavior stateTransitionBehavior) {
+    this.stateTransitionBehavior = stateTransitionBehavior;
     variableMappingBehavior = bpmnBehaviors.variableMappingBehavior();
     incidentBehavior = bpmnBehaviors.incidentBehavior();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -32,10 +32,12 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
   private final BpmnVariableMappingBehavior variableMappingBehavior;
   private final BpmnJobBehavior jobBehavior;
 
-  public EndEventProcessor(final BpmnBehaviors bpmnBehaviors) {
+  public EndEventProcessor(
+      final BpmnBehaviors bpmnBehaviors,
+      final BpmnStateTransitionBehavior stateTransitionBehavior) {
     eventPublicationBehavior = bpmnBehaviors.eventPublicationBehavior();
     incidentBehavior = bpmnBehaviors.incidentBehavior();
-    stateTransitionBehavior = bpmnBehaviors.stateTransitionBehavior();
+    this.stateTransitionBehavior = stateTransitionBehavior;
     variableMappingBehavior = bpmnBehaviors.variableMappingBehavior();
     jobBehavior = bpmnBehaviors.jobBehavior();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateCatchEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateCatchEventProcessor.java
@@ -24,10 +24,12 @@ public class IntermediateCatchEventProcessor
   private final BpmnStateTransitionBehavior stateTransitionBehavior;
   private final BpmnVariableMappingBehavior variableMappingBehavior;
 
-  public IntermediateCatchEventProcessor(final BpmnBehaviors bpmnBehaviors) {
+  public IntermediateCatchEventProcessor(
+      final BpmnBehaviors bpmnBehaviors,
+      final BpmnStateTransitionBehavior stateTransitionBehavior) {
     eventSubscriptionBehavior = bpmnBehaviors.eventSubscriptionBehavior();
     incidentBehavior = bpmnBehaviors.incidentBehavior();
-    stateTransitionBehavior = bpmnBehaviors.stateTransitionBehavior();
+    this.stateTransitionBehavior = stateTransitionBehavior;
     variableMappingBehavior = bpmnBehaviors.variableMappingBehavior();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
@@ -24,9 +24,11 @@ public class IntermediateThrowEventProcessor
   private final BpmnIncidentBehavior incidentBehavior;
   private final BpmnJobBehavior jobBehavior;
 
-  public IntermediateThrowEventProcessor(final BpmnBehaviors bpmnBehaviors) {
+  public IntermediateThrowEventProcessor(
+      final BpmnBehaviors bpmnBehaviors,
+      final BpmnStateTransitionBehavior stateTransitionBehavior) {
     variableMappingBehavior = bpmnBehaviors.variableMappingBehavior();
-    stateTransitionBehavior = bpmnBehaviors.stateTransitionBehavior();
+    this.stateTransitionBehavior = stateTransitionBehavior;
     incidentBehavior = bpmnBehaviors.incidentBehavior();
     jobBehavior = bpmnBehaviors.jobBehavior();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/StartEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/StartEventProcessor.java
@@ -27,9 +27,11 @@ public class StartEventProcessor implements BpmnElementProcessor<ExecutableStart
   private final BpmnEventSubscriptionBehavior eventSubscriptionBehavior;
   private final BpmnStateBehavior stateBehavior;
 
-  public StartEventProcessor(final BpmnBehaviors bpmnBehaviors) {
+  public StartEventProcessor(
+      final BpmnBehaviors bpmnBehaviors,
+      final BpmnStateTransitionBehavior stateTransitionBehavior) {
     incidentBehavior = bpmnBehaviors.incidentBehavior();
-    stateTransitionBehavior = bpmnBehaviors.stateTransitionBehavior();
+    this.stateTransitionBehavior = stateTransitionBehavior;
     variableMappingBehavior = bpmnBehaviors.variableMappingBehavior();
     eventSubscriptionBehavior = bpmnBehaviors.eventSubscriptionBehavior();
     stateBehavior = bpmnBehaviors.stateBehavior();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/EventBasedGatewayProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/EventBasedGatewayProcessor.java
@@ -23,8 +23,10 @@ public final class EventBasedGatewayProcessor
   private final BpmnEventSubscriptionBehavior eventSubscriptionBehavior;
   private final BpmnIncidentBehavior incidentBehavior;
 
-  public EventBasedGatewayProcessor(final BpmnBehaviors bpmnBehaviors) {
-    stateTransitionBehavior = bpmnBehaviors.stateTransitionBehavior();
+  public EventBasedGatewayProcessor(
+      final BpmnBehaviors bpmnBehaviors,
+      final BpmnStateTransitionBehavior stateTransitionBehavior) {
+    this.stateTransitionBehavior = stateTransitionBehavior;
     eventSubscriptionBehavior = bpmnBehaviors.eventSubscriptionBehavior();
     incidentBehavior = bpmnBehaviors.incidentBehavior();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
@@ -32,10 +32,11 @@ public final class ExclusiveGatewayProcessor
   private final BpmnIncidentBehavior incidentBehavior;
   private final ExpressionProcessor expressionBehavior;
 
-  public ExclusiveGatewayProcessor(final BpmnBehaviors behaviors) {
+  public ExclusiveGatewayProcessor(
+      final BpmnBehaviors behaviors, final BpmnStateTransitionBehavior stateTransitionBehavior) {
     expressionBehavior = behaviors.expressionBehavior();
     incidentBehavior = behaviors.incidentBehavior();
-    stateTransitionBehavior = behaviors.stateTransitionBehavior();
+    this.stateTransitionBehavior = stateTransitionBehavior;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/InclusiveGatewayProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/InclusiveGatewayProcessor.java
@@ -33,10 +33,11 @@ public final class InclusiveGatewayProcessor
   private final BpmnIncidentBehavior incidentBehavior;
   private final ExpressionProcessor expressionBehavior;
 
-  public InclusiveGatewayProcessor(final BpmnBehaviors behaviors) {
+  public InclusiveGatewayProcessor(
+      final BpmnBehaviors behaviors, final BpmnStateTransitionBehavior stateTransitionBehavior) {
     expressionBehavior = behaviors.expressionBehavior();
     incidentBehavior = behaviors.incidentBehavior();
-    stateTransitionBehavior = behaviors.stateTransitionBehavior();
+    this.stateTransitionBehavior = stateTransitionBehavior;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ParallelGatewayProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ParallelGatewayProcessor.java
@@ -20,8 +20,9 @@ public final class ParallelGatewayProcessor implements BpmnElementProcessor<Exec
   private final BpmnStateTransitionBehavior stateTransitionBehavior;
   private final BpmnIncidentBehavior bpmnIncidentBehavior;
 
-  public ParallelGatewayProcessor(final BpmnBehaviors behaviors) {
-    stateTransitionBehavior = behaviors.stateTransitionBehavior();
+  public ParallelGatewayProcessor(
+      final BpmnBehaviors behaviors, final BpmnStateTransitionBehavior stateTransitionBehavior) {
+    this.stateTransitionBehavior = stateTransitionBehavior;
     bpmnIncidentBehavior = behaviors.incidentBehavior();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/BusinessRuleTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/BusinessRuleTaskProcessor.java
@@ -25,9 +25,11 @@ public final class BusinessRuleTaskProcessor
   private final BusinessRuleTaskBehavior calledDecisionBehavior;
   private final BusinessRuleTaskBehavior jobWorkerTaskBehavior;
 
-  public BusinessRuleTaskProcessor(final BpmnBehaviors bpmnBehaviors) {
-    calledDecisionBehavior = new CalledDecisionBehavior(bpmnBehaviors);
-    jobWorkerTaskBehavior = new JobWorkerTaskBehavior(bpmnBehaviors);
+  public BusinessRuleTaskProcessor(
+      final BpmnBehaviors bpmnBehaviors,
+      final BpmnStateTransitionBehavior stateTransitionBehavior) {
+    calledDecisionBehavior = new CalledDecisionBehavior(bpmnBehaviors, stateTransitionBehavior);
+    jobWorkerTaskBehavior = new JobWorkerTaskBehavior(bpmnBehaviors, stateTransitionBehavior);
   }
 
   @Override
@@ -75,11 +77,13 @@ public final class BusinessRuleTaskProcessor
     private final BpmnVariableMappingBehavior variableMappingBehavior;
     private final BpmnStateBehavior stateBehavior;
 
-    public CalledDecisionBehavior(final BpmnBehaviors bpmnBehaviors) {
+    public CalledDecisionBehavior(
+        final BpmnBehaviors bpmnBehaviors,
+        final BpmnStateTransitionBehavior stateTransitionBehavior) {
       decisionBehavior = bpmnBehaviors.decisionBehavior();
       eventSubscriptionBehavior = bpmnBehaviors.eventSubscriptionBehavior();
       incidentBehavior = bpmnBehaviors.incidentBehavior();
-      stateTransitionBehavior = bpmnBehaviors.stateTransitionBehavior();
+      this.stateTransitionBehavior = stateTransitionBehavior;
       variableMappingBehavior = bpmnBehaviors.variableMappingBehavior();
       stateBehavior = bpmnBehaviors.stateBehavior();
     }
@@ -139,8 +143,10 @@ public final class BusinessRuleTaskProcessor
 
     private final JobWorkerTaskProcessor delegate;
 
-    public JobWorkerTaskBehavior(final BpmnBehaviors bpmnBehaviors) {
-      delegate = new JobWorkerTaskProcessor(bpmnBehaviors);
+    public JobWorkerTaskBehavior(
+        final BpmnBehaviors bpmnBehaviors,
+        final BpmnStateTransitionBehavior stateTransitionBehavior) {
+      delegate = new JobWorkerTaskProcessor(bpmnBehaviors, stateTransitionBehavior);
     }
 
     @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskProcessor.java
@@ -31,10 +31,11 @@ public final class JobWorkerTaskProcessor implements BpmnElementProcessor<Execut
   private final BpmnJobBehavior jobBehavior;
   private final BpmnStateBehavior stateBehavior;
 
-  public JobWorkerTaskProcessor(final BpmnBehaviors behaviors) {
+  public JobWorkerTaskProcessor(
+      final BpmnBehaviors behaviors, final BpmnStateTransitionBehavior stateTransitionBehavior) {
     eventSubscriptionBehavior = behaviors.eventSubscriptionBehavior();
     incidentBehavior = behaviors.incidentBehavior();
-    stateTransitionBehavior = behaviors.stateTransitionBehavior();
+    this.stateTransitionBehavior = stateTransitionBehavior;
     variableMappingBehavior = behaviors.variableMappingBehavior();
     jobBehavior = behaviors.jobBehavior();
     stateBehavior = behaviors.stateBehavior();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ManualTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ManualTaskProcessor.java
@@ -19,8 +19,10 @@ public class ManualTaskProcessor implements BpmnElementProcessor<ExecutableActiv
   private final BpmnStateTransitionBehavior stateTransitionBehavior;
   private final BpmnIncidentBehavior incidentBehavior;
 
-  public ManualTaskProcessor(final BpmnBehaviors bpmnBehaviors) {
-    stateTransitionBehavior = bpmnBehaviors.stateTransitionBehavior();
+  public ManualTaskProcessor(
+      final BpmnBehaviors bpmnBehaviors,
+      final BpmnStateTransitionBehavior stateTransitionBehavior) {
+    this.stateTransitionBehavior = stateTransitionBehavior;
     incidentBehavior = bpmnBehaviors.incidentBehavior();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ReceiveTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ReceiveTaskProcessor.java
@@ -25,10 +25,11 @@ public final class ReceiveTaskProcessor implements BpmnElementProcessor<Executab
   private final BpmnEventSubscriptionBehavior eventSubscriptionBehavior;
   private final BpmnStateBehavior stateBehavior;
 
-  public ReceiveTaskProcessor(final BpmnBehaviors behaviors) {
+  public ReceiveTaskProcessor(
+      final BpmnBehaviors behaviors, final BpmnStateTransitionBehavior stateTransitionBehavior) {
     eventSubscriptionBehavior = behaviors.eventSubscriptionBehavior();
     incidentBehavior = behaviors.incidentBehavior();
-    stateTransitionBehavior = behaviors.stateTransitionBehavior();
+    this.stateTransitionBehavior = stateTransitionBehavior;
     variableMappingBehavior = behaviors.variableMappingBehavior();
     stateBehavior = behaviors.stateBehavior();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.deployment;
 import static io.camunda.zeebe.engine.state.instance.TimerInstance.NO_ELEMENT_INSTANCE;
 
 import io.camunda.zeebe.engine.api.TypedRecord;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationException;
@@ -65,8 +66,7 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
 
   public DeploymentCreateProcessor(
       final ZeebeState zeebeState,
-      final CatchEventBehavior catchEventBehavior,
-      final ExpressionProcessor expressionProcessor,
+      final BpmnBehaviors bpmnBehaviors,
       final int partitionsCount,
       final Writers writers,
       final DeploymentDistributionCommandSender deploymentDistributionCommandSender,
@@ -78,10 +78,10 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     commandWriter = writers.command();
+    catchEventBehavior = bpmnBehaviors.catchEventBehavior();
+    expressionProcessor = bpmnBehaviors.expressionBehavior();
     deploymentTransformer =
         new DeploymentTransformer(stateWriter, zeebeState, expressionProcessor, keyGenerator);
-    this.catchEventBehavior = catchEventBehavior;
-    this.expressionProcessor = expressionProcessor;
     messageStartEventSubscriptionManager =
         new MessageStartEventSubscriptionManager(
             processState, zeebeState.getMessageStartEventSubscriptionState(), keyGenerator);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -10,9 +10,8 @@ package io.camunda.zeebe.engine.processing.job;
 import io.camunda.zeebe.engine.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
-import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventPublicationBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviorsImpl;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
-import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
@@ -27,10 +26,9 @@ public final class JobEventProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final MutableZeebeState zeebeState,
       final Consumer<String> onJobsAvailableCallback,
-      final BpmnEventPublicationBehavior eventPublicationBehavior,
+      final BpmnBehaviorsImpl bpmnBehaviors,
       final Writers writers,
-      final JobMetrics jobMetrics,
-      final EventTriggerBehavior eventTriggerBehavior) {
+      final JobMetrics jobMetrics) {
 
     final var jobState = zeebeState.getJobState();
     final var keyGenerator = zeebeState.getKeyGenerator();
@@ -57,8 +55,7 @@ public final class JobEventProcessors {
         .onCommand(
             ValueType.JOB,
             JobIntent.THROW_ERROR,
-            new JobThrowErrorProcessor(
-                zeebeState, eventPublicationBehavior, keyGenerator, jobMetrics))
+            new JobThrowErrorProcessor(zeebeState, bpmnBehaviors, keyGenerator, jobMetrics))
         .onCommand(
             ValueType.JOB, JobIntent.TIME_OUT, new JobTimeOutProcessor(zeebeState, jobMetrics))
         .onCommand(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.engine.processing.job;
 import io.camunda.zeebe.engine.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
-import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviorsImpl;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -26,7 +26,7 @@ public final class JobEventProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final MutableZeebeState zeebeState,
       final Consumer<String> onJobsAvailableCallback,
-      final BpmnBehaviorsImpl bpmnBehaviors,
+      final BpmnBehaviors bpmnBehaviors,
       final Writers writers,
       final JobMetrics jobMetrics) {
 
@@ -39,7 +39,7 @@ public final class JobEventProcessors {
             zeebeState.getEventScopeInstanceState(),
             writers,
             zeebeState.getProcessState(),
-            eventTriggerBehavior);
+            bpmnBehaviors.eventTriggerBehavior());
 
     final var jobBackoffChecker = new JobBackoffChecker(jobState);
     typedRecordProcessors
@@ -55,7 +55,8 @@ public final class JobEventProcessors {
         .onCommand(
             ValueType.JOB,
             JobIntent.THROW_ERROR,
-            new JobThrowErrorProcessor(zeebeState, bpmnBehaviors, keyGenerator, jobMetrics))
+            new JobThrowErrorProcessor(
+                zeebeState, bpmnBehaviors.eventPublicationBehavior(), keyGenerator, jobMetrics))
         .onCommand(
             ValueType.JOB, JobIntent.TIME_OUT, new JobTimeOutProcessor(zeebeState, jobMetrics))
         .onCommand(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.camunda.zeebe.engine.api.TypedRecord;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.ElementActivationBehavior;
 import io.camunda.zeebe.engine.processing.common.EventSubscriptionException;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
@@ -83,11 +84,11 @@ public final class CreateProcessInstanceProcessor
       final ProcessState processState,
       final KeyGenerator keyGenerator,
       final Writers writers,
-      final VariableBehavior variableBehavior,
+      final BpmnBehaviors bpmnBehaviors,
       final ElementActivationBehavior elementActivationBehavior,
       final ProcessEngineMetrics metrics) {
     this.processState = processState;
-    this.variableBehavior = variableBehavior;
+    variableBehavior = bpmnBehaviors.variableBehavior();
     this.keyGenerator = keyGenerator;
     commandWriter = writers.command();
     rejectionWriter = writers.rejection();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -85,7 +85,6 @@ public final class CreateProcessInstanceProcessor
       final KeyGenerator keyGenerator,
       final Writers writers,
       final BpmnBehaviors bpmnBehaviors,
-      final ElementActivationBehavior elementActivationBehavior,
       final ProcessEngineMetrics metrics) {
     this.processState = processState;
     variableBehavior = bpmnBehaviors.variableBehavior();
@@ -93,7 +92,7 @@ public final class CreateProcessInstanceProcessor
     commandWriter = writers.command();
     rejectionWriter = writers.rejection();
     this.metrics = metrics;
-    this.elementActivationBehavior = elementActivationBehavior;
+    elementActivationBehavior = bpmnBehaviors.elementActivationBehavior();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -49,8 +49,7 @@ public final class ProcessInstanceModificationProcessor
       final Writers writers,
       final ElementInstanceState elementInstanceState,
       final ProcessState processState,
-      final BpmnBehaviors bpmnBehaviors,
-      final ElementActivationBehavior elementActivationBehavior) {
+      final BpmnBehaviors bpmnBehaviors) {
     stateWriter = writers.state();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
@@ -59,7 +58,7 @@ public final class ProcessInstanceModificationProcessor
     jobBehavior = bpmnBehaviors.jobBehavior();
     incidentBehavior = bpmnBehaviors.incidentBehavior();
     catchEventBehavior = bpmnBehaviors.catchEventBehavior();
-    this.elementActivationBehavior = elementActivationBehavior;
+    elementActivationBehavior = bpmnBehaviors.elementActivationBehavior();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.processinstance;
 
 import io.camunda.zeebe.engine.api.TypedRecord;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
@@ -48,18 +49,16 @@ public final class ProcessInstanceModificationProcessor
       final Writers writers,
       final ElementInstanceState elementInstanceState,
       final ProcessState processState,
-      final BpmnJobBehavior jobBehavior,
-      final BpmnIncidentBehavior incidentBehavior,
-      final CatchEventBehavior catchEventBehavior,
+      final BpmnBehaviors bpmnBehaviors,
       final ElementActivationBehavior elementActivationBehavior) {
     stateWriter = writers.state();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     this.elementInstanceState = elementInstanceState;
     this.processState = processState;
-    this.jobBehavior = jobBehavior;
-    this.incidentBehavior = incidentBehavior;
-    this.catchEventBehavior = catchEventBehavior;
+    jobBehavior = bpmnBehaviors.jobBehavior();
+    incidentBehavior = bpmnBehaviors.incidentBehavior();
+    catchEventBehavior = bpmnBehaviors.catchEventBehavior();
     this.elementActivationBehavior = elementActivationBehavior;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
@@ -8,9 +8,9 @@
 package io.camunda.zeebe.engine.processing.timer;
 
 import io.camunda.zeebe.engine.api.TypedRecord;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
-import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
@@ -59,12 +59,10 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
 
   public TriggerTimerProcessor(
       final MutableZeebeState zeebeState,
-      final CatchEventBehavior catchEventBehavior,
-      final EventTriggerBehavior eventTriggerBehavior,
-      final ExpressionProcessor expressionProcessor,
+      final BpmnBehaviors bpmnBehaviors,
       final Writers writers) {
-    this.catchEventBehavior = catchEventBehavior;
-    this.expressionProcessor = expressionProcessor;
+    catchEventBehavior = bpmnBehaviors.catchEventBehavior();
+    expressionProcessor = bpmnBehaviors.expressionBehavior();
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
 
@@ -79,7 +77,7 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
             zeebeState.getEventScopeInstanceState(),
             writers,
             processState,
-            eventTriggerBehavior);
+            bpmnBehaviors.eventTriggerBehavior());
   }
 
   @Override


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR refactors the `BpmnBehavior` and the creation of the object. In the old scenario we had a lot of behaviours being passed around, yet in some places we used a `BpmnBehavior.` With this change we create a single `BpmnBehavior` earlier on and pass this around. All the processors can take the behaviors they need from this object.

There is 1 exception to this rule. The `BpmnStateTransitionBehavior` requires `BpmnElementProcessors`, which in turn requires the `BpmnBehavior`. Because of this we can't easily make this behavior available in the `BpmnBehaviors`, unless we move the creation of the `BpmnElementProcessors` to a non-sensible place. This specific behavior is also not used outside of the `BpmnStreamProcessor`. For this reason we have decided to leave this behavior out of the `BpmnBehaviors` and create it in the `BpmnStreamProcessor`.

## Related issues

<!-- Which issues are closed by this PR or are related -->

Follow up of https://github.com/camunda/zeebe/pull/10049#discussion_r946682848

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
