### PR TITLE
[Backport stable/1.3] Add more abbreviations to the compact record logger

### DIFF
--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -60,8 +60,11 @@ public class CompactRecordLogger {
   // List rather than Map to preserve order
   private static final List<Entry<String, String>> ABBREVIATIONS =
       List.of(
+          entry("PROCESS_INSTANCE_CREATION", "CREA"),
+          entry("PROCESS_INSTANCE_MODIFICATION", "MOD"),
+          entry("PROCESS_INSTANCE", "PI"),
           entry("PROCESS", "PROC"),
-          entry("INSTANCE", "INST"),
+          entry("TIMER", "TIME"),
           entry("MESSAGE", "MSG"),
           entry("SUBSCRIPTION", "SUB"),
           entry("SEQUENCE", "SEQ"),


### PR DESCRIPTION
# Description
Backport of #10144 to `stable/1.3`.

relates to #999 #999 #9663