### PR TITLE
Allow users to configure backup store

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -68,9 +68,20 @@ public final class SystemContext {
 
   private void validateConfiguration() {
     final ClusterCfg cluster = brokerCfg.getCluster();
-    final DataCfg data = brokerCfg.getData();
-    final var experimental = brokerCfg.getExperimental();
 
+    validateClusterConfig(cluster);
+
+    validateDataConfig(brokerCfg.getData());
+
+    validateExperimentalConfigs(cluster, brokerCfg.getExperimental());
+
+    final var security = brokerCfg.getNetwork().getSecurity();
+    if (security.isEnabled()) {
+      validateNetworkSecurityConfig(security);
+    }
+  }
+
+  private static void validateClusterConfig(final ClusterCfg cluster) {
     final int partitionCount = cluster.getPartitionsCount();
     if (partitionCount < 1) {
       throw new IllegalArgumentException("Partition count must not be smaller then 1.");
@@ -82,20 +93,49 @@ public final class SystemContext {
       throw new IllegalArgumentException(String.format(NODE_ID_ERROR_MSG, nodeId, clusterSize));
     }
 
-    final var maxAppendBatchSize = experimental.getMaxAppendBatchSize();
-    if (maxAppendBatchSize.isNegative() || maxAppendBatchSize.toBytes() >= Integer.MAX_VALUE) {
-      throw new IllegalArgumentException(
-          String.format(MAX_BATCH_SIZE_ERROR_MSG, Integer.MAX_VALUE, maxAppendBatchSize));
-    }
-
     final int replicationFactor = cluster.getReplicationFactor();
     if (replicationFactor < 1 || replicationFactor > clusterSize) {
       throw new IllegalArgumentException(
           String.format(REPLICATION_FACTOR_ERROR_MSG, replicationFactor, clusterSize));
     }
 
-    final var dataCfg = brokerCfg.getData();
+    final var heartbeatInterval = cluster.getHeartbeatInterval();
+    final var electionTimeout = cluster.getElectionTimeout();
+    if (heartbeatInterval.toMillis() < 1) {
+      throw new IllegalArgumentException(
+          String.format("heartbeatInterval %s must be at least 1ms", heartbeatInterval));
+    }
+    if (electionTimeout.toMillis() < 1) {
+      throw new IllegalArgumentException(
+          String.format("electionTimeout %s must be at least 1ms", electionTimeout));
+    }
+    if (electionTimeout.compareTo(heartbeatInterval) < 1) {
+      throw new IllegalArgumentException(
+          String.format(
+              "electionTimeout %s must be greater than heartbeatInterval %s",
+              electionTimeout, heartbeatInterval));
+    }
+  }
 
+  private void validateExperimentalConfigs(
+      final ClusterCfg cluster, final ExperimentalCfg experimental) {
+    if (experimental.isDisableExplicitRaftFlush()) {
+      LOG.warn(REPLICATION_WITH_DISABLED_FLUSH_WARNING);
+    }
+
+    final var maxAppendBatchSize = experimental.getMaxAppendBatchSize();
+    if (maxAppendBatchSize.isNegative() || maxAppendBatchSize.toBytes() >= Integer.MAX_VALUE) {
+      throw new IllegalArgumentException(
+          String.format(MAX_BATCH_SIZE_ERROR_MSG, Integer.MAX_VALUE, maxAppendBatchSize));
+    }
+
+    final var partitioningConfig = experimental.getPartitioning();
+    if (partitioningConfig.getScheme() == Scheme.FIXED) {
+      validateFixedPartitioningScheme(cluster, experimental);
+    }
+  }
+
+  private void validateDataConfig(final DataCfg dataCfg) {
     final var snapshotPeriod = dataCfg.getSnapshotPeriod();
     if (snapshotPeriod.isNegative() || snapshotPeriod.minus(MINIMUM_SNAPSHOT_PERIOD).isNegative()) {
       throw new IllegalArgumentException(String.format(SNAPSHOT_PERIOD_ERROR_MSG, snapshotPeriod));
@@ -117,7 +157,7 @@ public final class SystemContext {
               diskUsageReplicationWatermark));
     }
 
-    if (data.isDiskUsageMonitoringEnabled()
+    if (dataCfg.isDiskUsageMonitoringEnabled()
         && diskUsageCommandWatermark >= diskUsageReplicationWatermark) {
       throw new IllegalArgumentException(
           String.format(
@@ -126,37 +166,6 @@ public final class SystemContext {
     }
 
     validateBackupCfg(dataCfg.getBackup());
-
-    if (experimental.isDisableExplicitRaftFlush()) {
-      LOG.warn(REPLICATION_WITH_DISABLED_FLUSH_WARNING);
-    }
-
-    final var heartbeatInterval = cluster.getHeartbeatInterval();
-    final var electionTimeout = cluster.getElectionTimeout();
-    if (heartbeatInterval.toMillis() < 1) {
-      throw new IllegalArgumentException(
-          String.format("heartbeatInterval %s must be at least 1ms", heartbeatInterval));
-    }
-    if (electionTimeout.toMillis() < 1) {
-      throw new IllegalArgumentException(
-          String.format("electionTimeout %s must be at least 1ms", electionTimeout));
-    }
-    if (electionTimeout.compareTo(heartbeatInterval) < 1) {
-      throw new IllegalArgumentException(
-          String.format(
-              "electionTimeout %s must be greater than heartbeatInterval %s",
-              electionTimeout, heartbeatInterval));
-    }
-
-    final var partitioningConfig = experimental.getPartitioning();
-    if (partitioningConfig.getScheme() == Scheme.FIXED) {
-      validateFixedPartitioningScheme(cluster, experimental);
-    }
-
-    final var security = brokerCfg.getNetwork().getSecurity();
-    if (security.isEnabled()) {
-      validateNetworkSecurityConfig(security);
-    }
   }
 
   private void validateBackupCfg(final BackupStoreCfg backup) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -169,6 +169,11 @@ public final class SystemContext {
   }
 
   private void validateBackupCfg(final BackupStoreCfg backup) {
+    if (backup.getStore() == BackupStoreType.NONE) {
+      LOG.warn("No backup store is configured. Backups will not be taken");
+      return;
+    }
+
     if (backup.getStore() == BackupStoreType.S3) {
       final var s3Config = backup.getS3();
       if (s3Config.getBucketName() == null || s3Config.getBucketName().isEmpty()) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/DataCfg.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.configuration;
 
 import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
 import java.io.File;
 import java.time.Duration;
 import java.util.Optional;
@@ -40,6 +41,8 @@ public final class DataCfg implements ConfigurationEntry {
   private double diskUsageCommandWatermark = DEFAULT_DISK_USAGE_COMMAND_WATERMARK;
   private Duration diskUsageMonitoringInterval = DEFAULT_DISK_USAGE_MONITORING_DELAY;
 
+  private BackupStoreCfg backup = new BackupStoreCfg();
+
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
     directory = ConfigurationUtil.toAbsolutePath(directory, brokerBase);
@@ -51,6 +54,8 @@ public final class DataCfg implements ConfigurationEntry {
       diskUsageReplicationWatermark = DISABLED_DISK_USAGE_WATERMARK;
       diskUsageCommandWatermark = DISABLED_DISK_USAGE_WATERMARK;
     }
+
+    backup.init(globalConfig, brokerBase);
   }
 
   public String getDirectory() {
@@ -131,11 +136,20 @@ public final class DataCfg implements ConfigurationEntry {
     this.diskUsageMonitoringInterval = diskUsageMonitoringInterval;
   }
 
+  public BackupStoreCfg getBackup() {
+    return backup;
+  }
+
+  public void setBackup(final BackupStoreCfg backup) {
+    this.backup = backup;
+  }
+
   @Override
   public String toString() {
     return "DataCfg{"
-        + "directory="
+        + "directory='"
         + directory
+        + '\''
         + ", logSegmentSize="
         + logSegmentSize
         + ", snapshotPeriod="
@@ -150,6 +164,8 @@ public final class DataCfg implements ConfigurationEntry {
         + diskUsageCommandWatermark
         + ", diskUsageMonitoringInterval="
         + diskUsageMonitoringInterval
+        + ", backup="
+        + backup
         + '}';
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/BackupStoreCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/BackupStoreCfg.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration.backup;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+
+public class BackupStoreCfg implements ConfigurationEntry {
+
+  private BackupStoreType store = BackupStoreType.NONE;
+
+  private S3BackupStoreConfig s3 = new S3BackupStoreConfig();
+
+  public S3BackupStoreConfig getS3() {
+    return s3;
+  }
+
+  public void setS3(final S3BackupStoreConfig s3) {
+    this.s3 = s3;
+  }
+
+  public BackupStoreType getStore() {
+    return store;
+  }
+
+  public void setStore(final BackupStoreType store) {
+    this.store = store;
+  }
+
+  @Override
+  public String toString() {
+    return "BackupStoreCfg{" + "store=" + store + ", s3=" + s3 + '}';
+  }
+
+  public enum BackupStoreType {
+    /**
+     * When type = S3, {@link io.camunda.zeebe.backup.s3.S3BackupStore} will be used as the backup
+     * store
+     */
+    S3,
+
+    /** Set type = NONE when no backup store is available. No backup will be taken. */
+    NONE
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration.backup;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import java.util.Objects;
+
+public class S3BackupStoreConfig implements ConfigurationEntry {
+
+  private String bucketName;
+  private String endpoint;
+  private String region;
+  private String accessKey;
+  private String secretKey;
+
+  public String getBucketName() {
+    return bucketName;
+  }
+
+  public void setBucketName(final String bucketName) {
+    this.bucketName = bucketName;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public void setEndpoint(final String endpoint) {
+    this.endpoint = endpoint;
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  public void setRegion(final String region) {
+    this.region = region;
+  }
+
+  public String getAccessKey() {
+    return accessKey;
+  }
+
+  public void setAccessKey(final String accessKey) {
+    this.accessKey = accessKey;
+  }
+
+  public String getSecretKey() {
+    return secretKey;
+  }
+
+  public void setSecretKey(final String secretKey) {
+    this.secretKey = secretKey;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = bucketName != null ? bucketName.hashCode() : 0;
+    result = 31 * result + (endpoint != null ? endpoint.hashCode() : 0);
+    result = 31 * result + (region != null ? region.hashCode() : 0);
+    result = 31 * result + (accessKey != null ? accessKey.hashCode() : 0);
+    result = 31 * result + (secretKey != null ? secretKey.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final S3BackupStoreConfig that = (S3BackupStoreConfig) o;
+
+    if (!Objects.equals(bucketName, that.bucketName)) {
+      return false;
+    }
+    if (!Objects.equals(endpoint, that.endpoint)) {
+      return false;
+    }
+    if (!Objects.equals(region, that.region)) {
+      return false;
+    }
+    if (!Objects.equals(accessKey, that.accessKey)) {
+      return false;
+    }
+    return Objects.equals(secretKey, that.secretKey);
+  }
+
+  @Override
+  public String toString() {
+    return "S3BackupStoreConfig{"
+        + "bucketName='"
+        + bucketName
+        + '\''
+        + ", endpoint='"
+        + endpoint
+        + '\''
+        + ", region='"
+        + region
+        + '\''
+        + ", accessKey='"
+        + accessKey
+        + '\''
+        + ", secretKey='"
+        + "<redacted>"
+        + '\''
+        + '}';
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg.NodeCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
@@ -393,6 +394,18 @@ final class SystemContextTest {
         .hasMessage(
             "Expected to have a valid certificate chain path for network security, but none "
                 + "configured");
+  }
+
+  @Test
+  void shouldThrowExceptionWhenS3BucketIsNotProvided() throws CertificateException {
+    // given
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg.getData().getBackup().setStore(BackupStoreType.S3);
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("bucketName must not be empty");
   }
 
   private SystemContext initSystemContext(final BrokerCfg brokerCfg) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BackupStoreCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BackupStoreCfgTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public final class BackupStoreCfgTest {
+
+  public final Map<String, String> environment = new HashMap<>();
+
+  @Test
+  public void shouldSetPartialS3Config() {
+    // given
+    final S3BackupStoreConfig expectedConfig = new S3BackupStoreConfig();
+    expectedConfig.setBucketName("bucket");
+    expectedConfig.setEndpoint("endpoint");
+    expectedConfig.setRegion("region-1");
+    expectedConfig.setAccessKey(null);
+    expectedConfig.setSecretKey(null);
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("backup-cfg", environment);
+    final BackupStoreCfg backup = cfg.getData().getBackup();
+
+    // then
+    assertThat(backup.getStore()).isEqualTo(BackupStoreType.S3);
+    assertThat(backup.getS3()).isEqualTo(expectedConfig);
+  }
+}

--- a/broker/src/test/resources/system/backup-cfg.yaml
+++ b/broker/src/test/resources/system/backup-cfg.yaml
@@ -1,0 +1,9 @@
+zeebe:
+  broker:
+    data:
+      backup:
+        store: s3
+        s3 :
+          bucketName: "bucket"
+          endpoint: "endpoint"
+          region: "region-1"

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -230,6 +230,39 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEMONITORINGINTERVAL
       # diskUsageMonitoringInterval = 1s
 
+      # backup:
+        # Configure backup store. NOTE:- Use the same configuration on all brokers of this cluster.
+
+        # Set the backup store type. Supported values are [NONE, S3]. Default value is NONE
+        # When NONE, no backup store is configured and no backup will be taken.
+        # Use S3 to use any S3 compatible storage (https://docs.aws.amazon.com/AmazonS3/latest/API/Type_API_Reference.html).
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_STORE
+        # store: NONE
+
+        # Configure the following if store is set to S3
+        # s3:
+
+          # Name of the bucket where the backup will be stored.
+          # The bucket must be already created. The bucket must not be shared with other zeebe clusters. bucketName must not be empty.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_BUCKETNAME
+          # bucketName:
+
+          # Configure URL endpoint for the store.
+          # If no endpoint is provided, it will be determined based on the configured region.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_ENDPOINT
+          # endpoint:
+
+          # Configure AWS region. If no region is provided it will be determined as documented in
+          # https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html#automatically-determine-the-aws-region-from-the-environment
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_REGION
+          # region:
+
+          # Configure access credentials. If either accessKey or secretKey is not provided, the credentials
+          # will be determined as documented in https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html#credentials-chain
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_ACCESSKEY
+          # accessKey:
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_SECRETKEY
+          # secretKey:
 
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -170,6 +170,40 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEMONITORINGINTERVAL
       # diskUsageMonitoringInterval = 1s
 
+      # backup:
+        # Configure backup store. NOTE:- Use the same configuration on all brokers of this cluster.
+
+        # Set the backup store type. Supported values are [NONE, S3]. Default value is NONE
+        # When NONE, no backup store is configured and no backup will be taken.
+        # Use S3 to use any S3 compatible storage (https://docs.aws.amazon.com/AmazonS3/latest/API/Type_API_Reference.html).
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_STORE
+        # store: NONE
+
+        # Configure the following if store is set to S3
+        # s3:
+
+          # Name of the bucket where the backup will be stored.
+          # The bucket must be already created. The bucket must not be shared with other zeebe clusters. bucketName must not be empty.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_BUCKETNAME
+          # bucketName:
+
+          # Configure URL endpoint for the store.
+          # If no endpoint is provided, it will be determined based on the configured region.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_ENDPOINT
+          # endpoint:
+
+          # Configure AWS region. If no region is provided it will be determined as documented in
+          # https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html#automatically-determine-the-aws-region-from-the-environment
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_REGION
+          # region:
+
+          # Configure access credentials. If either accessKey or secretKey is not provided, the credentials
+          # will be determined as documented in https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html#credentials-chain
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_ACCESSKEY
+          # accessKey:
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_SECRETKEY
+          # secretKey:
+
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
 


### PR DESCRIPTION
## Description

This PR exposes the configuration for S3 backup store. 

As an example, S3 backup store can be configured as follows:
```
zeebe:
  broker:
    data:
      backup:
        store: s3
        s3 :
          bucketName: "bucket"
          endpoint: "endpoint"
          region: "region-1"
```
To disable backups, you can set `store` to `NONE`.

When adding support for new stores, the configuration can be extended by adding more store types and new configuration class for the new store. We don't have a concrete solution for supporting external implementations of backup stores. But the idea is that all external implementations will be identified as store type "external" and will have generic way of configuring them. This would be different from how we configure internally supported backup stores.

PS:- In this PR the configuration is exposed, but not yet used. This will be done in a follow up issue.

## Related issues

closes #10264 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
