### PR TITLE
feat(backup): find valid snapshot and reserve

### DIFF
--- a/backup/pom.xml
+++ b/backup/pom.xml
@@ -51,6 +51,16 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-snapshots</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -60,6 +60,7 @@ public final class BackupService extends Actor implements BackupManager {
         () -> {
           final InProgressBackupImpl inProgressBackup =
               new InProgressBackupImpl(
+                  null,
                   new BackupIdentifierImpl(nodeId, partitionId, checkpointId),
                   checkpointPosition,
                   numberOfPartitions,

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,20 +26,27 @@ public final class BackupService extends Actor implements BackupManager {
   private final int partitionId;
   private final int numberOfPartitions;
   private final BackupServiceImpl internalBackupManager;
+  private final PersistedSnapshotStore snapshotStore;
 
-  public BackupService(final int nodeId, final int partitionId, final int numberOfPartitions) {
+  public BackupService(
+      final int nodeId,
+      final int partitionId,
+      final int numberOfPartitions,
+      final PersistedSnapshotStore snapshotStore) {
     // Use a noop backup store until a proper backup store is available
-    this(nodeId, partitionId, numberOfPartitions, NoopBackupStore.INSTANCE);
+    this(nodeId, partitionId, numberOfPartitions, NoopBackupStore.INSTANCE, snapshotStore);
   }
 
   public BackupService(
       final int nodeId,
       final int partitionId,
       final int numberOfPartitions,
-      final BackupStore backupStore) {
+      final BackupStore backupStore,
+      final PersistedSnapshotStore snapshotStore) {
     this.nodeId = nodeId;
     this.partitionId = partitionId;
     this.numberOfPartitions = numberOfPartitions;
+    this.snapshotStore = snapshotStore;
     internalBackupManager =
         new BackupServiceImpl(nodeId, partitionId, numberOfPartitions, backupStore);
     actorName = buildActorName(nodeId, "BackupService", partitionId);
@@ -60,7 +68,7 @@ public final class BackupService extends Actor implements BackupManager {
         () -> {
           final InProgressBackupImpl inProgressBackup =
               new InProgressBackupImpl(
-                  null,
+                  snapshotStore,
                   new BackupIdentifierImpl(nodeId, partitionId, checkpointId),
                   checkpointPosition,
                   numberOfPartitions,

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackup.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackup.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.backup.management;
 
-import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 
 interface InProgressBackup {
@@ -24,7 +24,7 @@ interface InProgressBackup {
 
   ActorFuture<Void> findSegmentFiles();
 
-  ActorFuture<Void> save(BackupStore store);
+  Backup createBackup();
 
   void fail(Throwable error);
 

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -11,19 +11,34 @@ import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
+import io.camunda.zeebe.snapshots.SnapshotException.SnapshotNotFoundException;
+import io.camunda.zeebe.util.Either;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 final class InProgressBackupImpl implements InProgressBackup {
+  private static final String ERROR_MSG_NO_VALID_SNAPSHOT =
+      "Cannot find a snapshot that can be included in the backup %d. All available snapshots (%s) have processedPosition or exportedPosition > checkpointPosition %d";
 
+  private final PersistedSnapshotStore snapshotStore;
   private final BackupIdentifier backupId;
   private final long checkpointPosition;
   private final int numberOfPartitions;
   private final ConcurrencyControl concurrencyControl;
 
+  // Snapshot related data
+  private boolean hasSnapshot = true;
+  private Set<PersistedSnapshot> availableValidSnapshots;
+
   InProgressBackupImpl(
+      final PersistedSnapshotStore snapshotStore,
       final BackupIdentifier backupId,
       final long checkpointPosition,
       final int numberOfPartitions,
       final ConcurrencyControl concurrencyControl) {
+    this.snapshotStore = snapshotStore;
     this.backupId = backupId;
     this.checkpointPosition = checkpointPosition;
     this.numberOfPartitions = numberOfPartitions;
@@ -42,7 +57,30 @@ final class InProgressBackupImpl implements InProgressBackup {
 
   @Override
   public ActorFuture<Void> findValidSnapshot() {
-    return concurrencyControl.createCompletedFuture();
+    final ActorFuture<Void> result = concurrencyControl.createFuture();
+    snapshotStore
+        .getAvailableSnapshots()
+        .onComplete(
+            (snapshots, error) -> {
+              if (error != null) {
+                result.completeExceptionally(error);
+              } else if (snapshots.isEmpty()) {
+                // no snapshot is taken until now, so return successfully
+                hasSnapshot = false;
+                result.complete(null);
+              } else {
+                final var eitherSnapshots = findValidSnapshot(snapshots);
+                if (eitherSnapshots.isLeft()) {
+                  result.completeExceptionally(
+                      new SnapshotNotFoundException(eitherSnapshots.getLeft()));
+                } else {
+                  availableValidSnapshots = eitherSnapshots.get();
+                  result.complete(null);
+                }
+              }
+            });
+
+    return result;
   }
 
   @Override
@@ -74,5 +112,22 @@ final class InProgressBackupImpl implements InProgressBackup {
   @Override
   public void close() {
     // To be implemented
+  }
+
+  private Either<String, Set<PersistedSnapshot>> findValidSnapshot(
+      final Set<PersistedSnapshot> snapshots) {
+    final var validSnapshots =
+        snapshots.stream()
+            .filter(s -> s.getMetadata().processedPosition() < checkpointPosition) // &&
+            .filter(s -> s.getMetadata().lastFollowupEventPosition() < checkpointPosition)
+            .collect(Collectors.toSet());
+
+    if (validSnapshots.isEmpty()) {
+      return Either.left(
+          String.format(
+              ERROR_MSG_NO_VALID_SNAPSHOT, checkpointId(), snapshots, checkpointPosition));
+    } else {
+      return Either.right(validSnapshots);
+    }
   }
 }

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -30,7 +30,7 @@ final class InProgressBackupImpl implements InProgressBackup {
   private static final Logger LOG = LoggerFactory.getLogger(InProgressBackup.class);
 
   private static final String ERROR_MSG_NO_VALID_SNAPSHOT =
-      "Cannot find a snapshot that can be included in the backup %d. All available snapshots (%s) have processedPosition or exportedPosition > checkpointPosition %d";
+      "Cannot find a snapshot that can be included in the backup %d. All available snapshots (%s) have processedPosition or lastFollowupEventPosition > checkpointPosition %d";
 
   private final PersistedSnapshotStore snapshotStore;
   private final BackupIdentifier backupId;

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.backup.management;
 
+import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
-import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 
@@ -61,9 +61,9 @@ final class InProgressBackupImpl implements InProgressBackup {
   }
 
   @Override
-  public ActorFuture<Void> save(final BackupStore store) {
-    // save backup
-    return concurrencyControl.createCompletedFuture();
+  public Backup createBackup() {
+    // Should return a Backup object
+    return null;
   }
 
   @Override

--- a/backup/src/test/java/io/camunda/zeebe/backup/management/InProgressBackupImplTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/management/InProgressBackupImplTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.scheduler.testing.TestActorFuture;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
+import io.camunda.zeebe.snapshots.SnapshotException.SnapshotNotFoundException;
+import io.camunda.zeebe.snapshots.SnapshotMetadata;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InProgressBackupImplTest {
+
+  @Mock PersistedSnapshotStore snapshotStore;
+
+  InProgressBackupImpl inProgressBackup;
+  private final TestConcurrencyControl concurrencyControl = new TestConcurrencyControl();
+
+  @BeforeEach
+  void setup() {
+    inProgressBackup =
+        new InProgressBackupImpl(
+            snapshotStore, new BackupIdentifierImpl(1, 1, 1), 10, 1, concurrencyControl);
+  }
+
+  @Test
+  void shouldCompleteFutureNoSnapshotExists() {
+    // given
+    when(snapshotStore.getAvailableSnapshots())
+        .thenReturn(TestActorFuture.completedFuture(Set.of()));
+
+    // when
+    final var future = inProgressBackup.findValidSnapshot();
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofMillis(100));
+  }
+
+  @Test
+  void shouldCompleteFutureWhenValidSnapshotFound() {
+    // given
+    final var validSnapshot = snapshotWith(1L, 5L);
+    final var invalidSnapshot = snapshotWith(8L, 20L);
+    final Set<PersistedSnapshot> snapshots = Set.of(validSnapshot, invalidSnapshot);
+    when(snapshotStore.getAvailableSnapshots())
+        .thenReturn(TestActorFuture.completedFuture(snapshots));
+
+    // when
+    final var future = inProgressBackup.findValidSnapshot();
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofMillis(100));
+  }
+
+  @Test
+  void shouldFailFutureWhenSnapshotIsPastCheckpointPosition() {
+    // given - checkpointPosition < processedPosition <  followupPosition
+    final var invalidSnapshot = snapshotWith(11L, 20L);
+    final Set<PersistedSnapshot> snapshots = Set.of(invalidSnapshot);
+    when(snapshotStore.getAvailableSnapshots())
+        .thenReturn(TestActorFuture.completedFuture(snapshots));
+
+    // when - then
+    // when
+    final var future = inProgressBackup.findValidSnapshot();
+
+    // then
+    assertThat(future)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableOfType(ExecutionException.class)
+        .withRootCauseInstanceOf(SnapshotNotFoundException.class);
+  }
+
+  @Test
+  void shouldFailFutureWhenSnapshotOverlapsWithCheckpoint() {
+    // given - processedPosition < checkpointPosition < followupPosition
+    final var invalidSnapshot = snapshotWith(8L, 20L);
+    final Set<PersistedSnapshot> snapshots = Set.of(invalidSnapshot);
+    when(snapshotStore.getAvailableSnapshots())
+        .thenReturn(TestActorFuture.completedFuture(snapshots));
+
+    // when
+    final var future = inProgressBackup.findValidSnapshot();
+
+    // then
+    assertThat(future)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableOfType(ExecutionException.class)
+        .withRootCauseInstanceOf(SnapshotNotFoundException.class);
+  }
+
+  private PersistedSnapshot snapshotWith(
+      final long processedPosition, final long followUpPosition) {
+    final PersistedSnapshot snapshot = mock(PersistedSnapshot.class);
+    final SnapshotMetadata snapshotMetadata = mock(SnapshotMetadata.class);
+    when(snapshotMetadata.processedPosition()).thenReturn(processedPosition);
+    lenient().when(snapshotMetadata.lastFollowupEventPosition()).thenReturn(followUpPosition);
+
+    when(snapshot.getMetadata()).thenReturn(snapshotMetadata);
+    return snapshot;
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import java.util.Collection;
@@ -48,6 +49,8 @@ public interface PartitionTransitionContext extends PartitionContext {
   void setSnapshotDirector(AsyncSnapshotDirector snapshotDirector);
 
   StateController getStateController();
+
+  PersistedSnapshotStore getPersistedSnapshotStore();
 
   List<PartitionListener> getPartitionListeners();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
@@ -54,7 +54,8 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
         new BackupService(
             context.getNodeId(),
             context.getPartitionId(),
-            context.getBrokerCfg().getCluster().getPartitionsCount());
+            context.getBrokerCfg().getCluster().getPartitionsCount(),
+            context.getPersistedSnapshotStore());
     final ActorFuture<Void> installed = context.getConcurrencyControl().createFuture();
     context
         .getActorSchedulingService()

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
+import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.streamprocessor.StreamProcessor;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthMonitor;
@@ -352,6 +353,11 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public StateController getStateController() {
     return stateController;
+  }
+
+  @Override
+  public PersistedSnapshotStore getPersistedSnapshotStore() {
+    return null;
   }
 
   @Override


### PR DESCRIPTION
## Description

- Find a valid snapshot from the set of available snapshots.
- Reserve one of the available snapshot. If more snapshots are available, it tries to reserve the newest first. If it fails, it move on to the next available snapshot.
- For testability, changed the interface of InProgressBackup - removed `save` and added `createBackup` which should return a Backup object. We can use this in tests to verify `InProgressBackupImpl`. `BackupService` uses it to save the backup.

## Related issues

related #9979 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
