### PR TITLE
Reject terminate instruction when element instance not found

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -270,6 +270,7 @@ public final class ProcessInstanceModificationProcessor
     final List<AbstractFlowElement> elementsWithUnsupportedElementType =
         activateInstructions.stream()
             .map(ProcessInstanceModificationActivateInstructionValue::getElementId)
+            .distinct()
             .map(elementId -> process.getProcess().getElementById(elementId))
             .filter(element -> UNSUPPORTED_ELEMENT_TYPES.contains(element.getElementType()))
             .toList();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -52,9 +52,9 @@ public final class ProcessInstanceModificationProcessor
 
   private static final String ERROR_MESSAGE_PROCESS_INSTANCE_NOT_FOUND =
       "Expected to modify process instance but no process instance found with key '%d'";
-  private static final String ERROR_MESSAGE_TARGET_ELEMENT_NOT_FOUND =
+  private static final String ERROR_MESSAGE_ACTIVATE_ELEMENT_NOT_FOUND =
       "Expected to modify instance of process '%s' but it contains one or more activate instructions with an element that could not be found: '%s'";
-  private static final String ERROR_MESSAGE_TARGET_ELEMENT_UNSUPPORTED =
+  private static final String ERROR_MESSAGE_ACTIVATE_ELEMENT_UNSUPPORTED =
       "Expected to modify instance of process '%s' but it contains one or more activate instructions"
           + " for elements that are unsupported: '%s'. %s.";
   private static final String ERROR_MESSAGE_TERMINATE_ELEMENT_INSTANCE_NOT_FOUND =
@@ -197,7 +197,7 @@ public final class ProcessInstanceModificationProcessor
 
     final String reason =
         String.format(
-            ERROR_MESSAGE_TARGET_ELEMENT_NOT_FOUND,
+            ERROR_MESSAGE_ACTIVATE_ELEMENT_NOT_FOUND,
             BufferUtil.bufferAsString(process.getBpmnProcessId()),
             String.join("', '", unknownElementIds));
     return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, reason));
@@ -232,7 +232,7 @@ public final class ProcessInstanceModificationProcessor
     }
 
     final var reason =
-        ERROR_MESSAGE_TARGET_ELEMENT_UNSUPPORTED.formatted(
+        ERROR_MESSAGE_ACTIVATE_ELEMENT_UNSUPPORTED.formatted(
             BufferUtil.bufferAsString(process.getBpmnProcessId()),
             String.join("', '", elementIdsConnectedToEventBasedGateway),
             "The activation of events belonging to an event-based gateway is not supported");
@@ -256,7 +256,7 @@ public final class ProcessInstanceModificationProcessor
 
     final String reason =
         String.format(
-            ERROR_MESSAGE_TARGET_ELEMENT_UNSUPPORTED,
+            ERROR_MESSAGE_ACTIVATE_ELEMENT_UNSUPPORTED,
             BufferUtil.bufferAsString(process.getBpmnProcessId()),
             String.join("', '", elementsInsideMultiInstance),
             "The activation of elements inside a multi-instance subprocess is not supported");
@@ -291,7 +291,7 @@ public final class ProcessInstanceModificationProcessor
             .distinct()
             .collect(Collectors.joining("', '"));
     final var reason =
-        ERROR_MESSAGE_TARGET_ELEMENT_UNSUPPORTED.formatted(
+        ERROR_MESSAGE_ACTIVATE_ELEMENT_UNSUPPORTED.formatted(
             BufferUtil.bufferAsString(process.getBpmnProcessId()),
             usedUnsupportedElementIds,
             "The activation of elements with type '%s' is not supported. Supported element types are: %s"

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -215,16 +215,17 @@ public final class ProcessInstanceModificationProcessor
   private static Either<Rejection, ?> validateElementsDoNotBelongToEventBasedGateway(
       final DeployedProcess process,
       final List<ProcessInstanceModificationActivateInstructionValue> activateInstructions) {
-    final Set<String> elementIdsConnectedToEventBasedGateway =
+    final List<String> elementIdsConnectedToEventBasedGateway =
         activateInstructions.stream()
             .map(ProcessInstanceModificationActivateInstructionValue::getElementId)
+            .distinct()
             .filter(
                 elementId -> {
                   final var element = process.getProcess().getElementById(elementId);
                   return element instanceof ExecutableCatchEventElement event
                       && event.isConnectedToEventBasedGateway();
                 })
-            .collect(Collectors.toSet());
+            .toList();
 
     if (elementIdsConnectedToEventBasedGateway.isEmpty()) {
       return VALID;
@@ -241,12 +242,13 @@ public final class ProcessInstanceModificationProcessor
   private Either<Rejection, ?> validateElementsNotInsideMultiInstance(
       final DeployedProcess process,
       final List<ProcessInstanceModificationActivateInstructionValue> activateInstructions) {
-    final Set<String> elementsInsideMultiInstance =
+    final List<String> elementsInsideMultiInstance =
         activateInstructions.stream()
             .map(ProcessInstanceModificationActivateInstructionValue::getElementId)
+            .distinct()
             .filter(
                 elementId -> isInsideMultiInstanceBody(process, BufferUtil.wrapString(elementId)))
-            .collect(Collectors.toSet());
+            .toList();
 
     if (elementsInsideMultiInstance.isEmpty()) {
       return VALID;
@@ -316,11 +318,12 @@ public final class ProcessInstanceModificationProcessor
       final ElementInstance processInstance,
       final List<ProcessInstanceModificationTerminateInstructionValue> terminateInstructions) {
 
-    final Set<Long> unknownElementInstanceKeys =
+    final List<Long> unknownElementInstanceKeys =
         terminateInstructions.stream()
             .map(ProcessInstanceModificationTerminateInstructionValue::getElementInstanceKey)
+            .distinct()
             .filter(instanceKey -> elementInstanceState.getInstance(instanceKey) == null)
-            .collect(Collectors.toSet());
+            .toList();
 
     if (unknownElementInstanceKeys.isEmpty()) {
       return VALID;

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -57,7 +57,7 @@ public class ModifyProcessInstanceRejectionTest {
   }
 
   @Test
-  public void shouldRejectCommandWhenAtLeastOneElementIdIsUnknown() {
+  public void shouldRejectCommandWhenAtLeastOneActivateElementIdIsUnknown() {
     // given
     ENGINE
         .deployment()


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The modification command can contain terminate instructions for different element instances. The element instances are identified by their keys. If at least one element instance key is unknown (i.e. no element instance with the given key can be found) then the command is rejected as NOT_FOUND.

The reason for the rejection contains a reference to the Bpmn Process ID and all of the unknown element instance keys. For example:
`Expected to modify instance of process 'process' but it contains one or more terminate instructions with an element instance that could not be found: '123', '456'`

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9983 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
