### PR TITLE
Unflake TimerStartEventTest.shouldTriggerOnlyTwice

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
@@ -1108,6 +1108,9 @@ public final class TimerStartEventTest {
     // when
     engine.increaseTime(Duration.ofSeconds(10));
 
+    // disable because we'll await with Awaitility
+    RecordingExporter.disableAwaitingIncomingRecords();
+
     // then
     Awaitility.await()
         .untilAsserted(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
@@ -30,6 +30,7 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -1103,6 +1104,9 @@ public final class TimerStartEventTest {
             secondDeploymentProcessDefinitionKey,
             firstDeploymentProcessDefinitionKey,
             secondDeploymentProcessDefinitionKey);
+
+    // due timers are only checked if the engine is not currently processing #10112
+    Awaitility.await("until the engine is idle again").until(engine::hasReachedEnd);
 
     // when
     engine.increaseTime(Duration.ofSeconds(10));

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
@@ -30,6 +30,7 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.stream.Collectors;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -88,6 +89,11 @@ public final class TimerStartEventTest {
     final ProcessBuilder builder = Bpmn.createExecutableProcess("process_4");
     builder.startEvent("start_4").timerWithCycle("R/PT2S").endEvent("end_4");
     return builder.startEvent("start_4_2").timerWithCycle("R/PT3S").endEvent("end_4_2").done();
+  }
+
+  @Before
+  public void controlTheClock() {
+    engine.getClock().pinCurrentTime();
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This test became flaky after a [change in the task scheduler](https://github.com/camunda/zeebe/pull/10112). Since then, tasks that have been scheduled are only executed when the engine is in the PROCESSING phase, but isn't currently processing a command. If that is the case, then it is rescheduled. That means that sometimes things take longer, especially when the processor is busy.

In this specific test case, new process instances are created using 2 timer start events on different processes. Each time they trigger, they produce a bunch of records because they start new process instances. The processing of the relevant commands for these instances can interfere with the DueDateTimerChecker which is a scheduled task. Because of the new task scheduler change, it can happen that the DueDateTimerChecker is postponed.

The problem is solved by periodically checking that the assertion holds, and increasing the clock's time every time we check this. This makes sure that the DueDateTimerChecker's task can be executed, even when it's rescheduled.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10169 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
