### PR TITLE
Reject the modification command if the scope of the variables for activation is unknown

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -78,7 +78,7 @@ public final class ProcessInstanceModificationProcessor
   private static final String ERROR_MESSAGE_VARIABLE_SCOPE_NOT_FLOW_SCOPE =
       """
       Expected to modify instance of process '%s' but it contains one or more variable instructions \
-      with a scope element that doesn't belong the element's flow scope: '%s'. \
+      with a scope element that doesn't belong to the element's flow scope: '%s'. \
       These variables should be set before or after the modification.""";
 
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -71,13 +71,15 @@ public final class ProcessInstanceModificationProcessor
           + " Please reduce the size by splitting the modification into multiple commands.";
 
   private static final String ERROR_MESSAGE_VARIABLE_SCOPE_NOT_FOUND =
-      "Expected to modify instance of process '%s' but it contains one or more variable instructions"
-          + " with a scope element id that could not be found: '%s'";
+      """
+      Expected to modify instance of process '%s' but it contains one or more variable instructions \
+      with a scope element id that could not be found: '%s'""";
 
   private static final String ERROR_MESSAGE_VARIABLE_SCOPE_NOT_FLOW_SCOPE =
-      "Expected to modify instance of process '%s' but it contains one or more variable instructions"
-          + " with a scope element that doesn't belong the element's flow scope: '%s'. "
-          + "These variables should be set before or after the modification.";
+      """
+      Expected to modify instance of process '%s' but it contains one or more variable instructions \
+      with a scope element that doesn't belong the element's flow scope: '%s'. \
+      These variables should be set before or after the modification.""";
 
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       Set.of(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -78,7 +78,7 @@ public final class ProcessInstanceModificationProcessor
   private static final String ERROR_MESSAGE_VARIABLE_SCOPE_NOT_FLOW_SCOPE =
       """
       Expected to modify instance of process '%s' but it contains one or more variable instructions \
-      with a scope element that doesn't belong to the element's flow scope: '%s'. \
+      with a scope element that doesn't belong to the activating element's flow scope. \
       These variables should be set before or after the modification.""";
 
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
@@ -444,8 +444,7 @@ public final class ProcessInstanceModificationProcessor
 
     final var reason =
         ERROR_MESSAGE_VARIABLE_SCOPE_NOT_FLOW_SCOPE.formatted(
-            BufferUtil.bufferAsString(process.getBpmnProcessId()),
-            String.join("', '", nonFlowScopeIds));
+            BufferUtil.bufferAsString(process.getBpmnProcessId()));
     return Either.left(new Rejection(RejectionType.INVALID_ARGUMENT, reason));
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -252,8 +252,9 @@ public class ModifyProcessInstanceRejectionTest {
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
             String.format(
-                "Expected to modify instance of process '%s' but it contains one or more variable "
-                    + "instructions with a scope element id that could not be found: 'C', 'D'",
+                """
+                Expected to modify instance of process '%s' but it contains one or more variable instructions \
+                with a scope element id that could not be found: 'C', 'D'""",
                 PROCESS_ID));
   }
 
@@ -297,9 +298,10 @@ public class ModifyProcessInstanceRejectionTest {
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
             String.format(
-                "Expected to modify instance of process '%s' but it contains one or more variable "
-                    + "instructions with a scope element that doesn't belong the element's flow scope: 'A', 'B'. "
-                    + "These variables should be set before or after the modification.",
+                """
+                Expected to modify instance of process '%s' but it contains one or more variable instructions \
+                with a scope element that doesn't belong the element's flow scope: 'A', 'B'. \
+                These variables should be set before or after the modification.""",
                 PROCESS_ID));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -300,8 +300,8 @@ public class ModifyProcessInstanceRejectionTest {
             String.format(
                 """
                 Expected to modify instance of process '%s' but it contains one or more variable \
-                instructions with a scope element that doesn't belong to the element's flow scope: \
-                'A', 'B'. These variables should be set before or after the modification.""",
+                instructions with a scope element that doesn't belong to the activating element's \
+                flow scope. These variables should be set before or after the modification.""",
                 PROCESS_ID));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -253,8 +253,8 @@ public class ModifyProcessInstanceRejectionTest {
         .hasRejectionReason(
             String.format(
                 """
-                Expected to modify instance of process '%s' but it contains one or more variable instructions \
-                with a scope element id that could not be found: 'C', 'D'""",
+                Expected to modify instance of process '%s' but it contains one or more variable \
+                instructions with a scope element id that could not be found: 'C', 'D'""",
                 PROCESS_ID));
   }
 
@@ -299,9 +299,9 @@ public class ModifyProcessInstanceRejectionTest {
         .hasRejectionReason(
             String.format(
                 """
-                Expected to modify instance of process '%s' but it contains one or more variable instructions \
-                with a scope element that doesn't belong to the element's flow scope: 'A', 'B'. \
-                These variables should be set before or after the modification.""",
+                Expected to modify instance of process '%s' but it contains one or more variable \
+                instructions with a scope element that doesn't belong to the element's flow scope: \
+                'A', 'B'. These variables should be set before or after the modification.""",
                 PROCESS_ID));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -300,7 +300,7 @@ public class ModifyProcessInstanceRejectionTest {
             String.format(
                 """
                 Expected to modify instance of process '%s' but it contains one or more variable instructions \
-                with a scope element that doesn't belong the element's flow scope: 'A', 'B'. \
+                with a scope element that doesn't belong to the element's flow scope: 'A', 'B'. \
                 These variables should be set before or after the modification.""",
                 PROCESS_ID));
   }


### PR DESCRIPTION
## Description

* reject the modification command if one or more variable instructions reference an element id that doesn't exist in the process
* reject the modification command if one or more variable instructions reference an element id that doesn't belong to one of the element's flow scope
  * we don't see a reason (at the moment) to create variables that don't belong to a flow scope since they are not required to create a flow scope
  * these variables should be created before and after the modification

## Related issues

closes #9982 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
