### PR TITLE
feat(backup): collect snapshot files to include in backup

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
@@ -136,6 +136,11 @@ public class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapshot {
   }
 
   @Override
+  public Path getChecksumPath() {
+    return null;
+  }
+
+  @Override
   public long getCompactionBound() {
     return index;
   }

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshot.java
@@ -55,6 +55,11 @@ public interface PersistedSnapshot extends CloseableSilently {
   Path getPath();
 
   /**
+   * @return path to checksum file
+   */
+  Path getChecksumPath();
+
+  /**
    * Returns an implementation specific compaction bound, e.g. a log stream position, index etc.,
    * used during compaction
    *

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
@@ -68,10 +68,6 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
     return directory;
   }
 
-  public Path getChecksumFile() {
-    return checksumFile;
-  }
-
   @Override
   public int version() {
     return VERSION;
@@ -99,6 +95,11 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
   @Override
   public Path getPath() {
     return getDirectory();
+  }
+
+  @Override
+  public Path getChecksumPath() {
+    return checksumFile;
   }
 
   @Override

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -147,7 +147,7 @@ public final class FileBasedSnapshotStore extends Actor
   private void cleanupSnapshotDirectory(
       final Path snapshotDirectory, final FileBasedSnapshot latestPersistedSnapshot)
       throws IOException {
-    final var latestChecksumFile = latestPersistedSnapshot.getChecksumFile();
+    final var latestChecksumFile = latestPersistedSnapshot.getChecksumPath();
     final var latestDirectory = latestPersistedSnapshot.getDirectory();
     try (final var paths =
         Files.newDirectoryStream(

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -138,7 +138,7 @@ public class FileBasedReceivedSnapshotTest {
         .as("there is only the latest snapshot in the receiver's snapshot directory")
         .isDirectoryContainingExactly(
             secondReceivedPersistedSnapshot.getPath(),
-            secondReceivedPersistedSnapshot.getChecksumFile());
+            secondReceivedPersistedSnapshot.getChecksumPath());
   }
 
   @Test
@@ -167,7 +167,7 @@ public class FileBasedReceivedSnapshotTest {
     final var corruptedSnapshot =
         new FileBasedSnapshot(
             persistedSnapshot.getDirectory(),
-            persistedSnapshot.getChecksumFile(),
+            persistedSnapshot.getChecksumPath(),
             0xDEADBEEFL,
             persistedSnapshot.getSnapshotId(),
             null,

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -114,14 +114,14 @@ public class FileBasedSnapshotStoreTest {
     assertThat(snapshotsDir)
         .asInstanceOf(DirectoryAssert.factory())
         .as("the older snapshots should have been deleted")
-        .isDirectoryContainingExactly(newerSnapshot.getPath(), newerSnapshot.getChecksumFile());
+        .isDirectoryContainingExactly(newerSnapshot.getPath(), newerSnapshot.getChecksumPath());
   }
 
   @Test
   public void shouldNotLoadCorruptedSnapshot() throws Exception {
     // given
     final var persistedSnapshot = (FileBasedSnapshot) takeTransientSnapshot().persist().join();
-    SnapshotChecksum.persist(persistedSnapshot.getChecksumFile(), new SfvChecksum(0xCAFEL));
+    SnapshotChecksum.persist(persistedSnapshot.getChecksumPath(), new SfvChecksum(0xCAFEL));
 
     // when
     snapshotStore.close();
@@ -135,7 +135,7 @@ public class FileBasedSnapshotStoreTest {
   public void shouldDeleteSnapshotWithoutChecksumFile() throws IOException {
     // given
     final var persistedSnapshot = (FileBasedSnapshot) takeTransientSnapshot().persist().join();
-    Files.delete(persistedSnapshot.getChecksumFile());
+    Files.delete(persistedSnapshot.getChecksumPath());
 
     // when
     snapshotStore.close();
@@ -152,7 +152,7 @@ public class FileBasedSnapshotStoreTest {
     final var otherStore = createStore(snapshotsDir, pendingSnapshotsDir);
     final var corruptOlderSnapshot =
         (FileBasedSnapshot) takeTransientSnapshot(1, otherStore).persist().join();
-    SnapshotChecksum.persist(corruptOlderSnapshot.getChecksumFile(), new SfvChecksum(0xCAFEL));
+    SnapshotChecksum.persist(corruptOlderSnapshot.getChecksumPath(), new SfvChecksum(0xCAFEL));
 
     final var newerSnapshot =
         (FileBasedSnapshot) takeTransientSnapshot(2, snapshotStore).persist().join();
@@ -164,9 +164,9 @@ public class FileBasedSnapshotStoreTest {
     // then
     assertThat(snapshotStore.getLatestSnapshot()).hasValue(newerSnapshot);
     assertThat(newerSnapshot.getDirectory()).exists();
-    assertThat(newerSnapshot.getChecksumFile()).exists();
+    assertThat(newerSnapshot.getChecksumPath()).exists();
     assertThat(corruptOlderSnapshot.getDirectory()).doesNotExist();
-    assertThat(corruptOlderSnapshot.getChecksumFile()).doesNotExist();
+    assertThat(corruptOlderSnapshot.getChecksumPath()).doesNotExist();
   }
 
   @Test
@@ -175,7 +175,7 @@ public class FileBasedSnapshotStoreTest {
     final var otherStore = createStore(snapshotsDir, pendingSnapshotsDir);
     final var corruptOlderSnapshot =
         (FileBasedSnapshot) takeTransientSnapshot(1, otherStore).persist().join();
-    Files.delete(corruptOlderSnapshot.getChecksumFile());
+    Files.delete(corruptOlderSnapshot.getChecksumPath());
 
     final var newerSnapshot =
         (FileBasedSnapshot) takeTransientSnapshot(2, snapshotStore).persist().join();
@@ -187,9 +187,9 @@ public class FileBasedSnapshotStoreTest {
     // then
     assertThat(snapshotStore.getLatestSnapshot()).get().isEqualTo(newerSnapshot);
     assertThat(newerSnapshot.getDirectory()).exists();
-    assertThat(newerSnapshot.getChecksumFile()).exists();
+    assertThat(newerSnapshot.getChecksumPath()).exists();
     assertThat(corruptOlderSnapshot.getDirectory()).doesNotExist();
-    assertThat(corruptOlderSnapshot.getChecksumFile()).doesNotExist();
+    assertThat(corruptOlderSnapshot.getChecksumPath()).doesNotExist();
   }
 
   @Test
@@ -200,16 +200,16 @@ public class FileBasedSnapshotStoreTest {
     final var otherStore = createStore(snapshotsDir, pendingSnapshotsDir);
 
     // when - corrupting old snapshot and adding new valid snapshot
-    SnapshotChecksum.persist(olderSnapshot.getChecksumFile(), new SfvChecksum(0xCAFEL));
+    SnapshotChecksum.persist(olderSnapshot.getChecksumPath(), new SfvChecksum(0xCAFEL));
     final var newerSnapshot =
         (FileBasedSnapshot) takeTransientSnapshot(2, otherStore).persist().join();
 
     // then -- valid snapshot is unaffected and corrupt snapshot is deleted
     assertThat(otherStore.getLatestSnapshot()).get().isEqualTo(newerSnapshot);
     assertThat(newerSnapshot.getDirectory()).exists();
-    assertThat(newerSnapshot.getChecksumFile()).exists();
+    assertThat(newerSnapshot.getChecksumPath()).exists();
     assertThat(olderSnapshot.getDirectory()).doesNotExist();
-    assertThat(olderSnapshot.getChecksumFile()).doesNotExist();
+    assertThat(olderSnapshot.getChecksumPath()).doesNotExist();
   }
 
   @Test
@@ -218,7 +218,7 @@ public class FileBasedSnapshotStoreTest {
     final var otherStore = createStore(snapshotsDir, pendingSnapshotsDir);
     final var corruptSnapshot =
         (FileBasedSnapshot) takeTransientSnapshot(1, otherStore).persist().join();
-    SnapshotChecksum.persist(corruptSnapshot.getChecksumFile(), new SfvChecksum(0xCAFEL));
+    SnapshotChecksum.persist(corruptSnapshot.getChecksumPath(), new SfvChecksum(0xCAFEL));
 
     // when
     snapshotStore.close();
@@ -227,7 +227,7 @@ public class FileBasedSnapshotStoreTest {
     // then
     assertThat(snapshotStore.getLatestSnapshot()).isEmpty();
     assertThat(corruptSnapshot.getDirectory()).exists();
-    assertThat(corruptSnapshot.getChecksumFile()).exists();
+    assertThat(corruptSnapshot.getChecksumPath()).exists();
   }
 
   @Test

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
@@ -196,7 +196,7 @@ public class FileBasedTransientSnapshotTest {
         .asInstanceOf(DirectoryAssert.factory())
         .as("the committed snapshots directory only contains the latest snapshot")
         .isDirectoryContainingExactly(
-            persistedSnapshot.getPath(), persistedSnapshot.getChecksumFile());
+            persistedSnapshot.getPath(), persistedSnapshot.getChecksumPath());
   }
 
   @Test
@@ -316,7 +316,7 @@ public class FileBasedTransientSnapshotTest {
     assertThat(snapshotsDir)
         .asInstanceOf(DirectoryAssert.factory())
         .as("snapshots directory only contains snapshot %s", firstSnapshot.getId())
-        .isDirectoryContainingExactly(firstSnapshot.getPath(), firstSnapshot.getChecksumFile());
+        .isDirectoryContainingExactly(firstSnapshot.getPath(), firstSnapshot.getChecksumPath());
   }
 
   @Test


### PR DESCRIPTION
## Description

- collect snapshot files and checksum file to included in the backup
- Added `getChecksumPath` in interface `PersistedSnapshot` to easily get the checksum file without violating the abstraction. Since `getPath` is already there in the interface, it already assumes the persisted snapshot is persisted on a filesystem. So there is no harm in adding checksum path to the interface.

## Related issues

related #9979

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
