### PR TITLE
chore(docker): removal of dev image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-ARG APP_ENV=prod
 # Override this based on the architecture; this is currently pointing to amd64
 ARG BASE_SHA="fce37e5146419a158c2199c6089fa39b92445fb2e66dc0331f8591891239ea3b"
 
@@ -23,30 +22,19 @@ COPY docker/utils/startup.sh ${TMP_DIR}/bin/startup.sh
 RUN chmod +x -R ${TMP_DIR}/bin/ && \
     chmod 0775 ${TMP_DIR} ${TMP_DIR}/data
 
-# Building prod image
-FROM eclipse-temurin:17-jre-focal@sha256:${BASE_SHA} as prod
+# Building application image
+# hadolint ignore=DL3006
+FROM eclipse-temurin:17-jre-focal@sha256:${BASE_SHA} as app
 
 # leave unset to use the default value at the top of the file
 ARG BASE_SHA
-
-LABEL org.opencontainers.image.base.digest="${BASE_SHA}"
-LABEL org.opencontainers.image.base.name="docker.io/library/eclipse-temurin:17-jre-focal"
-
-# Building dev image
-FROM eclipse-temurin:17-jdk-focal as dev
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN echo "running DEV pre-install commands" && \
-    curl -sSL https://github.com/jvm-profiling-tools/async-profiler/releases/download/v1.7.1/async-profiler-1.7.1-linux-x64.tar.gz | tar xzv
-
-# Building application image
-# hadolint ignore=DL3006
-FROM ${APP_ENV} as app
-
 ARG VERSION=""
 ARG DATE=""
 ARG REVISION=""
 
 # OCI labels: https://github.com/opencontainers/image-spec/blob/main/annotations.md
+LABEL org.opencontainers.image.base.digest="${BASE_SHA}"
+LABEL org.opencontainers.image.base.name="docker.io/library/eclipse-temurin:17-jre-focal"
 LABEL org.opencontainers.image.created="${DATE}"
 LABEL org.opencontainers.image.authors="zeebe@camunda.com"
 LABEL org.opencontainers.image.url="https://zeebe.io"

--- a/createBenchmark.sh
+++ b/createBenchmark.sh
@@ -44,7 +44,7 @@ set -x
 
 mvn clean install -DskipTests -DskipChecks -T1C
 
-docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t "gcr.io/zeebe-io/zeebe:$benchmark" .
+docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz -t "gcr.io/zeebe-io/zeebe:$benchmark" .
 docker push "gcr.io/zeebe-io/zeebe:$benchmark"
 
 cd benchmarks/project

--- a/createBenchmark.sh
+++ b/createBenchmark.sh
@@ -44,7 +44,7 @@ set -x
 
 mvn clean install -DskipTests -DskipChecks -T1C
 
-docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz -t "gcr.io/zeebe-io/zeebe:$benchmark" .
+docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz -t "gcr.io/zeebe-io/zeebe:$benchmark" --target app .
 docker push "gcr.io/zeebe-io/zeebe:$benchmark"
 
 cd benchmarks/project

--- a/recreateBenchmark.sh
+++ b/recreateBenchmark.sh
@@ -51,7 +51,7 @@ set -x
 
 mvn clean install -DskipTests -DskipChecks -T1C
 
-docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz -t "gcr.io/zeebe-io/zeebe:$benchmark" .
+docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz -t "gcr.io/zeebe-io/zeebe:$benchmark" --target app .
 docker push "gcr.io/zeebe-io/zeebe:$benchmark"
 
 cd "$pwd/benchmarks/project"

--- a/recreateBenchmark.sh
+++ b/recreateBenchmark.sh
@@ -51,7 +51,7 @@ set -x
 
 mvn clean install -DskipTests -DskipChecks -T1C
 
-docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz --build-arg APP_ENV=dev -t "gcr.io/zeebe-io/zeebe:$benchmark" .
+docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz -t "gcr.io/zeebe-io/zeebe:$benchmark" .
 docker push "gcr.io/zeebe-io/zeebe:$benchmark"
 
 cd "$pwd/benchmarks/project"


### PR DESCRIPTION
## Description

With the introduction of ephemeral containers by docker there is no need to build a dedicated dev image anymore.

## Related issues

closes #10104

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [x] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
