### PR TITLE
PI modification: Activate and terminate elements within the same scope

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.ElementActivationBehavior;
+import io.camunda.zeebe.engine.processing.common.ElementActivationBehavior.ActivatedElementKeys;
 import io.camunda.zeebe.engine.processing.common.EventSubscriptionException;
 import io.camunda.zeebe.engine.processing.deployment.model.element.AbstractFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
@@ -153,24 +154,27 @@ public final class ProcessInstanceModificationProcessor
       return;
     }
 
-    value
-        .getActivateInstructions()
-        .forEach(
-            instruction -> {
-              final var elementToActivate =
-                  process.getProcess().getElementById(instruction.getElementId());
+    final var requiredKeysForActivation =
+        value.getActivateInstructions().stream()
+            .flatMap(
+                instruction -> {
+                  final var elementToActivate =
+                      process.getProcess().getElementById(instruction.getElementId());
 
-              elementActivationBehavior.activateElement(
-                  processInstanceRecord,
-                  elementToActivate,
-                  (elementId, scopeKey) ->
-                      executeVariableInstruction(
-                          BufferUtil.bufferAsString(elementId),
-                          scopeKey,
-                          processInstance,
-                          process,
-                          instruction));
-            });
+                  final ActivatedElementKeys activatedElementKeys =
+                      elementActivationBehavior.activateElement(
+                          processInstanceRecord,
+                          elementToActivate,
+                          (elementId, scopeKey) ->
+                              executeVariableInstruction(
+                                  BufferUtil.bufferAsString(elementId),
+                                  scopeKey,
+                                  processInstance,
+                                  process,
+                                  instruction));
+                  return activatedElementKeys.getFlowScopeKeys().stream();
+                })
+            .collect(Collectors.toSet());
 
     final var sideEffectQueue = new SideEffectQueue();
     sideEffect.accept(sideEffectQueue);
@@ -184,7 +188,7 @@ public final class ProcessInstanceModificationProcessor
               final var flowScopeKey = elementInstance.getValue().getFlowScopeKey();
 
               terminateElement(elementInstance, sideEffectQueue);
-              terminateFlowScopes(flowScopeKey, sideEffectQueue);
+              terminateFlowScopes(flowScopeKey, sideEffectQueue, requiredKeysForActivation);
             });
 
     stateWriter.appendFollowUpEvent(eventKey, ProcessInstanceModificationIntent.MODIFIED, value);
@@ -512,10 +516,13 @@ public final class ProcessInstanceModificationProcessor
         elementInstanceKey, ProcessInstanceIntent.ELEMENT_TERMINATED, elementInstanceRecord);
   }
 
-  private void terminateFlowScopes(final long elementInstanceKey, final SideEffects sideEffects) {
+  private void terminateFlowScopes(
+      final long elementInstanceKey,
+      final SideEffects sideEffects,
+      final Set<Long> requiredKeysForActivation) {
     var currentElementInstance = elementInstanceState.getInstance(elementInstanceKey);
 
-    while (canTerminateElementInstance(currentElementInstance)) {
+    while (canTerminateElementInstance(currentElementInstance, requiredKeysForActivation)) {
       final var flowScopeKey = currentElementInstance.getValue().getFlowScopeKey();
 
       terminateElement(currentElementInstance, sideEffects);
@@ -524,12 +531,15 @@ public final class ProcessInstanceModificationProcessor
     }
   }
 
-  private boolean canTerminateElementInstance(final ElementInstance elementInstance) {
+  private boolean canTerminateElementInstance(
+      final ElementInstance elementInstance, final Set<Long> requiredKeysForActivation) {
     return elementInstance != null
         // if it has no active element instances
         && elementInstance.getNumberOfActiveElementInstances() == 0
         // and no pending element activations (i.e. activate command is written but not processed)
-        && elementInstance.getActiveSequenceFlows() == 0;
+        && elementInstance.getActiveSequenceFlows() == 0
+        // no activate instruction requires this element instance
+        && !requiredKeysForActivation.contains(elementInstance.getKey());
   }
 
   private record Rejection(RejectionType type, String reason) {}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -179,7 +179,6 @@ public final class ProcessInstanceModificationProcessor
         .getTerminateInstructions()
         .forEach(
             instruction -> {
-              // todo: deal with non-existing element instance (#9983)
               final var elementInstance =
                   elementInstanceState.getInstance(instruction.getElementInstanceKey());
               final var flowScopeKey = elementInstance.getValue().getFlowScopeKey();


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
When we terminate an element we will terminate the flow scope if this is the only active element in it. If we have an activate instruction for an element in the same scope, we should not terminate the flow scope, as it is still required.

This PR makes it so that when an element gets activated it returns it's element instance key as well as a Set of all it's flow scopes. This set will be used in the termination logic to check if the flow scope is required for the activation of an element. If it is, the scope will not be terminated.

**Note:** the issue this solves mentions a different solution where we can process the activate instruction before the terminate instructions. Unfortunately this is not possible, as the activation of an element needs to be done through a command, whereas the termination needs to be done using events.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9709 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
