### PR TITLE
Reject modification command when it contains activate instruction inside of multi instance

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -146,8 +146,8 @@ public final class ProcessInstanceModificationProcessor
         .map(valid -> process);
   }
 
-
-  private Either<Rejection, DeployedProcess> validateElementExists(final DeployedProcess process,
+  private Either<Rejection, DeployedProcess> validateElementExists(
+      final DeployedProcess process,
       final List<ProcessInstanceModificationActivateInstructionValue> activateInstructions) {
     final Set<String> unknownElementIds =
         activateInstructions.stream()
@@ -164,12 +164,15 @@ public final class ProcessInstanceModificationProcessor
     }
     return Either.right(process);
   }
-  private Either<Rejection, DeployedProcess> validateElementsNotInsideMultiInstance(final DeployedProcess process,
+
+  private Either<Rejection, DeployedProcess> validateElementsNotInsideMultiInstance(
+      final DeployedProcess process,
       final List<ProcessInstanceModificationActivateInstructionValue> activateInstructions) {
     final Set<String> elementsInsideMultiInstance =
         activateInstructions.stream()
             .map(ProcessInstanceModificationActivateInstructionValue::getElementId)
-            .filter(elementId -> isInsideMultiInstanceBody(process, BufferUtil.wrapString(elementId)))
+            .filter(
+                elementId -> isInsideMultiInstanceBody(process, BufferUtil.wrapString(elementId)))
             .collect(Collectors.toSet());
     if (!elementsInsideMultiInstance.isEmpty()) {
       final String reason =
@@ -182,7 +185,8 @@ public final class ProcessInstanceModificationProcessor
     return Either.right(process);
   }
 
-  private boolean isInsideMultiInstanceBody(final DeployedProcess process, final DirectBuffer elementId) {
+  private boolean isInsideMultiInstanceBody(
+      final DeployedProcess process, final DirectBuffer elementId) {
     final var element = process.getProcess().getElementById(elementId);
 
     if (element.getFlowScope() == null) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -156,15 +156,17 @@ public final class ProcessInstanceModificationProcessor
             .map(ProcessInstanceModificationActivateInstructionValue::getElementId)
             .filter(targetElementId -> process.getProcess().getElementById(targetElementId) == null)
             .collect(Collectors.toSet());
-    if (!unknownElementIds.isEmpty()) {
-      final String reason =
-          String.format(
-              ERROR_MESSAGE_TARGET_ELEMENT_NOT_FOUND,
-              BufferUtil.bufferAsString(process.getBpmnProcessId()),
-              String.join("', '", unknownElementIds));
-      return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, reason));
+
+    if (unknownElementIds.isEmpty()) {
+      return VALID;
     }
-    return VALID;
+
+    final String reason =
+        String.format(
+            ERROR_MESSAGE_TARGET_ELEMENT_NOT_FOUND,
+            BufferUtil.bufferAsString(process.getBpmnProcessId()),
+            String.join("', '", unknownElementIds));
+    return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, reason));
   }
 
   private Either<Rejection, ?> validateElementsNotInsideMultiInstance(
@@ -176,15 +178,17 @@ public final class ProcessInstanceModificationProcessor
             .filter(
                 elementId -> isInsideMultiInstanceBody(process, BufferUtil.wrapString(elementId)))
             .collect(Collectors.toSet());
-    if (!elementsInsideMultiInstance.isEmpty()) {
-      final String reason =
-          String.format(
-              ERROR_MESSAGE_TARGET_ELEMENT_IN_MULTI_INSTANCE_BODY,
-              BufferUtil.bufferAsString(process.getBpmnProcessId()),
-              String.join("', '", elementsInsideMultiInstance));
-      return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, reason));
+
+    if (elementsInsideMultiInstance.isEmpty()) {
+      return VALID;
     }
-    return VALID;
+
+    final String reason =
+        String.format(
+            ERROR_MESSAGE_TARGET_ELEMENT_IN_MULTI_INSTANCE_BODY,
+            BufferUtil.bufferAsString(process.getBpmnProcessId()),
+            String.join("', '", elementsInsideMultiInstance));
+    return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, reason));
   }
 
   private boolean isInsideMultiInstanceBody(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -47,11 +47,12 @@ public final class ProcessInstanceModificationProcessor
   private static final String ERROR_MESSAGE_PROCESS_INSTANCE_NOT_FOUND =
       "Expected to modify process instance but no process instance found with key '%d'";
   private static final String ERROR_MESSAGE_TARGET_ELEMENT_NOT_FOUND =
-      "Expected to activate element but no element found in process '%s' for element id(s): '%s'";
+      "Expected to modify instance of process '%s' but it contains one or more activate instructions with an element that could not be found: '%s'";
   private static final String ERROR_MESSAGE_TARGET_ELEMENT_IN_MULTI_INSTANCE_BODY =
-      "Expected to modify instance of process '%s' with activate instructions but the element(s) "
-          + "with id(s) '%s' is inside a multi-instance subprocess. The activation of element(s) "
-          + "inside a multi-instance subprocess is not supported.";
+      "Expected to modify instance of process '%s' but it contains one or more activate instructions"
+          + " for elements inside a multi-instance subprocess: '%s'. The activation of elements inside"
+          + " a multi-instance subprocess is not supported.";
+
   private static final Either<Rejection, Object> VALID = Either.right(null);
 
   private final StateWriter stateWriter;

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -104,7 +104,7 @@ public class ModifyProcessInstanceRejectionTest {
                     "subprocess",
                     s -> s.embeddedSubProcess().startEvent().manualTask("B").manualTask("C").done())
                 .multiInstance(m -> m.zeebeInputCollectionExpression("[1,2,3]"))
-                .manualTask("task")
+                .manualTask("D")
                 .endEvent()
                 .done())
         .deploy();
@@ -122,6 +122,7 @@ public class ModifyProcessInstanceRejectionTest {
             .modification()
             .activateElement("B")
             .activateElement("C")
+            .activateElement("D")
             .expectRejection()
             .modify();
 
@@ -131,7 +132,8 @@ public class ModifyProcessInstanceRejectionTest {
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
             ("Expected to modify instance of process '%s' with activate instructions but the element(s) with id(s) 'B', 'C'"
-                    + " is inside a multi-instance subprocess. The activation of element(s) inside a multi-instance subprocess is not supported.")
+                    + " is inside a multi-instance subprocess. The activation of element(s) inside a multi-instance"
+                    + " subprocess is not supported.")
                 .formatted(PROCESS_ID));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -87,7 +87,8 @@ public class ModifyProcessInstanceRejectionTest {
         .describedAs("Expect that elements with ids 'B' and 'C' are not found")
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
-            "Expected to activate element but no element found in process '%s' for element id(s): 'B', 'C'"
+            ("Expected to modify instance of process '%s' but it contains one or more activate instructions"
+                    + " with an element that could not be found: 'B', 'C'")
                 .formatted(PROCESS_ID));
   }
 
@@ -131,9 +132,9 @@ public class ModifyProcessInstanceRejectionTest {
         .describedAs("Expect that elements with ids 'B' and 'C' are inside multi-instance")
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
-            ("Expected to modify instance of process '%s' with activate instructions but the element(s) with id(s) 'B', 'C'"
-                    + " is inside a multi-instance subprocess. The activation of element(s) inside a multi-instance"
-                    + " subprocess is not supported.")
+            ("Expected to modify instance of process '%s' but it contains one or more activate"
+                    + " instructions for elements inside a multi-instance subprocess: 'B', 'C'."
+                    + " The activation of elements inside a multi-instance subprocess is not supported.")
                 .formatted(PROCESS_ID));
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ModifyProcessInstanceTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ModifyProcessInstanceTest.java
@@ -53,7 +53,7 @@ public class ModifyProcessInstanceTest {
             .send();
 
     // then
-    assertThatThrownBy(() -> command.join())
+    assertThatThrownBy(command::join)
         .isInstanceOf(ClientStatusException.class)
         .hasMessageContaining(
             String.format(


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Activating elements inside of a multi-instance is not supported as of now. If we receive a command containing activate instructions of an element inside a multi-instance the command should be rejected.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9977

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
