### PR TITLE
Add Message Publisher for benchmarks

### DIFF
--- a/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
+++ b/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
@@ -135,9 +135,7 @@ public class Starter extends App {
                   .correlationKey("") // for start-events it is empty
                   .variables(variables)
                   .send());
-        }
-        else
-        {
+        } else {
           startViaCommand(starterCfg, processId, requestFutures, client, variables);
         }
 
@@ -149,9 +147,13 @@ public class Starter extends App {
     }
   }
 
-  private static void startViaCommand(final StarterCfg starterCfg, final String processId,
-      final BlockingQueue<Future<?>> requestFutures, final ZeebeClient client,
-      final String variables) throws InterruptedException {
+  private static void startViaCommand(
+      final StarterCfg starterCfg,
+      final String processId,
+      final BlockingQueue<Future<?>> requestFutures,
+      final ZeebeClient client,
+      final String variables)
+      throws InterruptedException {
     if (starterCfg.isWithResults()) {
       requestFutures.put(
           client

--- a/benchmarks/project/src/main/java/io/camunda/zeebe/config/StarterCfg.java
+++ b/benchmarks/project/src/main/java/io/camunda/zeebe/config/StarterCfg.java
@@ -32,11 +32,30 @@ public class StarterCfg {
 
   private int durationLimit;
 
+  private boolean startViaMessage;
+  private String msgName;
+
+  public boolean isStartViaMessage() {
+    return startViaMessage;
+  }
+
+  public void setStartViaMessage(final boolean startViaMessage) {
+    this.startViaMessage = startViaMessage;
+  }
+
+  public String getMsgName() {
+    return msgName;
+  }
+
+  public void setMsgName(final String msgName) {
+    this.msgName = msgName;
+  }
+
   public String getProcessId() {
     return processId;
   }
 
-  public void setProcessId(String processId) {
+  public void setProcessId(final String processId) {
     this.processId = processId;
   }
 
@@ -44,7 +63,7 @@ public class StarterCfg {
     return rate;
   }
 
-  public void setRate(int rate) {
+  public void setRate(final int rate) {
     this.rate = rate;
   }
 
@@ -52,7 +71,7 @@ public class StarterCfg {
     return threads;
   }
 
-  public void setThreads(int threads) {
+  public void setThreads(final int threads) {
     this.threads = threads;
   }
 
@@ -60,7 +79,7 @@ public class StarterCfg {
     return bpmnXmlPath;
   }
 
-  public void setBpmnXmlPath(String bpmnXmlPath) {
+  public void setBpmnXmlPath(final String bpmnXmlPath) {
     this.bpmnXmlPath = bpmnXmlPath;
   }
 
@@ -68,15 +87,15 @@ public class StarterCfg {
     return payloadPath;
   }
 
-  public void setPayloadPath(String payloadPath) {
+  public void setPayloadPath(final String payloadPath) {
     this.payloadPath = payloadPath;
   }
 
   public boolean isWithResults() {
-    return this.withResults;
+    return withResults;
   }
 
-  public void setWithResults(boolean withResults) {
+  public void setWithResults(final boolean withResults) {
     this.withResults = withResults;
   }
 
@@ -84,7 +103,7 @@ public class StarterCfg {
     return withResultsTimeout;
   }
 
-  public void setWithResultsTimeout(Duration withResultsTimeout) {
+  public void setWithResultsTimeout(final Duration withResultsTimeout) {
     this.withResultsTimeout = withResultsTimeout;
   }
 
@@ -92,7 +111,9 @@ public class StarterCfg {
     return durationLimit;
   }
 
-  public void setDurationLimit(int durationLimit) {
+  public void setDurationLimit(final int durationLimit) {
     this.durationLimit = durationLimit;
   }
+
+
 }

--- a/benchmarks/project/src/main/java/io/camunda/zeebe/config/StarterCfg.java
+++ b/benchmarks/project/src/main/java/io/camunda/zeebe/config/StarterCfg.java
@@ -114,6 +114,4 @@ public class StarterCfg {
   public void setDurationLimit(final int durationLimit) {
     this.durationLimit = durationLimit;
   }
-
-
 }

--- a/benchmarks/project/src/main/resources/application.conf
+++ b/benchmarks/project/src/main/resources/application.conf
@@ -13,6 +13,8 @@ app {
     withResults = false
     withResultsTimeout = 60s
     durationLimit = 0
+    msgName = "msg"
+    startViaMessage = false
   }
 
   worker {

--- a/benchmarks/project/src/main/resources/bpmn/msg_one_task.bpmn
+++ b/benchmarks/project/src/main/resources/bpmn/msg_one_task.bpmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_19exoz2" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.2.0">
+  <bpmn:process id="benchmark" name="One task process" isExecutable="true">
+    <bpmn:serviceTask id="task" name="task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="benchmark-task" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0xll35j</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1wkb5x5</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0xll35j" sourceRef="start" targetRef="task" />
+    <bpmn:endEvent id="end" name="end">
+      <bpmn:incoming>SequenceFlow_1wkb5x5</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1wkb5x5" sourceRef="task" targetRef="end" />
+    <bpmn:startEvent id="start" name="start">
+      <bpmn:outgoing>SequenceFlow_0xll35j</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_08ax49g" messageRef="Message_3s6uu59" />
+    </bpmn:startEvent>
+  </bpmn:process>
+  <bpmn:message id="Message_3s6uu59" name="msg" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="benchmark">
+      <bpmndi:BPMNEdge id="SequenceFlow_1wkb5x5_di" bpmnElement="SequenceFlow_1wkb5x5">
+        <di:waypoint x="392" y="121" />
+        <di:waypoint x="464" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0xll35j_di" bpmnElement="SequenceFlow_0xll35j">
+        <di:waypoint x="215" y="121" />
+        <di:waypoint x="292" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_060uah3_di" bpmnElement="task">
+        <dc:Bounds x="292" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0hz2fmb_di" bpmnElement="end">
+        <dc:Bounds x="464" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="473" y="146" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0sr8vav_di" bpmnElement="start">
+        <dc:Bounds x="179" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="187" y="146" width="22" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/benchmarks/setup/default/Makefile
+++ b/benchmarks/setup/default/Makefile
@@ -1,7 +1,7 @@
 namespace ?= default
 
 .PHONY: all
-all: zeebe starter timer simpleStarter worker
+all: zeebe starter publisher timer simpleStarter worker
 
 .PHONY: zeebe
 zeebe:
@@ -21,6 +21,10 @@ update:
 starter:
 	kubectl apply -n $(namespace) -f starter.yaml
 
+.PHONY: publisher
+publisher:
+	kubectl apply -n $(namespace) -f publisher.yaml
+
 .PHONY: timer
 timer:
 	kubectl apply -n $(namespace) -f timer.yaml
@@ -35,7 +39,7 @@ worker:
 
 
 .PHONY: clean
-clean: clean-starter clean-timer clean-simpleStarter clean-worker clean-zeebe
+clean: clean-starter clean-publisher clean-timer clean-simpleStarter clean-worker clean-zeebe
 
 .PHONY: clean-zeebe
 clean-zeebe:
@@ -46,6 +50,10 @@ clean-zeebe:
 .PHONY: clean-starter
 clean-starter:
 	-kubectl delete -n $(namespace) -f starter.yaml
+
+.PHONY: clean-publisher
+clean-publisher:
+	-kubectl delete -n $(namespace) -f publisher.yaml
 
 .PHONY: clean-timer
 clean-timer:

--- a/benchmarks/setup/default/publisher.yaml
+++ b/benchmarks/setup/default/publisher.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: publisher
+  labels:
+    app: publisher
+spec:
+  selector:
+    matchLabels:
+      app: publisher
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: publisher
+    spec:
+      containers:
+      - name: publisher
+        image: gcr.io/zeebe-io/starter:SNAPSHOT
+        imagePullPolicy: Always
+        env:
+          - name: JAVA_OPTIONS
+            value: >-
+              -Dapp.brokerUrl=default-zeebe-gateway:26500
+              -Dapp.starter.rate=100
+              -Dzeebe.client.requestTimeout=62000
+              -XX:+HeapDumpOnOutOfMemoryError
+              -Dapp.starter.bpmnXmlPath=bpmn/msg_one_task.bpmn
+              -Dapp.starter.startViaMessage=true
+          - name: LOG_LEVEL
+            value: "warn"
+        resources:
+          limits:
+            cpu: 250m
+            memory: 256Mi
+          requests:
+            cpu: 250m
+            memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: zeebe
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/name: zeebe-cluster
+  name: publisher
+spec:
+  clusterIP: None
+  ports:
+  - name: http
+    port: 9600
+    protocol: TCP
+    targetPort: 9600
+  publishNotReadyAddresses: true
+  selector:
+    app: publisher
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/benchmarks/setup/newBenchmark.sh
+++ b/benchmarks/setup/newBenchmark.sh
@@ -23,7 +23,7 @@ cp -rv default/ $namespace
 cd $namespace
 
 # calls OS specific sed inplace function
-sed_inplace "s/default/$namespace/g" Makefile starter.yaml timer.yaml simpleStarter.yaml worker.yaml
+sed_inplace "s/default/$namespace/g" Makefile *.yaml
 
 # get latest updates from zeebe repo
 helm repo add camunda https://helm.camunda.io # skips if already exists


### PR DESCRIPTION
## Description

This PR should improve our feature coverage in benchmarks. With that publisher, we should be able to execute workflows with message catch events (to be specific for now message start events)

![msg_one_task](https://user-images.githubusercontent.com/2758593/185961483-ab7befc3-b387-4535-a1c8-254803acaa24.png)

Example Benchmark:


![msg](https://user-images.githubusercontent.com/2758593/185961379-3a580a6a-cd32-4034-a663-0e3c63f0141e.png)


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
