### PR TITLE
Reject modify command when an element for activation is unknown

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceProcessor.java
@@ -392,7 +392,7 @@ public final class CreateProcessInstanceProcessor
         });
   }
 
-  record Rejection(RejectionType type, String reason) {}
+  private record Rejection(RejectionType type, String reason) {}
 
-  record ElementIdAndType(String elementId, BpmnElementType elementType) {}
+  private record ElementIdAndType(String elementId, BpmnElementType elementType) {}
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -199,5 +199,5 @@ public final class ProcessInstanceModificationProcessor
         elementInstanceKey, ProcessInstanceIntent.ELEMENT_TERMINATED, elementInstanceRecord);
   }
 
-  record Rejection(RejectionType type, String reason) {}
+  private record Rejection(RejectionType type, String reason) {}
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -31,7 +31,10 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationActivateInstructionValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.agrona.Strings;
 
 public final class ProcessInstanceModificationProcessor
@@ -39,6 +42,8 @@ public final class ProcessInstanceModificationProcessor
 
   private static final String ERROR_MESSAGE_PROCESS_INSTANCE_NOT_FOUND =
       "Expected to modify process instance but no process instance found with key '%d'";
+  private static final String ERROR_MESSAGE_TARGET_ELEMENT_NOT_FOUND =
+      "Expected to activate element but no element found in process '%s' for element id(s): '%s'";
 
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
@@ -92,14 +97,28 @@ public final class ProcessInstanceModificationProcessor
     final var process =
         processState.getProcessByKey(processInstanceRecord.getProcessDefinitionKey());
 
+    final Set<String> unknownElementIds =
+        value.getActivateInstructions().stream()
+            .map(ProcessInstanceModificationActivateInstructionValue::getElementId)
+            .filter(targetElementId -> process.getProcess().getElementById(targetElementId) == null)
+            .collect(Collectors.toSet());
+    if (!unknownElementIds.isEmpty()) {
+      final String reason =
+          String.format(
+              ERROR_MESSAGE_TARGET_ELEMENT_NOT_FOUND,
+              BufferUtil.bufferAsString(process.getBpmnProcessId()),
+              String.join("', '", unknownElementIds));
+      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, reason);
+      rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, reason);
+      return;
+    }
+
     value
         .getActivateInstructions()
         .forEach(
             instruction -> {
               final var elementToActivate =
                   process.getProcess().getElementById(instruction.getElementId());
-
-              // todo: reject if elementToActivate could not be found (#9976)
 
               executeGlobalVariableInstructions(processInstance, process, instruction);
               // todo(#9663): execute local variable instructions

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -144,7 +144,7 @@ public final class ProcessInstanceModificationProcessor
               ERROR_MESSAGE_TARGET_ELEMENT_NOT_FOUND,
               BufferUtil.bufferAsString(process.getBpmnProcessId()),
               String.join("', '", unknownElementIds));
-      return Optional.of(new Rejection(RejectionType.NOT_FOUND, reason));
+      return Optional.of(new Rejection(RejectionType.INVALID_ARGUMENT, reason));
     }
 
     return Optional.empty();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -85,7 +85,7 @@ public class ModifyProcessInstanceRejectionTest {
     // then
     assertThat(rejection)
         .describedAs("Expect that elements with ids 'B' and 'C' are not found")
-        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
             "Expected to activate element but no element found in process '%s' for element id(s): 'B', 'C'"
                 .formatted(PROCESS_ID));


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The modification command can contain activation instructions for different elements. The elements are identified by their element ids. If at least one element id is unknown (i.e. the process of the given instance doesn't contain an element with the given id) then the command is rejected as `NOT_FOUND`.

The reason for the rejection contains a reference to the Bpmn Process ID and all of the unknown element IDs. For example:
`Expected to activate element but no element found in process 'my_process' for element id(s): 'B', 'C'`

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9976 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
