### PR TITLE
Add canWriteRecord method to RecordBatch

### DIFF
--- a/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
@@ -109,10 +109,5 @@ record MockProcessingResult(List<Event> records) implements ProcessingResult {
     public boolean canWriteEventOfLength(final int eventLength) {
       return false;
     }
-
-    @Override
-    public int getMaxEventLength() {
-      return 0;
-    }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResultBuilder.java
@@ -72,6 +72,4 @@ public interface ProcessingResultBuilder {
   ProcessingResult build();
 
   boolean canWriteEventOfLength(int eventLength);
-
-  int getMaxEventLength();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/records/MutableRecordBatch.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/records/MutableRecordBatch.java
@@ -45,8 +45,8 @@ public interface MutableRecordBatch extends ImmutableRecordBatch {
 
   /**
    * Allows to verify whether the given record length is suitable to be appended in the current
-   * batch. This method is useful if you have one record which will be updated and you don't want
-   * to append it right now, just to verify whether it would still fit.
+   * batch. This method is useful if you have one record which will be updated and you don't want to
+   * append it right now, just to verify whether it would still fit.
    *
    * @param recordLength the expected record length, which needs to be verified
    * @return true if the record length would fit into the batch, false otherwise

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/records/MutableRecordBatch.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/records/MutableRecordBatch.java
@@ -42,4 +42,14 @@ public interface MutableRecordBatch extends ImmutableRecordBatch {
       final String rejectionReason,
       final ValueType valueType,
       final BufferWriter valueWriter);
+
+  /**
+   * Allows to verify whether the given record length is suitable to be appended in the current
+   * batch. This method is useful if you have one record which will be updated and you don't want
+   * to append it right now, just to verify whether it would still fit.
+   *
+   * @param recordLength the expected record length, which needs to be verified
+   * @return true if the record length would fit into the batch, false otherwise
+   */
+  boolean canAppendRecordOfLength(int recordLength);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/records/RecordBatch.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/records/RecordBatch.java
@@ -73,6 +73,11 @@ public final class RecordBatch implements MutableRecordBatch {
     batchSize += entryLength;
   }
 
+  @Override
+  public boolean canAppendRecordOfLength(final int recordLength) {
+    return recordBatchSizePredicate.test(recordBatchEntries.size() + 1, batchSize + recordLength);
+  }
+
   public int getBatchSize() {
     return batchSize;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -79,7 +79,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     final Either<TooLargeJob, Integer> result = jobBatchCollector.collectJobs(record);
     final var activatedJobCount = result.getOrElse(0);
     result.ifLeft(
-        largeJob -> raiseIncidentJobTooLargeForMessageSize(largeJob.key(), largeJob.record()));
+        largeJob -> raiseIncidentJobTooLargeForMessageSize(largeJob.key(), largeJob.jobRecord(), largeJob.expectedEventLength()));
 
     activateJobBatch(record, value, jobBatchKey, activatedJobCount);
   }
@@ -125,14 +125,17 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     jobMetrics.jobActivated(value.getType(), activatedCount);
   }
 
-  private void raiseIncidentJobTooLargeForMessageSize(final long jobKey, final JobRecord job) {
-    final String messageSize = ByteValue.prettyPrint(stateWriter.getMaxEventLength());
+  private void raiseIncidentJobTooLargeForMessageSize(
+      final long jobKey,
+      final JobRecord job,
+      final int expectedJobRecordSize) {
+    final String jobSize = ByteValue.prettyPrint(expectedJobRecordSize);
     final DirectBuffer incidentMessage =
         wrapString(
             String.format(
-                "The job with key '%s' can not be activated because it is larger than the configured message size (%s). "
+                "The job with key '%s' can not be activated, because with %s it is larger than the configured message size (per default is 4 MB). "
                     + "Try to reduce the size by reducing the number of fetched variables or modifying the variable values.",
-                jobKey, messageSize));
+                jobKey, jobSize));
     final var incidentEvent =
         new IncidentRecord()
             .setErrorType(ErrorType.MESSAGE_SIZE_EXCEEDED)

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -79,7 +79,9 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     final Either<TooLargeJob, Integer> result = jobBatchCollector.collectJobs(record);
     final var activatedJobCount = result.getOrElse(0);
     result.ifLeft(
-        largeJob -> raiseIncidentJobTooLargeForMessageSize(largeJob.key(), largeJob.jobRecord(), largeJob.expectedEventLength()));
+        largeJob ->
+            raiseIncidentJobTooLargeForMessageSize(
+                largeJob.key(), largeJob.jobRecord(), largeJob.expectedEventLength()));
 
     activateJobBatch(record, value, jobBatchKey, activatedJobCount);
   }
@@ -126,9 +128,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   }
 
   private void raiseIncidentJobTooLargeForMessageSize(
-      final long jobKey,
-      final JobRecord job,
-      final int expectedJobRecordSize) {
+      final long jobKey, final JobRecord job, final int expectedJobRecordSize) {
     final String jobSize = ByteValue.prettyPrint(expectedJobRecordSize);
     final DirectBuffer incidentMessage =
         wrapString(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -99,7 +99,7 @@ final class JobBatchCollector {
             // if no jobs were activated, then the current job is simply too large, and we cannot
             // activate it
             if (activatedCount.value == 0) {
-              unwritableJob.set(new TooLargeJob(key, jobRecord));
+              unwritableJob.set(new TooLargeJob(key, jobRecord, expectedEventLength));
             }
 
             value.setTruncated(true);
@@ -165,5 +165,5 @@ final class JobBatchCollector {
     return variables;
   }
 
-  record TooLargeJob(long key, JobRecord record) {}
+  record TooLargeJob(long key, JobRecord jobRecord, int expectedEventLength) {}
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
@@ -45,9 +45,4 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
   public boolean canWriteEventOfLength(final int eventLength) {
     return resultBuilder().canWriteEventOfLength(eventLength);
   }
-
-  @Override
-  public int getMaxEventLength() {
-    return resultBuilder().getMaxEventLength();
-  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
@@ -33,12 +33,5 @@ public interface TypedEventWriter {
    * @param eventLength the length of the event that will be written
    * @return true if an event of length {@code eventLength} can be written
    */
-  default boolean canWriteEventOfLength(final int eventLength) {
-    return eventLength <= getMaxEventLength();
-  }
-
-  /**
-   * @return the maximum event length
-   */
-  int getMaxEventLength();
+  boolean canWriteEventOfLength(final int eventLength);
 }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResultBuilder.java
@@ -142,9 +142,4 @@ final class DirectProcessingResultBuilder implements ProcessingResultBuilder {
   public boolean canWriteEventOfLength(final int eventLength) {
     return mutableRecordBatch.canAppendRecordOfLength(eventLength);
   }
-
-  @Override
-  public int getMaxEventLength() {
-    return streamWriter.getMaxEventLength();
-  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResultBuilder.java
@@ -140,7 +140,7 @@ final class DirectProcessingResultBuilder implements ProcessingResultBuilder {
 
   @Override
   public boolean canWriteEventOfLength(final int eventLength) {
-    return streamWriter.canWriteEventOfLength(eventLength);
+    return mutableRecordBatch.canAppendRecordOfLength(eventLength);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/LegacyTypedStreamWriterImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/LegacyTypedStreamWriterImpl.java
@@ -123,16 +123,4 @@ public class LegacyTypedStreamWriterImpl implements LegacyTypedStreamWriter {
   public boolean canWriteEventOfLength(final int eventLength) {
     return batchWriter.canWriteAdditionalEvent(eventLength);
   }
-
-  /**
-   * This is not actually accurate, as the frame length needs to also be aligned by the same amount
-   * of bytes as the batch. However, this would break concerns here, i.e. the writer here would have
-   * to become Dispatcher aware.
-   *
-   * @return an approximate value of the max fragment length
-   */
-  @Override
-  public int getMaxEventLength() {
-    return batchWriter.getMaxFragmentLength();
-  }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
@@ -166,8 +166,8 @@ public class StreamProcessorHealthTest {
     public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {}
 
     @Override
-    public int getMaxEventLength() {
-      return Integer.MAX_VALUE;
+    public boolean canWriteEventOfLength(final int eventLength) {
+      return true;
     }
 
     @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/EventApplyingStateWriter.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/EventApplyingStateWriter.java
@@ -43,9 +43,4 @@ public final class EventApplyingStateWriter implements StateWriter {
   public boolean canWriteEventOfLength(final int eventLength) {
     return eventWriter.canWriteEventOfLength(eventLength);
   }
-
-  @Override
-  public int getMaxEventLength() {
-    return eventWriter.getMaxEventLength();
-  }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingTypedEventWriter.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingTypedEventWriter.java
@@ -32,8 +32,8 @@ public final class RecordingTypedEventWriter implements TypedEventWriter {
   }
 
   @Override
-  public int getMaxEventLength() {
-    return Integer.MAX_VALUE;
+  public boolean canWriteEventOfLength(final int eventLength) {
+    return true;
   }
 
   public static final class RecordedEvent<T extends RecordValue> {

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/RecordBatchTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/RecordBatchTest.java
@@ -22,10 +22,10 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
-public class RecordBatchTest {
+class RecordBatchTest {
 
   @Test
-  public void shouldAppendToRecordBatch() {
+  void shouldAppendToRecordBatch() {
     // given
     final var recordBatch = new RecordBatch((count, size) -> true);
     final var processInstanceRecord = Records.processInstance(1);
@@ -73,7 +73,7 @@ public class RecordBatchTest {
   }
 
   @Test
-  public void shouldUseRecordSizePredicate() {
+  void shouldUseRecordSizePredicate() {
     // given
     final AtomicInteger batchEntryCount = new AtomicInteger(-1);
     final AtomicInteger batchSize = new AtomicInteger(-1);
@@ -107,7 +107,7 @@ public class RecordBatchTest {
   }
 
   @Test
-  public void shouldUpdateBatchEntryCountWhenUsingRecordSizePredicate() {
+  void shouldUpdateBatchEntryCountWhenUsingRecordSizePredicate() {
     // given
     final AtomicInteger batchEntryCount = new AtomicInteger(-1);
     final AtomicInteger batchSize = new AtomicInteger(-1);
@@ -150,7 +150,7 @@ public class RecordBatchTest {
   }
 
   @Test
-  public void shouldNotAppendToRecordBatchIfMaxSizeIsReached() {
+  void shouldNotAppendToRecordBatchIfMaxSizeIsReached() {
     // given
     final var recordBatch = new RecordBatch((count, size) -> false);
     final var processInstanceRecord = Records.processInstance(1);
@@ -172,7 +172,7 @@ public class RecordBatchTest {
   }
 
   @Test
-  public void shouldOnlyAddUntilMaxBatchSizeIsReached() {
+  void shouldOnlyAddUntilMaxBatchSizeIsReached() {
     // given
     final var recordBatch = new RecordBatch((count, size) -> count < 2);
     final var processInstanceRecord = Records.processInstance(1);
@@ -204,7 +204,7 @@ public class RecordBatchTest {
   }
 
   @Test
-  public void shouldReturnFalseIfRecordSizeDoesReachSizelimit() {
+  void shouldReturnFalseIfRecordSizeDoesReachSizelimit() {
     // given
     final var recordBatch = new RecordBatch((count, size) -> size < 100);
 
@@ -216,7 +216,7 @@ public class RecordBatchTest {
   }
 
   @Test
-  public void shouldReturnTrueIfRecordSizeDoesntReachSizelimit() {
+  void shouldReturnTrueIfRecordSizeDoesntReachSizelimit() {
     // given
     final var recordBatch = new RecordBatch((count, size) -> size < 100);
 
@@ -228,7 +228,7 @@ public class RecordBatchTest {
   }
 
   @Test
-  public void shouldOnlyReturnTrueUntilMaxBatchSizeIsReached() {
+  void shouldOnlyReturnTrueUntilMaxBatchSizeIsReached() {
     // given
     final var recordBatch = new RecordBatch((count, size) -> size < 300);
     final var processInstanceRecord = Records.processInstance(1);
@@ -251,7 +251,7 @@ public class RecordBatchTest {
   }
 
   @Test
-  public void shouldOnlyReturnTrueUntilMaxCountIsReached() {
+  void shouldOnlyReturnTrueUntilMaxCountIsReached() {
     // given
     final var recordBatch = new RecordBatch((count, size) -> count < 2);
     final var processInstanceRecord = Records.processInstance(1);

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/RecordBatchTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/RecordBatchTest.java
@@ -249,6 +249,7 @@ public class RecordBatchTest {
     // then
     assertThat(canAppend).isFalse();
   }
+
   @Test
   public void shouldOnlyReturnTrueUntilMaxCountIsReached() {
     // given


### PR DESCRIPTION
## Description

This method can be used to verify whether a record length could potentially be appended to the batch, this is useful if you don't want to append the record right now, like if you add more and more data and always check whether it still fits. This is used in the JobBatchCollector for example.

Removed the maxMessageLength, since this was only used in one place and I felt is somehow breaks the abstraction, especially it would block us to really remove the write from the implementation.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related #10001 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
