### PR TITLE
Don't over abbreviate rejections in compact record logger

### DIFF
--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -552,7 +552,7 @@ public class CompactRecordLogger {
         .append("!")
         .append(record.getRejectionType())
         .append(" (")
-        .append(StringUtils.abbreviate(record.getRejectionReason(), "..", 200))
+        .append(StringUtils.abbreviate(record.getRejectionReason(), "..", 500))
         .append(")");
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

The compact record logger abbreviates long rejection reasons. This makes sense, because these can be excessively long in some cases. However, the compact record logger shouldn't reduce the usefulness of this data.

Before:

```
--------
C DPLY CREATE - #1->-1 -1 -
R DPLY CREATE - #2->#1 -1 -  !INVALID_ARGUMENT (Expected to deploy new resources, but encountered the following errors:
'process.xml': - Element: message_8722b478-fc0f-4c67-82fe-46ee7c067da2 > extensionElements > subscription
    - ERROR: Expecte..)

-------------- Deployed Processes ----------------------
```

After:

```
--------
C DPLY CREATE - #1->-1 -1 -
R DPLY CREATE - #2->#1 -1 -  !INVALID_ARGUMENT (Expected to deploy new resources, but encountered the following errors:
'process.xml': - Element: message_252ebafa-ed9a-40a6-be98-ec31e71316a8 > extensionElements > subscription
    - ERROR: Expected expression but found static value 'key'. An expression must start with '=' (e.g. '=key').
)

-------------- Deployed Processes ----------------------
```

We could consider further abbreviating this rejection message in a smart way, but for now this seems enough.

## Related issues

<!-- Which issues are closed by this PR or are related -->

NA

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
