### PR TITLE
Create local variables during PI modification

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -111,12 +111,6 @@
       <artifactId>cron-utils</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
     <!-- TEST DEPENDENCIES -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -135,8 +135,8 @@ public final class ElementActivationBehavior {
       // there is no active instance of this flow scope
       // - create/activate a new instance and continue with the remaining flow scopes
       final long elementInstanceKey =
-          activateFlowScope(processInstanceRecord, flowScopeKey, flowScope);
-      createVariablesCallback.accept(flowScope.getId(), elementInstanceKey);
+          activateFlowScope(
+              processInstanceRecord, flowScopeKey, flowScope, createVariablesCallback);
       return activateFlowScopes(
           processInstanceRecord, elementInstanceKey, flowScopes, createVariablesCallback);
 
@@ -178,7 +178,8 @@ public final class ElementActivationBehavior {
   private long activateFlowScope(
       final ProcessInstanceRecord processInstanceRecord,
       final long flowScopeKey,
-      final ExecutableFlowElement flowScope) {
+      final ExecutableFlowElement flowScope,
+      final BiConsumer<DirectBuffer, Long> createVariablesCallback) {
     final long elementInstanceKey;
     final long elementInstanceFlowScopeKey;
 
@@ -191,6 +192,7 @@ public final class ElementActivationBehavior {
       elementInstanceFlowScopeKey = flowScopeKey;
     }
 
+    createVariablesCallback.accept(flowScope.getId(), elementInstanceKey);
     activateFlowScopeByEvents(
         processInstanceRecord, flowScope, elementInstanceKey, elementInstanceFlowScopeKey);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -28,6 +28,8 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BiConsumer;
+import org.agrona.DirectBuffer;
 
 public final class ElementActivationBehavior {
 
@@ -64,15 +66,32 @@ public final class ElementActivationBehavior {
   public long activateElement(
       final ProcessInstanceRecord processInstanceRecord,
       final AbstractFlowElement elementToActivate) {
+    return activateElement(processInstanceRecord, elementToActivate, (empty, function) -> {});
+  }
 
+  /**
+   * Activates the given element. If the element is nested inside a flow scope and there is no
+   * active instance of the flow scope then it creates a new instance. This is used when modifying a
+   * process instance or starting a process instance at a different place than the start event.
+   *
+   * @param processInstanceRecord the record of the process instance
+   * @param elementToActivate The element to activate
+   * @param createVariablesCallback Callback to create variables at a given scope
+   * @return The key of the activated element instance
+   */
+  public long activateElement(
+      final ProcessInstanceRecord processInstanceRecord,
+      final AbstractFlowElement elementToActivate,
+      final BiConsumer<DirectBuffer, Long> createVariablesCallback) {
     final var flowScopes = collectFlowScopesOfElement(elementToActivate);
 
     final var flowScopeKey =
         activateFlowScopes(
-            processInstanceRecord, processInstanceRecord.getProcessInstanceKey(), flowScopes);
+            processInstanceRecord, processInstanceRecord.getProcessInstanceKey(), flowScopes, createVariablesCallback);
 
     final long elementInstanceKey =
         activateElementByCommand(processInstanceRecord, elementToActivate, flowScopeKey);
+    createVariablesCallback.accept(elementToActivate.getId(), elementInstanceKey);
 
     // applying the side effects is part of creating the event subscriptions
     sideEffectQueue.flush();
@@ -98,7 +117,8 @@ public final class ElementActivationBehavior {
   private long activateFlowScopes(
       final ProcessInstanceRecord processInstanceRecord,
       final long flowScopeKey,
-      final Deque<ExecutableFlowElement> flowScopes) {
+      final Deque<ExecutableFlowElement> flowScopes,
+      final BiConsumer<DirectBuffer, Long> createVariablesCallback) {
 
     if (flowScopes.isEmpty()) {
       return flowScopeKey;
@@ -113,13 +133,16 @@ public final class ElementActivationBehavior {
       // - create/activate a new instance and continue with the remaining flow scopes
       final long elementInstanceKey =
           activateFlowScope(processInstanceRecord, flowScopeKey, flowScope);
-      return activateFlowScopes(processInstanceRecord, elementInstanceKey, flowScopes);
+      createVariablesCallback.accept(flowScope.getId(), elementInstanceKey);
+      return activateFlowScopes(processInstanceRecord, elementInstanceKey, flowScopes, createVariablesCallback);
 
     } else if (elementInstancesOfScope.size() == 1) {
       // there is an active instance of this flow scope
       // - no need to create a new instance; continue with the remaining flow scopes
       final var elementInstance = elementInstancesOfScope.get(0);
-      return activateFlowScopes(processInstanceRecord, elementInstance.getKey(), flowScopes);
+      createVariablesCallback.accept(flowScope.getId(), elementInstance.getKey());
+      return activateFlowScopes(processInstanceRecord, elementInstance.getKey(), flowScopes,
+          createVariablesCallback);
 
     } else {
       // todo: deal with multiple flow scopes found without ancestor selection (#10008)

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -192,9 +192,12 @@ public final class ElementActivationBehavior {
       elementInstanceFlowScopeKey = flowScopeKey;
     }
 
-    createVariablesCallback.accept(flowScope.getId(), elementInstanceKey);
     activateFlowScopeByEvents(
-        processInstanceRecord, flowScope, elementInstanceKey, elementInstanceFlowScopeKey);
+        processInstanceRecord,
+        flowScope,
+        elementInstanceKey,
+        elementInstanceFlowScopeKey,
+        createVariablesCallback);
 
     return elementInstanceKey;
   }
@@ -203,12 +206,14 @@ public final class ElementActivationBehavior {
       final ProcessInstanceRecord processInstanceRecord,
       final ExecutableFlowElement element,
       final long elementInstanceKey,
-      final long flowScopeKey) {
+      final long flowScopeKey,
+      final BiConsumer<DirectBuffer, Long> createVariablesCallback) {
 
     final var elementRecord = createElementRecord(processInstanceRecord, element, flowScopeKey);
 
     stateWriter.appendFollowUpEvent(
         elementInstanceKey, ProcessInstanceIntent.ELEMENT_ACTIVATING, elementRecord);
+    createVariablesCallback.accept(element.getId(), elementInstanceKey);
     stateWriter.appendFollowUpEvent(
         elementInstanceKey, ProcessInstanceIntent.ELEMENT_ACTIVATED, elementRecord);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -87,7 +87,10 @@ public final class ElementActivationBehavior {
 
     final var flowScopeKey =
         activateFlowScopes(
-            processInstanceRecord, processInstanceRecord.getProcessInstanceKey(), flowScopes, createVariablesCallback);
+            processInstanceRecord,
+            processInstanceRecord.getProcessInstanceKey(),
+            flowScopes,
+            createVariablesCallback);
 
     final long elementInstanceKey =
         activateElementByCommand(processInstanceRecord, elementToActivate, flowScopeKey);
@@ -134,15 +137,16 @@ public final class ElementActivationBehavior {
       final long elementInstanceKey =
           activateFlowScope(processInstanceRecord, flowScopeKey, flowScope);
       createVariablesCallback.accept(flowScope.getId(), elementInstanceKey);
-      return activateFlowScopes(processInstanceRecord, elementInstanceKey, flowScopes, createVariablesCallback);
+      return activateFlowScopes(
+          processInstanceRecord, elementInstanceKey, flowScopes, createVariablesCallback);
 
     } else if (elementInstancesOfScope.size() == 1) {
       // there is an active instance of this flow scope
       // - no need to create a new instance; continue with the remaining flow scopes
       final var elementInstance = elementInstancesOfScope.get(0);
       createVariablesCallback.accept(flowScope.getId(), elementInstance.getKey());
-      return activateFlowScopes(processInstanceRecord, elementInstance.getKey(), flowScopes,
-          createVariablesCallback);
+      return activateFlowScopes(
+          processInstanceRecord, elementInstance.getKey(), flowScopes, createVariablesCallback);
 
     } else {
       // todo: deal with multiple flow scopes found without ancestor selection (#10008)

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -143,8 +143,6 @@ public final class ProcessInstanceModificationProcessor
                   process.getProcess().getElementById(instruction.getElementId());
 
               executeGlobalVariableInstructions(processInstance, process, instruction);
-              // todo(#9663): execute local variable instructions
-
               elementActivationBehavior.activateElement(
                   processInstanceRecord,
                   elementToActivate,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -344,28 +344,8 @@ public final class ProcessInstanceModificationProcessor
       final ElementInstance processInstance,
       final DeployedProcess process,
       final ProcessInstanceModificationActivateInstructionValue activate) {
-    final var scopeKey = processInstance.getKey();
-    activate.getVariableInstructions().stream()
-        .filter(v -> Strings.isEmpty(v.getElementId()))
-        .map(
-            instruction -> {
-              if (instruction instanceof ProcessInstanceModificationVariableInstruction vi) {
-                return vi.getVariablesBuffer();
-              }
-              throw new UnsupportedOperationException(
-                  "Expected variable instruction of type %s, but was %s"
-                      .formatted(
-                          ProcessInstanceModificationActivateInstructionValue.class.getName(),
-                          instruction.getClass().getName()));
-            })
-        .forEach(
-            variableDocument ->
-                variableBehavior.mergeLocalDocument(
-                    scopeKey,
-                    process.getKey(),
-                    processInstance.getKey(),
-                    process.getBpmnProcessId(),
-                    variableDocument));
+    final Predicate<ProcessInstanceModificationVariableInstructionValue> filter = instruction -> Strings.isEmpty(instruction.getElementId());
+    executeVariableInstruction(filter, processInstance.getKey(), processInstance, process, activate);
   }
 
   private void executeLocalVariableInstruction(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -145,7 +145,16 @@ public final class ProcessInstanceModificationProcessor
               executeGlobalVariableInstructions(processInstance, process, instruction);
               // todo(#9663): execute local variable instructions
 
-              elementActivationBehavior.activateElement(processInstanceRecord, elementToActivate, (elementId, scopeKey) -> executeLocalVariableInstruction(BufferUtil.bufferAsString(elementId), scopeKey, processInstance, process, instruction));
+              elementActivationBehavior.activateElement(
+                  processInstanceRecord,
+                  elementToActivate,
+                  (elementId, scopeKey) ->
+                      executeLocalVariableInstruction(
+                          BufferUtil.bufferAsString(elementId),
+                          scopeKey,
+                          processInstance,
+                          process,
+                          instruction));
             });
 
     final var sideEffectQueue = new SideEffectQueue();
@@ -344,8 +353,10 @@ public final class ProcessInstanceModificationProcessor
       final ElementInstance processInstance,
       final DeployedProcess process,
       final ProcessInstanceModificationActivateInstructionValue activate) {
-    final Predicate<ProcessInstanceModificationVariableInstructionValue> filter = instruction -> Strings.isEmpty(instruction.getElementId());
-    executeVariableInstruction(filter, processInstance.getKey(), processInstance, process, activate);
+    final Predicate<ProcessInstanceModificationVariableInstructionValue> filter =
+        instruction -> Strings.isEmpty(instruction.getElementId());
+    executeVariableInstruction(
+        filter, processInstance.getKey(), processInstance, process, activate);
   }
 
   private void executeLocalVariableInstruction(
@@ -354,17 +365,18 @@ public final class ProcessInstanceModificationProcessor
       final ElementInstance processInstance,
       final DeployedProcess process,
       final ProcessInstanceModificationActivateInstructionValue activate) {
-    final Predicate<ProcessInstanceModificationVariableInstructionValue> filter = instruction -> instruction.getElementId().equals(elementId);
+    final Predicate<ProcessInstanceModificationVariableInstructionValue> filter =
+        instruction -> instruction.getElementId().equals(elementId);
     executeVariableInstruction(filter, scopeKey, processInstance, process, activate);
   }
 
-  private void executeVariableInstruction(final Predicate<ProcessInstanceModificationVariableInstructionValue> filter,
+  private void executeVariableInstruction(
+      final Predicate<ProcessInstanceModificationVariableInstructionValue> filter,
       final Long scopeKey,
       final ElementInstance processInstance,
       final DeployedProcess process,
       final ProcessInstanceModificationActivateInstructionValue activate) {
-    activate.getVariableInstructions()
-        .stream()
+    activate.getVariableInstructions().stream()
         .filter(filter)
         .map(
             instruction -> {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -355,7 +355,7 @@ public final class ProcessInstanceModificationProcessor
             instruction ->
                 instruction.getElementId().equals(elementId)
                     || (Strings.isEmpty(instruction.getElementId())
-                        && elementId.equals(processInstance.getValue().getElementId())))
+                        && elementId.equals(processInstance.getValue().getBpmnProcessId())))
         .map(
             instruction -> {
               if (instruction instanceof ProcessInstanceModificationVariableInstruction vi) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceVariablesTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceVariablesTest.java
@@ -453,14 +453,15 @@ public class ModifyProcessInstanceVariablesTest {
         processInstanceKey,
         "global",
         "\"global\"");
-    Assertions.assertThat(RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
-        .withProcessInstanceKey(processInstanceKey)
-            .limit(2L))
+    Assertions.assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(2L))
         .extracting(Record::getValue)
-        .extracting(MessageSubscriptionRecordValue::getCorrelationKey, MessageSubscriptionRecordValue::getElementInstanceKey)
-        .containsExactlyInAnyOrder(
-            tuple("global", subProcessKey),
-            tuple("local", subProcessKey));
+        .extracting(
+            MessageSubscriptionRecordValue::getCorrelationKey,
+            MessageSubscriptionRecordValue::getElementInstanceKey)
+        .containsExactlyInAnyOrder(tuple("global", subProcessKey), tuple("local", subProcessKey));
   }
 
   private void assertThatVariableCreatedInScope(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceVariablesTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceVariablesTest.java
@@ -317,5 +317,53 @@ public class ModifyProcessInstanceVariablesTest {
                 processInstanceKey));
   }
 
-  // TODO testcase for creating variable on subprocess
+  @Test
+  public void shouldCreateLocalVariablesInNonExistingFlowscope() {
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(PROCESS_ID)
+                    .startEvent()
+                    .userTask("A")
+                    .subProcess(
+                        "sp", sp -> sp.embeddedSubProcess().startEvent().userTask("B").endEvent())
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .activateElement("B")
+        .withVariables("sp", Map.of("x", "variable"))
+        .modify();
+
+    final Record<ProcessInstanceRecordValue> activatedElement =
+        RecordingExporter.processInstanceRecords()
+            .onlyEvents()
+            .withElementId("sp")
+            .withProcessInstanceKey(processInstanceKey)
+            .limit("sp", ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .getFirst();
+
+    // then
+    assertThat(
+            RecordingExporter.variableRecords(VariableIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that variable is created")
+        .hasName("x")
+        .hasValue("\"variable\"")
+        .hasBpmnProcessId(PROCESS_ID)
+        .hasProcessDefinitionKey(
+            deployment.getValue().getProcessesMetadata().get(0).getProcessDefinitionKey())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasScopeKey(activatedElement.getKey());
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Using a callback create the variables during activation of of the element and flow scopes

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9689 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
