### PR TITLE
DO NOT MERGE - disable reruns to preserve output for now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           mvn -B -T2 --no-snapshot-updates
           -D junitThreadCount=12
           -D skipUTs -D skipChecks
-          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
+          -D failsafe.rerunFailingTestsCount=0 -D flaky.test.reportDir=failsafe-reports
           -P parallel-tests,extract-flaky-tests
           -pl !:zeebe-elasticsearch-exporter
           verify

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterEventService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterEventService.java
@@ -93,6 +93,10 @@ public class DefaultClusterEventService
     getSubscriberNodes(topic)
         .forEach(
             memberId -> {
+              if ("jobsAvailable".equals(topic)) {
+                LOGGER.info("Sending jobs available notification to {}", memberId);
+              }
+
               final Member member = membershipService.getMember(memberId);
               if (member != null && member.isReachable()) {
                 messagingService.sendAsync(member.address(), topic, payload);

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterEventService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterEventService.java
@@ -94,7 +94,7 @@ public class DefaultClusterEventService
         .forEach(
             memberId -> {
               if ("jobsAvailable".equals(topic)) {
-                LOGGER.info("Sending jobs available notification to {}", memberId);
+                LOGGER.warn("Sending jobs available notification to {}", memberId);
               }
 
               final Member member = membershipService.getMember(memberId);

--- a/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/LongPollingJobNotification.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/LongPollingJobNotification.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.engine.impl;
 
 import io.atomix.cluster.messaging.ClusterEventService;
+import io.camunda.zeebe.gateway.Loggers;
 
 public final class LongPollingJobNotification {
   private static final String TOPIC = "jobsAvailable";
@@ -18,6 +19,7 @@ public final class LongPollingJobNotification {
   }
 
   public void onJobsAvailable(final String jobType) {
+    Loggers.LONG_POLLING.trace("Sending notification for {}", jobType);
     eventService.broadcast(TOPIC, jobType);
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
@@ -65,8 +65,8 @@ final class LongPollingIT {
   @BeforeEach
   void beforeEach() {
     // set log level for long polling to trace to have more debugging info when the test fails
-    for (final var gateway : cluster.getGateways().values()) {
-      LoggersActuator.of(gateway).set(Loggers.LONG_POLLING.getName(), Level.TRACE);
+    for (final var node : cluster.getNodes().values()) {
+      LoggersActuator.of(node).set(Loggers.LONG_POLLING.getName(), Level.TRACE);
     }
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
@@ -76,7 +76,7 @@ final class LongPollingIT {
   }
 
   // regression test of https://github.com/camunda/zeebe/issues/9658
-  @RepeatedTest(100)
+  @RepeatedTest(20)
   void shouldActivateAndCompleteJobsInTime() throws InterruptedException, TimeoutException {
     // given
     final var process =

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
@@ -130,7 +130,6 @@ final class LongPollingIT {
       engine.waitForIdleState(Duration.ofSeconds(30));
       Loggers.LONG_POLLING.error("Checking if we have two job batch activate commands...");
 
-
       assertThat(records())
           .as("long polling should trigger a second ACTIVATE command without the client doing so")
           .extracting(Record::getValueType, Record::getIntent)
@@ -164,7 +163,7 @@ final class LongPollingIT {
     @Override
     public void testFailed(final ExtensionContext context, final Throwable cause) {
       Loggers.LONG_POLLING.error("Printing log entirely: ");
-      new CompactRecordLogger(records().collect(Collectors.toList()));
+      new CompactRecordLogger(records().collect(Collectors.toList())).log();
     }
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.qa.util.actuator.LoggersActuator;
 import io.camunda.zeebe.qa.util.testcontainers.ContainerLogsDumper;
 import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.test.util.record.CompactRecordLogger;
 import io.camunda.zeebe.test.util.record.RecordStream;
 import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.ZeebePort;
@@ -29,6 +30,7 @@ import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.agrona.CloseHelper;
 import org.assertj.core.groups.Tuple;
@@ -119,6 +121,11 @@ final class LongPollingIT {
       // then - ensure that we tried to activate before the job was created, and that we activated
       // it AGAIN after it was created, without the client sending a new request
       engine.waitForIdleState(Duration.ofSeconds(30));
+
+      Loggers.LONG_POLLING.error("Checking if we have two job batch activate commands...");
+      Loggers.LONG_POLLING.error("Printing log entirely: ");
+      new CompactRecordLogger(records().collect(Collectors.toList()));
+
       assertThat(records())
           .as("long polling should trigger a second ACTIVATE command without the client doing so")
           .extracting(Record::getValueType, Record::getIntent)

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
@@ -34,7 +34,7 @@ import org.agrona.CloseHelper;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
 import org.testcontainers.containers.Network;
@@ -76,7 +76,7 @@ final class LongPollingIT {
   }
 
   // regression test of https://github.com/camunda/zeebe/issues/9658
-  @Test
+  @RepeatedTest(100)
   void shouldActivateAndCompleteJobsInTime() throws InterruptedException, TimeoutException {
     // given
     final var process =

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -260,9 +260,6 @@ public class CompactRecordLogger {
   }
 
   private String summarizeTimestamp(final Record<?> record) {
-    if (!hasTimerEvents) {
-      return "";
-    }
     final var timestampWithoutMillis =
         ZonedDateTime.ofInstant(Instant.ofEpochMilli(record.getTimestamp()), ZoneId.systemDefault())
             .withNano(0);


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
