### PR TITLE
Handle append error differently based on ResultBuilder

### DIFF
--- a/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -52,17 +53,13 @@ record MockProcessingResult(List<Event> records) implements ProcessingResult {
     final List<Event> followupRecords = new ArrayList<>();
 
     @Override
-    public ProcessingResultBuilder appendRecord(
-        final long key,
-        final RecordType type,
-        final Intent intent,
-        final RejectionType rejectionType,
-        final String rejectionReason,
-        final RecordValue value) {
+    public Either<RuntimeException, ProcessingResultBuilder> appendRecordReturnEither(
+        final long key, final RecordType type, final Intent intent,
+        final RejectionType rejectionType, final String rejectionReason, final RecordValue value) {
 
       final var record = new Event(intent, type, rejectionType, rejectionReason, key, value);
       followupRecords.add(record);
-      return null;
+      return Either.right(null);
     }
 
     @Override

--- a/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
@@ -54,8 +54,12 @@ record MockProcessingResult(List<Event> records) implements ProcessingResult {
 
     @Override
     public Either<RuntimeException, ProcessingResultBuilder> appendRecordReturnEither(
-        final long key, final RecordType type, final Intent intent,
-        final RejectionType rejectionType, final String rejectionReason, final RecordValue value) {
+        final long key,
+        final RecordType type,
+        final Intent intent,
+        final RejectionType rejectionType,
+        final String rejectionReason,
+        final RecordValue value) {
 
       final var record = new Event(intent, type, rejectionType, rejectionReason, key, value);
       followupRecords.add(record);

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResultBuilder.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.util.Either;
 
 /** Builder to compose the processing result */
 public interface ProcessingResultBuilder {
@@ -21,8 +22,37 @@ public interface ProcessingResultBuilder {
    * Appends a record to the result
    *
    * @return returns itself for method chaining
+   * @throws RuntimeException if to appended record doesn't fit into the RecordBatch
    */
-  ProcessingResultBuilder appendRecord(
+  default ProcessingResultBuilder appendRecord(
+      final long key,
+      final RecordType type,
+      final Intent intent,
+      final RejectionType rejectionType,
+      final String rejectionReason,
+      final RecordValue value) throws RuntimeException {
+    final var either = appendRecordReturnEither(key, type,
+        intent, rejectionType, rejectionReason, value);
+
+    if (either.isLeft()) {
+      // This is how we handled too big record batches as well, except that this is now a
+      // different place. Before an exception was raised during the writing, now it is during
+      // processing. Both will lead to the onError call, such that the RecordProcessors can handle
+      // this case.
+      throw either.getLeft();
+    }
+    return either.get();
+  }
+
+  /**
+   * Appends a record to the result, returns an {@link Either<RuntimeException, ProcessingResultBuilder>}
+   * which indicates whether the appending was successful or not. This is useful in case were potentially
+   * we could reach the record batch limit size.
+   * The return either allows to handle such error case gracefully.
+   *
+   * @return returns either a failure or itself for chaining
+   */
+  Either<RuntimeException, ProcessingResultBuilder> appendRecordReturnEither(
       final long key,
       final RecordType type,
       final Intent intent,

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingResultBuilder.java
@@ -30,9 +30,10 @@ public interface ProcessingResultBuilder {
       final Intent intent,
       final RejectionType rejectionType,
       final String rejectionReason,
-      final RecordValue value) throws RuntimeException {
-    final var either = appendRecordReturnEither(key, type,
-        intent, rejectionType, rejectionReason, value);
+      final RecordValue value)
+      throws RuntimeException {
+    final var either =
+        appendRecordReturnEither(key, type, intent, rejectionType, rejectionReason, value);
 
     if (either.isLeft()) {
       // This is how we handled too big record batches as well, except that this is now a
@@ -45,10 +46,10 @@ public interface ProcessingResultBuilder {
   }
 
   /**
-   * Appends a record to the result, returns an {@link Either<RuntimeException, ProcessingResultBuilder>}
-   * which indicates whether the appending was successful or not. This is useful in case were potentially
-   * we could reach the record batch limit size.
-   * The return either allows to handle such error case gracefully.
+   * Appends a record to the result, returns an {@link Either<RuntimeException,
+   * ProcessingResultBuilder>} which indicates whether the appending was successful or not. This is
+   * useful in case were potentially we could reach the record batch limit size. The return either
+   * allows to handle such error case gracefully.
    *
    * @return returns either a failure or itself for chaining
    */

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/TaskResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/TaskResultBuilder.java
@@ -16,9 +16,9 @@ public interface TaskResultBuilder {
   /**
    * Appends a record to the result
    *
-   * @return returns itself for method chaining
+   * @return returns true if the record still fits into the result, false otherwise
    */
-  TaskResultBuilder appendCommandRecord(
+  boolean appendCommandRecord(
       final long key, final Intent intent, final UnifiedRecordValue value);
 
   TaskResult build();

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/TaskResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/TaskResultBuilder.java
@@ -18,8 +18,7 @@ public interface TaskResultBuilder {
    *
    * @return returns true if the record still fits into the result, false otherwise
    */
-  boolean appendCommandRecord(
-      final long key, final Intent intent, final UnifiedRecordValue value);
+  boolean appendCommandRecord(final long key, final Intent intent, final UnifiedRecordValue value);
 
   TaskResult build();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/records/MutableRecordBatch.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/records/MutableRecordBatch.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 
 /**
@@ -32,8 +33,9 @@ public interface MutableRecordBatch extends ImmutableRecordBatch {
    * @param rejectionReason the rejection reason, part of the record metadata, can be empty
    * @param valueType the value type, part of the record metadata, must be set
    * @param valueWriter the actual record value
+   * @return either a failure if record can't be added to the batch or null on success
    */
-  void appendRecord(
+  Either<RuntimeException, Void> appendRecord(
       final long key,
       final int sourceIndex,
       final RecordType recordType,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBackoffChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBackoffChecker.java
@@ -28,8 +28,9 @@ public final class JobBackoffChecker implements StreamProcessorLifecycleAware {
             taskResultBuilder ->
                 jobState.findBackedOffJobs(
                     ActorClock.currentTimeMillis(),
-                    (key, record) -> taskResultBuilder.appendCommandRecord(
-                        key, JobIntent.RECUR_AFTER_BACKOFF, record)));
+                    (key, record) ->
+                        taskResultBuilder.appendCommandRecord(
+                            key, JobIntent.RECUR_AFTER_BACKOFF, record)));
   }
 
   public void scheduleBackOff(final long dueDate) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBackoffChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBackoffChecker.java
@@ -28,12 +28,8 @@ public final class JobBackoffChecker implements StreamProcessorLifecycleAware {
             taskResultBuilder ->
                 jobState.findBackedOffJobs(
                     ActorClock.currentTimeMillis(),
-                    (key, record) -> {
-                      taskResultBuilder.appendCommandRecord(
-                          key, JobIntent.RECUR_AFTER_BACKOFF, record);
-
-                      return true;
-                    }));
+                    (key, record) -> taskResultBuilder.appendCommandRecord(
+                        key, JobIntent.RECUR_AFTER_BACKOFF, record)));
   }
 
   public void scheduleBackOff(final long dueDate) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutTrigger.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutTrigger.java
@@ -79,10 +79,7 @@ public final class JobTimeoutTrigger implements StreamProcessorLifecycleAware {
       final long now = currentTimeMillis();
       state.forEachTimedOutEntry(
           now,
-          (key, record) -> {
-            taskResultBuilder.appendCommandRecord(key, JobIntent.TIME_OUT, record);
-            return true;
-          });
+          (key, record) -> taskResultBuilder.appendCommandRecord(key, JobIntent.TIME_OUT, record));
       if (shouldReschedule) {
         scheduleDeactivateTimedOutJobsTask();
       }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
@@ -49,8 +49,7 @@ public final class MessageTimeToLiveChecker implements Task {
       deleteMessageCommand.setMessageId(message.getMessageIdBuffer());
     }
 
-    taskResultBuilder.appendCommandRecord(
+    return taskResultBuilder.appendCommandRecord(
         storedMessage.getMessageKey(), MessageIntent.EXPIRE, deleteMessageCommand);
-    return true;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerChecker.java
@@ -122,9 +122,7 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
           .setRepetitions(timer.getRepetitions())
           .setProcessDefinitionKey(timer.getProcessDefinitionKey());
 
-      taskResultBuilder.appendCommandRecord(timer.getKey(), TimerIntent.TRIGGER, timerRecord);
-
-      return true;
+      return taskResultBuilder.appendCommandRecord(timer.getKey(), TimerIntent.TRIGGER, timerRecord);
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerChecker.java
@@ -122,7 +122,8 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
           .setRepetitions(timer.getRepetitions())
           .setProcessDefinitionKey(timer.getProcessDefinitionKey());
 
-      return taskResultBuilder.appendCommandRecord(timer.getKey(), TimerIntent.TRIGGER, timerRecord);
+      return taskResultBuilder.appendCommandRecord(
+          timer.getKey(), TimerIntent.TRIGGER, timerRecord);
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResultBuilder.java
@@ -72,10 +72,10 @@ final class DirectProcessingResultBuilder implements ProcessingResultBuilder {
     }
 
     if (value instanceof UnifiedRecordValue unifiedRecordValue) {
-      final var either = mutableRecordBatch.appendRecord(
-          key, -1, type, intent, rejectionType, rejectionReason, valueType, unifiedRecordValue);
-      if (either.isLeft())
-      {
+      final var either =
+          mutableRecordBatch.appendRecord(
+              key, -1, type, intent, rejectionType, rejectionReason, valueType, unifiedRecordValue);
+      if (either.isLeft()) {
         return Either.left(either.getLeft());
       }
     } else {

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectTaskResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectTaskResultBuilder.java
@@ -48,8 +48,9 @@ final class DirectTaskResultBuilder implements TaskResultBuilder {
       throw new IllegalStateException("Missing value type mapping for record: " + value.getClass());
     }
 
-    final var either = mutableRecordBatch.appendRecord(
-        key, -1, RecordType.COMMAND, intent, RejectionType.NULL_VAL, "", valueType, value);
+    final var either =
+        mutableRecordBatch.appendRecord(
+            key, -1, RecordType.COMMAND, intent, RejectionType.NULL_VAL, "", valueType, value);
 
     return either.isRight();
   }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectTaskResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectTaskResultBuilder.java
@@ -39,7 +39,7 @@ final class DirectTaskResultBuilder implements TaskResultBuilder {
   }
 
   @Override
-  public DirectTaskResultBuilder appendCommandRecord(
+  public boolean appendCommandRecord(
       final long key, final Intent intent, final UnifiedRecordValue value) {
 
     final ValueType valueType = TYPE_REGISTRY.get(value.getClass());
@@ -48,9 +48,10 @@ final class DirectTaskResultBuilder implements TaskResultBuilder {
       throw new IllegalStateException("Missing value type mapping for record: " + value.getClass());
     }
 
-    mutableRecordBatch.appendRecord(
+    final var either = mutableRecordBatch.appendRecord(
         key, -1, RecordType.COMMAND, intent, RejectionType.NULL_VAL, "", valueType, value);
-    return this;
+
+    return either.isRight();
   }
 
   @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
@@ -193,7 +193,10 @@ public class ProcessingScheduleServiceTest {
     // when
     dummyProcessorSpy.scheduleService.runDelayed(
         Duration.ZERO,
-        (builder) -> builder.appendCommandRecord(1, ACTIVATE_ELEMENT, RECORD).build());
+        (builder) -> {
+          builder.appendCommandRecord(1, ACTIVATE_ELEMENT, RECORD);
+          return builder.build();
+        });
 
     // then
     verify(dummyProcessorSpy, TIMEOUT)
@@ -209,7 +212,10 @@ public class ProcessingScheduleServiceTest {
     // when
     dummyProcessorSpy.scheduleService.runAtFixedRate(
         Duration.ofMillis(100),
-        (builder) -> builder.appendCommandRecord(1, ACTIVATE_ELEMENT, RECORD).build());
+        (builder) -> {
+          builder.appendCommandRecord(1, ACTIVATE_ELEMENT, RECORD);
+          return builder.build();
+        });
 
     // then
     verify(dummyProcessorSpy, TIMEOUT.times(5))

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/RecordBatchTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/RecordBatchTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.streamprocessor;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.engine.api.records.ImmutableRecordBatchEntry;
 import io.camunda.zeebe.engine.api.records.RecordBatch;
@@ -155,18 +154,21 @@ class RecordBatchTest {
     final var recordBatch = new RecordBatch((count, size) -> false);
     final var processInstanceRecord = Records.processInstance(1);
 
-    // expect
-    assertThatThrownBy(
-            () ->
-                recordBatch.appendRecord(
-                    1,
-                    -1,
-                    RecordType.COMMAND,
-                    ProcessInstanceIntent.ACTIVATE_ELEMENT,
-                    RejectionType.ALREADY_EXISTS,
-                    "broken somehow",
-                    ValueType.PROCESS_INSTANCE,
-                    processInstanceRecord))
+    // when
+    final var either =
+        recordBatch.appendRecord(
+            1,
+            -1,
+            RecordType.COMMAND,
+            ProcessInstanceIntent.ACTIVATE_ELEMENT,
+            RejectionType.ALREADY_EXISTS,
+            "broken somehow",
+            ValueType.PROCESS_INSTANCE,
+            processInstanceRecord);
+
+    // then
+    assertThat(either.isLeft()).isTrue();
+    assertThat(either.getLeft())
         .hasMessageContaining("Can't append entry")
         .hasMessageContaining("[ currentBatchEntryCount: 0, currentBatchSize: 0]");
   }
@@ -187,18 +189,21 @@ class RecordBatchTest {
         ValueType.PROCESS_INSTANCE,
         processInstanceRecord);
 
-    // expect
-    assertThatThrownBy(
-            () ->
-                recordBatch.appendRecord(
-                    1,
-                    -1,
-                    RecordType.COMMAND,
-                    ProcessInstanceIntent.ACTIVATE_ELEMENT,
-                    RejectionType.ALREADY_EXISTS,
-                    "broken somehow",
-                    ValueType.PROCESS_INSTANCE,
-                    processInstanceRecord))
+    // when
+    final var either =
+        recordBatch.appendRecord(
+            1,
+            -1,
+            RecordType.COMMAND,
+            ProcessInstanceIntent.ACTIVATE_ELEMENT,
+            RejectionType.ALREADY_EXISTS,
+            "broken somehow",
+            ValueType.PROCESS_INSTANCE,
+            processInstanceRecord);
+
+    // then
+    assertThat(either.isLeft()).isTrue();
+    assertThat(either.getLeft())
         .hasMessageContaining("Can't append entry")
         .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 249]");
   }


### PR DESCRIPTION
## Description

:x: Blocked by #10188 

This PR adds Either to the RecordBatch as return value. This allows to handle the error case differently. For example in the Processing right now we want to throw an exception, but later this can also handled differently which is why we added here a separate Method on the ProcessingResultBuilder. This is discussable whether we already want that.

What we need and want is to being able to handle failed appends in the consumers of the ProcessingScheduleService. Means at the TaskResultBuilder we want to now whether it was successful or not and just stop to append more records. This is slightly similar to how we did it before. 

This fixes a critical bug https://github.com/camunda/zeebe/issues/10147

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/10147
related #10001 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
