### PR TITLE
[Backport stable/8.0] fix(gateway): store followers and inactive nodes in sets

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -53,7 +53,7 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 
 public final class EndpointManager {
@@ -129,8 +129,8 @@ public final class EndpointManager {
       final BrokerClusterState topology,
       final Partition.Builder partitionBuilder) {
     final int partitionLeader = topology.getLeaderForPartition(partitionId);
-    final List<Integer> partitionFollowers = topology.getFollowersForPartition(partitionId);
-    final List<Integer> partitionInactives = topology.getInactiveNodesForPartition(partitionId);
+    final Set<Integer> partitionFollowers = topology.getFollowersForPartition(partitionId);
+    final Set<Integer> partitionInactives = topology.getInactiveNodesForPartition(partitionId);
 
     if (partitionLeader == brokerId) {
       partitionBuilder.setRole(PartitionBrokerRole.LEADER);

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerClusterState.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerClusterState.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.impl.broker.cluster;
 
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.List;
+import java.util.Set;
 
 public interface BrokerClusterState {
 
@@ -24,9 +25,9 @@ public interface BrokerClusterState {
 
   int getLeaderForPartition(int partition);
 
-  List<Integer> getFollowersForPartition(int partition);
+  Set<Integer> getFollowersForPartition(int partition);
 
-  List<Integer> getInactiveNodesForPartition(int partition);
+  Set<Integer> getInactiveNodesForPartition(int partition);
 
   /**
    * @return the node id of a random broker or {@link BrokerClusterState#UNKNOWN_NODE_ID} if no


### PR DESCRIPTION
# Description
Backport of #10255 to `stable/8.0`.

relates to #8724