### PR TITLE
Improve logging of LongPollingIT test on failure

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
@@ -13,11 +13,14 @@ import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
 import io.camunda.zeebe.gateway.Loggers;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.qa.util.actuator.LoggersActuator;
 import io.camunda.zeebe.qa.util.testcontainers.ContainerLogsDumper;
 import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
-import io.camunda.zeebe.test.util.record.JobBatchRecordStream;
+import io.camunda.zeebe.test.util.record.RecordStream;
 import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.ZeebePort;
 import io.zeebe.containers.cluster.ZeebeCluster;
@@ -28,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.StreamSupport;
 import org.agrona.CloseHelper;
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -115,9 +119,12 @@ final class LongPollingIT {
       // then - ensure that we tried to activate before the job was created, and that we activated
       // it AGAIN after it was created, without the client sending a new request
       engine.waitForIdleState(Duration.ofSeconds(30));
-      assertThat(records().withIntent(JobBatchIntent.ACTIVATE).limit(2))
+      assertThat(records())
           .as("long polling should trigger a second ACTIVATE command without the client doing so")
-          .hasSize(2);
+          .extracting(Record::getValueType, Record::getIntent)
+          .containsSubsequence(
+              Tuple.tuple(ValueType.JOB_BATCH, JobBatchIntent.ACTIVATE),
+              Tuple.tuple(ValueType.JOB_BATCH, JobBatchIntent.ACTIVATE));
       assertThat((CompletionStage<ActivateJobsResponse>) jobs)
           .succeedsWithin(30, TimeUnit.SECONDS)
           .extracting(ActivateJobsResponse::getJobs)
@@ -126,9 +133,11 @@ final class LongPollingIT {
     }
   }
 
-  private JobBatchRecordStream records() {
-    return new JobBatchRecordStream(
-        StreamSupport.stream(BpmnAssert.getRecordStream().jobBatchRecords().spliterator(), false));
+  @SuppressWarnings("unchecked")
+  private RecordStream records() {
+    return new RecordStream(
+        StreamSupport.stream(BpmnAssert.getRecordStream().records().spliterator(), false)
+            .map(r -> (Record<RecordValue>) r));
   }
 
   private void configureGateway(final ZeebeGatewayNode<?> gateway) {


### PR DESCRIPTION
## Description

This PR improves the output we get on failure so we know all the records that were seen. This should help debug when we don't have the two activate commands, at least until we figure out how to preserve the output of flaky tests between runs.

## Related issues

related to #9740 

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
