### PR TITLE
Cleanup unused parameters and methods

### DIFF
--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -64,8 +64,7 @@ public final class BackupService extends Actor implements BackupManager {
     this.snapshotStore = snapshotStore;
     this.segmentsDirectory = segmentsDirectory;
     this.isSegmentsFile = isSegmentsFile;
-    internalBackupManager =
-        new BackupServiceImpl(nodeId, partitionId, numberOfPartitions, backupStore);
+    internalBackupManager = new BackupServiceImpl(backupStore);
     actorName = buildActorName(nodeId, "BackupService", partitionId);
   }
 

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -98,7 +98,7 @@ final class BackupServiceImpl {
       final ActorFuture<Void> backupSaved,
       final Throwable error) {
     backupSaved.completeExceptionally(error);
-    inProgressBackup.fail(error);
+    backupStore.markFailed(inProgressBackup.id());
     closeInProgressBackup(inProgressBackup);
   }
 

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -16,23 +16,12 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 final class BackupServiceImpl {
-  private final int nodeId;
-  private final int partitionId;
-
-  private final int numberOfPartitions;
-
   private final Set<InProgressBackup> backupsInProgress = new HashSet<>();
   private final BackupStore backupStore;
   private ConcurrencyControl concurrencyControl;
 
-  BackupServiceImpl(
-      final int nodeId,
-      final int partitionId,
-      final int numberOfPartitions,
-      final BackupStore backupStore) {
-    this.nodeId = nodeId;
-    this.partitionId = partitionId;
-    this.numberOfPartitions = numberOfPartitions;
+  BackupServiceImpl(final BackupStore backupStore) {
+
     this.backupStore = backupStore;
   }
 

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackup.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackup.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.management;
 
 import io.camunda.zeebe.backup.api.Backup;
+import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 
 interface InProgressBackup {
@@ -15,6 +16,8 @@ interface InProgressBackup {
   long checkpointId();
 
   long checkpointPosition();
+
+  BackupIdentifier id();
 
   ActorFuture<Void> findValidSnapshot();
 
@@ -25,8 +28,6 @@ interface InProgressBackup {
   ActorFuture<Void> findSegmentFiles();
 
   Backup createBackup();
-
-  void fail(Throwable error);
 
   void close();
 }

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 
 final class InProgressBackupImpl implements InProgressBackup {
 
-  private static final Logger LOG = LoggerFactory.getLogger(InProgressBackup.class);
+  private static final Logger LOG = LoggerFactory.getLogger(InProgressBackupImpl.class);
 
   private static final String ERROR_MSG_NO_VALID_SNAPSHOT =
       "Cannot find a snapshot that can be included in the backup %d. All available snapshots (%s) have processedPosition or lastFollowupEventPosition > checkpointPosition %d";
@@ -83,6 +83,11 @@ final class InProgressBackupImpl implements InProgressBackup {
   @Override
   public long checkpointPosition() {
     return checkpointPosition;
+  }
+
+  @Override
+  public BackupIdentifier id() {
+    return backupId;
   }
 
   @Override
@@ -206,11 +211,6 @@ final class InProgressBackupImpl implements InProgressBackup {
     final var backupDescriptor =
         new BackupDescriptorImpl(snapshotId, checkpointPosition, numberOfPartitions);
     return new BackupImpl(backupId, backupDescriptor, snapshotFileSet, segmentsFileSet);
-  }
-
-  @Override
-  public void fail(final Throwable error) {
-    // To be implemented
   }
 
   @Override

--- a/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -50,6 +50,7 @@ class BackupServiceImplTest {
 
     // then
     assertThat(result).succeedsWithin(Duration.ofMillis(100));
+    verify(backupStore).save(any());
   }
 
   @Test

--- a/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -37,7 +37,7 @@ class BackupServiceImplTest {
 
   @BeforeEach
   void setup() {
-    backupService = new BackupServiceImpl(0, 1, 1, backupStore);
+    backupService = new BackupServiceImpl(backupStore);
   }
 
   @Test

--- a/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -98,8 +98,7 @@ class BackupServiceImplTest {
         .failsWithin(Duration.ofMillis(1000))
         .withThrowableOfType(ExecutionException.class)
         .withMessageContaining("Expected");
-    verify(inProgressBackup).fail(any());
-    verify(inProgressBackup).close();
+    verifyInProgressBackupIsCleanedUpAfterFailure();
   }
 
   @Test
@@ -114,8 +113,7 @@ class BackupServiceImplTest {
 
     // then
     assertThat(result).failsWithin(Duration.ofMillis(100));
-    verify(inProgressBackup).fail(any());
-    verify(inProgressBackup).close();
+    verifyInProgressBackupIsCleanedUpAfterFailure();
   }
 
   @Test
@@ -131,8 +129,7 @@ class BackupServiceImplTest {
 
     // then
     assertThat(result).failsWithin(Duration.ofMillis(100));
-    verify(inProgressBackup).fail(any());
-    verify(inProgressBackup).close();
+    verifyInProgressBackupIsCleanedUpAfterFailure();
   }
 
   @Test
@@ -145,8 +142,7 @@ class BackupServiceImplTest {
 
     // then
     assertThat(result).failsWithin(Duration.ofMillis(100));
-    verify(inProgressBackup).fail(any());
-    verify(inProgressBackup).close();
+    verifyInProgressBackupIsCleanedUpAfterFailure();
   }
 
   @Test
@@ -164,8 +160,7 @@ class BackupServiceImplTest {
 
     // then
     assertThat(result).failsWithin(Duration.ofMillis(100));
-    verify(inProgressBackup).fail(any());
-    verify(inProgressBackup).close();
+    verifyInProgressBackupIsCleanedUpAfterFailure();
   }
 
   private ActorFuture<Void> failedFuture() {
@@ -203,5 +198,10 @@ class BackupServiceImplTest {
   private void mockFindSegmentFiles() {
     when(inProgressBackup.findSegmentFiles())
         .thenReturn(concurrencyControl.createCompletedFuture());
+  }
+
+  private void verifyInProgressBackupIsCleanedUpAfterFailure() {
+    verify(backupStore).markFailed(any());
+    verify(inProgressBackup).close();
   }
 }


### PR DESCRIPTION
## Description

- Cleanup unused parameters and methods
- Removed `fail` from `InProgressBackup` interface. It exposes a `close` method, which is enough to cleanup after a failure. 

## Related issues

related #9979 
