### PR TITLE
fix(raft): follower reset pendingsnapshot after rejecting install request

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -51,7 +51,6 @@ import io.atomix.raft.zeebe.ZeebeLogAppender;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.concurrent.Scheduled;
 import io.camunda.zeebe.journal.JournalException;
-import io.camunda.zeebe.snapshots.PersistedSnapshotListener;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
@@ -104,11 +103,6 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
         .thenRun(appender::close)
         .thenRun(this::cancelTimers)
         .thenRun(this::stepDown);
-  }
-
-  @Override
-  protected PersistedSnapshotListener createSnapshotListener() {
-    return null;
   }
 
   @Override

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -200,7 +200,7 @@ public class PassiveRole extends InactiveRole {
                     .withStatus(RaftResponse.Status.ERROR)
                     .withError(
                         RaftError.Type.ILLEGAL_MEMBER_STATE,
-                        "Request chunk is was received out of order")
+                        "Snapshot chunk is received out of order")
                     .build()));
       }
     }

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -182,6 +182,7 @@ public class PassiveRole extends InactiveRole {
     }
 
     if (!request.complete() && request.nextChunkId() == null) {
+      abortPendingSnapshots();
       return CompletableFuture.completedFuture(
           logResponse(
               InstallResponse.builder()
@@ -195,6 +196,7 @@ public class PassiveRole extends InactiveRole {
     final var snapshotChunk = new SnapshotChunkImpl();
     final var snapshotChunkBuffer = new UnsafeBuffer(request.data());
     if (!snapshotChunk.tryWrap(snapshotChunkBuffer)) {
+      abortPendingSnapshots();
       return CompletableFuture.completedFuture(
           logResponse(
               InstallResponse.builder()
@@ -229,6 +231,7 @@ public class PassiveRole extends InactiveRole {
     } else {
       // fail the request if this is not the expected next chunk
       if (!isExpectedChunk(request.chunkId())) {
+        abortPendingSnapshots();
         return CompletableFuture.completedFuture(
             logResponse(
                 InstallResponse.builder()

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -480,14 +480,18 @@ public final class ControllableRaftContexts {
     long nextIndex = firstIndex;
     try (final var reader = s.getLog().openCommittedReader()) {
       while (reader.hasNext()) {
-        assertThat(reader.next().index()).isEqualTo(nextIndex);
+        assertThat(reader.next().index())
+            .describedAs("There is no gap in the log %s", memberId.id())
+            .isEqualTo(nextIndex);
         nextIndex++;
       }
     }
 
     if (firstIndex != 1) {
       final var currentSnapshotIndex = snapshotStores.get(memberId).getCurrentSnapshotIndex();
-      assertThat(currentSnapshotIndex).isGreaterThanOrEqualTo(firstIndex - 1);
+      assertThat(currentSnapshotIndex)
+          .describedAs("The log is compacted in %s. Hence a snapshot must exist.")
+          .isGreaterThanOrEqualTo(firstIndex - 1);
     }
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -435,17 +435,15 @@ public final class ControllableRaftContexts {
   }
 
   public void assertAllEntriesCommittedAndReplicatedToAll() {
-    raftServers
-        .values()
-        .forEach(
-            s -> {
-              final var lastCommittedEntry = getLastCommittedEntry(s);
-              final var lastUncommittedEntry = getLastUncommittedEntry(s);
+    raftServers.forEach(
+        (memberId, raftServer) -> {
+          final var lastCommittedEntry = getLastCommittedEntry(raftServer);
+          final var lastUncommittedEntry = getLastUncommittedEntry(raftServer);
 
-              assertThat(lastCommittedEntry)
-                  .describedAs("All entries should be committed")
-                  .isEqualTo(lastUncommittedEntry);
-            });
+          assertThat(lastCommittedEntry)
+              .describedAs("All entries should be committed in %s", memberId.id())
+              .isEqualTo(lastUncommittedEntry);
+        });
 
     assertThat(hasReplicatedAllEntries())
         .describedAs("All entries are replicated to all followers")

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -360,8 +360,6 @@ public final class ControllableRaftContexts {
                 .orElse(1L)
             - 1;
 
-    readers.values().forEach(r -> r.seek(-1)); // seek to first
-
     final long commitIndexOnLeader =
         raftServers.values().stream()
             .map(RaftContext::getCommitIndex)

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -335,7 +335,7 @@ public final class ControllableRaftContexts {
       final long term = reader.next().term();
 
       InMemorySnapshot.newPersistedSnapshot(
-          snapshotIndex, term, random.nextInt(2, 10), testSnapshotStore);
+          snapshotIndex, term, random.nextInt(1, 10), testSnapshotStore);
 
       LOG.info(
           "Snapshot taken at index {}. Current commit index is {}",

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftOperation.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftOperation.java
@@ -48,6 +48,13 @@ public final class RaftOperation {
   }
 
   /** Returns a list of RaftOperation */
+  public static List<RaftOperation> getRaftOperationsWithSnapshot() {
+    final List<RaftOperation> defaultRaftOperation = getDefaultRaftOperations();
+    defaultRaftOperation.add(
+        RaftOperation.of("Take snapshot", ControllableRaftContexts::snapshotAndCompact));
+    return defaultRaftOperation;
+  }
+
   public static List<RaftOperation> getDefaultRaftOperations() {
     final List<RaftOperation> defaultRaftOperation = new ArrayList<>();
     defaultRaftOperation.add(

--- a/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
@@ -65,7 +65,7 @@ public class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapshot {
       final long index, final long term, final int size, final TestSnapshotStore snapshotStore) {
     final var snapshot = new InMemorySnapshot(snapshotStore, index, term);
     for (int i = 0; i < size; i++) {
-      snapshot.writeChunks("chunk-" + i, "test".getBytes());
+      snapshot.writeChunks("chunk-" + i, ("test-" + i).getBytes());
     }
     snapshot.persist();
     return snapshot;


### PR DESCRIPTION
## Description

- Extended RandomizedRaftTest to include snapshotting and compaction. This test could reproduce the bug #10180 
- Without this fix, when a follower rejects a snapshot install request because it receives a duplicate chunk, the leader resets the snapshot replication and restart sending the same snapshot. But the follower has not reset its state, so it is still expecting a different chunk and reject the request again. The fix is to reset the pending snapshot when follower rejects a request on any error.

Extended RandomizedRaftTest partially covers #9837 

## Related issues

closes #10180 
closes #10202 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
