### PR TITLE
test(backup/s3): additional integration tests

### DIFF
--- a/backup-stores/s3/pom.xml
+++ b/backup-stores/s3/pom.xml
@@ -87,6 +87,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>localstack</artifactId>
       <scope>test</scope>

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/Metadata.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/Metadata.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -29,7 +30,7 @@ record Metadata(
     int nodeId,
     long checkpointPosition,
     int numberOfPartitions,
-    String snapshotId,
+    Optional<String> snapshotId,
     Set<String> snapshotFileNames,
     Set<String> segmentFileNames) {
 

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/AbstractBackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/AbstractBackupStoreIT.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.backup.s3;
 
-import static io.camunda.zeebe.backup.s3.BackupAssert.assertThatBackup;
+import static io.camunda.zeebe.backup.s3.support.BackupAssert.assertThatBackup;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.from;
 
@@ -19,6 +19,7 @@ import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.s3.S3BackupStoreException.BackupInInvalidStateException;
 import io.camunda.zeebe.backup.s3.S3BackupStoreException.MetadataParseException;
 import io.camunda.zeebe.backup.s3.S3BackupStoreException.StatusParseException;
+import io.camunda.zeebe.backup.s3.support.TestBackupProvider;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -26,83 +27,42 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.containers.localstack.LocalStackContainer.Service;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
-import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
-@Testcontainers
-final class S3BackupStoreIT {
+public abstract class AbstractBackupStoreIT {
 
-  @Container
-  private static final LocalStackContainer S3 =
-      new LocalStackContainer(DockerImageName.parse("localstack/localstack:0.14.5"))
-          .withServices(Service.S3);
+  protected abstract S3AsyncClient getClient();
 
-  private static S3AsyncClient client;
-  private S3BackupConfig config;
-  private S3BackupStore store;
+  protected abstract S3BackupConfig getConfig();
 
-  @BeforeEach
-  void setupBucket() {
-    config = new S3BackupConfig(RandomStringUtils.randomAlphabetic(10).toLowerCase());
-    store = new S3BackupStore(config, client);
-    client.createBucket(CreateBucketRequest.builder().bucket(config.bucketName()).build()).join();
-  }
-
-  @BeforeAll
-  static void startClient() {
-    client =
-        S3AsyncClient.builder()
-            .endpointOverride(S3.getEndpointOverride(Service.S3))
-            .region(Region.of(S3.getRegion()))
-            .credentialsProvider(
-                StaticCredentialsProvider.create(
-                    AwsBasicCredentials.create(S3.getAccessKey(), S3.getSecretKey())))
-            .build();
-  }
-
-  @AfterAll
-  static void closeClient() {
-    client.close();
-  }
+  protected abstract S3BackupStore getStore();
 
   @ParameterizedTest
   @ArgumentsSource(TestBackupProvider.class)
   void savingBackupIsSuccessful(Backup backup) {
-    assertThat(store.save(backup)).succeedsWithin(Duration.ofSeconds(10));
+    assertThat(getStore().save(backup)).succeedsWithin(Duration.ofSeconds(10));
   }
 
   @ParameterizedTest
   @ArgumentsSource(TestBackupProvider.class)
   void savesMetadata(Backup backup) throws IOException {
     // when
-    store.save(backup).join();
+    getStore().save(backup).join();
 
     // then
     final var metadataObject =
-        client
+        getClient()
             .getObject(
                 GetObjectRequest.builder()
-                    .bucket(config.bucketName())
+                    .bucket(getConfig().bucketName())
                     .key(S3BackupStore.objectPrefix(backup.id()) + Metadata.OBJECT_KEY)
                     .build(),
                 AsyncResponseTransformer.toBytes())
@@ -128,11 +88,13 @@ final class S3BackupStoreIT {
         backup.snapshot().names().stream().map(name -> prefix + name).toList();
 
     // when
-    store.save(backup).join();
+    getStore().save(backup).join();
 
     // then
     final var listed =
-        client.listObjectsV2(req -> req.bucket(config.bucketName()).prefix(prefix)).join();
+        getClient()
+            .listObjectsV2(req -> req.bucket(getConfig().bucketName()).prefix(prefix))
+            .join();
 
     assertThat(listed.contents().stream().map(S3Object::key))
         .allSatisfy(k -> assertThat(k).startsWith(prefix).isIn(expectedObjects));
@@ -148,11 +110,13 @@ final class S3BackupStoreIT {
         backup.segments().names().stream().map(name -> prefix + name).toList();
 
     // when
-    store.save(backup).join();
+    getStore().save(backup).join();
 
     // then
     final var listed =
-        client.listObjectsV2(req -> req.bucket(config.bucketName()).prefix(prefix)).join();
+        getClient()
+            .listObjectsV2(req -> req.bucket(getConfig().bucketName()).prefix(prefix))
+            .join();
 
     assertThat(listed.contents().stream().map(S3Object::key))
         .allSatisfy(k -> assertThat(k).startsWith(prefix).isIn(expectedObjects));
@@ -178,11 +142,15 @@ final class S3BackupStoreIT {
     final var expectedObjects = Stream.concat(managementObjects, contentObjects).toList();
 
     // when
-    store.save(backup).join();
+    getStore().save(backup).join();
 
     // then
     final var listedObjects =
-        client.listObjectsV2(req -> req.bucket(config.bucketName())).join().contents().stream()
+        getClient()
+            .listObjectsV2(req -> req.bucket(getConfig().bucketName()))
+            .join()
+            .contents()
+            .stream()
             .map(S3Object::key)
             .toList();
 
@@ -193,10 +161,10 @@ final class S3BackupStoreIT {
   @ArgumentsSource(TestBackupProvider.class)
   void backupFailsIfBackupAlreadyExists(Backup backup) {
     // when
-    store.save(backup).join();
+    getStore().save(backup).join();
 
     // then
-    assertThat(store.save(backup))
+    assertThat(getStore().save(backup))
         .failsWithin(Duration.ofSeconds(10))
         .withThrowableOfType(Throwable.class)
         .withRootCauseInstanceOf(BackupInInvalidStateException.class);
@@ -210,7 +178,7 @@ final class S3BackupStoreIT {
     Files.delete(deletedFile);
 
     // then
-    assertThat(store.save(backup))
+    assertThat(getStore().save(backup))
         .failsWithin(Duration.ofMinutes(1))
         .withThrowableOfType(Throwable.class)
         .withRootCauseInstanceOf(NoSuchFileException.class)
@@ -221,14 +189,14 @@ final class S3BackupStoreIT {
   @ArgumentsSource(TestBackupProvider.class)
   void backupIsMarkedAsCompleted(Backup backup) throws IOException {
     // when
-    store.save(backup).join();
+    getStore().save(backup).join();
 
     // then
     final var statusObject =
-        client
+        getClient()
             .getObject(
                 GetObjectRequest.builder()
-                    .bucket(config.bucketName())
+                    .bucket(getConfig().bucketName())
                     .key(S3BackupStore.objectPrefix(backup.id()) + Status.OBJECT_KEY)
                     .build(),
                 AsyncResponseTransformer.toBytes())
@@ -244,17 +212,17 @@ final class S3BackupStoreIT {
   @ArgumentsSource(TestBackupProvider.class)
   void backupCanBeMarkedAsFailed(Backup backup) throws IOException {
     // given
-    store.save(backup).join();
+    getStore().save(backup).join();
 
     // when
-    store.markFailed(backup.id()).join();
+    getStore().markFailed(backup.id()).join();
 
     // then
     final var statusObject =
-        client
+        getClient()
             .getObject(
                 GetObjectRequest.builder()
-                    .bucket(config.bucketName())
+                    .bucket(getConfig().bucketName())
                     .key(S3BackupStore.objectPrefix(backup.id()) + Status.OBJECT_KEY)
                     .build(),
                 AsyncResponseTransformer.toBytes())
@@ -271,10 +239,10 @@ final class S3BackupStoreIT {
   @ArgumentsSource(TestBackupProvider.class)
   void canGetStatus(Backup backup) {
     // given
-    store.save(backup).join();
+    getStore().save(backup).join();
 
     // when
-    final var status = store.getStatus(backup.id());
+    final var status = getStore().getStatus(backup.id());
 
     // then
     assertThat(status)
@@ -289,11 +257,11 @@ final class S3BackupStoreIT {
   @ArgumentsSource(TestBackupProvider.class)
   void statusIsFailedAfterMarkingAsFailed(Backup backup) {
     // given
-    store.save(backup).join();
+    getStore().save(backup).join();
 
     // when
-    store.markFailed(backup.id()).join();
-    final var status = store.getStatus(backup.id());
+    getStore().markFailed(backup.id()).join();
+    final var status = getStore().getStatus(backup.id());
 
     // then
     assertThat(status)
@@ -308,19 +276,19 @@ final class S3BackupStoreIT {
   @ArgumentsSource(TestBackupProvider.class)
   void statusQueryFailsIfStatusIsCorrupt(Backup backup) {
     // given
-    store.save(backup).join();
+    getStore().save(backup).join();
 
     // when
-    client
+    getClient()
         .putObject(
             req ->
-                req.bucket(config.bucketName())
+                req.bucket(getConfig().bucketName())
                     .key(S3BackupStore.objectPrefix(backup.id()) + Status.OBJECT_KEY),
             AsyncRequestBody.fromString("{s"))
         .join();
 
     // then
-    final var status = store.getStatus(backup.id());
+    final var status = getStore().getStatus(backup.id());
     assertThat(status)
         .failsWithin(Duration.ofSeconds(10))
         .withThrowableOfType(Throwable.class)
@@ -331,19 +299,19 @@ final class S3BackupStoreIT {
   @ArgumentsSource(TestBackupProvider.class)
   void statusQueryFailsIfMetadataIsCorrupt(Backup backup) {
     // given
-    store.save(backup).join();
+    getStore().save(backup).join();
 
     // when
-    client
+    getClient()
         .putObject(
             req ->
-                req.bucket(config.bucketName())
+                req.bucket(getConfig().bucketName())
                     .key(S3BackupStore.objectPrefix(backup.id()) + Metadata.OBJECT_KEY),
             AsyncRequestBody.fromString("{s"))
         .join();
 
     // then
-    final var status = store.getStatus(backup.id());
+    final var status = getStore().getStatus(backup.id());
     assertThat(status)
         .failsWithin(Duration.ofSeconds(10))
         .withThrowableOfType(Throwable.class)
@@ -353,7 +321,7 @@ final class S3BackupStoreIT {
   @Test
   void statusQueryFailsIfBackupDoesNotExist() {
     // when
-    final var result = store.getStatus(new BackupIdentifierImpl(1, 1, 15));
+    final var result = getStore().getStatus(new BackupIdentifierImpl(1, 1, 15));
     // then
     assertThat(result)
         .succeedsWithin(Duration.ofSeconds(10))
@@ -364,17 +332,18 @@ final class S3BackupStoreIT {
   @ArgumentsSource(TestBackupProvider.class)
   void allBackupObjectsAreDeleted(Backup backup) {
     // given
-    store.save(backup).join();
+    getStore().save(backup).join();
 
     // when
-    store.delete(backup.id()).join();
+    getStore().delete(backup.id()).join();
 
     // then
     final var listed =
-        client
+        getClient()
             .listObjectsV2(
                 req ->
-                    req.bucket(config.bucketName()).prefix(S3BackupStore.objectPrefix(backup.id())))
+                    req.bucket(getConfig().bucketName())
+                        .prefix(S3BackupStore.objectPrefix(backup.id())))
             .join();
     assertThat(listed.contents()).isEmpty();
   }
@@ -382,7 +351,7 @@ final class S3BackupStoreIT {
   @Test
   void deletingNonExistingBackupSucceeds() {
     // when
-    final var delete = store.delete(new BackupIdentifierImpl(1, 2, 3));
+    final var delete = getStore().delete(new BackupIdentifierImpl(1, 2, 3));
 
     // then
     assertThat(delete).succeedsWithin(Duration.ofSeconds(10));
@@ -392,30 +361,30 @@ final class S3BackupStoreIT {
   @ArgumentsSource(TestBackupProvider.class)
   void deletingPartialBackupSucceeds(Backup backup) {
     // given
-    store.save(backup).join();
+    getStore().save(backup).join();
 
     // when
-    client
+    getClient()
         .deleteObject(
             delete ->
                 delete
-                    .bucket(config.bucketName())
+                    .bucket(getConfig().bucketName())
                     .key(S3BackupStore.objectPrefix(backup.id()) + Status.OBJECT_KEY))
         .join();
 
     // then
-    assertThat(store.delete(backup.id())).succeedsWithin(Duration.ofSeconds(10));
+    assertThat(getStore().delete(backup.id())).succeedsWithin(Duration.ofSeconds(10));
   }
 
   @ParameterizedTest
   @ArgumentsSource(TestBackupProvider.class)
   void deletingInProgressBackupFails(Backup backup) {
     // given
-    store.save(backup).join();
+    getStore().save(backup).join();
 
     // when
-    store.setStatus(backup.id(), new Status(BackupStatusCode.IN_PROGRESS)).join();
-    final var delete = store.delete(backup.id());
+    getStore().setStatus(backup.id(), new Status(BackupStatusCode.IN_PROGRESS)).join();
+    final var delete = getStore().delete(backup.id());
 
     // then
     assertThat(delete)
@@ -428,10 +397,10 @@ final class S3BackupStoreIT {
   @ArgumentsSource(TestBackupProvider.class)
   void restoreIsSuccessful(Backup backup, @TempDir Path targetDir) {
     // given
-    store.save(backup).join();
+    getStore().save(backup).join();
 
     // when
-    final var result = store.restore(backup.id(), targetDir);
+    final var result = getStore().restore(backup.id(), targetDir);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(10));
@@ -441,10 +410,10 @@ final class S3BackupStoreIT {
   @ArgumentsSource(TestBackupProvider.class)
   void restoredBackupHasSameContents(Backup originalBackup, @TempDir Path targetDir) {
     // given
-    store.save(originalBackup).join();
+    getStore().save(originalBackup).join();
 
     // when
-    final var restored = store.restore(originalBackup.id(), targetDir).join();
+    final var restored = getStore().restore(originalBackup.id(), targetDir).join();
 
     // then
     assertThatBackup(restored).hasSameContentsAs(originalBackup).residesInPath(targetDir);

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/AbstractBackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/AbstractBackupStoreIT.java
@@ -27,8 +27,11 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
@@ -37,6 +40,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
+@Execution(ExecutionMode.CONCURRENT)
 public abstract class AbstractBackupStoreIT {
 
   protected abstract S3AsyncClient getClient();
@@ -45,377 +49,397 @@ public abstract class AbstractBackupStoreIT {
 
   protected abstract S3BackupStore getStore();
 
-  @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
-  void savingBackupIsSuccessful(Backup backup) {
-    assertThat(getStore().save(backup)).succeedsWithin(Duration.ofSeconds(10));
+  @Nested
+  final class Saving {
+
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void savingBackupIsSuccessful(Backup backup) {
+      assertThat(getStore().save(backup)).succeedsWithin(Duration.ofSeconds(10));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void savesMetadata(Backup backup) throws IOException {
+      // when
+      getStore().save(backup).join();
+
+      // then
+      final var metadataObject =
+          getClient()
+              .getObject(
+                  GetObjectRequest.builder()
+                      .bucket(getConfig().bucketName())
+                      .key(S3BackupStore.objectPrefix(backup.id()) + Metadata.OBJECT_KEY)
+                      .build(),
+                  AsyncResponseTransformer.toBytes())
+              .join();
+
+      final var readMetadata =
+          S3BackupStore.MAPPER.readValue(metadataObject.asByteArray(), Metadata.class);
+
+      assertThat(readMetadata.descriptor()).isEqualTo(backup.descriptor());
+      assertThat(readMetadata.id()).isEqualTo(backup.id());
+
+      assertThat(readMetadata.snapshotFileNames()).isEqualTo(backup.snapshot().names());
+      assertThat(readMetadata.segmentFileNames()).isEqualTo(backup.segments().names());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void snapshotFilesExist(Backup backup) {
+      // given
+      final var prefix = S3BackupStore.objectPrefix(backup.id()) + S3BackupStore.SNAPSHOT_PREFIX;
+
+      final var expectedObjects =
+          backup.snapshot().names().stream().map(name -> prefix + name).toList();
+
+      // when
+      getStore().save(backup).join();
+
+      // then
+      final var listed =
+          getClient()
+              .listObjectsV2(req -> req.bucket(getConfig().bucketName()).prefix(prefix))
+              .join();
+
+      assertThat(listed.contents().stream().map(S3Object::key))
+          .allSatisfy(k -> assertThat(k).startsWith(prefix).isIn(expectedObjects));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void segmentFilesExist(Backup backup) {
+      // given
+      final var prefix = S3BackupStore.objectPrefix(backup.id()) + S3BackupStore.SEGMENTS_PREFIX;
+
+      final var expectedObjects =
+          backup.segments().names().stream().map(name -> prefix + name).toList();
+
+      // when
+      getStore().save(backup).join();
+
+      // then
+      final var listed =
+          getClient()
+              .listObjectsV2(req -> req.bucket(getConfig().bucketName()).prefix(prefix))
+              .join();
+
+      assertThat(listed.contents().stream().map(S3Object::key))
+          .allSatisfy(k -> assertThat(k).startsWith(prefix).isIn(expectedObjects));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void bucketContainsExpectedObjectsOnly(Backup backup) {
+      // given
+      final var prefix = S3BackupStore.objectPrefix(backup.id());
+
+      final var metadata = prefix + Metadata.OBJECT_KEY;
+      final var status = prefix + Status.OBJECT_KEY;
+      final var snapshotObjects =
+          backup.snapshot().names().stream()
+              .map(name -> prefix + S3BackupStore.SNAPSHOT_PREFIX + name);
+      final var segmentObjects =
+          backup.segments().names().stream()
+              .map(name -> prefix + S3BackupStore.SEGMENTS_PREFIX + name);
+
+      final var contentObjects = Stream.concat(snapshotObjects, segmentObjects);
+      final var managementObjects = Stream.of(metadata, status);
+      final var expectedObjects = Stream.concat(managementObjects, contentObjects).toList();
+
+      // when
+      getStore().save(backup).join();
+
+      // then
+      final var listedObjects =
+          getClient()
+              .listObjectsV2(req -> req.bucket(getConfig().bucketName()))
+              .join()
+              .contents()
+              .stream()
+              .map(S3Object::key)
+              .toList();
+
+      assertThat(listedObjects).containsExactlyInAnyOrderElementsOf(expectedObjects);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void backupFailsIfBackupAlreadyExists(Backup backup) {
+      // when
+      getStore().save(backup).join();
+
+      // then
+      assertThat(getStore().save(backup))
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableOfType(Throwable.class)
+          .withRootCauseInstanceOf(BackupInInvalidStateException.class);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void backupFailsIfFilesAreMissing(Backup backup) throws IOException {
+      // when
+      final var deletedFile = backup.segments().files().stream().findFirst().orElseThrow();
+      Files.delete(deletedFile);
+
+      // then
+      assertThat(getStore().save(backup))
+          .failsWithin(Duration.ofMinutes(1))
+          .withThrowableOfType(Throwable.class)
+          .withRootCauseInstanceOf(NoSuchFileException.class)
+          .withMessageContaining(deletedFile.toString());
+    }
   }
 
-  @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
-  void savesMetadata(Backup backup) throws IOException {
-    // when
-    getStore().save(backup).join();
+  @Nested
+  final class UpdatingStatus {
 
-    // then
-    final var metadataObject =
-        getClient()
-            .getObject(
-                GetObjectRequest.builder()
-                    .bucket(getConfig().bucketName())
-                    .key(S3BackupStore.objectPrefix(backup.id()) + Metadata.OBJECT_KEY)
-                    .build(),
-                AsyncResponseTransformer.toBytes())
-            .join();
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void backupIsMarkedAsCompleted(Backup backup) throws IOException {
+      // when
+      getStore().save(backup).join();
 
-    final var readMetadata =
-        S3BackupStore.MAPPER.readValue(metadataObject.asByteArray(), Metadata.class);
+      // then
+      final var statusObject =
+          getClient()
+              .getObject(
+                  GetObjectRequest.builder()
+                      .bucket(getConfig().bucketName())
+                      .key(S3BackupStore.objectPrefix(backup.id()) + Status.OBJECT_KEY)
+                      .build(),
+                  AsyncResponseTransformer.toBytes())
+              .join();
 
-    assertThat(readMetadata.descriptor()).isEqualTo(backup.descriptor());
-    assertThat(readMetadata.id()).isEqualTo(backup.id());
+      final var objectMapper = new ObjectMapper();
+      final var readStatus = objectMapper.readValue(statusObject.asByteArray(), Status.class);
 
-    assertThat(readMetadata.snapshotFileNames()).isEqualTo(backup.snapshot().names());
-    assertThat(readMetadata.segmentFileNames()).isEqualTo(backup.segments().names());
+      assertThat(readStatus.statusCode()).isEqualTo(BackupStatusCode.COMPLETED);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void backupCanBeMarkedAsFailed(Backup backup) throws IOException {
+      // given
+      getStore().save(backup).join();
+
+      // when
+      getStore().markFailed(backup.id()).join();
+
+      // then
+      final var statusObject =
+          getClient()
+              .getObject(
+                  GetObjectRequest.builder()
+                      .bucket(getConfig().bucketName())
+                      .key(S3BackupStore.objectPrefix(backup.id()) + Status.OBJECT_KEY)
+                      .build(),
+                  AsyncResponseTransformer.toBytes())
+              .join();
+
+      final var objectMapper = S3BackupStore.MAPPER;
+      final var readStatus = objectMapper.readValue(statusObject.asByteArray(), Status.class);
+
+      assertThat(readStatus.statusCode()).isEqualTo(BackupStatusCode.FAILED);
+      assertThat(readStatus.failureReason()).isNotEmpty();
+    }
   }
 
-  @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
-  void snapshotFilesExist(Backup backup) {
-    // given
-    final var prefix = S3BackupStore.objectPrefix(backup.id()) + S3BackupStore.SNAPSHOT_PREFIX;
+  @Nested
+  final class QueryingStatus {
 
-    final var expectedObjects =
-        backup.snapshot().names().stream().map(name -> prefix + name).toList();
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void canGetStatus(Backup backup) {
+      // given
+      getStore().save(backup).join();
 
-    // when
-    getStore().save(backup).join();
+      // when
+      final var status = getStore().getStatus(backup.id());
 
-    // then
-    final var listed =
-        getClient()
-            .listObjectsV2(req -> req.bucket(getConfig().bucketName()).prefix(prefix))
-            .join();
+      // then
+      assertThat(status)
+          .succeedsWithin(Duration.ofSeconds(10))
+          .returns(BackupStatusCode.COMPLETED, from(BackupStatus::statusCode))
+          .returns(Optional.empty(), from(BackupStatus::failureReason))
+          .returns(backup.id(), from(BackupStatus::id))
+          .returns(Optional.of(backup.descriptor()), from(BackupStatus::descriptor));
+    }
 
-    assertThat(listed.contents().stream().map(S3Object::key))
-        .allSatisfy(k -> assertThat(k).startsWith(prefix).isIn(expectedObjects));
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void statusIsFailedAfterMarkingAsFailed(Backup backup) {
+      // given
+      getStore().save(backup).join();
+
+      // when
+      getStore().markFailed(backup.id()).join();
+      final var status = getStore().getStatus(backup.id());
+
+      // then
+      assertThat(status)
+          .succeedsWithin(Duration.ofSeconds(10))
+          .returns(BackupStatusCode.FAILED, from(BackupStatus::statusCode))
+          .doesNotReturn(Optional.empty(), from(BackupStatus::failureReason))
+          .returns(backup.id(), from(BackupStatus::id))
+          .returns(Optional.of(backup.descriptor()), from(BackupStatus::descriptor));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void statusQueryFailsIfStatusIsCorrupt(Backup backup) {
+      // given
+      getStore().save(backup).join();
+
+      // when
+      getClient()
+          .putObject(
+              req ->
+                  req.bucket(getConfig().bucketName())
+                      .key(S3BackupStore.objectPrefix(backup.id()) + Status.OBJECT_KEY),
+              AsyncRequestBody.fromString("{s"))
+          .join();
+
+      // then
+      final var status = getStore().getStatus(backup.id());
+      assertThat(status)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableOfType(Throwable.class)
+          .withCauseInstanceOf(StatusParseException.class);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void statusQueryFailsIfMetadataIsCorrupt(Backup backup) {
+      // given
+      getStore().save(backup).join();
+
+      // when
+      getClient()
+          .putObject(
+              req ->
+                  req.bucket(getConfig().bucketName())
+                      .key(S3BackupStore.objectPrefix(backup.id()) + Metadata.OBJECT_KEY),
+              AsyncRequestBody.fromString("{s"))
+          .join();
+
+      // then
+      final var status = getStore().getStatus(backup.id());
+      assertThat(status)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableOfType(Throwable.class)
+          .withCauseInstanceOf(MetadataParseException.class);
+    }
+
+    @Test
+    void statusQueryFailsIfBackupDoesNotExist() {
+      // when
+      final var result = getStore().getStatus(new BackupIdentifierImpl(1, 1, 15));
+      // then
+      assertThat(result)
+          .succeedsWithin(Duration.ofSeconds(10))
+          .returns(BackupStatusCode.DOES_NOT_EXIST, from(BackupStatus::statusCode));
+    }
   }
 
-  @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
-  void segmentFilesExist(Backup backup) {
-    // given
-    final var prefix = S3BackupStore.objectPrefix(backup.id()) + S3BackupStore.SEGMENTS_PREFIX;
+  @Nested
+  final class Deleting {
 
-    final var expectedObjects =
-        backup.segments().names().stream().map(name -> prefix + name).toList();
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void allBackupObjectsAreDeleted(Backup backup) {
+      // given
+      getStore().save(backup).join();
 
-    // when
-    getStore().save(backup).join();
+      // when
+      getStore().delete(backup.id()).join();
 
-    // then
-    final var listed =
-        getClient()
-            .listObjectsV2(req -> req.bucket(getConfig().bucketName()).prefix(prefix))
-            .join();
+      // then
+      final var listed =
+          getClient()
+              .listObjectsV2(
+                  req ->
+                      req.bucket(getConfig().bucketName())
+                          .prefix(S3BackupStore.objectPrefix(backup.id())))
+              .join();
+      assertThat(listed.contents()).isEmpty();
+    }
 
-    assertThat(listed.contents().stream().map(S3Object::key))
-        .allSatisfy(k -> assertThat(k).startsWith(prefix).isIn(expectedObjects));
+    @Test
+    void deletingNonExistingBackupSucceeds() {
+      // when
+      final var delete = getStore().delete(new BackupIdentifierImpl(1, 2, 3));
+
+      // then
+      assertThat(delete).succeedsWithin(Duration.ofSeconds(10));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void deletingPartialBackupSucceeds(Backup backup) {
+      // given
+      getStore().save(backup).join();
+
+      // when
+      getClient()
+          .deleteObject(
+              delete ->
+                  delete
+                      .bucket(getConfig().bucketName())
+                      .key(S3BackupStore.objectPrefix(backup.id()) + Status.OBJECT_KEY))
+          .join();
+
+      // then
+      assertThat(getStore().delete(backup.id())).succeedsWithin(Duration.ofSeconds(10));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void deletingInProgressBackupFails(Backup backup) {
+      // given
+      getStore().save(backup).join();
+
+      // when
+      getStore().setStatus(backup.id(), new Status(BackupStatusCode.IN_PROGRESS)).join();
+      final var delete = getStore().delete(backup.id());
+
+      // then
+      assertThat(delete)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableOfType(Throwable.class)
+          .withRootCauseInstanceOf(BackupInInvalidStateException.class);
+    }
   }
 
-  @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
-  void bucketContainsExpectedObjectsOnly(Backup backup) {
-    // given
-    final var prefix = S3BackupStore.objectPrefix(backup.id());
+  @Nested
+  final class Restoring {
 
-    final var metadata = prefix + Metadata.OBJECT_KEY;
-    final var status = prefix + Status.OBJECT_KEY;
-    final var snapshotObjects =
-        backup.snapshot().names().stream()
-            .map(name -> prefix + S3BackupStore.SNAPSHOT_PREFIX + name);
-    final var segmentObjects =
-        backup.segments().names().stream()
-            .map(name -> prefix + S3BackupStore.SEGMENTS_PREFIX + name);
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void restoreIsSuccessful(Backup backup, @TempDir Path targetDir) {
+      // given
+      getStore().save(backup).join();
 
-    final var contentObjects = Stream.concat(snapshotObjects, segmentObjects);
-    final var managementObjects = Stream.of(metadata, status);
-    final var expectedObjects = Stream.concat(managementObjects, contentObjects).toList();
+      // when
+      final var result = getStore().restore(backup.id(), targetDir);
 
-    // when
-    getStore().save(backup).join();
+      // then
+      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
+    }
 
-    // then
-    final var listedObjects =
-        getClient()
-            .listObjectsV2(req -> req.bucket(getConfig().bucketName()))
-            .join()
-            .contents()
-            .stream()
-            .map(S3Object::key)
-            .toList();
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void restoredBackupHasSameContents(Backup originalBackup, @TempDir Path targetDir) {
+      // given
+      getStore().save(originalBackup).join();
 
-    assertThat(listedObjects).containsExactlyInAnyOrderElementsOf(expectedObjects);
-  }
+      // when
+      final var restored = getStore().restore(originalBackup.id(), targetDir).join();
 
-  @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
-  void backupFailsIfBackupAlreadyExists(Backup backup) {
-    // when
-    getStore().save(backup).join();
-
-    // then
-    assertThat(getStore().save(backup))
-        .failsWithin(Duration.ofSeconds(10))
-        .withThrowableOfType(Throwable.class)
-        .withRootCauseInstanceOf(BackupInInvalidStateException.class);
-  }
-
-  @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
-  void backupFailsIfFilesAreMissing(Backup backup) throws IOException {
-    // when
-    final var deletedFile = backup.segments().files().stream().findFirst().orElseThrow();
-    Files.delete(deletedFile);
-
-    // then
-    assertThat(getStore().save(backup))
-        .failsWithin(Duration.ofMinutes(1))
-        .withThrowableOfType(Throwable.class)
-        .withRootCauseInstanceOf(NoSuchFileException.class)
-        .withMessageContaining(deletedFile.toString());
-  }
-
-  @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
-  void backupIsMarkedAsCompleted(Backup backup) throws IOException {
-    // when
-    getStore().save(backup).join();
-
-    // then
-    final var statusObject =
-        getClient()
-            .getObject(
-                GetObjectRequest.builder()
-                    .bucket(getConfig().bucketName())
-                    .key(S3BackupStore.objectPrefix(backup.id()) + Status.OBJECT_KEY)
-                    .build(),
-                AsyncResponseTransformer.toBytes())
-            .join();
-
-    final var objectMapper = new ObjectMapper();
-    final var readStatus = objectMapper.readValue(statusObject.asByteArray(), Status.class);
-
-    assertThat(readStatus.statusCode()).isEqualTo(BackupStatusCode.COMPLETED);
-  }
-
-  @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
-  void backupCanBeMarkedAsFailed(Backup backup) throws IOException {
-    // given
-    getStore().save(backup).join();
-
-    // when
-    getStore().markFailed(backup.id()).join();
-
-    // then
-    final var statusObject =
-        getClient()
-            .getObject(
-                GetObjectRequest.builder()
-                    .bucket(getConfig().bucketName())
-                    .key(S3BackupStore.objectPrefix(backup.id()) + Status.OBJECT_KEY)
-                    .build(),
-                AsyncResponseTransformer.toBytes())
-            .join();
-
-    final var objectMapper = S3BackupStore.MAPPER;
-    final var readStatus = objectMapper.readValue(statusObject.asByteArray(), Status.class);
-
-    assertThat(readStatus.statusCode()).isEqualTo(BackupStatusCode.FAILED);
-    assertThat(readStatus.failureReason()).isNotEmpty();
-  }
-
-  @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
-  void canGetStatus(Backup backup) {
-    // given
-    getStore().save(backup).join();
-
-    // when
-    final var status = getStore().getStatus(backup.id());
-
-    // then
-    assertThat(status)
-        .succeedsWithin(Duration.ofSeconds(10))
-        .returns(BackupStatusCode.COMPLETED, from(BackupStatus::statusCode))
-        .returns(Optional.empty(), from(BackupStatus::failureReason))
-        .returns(backup.id(), from(BackupStatus::id))
-        .returns(Optional.of(backup.descriptor()), from(BackupStatus::descriptor));
-  }
-
-  @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
-  void statusIsFailedAfterMarkingAsFailed(Backup backup) {
-    // given
-    getStore().save(backup).join();
-
-    // when
-    getStore().markFailed(backup.id()).join();
-    final var status = getStore().getStatus(backup.id());
-
-    // then
-    assertThat(status)
-        .succeedsWithin(Duration.ofSeconds(10))
-        .returns(BackupStatusCode.FAILED, from(BackupStatus::statusCode))
-        .doesNotReturn(Optional.empty(), from(BackupStatus::failureReason))
-        .returns(backup.id(), from(BackupStatus::id))
-        .returns(Optional.of(backup.descriptor()), from(BackupStatus::descriptor));
-  }
-
-  @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
-  void statusQueryFailsIfStatusIsCorrupt(Backup backup) {
-    // given
-    getStore().save(backup).join();
-
-    // when
-    getClient()
-        .putObject(
-            req ->
-                req.bucket(getConfig().bucketName())
-                    .key(S3BackupStore.objectPrefix(backup.id()) + Status.OBJECT_KEY),
-            AsyncRequestBody.fromString("{s"))
-        .join();
-
-    // then
-    final var status = getStore().getStatus(backup.id());
-    assertThat(status)
-        .failsWithin(Duration.ofSeconds(10))
-        .withThrowableOfType(Throwable.class)
-        .withCauseInstanceOf(StatusParseException.class);
-  }
-
-  @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
-  void statusQueryFailsIfMetadataIsCorrupt(Backup backup) {
-    // given
-    getStore().save(backup).join();
-
-    // when
-    getClient()
-        .putObject(
-            req ->
-                req.bucket(getConfig().bucketName())
-                    .key(S3BackupStore.objectPrefix(backup.id()) + Metadata.OBJECT_KEY),
-            AsyncRequestBody.fromString("{s"))
-        .join();
-
-    // then
-    final var status = getStore().getStatus(backup.id());
-    assertThat(status)
-        .failsWithin(Duration.ofSeconds(10))
-        .withThrowableOfType(Throwable.class)
-        .withCauseInstanceOf(MetadataParseException.class);
-  }
-
-  @Test
-  void statusQueryFailsIfBackupDoesNotExist() {
-    // when
-    final var result = getStore().getStatus(new BackupIdentifierImpl(1, 1, 15));
-    // then
-    assertThat(result)
-        .succeedsWithin(Duration.ofSeconds(10))
-        .returns(BackupStatusCode.DOES_NOT_EXIST, from(BackupStatus::statusCode));
-  }
-
-  @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
-  void allBackupObjectsAreDeleted(Backup backup) {
-    // given
-    getStore().save(backup).join();
-
-    // when
-    getStore().delete(backup.id()).join();
-
-    // then
-    final var listed =
-        getClient()
-            .listObjectsV2(
-                req ->
-                    req.bucket(getConfig().bucketName())
-                        .prefix(S3BackupStore.objectPrefix(backup.id())))
-            .join();
-    assertThat(listed.contents()).isEmpty();
-  }
-
-  @Test
-  void deletingNonExistingBackupSucceeds() {
-    // when
-    final var delete = getStore().delete(new BackupIdentifierImpl(1, 2, 3));
-
-    // then
-    assertThat(delete).succeedsWithin(Duration.ofSeconds(10));
-  }
-
-  @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
-  void deletingPartialBackupSucceeds(Backup backup) {
-    // given
-    getStore().save(backup).join();
-
-    // when
-    getClient()
-        .deleteObject(
-            delete ->
-                delete
-                    .bucket(getConfig().bucketName())
-                    .key(S3BackupStore.objectPrefix(backup.id()) + Status.OBJECT_KEY))
-        .join();
-
-    // then
-    assertThat(getStore().delete(backup.id())).succeedsWithin(Duration.ofSeconds(10));
-  }
-
-  @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
-  void deletingInProgressBackupFails(Backup backup) {
-    // given
-    getStore().save(backup).join();
-
-    // when
-    getStore().setStatus(backup.id(), new Status(BackupStatusCode.IN_PROGRESS)).join();
-    final var delete = getStore().delete(backup.id());
-
-    // then
-    assertThat(delete)
-        .failsWithin(Duration.ofSeconds(10))
-        .withThrowableOfType(Throwable.class)
-        .withRootCauseInstanceOf(BackupInInvalidStateException.class);
-  }
-
-  @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
-  void restoreIsSuccessful(Backup backup, @TempDir Path targetDir) {
-    // given
-    getStore().save(backup).join();
-
-    // when
-    final var result = getStore().restore(backup.id(), targetDir);
-
-    // then
-    assertThat(result).succeedsWithin(Duration.ofSeconds(10));
-  }
-
-  @ParameterizedTest
-  @ArgumentsSource(TestBackupProvider.class)
-  void restoredBackupHasSameContents(Backup originalBackup, @TempDir Path targetDir) {
-    // given
-    getStore().save(originalBackup).join();
-
-    // when
-    final var restored = getStore().restore(originalBackup.id(), targetDir).join();
-
-    // then
-    assertThatBackup(restored).hasSameContentsAs(originalBackup).residesInPath(targetDir);
+      // then
+      assertThatBackup(restored).hasSameContentsAs(originalBackup).residesInPath(targetDir);
+    }
   }
 }

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/TestBackupProvider.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/TestBackupProvider.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import io.camunda.zeebe.backup.api.Backup;
+import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupImpl;
+import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+final class TestBackupProvider implements ArgumentsProvider {
+
+  @Override
+  public Stream<? extends Arguments> provideArguments(final ExtensionContext context)
+      throws Exception {
+    return Stream.of(
+        arguments(named("stub", simpleBackup())),
+        arguments(named("stub without snapshot", backupWithoutSnapshot())));
+  }
+
+  private Backup backupWithoutSnapshot() throws IOException {
+    final var tempDir = Files.createTempDirectory("backup");
+    Files.createDirectory(tempDir.resolve("segments/"));
+    final var seg1 = Files.createFile(tempDir.resolve("segments/segment-file-1"));
+    final var seg2 = Files.createFile(tempDir.resolve("segments/segment-file-2"));
+    Files.write(seg1, RandomUtils.nextBytes(1024));
+    Files.write(seg2, RandomUtils.nextBytes(1024));
+
+    return new BackupImpl(
+        new BackupIdentifierImpl(1, 2, 3),
+        new BackupDescriptorImpl(Optional.empty(), 4, 5),
+        new NamedFileSetImpl(Map.of()),
+        new NamedFileSetImpl(Map.of("segment-file-1", seg1, "segment-file-2", seg2)));
+  }
+
+  private Backup simpleBackup() throws IOException {
+    final var tempDir = Files.createTempDirectory("backup");
+    Files.createDirectory(tempDir.resolve("segments/"));
+    final var seg1 = Files.createFile(tempDir.resolve("segments/segment-file-1"));
+    final var seg2 = Files.createFile(tempDir.resolve("segments/segment-file-2"));
+    Files.write(seg1, RandomUtils.nextBytes(1024));
+    Files.write(seg2, RandomUtils.nextBytes(1024));
+
+    Files.createDirectory(tempDir.resolve("snapshot/"));
+    final var s1 = Files.createFile(tempDir.resolve("snapshot/snapshot-file-1"));
+    final var s2 = Files.createFile(tempDir.resolve("snapshot/snapshot-file-2"));
+    Files.write(s1, RandomUtils.nextBytes(1024));
+    Files.write(s2, RandomUtils.nextBytes(1024));
+
+    return new BackupImpl(
+        new BackupIdentifierImpl(1, 2, 3),
+        new BackupDescriptorImpl(Optional.of("test-snapshot-id"), 4, 5),
+        new NamedFileSetImpl(Map.of("segment-file-1", seg1, "segment-file-2", seg2)),
+        new NamedFileSetImpl(Map.of("snapshot-file-1", s1, "snapshot-file-2", s2)));
+  }
+}

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/impl/LocalstackBackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/impl/LocalstackBackupStoreIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.s3.impl;
+
+import io.camunda.zeebe.backup.s3.AbstractBackupStoreIT;
+import io.camunda.zeebe.backup.s3.S3BackupConfig;
+import io.camunda.zeebe.backup.s3.S3BackupStore;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer.Service;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+
+@Testcontainers
+final class LocalstackBackupStoreIT extends AbstractBackupStoreIT {
+
+  @Container
+  private static final LocalStackContainer S3 =
+      new LocalStackContainer(DockerImageName.parse("localstack/localstack:0.14.5"))
+          .withServices(Service.S3);
+
+  private static S3AsyncClient client;
+  private S3BackupStore store;
+  private S3BackupConfig config;
+
+  @BeforeAll
+  static void setup() {
+    client =
+        S3AsyncClient.builder()
+            .endpointOverride(S3.getEndpointOverride(Service.S3))
+            .region(Region.of(S3.getRegion()))
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(S3.getAccessKey(), S3.getSecretKey())))
+            .build();
+  }
+
+  @BeforeEach
+  void setupBucket() {
+    config = new S3BackupConfig(RandomStringUtils.randomAlphabetic(10).toLowerCase());
+    store = new S3BackupStore(config, client);
+    client.createBucket(CreateBucketRequest.builder().bucket(config.bucketName()).build()).join();
+  }
+
+  @Override
+  protected S3AsyncClient getClient() {
+    return client;
+  }
+
+  @Override
+  protected S3BackupConfig getConfig() {
+    return config;
+  }
+
+  @Override
+  protected S3BackupStore getStore() {
+    return store;
+  }
+}

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/impl/MinioBackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/impl/MinioBackupStoreIT.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.s3.impl;
+
+import io.camunda.zeebe.backup.s3.AbstractBackupStoreIT;
+import io.camunda.zeebe.backup.s3.S3BackupConfig;
+import io.camunda.zeebe.backup.s3.S3BackupStore;
+import java.net.URI;
+import java.time.Duration;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+
+@Testcontainers
+final class MinioBackupStoreIT extends AbstractBackupStoreIT {
+  public static final String ACCESS_KEY = "letmein";
+  public static final String SECRET_KEY = "letmein1234";
+  public static final int DEFAULT_PORT = 9000;
+
+  @SuppressWarnings("resource")
+  @Container
+  private static final GenericContainer<?> S3 =
+      new GenericContainer<>(DockerImageName.parse("minio/minio:edge"))
+          .withCommand("server /data")
+          .withExposedPorts(DEFAULT_PORT)
+          .withEnv("MINIO_ACCESS_KEY", ACCESS_KEY)
+          .withEnv("MINIO_SECRET_KEY", SECRET_KEY)
+          .waitingFor(
+              new HttpWaitStrategy()
+                  .forPath("/minio/health/ready")
+                  .forPort(DEFAULT_PORT)
+                  .withStartupTimeout(Duration.ofMinutes(1)));
+
+  private static S3AsyncClient client;
+  private S3BackupStore store;
+  private S3BackupConfig config;
+
+  @BeforeAll
+  static void setup() {
+    client =
+        S3AsyncClient.builder()
+            .endpointOverride(
+                URI.create("http://%s:%d".formatted(S3.getHost(), S3.getMappedPort(DEFAULT_PORT))))
+            .region(Region.US_EAST_1) // the default region for MinIO
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY)))
+            .build();
+  }
+
+  @BeforeEach
+  void setupBucket() {
+    config = new S3BackupConfig(RandomStringUtils.randomAlphabetic(10).toLowerCase());
+    store = new S3BackupStore(config, client);
+    client.createBucket(CreateBucketRequest.builder().bucket(config.bucketName()).build()).join();
+  }
+
+  @Override
+  protected S3AsyncClient getClient() {
+    return client;
+  }
+
+  @Override
+  protected S3BackupConfig getConfig() {
+    return config;
+  }
+
+  @Override
+  protected S3BackupStore getStore() {
+    return store;
+  }
+}

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/support/BackupAssert.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/support/BackupAssert.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.backup.s3;
+package io.camunda.zeebe.backup.s3.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,7 +13,7 @@ import io.camunda.zeebe.backup.api.Backup;
 import java.nio.file.Path;
 import org.assertj.core.api.AbstractAssert;
 
-final class BackupAssert extends AbstractAssert<BackupAssert, Backup> {
+public final class BackupAssert extends AbstractAssert<BackupAssert, Backup> {
 
   private BackupAssert(final Backup actual, final Class<?> selfType) {
     super(actual, selfType);

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/support/NamedFileSetAssert.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/support/NamedFileSetAssert.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.backup.s3;
+package io.camunda.zeebe.backup.s3.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/support/TestBackupProvider.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/support/TestBackupProvider.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.backup.s3;
+package io.camunda.zeebe.backup.s3.support;
 
 import static org.junit.jupiter.api.Named.named;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 
-final class TestBackupProvider implements ArgumentsProvider {
+public final class TestBackupProvider implements ArgumentsProvider {
 
   @Override
   public Stream<? extends Arguments> provideArguments(final ExtensionContext context)

--- a/backup-stores/s3/src/test/resources/junit-platform.properties
+++ b/backup-stores/s3/src/test/resources/junit-platform.properties
@@ -1,0 +1,10 @@
+#
+# Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+# one or more contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright ownership.
+# Licensed under the Zeebe Community License 1.1. You may not use this file
+# except in compliance with the Zeebe Community License 1.1.
+#
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=same_thread

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupDescriptor.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupDescriptor.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.backup.api;
 
+import java.util.Optional;
+
 /**
  * Additional information about the backup that might be required for restoring or querying the
  * status
@@ -15,7 +17,7 @@ public interface BackupDescriptor {
   /**
    * @return id of the snapshot included in the backup
    */
-  String snapshotId();
+  Optional<String> snapshotId();
 
   /**
    * @return the checkpoint position of the checkpoint included in the backup

--- a/backup/src/main/java/io/camunda/zeebe/backup/common/BackupDescriptorImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/common/BackupDescriptorImpl.java
@@ -8,7 +8,8 @@
 package io.camunda.zeebe.backup.common;
 
 import io.camunda.zeebe.backup.api.BackupDescriptor;
+import java.util.Optional;
 
 public record BackupDescriptorImpl(
-    String snapshotId, long checkpointPosition, int numberOfPartitions)
+    Optional<String> snapshotId, long checkpointPosition, int numberOfPartitions)
     implements BackupDescriptor {}

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -26,6 +26,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -162,13 +163,12 @@ final class InProgressBackupImpl implements InProgressBackup {
 
   @Override
   public Backup createBackup() {
-    final String snapshotId;
+    final Optional<String> snapshotId;
 
     if (hasSnapshot) {
-      snapshotId = reservedSnapshot.getId();
+      snapshotId = Optional.of(reservedSnapshot.getId());
     } else {
-      // To do : change snapshotId in BackupDescriptor to Optional
-      snapshotId = null;
+      snapshotId = Optional.empty();
     }
 
     final var backupDescriptor =

--- a/backup/src/test/java/io/camunda/zeebe/backup/management/InProgressBackupImplTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/management/InProgressBackupImplTest.java
@@ -123,7 +123,7 @@ class InProgressBackupImplTest {
     final var backup = collectBackupContents();
 
     // then
-    assertThat(backup.descriptor().snapshotId()).isEqualTo(validSnapshot.getId());
+    assertThat(backup.descriptor().snapshotId()).hasValue(validSnapshot.getId());
     verify(validSnapshot).reserve();
   }
 
@@ -155,7 +155,7 @@ class InProgressBackupImplTest {
     final var backup = collectBackupContents();
 
     // then
-    assertThat(backup.descriptor().snapshotId()).isEqualTo(latestValidSnapshot.getId());
+    assertThat(backup.descriptor().snapshotId()).hasValue(latestValidSnapshot.getId());
     verify(latestValidSnapshot).reserve();
   }
 
@@ -194,7 +194,7 @@ class InProgressBackupImplTest {
     final var backup = collectBackupContents();
 
     // then
-    assertThat(backup.descriptor().snapshotId()).isEqualTo(oldValidSnapshot.getId());
+    assertThat(backup.descriptor().snapshotId()).hasValue(oldValidSnapshot.getId());
     verify(oldValidSnapshot).reserve();
   }
 


### PR DESCRIPTION
* Adjusts the backup descriptor to allow for backups without snapshot
* All tests run for backups with and without snapshots
* All tests are run on Localstack and MinIO
* Organizes tests into multiple nested classes
* Adds another test case to show that deleting objects prevents a restore

closes #10184 