### PR TITLE
Add more abbreviations to the compact record logger

### DIFF
--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -66,8 +66,11 @@ public class CompactRecordLogger {
   // List rather than Map to preserve order
   private static final List<Entry<String, String>> ABBREVIATIONS =
       List.of(
+          entry("PROCESS_INSTANCE_CREATION", "CREA"),
+          entry("PROCESS_INSTANCE_MODIFICATION", "MOD"),
+          entry("PROCESS_INSTANCE", "PI"),
           entry("PROCESS", "PROC"),
-          entry("INSTANCE", "INST"),
+          entry("TIMER", "TIME"),
           entry("MESSAGE", "MSG"),
           entry("SUBSCRIPTION", "SUB"),
           entry("SEQUENCE", "SEQ"),


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

While writing an engine test, I encountered some more unabbreviated record value types. This adds a few more abbreviations to create a compact, and easier-to-read record log.

### Before

```
--------
	[Partition] ['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position]  P[partitionId]K[key] - [summary of value]
	P9K999 - key; #999 - record position; "ID" element/process id; @"elementid"/[P9K999] - element with ID and key
	Keys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.
	Long IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'
--------
C DPLY                   CREATE            - #01-> -1  -1 - 
E PROC                   CREATED           - #02->#01 K01 - process.xml -> "process" (version:1)
E DPLY                   CREATED           - #03->#01 K02 - process.xml
E DPLY                   FULLY_DISTRIBUTED - #04->#01 K02 - 
C PROC_INST_CREATION     CREATE            - #05-> -1  -1 - new <process "process"> (default start)  with variables: {x=variable}
E VAR                    CREATED           - #06->#05 K04 - x->"variable" in <process [K03]>
C PROC_INST              ACTIVATE          - #07->#05 K03 - PROCESS "process" in <process "process"[K03]>
E PROC_INST_CREATION     CREATED           - #08->#05 K05 - new <process "process"> (default start)  with variables: {x=variable}
E PROC_INST              ACTIVATING        - #09->#07 K03 - PROCESS "process" in <process "process"[K03]>
E PROC_INST              ACTIVATED         - #10->#07 K03 - PROCESS "process" in <process "process"[K03]>
C PROC_INST              ACTIVATE          - #11->#07  -1 - START_EVENT "startEv..b44a7b4" in <process "process"[K03]>
C PROC_INST_MODIFICATION MODIFY            - #12-> -1 K03 - ProcessInstanceModificationRecord {"processInstanceKey":2251799813685251,"terminateInstructions":[],"activateInstructions":[{"elementId":"B","ancestorScopeKey":-1,"variableInstructions":[{"elementId":"","variables":{"x":"updated"}}]}]}
E PROC_INST              ACTIVATING        - #13->#11 K06 - START_EVENT "startEv..b44a7b4" in <process "process"[K03]>
E PROC_INST              ACTIVATED         - #14->#11 K06 - START_EVENT "startEv..b44a7b4" in <process "process"[K03]>
C PROC_INST              COMPLETE          - #15->#11 K06 - START_EVENT "startEv..b44a7b4" in <process "process"[K03]>
E VAR                    UPDATED           - #16->#12 K04 - x->"updated" in <process [K03]>
C PROC_INST              ACTIVATE          - #17->#12 K07 - USER_TASK "B" in <process "process"[K03]>
E PROC_INST_MODIFICATION MODIFIED          - #18->#12 K03 - ProcessInstanceModificationRecord {"processInstanceKey":2251799813685251,"terminateInstructions":[],"activateInstructions":[{"elementId":"B","ancestorScopeKey":-1,"variableInstructions":[{"elementId":"","variables":{"x":"updated"}}]}]}
E PROC_INST              COMPLETING        - #19->#15 K06 - START_EVENT "startEv..b44a7b4" in <process "process"[K03]>
E PROC_INST              COMPLETED         - #20->#15 K06 - START_EVENT "startEv..b44a7b4" in <process "process"[K03]>
E PROC_INST              SEQ_FLOW_TAKEN    - #21->#15 K08 - SEQUENCE_FLOW "sequenc..25183c6" in <process "process"[K03]>
C PROC_INST              ACTIVATE          - #22->#15 K09 - USER_TASK "A" in <process "process"[K03]>
E PROC_INST              ACTIVATING        - #23->#17 K07 - USER_TASK "B" in <process "process"[K03]>
E JOB                    CREATED           - #24->#17 K10 - K10 "io.camunda.zeebe:userTask" @"B"[K07] 1 retries, in <process "process"[K03]> (no vars)
E PROC_INST              ACTIVATED         - #25->#17 K07 - USER_TASK "B" in <process "process"[K03]>
E PROC_INST              ACTIVATING        - #26->#22 K09 - USER_TASK "A" in <process "process"[K03]>
E JOB                    CREATED           - #27->#22 K11 - K11 "io.camunda.zeebe:userTask" @"A"[K09] 1 retries, in <process "process"[K03]> (no vars)
E PROC_INST              ACTIVATED         - #28->#22 K09 - USER_TASK "A" in <process "process"[K03]>
```

### After

```
--------
	[Partition] ['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position]  P[partitionId]K[key] - [summary of value]
	P9K999 - key; #999 - record position; "ID" element/process id; @"elementid"/[P9K999] - element with ID and key
	Keys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.
	Long IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'
--------
C DPLY CREATE            - #01-> -1  -1 - 
E PROC CREATED           - #02->#01 K01 - process.xml -> "process" (version:1)
E DPLY CREATED           - #03->#01 K02 - process.xml
E DPLY FULLY_DISTRIBUTED - #04->#01 K02 - 
C CREA CREATE            - #05-> -1  -1 - new <process "process"> (default start)  with variables: {x=variable}
E VAR  CREATED           - #06->#05 K04 - x->"variable" in <process [K03]>
C PI   ACTIVATE          - #07->#05 K03 - PROCESS "process" in <process "process"[K03]>
E CREA CREATED           - #08->#05 K05 - new <process "process"> (default start)  with variables: {x=variable}
E PI   ACTIVATING        - #09->#07 K03 - PROCESS "process" in <process "process"[K03]>
E PI   ACTIVATED         - #10->#07 K03 - PROCESS "process" in <process "process"[K03]>
C PI   ACTIVATE          - #11->#07  -1 - START_EVENT "startEv..ea8bb20" in <process "process"[K03]>
C MOD  MODIFY            - #12-> -1 K03 - ProcessInstanceModificationRecord {"processInstanceKey":2251799813685251,"terminateInstructions":[],"activateInstructions":[{"elementId":"B","ancestorScopeKey":-1,"variableInstructions":[{"elementId":"","variables":{"x":"updated"}}]}]}
E PI   ACTIVATING        - #13->#11 K06 - START_EVENT "startEv..ea8bb20" in <process "process"[K03]>
E PI   ACTIVATED         - #14->#11 K06 - START_EVENT "startEv..ea8bb20" in <process "process"[K03]>
C PI   COMPLETE          - #15->#11 K06 - START_EVENT "startEv..ea8bb20" in <process "process"[K03]>
E VAR  UPDATED           - #16->#12 K04 - x->"updated" in <process [K03]>
C PI   ACTIVATE          - #17->#12 K07 - USER_TASK "B" in <process "process"[K03]>
E MOD  MODIFIED          - #18->#12 K03 - ProcessInstanceModificationRecord {"processInstanceKey":2251799813685251,"terminateInstructions":[],"activateInstructions":[{"elementId":"B","ancestorScopeKey":-1,"variableInstructions":[{"elementId":"","variables":{"x":"updated"}}]}]}
E PI   COMPLETING        - #19->#15 K06 - START_EVENT "startEv..ea8bb20" in <process "process"[K03]>
E PI   COMPLETED         - #20->#15 K06 - START_EVENT "startEv..ea8bb20" in <process "process"[K03]>
E PI   SEQ_FLOW_TAKEN    - #21->#15 K08 - SEQUENCE_FLOW "sequenc..d3f792d" in <process "process"[K03]>
C PI   ACTIVATE          - #22->#15 K09 - USER_TASK "A" in <process "process"[K03]>
E PI   ACTIVATING        - #23->#17 K07 - USER_TASK "B" in <process "process"[K03]>
E JOB  CREATED           - #24->#17 K10 - K10 "io.camunda.zeebe:userTask" @"B"[K07] 1 retries, in <process "process"[K03]> (no vars)
E PI   ACTIVATED         - #25->#17 K07 - USER_TASK "B" in <process "process"[K03]>
E PI   ACTIVATING        - #26->#22 K09 - USER_TASK "A" in <process "process"[K03]>
E JOB  CREATED           - #27->#22 K11 - K11 "io.camunda.zeebe:userTask" @"A"[K09] 1 retries, in <process "process"[K03]> (no vars)
E PI   ACTIVATED         - #28->#22 K09 - USER_TASK "A" in <process "process"[K03]>
```

## Related issues

<!-- Which issues are closed by this PR or are related -->

while working on #9663 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
