### PR TITLE
[Backport stable/1.3] Don't over abbreviate rejections in compact record logger

### DIFF
--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -525,7 +525,7 @@ public class CompactRecordLogger {
         .append("!")
         .append(record.getRejectionType())
         .append(" (")
-        .append(StringUtils.abbreviate(record.getRejectionReason(), "..", 200))
+        .append(StringUtils.abbreviate(record.getRejectionReason(), "..", 500))
         .append(")");
   }
 


### PR DESCRIPTION
# Description
Backport of #10156 to `stable/1.3`.

relates to 