### PR TITLE
fix(gateway): store followers and inactive nodes in sets

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -53,7 +53,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRespo
 import io.camunda.zeebe.util.VersionUtil;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 
 public final class EndpointManager {
@@ -129,8 +129,8 @@ public final class EndpointManager {
       final BrokerClusterState topology,
       final Partition.Builder partitionBuilder) {
     final int partitionLeader = topology.getLeaderForPartition(partitionId);
-    final List<Integer> partitionFollowers = topology.getFollowersForPartition(partitionId);
-    final List<Integer> partitionInactives = topology.getInactiveNodesForPartition(partitionId);
+    final Set<Integer> partitionFollowers = topology.getFollowersForPartition(partitionId);
+    final Set<Integer> partitionInactives = topology.getInactiveNodesForPartition(partitionId);
 
     if (partitionLeader == brokerId) {
       partitionBuilder.setRole(PartitionBrokerRole.LEADER);

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerClusterState.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerClusterState.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.impl.broker.cluster;
 
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.List;
+import java.util.Set;
 
 public interface BrokerClusterState {
 
@@ -24,9 +25,9 @@ public interface BrokerClusterState {
 
   int getLeaderForPartition(int partition);
 
-  List<Integer> getFollowersForPartition(int partition);
+  Set<Integer> getFollowersForPartition(int partition);
 
-  List<Integer> getInactiveNodesForPartition(int partition);
+  Set<Integer> getInactiveNodesForPartition(int partition);
 
   /**
    * @return the node id of a random broker or {@link BrokerClusterState#UNKNOWN_NODE_ID} if no


### PR DESCRIPTION
Previous use of lists resulted in unbounded growth due to duplication of the same broker ids.

## Description

Replaces the usage of Lists to keep track of followers and inactiveNodes in the BrokerClusterState with Sets to prevent duplication on arbitrary metadata updates.

## Related issues

closes #8724

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
