### PR TITLE
feat: s3 backup store can query status

### DIFF
--- a/backup-stores/s3/pom.xml
+++ b/backup-stores/s3/pom.xml
@@ -58,6 +58,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <scope>test</scope>

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/Metadata.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/Metadata.java
@@ -9,6 +9,10 @@ package io.camunda.zeebe.backup.s3;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.backup.api.Backup;
+import io.camunda.zeebe.backup.api.BackupDescriptor;
+import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import java.util.Set;
 
 /**
@@ -41,5 +45,13 @@ record Metadata(
         backup.descriptor().snapshotId(),
         backup.snapshot().names(),
         backup.segments().names());
+  }
+
+  BackupIdentifier id() {
+    return new BackupIdentifierImpl(nodeId, partitionId, checkpointId);
+  }
+
+  BackupDescriptor descriptor() {
+    return new BackupDescriptorImpl(snapshotId, checkpointPosition, numberOfPartitions);
   }
 }

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -44,7 +44,7 @@ public final class S3BackupStore implements BackupStore {
   public static final String SNAPSHOT_PREFIX = "snapshot/";
   public static final String SEGMENTS_PREFIX = "segments/";
 
-  static final ObjectMapper MAPPER = new ObjectMapper();
+  static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new Jdk8Module());
 
   private final S3BackupConfig config;
   private final S3AsyncClient client;
@@ -91,7 +91,8 @@ public final class S3BackupStore implements BackupStore {
 
   @Override
   public CompletableFuture<BackupStatusCode> markFailed(final BackupIdentifier id) {
-    return setStatus(id, new Status(BackupStatusCode.FAILED, "Explicitly marked as failed"));
+    return setStatus(
+        id, new Status(BackupStatusCode.FAILED, Optional.of("Explicitly marked as failed")));
   }
 
   private CompletableFuture<BackupStatusCode> setStatus(BackupIdentifier id, Status status) {

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.s3;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -16,6 +17,9 @@ import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
+import io.camunda.zeebe.backup.s3.S3BackupStoreException.BackupReadException;
+import io.camunda.zeebe.backup.s3.S3BackupStoreException.MetadataParseException;
+import io.camunda.zeebe.backup.s3.S3BackupStoreException.StatusParseException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -23,6 +27,7 @@ import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
 /**
@@ -81,26 +86,31 @@ public final class S3BackupStore implements BackupStore {
 
   @Override
   public CompletableFuture<BackupStatus> getStatus(final BackupIdentifier id) {
-    final var metadataResponseFuture =
-        client.getObject(
-            req -> req.bucket(config.bucketName()).key(objectPrefix(id) + Metadata.OBJECT_KEY),
-            AsyncResponseTransformer.toBytes());
-    final var statusResponseFuture =
-        client.getObject(
-            req -> req.bucket(config.bucketName()).key(objectPrefix(id) + Status.OBJECT_KEY),
-            AsyncResponseTransformer.toBytes());
-    return statusResponseFuture.thenCombine(
-        metadataResponseFuture,
-        (statusResponse, metadataResponse) -> {
-          try {
-            final var status = MAPPER.readValue(statusResponse.asByteArray(), Status.class);
-            final var metadata = MAPPER.readValue(metadataResponse.asByteArray(), Metadata.class);
-            return new BackupStatusImpl(
-                id, metadata.descriptor(), status.statusCode(), status.failureReason());
-          } catch (IOException e) {
-            throw new RuntimeException(e);
-          }
-        });
+    return readStatusObject(id)
+        .thenCombine(
+            readMetadataObject(id),
+            (status, metadata) ->
+                (BackupStatus)
+                    new BackupStatusImpl(
+                        id,
+                        Optional.of(metadata.descriptor()),
+                        status.statusCode(),
+                        status.failureReason()))
+        .exceptionally(
+            throwable -> {
+              // throwable is a `CompletionException`, `getCause` to handle the underlying exception
+              if (throwable.getCause() instanceof NoSuchKeyException) {
+                // Couldn't find status or metadata, indicating that the backup doesn't exist
+                return new BackupStatusImpl(
+                    id, Optional.empty(), BackupStatusCode.DOES_NOT_EXIST, Optional.empty());
+              } else if (throwable.getCause() instanceof S3BackupStoreException e) {
+                // Exception was already wrapped, no need to re-wrap
+                throw e;
+              } else {
+                // Something else happened, we don't know the status of the backup
+                throw new BackupReadException("Failed to retrieve backup status", throwable);
+              }
+            });
   }
 
   @Override
@@ -117,6 +127,40 @@ public final class S3BackupStore implements BackupStore {
   public CompletableFuture<BackupStatusCode> markFailed(final BackupIdentifier id) {
     return setStatus(
         id, new Status(BackupStatusCode.FAILED, Optional.of("Explicitly marked as failed")));
+  }
+
+  private CompletableFuture<Status> readStatusObject(BackupIdentifier id) {
+    return client
+        .getObject(
+            req -> req.bucket(config.bucketName()).key(objectPrefix(id) + Status.OBJECT_KEY),
+            AsyncResponseTransformer.toBytes())
+        .thenApply(
+            response -> {
+              try {
+                return MAPPER.readValue(response.asInputStream(), Status.class);
+              } catch (JsonParseException e) {
+                throw new StatusParseException("Failed to parse status object", e);
+              } catch (IOException e) {
+                throw new BackupReadException("Failed to read status object", e);
+              }
+            });
+  }
+
+  private CompletableFuture<Metadata> readMetadataObject(BackupIdentifier id) {
+    return client
+        .getObject(
+            req -> req.bucket(config.bucketName()).key(objectPrefix(id) + Metadata.OBJECT_KEY),
+            AsyncResponseTransformer.toBytes())
+        .thenApply(
+            response -> {
+              try {
+                return MAPPER.readValue(response.asInputStream(), Metadata.class);
+              } catch (JsonParseException e) {
+                throw new MetadataParseException("Failed to parse metadata object", e);
+              } catch (IOException e) {
+                throw new BackupReadException("Failed to read metadata object", e);
+              }
+            });
   }
 
   private CompletableFuture<BackupStatusCode> setStatus(BackupIdentifier id, Status status) {

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStoreException.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStoreException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.s3;
+
+public abstract sealed class S3BackupStoreException extends RuntimeException {
+
+  private S3BackupStoreException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+  /**
+   * Thrown when the {@link Status} object exists but can't be parsed. This is unlikely to be
+   * recoverable and indicates a corrupted backup.
+   */
+  public static final class StatusParseException extends S3BackupStoreException {
+    public StatusParseException(final String message, final Throwable cause) {
+      super(message, cause);
+    }
+  }
+
+  /**
+   * Thrown when the {@link Metadata} object exists but can't be parsed. This is unlikely to be
+   * recoverable and indicates a corrupted backup.
+   */
+  public static final class MetadataParseException extends S3BackupStoreException {
+    public MetadataParseException(final String message, final Throwable cause) {
+      super(message, cause);
+    }
+  }
+
+  /**
+   * Thrown when reading some parts of the backup from S3 failed. This might be a transient error
+   * and does not necessarily indicate a failed or corrupted backup.
+   */
+  public static final class BackupReadException extends S3BackupStoreException {
+    public BackupReadException(final String message, final Throwable cause) {
+      super(message, cause);
+    }
+  }
+}

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/Status.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/Status.java
@@ -8,24 +8,22 @@
 package io.camunda.zeebe.backup.s3;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Optional;
 
 /**
  * Holds the current {@link BackupStatusCode} and an optional failureReason in case of failed
  * backups.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record Status(
-    BackupStatusCode statusCode, @JsonInclude(Include.NON_EMPTY) String failureReason) {
+public record Status(BackupStatusCode statusCode, Optional<String> failureReason) {
 
   public static final String OBJECT_KEY = "status.json";
 
   public Status(BackupStatusCode status) {
-    this(status, "");
+    this(status, Optional.empty());
   }
 
   public static Status inProgress() {
@@ -39,6 +37,6 @@ public record Status(
   public static Status failed(Throwable throwable) {
     final var writer = new StringWriter();
     throwable.printStackTrace(new PrintWriter(writer));
-    return new Status(BackupStatusCode.FAILED, writer.toString());
+    return new Status(BackupStatusCode.FAILED, Optional.of(writer.toString()));
   }
 }

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStatus.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStatus.java
@@ -7,7 +7,15 @@
  */
 package io.camunda.zeebe.backup.api;
 
+import java.util.Optional;
+
 /** Represents the status of a backup. */
 public interface BackupStatus {
+  BackupIdentifier id();
+
+  BackupDescriptor descriptor();
+
   BackupStatusCode statusCode();
+
+  Optional<String> failureReason();
 }

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStatus.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStatus.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public interface BackupStatus {
   BackupIdentifier id();
 
-  BackupDescriptor descriptor();
+  Optional<BackupDescriptor> descriptor();
 
   BackupStatusCode statusCode();
 

--- a/backup/src/main/java/io/camunda/zeebe/backup/common/BackupStatusImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/common/BackupStatusImpl.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 
 public record BackupStatusImpl(
     BackupIdentifier id,
-    BackupDescriptor descriptor,
+    Optional<BackupDescriptor> descriptor,
     BackupStatusCode statusCode,
     Optional<String> failureReason)
     implements BackupStatus {}

--- a/backup/src/main/java/io/camunda/zeebe/backup/common/BackupStatusImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/common/BackupStatusImpl.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.common;
+
+import io.camunda.zeebe.backup.api.BackupDescriptor;
+import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
+import java.util.Optional;
+
+public record BackupStatusImpl(
+    BackupIdentifier id,
+    BackupDescriptor descriptor,
+    BackupStatusCode statusCode,
+    Optional<String> failureReason)
+    implements BackupStatus {}

--- a/backup/src/main/java/io/camunda/zeebe/backup/common/NamedFileSetImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/common/NamedFileSetImpl.java
@@ -9,30 +9,22 @@ package io.camunda.zeebe.backup.common;
 
 import io.camunda.zeebe.backup.api.NamedFileSet;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-public class NamedFileSetImpl implements NamedFileSet {
+public record NamedFileSetImpl(Map<String, Path> namedFiles) implements NamedFileSet {
 
-  private final Map<String, Path> namedFiles = new HashMap<>();
+  public NamedFileSetImpl(Map<String, Path> namedFiles) {
+    this.namedFiles = Map.copyOf(namedFiles);
+  }
 
   @Override
   public Set<String> names() {
-    return Set.copyOf(namedFiles.keySet());
+    return namedFiles.keySet();
   }
 
   @Override
   public Set<Path> files() {
     return Set.copyOf(namedFiles.values());
-  }
-
-  @Override
-  public Map<String, Path> namedFiles() {
-    return namedFiles;
-  }
-
-  public void addFile(final String name, final Path file) {
-    namedFiles.put(name, file);
   }
 }


### PR DESCRIPTION
The s3 backup store can now query the status of backups.

The resulting future will complete exceptionally in case of any unexpected exceptions. If the `status` or `metadata` objects can't be found, the future will complete successfully but with status code `DOES_NOT_EXIST` and with no `BackupDescriptor`.

closes #10146 