### PR TITLE
Print record timestamp in compact record logger

### DIFF
--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -188,16 +188,23 @@ public class CompactRecordLogger {
     if (hasTimerEvents) {
       bulkMessage.append("[Timestamp] ");
     }
+    if (multiPartition) {
+      bulkMessage.append("[Partition] ");
+    }
     bulkMessage.append(
-        "[Partition] ['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position]  P[partitionId]K[key] - [summary of value]\n");
-    bulkMessage
-        .append(
-            "\tP9K999 - key; #999 - record position; \"ID\" element/process id; @\"elementid\"/[P9K999] - element with ID and key\n")
-        .append(
-            "\tKeys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.\n")
-        .append(
-            "\tLong IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'\n")
-        .append("--------\n");
+        "['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position] ");
+    if (multiPartition) {
+      bulkMessage.append("P[partitionId]");
+    }
+    bulkMessage.append("K[key] - [summary of value]\n");
+
+    bulkMessage.append(
+        "\tP9K999 - key; #999 - record position; \"ID\" element/process id; @\"elementid\"/[P9K999] - element with ID and key\n");
+    bulkMessage.append(
+        "\tKeys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.\n");
+    bulkMessage.append(
+        "\tLong IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'\n");
+    bulkMessage.append("--------\n");
 
     records.forEach(record -> bulkMessage.append(summarizeRecord(record)).append("\n"));
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -182,10 +182,15 @@ public class CompactRecordLogger {
   }
 
   private void addSummarizedRecords(final StringBuilder bulkMessage) {
+    bulkMessage.append("--------\n");
+
+    bulkMessage.append("\t");
+    if (hasTimerEvents) {
+      bulkMessage.append("[Timestamp] ");
+    }
+    bulkMessage.append(
+        "[Partition] ['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position]  P[partitionId]K[key] - [summary of value]\n");
     bulkMessage
-        .append("--------\n")
-        .append(
-            "\t[Timestamp] [Partition] ['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position]  P[partitionId]K[key] - [summary of value]\n")
         .append(
             "\tP9K999 - key; #999 - record position; \"ID\" element/process id; @\"elementid\"/[P9K999] - element with ID and key\n")
         .append(

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -94,6 +94,7 @@ public class CompactRecordLogger {
   private final int valueTypeChars;
   private final int intentChars;
   private final boolean multiPartition;
+  private final boolean hasTimerEvents;
   private final Map<Long, String> substitutions = new HashMap<>();
   private final ArrayList<Record<?>> records;
 
@@ -126,6 +127,7 @@ public class CompactRecordLogger {
   public CompactRecordLogger(final Collection<Record<?>> records) {
     this.records = new ArrayList<>(records);
     multiPartition = isMultiPartition();
+    hasTimerEvents = records.stream().anyMatch(r -> r.getValueType() == ValueType.TIMER);
 
     final var highestPosition = this.records.get(this.records.size() - 1).getPosition();
 
@@ -183,7 +185,7 @@ public class CompactRecordLogger {
     bulkMessage
         .append("--------\n")
         .append(
-            "\t[Partition] ['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position]  P[partitionId]K[key] - [summary of value]\n")
+            "\t[Timestamp] [Partition] ['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position]  P[partitionId]K[key] - [summary of value]\n")
         .append(
             "\tP9K999 - key; #999 - record position; \"ID\" element/process id; @\"elementid\"/[P9K999] - element with ID and key\n")
         .append(
@@ -225,6 +227,7 @@ public class CompactRecordLogger {
   private StringBuilder summarizeRecord(final Record<?> record) {
     final StringBuilder message = new StringBuilder();
 
+    message.append(summarizeTimestamp(record));
     message.append(summarizePartition(record));
     message.append(summarizeIntent(record));
     message.append(summarizePositionFields(record));
@@ -236,6 +239,16 @@ public class CompactRecordLogger {
     }
 
     return message;
+  }
+
+  private String summarizeTimestamp(final Record<?> record) {
+    if (!hasTimerEvents) {
+      return "";
+    }
+    final var timestampWithoutMillis =
+        ZonedDateTime.ofInstant(Instant.ofEpochMilli(record.getTimestamp()), ZoneId.systemDefault())
+            .withNano(0);
+    return DateTimeFormatter.ISO_LOCAL_TIME.format(timestampWithoutMillis) + " ";
   }
 
   private String summarizePartition(final Record<?> record) {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
When troubleshooting issues (or writing tests) for Timer related topics, we're often interested in both the Timer record's Duedate, as well as the actual time that the record was written, i.e. the record's Timestamp.

This PR adds the Timestamp to the compact record logger when there are Timer records on the recorded log.

While working on this, I also noticed that the compact record logger's Legend could be improved to only include Partition related info when the partition is actually printed as well (i.e. when there are multiple partitions).

This is another PR in a series of QoL improvements I've recently made to the compact record logger.
- #10156 
- #10144 
- #9885

### Before
```
--------
	[Partition] ['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position]  P[partitionId]K[key] - [summary of value]
	P9K999 - key; #999 - record position; "ID" element/process id; @"elementid"/[P9K999] - element with ID and key
	Keys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.
	Long IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'
--------
C DPLY CREATE            - #1->-1 -1 - 
E PROC CREATED           - #2->#1 K1 - process.xml -> "process" (version:1)
E TIME CREATED           - #3->#1 K3 -  @"start_1"[-1]  in <process "K1"[?]> due T15:10:34.329
E DPLY CREATED           - #4->#1 K2 - process.xml
E DPLY FULLY_DISTRIBUTED - #5->#1 K2 - 
```

### After

With Timer records:
```
--------
	[Timestamp] ['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position] K[key] - [summary of value]
	P9K999 - key; #999 - record position; "ID" element/process id; @"elementid"/[P9K999] - element with ID and key
	Keys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.
	Long IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'
--------
15:28:01 C DPLY CREATE            - #1->-1 -1 - 
15:28:02 E PROC CREATED           - #2->#1 K1 - process.xml -> "process" (version:1)
15:28:02 E TIME CREATED           - #3->#1 K3 -  @"start_1"[-1]  in <process "K1"[?]> due T15:28:03.087
15:28:02 E DPLY CREATED           - #4->#1 K2 - process.xml
15:28:02 E DPLY FULLY_DISTRIBUTED - #5->#1 K2 - 
```

Without Timer records:
```
--------
	['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position] K[key] - [summary of value]
	P9K999 - key; #999 - record position; "ID" element/process id; @"elementid"/[P9K999] - element with ID and key
	Keys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.
	Long IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'
--------
C DPLY CREATE            - #01-> -1  -1 - 
E PROC CREATED           - #02->#01 K01 - process.xml -> "process" (version:1)
E DPLY CREATED           - #03->#01 K02 - process.xml
E DPLY FULLY_DISTRIBUTED - #04->#01 K02 - 
```

When there are multiple partitions:
```
--------
	[Partition] ['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position] P[partitionId]K[key] - [summary of value]
	P9K999 - key; #999 - record position; "ID" element/process id; @"elementid"/[P9K999] - element with ID and key
	Keys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.
	Long IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'
--------
1 C DPLY CREATE            - #1->-1   -1 - 
1 E PROC CREATED           - #2->#1 P1K1 - process.bpmn -> "shouldR..ecovery" (version:1)
1 E DPLY CREATED           - #3->#1 P1K2 - process.bpmn
1 E DSTR DISTRIBUTING      - #4->#1 P1K2 - on partition 2
1 E DSTR DISTRIBUTING      - #5->#1 P1K2 - on partition 3
1 C DSTR COMPLETE          - #6->-1 P1K2 - on partition 2
1 C DSTR COMPLETE          - #7->-1 P1K2 - on partition 3
1 E DSTR COMPLETED         - #8->#6 P1K2 - on partition 2
1 E DSTR COMPLETED         - #9->#7 P1K2 - on partition 3
1 E DPLY FULLY_DISTRIBUTED - #10->#7 P1K2 - 
2 C DPLY DISTRIBUTE        - #1->-1 P1K2 - process.bpmn
2 E DPLY DISTRIBUTED       - #2->#1 P1K2 - process.bpmn
3 C DPLY DISTRIBUTE        - #1->-1 P1K2 - process.bpmn
3 E DPLY DISTRIBUTED       - #2->#1 P1K2 - process.bpmn
```

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #10169

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
