### PR TITLE
Execute global variable instructions on instance modification

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -111,6 +111,12 @@
       <artifactId>cron-utils</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- TEST DEPENDENCIES -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceVariablesTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceVariablesTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class ModifyProcessInstanceVariablesTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  private static final String PROCESS_ID = "process";
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCreateGlobalVariables() {
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(PROCESS_ID)
+                    .startEvent()
+                    .userTask("A")
+                    .userTask("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .activateElement("B", null, Map.of("x", "variable"))
+        .modify();
+
+    // then
+    assertThat(
+            RecordingExporter.variableRecords(VariableIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that variable is created")
+        .hasName("x")
+        .hasValue("\"variable\"")
+        .hasBpmnProcessId(PROCESS_ID)
+        .hasProcessDefinitionKey(
+            deployment.getValue().getProcessesMetadata().get(0).getProcessDefinitionKey())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasScopeKey(processInstanceKey);
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationActivateInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationTerminateInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationVariableInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
@@ -30,6 +31,8 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.agrona.DirectBuffer;
 
 public final class ProcessInstanceClient {
 
@@ -276,6 +279,34 @@ public final class ProcessInstanceClient {
     public ProcessInstanceModificationClient activateElement(final String elementId) {
       record.addActivateInstruction(
           new ProcessInstanceModificationActivateInstruction().setElementId(elementId));
+      return this;
+    }
+
+    public ProcessInstanceModificationClient activateElement(
+        final String elementId, @Nullable final String variablesScopeId, final String variables) {
+      return activateElement(elementId, variablesScopeId, MsgPackUtil.asMsgPack(variables));
+    }
+
+    public ProcessInstanceModificationClient activateElement(
+        final String elementId,
+        @Nullable final String variablesScopeId,
+        final Map<String, Object> variables) {
+      return activateElement(elementId, variablesScopeId, MsgPackUtil.asMsgPack(variables));
+    }
+
+    public ProcessInstanceModificationClient activateElement(
+        final String elementId,
+        @Nullable final String variablesScopeId,
+        final DirectBuffer variables) {
+      final var variableInstruction = new ProcessInstanceModificationVariableInstruction();
+      if (variablesScopeId != null) {
+        variableInstruction.setElementId(variablesScopeId);
+      }
+      variableInstruction.setVariables(variables);
+      record.addActivateInstruction(
+          new ProcessInstanceModificationActivateInstruction()
+              .setElementId(elementId)
+              .addVariableInstruction(variableInstruction));
       return this;
     }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -276,17 +276,45 @@ public final class ProcessInstanceClient {
       record = new ProcessInstanceModificationRecord();
     }
 
+    /**
+     * Add an activate element instruction.
+     *
+     * @param elementId the id of the element to activate
+     * @return this client builder for chaining
+     */
     public ProcessInstanceModificationClient activateElement(final String elementId) {
       record.addActivateInstruction(
           new ProcessInstanceModificationActivateInstruction().setElementId(elementId));
       return this;
     }
 
+    /**
+     * Add an activate element instruction, with variables.
+     *
+     * <p>The variables will be set locally on the defined {@code variablesScopeId}, or globally if
+     * the {@code variablesScopeId} is {@code null}.
+     *
+     * @param elementId the id of the element to activate
+     * @param variablesScopeId the element id to use as variable scope for the provided variables
+     * @param variables the variables to set locally
+     * @return this client builder for chaining
+     */
     public ProcessInstanceModificationClient activateElement(
         final String elementId, @Nullable final String variablesScopeId, final String variables) {
       return activateElement(elementId, variablesScopeId, MsgPackUtil.asMsgPack(variables));
     }
 
+    /**
+     * Add an activate element instruction, with variables.
+     *
+     * <p>The variables will be set locally on the defined {@code variablesScopeId}, or globally if
+     * the {@code variablesScopeId} is {@code null}.
+     *
+     * @param elementId the id of the element to activate
+     * @param variablesScopeId the element id to use as variable scope for the provided variables
+     * @param variables the variables to set locally
+     * @return this client builder for chaining
+     */
     public ProcessInstanceModificationClient activateElement(
         final String elementId,
         @Nullable final String variablesScopeId,
@@ -294,6 +322,17 @@ public final class ProcessInstanceClient {
       return activateElement(elementId, variablesScopeId, MsgPackUtil.asMsgPack(variables));
     }
 
+    /**
+     * Add an activate element instruction, with variables.
+     *
+     * <p>The variables will be set locally on the defined {@code variablesScopeId}, or globally if
+     * the {@code variablesScopeId} is {@code null}.
+     *
+     * @param elementId the id of the element to activate
+     * @param variablesScopeId the element id to use as variable scope for the provided variables
+     * @param variables the variables to set locally
+     * @return this client builder for chaining
+     */
     public ProcessInstanceModificationClient activateElement(
         final String elementId,
         @Nullable final String variablesScopeId,


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Activate instructions with variable instructions without a variable scope create global variables (i.e. at the process instance scope).

Note that variables may already exist on the process instance scope with the same name. In that case, the variable is `UPDATED` instead of `CREATED`.

Also note that variables must be available during element scope creation, e.g. to subscribe to events. Since the events can exist at any scope, global variables are created before the element scopes are created.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9663 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
