### PR TITLE
feat: s3 backup store can restore a backup

### DIFF
--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -131,7 +131,7 @@ public final class S3BackupStore implements BackupStore {
   }
 
   @Override
-  public CompletableFuture<Backup> restore(final BackupIdentifier id) {
+  public CompletableFuture<Backup> restore(final BackupIdentifier id, Path targetFolder) {
     throw new UnsupportedOperationException();
   }
 

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/BackupAssert.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/BackupAssert.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.backup.api.Backup;
+import java.nio.file.Path;
+import org.assertj.core.api.AbstractAssert;
+
+final class BackupAssert extends AbstractAssert<BackupAssert, Backup> {
+
+  private BackupAssert(final Backup actual, final Class<?> selfType) {
+    super(actual, selfType);
+  }
+
+  public static BackupAssert assertThatBackup(Backup actual) {
+    return new BackupAssert(actual, BackupAssert.class);
+  }
+
+  @SuppressWarnings("UnusedReturnValue")
+  public BackupAssert hasSameContentsAs(Backup expected) {
+    assertThat(actual.id()).isEqualTo(expected.id());
+    assertThat(actual.descriptor()).isEqualTo(expected.descriptor());
+    assertThat(actual.snapshot().names()).isEqualTo(expected.snapshot().names());
+    assertThat(actual.segments().names()).isEqualTo(expected.segments().names());
+
+    NamedFileSetAssert.assertThatNamedFileSet(actual.snapshot())
+        .hasSameContentsAs(expected.snapshot());
+    NamedFileSetAssert.assertThatNamedFileSet(actual.segments())
+        .hasSameContentsAs(expected.segments());
+
+    return this;
+  }
+
+  @SuppressWarnings("UnusedReturnValue")
+  public BackupAssert residesInPath(Path expectedPath) {
+    NamedFileSetAssert.assertThatNamedFileSet(actual.snapshot()).residesInPath(expectedPath);
+    NamedFileSetAssert.assertThatNamedFileSet(actual.segments()).residesInPath(expectedPath);
+    return this;
+  }
+}

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/NamedFileSetAssert.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/NamedFileSetAssert.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.backup.api.NamedFileSet;
+import java.nio.file.Path;
+import org.assertj.core.api.AbstractAssert;
+
+final class NamedFileSetAssert extends AbstractAssert<NamedFileSetAssert, NamedFileSet> {
+
+  private NamedFileSetAssert(final NamedFileSet namedFileSet, final Class<?> selfType) {
+    super(namedFileSet, selfType);
+  }
+
+  public static NamedFileSetAssert assertThatNamedFileSet(NamedFileSet actual) {
+    return new NamedFileSetAssert(actual, NamedFileSetAssert.class);
+  }
+
+  @SuppressWarnings("UnusedReturnValue")
+  public NamedFileSetAssert hasSameContentsAs(NamedFileSet expected) {
+    for (final var expectedEntry : expected.namedFiles().entrySet()) {
+      final var expectedName = expectedEntry.getKey();
+      final var expectedPath = expectedEntry.getValue();
+      final var actualNamedFiles = actual.namedFiles();
+
+      assertThat(actualNamedFiles).containsKey(expectedName);
+      final var actualPath = actualNamedFiles.get(expectedEntry.getKey());
+      assertThat(actualPath).hasSameBinaryContentAs(expectedPath);
+    }
+    return this;
+  }
+
+  @SuppressWarnings("UnusedReturnValue")
+  public NamedFileSetAssert residesInPath(Path expectedPath) {
+    assertThat(actual.files())
+        .allSatisfy(
+            actualPath -> {
+              assertThat(actualPath).hasParent(expectedPath);
+            });
+    return this;
+  }
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.api;
 
+import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 
 /** A store where the backup is stored * */
@@ -22,7 +23,7 @@ public interface BackupStore {
   CompletableFuture<Void> delete(BackupIdentifier id);
 
   /** Restores the backup */
-  CompletableFuture<Backup> restore(BackupIdentifier id);
+  CompletableFuture<Backup> restore(BackupIdentifier id, Path targetFolder);
 
   /**
    * Marks the backup as failed. If saving a backup failed, the backups store must mark it as

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupStore.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupStore.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
+import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 
 // A placeholder backup store until a proper backup store is available
@@ -38,7 +39,7 @@ final class NoopBackupStore implements BackupStore {
   }
 
   @Override
-  public CompletableFuture<Backup> restore(final BackupIdentifier id) {
+  public CompletableFuture<Backup> restore(final BackupIdentifier id, final Path targetFolder) {
     return CompletableFuture.failedFuture(
         new UnsupportedOperationException("No backup store configured"));
   }


### PR DESCRIPTION
Restores a backup by downloading snapshot and segment objects and storing them as files in a given target folder.

closes #10179 