### PR TITLE
Mark ongoing backup as failed

### DIFF
--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -171,10 +171,10 @@ public final class S3BackupStore implements BackupStore {
   }
 
   @Override
-  public CompletableFuture<BackupStatusCode> markFailed(final BackupIdentifier id) {
+  public CompletableFuture<BackupStatusCode> markFailed(
+      final BackupIdentifier id, final String failureReason) {
     LOG.info("Marking {} as failed", id);
-    return setStatus(
-        id, new Status(BackupStatusCode.FAILED, Optional.of("Explicitly marked as failed")));
+    return setStatus(id, new Status(BackupStatusCode.FAILED, Optional.of(failureReason)));
   }
 
   private CompletableFuture<NamedFileSet> downloadNamedFileSet(

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
@@ -42,4 +42,6 @@ public interface BackupManager {
 
   /** Close Backup manager */
   ActorFuture<Void> closeAsync();
+
+  void failInProgressBackup(long lastCheckpointId);
 }

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
@@ -29,5 +29,5 @@ public interface BackupStore {
    * Marks the backup as failed. If saving a backup failed, the backups store must mark it as
    * failed. This method can be used if we want to explicitly mark a partial backup as failed.
    */
-  CompletableFuture<BackupStatusCode> markFailed(BackupIdentifier id);
+  CompletableFuture<BackupStatusCode> markFailed(BackupIdentifier id, final String failureReason);
 }

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -169,7 +169,7 @@ final class BackupServiceImpl {
         .thenAccept(
             status -> {
               if (status.statusCode() == BackupStatusCode.IN_PROGRESS) {
-                LOG.debug(
+                LOG.info(
                     "The backup {} initiated by previous leader is still in progress. Marking it as failed.",
                     backupId);
                 backupStore
@@ -177,14 +177,14 @@ final class BackupServiceImpl {
                     .thenAccept(ignore -> LOG.trace("Marked backup {} as failed.", backupId))
                     .exceptionally(
                         failed -> {
-                          LOG.debug("Failed to mark backup {} as failed", backupId, failed);
+                          LOG.warn("Failed to mark backup {} as failed", backupId, failed);
                           return null;
                         });
               }
             })
         .exceptionally(
             error -> {
-              LOG.debug("Failed to retrieve status of backup {}", backupId);
+              LOG.warn("Failed to retrieve status of backup {}", backupId);
               return null;
             });
   }

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -9,16 +9,23 @@ package io.camunda.zeebe.backup.management;
 
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class BackupServiceImpl {
+  private static final Logger LOG = LoggerFactory.getLogger(BackupServiceImpl.class);
   private final Set<InProgressBackup> backupsInProgress = new HashSet<>();
   private final BackupStore backupStore;
   private ConcurrencyControl concurrencyControl;
@@ -137,5 +144,49 @@ final class BackupServiceImpl {
                       }
                     }));
     return future;
+  }
+
+  void failInProgressBackups(
+      final int partitionId,
+      final long lastCheckpointId,
+      final Collection<Integer> brokers,
+      final ConcurrencyControl executor) {
+    if (lastCheckpointId != CheckpointState.NO_CHECKPOINT) {
+      executor.run(
+          () -> {
+            final var backupIds =
+                brokers.stream()
+                    .map(b -> new BackupIdentifierImpl(b, partitionId, lastCheckpointId))
+                    .toList();
+            // Fail backups initiated by previous leaders
+            backupIds.forEach(this::failInProgressBackup);
+          });
+    }
+  }
+
+  private void failInProgressBackup(final BackupIdentifier backupId) {
+    backupStore
+        .getStatus(backupId)
+        .thenAccept(
+            status -> {
+              if (status.statusCode() == BackupStatusCode.IN_PROGRESS) {
+                LOG.debug(
+                    "The backup {} initiated by previous leader is still in progress. Marking it as failed.",
+                    backupId);
+                backupStore
+                    .markFailed(backupId)
+                    .thenAccept(ignore -> LOG.trace("Marked backup {} as failed.", backupId))
+                    .exceptionally(
+                        failed -> {
+                          LOG.debug("Failed to mark backup {} as failed", backupId, failed);
+                          return null;
+                        });
+              }
+            })
+        .exceptionally(
+            error -> {
+              LOG.debug("Failed to retrieve status of backup {}", backupId);
+              return null;
+            });
   }
 }

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -31,7 +31,6 @@ final class BackupServiceImpl {
   private ConcurrencyControl concurrencyControl;
 
   BackupServiceImpl(final BackupStore backupStore) {
-
     this.backupStore = backupStore;
   }
 
@@ -108,7 +107,7 @@ final class BackupServiceImpl {
       final ActorFuture<Void> backupSaved,
       final Throwable error) {
     backupSaved.completeExceptionally(error);
-    backupStore.markFailed(inProgressBackup.id());
+    backupStore.markFailed(inProgressBackup.id(), error.getMessage());
     closeInProgressBackup(inProgressBackup);
   }
 
@@ -174,7 +173,7 @@ final class BackupServiceImpl {
                     "The backup {} initiated by previous leader is still in progress. Marking it as failed.",
                     backupId);
                 backupStore
-                    .markFailed(backupId)
+                    .markFailed(backupId, "Backup is cancelled due to leader change.")
                     .thenAccept(ignore -> LOG.trace("Marked backup {} as failed.", backupId))
                     .exceptionally(
                         failed -> {

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupStore.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupStore.java
@@ -45,7 +45,8 @@ final class NoopBackupStore implements BackupStore {
   }
 
   @Override
-  public CompletableFuture<BackupStatusCode> markFailed(final BackupIdentifier id) {
+  public CompletableFuture<BackupStatusCode> markFailed(
+      final BackupIdentifier id, final String failureReason) {
     return CompletableFuture.completedFuture(null);
   }
 }

--- a/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -228,9 +228,9 @@ class BackupServiceImplTest {
     backupService.failInProgressBackups(1, 10, List.of(1, 2, 3), concurrencyControl);
 
     // then
-    verify(backupStore, timeout(1000)).markFailed(inProgressBackup);
-    verify(backupStore, never()).markFailed(notExistingBackup);
-    verify(backupStore, never()).markFailed(completedBackup);
+    verify(backupStore, timeout(1000)).markFailed(inProgressBackup, any());
+    verify(backupStore, never()).markFailed(notExistingBackup, any());
+    verify(backupStore, never()).markFailed(completedBackup, any());
   }
 
   @Test
@@ -250,7 +250,7 @@ class BackupServiceImplTest {
     backupService.failInProgressBackups(1, 10, List.of(1, 2), concurrencyControl);
 
     // then
-    verify(backupStore, timeout(1000)).markFailed(inProgressBackup);
+    verify(backupStore, timeout(1000)).markFailed(inProgressBackup, any());
   }
 
   private ActorFuture<Void> failedFuture() {
@@ -291,7 +291,7 @@ class BackupServiceImplTest {
   }
 
   private void verifyInProgressBackupIsCleanedUpAfterFailure() {
-    verify(backupStore).markFailed(any());
+    verify(backupStore).markFailed(any(), any());
     verify(inProgressBackup).close();
   }
 }

--- a/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -10,16 +10,22 @@ package io.camunda.zeebe.backup.management;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
@@ -194,6 +200,37 @@ class BackupServiceImplTest {
         .failsWithin(Duration.ofMillis(100))
         .withThrowableOfType(ExecutionException.class)
         .withMessageContaining("Expected");
+  }
+
+  @Test
+  void shouldMarkInProgressBackupsAsFailed() {
+    // given
+    final var inProgressBackup = new BackupIdentifierImpl(1, 1, 10);
+    final var notExistingBackup = new BackupIdentifierImpl(2, 1, 10);
+    final var completedBackup = new BackupIdentifierImpl(3, 1, 10);
+    final var inProgressStatus =
+        new BackupStatusImpl(
+            inProgressBackup, Optional.empty(), BackupStatusCode.IN_PROGRESS, Optional.empty());
+    final var notExistingStatus =
+        new BackupStatusImpl(
+            notExistingBackup, Optional.empty(), BackupStatusCode.DOES_NOT_EXIST, Optional.empty());
+    final var completedStatus =
+        new BackupStatusImpl(
+            completedBackup, Optional.empty(), BackupStatusCode.COMPLETED, Optional.empty());
+    when(backupStore.getStatus(inProgressBackup))
+        .thenReturn(CompletableFuture.completedFuture(inProgressStatus));
+    when(backupStore.getStatus(notExistingBackup))
+        .thenReturn(CompletableFuture.completedFuture(notExistingStatus));
+    when(backupStore.getStatus(completedBackup))
+        .thenReturn(CompletableFuture.completedFuture(completedStatus));
+
+    // when
+    backupService.failInProgressBackups(1, 10, List.of(1, 2, 3), concurrencyControl);
+
+    // then
+    verify(backupStore, timeout(1000)).markFailed(inProgressBackup);
+    verify(backupStore, never()).markFailed(notExistingBackup);
+    verify(backupStore, never()).markFailed(completedBackup);
   }
 
   private ActorFuture<Void> failedFuture() {

--- a/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -228,9 +228,10 @@ class BackupServiceImplTest {
     backupService.failInProgressBackups(1, 10, List.of(1, 2, 3), concurrencyControl);
 
     // then
-    verify(backupStore, timeout(1000)).markFailed(inProgressBackup, any());
-    verify(backupStore, never()).markFailed(notExistingBackup, any());
-    verify(backupStore, never()).markFailed(completedBackup, any());
+    final var expectedFailureReason = "Backup is cancelled due to leader change.";
+    verify(backupStore, timeout(1000)).markFailed(inProgressBackup, expectedFailureReason);
+    verify(backupStore, never()).markFailed(notExistingBackup, expectedFailureReason);
+    verify(backupStore, never()).markFailed(completedBackup, expectedFailureReason);
   }
 
   @Test
@@ -250,7 +251,8 @@ class BackupServiceImplTest {
     backupService.failInProgressBackups(1, 10, List.of(1, 2), concurrencyControl);
 
     // then
-    verify(backupStore, timeout(1000)).markFailed(inProgressBackup, any());
+    verify(backupStore, timeout(1000))
+        .markFailed(inProgressBackup, "Backup is cancelled due to leader change.");
   }
 
   private ActorFuture<Void> failedFuture() {


### PR DESCRIPTION
## Description

The new leader will not continue taking the backup which was initiated by the previous leader. Instead it marks it as failed, so that the users can monitor it and retry if required. We do not delete it so that the users can observe what happens. Users can delete the backup explicitly. 

Note:- If there are more than one backup in progress, it only mark the last one as failed. Ideally we should delete all previous checkpoints. But to keep it simple we just delete the previous one. We can improve this later, and can also provide a "prune" operation to delete old and incomplete backups.

## Related issues

closes #10189 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
