### PR TITLE
feat(backup): collect segment files for backup

### DIFF
--- a/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.backup.management;
 
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.NamedFileSet;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
@@ -27,6 +28,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,24 +46,33 @@ final class InProgressBackupImpl implements InProgressBackup {
   private final int numberOfPartitions;
   private final ConcurrencyControl concurrencyControl;
 
+  private final Path segmentsDirectory;
+
+  private final Predicate<Path> isSegmentsFile;
+
   // Snapshot related data
   private boolean hasSnapshot = true;
   private Set<PersistedSnapshot> availableValidSnapshots;
   private SnapshotReservation snapshotReservation;
   private PersistedSnapshot reservedSnapshot;
-  private NamedFileSetImpl snapshotFileSet;
+  private NamedFileSet snapshotFileSet;
+  private NamedFileSet segmentsFileSet;
 
   InProgressBackupImpl(
       final PersistedSnapshotStore snapshotStore,
       final BackupIdentifier backupId,
       final long checkpointPosition,
       final int numberOfPartitions,
-      final ConcurrencyControl concurrencyControl) {
+      final ConcurrencyControl concurrencyControl,
+      final Path segmentsDirectory,
+      final Predicate<Path> isSegmentsFile) {
     this.snapshotStore = snapshotStore;
     this.backupId = backupId;
     this.checkpointPosition = checkpointPosition;
     this.numberOfPartitions = numberOfPartitions;
     this.concurrencyControl = concurrencyControl;
+    this.segmentsDirectory = segmentsDirectory;
+    this.isSegmentsFile = isSegmentsFile;
   }
 
   @Override
@@ -157,7 +168,28 @@ final class InProgressBackupImpl implements InProgressBackup {
 
   @Override
   public ActorFuture<Void> findSegmentFiles() {
-    return concurrencyControl.createCompletedFuture();
+    final ActorFuture<Void> filesCollected = concurrencyControl.createFuture();
+    try (final var stream = Files.list(segmentsDirectory)) {
+      final var fileSet =
+          stream
+              .filter(isSegmentsFile)
+              .collect(
+                  Collectors.toMap(
+                      path -> segmentsDirectory.relativize(path).toString(), path -> path));
+
+      if (fileSet.isEmpty()) {
+        filesCollected.completeExceptionally(
+            new IllegalStateException("Segments must not be empty"));
+        return filesCollected;
+      }
+
+      segmentsFileSet = new NamedFileSetImpl(fileSet);
+      filesCollected.complete(null);
+    } catch (final IOException e) {
+      filesCollected.completeExceptionally(e);
+    }
+
+    return filesCollected;
   }
 
   @Override
@@ -173,7 +205,7 @@ final class InProgressBackupImpl implements InProgressBackup {
 
     final var backupDescriptor =
         new BackupDescriptorImpl(snapshotId, checkpointPosition, numberOfPartitions);
-    return new BackupImpl(backupId, backupDescriptor, snapshotFileSet, null);
+    return new BackupImpl(backupId, backupDescriptor, snapshotFileSet, segmentsFileSet);
   }
 
   @Override

--- a/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -57,8 +57,8 @@ class BackupServiceImplTest {
     // given
     final InProgressBackup backup1 = mock(InProgressBackup.class);
     final InProgressBackup backup2 = mock(InProgressBackup.class);
-    when(backup1.findValidSnapshot()).thenReturn(concurrencyControl.createFuture());
-    when(backup2.findValidSnapshot()).thenReturn(concurrencyControl.createFuture());
+    when(backup1.findSegmentFiles()).thenReturn(concurrencyControl.createFuture());
+    when(backup2.findSegmentFiles()).thenReturn(concurrencyControl.createFuture());
 
     backupService.takeBackup(backup1, concurrencyControl);
     backupService.takeBackup(backup2, concurrencyControl);
@@ -86,8 +86,8 @@ class BackupServiceImplTest {
   @Test
   void shouldFailBackupWhenNoValidSnapshotFound() {
     // given
-    final var res = failedFuture();
-    when(inProgressBackup.findValidSnapshot()).thenReturn(res);
+    mockFindSegmentFiles();
+    when(inProgressBackup.findValidSnapshot()).thenReturn(failedFuture());
 
     // when
     final var result = backupService.takeBackup(inProgressBackup, concurrencyControl);
@@ -104,6 +104,7 @@ class BackupServiceImplTest {
   @Test
   void shouldFailBackupWhenSnapshotCannotBeReserved() {
     // given
+    mockFindSegmentFiles();
     mockFindValidSnapshot();
     when(inProgressBackup.reserveSnapshot()).thenReturn(failedFuture());
 
@@ -119,6 +120,7 @@ class BackupServiceImplTest {
   @Test
   void shouldFailBackupWhenSnapshotFilesCannotBeCollected() {
     // given
+    mockFindSegmentFiles();
     mockFindValidSnapshot();
     mockReserveSnapshot();
     when(inProgressBackup.findSnapshotFiles()).thenReturn(failedFuture());
@@ -135,9 +137,6 @@ class BackupServiceImplTest {
   @Test
   void shouldFailBackupWhenSegmentFilesCannotBeCollected() {
     // given
-    mockFindValidSnapshot();
-    mockReserveSnapshot();
-    mockFindSnapshotFiles();
     when(inProgressBackup.findSegmentFiles()).thenReturn(failedFuture());
 
     // when

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -117,6 +117,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-journal</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
     </dependency>

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentFile.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentFile.java
@@ -26,7 +26,7 @@ import java.nio.file.Path;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-final class SegmentFile {
+public final class SegmentFile {
 
   private static int deletedFileIndex = 0;
   private static final char PART_SEPARATOR = '-';


### PR DESCRIPTION
## Description

- Collect segment files to include in the backup
- To prevent a potential race condition than can happen between finding the snapshot and find the segments, we first collect the segment files. The records until the checkpoint position is guaranteed to be in the segment at this point. Now if a snapshot is taken and the segments are deleted, the backup will fail because backup store cannot read those files. This is not optimal, but still prevents unknowingly taking an incomplete backup. In practice, trying to take backup without snapshot is very unlikely because Zeebe takes snapshot very frequently. So instead of finding more complex solution to allow taking a backup in this scenario, we opted for this simple solution. 

## Related issues

related #9979 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
