### PR TITLE
[Backport stable/1.3] Print record timestamp in compact record logger

### DIFF
--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -178,16 +178,23 @@ public class CompactRecordLogger {
     if (hasTimerEvents) {
       bulkMessage.append("[Timestamp] ");
     }
+    if (multiPartition) {
+      bulkMessage.append("[Partition] ");
+    }
     bulkMessage.append(
-        "[Partition] ['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position]  P[partitionId]K[key] - [summary of value]\n");
-    bulkMessage
-        .append(
-            "\tP9K999 - key; #999 - record position; \"ID\" element/process id; @\"elementid\"/[P9K999] - element with ID and key\n")
-        .append(
-            "\tKeys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.\n")
-        .append(
-            "\tLong IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'\n")
-        .append("--------\n");
+        "['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position] ");
+    if (multiPartition) {
+      bulkMessage.append("P[partitionId]");
+    }
+    bulkMessage.append("K[key] - [summary of value]\n");
+
+    bulkMessage.append(
+        "\tP9K999 - key; #999 - record position; \"ID\" element/process id; @\"elementid\"/[P9K999] - element with ID and key\n");
+    bulkMessage.append(
+        "\tKeys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.\n");
+    bulkMessage.append(
+        "\tLong IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'\n");
+    bulkMessage.append("--------\n");
 
     records.forEach(record -> bulkMessage.append(summarizeRecord(record)).append("\n"));
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -172,10 +172,15 @@ public class CompactRecordLogger {
   }
 
   private void addSummarizedRecords(final StringBuilder bulkMessage) {
+    bulkMessage.append("--------\n");
+
+    bulkMessage.append("\t");
+    if (hasTimerEvents) {
+      bulkMessage.append("[Timestamp] ");
+    }
+    bulkMessage.append(
+        "[Partition] ['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position]  P[partitionId]K[key] - [summary of value]\n");
     bulkMessage
-        .append("--------\n")
-        .append(
-            "\t[Timestamp] [Partition] ['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position]  P[partitionId]K[key] - [summary of value]\n")
         .append(
             "\tP9K999 - key; #999 - record position; \"ID\" element/process id; @\"elementid\"/[P9K999] - element with ID and key\n")
         .append(


### PR DESCRIPTION
# Description
Backport of #10170 to `stable/1.3`.

relates to #10156 #10144 #9885 #10169