### PR TITLE
feat(backup/s3): add required configuration

### DIFF
--- a/backup-stores/s3/pom.xml
+++ b/backup-stores/s3/pom.xml
@@ -48,6 +48,16 @@
     </dependency>
 
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>regions</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>auth</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>
@@ -106,18 +116,6 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>auth</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>regions</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/Metadata.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/Metadata.java
@@ -36,7 +36,7 @@ record Metadata(
 
   static final String OBJECT_KEY = "metadata.json";
 
-  static Metadata of(Backup backup) {
+  static Metadata of(final Backup backup) {
     return new Metadata(
         backup.id().checkpointId(),
         backup.id().partitionId(),

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
@@ -7,5 +7,46 @@
  */
 package io.camunda.zeebe.backup.s3;
 
-/** Holds configuration for the {@link S3BackupStore S3 Backup Store}. */
-public record S3BackupConfig(String bucketName) {}
+import java.util.Optional;
+
+/**
+ * Holds configuration for the {@link S3BackupStore S3 Backup Store}.
+ *
+ * @param bucketName Name of the bucket that will be used for storing backups.
+ * @param region Name of the S3 region to use, will be parsed by {@link
+ *     software.amazon.awssdk.regions.Region#of(String)}. If no value is provided, the AWS SDK will
+ *     try to discover an appropriate value from the environment.
+ * @param credentials If no value is provided, the AWS SDK will try to discover appropriate values
+ *     from the environment.
+ * @see <a
+ *     href=https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html#automatically-determine-the-aws-region-from-the-environment>
+ *     Automatically determine the Region from the environment</a>
+ * @see software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+ */
+public record S3BackupConfig(
+    String bucketName, Optional<String> region, Optional<Credentials> credentials) {
+
+  /**
+   * Creates a config without setting the region and credentials.
+   *
+   * @param bucketName Name of the backup that will be used for storing backups
+   * @see S3BackupConfig#S3BackupConfig(String bucketName, Optional region, Optional credentials)
+   */
+  public S3BackupConfig(String bucketName) {
+    this(bucketName, Optional.empty(), Optional.empty());
+  }
+
+  record Credentials(String accessKey, String secretKey) {
+    @Override
+    public String toString() {
+      return "Credentials{"
+          + "accessKey='"
+          + accessKey
+          + '\''
+          + ", secretKey='"
+          + "<redacted>"
+          + '\''
+          + '}';
+    }
+  }
+}

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
@@ -13,6 +13,7 @@ import java.util.Optional;
  * Holds configuration for the {@link S3BackupStore S3 Backup Store}.
  *
  * @param bucketName Name of the bucket that will be used for storing backups.
+ * @param endpoint URL for the S3 endpoint to connect to.
  * @param region Name of the S3 region to use, will be parsed by {@link
  *     software.amazon.awssdk.regions.Region#of(String)}. If no value is provided, the AWS SDK will
  *     try to discover an appropriate value from the environment.
@@ -24,16 +25,20 @@ import java.util.Optional;
  * @see software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
  */
 public record S3BackupConfig(
-    String bucketName, Optional<String> region, Optional<Credentials> credentials) {
+    String bucketName,
+    Optional<String> endpoint,
+    Optional<String> region,
+    Optional<Credentials> credentials) {
 
   /**
    * Creates a config without setting the region and credentials.
    *
    * @param bucketName Name of the backup that will be used for storing backups
-   * @see S3BackupConfig#S3BackupConfig(String bucketName, Optional region, Optional credentials)
+   * @see S3BackupConfig#S3BackupConfig(String bucketName, Optional endpoint, Optional region,
+   *     Optional credentials)
    */
   public S3BackupConfig(String bucketName) {
-    this(bucketName, Optional.empty(), Optional.empty());
+    this(bucketName, Optional.empty(), Optional.empty(), Optional.empty());
   }
 
   record Credentials(String accessKey, String secretKey) {

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.backup.s3.S3BackupStoreException.BackupReadException;
 import io.camunda.zeebe.backup.s3.S3BackupStoreException.MetadataParseException;
 import io.camunda.zeebe.backup.s3.S3BackupStoreException.StatusParseException;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -356,6 +357,7 @@ public final class S3BackupStore implements BackupStore {
 
   private static S3AsyncClient buildClient(S3BackupConfig config) {
     final var builder = S3AsyncClient.builder();
+    config.endpoint().ifPresent(endpoint -> builder.endpointOverride(URI.create(endpoint)));
     config.region().ifPresent(region -> builder.region(Region.of(region)));
     config
         .credentials()

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/Status.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/Status.java
@@ -22,7 +22,7 @@ public record Status(BackupStatusCode statusCode, Optional<String> failureReason
 
   public static final String OBJECT_KEY = "status.json";
 
-  public Status(BackupStatusCode status) {
+  public Status(final BackupStatusCode status) {
     this(status, Optional.empty());
   }
 
@@ -34,7 +34,7 @@ public record Status(BackupStatusCode statusCode, Optional<String> failureReason
     return new Status(BackupStatusCode.COMPLETED);
   }
 
-  public static Status failed(Throwable throwable) {
+  public static Status failed(final Throwable throwable) {
     final var writer = new StringWriter();
     throwable.printStackTrace(new PrintWriter(writer));
     return new Status(BackupStatusCode.FAILED, Optional.of(writer.toString()));

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/AbstractBackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/AbstractBackupStoreIT.java
@@ -54,13 +54,13 @@ public abstract class AbstractBackupStoreIT {
 
     @ParameterizedTest
     @ArgumentsSource(TestBackupProvider.class)
-    void savingBackupIsSuccessful(Backup backup) {
+    void savingBackupIsSuccessful(final Backup backup) {
       assertThat(getStore().save(backup)).succeedsWithin(Duration.ofSeconds(10));
     }
 
     @ParameterizedTest
     @ArgumentsSource(TestBackupProvider.class)
-    void savesMetadata(Backup backup) throws IOException {
+    void savesMetadata(final Backup backup) throws IOException {
       // when
       getStore().save(backup).join();
 
@@ -87,7 +87,7 @@ public abstract class AbstractBackupStoreIT {
 
     @ParameterizedTest
     @ArgumentsSource(TestBackupProvider.class)
-    void snapshotFilesExist(Backup backup) {
+    void snapshotFilesExist(final Backup backup) {
       // given
       final var prefix = S3BackupStore.objectPrefix(backup.id()) + S3BackupStore.SNAPSHOT_PREFIX;
 
@@ -109,7 +109,7 @@ public abstract class AbstractBackupStoreIT {
 
     @ParameterizedTest
     @ArgumentsSource(TestBackupProvider.class)
-    void segmentFilesExist(Backup backup) {
+    void segmentFilesExist(final Backup backup) {
       // given
       final var prefix = S3BackupStore.objectPrefix(backup.id()) + S3BackupStore.SEGMENTS_PREFIX;
 
@@ -131,7 +131,7 @@ public abstract class AbstractBackupStoreIT {
 
     @ParameterizedTest
     @ArgumentsSource(TestBackupProvider.class)
-    void bucketContainsExpectedObjectsOnly(Backup backup) {
+    void bucketContainsExpectedObjectsOnly(final Backup backup) {
       // given
       final var prefix = S3BackupStore.objectPrefix(backup.id());
 
@@ -166,7 +166,7 @@ public abstract class AbstractBackupStoreIT {
 
     @ParameterizedTest
     @ArgumentsSource(TestBackupProvider.class)
-    void backupFailsIfBackupAlreadyExists(Backup backup) {
+    void backupFailsIfBackupAlreadyExists(final Backup backup) {
       // when
       getStore().save(backup).join();
 
@@ -179,7 +179,7 @@ public abstract class AbstractBackupStoreIT {
 
     @ParameterizedTest
     @ArgumentsSource(TestBackupProvider.class)
-    void backupFailsIfFilesAreMissing(Backup backup) throws IOException {
+    void backupFailsIfFilesAreMissing(final Backup backup) throws IOException {
       // when
       final var deletedFile = backup.segments().files().stream().findFirst().orElseThrow();
       Files.delete(deletedFile);
@@ -198,7 +198,7 @@ public abstract class AbstractBackupStoreIT {
 
     @ParameterizedTest
     @ArgumentsSource(TestBackupProvider.class)
-    void backupIsMarkedAsCompleted(Backup backup) throws IOException {
+    void backupIsMarkedAsCompleted(final Backup backup) throws IOException {
       // when
       getStore().save(backup).join();
 
@@ -221,7 +221,7 @@ public abstract class AbstractBackupStoreIT {
 
     @ParameterizedTest
     @ArgumentsSource(TestBackupProvider.class)
-    void backupCanBeMarkedAsFailed(Backup backup) throws IOException {
+    void backupCanBeMarkedAsFailed(final Backup backup) throws IOException {
       // given
       getStore().save(backup).join();
 
@@ -252,7 +252,7 @@ public abstract class AbstractBackupStoreIT {
 
     @ParameterizedTest
     @ArgumentsSource(TestBackupProvider.class)
-    void canGetStatus(Backup backup) {
+    void canGetStatus(final Backup backup) {
       // given
       getStore().save(backup).join();
 
@@ -270,7 +270,7 @@ public abstract class AbstractBackupStoreIT {
 
     @ParameterizedTest
     @ArgumentsSource(TestBackupProvider.class)
-    void statusIsFailedAfterMarkingAsFailed(Backup backup) {
+    void statusIsFailedAfterMarkingAsFailed(final Backup backup) {
       // given
       getStore().save(backup).join();
 
@@ -289,7 +289,7 @@ public abstract class AbstractBackupStoreIT {
 
     @ParameterizedTest
     @ArgumentsSource(TestBackupProvider.class)
-    void statusQueryFailsIfStatusIsCorrupt(Backup backup) {
+    void statusQueryFailsIfStatusIsCorrupt(final Backup backup) {
       // given
       getStore().save(backup).join();
 
@@ -312,7 +312,7 @@ public abstract class AbstractBackupStoreIT {
 
     @ParameterizedTest
     @ArgumentsSource(TestBackupProvider.class)
-    void statusQueryFailsIfMetadataIsCorrupt(Backup backup) {
+    void statusQueryFailsIfMetadataIsCorrupt(final Backup backup) {
       // given
       getStore().save(backup).join();
 
@@ -349,7 +349,7 @@ public abstract class AbstractBackupStoreIT {
 
     @ParameterizedTest
     @ArgumentsSource(TestBackupProvider.class)
-    void allBackupObjectsAreDeleted(Backup backup) {
+    void allBackupObjectsAreDeleted(final Backup backup) {
       // given
       getStore().save(backup).join();
 
@@ -378,7 +378,7 @@ public abstract class AbstractBackupStoreIT {
 
     @ParameterizedTest
     @ArgumentsSource(TestBackupProvider.class)
-    void deletingPartialBackupSucceeds(Backup backup) {
+    void deletingPartialBackupSucceeds(final Backup backup) {
       // given
       getStore().save(backup).join();
 
@@ -397,7 +397,7 @@ public abstract class AbstractBackupStoreIT {
 
     @ParameterizedTest
     @ArgumentsSource(TestBackupProvider.class)
-    void deletingInProgressBackupFails(Backup backup) {
+    void deletingInProgressBackupFails(final Backup backup) {
       // given
       getStore().save(backup).join();
 
@@ -418,7 +418,7 @@ public abstract class AbstractBackupStoreIT {
 
     @ParameterizedTest
     @ArgumentsSource(TestBackupProvider.class)
-    void restoreIsSuccessful(Backup backup, @TempDir Path targetDir) {
+    void restoreIsSuccessful(final Backup backup, @TempDir final Path targetDir) {
       // given
       getStore().save(backup).join();
 
@@ -431,7 +431,7 @@ public abstract class AbstractBackupStoreIT {
 
     @ParameterizedTest
     @ArgumentsSource(TestBackupProvider.class)
-    void restoredBackupHasSameContents(Backup originalBackup, @TempDir Path targetDir) {
+    void restoredBackupHasSameContents(final Backup originalBackup, @TempDir final Path targetDir) {
       // given
       getStore().save(originalBackup).join();
 

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/support/BackupAssert.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/support/BackupAssert.java
@@ -19,12 +19,12 @@ public final class BackupAssert extends AbstractAssert<BackupAssert, Backup> {
     super(actual, selfType);
   }
 
-  public static BackupAssert assertThatBackup(Backup actual) {
+  public static BackupAssert assertThatBackup(final Backup actual) {
     return new BackupAssert(actual, BackupAssert.class);
   }
 
   @SuppressWarnings("UnusedReturnValue")
-  public BackupAssert hasSameContentsAs(Backup expected) {
+  public BackupAssert hasSameContentsAs(final Backup expected) {
     assertThat(actual.id()).isEqualTo(expected.id());
     assertThat(actual.descriptor()).isEqualTo(expected.descriptor());
     assertThat(actual.snapshot().names()).isEqualTo(expected.snapshot().names());
@@ -39,7 +39,7 @@ public final class BackupAssert extends AbstractAssert<BackupAssert, Backup> {
   }
 
   @SuppressWarnings("UnusedReturnValue")
-  public BackupAssert residesInPath(Path expectedPath) {
+  public BackupAssert residesInPath(final Path expectedPath) {
     NamedFileSetAssert.assertThatNamedFileSet(actual.snapshot()).residesInPath(expectedPath);
     NamedFileSetAssert.assertThatNamedFileSet(actual.segments()).residesInPath(expectedPath);
     return this;

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/support/NamedFileSetAssert.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/support/NamedFileSetAssert.java
@@ -19,12 +19,12 @@ final class NamedFileSetAssert extends AbstractAssert<NamedFileSetAssert, NamedF
     super(namedFileSet, selfType);
   }
 
-  public static NamedFileSetAssert assertThatNamedFileSet(NamedFileSet actual) {
+  public static NamedFileSetAssert assertThatNamedFileSet(final NamedFileSet actual) {
     return new NamedFileSetAssert(actual, NamedFileSetAssert.class);
   }
 
   @SuppressWarnings("UnusedReturnValue")
-  public NamedFileSetAssert hasSameContentsAs(NamedFileSet expected) {
+  public NamedFileSetAssert hasSameContentsAs(final NamedFileSet expected) {
     for (final var expectedEntry : expected.namedFiles().entrySet()) {
       final var expectedName = expectedEntry.getKey();
       final var expectedPath = expectedEntry.getValue();
@@ -38,7 +38,7 @@ final class NamedFileSetAssert extends AbstractAssert<NamedFileSetAssert, NamedF
   }
 
   @SuppressWarnings("UnusedReturnValue")
-  public NamedFileSetAssert residesInPath(Path expectedPath) {
+  public NamedFileSetAssert residesInPath(final Path expectedPath) {
     assertThat(actual.files())
         .allSatisfy(
             actualPath -> {


### PR DESCRIPTION
* Adds a config value for client credentials.
* Adds a config value for the S3 endpoint.
* Adds a config value for bucket region.
* The store implementation can now build its own client, based on the given config.

closes #10220 