### PR TITLE
Ensure retries are not interleaved even on multiple sequential calls

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
@@ -112,6 +112,7 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService 
           writeRetryStrategy.runWithRetry(
               () -> {
                 Loggers.PROCESS_PROCESSOR_LOGGER.trace("Write scheduled TaskResult to dispatcher!");
+                logStreamBatchWriter.reset();
                 result
                     .getRecordBatch()
                     .forEach(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
@@ -11,13 +11,16 @@ import static io.camunda.zeebe.engine.util.RecordToWrite.command;
 import static io.camunda.zeebe.engine.util.RecordToWrite.event;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.api.EmptyProcessingResult;
 import io.camunda.zeebe.engine.api.ProcessingResult;
 import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
@@ -32,11 +35,17 @@ import io.camunda.zeebe.engine.api.records.RecordBatch;
 import io.camunda.zeebe.engine.util.Records;
 import io.camunda.zeebe.engine.util.StreamPlatform;
 import io.camunda.zeebe.engine.util.StreamPlatformExtension;
+import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,6 +63,9 @@ public class ProcessingScheduleServiceTest {
 
   @SuppressWarnings("unused") // injected by the extension
   private StreamPlatform streamPlatform;
+
+  @SuppressWarnings("unused") // injected by the extension
+  private ControlledActorClock clock;
 
   private DummyProcessor dummyProcessor;
 
@@ -220,6 +232,70 @@ public class ProcessingScheduleServiceTest {
     // then
     verify(dummyProcessorSpy, TIMEOUT.times(5))
         .process(Mockito.argThat(record -> record.getKey() == 1), any());
+  }
+
+  @RegressionTest("https://github.com/camunda/zeebe/issues/10240")
+  void shouldPreserveOrderingOfWritesEvenWithRetries() {
+    // given
+    final var dummyProcessorSpy = spy(dummyProcessor);
+    final var syncLogStream = spy(streamPlatform.createLogStream("stream", 1));
+    final var logStream = spy(syncLogStream.getAsyncLogStream());
+    final var batchWriter = spy(syncLogStream.newLogStreamBatchWriter());
+
+    when(syncLogStream.getAsyncLogStream()).thenReturn(logStream);
+    when(logStream.newLogStreamBatchWriter())
+        .thenReturn(CompletableActorFuture.completed(batchWriter));
+    streamPlatform
+        .withRecordProcessors(List.of(dummyProcessorSpy))
+        .buildStreamProcessor(syncLogStream, true);
+
+    // when - in order to make sure we would interleave tasks without the fix for #10240, we need to
+    // make sure we retry at least twice, such that the second task can be executed in between both
+    // invocations. ensure both tasks have an expiry far away enough such that they expire on
+    // different ticks, as tasks expiring on the same tick will be submitted in a non-deterministic
+    // order
+    final var counter = new AtomicInteger(0);
+    when(batchWriter.tryWrite())
+        .then(
+            i -> {
+              final var invocationCount = counter.incrementAndGet();
+              // wait a sufficiently high enough invocation count to ensure the second timer is
+              // expired, gets scheduled, and then the executions are interleaved. this is quite
+              // hard to do in a deterministic controlled way because of the way our timers are
+              // scheduled
+              if (invocationCount < 5000) {
+                return -1L;
+              }
+
+              Loggers.PROCESS_PROCESSOR_LOGGER.debug("Calling real method");
+              return i.callRealMethod();
+            });
+
+    dummyProcessorSpy.scheduleService.runDelayed(
+        Duration.ZERO,
+        builder -> {
+          // force trigger second task
+          clock.addTime(Duration.ofMinutes(1));
+          builder.appendCommandRecord(1, ACTIVATE_ELEMENT, RECORD);
+          return builder.build();
+        });
+    dummyProcessorSpy.scheduleService.runDelayed(
+        Duration.ofMinutes(1),
+        builder -> {
+          Loggers.PROCESS_PROCESSOR_LOGGER.debug("Running second timer");
+          builder.appendCommandRecord(2, ACTIVATE_ELEMENT, RECORD);
+          return builder.build();
+        });
+
+    // then
+    Awaitility.await("until both records are written to the stream")
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(
+            () -> assertThat(streamPlatform.events(syncLogStream.getLogName())).hasSize(2));
+    assertThat(streamPlatform.events(syncLogStream.getLogName()))
+        .as("records were written in order of submitted tasks")
+        .extracting(LoggedEvent::getKey)
+        .containsExactly(1L, 2L);
   }
 
   private static final class DummyTask implements Task {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
@@ -48,6 +48,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -235,6 +236,7 @@ public class ProcessingScheduleServiceTest {
   }
 
   @RegressionTest("https://github.com/camunda/zeebe/issues/10240")
+  @Disabled("Flaky test due to https://github.com/camunda/zeebe/issues/10306; enable once fixed")
   void shouldPreserveOrderingOfWritesEvenWithRetries() {
     // given
     final var dummyProcessorSpy = spy(dummyProcessor);

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/AbortableRetryStrategy.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/AbortableRetryStrategy.java
@@ -21,7 +21,7 @@ public final class AbortableRetryStrategy implements RetryStrategy {
 
   public AbortableRetryStrategy(final ActorControl actor) {
     this.actor = actor;
-    retryMechanism = new ActorRetryMechanism(actor);
+    retryMechanism = new ActorRetryMechanism();
   }
 
   @Override
@@ -44,7 +44,7 @@ public final class AbortableRetryStrategy implements RetryStrategy {
     try {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
-        actor.submit(this::run);
+        actor.run(this::run);
       }
     } catch (final Exception exception) {
       currentFuture.completeExceptionally(exception);

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/ActorRetryMechanism.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/ActorRetryMechanism.java
@@ -7,21 +7,13 @@
  */
 package io.camunda.zeebe.scheduler.retry;
 
-import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.util.function.BooleanSupplier;
 
 public final class ActorRetryMechanism {
-
-  private final ActorControl actor;
-
   private OperationToRetry currentCallable;
   private BooleanSupplier currentTerminateCondition;
   private ActorFuture<Boolean> currentFuture;
-
-  public ActorRetryMechanism(final ActorControl actor) {
-    this.actor = actor;
-  }
 
   void wrap(
       final OperationToRetry callable,

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/EndlessRetryStrategy.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/EndlessRetryStrategy.java
@@ -26,7 +26,7 @@ public final class EndlessRetryStrategy implements RetryStrategy {
 
   public EndlessRetryStrategy(final ActorControl actor) {
     this.actor = actor;
-    retryMechanism = new ActorRetryMechanism(actor);
+    retryMechanism = new ActorRetryMechanism();
   }
 
   @Override
@@ -50,15 +50,15 @@ public final class EndlessRetryStrategy implements RetryStrategy {
     try {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
-        actor.submit(this::run);
+        actor.run(this::run);
       }
     } catch (final Exception exception) {
       if (terminateCondition.getAsBoolean()) {
         currentFuture.complete(false);
       } else {
-        actor.submit(this::run);
+        actor.run(this::run);
         LOG.error(
-            "Catched exception {} with message {}, will retry...",
+            "Caught exception {} with message {}, will retry...",
             exception.getClass(),
             exception.getMessage(),
             exception);

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RecoverableRetryStrategy.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RecoverableRetryStrategy.java
@@ -23,7 +23,7 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
 
   public RecoverableRetryStrategy(final ActorControl actor) {
     this.actor = actor;
-    retryMechanism = new ActorRetryMechanism(actor);
+    retryMechanism = new ActorRetryMechanism();
   }
 
   @Override
@@ -47,11 +47,11 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
     try {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
-        actor.submit(this::run);
+        actor.run(this::run);
       }
     } catch (final RecoverableException ex) {
       if (!terminateCondition.getAsBoolean()) {
-        actor.submit(this::run);
+        actor.run(this::run);
       }
     } catch (final Exception exception) {
       currentFuture.completeExceptionally(exception);

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/retry/RetryStrategyTest.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/retry/RetryStrategyTest.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerRule;
 import java.lang.reflect.Constructor;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
@@ -122,19 +121,38 @@ public final class RetryStrategyTest {
   public void shouldNotInterleaveRetry() {
     // given
     final AtomicReference<ActorFuture<Boolean>> firstFuture = new AtomicReference<>();
-    final AtomicBoolean retryToggle = new AtomicBoolean();
     final AtomicReference<ActorFuture<Boolean>> secondFuture = new AtomicReference<>();
 
+    final AtomicInteger executionAttempt = new AtomicInteger(0);
+    final AtomicInteger firstResult = new AtomicInteger();
+    final AtomicInteger secondResult = new AtomicInteger();
+
     // when
+    final var retryCounts = 5;
     actorControl.run(
-        () -> firstFuture.set(retryStrategy.runWithRetry(() -> retryToggle.getAndSet(true))));
-    actorControl.run(() -> secondFuture.set(retryStrategy.runWithRetry(() -> true)));
+        () ->
+            firstFuture.set(
+                retryStrategy.runWithRetry(
+                    () -> {
+                      firstResult.set(executionAttempt.getAndIncrement());
+                      return executionAttempt.get() >= retryCounts;
+                    })));
+    actorControl.run(
+        () ->
+            secondFuture.set(
+                retryStrategy.runWithRetry(
+                    () -> {
+                      secondResult.set(executionAttempt.getAndIncrement());
+                      return true;
+                    })));
 
     schedulerRule.workUntilDone();
 
     // then
     assertThat(firstFuture.get()).isDone().isNotEqualTo(secondFuture.get());
     assertThat(secondFuture.get()).isDone();
+    assertThat(firstResult).hasValue(retryCounts - 1);
+    assertThat(secondResult).hasValue(retryCounts);
   }
 
   private static final class ControllableActor extends Actor {

--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -133,7 +133,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/junit/RegressionTest.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/junit/RegressionTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.junit;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code @RegressionTest} is used to signal that the annotated method is a <em>test</em> method,
+ * written specifically to address a regression bug. It should therefore be linked to an issue
+ * tracker URL, which is the expected and <em>required</em> value.
+ */
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Test
+public @interface RegressionTest {
+
+  /** The GitHub issue URL where the regression is described, and for which this is a test. */
+  String value();
+}


### PR DESCRIPTION
## Description

By using `ActorControl#submit` in some of the retry strategies, we can create race conditions if the retry strategy is reused. Since the initial call uses run to prepend a retry attempt, and further retries use submit, it's possible for one run to retry (thus submitting the retry job to the end of the queue) and the next call to `runWithRetry` cause its state to be overwritten, causing issues when it comes to completing the future (as well as potential shared state by the operations).

Additionally, this PR fixes an issue where on retry, we were not resetting the writer, causing the same command to be written multiple times.

There is a regression test added which isn't perfect, and I'd like some suggestions on how to improve it. The integration test added to the `ProcessingScheduleServiceTest` is not amazing and likely to flaky, as it's hard to write controlled tests with our timers. Suggestions are welcomed :+1: 

## Related issues

closes #10240 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
