### PR TITLE
feat: enable export of process instance creation by default

### DIFF
--- a/broker/src/test/resources/system/elasticexporter.yaml
+++ b/broker/src/test/resources/system/elasticexporter.yaml
@@ -43,5 +43,5 @@ zeebe:
         #     variable: true
         #     variableDocument: true
         #     processInstance: true
-        #     processInstanceCreation: false
+        #     processInstanceCreation: true
         #     processMessageSubscription: false

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -554,7 +554,7 @@
         #     messageSubscription: true
         #     process: true
         #     processInstance: true
-        #     processInstanceCreation: false
+        #     processInstanceCreation: true
         #     processInstanceModification: true
         #     processMessageSubscription: true
         #     variable: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -491,7 +491,7 @@
         #     messageSubscription: true
         #     process: true
         #     processInstance: true
-        #     processInstanceCreation: false
+        #     processInstanceCreation: true
         #     processInstanceModification: true
         #     processMessageSubscription: true
         #     variable: true

--- a/exporters/elasticsearch-exporter/README.md
+++ b/exporters/elasticsearch-exporter/README.md
@@ -194,7 +194,7 @@ exporters:
         messageSubscription: true
         process: true
         processInstance: true
-        processInstanceCreation: false
+        processInstanceCreation: true
         processInstanceModification: true
         processMessageSubscription: true
         variable: true

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -132,7 +132,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean messageSubscription = true;
     public boolean process = true;
     public boolean processInstance = true;
-    public boolean processInstanceCreation = false;
+    public boolean processInstanceCreation = true;
     public boolean processInstanceModification = true;
     public boolean processMessageSubscription = true;
     public boolean variable = true;


### PR DESCRIPTION
## Description

To be able to track the usage of the start process anywhere feature in zeebe analytics we need to export the creation to elasticsearch.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda/zeebe-analytics/issues/73