### PR TITLE
Auto merge dependency patch updates

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -39,6 +39,7 @@ jobs:
     permissions:
       contents: read
       checks: read
+      pull-requests: read
     steps:
     - id: await-tests
       uses: 'lewagon/wait-on-check-action@v1.1.2'
@@ -48,6 +49,7 @@ jobs:
         wait-interval: 30
         check-regexp: '(Test summary)|(Java checks)|(Go linting)|(Docker checks)|(CodeQL)'
         allowed-conclusions: success,skipped
+        verbose: true
 
   dependabot:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -44,7 +44,7 @@ jobs:
     - id: await-tests
       uses: 'lewagon/wait-on-check-action@v1.1.2'
       with:
-        ref: ${{ github.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         wait-interval: 30
         check-regexp: '(Test summary)|(Java checks)|(Go linting)|(Docker checks)|(CodeQL)'

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,0 +1,65 @@
+# This workflow will auto merge a PR authored by dependabot[bot]. It runs only on open PRs ready for
+# review.
+#
+# It will merge the PR only if: it is authored by dependabot[bot], is a patch semantic update, and
+# all CI checks are successful (ignoring the soon-to-be-removed Jenkins check).
+#
+# The workflow is divided into multiple sequential jobs to allow giving only minimal permissions to
+# the GitHub token passed around.
+name: Dependabot auto-merge updates
+on:
+  pull_request:
+    types:
+      - ready_for_review
+      - opened
+      - reopened
+
+jobs:
+  metadata:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+    outputs:
+      update-type: ${{ steps.metadata.outputs.update-type }}
+
+  await-checks:
+    runs-on: ubuntu-latest
+    needs:
+      - metadata
+    if: ${{ jobs.metadata.outputs.update-type == 'version-update:semver-patch' }}
+    permissions:
+      contents: read
+      checks: read
+    steps:
+    - id: await-tests
+      uses: 'lewagon/wait-on-check-action@v1.1.2'
+      with:
+        ref: ${{ github.ref }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        wait-interval: 30
+        check-regexp: '(Test summary)|(Java checks)|(Go linting)|(Docker checks)|(CodeQL)'
+        allowed-conclusions: success,skipped
+
+  dependabot:
+    runs-on: ubuntu-latest
+    needs:
+      - await-checks
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - run: gh pr review "${PR_ID}" --approve --comment -b "bors merge"
+        env:
+          PR_ID: ${{github.event.pull_request.number}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -59,7 +59,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - run: gh pr review "${PR_ID}" --approve --comment -b "would merge this baby"
+      - run: gh pr review ${{ github.event.pull_request.number }} --approve -b "would merge this baby"
         env:
-          PR_ID: ${{github.event.pull_request.number}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -17,7 +17,9 @@ on:
 jobs:
   metadata:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    # skip for now
+    if: ${{ false }}
+#    if: ${{ github.actor == 'dependabot[bot]' }}
     permissions:
       contents: read
       pull-requests: read
@@ -33,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - metadata
-    if: ${{ jobs.metadata.outputs.update-type == 'version-update:semver-patch' }}
+#    if: ${{ jobs.metadata.outputs.update-type == 'version-update:semver-patch' }}
     permissions:
       contents: read
       checks: read
@@ -54,12 +56,13 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+
     steps:
       - id: metadata
         uses: dependabot/fetch-metadata@v1.1.1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - run: gh pr review "${PR_ID}" --approve --comment -b "bors merge"
+      - run: gh pr review "${PR_ID}" --approve --comment -b "would merge this baby"
         env:
           PR_ID: ${{github.event.pull_request.number}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -33,8 +33,8 @@ jobs:
 
   await-checks:
     runs-on: ubuntu-latest
-    needs:
-      - metadata
+#    needs:
+#      - metadata
 #    if: ${{ jobs.metadata.outputs.update-type == 'version-update:semver-patch' }}
     permissions:
       contents: read

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -44,26 +44,21 @@ jobs:
     - id: await-tests
       uses: 'lewagon/wait-on-check-action@v1.1.2'
       with:
-        ref: ${{ github.ref }}
+        ref: ${{ github.sha }}
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         wait-interval: 30
         check-regexp: '(Test summary)|(Java checks)|(Go linting)|(Docker checks)|(CodeQL)'
         allowed-conclusions: success,skipped
         verbose: true
 
-  dependabot:
+  merge:
     runs-on: ubuntu-latest
     needs:
       - await-checks
     permissions:
       contents: read
       pull-requests: write
-
     steps:
-      - id: metadata
-        uses: dependabot/fetch-metadata@v1.1.1
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - run: gh pr review "${PR_ID}" --approve --comment -b "would merge this baby"
         env:
           PR_ID: ${{github.event.pull_request.number}}


### PR DESCRIPTION
## Description

This PR adds a workflow which runs on every dependabot PRs, and will automatically merge the PR iff the checks pass, and it is a patch version (according to dependabot). Merging is still  done via bors.

The workflow is made of three sequential jobs. This is done due to be able to always pass a GitHub token with the minimum required permissions for each job, as I don't think you can customize permissions on a per-step basis. Please advise if there's a simpler way of doing this.

- The first job checks for the type of semantic update (e.g. major, minor, patch). It will only run if the PR is authored by `dependabot[bot]`. This jobs only has the `contents: read` and `pull-requests: read` permissions.
- The second job runs will wait until all CI checks are green. It will only run if the PR is authored by `dependabot[bot]` and if the semantic update type is `patch`. This job only has the `checks: read` permissions for the token.
- The third job will approve the PR and comment `bors merge`, thus triggering the merge. It will only do so if the PR is authored by `dependabot[bot]`, the type of update is `patch`, and all the CI checks are passing. This job only has the `pull-requests: write` permission.

If bors fails to merge, or checks fail, then manual action is still required.

## Related issues

closes #10295

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
