### PR TITLE
Reject the modification command if multiple flow scope instances are active 

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -149,10 +149,9 @@ public final class ElementActivationBehavior {
           processInstanceRecord, elementInstance.getKey(), flowScopes, createVariablesCallback);
 
     } else {
-      // todo: deal with multiple flow scopes found without ancestor selection (#10008)
       final var flowScopeId = BufferUtil.bufferAsString(flowScope.getId());
-      throw new UnsupportedOperationException(
-          "Found more than one flow scope instance with id '%s'.".formatted(flowScopeId));
+      throw new MultipleFlowScopeInstancesFoundException(
+          flowScopeId, processInstanceRecord.getBpmnProcessId());
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/MultipleFlowScopeInstancesFoundException.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/MultipleFlowScopeInstancesFoundException.java
@@ -22,6 +22,7 @@ public final class MultipleFlowScopeInstancesFoundException extends RuntimeExcep
       "Expected to have zero or one instance of the flow scope '%s' but found multiple instances.";
 
   private final String bpmnProcessId;
+  private final String flowScopeId;
 
   /**
    * Constructs a new exception for the case that a flow scope has more instances as expected.
@@ -32,9 +33,14 @@ public final class MultipleFlowScopeInstancesFoundException extends RuntimeExcep
   MultipleFlowScopeInstancesFoundException(final String flowScopeId, final String bpmnProcessId) {
     super(ERROR_MESSAGE.formatted(flowScopeId));
     this.bpmnProcessId = bpmnProcessId;
+    this.flowScopeId = flowScopeId;
   }
 
   public String getBpmnProcessId() {
     return bpmnProcessId;
+  }
+
+  public String getFlowScopeId() {
+    return flowScopeId;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/MultipleFlowScopeInstancesFoundException.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/MultipleFlowScopeInstancesFoundException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.common;
+
+import io.camunda.zeebe.engine.api.TypedRecord;
+
+/**
+ * Exception that can be thrown during processing of a command, in case the engine found more than
+ * one instance of a flow scope, but it expects only one. This exception can be handled by the
+ * processor in {@link
+ * io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor#tryHandleError(TypedRecord,
+ * Throwable)}.
+ */
+public final class MultipleFlowScopeInstancesFoundException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE =
+      "Expected to have zero or one instance of the flow scope '%s' but found multiple instances.";
+
+  private final String bpmnProcessId;
+
+  /**
+   * Constructs a new exception for the case that a flow scope has more instances as expected.
+   *
+   * @param flowScopeId the element id of the flow scope
+   * @param bpmnProcessId the BPMN process id
+   */
+  MultipleFlowScopeInstancesFoundException(final String flowScopeId, final String bpmnProcessId) {
+    super(ERROR_MESSAGE.formatted(flowScopeId));
+    this.bpmnProcessId = bpmnProcessId;
+  }
+
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -85,8 +85,8 @@ public final class ProcessInstanceModificationProcessor
   private static final String ERROR_MESSAGE_MORE_THAN_ONE_FLOW_SCOPE_INSTANCE =
       """
       Expected to modify instance of process '%s' but it contains one or more activate instructions \
-      for an element that has a flow scope with more than one active instances. Can't decide in \
-      which instance of the flow scope the element should be activated.""";
+      for an element that has a flow scope with more than one active instance: '%s'. Can't decide \
+      in which instance of the flow scope the element should be activated.""";
 
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       Set.of(
@@ -213,7 +213,8 @@ public final class ProcessInstanceModificationProcessor
 
     } else if (error instanceof MultipleFlowScopeInstancesFoundException exception) {
       final var rejectionReason =
-          ERROR_MESSAGE_MORE_THAN_ONE_FLOW_SCOPE_INSTANCE.formatted(exception.getBpmnProcessId());
+          ERROR_MESSAGE_MORE_THAN_ONE_FLOW_SCOPE_INSTANCE.formatted(
+              exception.getBpmnProcessId(), exception.getFlowScopeId());
       rejectionWriter.appendRejection(
           typedCommand, RejectionType.INVALID_ARGUMENT, rejectionReason);
       responseWriter.writeRejectionOnCommand(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -373,8 +373,8 @@ public class ModifyProcessInstanceRejectionTest {
                 """
                 Expected to modify instance of process '%s' but it contains one or more activate \
                 instructions for an element that has a flow scope with more than one active \
-                instances. Can't decide in which instance of the flow scope the element should be \
-                activated.""",
+                instance: 'event-subprocess'. Can't decide in which instance of the flow scope the \
+                element should be activated.""",
                 PROCESS_ID));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -14,10 +14,12 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.camunda.zeebe.util.ByteValue;
 import java.util.Map;
+import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,6 +28,10 @@ import org.junit.rules.TestWatcher;
 public class ModifyProcessInstanceRejectionTest {
 
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @ClassRule
+  public static final BrokerClassRuleHelper CLASS_RULE_HELPER = new BrokerClassRuleHelper();
+
   private static final String PROCESS_ID = "process";
   private static final long MAX_MESSAGE_SIZE = ByteValue.ofMegabytes(4);
 
@@ -302,6 +308,73 @@ public class ModifyProcessInstanceRejectionTest {
                 Expected to modify instance of process '%s' but it contains one or more variable \
                 instructions with a scope element that doesn't belong to the activating element's \
                 flow scope. These variables should be set before or after the modification.""",
+                PROCESS_ID));
+  }
+
+  @Test
+  public void shouldRejectCommandWhenMoreThanOneAncestor() {
+    // given
+    final String correlationKey = CLASS_RULE_HELPER.getCorrelationValue();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .eventSubProcess(
+                    "event-subprocess",
+                    eventSubprocess ->
+                        eventSubprocess
+                            .startEvent()
+                            .interrupting(false)
+                            .message(m -> m.name("start").zeebeCorrelationKeyExpression("key"))
+                            .userTask("B")
+                            .userTask("C")
+                            .endEvent())
+                .startEvent()
+                .userTask("A")
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("key", correlationKey)
+            .create();
+
+    ENGINE.message().withName("start").withCorrelationKey(correlationKey).publish();
+    ENGINE.message().withName("start").withCorrelationKey(correlationKey).publish();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("B")
+                .limit(2)
+                .count())
+        .describedAs("Assuming that two event subprocesses are active")
+        .isEqualTo(2);
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .modification()
+            .activateElement("C")
+            .expectRejection()
+            .modify();
+
+    // then
+    assertThat(rejection)
+        .describedAs("Expect that the flow scope can have only one instance")
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            String.format(
+                """
+                Expected to modify instance of process '%s' but it contains one or more activate \
+                instructions for an element that has a flow scope with more than one active \
+                instances. Can't decide in which instance of the flow scope the element should be \
+                activated.""",
                 PROCESS_ID));
   }
 }


### PR DESCRIPTION
## Description

Reject the modification command if a flow scope of an activation element has more than one instance. The engine can't decide in which flow scope instance the element should be created.

The verification is implemented by throwing an exception, in the same way when we fail to create the event subscriptions of a flow scope. We could implement it like the other validations in the processor but we would need to duplicate the logic to walk through the flow scopes from top to down.

## Related issues

closes #10008 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
