### PR TITLE
Add broker endpoint to handle backup status query

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStep.java
@@ -66,7 +66,10 @@ public final class BackupApiRequestHandlerStep implements PartitionTransitionSte
       final LogStreamRecordWriter logStreamRecordWriter) {
     final var requestHandler =
         new BackupApiRequestHandler(
-            context.getGatewayBrokerTransport(), logStreamRecordWriter, context.getPartitionId());
+            context.getGatewayBrokerTransport(),
+            logStreamRecordWriter,
+            context.getBackupManager(),
+            context.getPartitionId());
     context.getActorSchedulingService().submitActor(requestHandler).onComplete(installed);
     installed.onComplete(
         (ignore, error) -> {

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -7,14 +7,19 @@
  */
 package io.camunda.zeebe.broker.transport.backupapi;
 
+import io.camunda.zeebe.backup.api.BackupManager;
+import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler;
 import io.camunda.zeebe.broker.transport.ErrorResponseWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
+import io.camunda.zeebe.protocol.impl.encoding.BackupStatusResponse;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.management.AdminRequestType;
 import io.camunda.zeebe.protocol.management.BackupRequestType;
+import io.camunda.zeebe.protocol.management.BackupStatusCode;
+import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
@@ -32,16 +37,19 @@ public final class BackupApiRequestHandler
     implements DiskSpaceUsageListener {
   private boolean isDiskSpaceAvailable = true;
   private final LogStreamRecordWriter logStreamRecordWriter;
+  private final BackupManager backupManager;
   private final AtomixServerTransport transport;
   private final int partitionId;
 
   public BackupApiRequestHandler(
       final AtomixServerTransport transport,
       final LogStreamRecordWriter logStreamRecordWriter,
+      final BackupManager backupManager,
       final int partitionId) {
     super(BackupApiRequestReader::new, BackupApiResponseWriter::new);
     this.logStreamRecordWriter = logStreamRecordWriter;
     this.transport = transport;
+    this.backupManager = backupManager;
     this.partitionId = partitionId;
     transport.unsubscribe(partitionId, RequestType.BACKUP);
     transport.subscribe(partitionId, RequestType.BACKUP, this);
@@ -66,6 +74,7 @@ public final class BackupApiRequestHandler
     return switch (requestReader.type()) {
       case TAKE_BACKUP -> CompletableActorFuture.completed(
           handleTakeBackupRequest(requestReader, responseWriter, errorWriter));
+      case QUERY_STATUS -> handleQueryStatusHandler(requestReader, responseWriter, errorWriter);
       default -> CompletableActorFuture.completed(
           unknownRequest(errorWriter, requestReader.getMessageDecoder().type()));
     };
@@ -98,6 +107,48 @@ public final class BackupApiRequestHandler
     }
   }
 
+  private ActorFuture<Either<ErrorResponseWriter, BackupApiResponseWriter>>
+      handleQueryStatusHandler(
+          final BackupApiRequestReader requestReader,
+          final BackupApiResponseWriter responseWriter,
+          final ErrorResponseWriter errorWriter) {
+    final ActorFuture<Either<ErrorResponseWriter, BackupApiResponseWriter>> result =
+        new CompletableActorFuture<>();
+    final var backupId = requestReader.backupId();
+    backupManager
+        .getBackupStatus(backupId)
+        .onComplete(
+            (status, error) -> {
+              if (error == null) {
+                final BackupStatusResponse response = buildResponse(status);
+                result.complete(Either.right(responseWriter.withStatus(response)));
+              } else {
+                errorWriter.errorCode(ErrorCode.INTERNAL_ERROR).errorMessage(error.getMessage());
+                result.complete(Either.left(errorWriter));
+              }
+            });
+    return result;
+  }
+
+  private BackupStatusResponse buildResponse(final BackupStatus status) {
+    final var response =
+        new BackupStatusResponse()
+            .setBackupId(status.id().checkpointId())
+            .setBrokerId(status.id().nodeId())
+            .setPartitionId(status.id().partitionId())
+            .setStatus(encodeStatusCode(status.statusCode()));
+    status
+        .descriptor()
+        .ifPresent(
+            backupDescriptor ->
+                response
+                    .setCheckpointPosition(backupDescriptor.checkpointPosition())
+                    .setSnapshotId(backupDescriptor.snapshotId().orElse(""))
+                    .setNumberOfPartitions(backupDescriptor.numberOfPartitions()));
+    status.failureReason().ifPresent(response::setFailureReason);
+    return response;
+  }
+
   private Either<ErrorResponseWriter, BackupApiResponseWriter> unknownRequest(
       final ErrorResponseWriter errorWriter, final BackupRequestType type) {
     errorWriter.unsupportedMessage(type, AdminRequestType.values());
@@ -112,5 +163,15 @@ public final class BackupApiRequestHandler
   @Override
   public void onDiskSpaceAvailable() {
     actor.submit(() -> isDiskSpaceAvailable = true);
+  }
+
+  private BackupStatusCode encodeStatusCode(
+      final io.camunda.zeebe.backup.api.BackupStatusCode statusCode) {
+    return switch (statusCode) {
+      case DOES_NOT_EXIST -> BackupStatusCode.DOES_NOT_EXIST;
+      case IN_PROGRESS -> BackupStatusCode.IN_PROGRESS;
+      case COMPLETED -> BackupStatusCode.COMPLETED;
+      case FAILED -> BackupStatusCode.FAILED;
+    };
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.zeebe.backup.api.BackupManager;
 import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
 import io.camunda.zeebe.protocol.impl.encoding.BackupRequest;
@@ -45,13 +46,15 @@ final class BackupApiRequestHandlerTest {
   @Mock(answer = Answers.RETURNS_SELF)
   LogStreamRecordWriter logStreamRecordWriter;
 
+  @Mock BackupManager backupManager;
+
   BackupApiRequestHandler handler;
   private ServerOutput serverOutput;
   private CompletableFuture<Either<ErrorResponse, AdminResponse>> responseFuture;
 
   @BeforeEach
   void setup() {
-    handler = new BackupApiRequestHandler(transport, logStreamRecordWriter, 1);
+    handler = new BackupApiRequestHandler(transport, logStreamRecordWriter, backupManager, 1);
     scheduler.submitActor(handler);
     scheduler.workUntilDone();
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -78,11 +78,7 @@ final class BackupApiRequestHandlerTest {
         new BackupRequest().setType(BackupRequestType.NULL_VAL).setPartitionId(1).setBackupId(10);
 
     // when
-    final var requestBuffer = new UnsafeBuffer(new byte[request.getLength()]);
-    request.write(requestBuffer, 0);
-
-    handler.onRequest(serverOutput, 1, 1, requestBuffer, 0, request.getLength());
-    scheduler.workUntilDone();
+    handleRequest(request);
 
     // then
     assertThat(responseFuture)
@@ -104,10 +100,7 @@ final class BackupApiRequestHandlerTest {
             .setBackupId(10);
 
     // when
-    final var requestBuffer = new UnsafeBuffer(new byte[request.getLength()]);
-    request.write(requestBuffer, 0);
-    handler.onRequest(serverOutput, 1, 1, requestBuffer, 0, request.getLength());
-    scheduler.workUntilDone();
+    handleRequest(request);
 
     // then
     verify(logStreamRecordWriter, times(1)).tryWrite();
@@ -126,11 +119,7 @@ final class BackupApiRequestHandlerTest {
     scheduler.workUntilDone();
 
     // when
-    final var requestBuffer = new UnsafeBuffer(new byte[request.getLength()]);
-    request.write(requestBuffer, 0);
-
-    handler.onRequest(serverOutput, 1, 1, requestBuffer, 0, request.getLength());
-    scheduler.workUntilDone();
+    handleRequest(request);
 
     // then
     assertThat(responseFuture)
@@ -157,11 +146,7 @@ final class BackupApiRequestHandlerTest {
     scheduler.workUntilDone();
 
     // when
-    final var requestBuffer = new UnsafeBuffer(new byte[request.getLength()]);
-    request.write(requestBuffer, 0);
-
-    handler.onRequest(serverOutput, 1, 1, requestBuffer, 0, request.getLength());
-    scheduler.workUntilDone();
+    handleRequest(request);
 
     // then
     assertThat(responseFuture).succeedsWithin(Duration.ofMillis(100));
@@ -180,7 +165,7 @@ final class BackupApiRequestHandlerTest {
     final BackupStatus status =
         new BackupStatusImpl(
             new BackupIdentifierImpl(1, 1, checkpointId),
-            Optional.of(new BackupDescriptorImpl("s-id", 100, 3)),
+            Optional.of(new BackupDescriptorImpl(Optional.of("s-id"), 100, 3)),
             io.camunda.zeebe.backup.api.BackupStatusCode.COMPLETED,
             Optional.empty());
 
@@ -188,11 +173,7 @@ final class BackupApiRequestHandlerTest {
         .thenReturn(CompletableActorFuture.completed(status));
 
     // when
-    final var requestBuffer = new UnsafeBuffer(new byte[request.getLength()]);
-    request.write(requestBuffer, 0);
-
-    handler.onRequest(serverOutput, 1, 1, requestBuffer, 0, request.getLength());
-    scheduler.workUntilDone();
+    handleRequest(request);
 
     // then
     assertThat(responseFuture)
@@ -230,11 +211,7 @@ final class BackupApiRequestHandlerTest {
         .thenReturn(CompletableActorFuture.completed(status));
 
     // when
-    final var requestBuffer = new UnsafeBuffer(new byte[request.getLength()]);
-    request.write(requestBuffer, 0);
-
-    handler.onRequest(serverOutput, 1, 1, requestBuffer, 0, request.getLength());
-    scheduler.workUntilDone();
+    handleRequest(request);
 
     // then
     assertThat(responseFuture)
@@ -270,11 +247,7 @@ final class BackupApiRequestHandlerTest {
             CompletableActorFuture.completedExceptionally(new RuntimeException("Expected")));
 
     // when
-    final var requestBuffer = new UnsafeBuffer(new byte[request.getLength()]);
-    request.write(requestBuffer, 0);
-
-    handler.onRequest(serverOutput, 1, 1, requestBuffer, 0, request.getLength());
-    scheduler.workUntilDone();
+    handleRequest(request);
 
     // then
     assertThat(responseFuture)
@@ -283,6 +256,14 @@ final class BackupApiRequestHandlerTest {
         .extracting(Either::getLeft)
         .extracting(ErrorResponse::getErrorCode)
         .isEqualTo(ErrorCode.INTERNAL_ERROR);
+  }
+
+  private void handleRequest(final BackupRequest request) {
+    final var requestBuffer = new UnsafeBuffer(new byte[request.getLength()]);
+    request.write(requestBuffer, 0);
+
+    handler.onRequest(serverOutput, 1, 1, requestBuffer, 0, request.getLength());
+    scheduler.workUntilDone();
   }
 
   private ServerOutput createServerOutput() {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupStatusResponse.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupStatusResponse.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.encoding;
+
+import io.camunda.zeebe.protocol.management.BackupStatusCode;
+import io.camunda.zeebe.protocol.management.BackupStatusResponseDecoder;
+import io.camunda.zeebe.protocol.management.BackupStatusResponseEncoder;
+import io.camunda.zeebe.protocol.management.MessageHeaderDecoder;
+import io.camunda.zeebe.protocol.management.MessageHeaderEncoder;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public class BackupStatusResponse implements BufferReader, BufferWriter {
+  private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+
+  private final BackupStatusResponseEncoder bodyEncoder = new BackupStatusResponseEncoder();
+  private final BackupStatusResponseDecoder bodyDecoder = new BackupStatusResponseDecoder();
+
+  private long backupId;
+
+  private int partitionId;
+  private int brokerId;
+  private BackupStatusCode status;
+
+  private long checkpointPosition = BackupStatusResponseEncoder.checkpointPositionNullValue();
+  private int numberOfPartitions = BackupStatusResponseEncoder.numberOfPartitionsNullValue();
+  private String snapshotId = null;
+  private String failureReason = null;
+
+  public long getBackupId() {
+    return backupId;
+  }
+
+  public BackupStatusResponse setBackupId(final long backupId) {
+    this.backupId = backupId;
+    return this;
+  }
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  public BackupStatusResponse setPartitionId(final int partitionId) {
+    this.partitionId = partitionId;
+    return this;
+  }
+
+  public int getBrokerId() {
+    return brokerId;
+  }
+
+  public BackupStatusResponse setBrokerId(final int brokerId) {
+    this.brokerId = brokerId;
+    return this;
+  }
+
+  public BackupStatusCode getStatus() {
+    return status;
+  }
+
+  public BackupStatusResponse setStatus(final BackupStatusCode status) {
+    this.status = status;
+    return this;
+  }
+
+  public long getCheckpointPosition() {
+    return checkpointPosition;
+  }
+
+  public BackupStatusResponse setCheckpointPosition(final long checkpointPosition) {
+    this.checkpointPosition = checkpointPosition;
+    return this;
+  }
+
+  public int getNumberOfPartitions() {
+    return numberOfPartitions;
+  }
+
+  public BackupStatusResponse setNumberOfPartitions(final int numberOfPartitions) {
+    this.numberOfPartitions = numberOfPartitions;
+    return this;
+  }
+
+  public String getSnapshotId() {
+    return snapshotId;
+  }
+
+  public BackupStatusResponse setSnapshotId(final String snapshotId) {
+    this.snapshotId = snapshotId;
+    return this;
+  }
+
+  public String getFailureReason() {
+    return failureReason;
+  }
+
+  public BackupStatusResponse setFailureReason(final String failureReason) {
+    this.failureReason = failureReason;
+    return this;
+  }
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    bodyDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
+
+    backupId = bodyDecoder.backupId();
+    partitionId = bodyDecoder.partitionId();
+    status = bodyDecoder.status();
+    brokerId = bodyDecoder.brokerId();
+    checkpointPosition = bodyDecoder.checkpointPosition();
+    numberOfPartitions = bodyDecoder.numberOfPartitions();
+    snapshotId = bodyDecoder.snapshotId();
+    failureReason = bodyDecoder.failureReason();
+  }
+
+  @Override
+  public int getLength() {
+    return 0;
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+
+    bodyEncoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
+    bodyEncoder
+        .backupId(backupId)
+        .brokerId(brokerId)
+        .partitionId(partitionId)
+        .checkpointPosition(checkpointPosition)
+        .numberOfPartitions(numberOfPartitions)
+        .status(status)
+        .snapshotId(snapshotId)
+        .failureReason(failureReason);
+  }
+}

--- a/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/protocol/src/main/resources/cluster-management-protocol.xml
@@ -14,6 +14,14 @@
 
     <enum name="BackupRequestType" encodingType="uint8">
       <validValue name="TAKE_BACKUP">0</validValue>
+      <validValue name="QUERY_STATUS">1</validValue>
+    </enum>
+
+    <enum name="BackupStatusCode" encodingType="uint8">
+      <validValue name="DOES_NOT_EXIST">0</validValue>
+      <validValue name="IN_PROGRESS">1</validValue>
+      <validValue name="COMPLETED">2</validValue>
+      <validValue name="FAILED">3</validValue>
     </enum>
   </types>
 
@@ -29,9 +37,19 @@
   <sbe:message name="BackupRequest" id="3">
     <field name="partitionId" id="1" type="uint16"/>
     <field name="type" id="2" type="BackupRequestType"/>
-    <field name="backupId" id = "3" type="int64"/>
+    <field name="backupId" id="3" type="int64"/>
   </sbe:message>
 
-  <sbe:message name="BackupResponse" id="4">
+  <sbe:message name="BackupStatusResponse" id="4">
+    <field name="backupId" id="1" type="int64"/>
+    <field name="status" id="2" type="BackupStatusCode"/>
+    <field name="partitionId" id="3" type="uint16"/>
+    <field name="brokerId" id="4" type="uint16"/>
+    <field name="checkpointPosition" id="5" type="int64"/>
+    <field name="numberOfPartitions" id="6" type="uint16"/>
+    <data name="snapshotId" id="7" type="varDataEncoding"/>
+    <data name="failureReason" id="8" type="varDataEncoding"/>
   </sbe:message>
+
+
 </sbe:messageSchema>


### PR DESCRIPTION
## Description

- BackupApiRequestHandler can handle backup status query
- Added a new response type for BackupStatus.


## Related issues

closes #9807 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
