### PR TITLE
fix(streamprocessor): stream processor can read checkpoint record values

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedEventRegistry.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedEventRegistry.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
@@ -67,6 +68,8 @@ public final class TypedEventRegistry {
     registry.put(ValueType.DECISION, DecisionRecord.class);
     registry.put(ValueType.DECISION_REQUIREMENTS, DecisionRequirementsRecord.class);
     registry.put(ValueType.DECISION_EVALUATION, DecisionEvaluationRecord.class);
+
+    registry.put(ValueType.CHECKPOINT, CheckpointRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
 


### PR DESCRIPTION
## Description

StreamProcessor uses this event registry to read the value based on the given ValueType.

This event registry and `RecordValues` that reads the record is now part of engine. It is not ideal to add checkpoint value types in the engine, as the engine shouldn't care about it. Alternatively, I tried to move `RecordValues` to StreamProcessor. The goal was that each `RecordProcessor` can define its own registry which we can feed it into `RecordValues`. However, this did not work because engine uses `RecordValues` in their tests. This will create a dependency from engine to streamprocessor which is not allowed. Engine should only depend on the common api. Besides, ExporterDirector also used `RecordValues` to read the record.

Because of these dependencies, changing anything here would required a lot of refactoring. So as a quick fix, I have added the checkpoint value type to the registry. It does not add any additional dependencies to the engine.

If this is ok, I will create a follow up issue to refactor this in engine-abstraction topic.

## Related issues

related #10262 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
