### PR TITLE
feat(backup/s3): log start of all operations

### DIFF
--- a/backup-stores/s3/pom.xml
+++ b/backup-stores/s3/pom.xml
@@ -33,6 +33,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
     </dependency>


### PR DESCRIPTION
This just adds a single logging statement at the start of each method. Together with logging from the backup manager, this should provide us with all information we need.

Exporting metrics was not possible, the AWS SDK only supports exporting to CloudWatch. Providing custom exporters is possible but we'd have to convert from the SDK metric types to prometheus which is not trivial. I found no libraries which would do this for us.

closes #10218 
