### PR TITLE
Add restarts to `RandomizedRaftTest`

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.impl.RaftContext;
+import io.atomix.raft.impl.RaftContext.State;
 import io.atomix.raft.partition.RaftElectionConfig;
 import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.protocol.ControllableRaftServerProtocol;
@@ -504,5 +505,9 @@ public final class ControllableRaftContexts {
           .describedAs("The log is compacted in %s. Hence a snapshot must exist.")
           .isGreaterThanOrEqualTo(firstIndex - 1);
     }
+  }
+
+  public void assertAllMembersAreReady() {
+    raftServers.values().forEach(raft -> assertThat(raft.getState()).isEqualTo(State.READY));
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -66,7 +66,7 @@ public final class ControllableRaftContexts {
   private static final Logger LOG = LoggerFactory.getLogger("TEST");
 
   private final Map<MemberId, ControllableRaftServerProtocol> serverProtocols = new HashMap<>();
-  private final Map<MemberId, Queue<Tuple<Runnable, CompletableFuture>>> messageQueue =
+  private final Map<MemberId, Queue<Tuple<Runnable, CompletableFuture<?>>>> messageQueue =
       new HashMap<>();
   private final Map<MemberId, DeterministicSingleThreadContext> deterministicExecutors =
       new HashMap<>();
@@ -78,7 +78,7 @@ public final class ControllableRaftContexts {
   private final Map<MemberId, RaftContext> raftServers = new HashMap<>();
   private final Map<MemberId, TestSnapshotStore> snapshotStores = new HashMap<>();
   private Duration electionTimeout;
-  private Duration hearbeatTimeout;
+  private Duration heartbeatTimeout;
   private int nextEntry = 0;
 
   // Used only for verification. Map[term -> leader]
@@ -108,13 +108,13 @@ public final class ControllableRaftContexts {
     }
     joinRaftServers();
     electionTimeout = getRaftContext(0).getElectionTimeout();
-    hearbeatTimeout = getRaftContext(0).getHeartbeatInterval();
+    heartbeatTimeout = getRaftContext(0).getHeartbeatInterval();
 
     // expecting 0 to be the leader
     tickHeartbeatTimeout(0);
   }
 
-  public void shudown() throws IOException {
+  public void shutdown() throws IOException {
     raftServers.forEach((m, c) -> c.close());
     raftServers.clear();
     serverProtocols.clear();
@@ -230,7 +230,7 @@ public final class ControllableRaftContexts {
     serverIds.forEach(memberId -> getDeterministicScheduler(memberId).runUntilIdle());
   }
 
-  // run until there are no more tasks to processon member's scheduler
+  // run until there are no more tasks to process on member's scheduler
   public void runUntilDone(final int memberId) {
     getServerProtocol(memberId).receiveAll();
     getDeterministicScheduler(memberId).runUntilIdle();
@@ -257,7 +257,7 @@ public final class ControllableRaftContexts {
     getServerProtocol(memberId).receiveAll();
   }
 
-  // Submit the next message from the incoming queue to the scheduler of memberid.
+  // Submit the next message from the incoming queue to the scheduler of memberId.
   public void processNextMessage(final MemberId memberId) {
     getServerProtocol(memberId).receiveNextMessage();
   }
@@ -271,15 +271,15 @@ public final class ControllableRaftContexts {
   }
 
   public void tickHeartbeatTimeout(final int memberId) {
-    tick(memberId, hearbeatTimeout);
+    tick(memberId, heartbeatTimeout);
   }
 
   public void tickHeartbeatTimeout(final MemberId memberId) {
-    tick(memberId, hearbeatTimeout);
+    tick(memberId, heartbeatTimeout);
   }
 
   public void tickHeartbeatTimeout() {
-    tick(hearbeatTimeout);
+    tick(heartbeatTimeout);
   }
 
   public void tick(final Duration time) {
@@ -297,18 +297,18 @@ public final class ControllableRaftContexts {
     getServerProtocol(memberId).tick(time.toMillis());
   }
 
-  // Execute an append on memberid. If memberid is not the the leader, the append will be rejected.
+  // Execute an append on memberId. If memberId is not the leader, the append request will be
+  // rejected.
   private void clientAppend(final MemberId memberId) {
     final var role = getRaftContext(memberId).getRaftRole();
-    if (role instanceof LeaderRole) {
+    if (role instanceof final LeaderRole leaderRole) {
       LoggerFactory.getLogger("TEST").info("Appending on leader {}", memberId.id());
       final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, nextEntry++);
-      final LeaderRole leaderRole = (LeaderRole) role;
       leaderRole.appendEntry(0, 1, data, mock(AppendListener.class));
     }
   }
 
-  // Find current leader and execute an append
+  // Find current leader and execute an append request
   public void clientAppendOnLeader() {
     final var leaderTerm = leadersAtTerms.keySet().stream().max(Long::compareTo);
     if (leaderTerm.isPresent()) {
@@ -387,7 +387,7 @@ public final class ControllableRaftContexts {
   }
 
   public void assertAtMostOneLeader() {
-    raftServers.values().forEach(s -> updateAndVerifyLeaderTerm(s));
+    raftServers.values().forEach(this::updateAndVerifyLeaderTerm);
   }
 
   private void updateAndVerifyLeaderTerm(final RaftContext s) {

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftOperation.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftOperation.java
@@ -55,6 +55,19 @@ public final class RaftOperation {
     return defaultRaftOperation;
   }
 
+  public static List<RaftOperation> getRaftOperationsWithRestarts() {
+    final List<RaftOperation> defaultRaftOperation = getDefaultRaftOperations();
+    defaultRaftOperation.add(RaftOperation.of("Restart member", ControllableRaftContexts::restart));
+    return defaultRaftOperation;
+  }
+
+  public static List<RaftOperation> getRaftOperationsWithSnapshotsAndRestarts() {
+    final List<RaftOperation> operationsWithSnapshot = getRaftOperationsWithSnapshot();
+    operationsWithSnapshot.add(
+        RaftOperation.of("Restart member", ControllableRaftContexts::restart));
+    return operationsWithSnapshot;
+  }
+
   public static List<RaftOperation> getDefaultRaftOperations() {
     final List<RaftOperation> defaultRaftOperation = new ArrayList<>();
     defaultRaftOperation.add(

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftOperation.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftOperation.java
@@ -58,20 +58,13 @@ public final class RaftOperation {
   public static List<RaftOperation> getDefaultRaftOperations() {
     final List<RaftOperation> defaultRaftOperation = new ArrayList<>();
     defaultRaftOperation.add(
-        RaftOperation.of(
-            "Run next task", (raftContexts, memberId) -> raftContexts.runNextTask(memberId)));
+        RaftOperation.of("Run next task", ControllableRaftContexts::runNextTask));
     defaultRaftOperation.add(
-        RaftOperation.of(
-            "Receive next message",
-            (raftContexts, memberId) -> raftContexts.processNextMessage(memberId)));
+        RaftOperation.of("Receive next message", ControllableRaftContexts::processNextMessage));
     defaultRaftOperation.add(
-        RaftOperation.of(
-            "Tick electionTimeout",
-            (raftContexts, memberId) -> raftContexts.tickElectionTimeout(memberId)));
+        RaftOperation.of("Tick electionTimeout", ControllableRaftContexts::tickElectionTimeout));
     defaultRaftOperation.add(
-        RaftOperation.of(
-            "Tick heartbeatTimeout",
-            (raftContexts, memberId) -> raftContexts.tickHeartbeatTimeout(memberId)));
+        RaftOperation.of("Tick heartbeatTimeout", ControllableRaftContexts::tickHeartbeatTimeout));
     defaultRaftOperation.add(
         RaftOperation.of(
             "Tick 50ms", (raftContexts, m) -> raftContexts.tick(m, Duration.ofMillis(50))));

--- a/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
@@ -45,6 +45,9 @@ public class RandomizedRaftTest {
   private ControllableRaftContexts raftContexts;
   private List<RaftOperation> defaultOperations;
   private List<RaftOperation> operationsWithSnapshot;
+  private List<RaftOperation> operationsWithRestarts;
+  private List<RaftOperation> operationsWithSnapshotsAndRestarts;
+
   private List<MemberId> raftMembers;
   private Path raftDataDirectory;
 
@@ -58,6 +61,8 @@ public class RandomizedRaftTest {
             .collect(Collectors.toList());
     defaultOperations = RaftOperation.getDefaultRaftOperations();
     operationsWithSnapshot = RaftOperation.getRaftOperationsWithSnapshot();
+    operationsWithRestarts = RaftOperation.getRaftOperationsWithRestarts();
+    operationsWithSnapshotsAndRestarts = RaftOperation.getRaftOperationsWithSnapshotsAndRestarts();
     raftMembers = servers;
   }
 
@@ -86,6 +91,44 @@ public class RandomizedRaftTest {
       throws Exception {
 
     consistencyTest(raftOperations, raftMembers, seed);
+  }
+
+  @Property(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
+  void consistencyTestWithRestarts(
+      @ForAll("raftOperationsWithRestarts") final List<RaftOperation> raftOperations,
+      @ForAll("raftMembers") final List<MemberId> raftMembers,
+      @ForAll("seeds") final long seed)
+      throws Exception {
+
+    consistencyTest(raftOperations, raftMembers, seed);
+  }
+
+  @Property(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
+  void consistencyTestWithSnapshotsAndRestarts(
+      @ForAll("raftOperationsWithSnapshotsAndRestarts") final List<RaftOperation> raftOperations,
+      @ForAll("raftMembers") final List<MemberId> raftMembers,
+      @ForAll("seeds") final long seed)
+      throws Exception {
+
+    consistencyTest(raftOperations, raftMembers, seed);
+  }
+
+  @Property(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
+  void livenessTestWithRestarts(
+      @ForAll("raftOperationsWithRestarts") final List<RaftOperation> raftOperations,
+      @ForAll("raftMembers") final List<MemberId> raftMembers,
+      @ForAll("seeds") final long seed)
+      throws Exception {
+    livenessTest(raftOperations, raftMembers, seed);
+  }
+
+  @Property(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
+  void livenessTestWithRestartsAndSnapshots(
+      @ForAll("raftOperationsWithSnapshotsAndRestarts") final List<RaftOperation> raftOperations,
+      @ForAll("raftMembers") final List<MemberId> raftMembers,
+      @ForAll("seeds") final long seed)
+      throws Exception {
+    livenessTest(raftOperations, raftMembers, seed);
   }
 
   @Property(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
@@ -196,6 +239,16 @@ public class RandomizedRaftTest {
   Arbitrary<List<RaftOperation>> raftOperationsWithSnapshot() {
     final var operation = Arbitraries.of(operationsWithSnapshot);
     return operation.list().ofSize(OPERATION_SIZE);
+  }
+
+  @Provide
+  Arbitrary<List<RaftOperation>> raftOperationsWithRestarts() {
+    return Arbitraries.of(operationsWithRestarts).list().ofSize(OPERATION_SIZE);
+  }
+
+  @Provide
+  Arbitrary<List<RaftOperation>> raftOperationsWithSnapshotsAndRestarts() {
+    return Arbitraries.of(operationsWithSnapshotsAndRestarts).list().ofSize(OPERATION_SIZE);
   }
 
   @Provide

--- a/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
@@ -63,7 +63,7 @@ public class RandomizedRaftTest {
 
   @AfterTry
   public void shutDownRaftNodes() throws IOException {
-    raftContexts.shudown();
+    raftContexts.shutdown();
     FileUtil.deleteFolder(raftDataDirectory);
     raftDataDirectory = null;
   }
@@ -184,7 +184,7 @@ public class RandomizedRaftTest {
     raftContexts.assertNoGapsInLog();
   }
 
-  /** Basic raft operations with out snapshotting, compaction or restart */
+  /** Basic raft operations without snapshotting, compaction or restart */
   @Provide
   Arbitrary<List<RaftOperation>> raftOperations() {
     final var operation = Arbitraries.of(defaultOperations);

--- a/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
@@ -221,6 +221,9 @@ public class RandomizedRaftTest {
       raftContexts.runUntilDone();
     }
 
+    // All member are be ready
+    raftContexts.assertAllMembersAreReady();
+
     // Verify all entries are replicated and committed in all replicas
     raftContexts.assertAllLogsEqual();
     raftContexts.assertAllEntriesCommittedAndReplicatedToAll();


### PR DESCRIPTION
Adds the ability to restart raft members without data loss. After the restart, the same data directory and snapshot store is used.

Adds additional randomized tests for default operations + restarts and default operations + snapshots + restarts.

relates to #9837