### PR TITLE
feat: s3 backup store can delete backups

### DIFF
--- a/backup-stores/s3/README.md
+++ b/backup-stores/s3/README.md
@@ -1,0 +1,7 @@
+# Backup Store for S3
+
+## Known limitations
+
+* Individual files in a backup may not exceed 5GiB, otherwise the upload may fail
+* If the backup consists of more than 1000 files, deleting a backup may leave behind some objects.
+

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -122,7 +122,9 @@ public final class S3BackupStore implements BackupStore {
 
   @Override
   public CompletableFuture<Void> delete(final BackupIdentifier id) {
-    throw new UnsupportedOperationException();
+    return requireBackupStatus(id, EnumSet.complementOf(EnumSet.of(BackupStatusCode.IN_PROGRESS)))
+        .thenComposeAsync(this::listBackupObjects)
+        .thenComposeAsync(this::deleteBackupObjects);
   }
 
   @Override
@@ -219,7 +221,7 @@ public final class S3BackupStore implements BackupStore {
             });
   }
 
-  private CompletableFuture<BackupStatusCode> setStatus(BackupIdentifier id, Status status) {
+  public CompletableFuture<BackupStatusCode> setStatus(BackupIdentifier id, Status status) {
     final AsyncRequestBody body;
     try {
       body = AsyncRequestBody.fromBytes(MAPPER.writeValueAsBytes(status));

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStoreException.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStoreException.java
@@ -42,4 +42,25 @@ public abstract sealed class S3BackupStoreException extends RuntimeException {
       super(message, cause);
     }
   }
+
+  /**
+   * Thrown when the backup is in an invalid state, for example when attempting to restore a failed
+   * backup or deleting an in progress backup.
+   */
+  public static final class BackupInInvalidStateException extends S3BackupStoreException {
+    public BackupInInvalidStateException(final String message) {
+      super(message, null);
+    }
+  }
+
+  /**
+   * Thrown when not all objects belonging to a backup were deleted successfully. Retrying the
+   * deletion might resolve this.
+   */
+  public static final class BackupDeletionIncomplete extends S3BackupStoreException {
+
+    public BackupDeletionIncomplete(final String message) {
+      super(message, null);
+    }
+  }
 }

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreIT.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.backup.s3.S3BackupStoreException.BackupInInvalidStateException;
 import io.camunda.zeebe.backup.s3.S3BackupStoreException.MetadataParseException;
 import io.camunda.zeebe.backup.s3.S3BackupStoreException.StatusParseException;
 import java.io.IOException;
@@ -360,6 +361,70 @@ final class S3BackupStoreIT {
     assertThat(result)
         .succeedsWithin(Duration.ofSeconds(10))
         .returns(BackupStatusCode.DOES_NOT_EXIST, from(BackupStatus::statusCode));
+  }
+
+  @Test
+  void allBackupObjectsAreDeleted(@TempDir Path tempDir) throws IOException {
+    // given
+    final var backup = prepareTestBackup(tempDir);
+    store.save(backup).join();
+
+    // when
+    store.delete(backup.id()).join();
+
+    // then
+    final var listed =
+        client
+            .listObjectsV2(
+                req ->
+                    req.bucket(config.bucketName()).prefix(S3BackupStore.objectPrefix(backup.id())))
+            .join();
+    assertThat(listed.contents()).isEmpty();
+  }
+
+  @Test
+  void deletingNonExistingBackupSucceeds() {
+    // when
+    final var delete = store.delete(new BackupIdentifierImpl(1, 2, 3));
+
+    // then
+    assertThat(delete).succeedsWithin(Duration.ofSeconds(10));
+  }
+
+  @Test
+  void deletingPartialBackupSucceeds(@TempDir Path tempDir) throws IOException {
+    // given
+    final var backup = prepareTestBackup(tempDir);
+    store.save(backup).join();
+
+    // when
+    client
+        .deleteObject(
+            delete ->
+                delete
+                    .bucket(config.bucketName())
+                    .key(S3BackupStore.objectPrefix(backup.id()) + Status.OBJECT_KEY))
+        .join();
+
+    // then
+    assertThat(store.delete(backup.id())).succeedsWithin(Duration.ofSeconds(10));
+  }
+
+  @Test
+  void deletingInProgressBackupFails(@TempDir Path tempDir) throws IOException {
+    // given
+    final var backup = prepareTestBackup(tempDir);
+    store.save(backup).join();
+
+    // when
+    store.setStatus(backup.id(), new Status(BackupStatusCode.IN_PROGRESS)).join();
+    final var delete = store.delete(backup.id());
+
+    // then
+    assertThat(delete)
+        .failsWithin(Duration.ofSeconds(10))
+        .withThrowableOfType(Throwable.class)
+        .withRootCauseInstanceOf(BackupInInvalidStateException.class);
   }
 
   private Backup prepareTestBackup(Path tempDir) throws IOException {

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreIT.java
@@ -202,6 +202,21 @@ final class S3BackupStoreIT {
   }
 
   @Test
+  void backupFailsIfBackupAlreadyExists(@TempDir Path tempDir) throws IOException {
+    // given
+    final var backup = prepareTestBackup(tempDir);
+
+    // when
+    store.save(backup).join();
+
+    // then
+    assertThat(store.save(backup))
+        .failsWithin(Duration.ofSeconds(10))
+        .withThrowableOfType(Throwable.class)
+        .withRootCauseInstanceOf(BackupInInvalidStateException.class);
+  }
+
+  @Test
   void backupFailsIfFilesAreMissing(@TempDir Path tempDir) throws IOException {
     // given
     final var backup = prepareTestBackup(tempDir);


### PR DESCRIPTION
Deletes all objects with the prefix for the given `BackupIdentifier`.

Deleting an `IN_PROGRESS` backup is refused, operators can explicitly `markAsFailed` first.

closes #10159 