### PR TITLE
Summarize modification records in compact record logger

### DIFF
--- a/docs/developer_handbook.md
+++ b/docs/developer_handbook.md
@@ -22,10 +22,11 @@ This document contains instructions for developers who want to contribute to thi
 
 ## How to create a new record?
 
-Generally, you'll need to do 3 things:
+Generally, you'll need to do 4 things:
 1. [Expand our `protocol` with a new `RecordValue` interface (incl. a new `ValueType` value)](#expanding-our-protocol-with-a-new-recordvalue).
 2. [Implement this `RecordValue` in the `protocol-impl` module](#implement-a-new-recordvalue-in-protocol-impl).
 3. [Support this `RecordValue` in the Elasticsearch exporter](#support-a-recordvalue-in-the-elasticsearch-exporter).
+4. Add support for it to the [CompactRecordLogger](../test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java).
 
 ### Expanding our protocol with a new RecordValue
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -584,7 +584,7 @@ public class CompactRecordLogger {
       return "";
     }
     return terminateInstructions.stream()
-        .map(t -> "terminate " + formatKey(t.getElementInstanceKey()))
+        .map(t -> "terminate [%s]".formatted(shortenKey(t.getElementInstanceKey())))
         .collect(Collectors.joining("> <", "<", "> "));
   }
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -714,10 +714,32 @@ public class CompactRecordLogger {
     return String.format(" of <decision %s[%s]>", formatId(decisionId), formatKey(decisionKey));
   }
 
+  /**
+   * Shortens and formats the key and stores it in the key substitutions, that is printed in the
+   * list of decomposed keys for debugging at the end.
+   *
+   * @param input the key to shorten
+   * @return the shortened key, e.g. {@code "K01"}
+   */
   private String shortenKey(final long input) {
     return substitutions.computeIfAbsent(input, this::formatKey);
   }
 
+  /**
+   * Only formats the key. If you need a shortened key, you probably need {@link #shortenKey(long)}.
+   *
+   * <p>Formats the key to the format `[Pn]Km`, where:
+   *
+   * <ul>
+   *   <li>P: means Partition (only added in case of multiPartition)
+   *   <li>n: replaced with the partition id (only added in case of multiPartition)
+   *   <li>K: means Key
+   *   <li>m: the decoded key in the partition, leftpadded with '0's
+   * </ul>
+   *
+   * @param key the key to format (should be encoded with a partition id)
+   * @return the formatted key
+   */
   private String formatKey(final long key) {
     final var result = new StringBuilder();
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This adds summarized ProcessInstanceModification records to the compact record logger.

Example input:
```
<some_modification_command>
.terminateElement(1231123)
.activateElement("asdf")
.activateElement("gateway_timer_event", "foo", "{\"bar\":[12,34,45]}")
.modify()
```

Example output (still somewhat long, but there are vars and the terminate key is unknown):
```
C MOD  MODIFY  - #26-> -1 K03 - <activate "asdf" no vars> <activate "gateway..r_event" with vars @"foo"{bar=[12, 34, 45]}> <terminate [K1231123]>
```

But most often, a modification activates one element and terminates another:
```
C MOD  MODIFY  - #26-> -1 K03 - <activate "asdf" no vars> <terminate [K05]>
```

I picked up this issue a bit earlier than planned because it simply made my development process easier.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9993

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
