### PR TITLE
fix(bpmn-model): inclusive gateway only allows default flow with cond…

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/InclusiveGatewayValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/InclusiveGatewayValidator.java
@@ -34,10 +34,6 @@ public class InclusiveGatewayValidator implements ModelElementValidator<Inclusiv
     final SequenceFlow defaultFlow = element.getDefault();
     final int size = element.getIncoming().size();
     if (defaultFlow != null) {
-      if (defaultFlow.getConditionExpression() == null && size > 1) {
-        validationResultCollector.addError(
-            0, "Must have a condition even if it's marked as the default flow");
-      }
       if (defaultFlow.getSource() != element) {
         validationResultCollector.addError(0, "Default flow must start at gateway");
       }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SequenceFlowValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SequenceFlowValidator.java
@@ -54,9 +54,6 @@ public class SequenceFlowValidator implements ModelElementValidator<SequenceFlow
             out -> {
               if (gateway.getDefault() != element) {
                 validationResultCollector.addError(0, "Must have a condition");
-              } else {
-                validationResultCollector.addError(
-                    0, "Must have a condition even if it's marked as the default flow");
               }
             });
       }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeGatewayValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeGatewayValidationTest.java
@@ -54,21 +54,6 @@ public class ZeebeGatewayValidationTest extends AbstractZeebeValidationTest {
       },
       {
         Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .inclusiveGateway("gateway")
-            .defaultFlow()
-            .sequenceFlowId("flow1")
-            .endEvent()
-            .moveToLastInclusiveGateway()
-            .sequenceFlowId("flow2")
-            .conditionExpression("condition")
-            .endEvent()
-            .done(),
-        singletonList(
-            expect("flow1", "Must have a condition even if it's marked as the default flow"))
-      },
-      {
-        Bpmn.createExecutableProcess("process")
             .startEvent("start")
             .inclusiveGateway("fork")
             .defaultFlow()

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/InclusiveGatewayProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/InclusiveGatewayProcessor.java
@@ -100,15 +100,17 @@ public final class InclusiveGatewayProcessor
     }
 
     for (final ExecutableSequenceFlow sequenceFlow : element.getOutgoingWithCondition()) {
-      final Expression condition = sequenceFlow.getCondition();
-      final Either<Failure, Boolean> isFulfilledOrFailure =
-          expressionBehavior.evaluateBooleanExpression(condition, context.getElementInstanceKey());
-      if (isFulfilledOrFailure.isLeft()) {
-        return Either.left(isFulfilledOrFailure.getLeft());
-
-      } else if (isFulfilledOrFailure.get()) {
-        // the condition is fulfilled
-        executableSequenceFlows.add(sequenceFlow);
+      if (element.getDefaultFlow() == null || element.getDefaultFlow() != sequenceFlow) {
+        final Expression condition = sequenceFlow.getCondition();
+        final Either<Failure, Boolean> isFulfilledOrFailure =
+            expressionBehavior.evaluateBooleanExpression(
+                condition, context.getElementInstanceKey());
+        if (isFulfilledOrFailure.isLeft()) {
+          return Either.left(isFulfilledOrFailure.getLeft());
+        } else if (isFulfilledOrFailure.get()) {
+          // the condition is fulfilled
+          executableSequenceFlows.add(sequenceFlow);
+        }
       }
     }
     if (executableSequenceFlows.size() > 0) {


### PR DESCRIPTION

## Description

This solves a bug that inclusive gateway only allows default flow with condition.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10310 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [x] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
