### PR TITLE
Coordination in BackupService

### DIFF
--- a/backup/pom.xml
+++ b/backup/pom.xml
@@ -94,7 +94,6 @@
       <scope>test</scope>
     </dependency>
 
-
   </dependencies>
 
 </project>

--- a/backup/pom.xml
+++ b/backup/pom.xml
@@ -73,12 +73,27 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Should not depend on logstreams. But we have some dependencies in the test -->
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-logstreams</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-scheduler</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
 
   </dependencies>
 

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupIdentifierRecord.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupIdentifierRecord.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.management;
+
+import io.camunda.zeebe.backup.api.BackupIdentifier;
+
+public record BackupIdentifierRecord(int nodeId, int partitionId, long checkpointId)
+    implements BackupIdentifier {}

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -16,6 +16,24 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 /** Backup manager that takes and manages backup asynchronously */
 public class BackupService extends Actor implements BackupManager {
 
+  private final int nodeId;
+  private final int partitionId;
+  private final String actorName;
+
+  private final int numberOfPartitions;
+
+  public BackupService(final int nodeId, final int partitionId, final int numberOfPartitions) {
+    this.nodeId = nodeId;
+    this.partitionId = partitionId;
+    this.numberOfPartitions = numberOfPartitions;
+    actorName = buildActorName(nodeId, "SnapshotStore", partitionId);
+  }
+
+  @Override
+  public String getName() {
+    return actorName;
+  }
+
   @Override
   public void takeBackup(final long checkpointId, final long checkpointPosition) {
     // Will be implemented later

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -9,24 +9,38 @@ package io.camunda.zeebe.backup.management;
 
 import io.camunda.zeebe.backup.api.BackupManager;
 import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Backup manager that takes and manages backup asynchronously */
-public class BackupService extends Actor implements BackupManager {
-
+public final class BackupService extends Actor implements BackupManager {
+  private static final Logger LOG = LoggerFactory.getLogger(BackupService.class);
+  private final String actorName;
   private final int nodeId;
   private final int partitionId;
-  private final String actorName;
-
   private final int numberOfPartitions;
+  private final BackupServiceImpl internalBackupManager;
 
   public BackupService(final int nodeId, final int partitionId, final int numberOfPartitions) {
+    // Use a noop backup store until a proper backup store is available
+    this(nodeId, partitionId, numberOfPartitions, NoopBackupStore.INSTANCE);
+  }
+
+  public BackupService(
+      final int nodeId,
+      final int partitionId,
+      final int numberOfPartitions,
+      final BackupStore backupStore) {
     this.nodeId = nodeId;
     this.partitionId = partitionId;
     this.numberOfPartitions = numberOfPartitions;
-    actorName = buildActorName(nodeId, "SnapshotStore", partitionId);
+    internalBackupManager =
+        new BackupServiceImpl(nodeId, partitionId, numberOfPartitions, backupStore);
+    actorName = buildActorName(nodeId, "BackupService", partitionId);
   }
 
   @Override
@@ -35,8 +49,38 @@ public class BackupService extends Actor implements BackupManager {
   }
 
   @Override
+  protected void onActorClosing() {
+    internalBackupManager.close();
+  }
+
+  @Override
   public void takeBackup(final long checkpointId, final long checkpointPosition) {
-    // Will be implemented later
+    actor.run(
+        () -> {
+          final InProgressBackupImpl inProgressBackup =
+              new InProgressBackupImpl(
+                  new BackupIdentifierRecord(nodeId, partitionId, checkpointId),
+                  checkpointPosition,
+                  numberOfPartitions,
+                  actor);
+          internalBackupManager
+              .takeBackup(inProgressBackup, actor)
+              .onComplete(
+                  (ignore, error) -> {
+                    if (error != null) {
+                      LOG.warn(
+                          "Failed to take backup {} at position {}",
+                          inProgressBackup.checkpointId(),
+                          inProgressBackup.checkpointPosition(),
+                          error);
+                    } else {
+                      LOG.info(
+                          "Backup {} at position {} completed",
+                          inProgressBackup.checkpointId(),
+                          inProgressBackup.checkpointPosition());
+                    }
+                  });
+        });
   }
 
   @Override

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.management;
+
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+final class BackupServiceImpl {
+  private final int nodeId;
+  private final int partitionId;
+
+  private final int numberOfPartitions;
+
+  private final Set<InProgressBackup> backupsInProgress = new HashSet<>();
+  private final BackupStore backupStore;
+
+  BackupServiceImpl(
+      final int nodeId,
+      final int partitionId,
+      final int numberOfPartitions,
+      final BackupStore backupStore) {
+    this.nodeId = nodeId;
+    this.partitionId = partitionId;
+    this.numberOfPartitions = numberOfPartitions;
+    this.backupStore = backupStore;
+  }
+
+  void close() {
+    backupsInProgress.forEach(InProgressBackup::close);
+  }
+
+  ActorFuture<Void> takeBackup(
+      final InProgressBackup inProgressBackup, final ConcurrencyControl concurrencyControl) {
+
+    backupsInProgress.add(inProgressBackup);
+
+    final ActorFuture<Void> snapshotFound = inProgressBackup.findValidSnapshot();
+    final ActorFuture<Void> snapshotReserved = concurrencyControl.createFuture();
+    final ActorFuture<Void> snapshotFilesCollected = concurrencyControl.createFuture();
+    final ActorFuture<Void> segmentFilesCollected = concurrencyControl.createFuture();
+    final ActorFuture<Void> backupSaved = concurrencyControl.createFuture();
+
+    snapshotFound.onComplete(
+        proceed(
+            snapshotReserved::completeExceptionally,
+            () -> inProgressBackup.reserveSnapshot().onComplete(snapshotReserved)));
+
+    snapshotReserved.onComplete(
+        proceed(
+            snapshotFilesCollected::completeExceptionally,
+            () -> inProgressBackup.findSnapshotFiles().onComplete(snapshotFilesCollected)));
+
+    snapshotFilesCollected.onComplete(
+        proceed(
+            segmentFilesCollected::completeExceptionally,
+            () -> inProgressBackup.findSegmentFiles().onComplete(segmentFilesCollected)));
+
+    segmentFilesCollected.onComplete(
+        proceed(
+            error -> failBackup(inProgressBackup, backupSaved, error),
+            () -> saveBackup(inProgressBackup, backupSaved)));
+
+    return backupSaved;
+  }
+
+  private void saveBackup(
+      final InProgressBackup inProgressBackup, final ActorFuture<Void> backupSaved) {
+    inProgressBackup
+        .save(backupStore)
+        .onComplete(
+            proceed(
+                error -> failBackup(inProgressBackup, backupSaved, error),
+                () -> {
+                  backupSaved.complete(null);
+                  closeInProgressBackup(inProgressBackup);
+                }));
+  }
+
+  private void failBackup(
+      final InProgressBackup inProgressBackup,
+      final ActorFuture<Void> backupSaved,
+      final Throwable error) {
+    backupSaved.completeExceptionally(error);
+    inProgressBackup.fail(error);
+    closeInProgressBackup(inProgressBackup);
+  }
+
+  private void closeInProgressBackup(final InProgressBackup inProgressBackup) {
+    backupsInProgress.remove(inProgressBackup);
+    inProgressBackup.close();
+  }
+
+  private BiConsumer<Void, Throwable> proceed(
+      final Consumer<Throwable> onError, final Runnable nextStep) {
+    return (ignore, error) -> {
+      if (error != null) {
+        onError.accept(error);
+      } else {
+        nextStep.run();
+      }
+    };
+  }
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackup.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackup.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.management;
+
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+
+interface InProgressBackup {
+
+  long checkpointId();
+
+  long checkpointPosition();
+
+  ActorFuture<Void> findValidSnapshot();
+
+  ActorFuture<Void> reserveSnapshot();
+
+  ActorFuture<Void> findSnapshotFiles();
+
+  ActorFuture<Void> findSegmentFiles();
+
+  ActorFuture<Void> save(BackupStore store);
+
+  void fail(Throwable error);
+
+  void close();
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.management;
+
+import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+
+final class InProgressBackupImpl implements InProgressBackup {
+
+  private final BackupIdentifier backupId;
+  private final long checkpointPosition;
+  private final int numberOfPartitions;
+  private final ConcurrencyControl concurrencyControl;
+
+  InProgressBackupImpl(
+      final BackupIdentifier backupId,
+      final long checkpointPosition,
+      final int numberOfPartitions,
+      final ConcurrencyControl concurrencyControl) {
+    this.backupId = backupId;
+    this.checkpointPosition = checkpointPosition;
+    this.numberOfPartitions = numberOfPartitions;
+    this.concurrencyControl = concurrencyControl;
+  }
+
+  @Override
+  public long checkpointId() {
+    return backupId.checkpointId();
+  }
+
+  @Override
+  public long checkpointPosition() {
+    return checkpointPosition;
+  }
+
+  @Override
+  public ActorFuture<Void> findValidSnapshot() {
+    return concurrencyControl.createCompletedFuture();
+  }
+
+  @Override
+  public ActorFuture<Void> reserveSnapshot() {
+    return concurrencyControl.createCompletedFuture();
+  }
+
+  @Override
+  public ActorFuture<Void> findSnapshotFiles() {
+    return concurrencyControl.createCompletedFuture();
+  }
+
+  @Override
+  public ActorFuture<Void> findSegmentFiles() {
+    return concurrencyControl.createCompletedFuture();
+  }
+
+  @Override
+  public ActorFuture<Void> save(final BackupStore store) {
+    // save backup
+    return concurrencyControl.createCompletedFuture();
+  }
+
+  @Override
+  public void fail(final Throwable error) {
+    // To be implemented
+  }
+
+  @Override
+  public void close() {
+    // To be implemented
+  }
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupStore.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupStore.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.backup.management;
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
 import java.util.concurrent.CompletableFuture;
 
@@ -43,7 +44,7 @@ final class NoopBackupStore implements BackupStore {
   }
 
   @Override
-  public CompletableFuture<Void> markFailed(final BackupIdentifier id) {
+  public CompletableFuture<BackupStatusCode> markFailed(final BackupIdentifier id) {
     return CompletableFuture.completedFuture(null);
   }
 }

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupStore.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupStore.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.management;
+
+import io.camunda.zeebe.backup.api.Backup;
+import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStore;
+import java.util.concurrent.CompletableFuture;
+
+// A placeholder backup store until a proper backup store is available
+final class NoopBackupStore implements BackupStore {
+  public static final NoopBackupStore INSTANCE = new NoopBackupStore();
+
+  private NoopBackupStore() {}
+
+  @Override
+  public CompletableFuture<Void> save(final Backup backup) {
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<BackupStatus> getStatus(final BackupIdentifier id) {
+    return CompletableFuture.failedFuture(
+        new UnsupportedOperationException("No backup store configured"));
+  }
+
+  @Override
+  public CompletableFuture<Void> delete(final BackupIdentifier id) {
+    return CompletableFuture.failedFuture(
+        new UnsupportedOperationException("No backup store configured"));
+  }
+
+  @Override
+  public CompletableFuture<Backup> restore(final BackupIdentifier id) {
+    return CompletableFuture.failedFuture(
+        new UnsupportedOperationException("No backup store configured"));
+  }
+
+  @Override
+  public CompletableFuture<Void> markFailed(final BackupIdentifier id) {
+    return CompletableFuture.completedFuture(null);
+  }
+}

--- a/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -51,7 +51,26 @@ class BackupServiceImplTest {
   }
 
   @Test
-  void shouldCloseInProgressBackupAfterBackupIsTaken() {
+  void shouldCloseAllInProgressBackupsWhenClosing() {
+    // given
+    final InProgressBackup backup1 = mock(InProgressBackup.class);
+    final InProgressBackup backup2 = mock(InProgressBackup.class);
+    when(backup1.findValidSnapshot()).thenReturn(concurrencyControl.createFuture());
+    when(backup2.findValidSnapshot()).thenReturn(concurrencyControl.createFuture());
+
+    backupService.takeBackup(backup1, concurrencyControl);
+    backupService.takeBackup(backup2, concurrencyControl);
+
+    // when
+    backupService.close();
+
+    // then
+    verify(backup1).close();
+    verify(backup2).close();
+  }
+
+  @Test
+  void shouldCloseInProgressBackupsAfterBackupIsTaken() {
     // given
     mockInProgressBackup();
 
@@ -60,7 +79,6 @@ class BackupServiceImplTest {
 
     // then
     assertThat(result).succeedsWithin(Duration.ofMillis(100));
-    verify(inProgressBackup).close();
   }
 
   @Test

--- a/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BackupServiceImplTest {
+
+  @Mock InProgressBackup inProgressBackup;
+
+  private BackupServiceImpl backupService;
+  private final ConcurrencyControl concurrencyControl = new TestConcurrencyControl();
+
+  @BeforeEach
+  void setup() {
+    backupService = new BackupServiceImpl(0, 1, 1, mock(BackupStore.class));
+  }
+
+  @Test
+  void shouldTakeBackup() {
+    // given
+    mockInProgressBackup();
+
+    // when
+    final var result = backupService.takeBackup(inProgressBackup, concurrencyControl);
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofMillis(100));
+  }
+
+  @Test
+  void shouldCloseInProgressBackupAfterBackupIsTaken() {
+    // given
+    mockInProgressBackup();
+
+    // when
+    final var result = backupService.takeBackup(inProgressBackup, concurrencyControl);
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofMillis(100));
+    verify(inProgressBackup).close();
+  }
+
+  @Test
+  void shouldFailBackupWhenNoValidSnapshotFound() {
+    // given
+    final var res = failedFuture();
+    when(inProgressBackup.findValidSnapshot()).thenReturn(res);
+
+    // when
+    final var result = backupService.takeBackup(inProgressBackup, concurrencyControl);
+
+    // then
+    assertThat(result)
+        .failsWithin(Duration.ofMillis(1000))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("Expected");
+    verify(inProgressBackup).fail(any());
+    verify(inProgressBackup).close();
+  }
+
+  @Test
+  void shouldFailBackupWhenSnapshotCannotBeReserved() {
+    // given
+    mockFindValidSnapshot();
+    when(inProgressBackup.reserveSnapshot()).thenReturn(failedFuture());
+
+    // when
+    final var result = backupService.takeBackup(inProgressBackup, concurrencyControl);
+
+    // then
+    assertThat(result).failsWithin(Duration.ofMillis(100));
+    verify(inProgressBackup).fail(any());
+    verify(inProgressBackup).close();
+  }
+
+  @Test
+  void shouldFailBackupWhenSnapshotFilesCannotBeCollected() {
+    // given
+    mockFindValidSnapshot();
+    mockReserveSnapshot();
+    when(inProgressBackup.findSnapshotFiles()).thenReturn(failedFuture());
+
+    // when
+    final var result = backupService.takeBackup(inProgressBackup, concurrencyControl);
+
+    // then
+    assertThat(result).failsWithin(Duration.ofMillis(100));
+    verify(inProgressBackup).fail(any());
+    verify(inProgressBackup).close();
+  }
+
+  @Test
+  void shouldFailBackupWhenSegmentFilesCannotBeCollected() {
+    // given
+    mockFindValidSnapshot();
+    mockReserveSnapshot();
+    mockFindSnapshotFiles();
+    when(inProgressBackup.findSegmentFiles()).thenReturn(failedFuture());
+
+    // when
+    final var result = backupService.takeBackup(inProgressBackup, concurrencyControl);
+
+    // then
+    assertThat(result).failsWithin(Duration.ofMillis(100));
+    verify(inProgressBackup).fail(any());
+    verify(inProgressBackup).close();
+  }
+
+  @Test
+  void shouldFailBackupIfStoringFailed() {
+    // given
+    mockFindValidSnapshot();
+    mockReserveSnapshot();
+    mockFindSnapshotFiles();
+    mockFindSegmentFiles();
+    when(inProgressBackup.save(any())).thenReturn(failedFuture());
+
+    // when
+    final var result = backupService.takeBackup(inProgressBackup, concurrencyControl);
+
+    // then
+    assertThat(result).failsWithin(Duration.ofMillis(100));
+    verify(inProgressBackup).fail(any());
+    verify(inProgressBackup).close();
+  }
+
+  private ActorFuture<Void> failedFuture() {
+    final ActorFuture<Void> future = concurrencyControl.createFuture();
+    future.completeExceptionally(new RuntimeException("Expected"));
+    return future;
+  }
+
+  private void mockInProgressBackup() {
+    mockFindValidSnapshot();
+    mockReserveSnapshot();
+    mockFindSnapshotFiles();
+    mockFindSegmentFiles();
+    mockSaveBackup();
+  }
+
+  private void mockFindSnapshotFiles() {
+    when(inProgressBackup.findSnapshotFiles())
+        .thenReturn(concurrencyControl.createCompletedFuture());
+  }
+
+  private void mockReserveSnapshot() {
+    when(inProgressBackup.reserveSnapshot()).thenReturn(concurrencyControl.createCompletedFuture());
+  }
+
+  private void mockFindValidSnapshot() {
+    when(inProgressBackup.findValidSnapshot())
+        .thenReturn(concurrencyControl.createCompletedFuture());
+  }
+
+  private void mockSaveBackup() {
+    when(inProgressBackup.save(any())).thenReturn(concurrencyControl.createCompletedFuture());
+  }
+
+  private void mockFindSegmentFiles() {
+    when(inProgressBackup.findSegmentFiles())
+        .thenReturn(concurrencyControl.createCompletedFuture());
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
@@ -50,7 +50,11 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
   }
 
   private ActorFuture<Void> installBackupManager(final PartitionTransitionContext context) {
-    final BackupService backupManager = new BackupService();
+    final BackupService backupManager =
+        new BackupService(
+            context.getNodeId(),
+            context.getPartitionId(),
+            context.getBrokerCfg().getCluster().getPartitionsCount());
     final ActorFuture<Void> installed = context.getConcurrencyControl().createFuture();
     context
         .getActorSchedulingService()

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImplTest.java
@@ -32,8 +32,8 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.util.health.HealthMonitor;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -107,8 +107,8 @@ class PartitionTransitionImplTest {
     verify(mockStep2, never()).transitionTo(mockContext, DEFAULT_TERM, DEFAULT_ROLE);
 
     assertThatThrownBy(actualResult::join)
-        .isInstanceOf(CompletionException.class)
-        .getCause()
+        .isInstanceOf(ExecutionException.class)
+        .cause()
         .isSameAs(testException);
   }
 
@@ -330,8 +330,8 @@ class PartitionTransitionImplTest {
     verify(mockStep2, never()).transitionTo(mockContext, secondTerm, secondRole);
 
     assertThatThrownBy(secondTransitionFuture::join)
-        .isInstanceOf(CompletionException.class)
-        .getCause()
+        .isInstanceOf(ExecutionException.class)
+        .cause()
         .isSameAs(testException);
   }
 

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/startup/StartupProcessTest.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/startup/StartupProcessTest.java
@@ -26,8 +26,8 @@ import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -180,8 +180,8 @@ class StartupProcessTest {
       assertThat(actualResult.isCompletedExceptionally()).isTrue();
 
       assertThatThrownBy(actualResult::join)
-          .isInstanceOf(CompletionException.class)
-          .getCause()
+          .isInstanceOf(ExecutionException.class)
+          .cause()
           .isInstanceOf(StartupProcessException.class);
     }
 
@@ -208,8 +208,8 @@ class StartupProcessTest {
       assertThat(actualResult.isCompletedExceptionally()).isTrue();
 
       assertThatThrownBy(actualResult::join)
-          .isInstanceOf(CompletionException.class)
-          .getCause()
+          .isInstanceOf(ExecutionException.class)
+          .cause()
           .isInstanceOf(StartupProcessException.class);
     }
 

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestActorFuture.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestActorFuture.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -131,7 +130,7 @@ public final class TestActorFuture<V> implements ActorFuture<V> {
     if (result.isRight()) {
       return result.get();
     } else {
-      throw new CompletionException(result.getLeft());
+      throw new ExecutionException(result.getLeft());
     }
   }
 


### PR DESCRIPTION
## Description

This PR is in preparation to the tasks in #9979 . 

This PR implement how BackupService coordinates taking a backup. 

For testing, we split the actor part and the actual implementation of the BackupService. BackupServiceImpl implements the actual logic for coordinating taking backup of a single partition. For testability, we also added a InProgressBackup. This PR only includes the implementation on BackupServiceImpl. Only after implementing InProgressBackup, a backup will be taken.

## Related issues

related #9979 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
