### PR TITLE
test(backup/s3): wait for markFailed to complete before checking status

### DIFF
--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreIT.java
@@ -294,7 +294,7 @@ final class S3BackupStoreIT {
 
     // when
     store.save(backup).join();
-    store.markFailed(backup.id());
+    store.markFailed(backup.id()).join();
     final var status = store.getStatus(backup.id());
 
     // then


### PR DESCRIPTION
Closes #10161 by waiting for the `markFailed` to complete before checking that the status should be `FAILED`.