### PR TITLE
feat: s3 backup store can set status

### DIFF
--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -85,7 +85,8 @@ public final class S3BackupStore implements BackupStore {
 
   @Override
   public CompletableFuture<Void> markFailed(final BackupIdentifier id) {
-    throw new UnsupportedOperationException();
+    return setStatus(new Status(BackupStatus.FAILED, "Explicitly marked as failed"))
+        .thenApply(res -> null);
   }
 
   private CompletableFuture<PutObjectResponse> setStatus(Status status) {

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -89,7 +89,7 @@ public final class S3BackupStore implements BackupStore {
   }
 
   private CompletableFuture<BackupStatusCode> setStatus(BackupIdentifier id, Status status) {
-    AsyncRequestBody body;
+    final AsyncRequestBody body;
     try {
       body = AsyncRequestBody.fromBytes(MAPPER.writeValueAsBytes(status));
     } catch (JsonProcessingException e) {

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -65,7 +65,11 @@ public final class S3BackupStore implements BackupStore {
               return CompletableFuture.allOf(metadata, snapshot, segments);
             })
         .thenComposeAsync(content -> setStatus(backup.id(), Status.complete()))
-        .exceptionallyComposeAsync((throwable -> setStatus(backup.id(), Status.failed(throwable))));
+        .exceptionallyComposeAsync(
+            throwable ->
+                setStatus(backup.id(), Status.failed(throwable))
+                    // Mark the returned future as failed.
+                    .thenCompose(status -> CompletableFuture.failedStage(throwable)));
   }
 
   @Override

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -55,7 +55,7 @@ public final class S3BackupStore implements BackupStore {
   }
 
   @Override
-  public CompletableFuture<BackupStatusCode> save(final Backup backup) {
+  public CompletableFuture<Void> save(final Backup backup) {
     return setStatus(backup.id(), Status.inProgress())
         .thenComposeAsync(
             status -> {
@@ -69,7 +69,9 @@ public final class S3BackupStore implements BackupStore {
             throwable ->
                 setStatus(backup.id(), Status.failed(throwable))
                     // Mark the returned future as failed.
-                    .thenCompose(status -> CompletableFuture.failedStage(throwable)));
+                    .thenCompose(status -> CompletableFuture.failedStage(throwable)))
+        // Discard status, it's either COMPLETED or the future is completed exceptionally
+        .thenApply(status -> null);
   }
 
   @Override

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/Status.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/Status.java
@@ -10,34 +10,35 @@ package io.camunda.zeebe.backup.s3;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
 /**
- * Holds the current {@link BackupStatus backup status} and an optional description in case of
- * failed backups.
+ * Holds the current {@link BackupStatusCode} and an optional failureReason in case of failed
+ * backups.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record Status(BackupStatus status, @JsonInclude(Include.NON_EMPTY) String description) {
+public record Status(
+    BackupStatusCode statusCode, @JsonInclude(Include.NON_EMPTY) String failureReason) {
 
   public static final String OBJECT_KEY = "status.json";
 
-  public Status(BackupStatus status) {
+  public Status(BackupStatusCode status) {
     this(status, "");
   }
 
   public static Status inProgress() {
-    return new Status(BackupStatus.IN_PROGRESS);
+    return new Status(BackupStatusCode.IN_PROGRESS);
   }
 
   public static Status complete() {
-    return new Status(BackupStatus.COMPLETED);
+    return new Status(BackupStatusCode.COMPLETED);
   }
 
   public static Status failed(Throwable throwable) {
     final var writer = new StringWriter();
     throwable.printStackTrace(new PrintWriter(writer));
-    return new Status(BackupStatus.FAILED, writer.toString());
+    return new Status(BackupStatusCode.FAILED, writer.toString());
   }
 }

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/Status.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/Status.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import io.camunda.zeebe.backup.api.BackupStatus;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+/**
+ * Holds the current {@link BackupStatus backup status} and an optional description in case of
+ * failed backups.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Status(BackupStatus status, @JsonInclude(Include.NON_EMPTY) String description) {
+
+  public static final String OBJECT_KEY = "status.json";
+
+  public Status(BackupStatus status) {
+    this(status, "");
+  }
+
+  public static Status inProgress() {
+    return new Status(BackupStatus.IN_PROGRESS);
+  }
+
+  public static Status complete() {
+    return new Status(BackupStatus.COMPLETED);
+  }
+
+  public static Status failed(Throwable throwable) {
+    final var writer = new StringWriter();
+    throwable.printStackTrace(new PrintWriter(writer));
+    return new Status(BackupStatus.FAILED, writer.toString());
+  }
+}

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreIT.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.backup.s3;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.backup.api.Backup;
@@ -207,7 +206,11 @@ final class S3BackupStoreIT {
     Files.delete(backup.snapshot().files().stream().findFirst().orElseThrow());
 
     // then
-    assertThatCode(() -> store.save(backup)).hasCauseInstanceOf(NoSuchFileException.class);
+
+    //noinspection ResultOfMethodCallIgnored -- we only need to check the exception type
+    assertThat(store.save(backup))
+        .failsWithin(Duration.ofSeconds(10))
+        .withThrowableOfType(NoSuchFileException.class);
   }
 
   @Test

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreIT.java
@@ -206,11 +206,9 @@ final class S3BackupStoreIT {
     Files.delete(backup.snapshot().files().stream().findFirst().orElseThrow());
 
     // then
-
-    //noinspection ResultOfMethodCallIgnored -- we only need to check the exception type
     assertThat(store.save(backup))
-        .failsWithin(Duration.ofSeconds(10))
-        .withThrowableOfType(NoSuchFileException.class);
+        .succeedsWithin(Duration.ofMinutes(1))
+        .isEqualTo(BackupStatusCode.FAILED);
   }
 
   @Test
@@ -235,8 +233,9 @@ final class S3BackupStoreIT {
     final var objectMapper = new ObjectMapper();
     final var readStatus = objectMapper.readValue(statusObject.asByteArray(), Status.class);
 
-    assertThat(readStatus.status()).isEqualTo(BackupStatus.COMPLETED);
+    assertThat(readStatus.statusCode()).isEqualTo(BackupStatusCode.COMPLETED);
   }
+
 
   private TestBackup prepareTestBackup(Path tempDir) throws IOException {
     Files.createDirectory(tempDir.resolve("segments/"));

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreIT.java
@@ -89,7 +89,7 @@ final class S3BackupStoreIT {
     final var result = store.save(backup);
 
     // then
-    assertThat(result).succeedsWithin(Duration.ofSeconds(10)).isEqualTo(BackupStatusCode.COMPLETED);
+    assertThat(result).succeedsWithin(Duration.ofSeconds(10));
   }
 
   @Test

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreIT.java
@@ -13,11 +13,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
-import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.NamedFileSet;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Map;
@@ -89,7 +88,7 @@ final class S3BackupStoreIT {
     final var result = store.save(backup);
 
     // then
-    assertThat(result).succeedsWithin(Duration.ofSeconds(10));
+    assertThat(result).succeedsWithin(Duration.ofSeconds(10)).isEqualTo(BackupStatusCode.COMPLETED);
   }
 
   @Test

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreIT.java
@@ -175,13 +175,14 @@ final class S3BackupStoreIT {
     final var prefix = S3BackupStore.objectPrefix(backup.id);
 
     final var metadata = prefix + Metadata.OBJECT_KEY;
+    final var status = prefix + Status.OBJECT_KEY;
     final var snapshotObjects =
         backup.snapshot.names().stream().map(name -> prefix + S3BackupStore.SNAPSHOT_PREFIX + name);
     final var segmentObjects =
         backup.segments.names().stream().map(name -> prefix + S3BackupStore.SEGMENTS_PREFIX + name);
 
     final var contentObjects = Stream.concat(snapshotObjects, segmentObjects);
-    final var managementObjects = Stream.of(metadata);
+    final var managementObjects = Stream.of(metadata, status);
     final var expectedObjects = Stream.concat(managementObjects, contentObjects).toList();
 
     // when

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStatus.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStatus.java
@@ -8,4 +8,9 @@
 package io.camunda.zeebe.backup.api;
 
 /** Represents the status of a backup. */
-public interface BackupStatus {}
+public enum BackupStatus {
+  DOES_NOT_EXIST,
+  IN_PROGRESS,
+  COMPLETED,
+  FAILED,
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStatusCode.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStatusCode.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.backup.api;
 
-/** Represents the status of a backup. */
-public interface BackupStatus {
-  BackupStatusCode statusCode();
+public enum BackupStatusCode {
+  DOES_NOT_EXIST,
+  IN_PROGRESS,
+  COMPLETED,
+  FAILED,
 }

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
@@ -13,7 +13,7 @@ import java.util.concurrent.CompletableFuture;
 public interface BackupStore {
 
   /** Saves the backup to the backup storage. */
-  CompletableFuture<Void> save(Backup backup);
+  CompletableFuture<BackupStatusCode> save(Backup backup);
 
   /** Returns the status of the backup */
   CompletableFuture<BackupStatus> getStatus(BackupIdentifier id);
@@ -28,5 +28,5 @@ public interface BackupStore {
    * Marks the backup as failed. If saving a backup failed, the backups store must mark it as
    * failed. This method can be used if we want to explicitly mark a partial backup as failed.
    */
-  CompletableFuture<Void> markFailed(BackupIdentifier id);
+  CompletableFuture<BackupStatusCode> markFailed(BackupIdentifier id);
 }

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
@@ -13,7 +13,7 @@ import java.util.concurrent.CompletableFuture;
 public interface BackupStore {
 
   /** Saves the backup to the backup storage. */
-  CompletableFuture<BackupStatusCode> save(Backup backup);
+  CompletableFuture<Void> save(Backup backup);
 
   /** Returns the status of the backup */
   CompletableFuture<BackupStatus> getStatus(BackupIdentifier id);


### PR DESCRIPTION
The S3 backup store can now set the status of a backup. It does so on-demand when `markAsFailed` is called and during the `save` process where a backup first starts off as `IN_PROGRESS` and is then marked as failed or completed.

`BackupStatus` now contains a `BackupStatusCode`. We will extend the status with more fields later, once we tackle querying the status.

The `save` and `markAsFailed` methods now return a `BackupStatusCode` enum that indicates what status was set last (completed or failed).

 `save` will always return an exceptionally completed future if any of the steps failed. This keeps error handling (responsibility of the backup manager) easy and consistent.

closes #10134 