### PR TITLE
Create and configure scheduler in distribution module

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.io.File;
@@ -63,7 +64,10 @@ public final class SimpleBrokerStartTest {
     final var brokerCfg = new BrokerCfg();
     assignSocketAddresses(brokerCfg);
     final var systemContext =
-        new SystemContext(brokerCfg, newTemporaryFolder.getAbsolutePath(), null);
+        new SystemContext(
+            brokerCfg,
+            newTemporaryFolder.getAbsolutePath(),
+            ActorScheduler.newActorScheduler().build());
     systemContext.getScheduler().start();
 
     final var leaderLatch = new CountDownLatch(1);

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg.NodeCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
+import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import java.io.File;
@@ -395,6 +396,12 @@ final class SystemContextTest {
   }
 
   private SystemContext initSystemContext(final BrokerCfg brokerCfg) {
-    return new SystemContext(brokerCfg, "test", new ControlledActorClock());
+    final ActorScheduler scheduler =
+        ActorScheduler.newActorScheduler()
+            .setCpuBoundActorThreadCount(1)
+            .setIoBoundActorThreadCount(1)
+            .setActorClock(new ControlledActorClock())
+            .build();
+    return new SystemContext(brokerCfg, "test", scheduler);
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/broker/ActorSchedulerConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/ActorSchedulerConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.ThreadsCfg;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@SuppressWarnings("unused")
+@Configuration(proxyBeanMethods = false)
+public final class ActorSchedulerConfiguration {
+  private final BrokerCfg brokerCfg;
+  private final ActorClock clock;
+
+  @Autowired
+  public ActorSchedulerConfiguration(final BrokerCfg brokerCfg, final ActorClock clock) {
+    this.brokerCfg = brokerCfg;
+    this.clock = clock;
+  }
+
+  @Bean("actorScheduler")
+  public ActorScheduler getScheduler() {
+    final ThreadsCfg cfg = brokerCfg.getThreads();
+
+    final int cpuThreads = cfg.getCpuThreadCount();
+    final int ioThreads = cfg.getIoThreadCount();
+    final boolean metricsEnabled = brokerCfg.getExperimental().getFeatures().isEnableActorMetrics();
+
+    return ActorScheduler.newActorScheduler()
+        .setActorClock(clock)
+        .setCpuBoundActorThreadCount(cpuThreads)
+        .setIoBoundActorThreadCount(ioThreads)
+        .setMetricsEnabled(metricsEnabled)
+        .setSchedulerName(String.format("Broker-%d", brokerCfg.getCluster().getNodeId()))
+        .build();
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/shared/ActorClockConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/ActorClockConfiguration.java
@@ -16,7 +16,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.context.annotation.Bean;
-import org.springframework.web.context.annotation.ApplicationScope;
 
 @SuppressWarnings("unused")
 @ConfigurationProperties("zeebe.clock")
@@ -38,13 +37,11 @@ public final class ActorClockConfiguration {
   }
 
   @Bean
-  @ApplicationScope
   public ActorClock getClock() {
     return clock;
   }
 
   @Bean
-  @ApplicationScope
   public ActorClockService getClockService() {
     return service;
   }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -27,6 +27,7 @@ import io.atomix.cluster.messaging.impl.NettyUnicastService;
 import io.atomix.cluster.protocol.SwimMembershipProtocol;
 import io.atomix.raft.partition.RaftPartition;
 import io.atomix.utils.net.Address;
+import io.camunda.zeebe.broker.ActorSchedulerConfiguration;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -286,7 +287,10 @@ public final class ClusteringRule extends ExternalResource {
     final File brokerBase = getBrokerBase(nodeId);
     final BrokerCfg brokerCfg = getBrokerCfg(nodeId);
     final var systemContext =
-        new SystemContext(brokerCfg, brokerBase.getAbsolutePath(), controlledClock);
+        new SystemContext(
+            brokerCfg,
+            brokerBase.getAbsolutePath(),
+            new ActorSchedulerConfiguration(brokerCfg, controlledClock).getScheduler());
     systemContexts.put(nodeId, systemContext);
 
     systemContext.getScheduler().start();


### PR DESCRIPTION
## Description

As we want to use certain parts of the system in the actuators, we need to pull out of the broker and up into the distribution the creation of such instances. For this PR, we're moving the `ActorScheduler`' configuration and creation into dist, and instead injecting it directly in the broker at construction time.

There is some duplication as of now with the gateway's `ActorSchedulerComponent`, but I'd rather not deal with this now until we have a clearer picture of where we want to end up.

## Related issues

related to #9996 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
