### PR TITLE
Install backup store during role transitions

### DIFF
--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
@@ -37,8 +37,25 @@ public record S3BackupConfig(
    * @see S3BackupConfig#S3BackupConfig(String bucketName, Optional endpoint, Optional region,
    *     Optional credentials)
    */
-  public S3BackupConfig(String bucketName) {
+  public S3BackupConfig(final String bucketName) {
     this(bucketName, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  public static S3BackupConfig from(
+      final String bucketName,
+      final String endpoint,
+      final String region,
+      final String accessKey,
+      final String secretKey) {
+    Credentials credentials = null;
+    if (accessKey != null && secretKey != null) {
+      credentials = new Credentials(accessKey, secretKey);
+    }
+    return new S3BackupConfig(
+        bucketName,
+        Optional.ofNullable(endpoint),
+        Optional.ofNullable(region),
+        Optional.ofNullable(credentials));
   }
 
   record Credentials(String accessKey, String secretKey) {

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -91,6 +91,28 @@ public final class S3BackupStore implements BackupStore {
     return "%s/%s/%s/".formatted(id.partitionId(), id.checkpointId(), id.nodeId());
   }
 
+  public static void validateConfig(final S3BackupConfig config) {
+    if (config.bucketName() == null || config.bucketName().isEmpty()) {
+      throw new IllegalArgumentException(
+          "Configuration for S3 backup store is incomplete. bucketName must not be empty.");
+    }
+    if (config.region().isEmpty()) {
+      LOG.warn(
+          "No region configured for S3 backup store. Region will be determined from environment (see https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html#automatically-determine-the-aws-region-from-the-environment)");
+    }
+    if (config.endpoint().isEmpty()) {
+      LOG.warn(
+          "No endpoint configured for S3 backup store. Endpoint will be determined from the region");
+    }
+    if (config.credentials().isEmpty()) {
+      LOG.warn(
+          "Access credentials (accessKey, secretKey) not configured for S3 backup store. Credentials will be determined from environment (see https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html#credentials-chain)");
+    }
+    // Create a throw away client to verify if all configurations are available. This will throw an
+    // exception, if any of the required configuration is not available.
+    buildClient(config).close();
+  }
+
   @Override
   public CompletableFuture<Void> save(final Backup backup) {
     LOG.info("Saving {}", backup.id());

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -166,6 +166,12 @@ public final class S3BackupStore implements BackupStore {
         .thenApply(Manifest::statusCode);
   }
 
+  @Override
+  public CompletableFuture<Void> closeAsync() {
+    client.close();
+    return CompletableFuture.completedFuture(null);
+  }
+
   private CompletableFuture<NamedFileSet> downloadNamedFileSet(
       final String sourcePrefix, final Set<String> fileNames, final Path targetFolder) {
     LOG.debug(

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
@@ -30,4 +30,6 @@ public interface BackupStore {
    * failed. This method can be used if we want to explicitly mark a partial backup as failed.
    */
   CompletableFuture<BackupStatusCode> markFailed(BackupIdentifier id, final String failureReason);
+
+  CompletableFuture<Void> closeAsync();
 }

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -118,6 +118,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-backup-store-s3</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-journal</artifactId>
     </dependency>
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/InvalidConfigurationException.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/InvalidConfigurationException.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system;
+
+public class InvalidConfigurationException extends RuntimeException {
+  public InvalidConfigurationException(final String message, final Exception cause) {
+    super(message, cause);
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -178,23 +178,7 @@ public final class SystemContext {
 
     if (backup.getStore() == BackupStoreType.S3) {
       final var s3Config = backup.getS3();
-      if (s3Config.getBucketName() == null || s3Config.getBucketName().isEmpty()) {
-        throw new IllegalArgumentException(
-            "Configuration for S3 backup store is incomplete. bucketName must not be empty.");
-      }
-      if (s3Config.getRegion() == null) {
-        LOG.warn(
-            "No region configured for S3 backup store. Region will be determined from environment (see https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html#automatically-determine-the-aws-region-from-the-environment)");
-      }
-      if (s3Config.getEndpoint() == null) {
-        LOG.warn(
-            "No endpoint configured for S3 backup store. Endpoint will be determined from the region");
-      }
-      if (s3Config.getAccessKey() == null || s3Config.getSecretKey() == null) {
-        LOG.warn(
-            "Access credentials (accessKey, secretKey) not configured for S3 backup store. Credentials will be determined from environment (see https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html#credentials-chain)");
-      }
-      // Create a throw away S3BackupStore to verify if all configurations are available
+
       final S3BackupConfig storeConfig =
           S3BackupConfig.from(
               s3Config.getBucketName(),
@@ -203,8 +187,7 @@ public final class SystemContext {
               s3Config.getAccessKey(),
               s3Config.getSecretKey());
       try {
-        final S3BackupStore backupStore = new S3BackupStore(storeConfig);
-        backupStore.closeAsync();
+        S3BackupStore.validateConfig(storeConfig);
       } catch (final Exception e) {
         throw new InvalidConfigurationException("Cannot configure S3 backup store.", e);
       }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.s3.S3BackupConfig;
+import io.camunda.zeebe.backup.s3.S3BackupStore;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+
+public final class BackupStoreTransitionStep implements PartitionTransitionStep {
+
+  @Override
+  public ActorFuture<Void> prepareTransition(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    final BackupStore backupStore = context.getBackupStore();
+    if (backupStore != null && shouldCloseOnTransition(context.getCurrentRole(), targetRole)) {
+      final ActorFuture<Void> closed = context.getConcurrencyControl().createFuture();
+      backupStore
+          .closeAsync()
+          .thenAcceptAsync(
+              ignore -> {
+                context.setBackupStore(null);
+                context.setCheckpointProcessor(null);
+                closed.complete(null);
+              },
+              // updates to context must execute on this actor
+              context.getConcurrencyControl()::run);
+      return closed;
+    }
+    return CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  public ActorFuture<Void> transitionTo(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    final ActorFuture<Void> installed = context.getConcurrencyControl().createFuture();
+
+    if (shouldInstallOnTransition(context.getCurrentRole(), targetRole)
+        || (context.getBackupStore() == null && targetRole != Role.INACTIVE)) {
+
+      final var backupCfg = context.getBrokerCfg().getData().getBackup();
+      if (backupCfg.getStore() == BackupStoreType.NONE) {
+        // No backup store is installed. BackupManager can handle this case
+        context.setBackupManager(null);
+        installed.complete(null);
+      } else if (backupCfg.getStore() == BackupStoreType.S3) {
+        installS3Store(context, backupCfg, installed);
+      } else {
+        installed.completeExceptionally(
+            new IllegalArgumentException(
+                "Unknown backup store type %s".formatted(backupCfg.getStore())));
+      }
+    } else {
+      installed.complete(null);
+    }
+    return installed;
+  }
+
+  @Override
+  public String getName() {
+    return "BackupStore";
+  }
+
+  private static void installS3Store(
+      final PartitionTransitionContext context,
+      final BackupStoreCfg backupCfg,
+      final ActorFuture<Void> installed) {
+    try {
+      final var s3Config = backupCfg.getS3();
+      final S3BackupConfig storeConfig =
+          S3BackupConfig.from(
+              s3Config.getBucketName(),
+              s3Config.getEndpoint(),
+              s3Config.getRegion(),
+              s3Config.getAccessKey(),
+              s3Config.getSecretKey());
+      final S3BackupStore backupStore = new S3BackupStore(storeConfig);
+      context.setBackupStore(backupStore);
+      installed.complete(null);
+    } catch (final Exception error) {
+      installed.completeExceptionally("Failed to create backup store", error);
+    }
+  }
+
+  private boolean shouldInstallOnTransition(final Role currentRole, final Role targetRole) {
+    return targetRole == Role.LEADER
+        || (targetRole == Role.FOLLOWER && currentRole != Role.CANDIDATE)
+        || (targetRole == Role.CANDIDATE && currentRole != Role.FOLLOWER);
+  }
+
+  private boolean shouldCloseOnTransition(final Role currentRole, final Role targetRole) {
+    return shouldInstallOnTransition(currentRole, targetRole) || targetRole == Role.INACTIVE;
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -397,7 +397,7 @@ final class SystemContextTest {
   }
 
   @Test
-  void shouldThrowExceptionWhenS3BucketIsNotProvided() throws CertificateException {
+  void shouldThrowExceptionWhenS3BucketIsNotProvided() {
     // given
     final var brokerCfg = new BrokerCfg();
     brokerCfg.getData().getBackup().setStore(BackupStoreType.S3);
@@ -406,6 +406,20 @@ final class SystemContextTest {
     assertThatCode(() -> initSystemContext(brokerCfg))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("bucketName must not be empty");
+  }
+
+  @Test
+  void shouldThrowExceptionWhenS3IsNotConfigured() {
+    // given
+    final var brokerCfg = new BrokerCfg();
+    final var backupCfg = brokerCfg.getData().getBackup();
+    backupCfg.setStore(BackupStoreType.S3);
+    backupCfg.getS3().setBucketName("bucket");
+
+    // when - then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasMessageContaining("Cannot configure S3 backup store");
   }
 
   private SystemContext initSystemContext(final BrokerCfg brokerCfg) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -404,7 +404,9 @@ final class SystemContextTest {
 
     // when - then
     assertThatCode(() -> initSystemContext(brokerCfg))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(InvalidConfigurationException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class)
+        .cause()
         .hasMessageContaining("bucketName must not be empty");
   }
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStepTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.DataCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
+import io.camunda.zeebe.broker.system.partitions.TestPartitionTransitionContext;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldCloseService;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldDoNothing;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldInstallService;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BackupStoreTransitionStepTest {
+
+  private static final TestConcurrencyControl TEST_CONCURRENCY_CONTROL =
+      new TestConcurrencyControl();
+  @Mock BrokerCfg brokerCfg;
+  @Mock DataCfg dataCfg;
+  @Mock BackupStore backupStorePreviousRole;
+
+  private final TestPartitionTransitionContext transitionContext =
+      new TestPartitionTransitionContext();
+  private BackupStoreTransitionStep step;
+
+  @BeforeEach
+  void setup() {
+    transitionContext.setConcurrencyControl(TEST_CONCURRENCY_CONTROL);
+    transitionContext.setBrokerCfg(brokerCfg);
+
+    step = new BackupStoreTransitionStep();
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(TransitionsThatShouldCloseService.class)
+  void shouldCloseExistingService(final Role currentRole, final Role targetRole) {
+    // given
+    setUpCurrentRole(currentRole);
+
+    // when
+    step.prepareTransition(transitionContext, 1, targetRole).join();
+
+    // then
+    assertThat(transitionContext.getBackupStore())
+        .describedAs("BackupStore must be removed from the context")
+        .isNull();
+    verify(backupStorePreviousRole).closeAsync();
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(TransitionsThatShouldInstallService.class)
+  void shouldReInstallServiceWhenStoreTypeAvailable(final Role currentRole, final Role targetRole) {
+    // given
+    setUpCurrentRole(currentRole);
+    configureStore(BackupStoreType.S3);
+
+    // when
+    transitionTo(targetRole);
+
+    // then
+    assertThat(transitionContext.getBackupStore())
+        .describedAs("New BackupStore must be installed")
+        .isNotNull()
+        .isNotEqualTo(backupStorePreviousRole);
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(TransitionsThatShouldInstallService.class)
+  // This test fails if you have AWS configured locally (eg:- ~/.aws/)
+  void shouldFailToInstallWhenS3ConfigurationsAreNotAvailable(
+      final Role currentRole, final Role targetRole) {
+    // given
+    setUpCurrentRole(currentRole);
+    configureStore(BackupStoreType.S3, new S3BackupStoreConfig());
+
+    // when
+    step.prepareTransition(transitionContext, 1, targetRole).join();
+    final var transitionFuture = step.transitionTo(transitionContext, 1, targetRole);
+
+    // then
+    assertThat(transitionFuture)
+        .describedAs("Expected to fail installation when s3 configuration is not complete.")
+        .failsWithin(Duration.ofMillis(500))
+        .withThrowableOfType(ExecutionException.class);
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(TransitionsThatShouldInstallService.class)
+  void shouldNotInstallServiceWhenStoreTypeIsNone(final Role currentRole, final Role targetRole) {
+    // given
+    setUpCurrentRole(currentRole);
+    configureStore(BackupStoreType.NONE);
+
+    // when
+    transitionTo(targetRole);
+
+    // then
+    assertThat(transitionContext.getBackupStore()).isNull();
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(TransitionsThatShouldDoNothing.class)
+  void shouldNotReInstallService(final Role currentRole, final Role targetRole) {
+    // given
+    setUpCurrentRole(currentRole);
+    final var existingBackupStore = transitionContext.getBackupStore();
+
+    // when
+    transitionTo(targetRole);
+
+    // then
+    assertThat(transitionContext.getBackupStore())
+        .describedAs("Existing backup store must not be removed from the context.")
+        .isEqualTo(existingBackupStore);
+  }
+
+  private void configureStore(final BackupStoreType type) {
+    final S3BackupStoreConfig s3Config = new S3BackupStoreConfig();
+    s3Config.setBucketName("bucket");
+    s3Config.setRegion("region");
+    s3Config.setRegion("endpoint");
+    s3Config.setAccessKey("user");
+    s3Config.setSecretKey("password");
+    configureStore(type, s3Config);
+  }
+
+  private void configureStore(final BackupStoreType type, final S3BackupStoreConfig s3Config) {
+    final var backupCfg = new BackupStoreCfg();
+    backupCfg.setStore(type);
+    backupCfg.setS3(s3Config);
+    when(brokerCfg.getData()).thenReturn(dataCfg);
+    when(dataCfg.getBackup()).thenReturn(backupCfg);
+  }
+
+  private void transitionTo(final Role role) {
+    step.prepareTransition(transitionContext, 1, role).join();
+    step.transitionTo(transitionContext, 1, role).join();
+    transitionContext.setCurrentRole(role);
+  }
+
+  private void setUpCurrentRole(final Role currentRole) {
+    transitionContext.setCurrentRole(currentRole);
+    if (currentRole != null && currentRole != Role.INACTIVE) {
+      transitionContext.setBackupStore(backupStorePreviousRole);
+      lenient()
+          .when(backupStorePreviousRole.closeAsync())
+          .thenReturn(CompletableFuture.completedFuture(null));
+    }
+  }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -358,6 +358,12 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>zeebe-backup-store-s3</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>zeebe-backup-testkit</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
## Description

* `BackupStore` is installed and closed during role transitions. It is installed for follower roles also. But it won't be used because `NoopBackupManager` is installed for follower role.
*  When no backup store is configured, the step do not install a backup store. Otherwise a backup store is installed based on the given configuration.
* Install fails, if S3 configuration is not available in zeebe configs and it cannot be read from the environment. This check is done only during the role transition. The install fails and the partition will be "INACTIVE" and unhealthy.  But it does not fail during the startup. Alternatively, 
  1.  We can log an error, and continue installing as if no backup store is configured. In this case, the user would not get an immediate feedback, unless they check the logs. Later backup operations (such as get status) will fail with error message "No backup store configured". 
  2. OR, We can verify if the configurations are available by creating a backup store in SystemContext while validating the config. This would fail the startup if the configurations are not available from the environment. However, it does not look good to create the backup store just to validate the configuration.

Depends on #10335 

## Related issues

closes #10253 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
