### PR TITLE
Coordinate take backup request in gateway

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.admin.backup;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface BackupApi {
+
+  /**
+   * Triggers backup on all partitions. Returned future is completed successfully after all
+   * partitions have processed the request. Returned future fails if the request was not processed
+   * by at least one partition.
+   *
+   * @param backupId the id of the backup to be taken
+   * @return the backupId
+   */
+  CompletableFuture<Long> takeBackup(long backupId);
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupFailedException.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupFailedException.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.admin.backup;
+
+public class BackupFailedException extends RuntimeException {
+
+  public BackupFailedException(final long backupId, final Throwable error) {
+    super(
+        "Failed to trigger backup (id = %d) on at least one partition.".formatted(backupId), error);
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.admin.backup;
+
+import io.camunda.zeebe.gateway.cmd.NoTopologyAvailableException;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
+import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
+
+public class BackupRequestHandler implements BackupApi {
+
+  final BrokerClient brokerClient;
+  final BrokerTopologyManager topologyManager;
+
+  public BackupRequestHandler(final BrokerClient brokerClient) {
+    this.brokerClient = brokerClient;
+    topologyManager = brokerClient.getTopologyManager();
+  }
+
+  @Override
+  public CompletableFuture<Long> takeBackup(final long backupId) {
+    final BrokerClusterState topology = topologyManager.getTopology();
+    if (topology == null) {
+      return CompletableFuture.failedFuture(new NoTopologyAvailableException());
+    }
+
+    final int partitionsCount = topology.getPartitionsCount();
+
+    final var backupTriggered =
+        IntStream.rangeClosed(1, partitionsCount)
+            .mapToObj(partitionId -> getRequestForPartition(backupId, partitionId))
+            .map(brokerClient::sendRequestWithRetry)
+            .toArray(CompletableFuture[]::new);
+
+    return CompletableFuture.allOf(backupTriggered)
+        .thenApply(ignore -> backupId)
+        .exceptionallyCompose(
+            error ->
+                CompletableFuture.failedFuture(
+                    new BackupFailedException(backupId, error.getCause())));
+  }
+
+  private static BrokerBackupRequest getRequestForPartition(
+      final long backupId, final int partitionId) {
+    final var request = new BrokerBackupRequest();
+    request.setBackupId(backupId);
+    request.setPartitionId(partitionId);
+    return request;
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BrokerBackupRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BrokerBackupRequest.java
@@ -26,10 +26,10 @@ import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 
 /** Wraps the request and response for "Take Backup" sent between gateway and broker */
-public class BrokerBackupRequest extends BrokerRequest<CheckpointRecord> {
+public final class BrokerBackupRequest extends BrokerRequest<CheckpointRecord> {
 
-  protected final BackupRequest request = new BackupRequest();
-  protected final ExecuteCommandResponse response = new ExecuteCommandResponse();
+  final BackupRequest request = new BackupRequest();
+  final ExecuteCommandResponse response = new ExecuteCommandResponse();
 
   public BrokerBackupRequest() {
     super(BackupRequestEncoder.SCHEMA_ID, BackupRequestEncoder.TEMPLATE_ID);

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BrokerBackupRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BrokerBackupRequest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.admin.backup;
+
+import io.camunda.zeebe.gateway.cmd.UnsupportedBrokerResponseException;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerRequest;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerRejection;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerRejectionResponse;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.camunda.zeebe.protocol.impl.encoding.BackupRequest;
+import io.camunda.zeebe.protocol.impl.encoding.ExecuteCommandResponse;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.management.BackupRequestEncoder;
+import io.camunda.zeebe.protocol.management.BackupRequestType;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import io.camunda.zeebe.transport.RequestType;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+/** Wraps the request and response for "Take Backup" sent between gateway and broker */
+public class BrokerBackupRequest extends BrokerRequest<CheckpointRecord> {
+
+  protected final BackupRequest request = new BackupRequest();
+  protected final ExecuteCommandResponse response = new ExecuteCommandResponse();
+
+  public BrokerBackupRequest() {
+    super(BackupRequestEncoder.SCHEMA_ID, BackupRequestEncoder.TEMPLATE_ID);
+    request.setType(BackupRequestType.TAKE_BACKUP);
+  }
+
+  @Override
+  public int getPartitionId() {
+    return request.getPartitionId();
+  }
+
+  @Override
+  public void setPartitionId(final int partitionId) {
+    request.setPartitionId(partitionId);
+  }
+
+  @Override
+  public boolean addressesSpecificPartition() {
+    return true;
+  }
+
+  @Override
+  public boolean requiresPartitionId() {
+    return true;
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return null;
+  }
+
+  @Override
+  protected void setSerializedValue(final DirectBuffer buffer) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected void wrapResponse(final DirectBuffer buffer) {
+    response.wrap(buffer, 0, buffer.capacity());
+  }
+
+  @Override
+  protected BrokerResponse<CheckpointRecord> readResponse() {
+    if (response.getRecordType() == RecordType.COMMAND_REJECTION) {
+      final BrokerRejection brokerRejection =
+          new BrokerRejection(
+              CheckpointIntent.CREATE,
+              request.getBackupId(),
+              response.getRejectionType(),
+              response.getRejectionReason());
+      return new BrokerRejectionResponse<>(brokerRejection);
+    } else if (response.getValueType() == ValueType.CHECKPOINT) {
+      final CheckpointRecord responseDto = toResponseDto(response.getValue());
+      return new BrokerResponse<>(responseDto, response.getPartitionId(), response.getKey());
+    } else {
+      throw new UnsupportedBrokerResponseException(
+          ValueType.CHECKPOINT.name(), response.getValueType().name());
+    }
+  }
+
+  @Override
+  protected CheckpointRecord toResponseDto(final DirectBuffer buffer) {
+    final CheckpointRecord responseDto = new CheckpointRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+
+  @Override
+  public String getType() {
+    return "backup#take";
+  }
+
+  @Override
+  public RequestType getRequestType() {
+    return RequestType.BACKUP;
+  }
+
+  public long getBackupId() {
+    return request.getBackupId();
+  }
+
+  public void setBackupId(final long backupId) {
+    request.setBackupId(backupId);
+  }
+
+  @Override
+  public int getLength() {
+    return request.getLength();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    request.write(buffer, offset);
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/IncompleteTopologyException.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/IncompleteTopologyException.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.admin.backup;
+
+public class IncompleteTopologyException extends RuntimeException {
+
+  public IncompleteTopologyException(final String message) {
+    super(message);
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandlerTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandlerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.admin.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.gateway.api.util.GatewayTest;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BackupRequestHandlerTest extends GatewayTest {
+  BackupRequestHandler requestHandler;
+
+  @Before
+  public void setup() {
+    requestHandler = new BackupRequestHandler(brokerClient);
+  }
+
+  @Test
+  public void shouldCompleteRequestWhenAllPartitionsSucceeds() {
+    // given
+    final BackupStub stub = new BackupStub();
+    stub.registerWith(brokerClient);
+
+    // when
+    final var future = requestHandler.takeBackup(1);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofMillis(500));
+  }
+
+  @Test
+  public void shouldFailFutureWhenOnePartitionFails() {
+    // given
+    final int lastPartitionId =
+        brokerClient.getTopologyManager().getTopology().getPartitionsCount();
+    final BackupStub stub = new BackupStub().withErrorResponseFor(lastPartitionId);
+    stub.registerWith(brokerClient);
+
+    // when
+    final var future = requestHandler.takeBackup(1);
+
+    // then
+    assertThat(future)
+        .failsWithin(Duration.ofMillis(500))
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(BackupFailedException.class);
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupStub.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupStub.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.admin.backup;
+
+import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerError;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerErrorResponse;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.record.ErrorCode;
+import java.util.HashMap;
+import java.util.Map;
+
+public class BackupStub
+    implements RequestStub<BrokerBackupRequest, BrokerResponse<CheckpointRecord>> {
+
+  private final Map<Integer, BrokerResponse<CheckpointRecord>> responses = new HashMap<>();
+
+  @Override
+  public void registerWith(final StubbedBrokerClient gateway) {
+    gateway.registerHandler(BrokerBackupRequest.class, this);
+  }
+
+  @Override
+  public BrokerResponse<CheckpointRecord> handle(final BrokerBackupRequest request)
+      throws Exception {
+    return responses.getOrDefault(
+        request.getPartitionId(),
+        new BrokerResponse<>(
+            new CheckpointRecord().setCheckpointId(1), request.getPartitionId(), -1));
+  }
+
+  public BackupStub withErrorResponseFor(final int partitionId) {
+    responses.put(
+        partitionId, new BrokerErrorResponse<>(new BrokerError(ErrorCode.INTERNAL_ERROR, "ERROR")));
+    return this;
+  }
+}


### PR DESCRIPTION
## Description

- Added a request handler that sends take backup requests to all partitions.
- The request fails if atleast one partitions fails to successfully respond
- When the request is completed, backup would have started on all partition, but not necessarily completed.

## Related issues

closes #10281 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
