### PR TITLE
Coordinate backup status query in gateway

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.gateway.admin.backup;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 public interface BackupApi {
 
@@ -19,14 +19,13 @@ public interface BackupApi {
    * @param backupId the id of the backup to be taken
    * @return the backupId
    */
-  CompletableFuture<Long> takeBackup(long backupId);
+  CompletionStage<Long> takeBackup(long backupId);
 
   /**
    * Returns the status of the backup. The future fails if the request was not processed by at least
    * one partition.
    *
-   * @param backupId
    * @return the status of the backup
    */
-  CompletableFuture<BackupStatus> getStatus(long backupId);
+  CompletionStage<BackupStatus> getStatus(long backupId);
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
@@ -20,4 +20,13 @@ public interface BackupApi {
    * @return the backupId
    */
   CompletableFuture<Long> takeBackup(long backupId);
+
+  /**
+   * Returns the status of the backup. The future fails if the request was not processed by at least
+   * one partition.
+   *
+   * @param backupId
+   * @return the status of the backup
+   */
+  CompletableFuture<BackupStatus> getStatus(long backupId);
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupOperationFailedException.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupOperationFailedException.java
@@ -7,10 +7,12 @@
  */
 package io.camunda.zeebe.gateway.admin.backup;
 
-public class BackupFailedException extends RuntimeException {
+public class BackupOperationFailedException extends RuntimeException {
 
-  public BackupFailedException(final long backupId, final Throwable error) {
+  public BackupOperationFailedException(
+      final String operation, final long backupId, final Throwable error) {
     super(
-        "Failed to trigger backup (id = %d) on at least one partition.".formatted(backupId), error);
+        "Failed to %s backup (id = %d) on at least one partition.".formatted(operation, backupId),
+        error);
   }
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 public final class BackupRequestHandler implements BackupApi {
 
@@ -30,7 +31,7 @@ public final class BackupRequestHandler implements BackupApi {
   }
 
   @Override
-  public CompletableFuture<Long> takeBackup(final long backupId) {
+  public CompletionStage<Long> takeBackup(final long backupId) {
     final Either<Throwable, Boolean> topologyComplete = checkTopologyComplete();
     if (topologyComplete.isLeft()) {
       return CompletableFuture.failedFuture(
@@ -52,7 +53,7 @@ public final class BackupRequestHandler implements BackupApi {
   }
 
   @Override
-  public CompletableFuture<BackupStatus> getStatus(final long backupId) {
+  public CompletionStage<BackupStatus> getStatus(final long backupId) {
     final Either<Throwable, Boolean> topologyComplete = checkTopologyComplete();
     if (topologyComplete.isLeft()) {
       return CompletableFuture.failedFuture(

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
@@ -11,6 +11,12 @@ import io.camunda.zeebe.gateway.cmd.NoTopologyAvailableException;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.camunda.zeebe.protocol.impl.encoding.BackupStatusResponse;
+import io.camunda.zeebe.protocol.management.BackupStatusCode;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public final class BackupRequestHandler implements BackupApi {
@@ -25,26 +31,14 @@ public final class BackupRequestHandler implements BackupApi {
 
   @Override
   public CompletableFuture<Long> takeBackup(final long backupId) {
-    final BrokerClusterState topology = topologyManager.getTopology();
-    if (topology == null) {
-      return CompletableFuture.failedFuture(
-          backupFailed(backupId, new NoTopologyAvailableException()));
-    }
-
-    final int expectedPartitionCount = topology.getPartitionsCount();
-    final int knownPartitions = topology.getPartitions().size();
-    if (expectedPartitionCount != knownPartitions) {
-      return CompletableFuture.failedFuture(
-          backupFailed(
-              backupId,
-              new IncompleteTopologyException(
-                  "Expected to send request to all %d partitions, but found only %d partitions in topology."
-                      .formatted(expectedPartitionCount, knownPartitions))));
+    final Either<Throwable, Boolean> topologyComplete = checkTopologyComplete();
+    if (topologyComplete.isLeft()) {
+      return CompletableFuture.failedFuture(backupFailed(backupId, topologyComplete.getLeft()));
     }
 
     final var backupTriggered =
-        topology.getPartitions().stream()
-            .map(partitionId -> getRequestForPartition(backupId, partitionId))
+        topologyManager.getTopology().getPartitions().stream()
+            .map(partitionId -> getBackupRequestForPartition(backupId, partitionId))
             .map(brokerClient::sendRequestWithRetry)
             .toArray(CompletableFuture[]::new);
 
@@ -54,11 +48,120 @@ public final class BackupRequestHandler implements BackupApi {
             error -> CompletableFuture.failedFuture(backupFailed(backupId, error.getCause())));
   }
 
+  @Override
+  public CompletableFuture<BackupStatus> getStatus(final long backupId) {
+    final Either<Throwable, Boolean> topologyComplete = checkTopologyComplete();
+    if (topologyComplete.isLeft()) {
+      return CompletableFuture.failedFuture(backupFailed(backupId, topologyComplete.getLeft()));
+    }
+
+    final var statusesReceived =
+        topologyManager.getTopology().getPartitions().stream()
+            .map(partitionId -> getStatusQueryForPartition(backupId, partitionId))
+            .map(brokerClient::sendRequestWithRetry)
+            .toList();
+
+    CompletableFuture.allOf(statusesReceived.toArray(CompletableFuture[]::new))
+        .thenApply(ignore -> aggregatePartitionStatus(backupId, statusesReceived));
+
+    return null;
+  }
+
+  private Either<Throwable, Boolean> checkTopologyComplete() {
+    final BrokerClusterState topology = topologyManager.getTopology();
+    if (topology == null) {
+      return Either.left(new NoTopologyAvailableException());
+    }
+
+    final int expectedPartitionCount = topology.getPartitionsCount();
+    final int knownPartitions = topology.getPartitions().size();
+    if (expectedPartitionCount != knownPartitions) {
+      return Either.left(
+          new IncompleteTopologyException(
+              "Expected to send request to all %d partitions, but found only %d partitions in topology."
+                  .formatted(expectedPartitionCount, knownPartitions)));
+    }
+
+    return Either.right(true);
+  }
+
   private static BackupFailedException backupFailed(final long backupId, final Throwable error) {
     return new BackupFailedException(backupId, error);
   }
 
-  private static BrokerBackupRequest getRequestForPartition(
+  private BackupStatus aggregatePartitionStatus(
+      final long backupId,
+      final List<CompletableFuture<BrokerResponse<BackupStatusResponse>>> completedFutures) {
+
+    final var partitionStatuses =
+        completedFutures.stream()
+            .map(response -> response.join().getResponse())
+            .map(PartitionBackupStatus::from)
+            .toList();
+
+    final var combinedStatus = getAggregatedStatus(partitionStatuses);
+
+    if (combinedStatus.isEmpty()) {
+      throw new IllegalStateException(
+          "Backup status cannot be calculated from %s".formatted(partitionStatuses));
+    }
+
+    String failureReason = null;
+    if (combinedStatus.get() == BackupStatusCode.FAILED) {
+      failureReason = collectFailureReason(partitionStatuses);
+    }
+    return new BackupStatus(
+        backupId, combinedStatus.get(), Optional.ofNullable(failureReason), partitionStatuses);
+  }
+
+  private String collectFailureReason(final List<PartitionBackupStatus> partitionStatuses) {
+    return partitionStatuses.stream()
+        .filter(p -> p.status() == BackupStatusCode.FAILED)
+        .map(
+            p -> {
+              final var reason = p.failureReason().orElse("Unknown reason");
+              return "Backup on partition %d failed due to %s.".formatted(p.partitionId(), reason);
+            })
+        .toList()
+        .toString();
+  }
+
+  private static Optional<BackupStatusCode> getAggregatedStatus(
+      final List<PartitionBackupStatus> partitionStatuses) {
+    return partitionStatuses.stream()
+        .map(PartitionBackupStatus::status)
+        .reduce(BackupRequestHandler::combine);
+  }
+
+  private static BackupStatusCode combine(final BackupStatusCode x, final BackupStatusCode y) {
+    // Failed > DoesNotExist > InProgress > Completed
+
+    if (x == BackupStatusCode.FAILED || y == BackupStatusCode.FAILED) {
+      return BackupStatusCode.FAILED;
+    }
+    if (x == BackupStatusCode.DOES_NOT_EXIST || y == BackupStatusCode.DOES_NOT_EXIST) {
+      return BackupStatusCode.DOES_NOT_EXIST;
+    }
+    if (x == BackupStatusCode.IN_PROGRESS || y == BackupStatusCode.IN_PROGRESS) {
+      return BackupStatusCode.IN_PROGRESS;
+    }
+    if (x == BackupStatusCode.COMPLETED && y == BackupStatusCode.COMPLETED) {
+      return BackupStatusCode.COMPLETED;
+    }
+
+    // This would never happen
+    return BackupStatusCode.SBE_UNKNOWN;
+  }
+
+  private BackupStatusRequest getStatusQueryForPartition(
+      final long backupId, final int partitionId) {
+    final var request = new BackupStatusRequest();
+    request.setBackupId(backupId);
+    request.setPartitionId(partitionId);
+    return request;
+  }
+
+  private static BrokerBackupRequest getBackupRequestForPartition(
       final long backupId, final int partitionId) {
     final var request = new BrokerBackupRequest();
     request.setBackupId(backupId);

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
 
 public final class BackupRequestHandler implements BackupApi {
 
@@ -115,10 +116,9 @@ public final class BackupRequestHandler implements BackupApi {
         .map(
             p -> {
               final var reason = p.failureReason().orElse("Unknown reason");
-              return "Backup on partition %d failed due to %s.".formatted(p.partitionId(), reason);
+              return "Backup on partition %d failed due to %s. ".formatted(p.partitionId(), reason);
             })
-        .toList()
-        .toString();
+        .collect(Collectors.joining());
   }
 
   private Optional<BackupStatusCode> getAggregatedStatus(

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupStatus.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupStatus.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.admin.backup;
+
+import io.camunda.zeebe.protocol.management.BackupStatusCode;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Shows the aggregated status of the backup and status of backup of each partition.
+ *
+ * <p>Aggregates status is calculated as follows:
+ * <li>COMPLETED => If all partitions have completed backup
+ * <li>FAILED => If backup of atleast one partition is failed
+ * <li>DOES_NOT_EXIST => If backup of atleast one partition does not exist.
+ * <li>IN_PROGRESS => Otherwise
+ *
+ * @param backupId id of the backup
+ * @param status aggregated status of backup
+ * @param failureReason If the status == FAILED, then provides a reason for failure
+ * @param partitions status of backup of all partitions
+ */
+public record BackupStatus(
+    long backupId,
+    BackupStatusCode status,
+    Optional<String> failureReason,
+    List<PartitionBackupStatus> partitions) {}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupStatusRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupStatusRequest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.admin.backup;
+
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerRequest;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.camunda.zeebe.protocol.impl.encoding.BackupRequest;
+import io.camunda.zeebe.protocol.impl.encoding.BackupStatusResponse;
+import io.camunda.zeebe.protocol.management.BackupRequestEncoder;
+import io.camunda.zeebe.transport.RequestType;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public class BackupStatusRequest extends BrokerRequest<BackupStatusResponse> {
+
+  protected final BackupRequest request = new BackupRequest();
+  protected final BackupStatusResponse response = new BackupStatusResponse();
+
+  public BackupStatusRequest() {
+    super(BackupRequestEncoder.SCHEMA_ID, BackupRequestEncoder.TEMPLATE_ID);
+  }
+
+  public long getBackupId() {
+    return request.getBackupId();
+  }
+
+  public void setBackupId(final long backupId) {
+    request.setBackupId(backupId);
+  }
+
+  @Override
+  public int getPartitionId() {
+    return request.getPartitionId();
+  }
+
+  @Override
+  public void setPartitionId(final int partitionId) {
+    request.setPartitionId(partitionId);
+  }
+
+  @Override
+  public boolean addressesSpecificPartition() {
+    return true;
+  }
+
+  @Override
+  public boolean requiresPartitionId() {
+    return true;
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return null;
+  }
+
+  @Override
+  protected void setSerializedValue(final DirectBuffer buffer) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected void wrapResponse(final DirectBuffer buffer) {
+    response.wrap(buffer, 0, buffer.capacity());
+  }
+
+  @Override
+  protected BrokerResponse<BackupStatusResponse> readResponse() {
+    return new BrokerResponse<>(response, response.getPartitionId(), -1);
+  }
+
+  @Override
+  protected BackupStatusResponse toResponseDto(final DirectBuffer buffer) {
+    return response;
+  }
+
+  @Override
+  public String getType() {
+    return "backup#status";
+  }
+
+  @Override
+  public RequestType getRequestType() {
+    return RequestType.BACKUP;
+  }
+
+  @Override
+  public int getLength() {
+    return request.getLength();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    request.write(buffer, offset);
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/PartitionBackupDescriptor.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/PartitionBackupDescriptor.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.admin.backup;
+
+public record PartitionBackupDescriptor(String snapshotId, long checkpointPosition, int brokerId) {}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/PartitionBackupDescriptor.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/PartitionBackupDescriptor.java
@@ -7,4 +7,4 @@
  */
 package io.camunda.zeebe.gateway.admin.backup;
 
-public record PartitionBackupDescriptor(String snapshotId, long checkpointPosition, int brokerId) {}
+record PartitionBackupDescriptor(String snapshotId, long checkpointPosition, int brokerId) {}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/PartitionBackupStatus.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/PartitionBackupStatus.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.admin.backup;
+
+import io.camunda.zeebe.protocol.impl.encoding.BackupStatusResponse;
+import io.camunda.zeebe.protocol.management.BackupStatusCode;
+import java.util.Optional;
+
+public record PartitionBackupStatus(
+    int partitionId,
+    BackupStatusCode status,
+    Optional<PartitionBackupDescriptor> description,
+    Optional<String> failureReason) {
+
+  public static PartitionBackupStatus from(final BackupStatusResponse response) {
+
+    final var status = response.getStatus();
+    return switch (status) {
+      case FAILED -> failedStatus(response);
+      case DOES_NOT_EXIST -> notExistingStatus(response);
+      case IN_PROGRESS, COMPLETED -> validStatus(response);
+      default -> throw new IllegalArgumentException("Unknown backup status %s".formatted(status));
+    };
+  }
+
+  private static PartitionBackupStatus validStatus(final BackupStatusResponse response) {
+    final var descriptor =
+        new PartitionBackupDescriptor(
+            response.getSnapshotId(), response.getCheckpointPosition(), response.getBrokerId());
+    return new PartitionBackupStatus(
+        response.getPartitionId(), response.getStatus(), Optional.of(descriptor), Optional.empty());
+  }
+
+  private static PartitionBackupStatus notExistingStatus(final BackupStatusResponse response) {
+    return new PartitionBackupStatus(
+        response.getPartitionId(),
+        BackupStatusCode.DOES_NOT_EXIST,
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  private static PartitionBackupStatus failedStatus(final BackupStatusResponse response) {
+    return new PartitionBackupStatus(
+        response.getPartitionId(),
+        BackupStatusCode.FAILED,
+        Optional.empty(),
+        Optional.of(response.getFailureReason()));
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/PartitionBackupStatus.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/PartitionBackupStatus.java
@@ -11,13 +11,13 @@ import io.camunda.zeebe.protocol.impl.encoding.BackupStatusResponse;
 import io.camunda.zeebe.protocol.management.BackupStatusCode;
 import java.util.Optional;
 
-public record PartitionBackupStatus(
+record PartitionBackupStatus(
     int partitionId,
     BackupStatusCode status,
     Optional<PartitionBackupDescriptor> description,
     Optional<String> failureReason) {
 
-  public static PartitionBackupStatus from(final BackupStatusResponse response) {
+  static PartitionBackupStatus from(final BackupStatusResponse response) {
 
     final var status = response.getStatus();
     return switch (status) {

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupQueryStub.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupQueryStub.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.admin.backup;
+
+import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerError;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerErrorResponse;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.camunda.zeebe.protocol.impl.encoding.BackupStatusResponse;
+import io.camunda.zeebe.protocol.management.BackupStatusCode;
+import io.camunda.zeebe.protocol.record.ErrorCode;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public class BackupQueryStub
+    implements RequestStub<BackupStatusRequest, BrokerResponse<BackupStatusResponse>> {
+
+  private final Map<Integer, Function<BackupStatusRequest, BrokerResponse<BackupStatusResponse>>>
+      responses = new HashMap<>();
+
+  @Override
+  public void registerWith(final StubbedBrokerClient gateway) {
+    gateway.registerHandler(BackupStatusRequest.class, this);
+  }
+
+  @Override
+  public BrokerResponse<BackupStatusResponse> handle(final BackupStatusRequest request)
+      throws Exception {
+    return responses
+        .getOrDefault(request.getPartitionId(), r -> new BrokerResponse<>(getCompletedStatus(r)))
+        .apply(request);
+  }
+
+  private BackupStatusResponse getCompletedStatus(final BackupStatusRequest request) {
+    return new BackupStatusResponse()
+        .setBackupId(request.getBackupId())
+        .setStatus(BackupStatusCode.COMPLETED)
+        .setSnapshotId("sid")
+        .setFailureReason("")
+        .setCheckpointPosition(100)
+        .setBrokerId(1)
+        .setPartitionId(request.getPartitionId());
+  }
+
+  private BackupStatusResponse getFailedStatus(final BackupStatusRequest request) {
+    return new BackupStatusResponse()
+        .setBackupId(request.getBackupId())
+        .setStatus(BackupStatusCode.FAILED)
+        .setFailureReason("FAILED")
+        .setBrokerId(1)
+        .setPartitionId(request.getPartitionId());
+  }
+
+  private BackupStatusResponse getInProgressStatus(final BackupStatusRequest request) {
+    return new BackupStatusResponse()
+        .setBackupId(request.getBackupId())
+        .setStatus(BackupStatusCode.IN_PROGRESS)
+        .setSnapshotId("sid")
+        .setFailureReason("")
+        .setCheckpointPosition(100)
+        .setBrokerId(1)
+        .setPartitionId(request.getPartitionId());
+  }
+
+  private BackupStatusResponse getDoesNotExistStatus(final BackupStatusRequest request) {
+    return new BackupStatusResponse()
+        .setBackupId(request.getBackupId())
+        .setStatus(BackupStatusCode.DOES_NOT_EXIST)
+        .setFailureReason("");
+  }
+
+  public BackupQueryStub withErrorResponseFor(final int partitionId) {
+    responses.put(
+        partitionId,
+        r -> new BrokerErrorResponse<>(new BrokerError(ErrorCode.INTERNAL_ERROR, "ERROR")));
+    return this;
+  }
+
+  public BackupQueryStub withFailedResponseFor(final int partitionId) {
+    responses.put(partitionId, request -> new BrokerResponse<>(getFailedStatus(request)));
+    return this;
+  }
+
+  public BackupQueryStub withInProgressResponseFor(final int partitionId) {
+    responses.put(partitionId, request -> new BrokerResponse<>(getInProgressStatus(request)));
+    return this;
+  }
+
+  public BackupQueryStub withDoesNotExistFor(final int partitionId) {
+    responses.put(partitionId, request -> new BrokerResponse<>(getDoesNotExistStatus(request)));
+    return this;
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandlerTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandlerTest.java
@@ -51,6 +51,6 @@ public class BackupRequestHandlerTest extends GatewayTest {
     assertThat(future)
         .failsWithin(Duration.ofMillis(500))
         .withThrowableOfType(ExecutionException.class)
-        .withCauseInstanceOf(BackupFailedException.class);
+        .withCauseInstanceOf(BackupOperationFailedException.class);
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandlerTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandlerTest.java
@@ -69,7 +69,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
         .succeedsWithin(Duration.ofMillis(500))
         .returns(BackupStatusCode.COMPLETED, BackupStatus::status);
 
-    final var status = future.join();
+    final var status = future.toCompletableFuture().join();
     assertThat(status.partitions())
         .hasSize(brokerClient.getTopologyManager().getTopology().getPartitionsCount());
   }
@@ -89,7 +89,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
         .succeedsWithin(Duration.ofMillis(500))
         .returns(BackupStatusCode.IN_PROGRESS, BackupStatus::status);
 
-    final var status = future.join();
+    final var status = future.toCompletableFuture().join();
     assertThat(status.partitions())
         .hasSize(brokerClient.getTopologyManager().getTopology().getPartitionsCount());
   }
@@ -109,7 +109,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
         .succeedsWithin(Duration.ofMillis(500))
         .returns(BackupStatusCode.FAILED, BackupStatus::status);
 
-    final var status = future.join();
+    final var status = future.toCompletableFuture().join();
     assertThat(status.failureReason().orElseThrow()).contains("FAILED");
     assertThat(status.partitions())
         .hasSize(brokerClient.getTopologyManager().getTopology().getPartitionsCount());
@@ -130,7 +130,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
         .succeedsWithin(Duration.ofMillis(500))
         .returns(BackupStatusCode.DOES_NOT_EXIST, BackupStatus::status);
 
-    final var status = future.join();
+    final var status = future.toCompletableFuture().join();
     assertThat(status.partitions())
         .hasSize(brokerClient.getTopologyManager().getTopology().getPartitionsCount());
   }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandlerTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandlerTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.admin.backup;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
+import io.camunda.zeebe.protocol.management.BackupStatusCode;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import org.junit.Before;
@@ -46,6 +47,103 @@ public class BackupRequestHandlerTest extends GatewayTest {
 
     // when
     final var future = requestHandler.takeBackup(1);
+
+    // then
+    assertThat(future)
+        .failsWithin(Duration.ofMillis(500))
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(BackupOperationFailedException.class);
+  }
+
+  @Test
+  public void shouldReturnCompleteStatusWhenAllPartitionsHaveCompleteBackup() {
+    // given
+    final BackupQueryStub stub = new BackupQueryStub();
+    stub.registerWith(brokerClient);
+
+    // when
+    final var future = requestHandler.getStatus(1);
+
+    // then
+    assertThat(future)
+        .succeedsWithin(Duration.ofMillis(500))
+        .returns(BackupStatusCode.COMPLETED, BackupStatus::status);
+
+    final var status = future.join();
+    assertThat(status.partitions())
+        .hasSize(brokerClient.getTopologyManager().getTopology().getPartitionsCount());
+  }
+
+  @Test
+  public void shouldReturnInProgressStatusWhenOnePartitionIsInProgress() {
+    // given
+    final BackupQueryStub stub = new BackupQueryStub();
+    stub.withInProgressResponseFor(1);
+    stub.registerWith(brokerClient);
+
+    // when
+    final var future = requestHandler.getStatus(1);
+
+    // then
+    assertThat(future)
+        .succeedsWithin(Duration.ofMillis(500))
+        .returns(BackupStatusCode.IN_PROGRESS, BackupStatus::status);
+
+    final var status = future.join();
+    assertThat(status.partitions())
+        .hasSize(brokerClient.getTopologyManager().getTopology().getPartitionsCount());
+  }
+
+  @Test
+  public void shouldReturnFailedStatusWhenOnePartitionIsFailed() {
+    // given
+    final BackupQueryStub stub = new BackupQueryStub();
+    stub.withFailedResponseFor(1).withInProgressResponseFor(2);
+    stub.registerWith(brokerClient);
+
+    // when
+    final var future = requestHandler.getStatus(1);
+
+    // then
+    assertThat(future)
+        .succeedsWithin(Duration.ofMillis(500))
+        .returns(BackupStatusCode.FAILED, BackupStatus::status);
+
+    final var status = future.join();
+    assertThat(status.failureReason().orElseThrow()).contains("FAILED");
+    assertThat(status.partitions())
+        .hasSize(brokerClient.getTopologyManager().getTopology().getPartitionsCount());
+  }
+
+  @Test
+  public void shouldReturnDoesNotExistStatusWhenOnePartitionBackupDoesNotExist() {
+    // given
+    final BackupQueryStub stub = new BackupQueryStub();
+    stub.withDoesNotExistFor(1).withInProgressResponseFor(2);
+    stub.registerWith(brokerClient);
+
+    // when
+    final var future = requestHandler.getStatus(1);
+
+    // then
+    assertThat(future)
+        .succeedsWithin(Duration.ofMillis(500))
+        .returns(BackupStatusCode.DOES_NOT_EXIST, BackupStatus::status);
+
+    final var status = future.join();
+    assertThat(status.partitions())
+        .hasSize(brokerClient.getTopologyManager().getTopology().getPartitionsCount());
+  }
+
+  @Test
+  public void shouldFailWhenQueryToOnePartitionFails() {
+    // given
+    final BackupQueryStub stub = new BackupQueryStub();
+    stub.withErrorResponseFor(1).withInProgressResponseFor(2);
+    stub.registerWith(brokerClient);
+
+    // when
+    final var future = requestHandler.getStatus(1);
 
     // then
     assertThat(future)


### PR DESCRIPTION
## Description

* BackupRequestHandler coordinates status query. It sends the requests to all partitions and collect the responses. The aggregate status of the backup is calculated by combining status of backups of all partition. The status is completed only if all partitions have completed backup.
* Returned `BackupStatus` consists of an aggregate status and the status of each partition. So if backup is not completed, we can see which one is not completed and the reasons for it.

## Related issues

closes #10288

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
