### PR TITLE
Reject modification command if flow scope can't be created

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -238,7 +238,7 @@ public final class ElementActivationBehavior {
 
       if (subscribedOrFailure.isLeft()) {
         final var message =
-            "expected to subscribe to catch event(s) of '%s' but %s"
+            "Expected to subscribe to catch event(s) of '%s' but %s"
                 .formatted(
                     BufferUtil.bufferAsString(element.getId()),
                     subscribedOrFailure.getLeft().getMessage());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -170,10 +170,13 @@ public final class ProcessInstanceModificationProcessor
   }
 
   @Override
-  public ProcessingError tryHandleError(final TypedRecord<ProcessInstanceModificationRecord> typedCommand, final Throwable error) {
+  public ProcessingError tryHandleError(
+      final TypedRecord<ProcessInstanceModificationRecord> typedCommand, final Throwable error) {
     if (error instanceof EventSubscriptionException exception) {
-      rejectionWriter.appendRejection(typedCommand, RejectionType.INVALID_ARGUMENT, exception.getMessage());
-      responseWriter.writeRejectionOnCommand(typedCommand, RejectionType.INVALID_ARGUMENT, exception.getMessage());
+      rejectionWriter.appendRejection(
+          typedCommand, RejectionType.INVALID_ARGUMENT, exception.getMessage());
+      responseWriter.writeRejectionOnCommand(
+          typedCommand, RejectionType.INVALID_ARGUMENT, exception.getMessage());
       return ProcessingError.EXPECTED_ERROR;
     }
     return ProcessingError.UNEXPECTED_ERROR;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.ElementActivationBehavior;
+import io.camunda.zeebe.engine.processing.common.EventSubscriptionException;
 import io.camunda.zeebe.engine.processing.deployment.model.element.AbstractFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -166,6 +167,16 @@ public final class ProcessInstanceModificationProcessor
 
     responseWriter.writeEventOnCommand(
         eventKey, ProcessInstanceModificationIntent.MODIFIED, value, command);
+  }
+
+  @Override
+  public ProcessingError tryHandleError(final TypedRecord<ProcessInstanceModificationRecord> typedCommand, final Throwable error) {
+    if (error instanceof EventSubscriptionException exception) {
+      rejectionWriter.appendRejection(typedCommand, RejectionType.INVALID_ARGUMENT, exception.getMessage());
+      responseWriter.writeRejectionOnCommand(typedCommand, RejectionType.INVALID_ARGUMENT, exception.getMessage());
+      return ProcessingError.EXPECTED_ERROR;
+    }
+    return ProcessingError.UNEXPECTED_ERROR;
   }
 
   private Either<Rejection, ?> validateCommand(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
@@ -190,7 +190,7 @@ public class CreateProcessInstanceRejectionTest {
         .hasIntent(ProcessInstanceCreationIntent.CREATE)
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
-            "expected to subscribe to catch event(s) of 'subprocess' but failed to evaluate "
+            "Expected to subscribe to catch event(s) of 'subprocess' but failed to evaluate "
                 + "expression 'unknown_var': no variable found for name 'unknown_var'");
 
     Assertions.assertThat(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -167,7 +167,7 @@ public class ModifyProcessInstanceRejectionTest {
         .describedAs("Expect that flow scope could not be created")
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
-            ("expected to subscribe to catch event(s) of 'sp' but failed to evaluate expression "
+            ("Expected to subscribe to catch event(s) of 'sp' but failed to evaluate expression "
                 + "'missingVariable': no variable found for name 'missingVariable'"));
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The creation of a flow scope could fail if it subscribes to an event. For example, if the event requires a variable that does not exist. When this happens the command should be rejected and a response should be written to the client.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9980 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
