### PR TITLE
PI Modification: terminate embedded subprocess

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -528,7 +528,9 @@ public final class ProcessInstanceModificationProcessor
     catchEventBehavior.unsubscribeFromEvents(elementInstanceKey, sideEffects);
 
     // terminate all child instances if the element is an event subprocess
-    if (elementInstance.getValue().getBpmnElementType() == BpmnElementType.EVENT_SUB_PROCESS) {
+    final BpmnElementType elementType = elementInstance.getValue().getBpmnElementType();
+    if (elementType == BpmnElementType.EVENT_SUB_PROCESS
+        || elementType == BpmnElementType.SUB_PROCESS) {
       elementInstanceState.getChildren(elementInstanceKey).stream()
           .filter(ElementInstance::canTerminate)
           .forEach(childInstance -> terminateElement(childInstance, sideEffects));

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTerminationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTerminationTest.java
@@ -591,7 +591,14 @@ public class ModifyProcessInstanceTerminationTest {
                     eventSubprocess
                         .startEvent()
                         .message(m -> m.name("start").zeebeCorrelationKeyExpression("key"))
-                        .userTask("B")
+                        .subProcess(
+                            "subprocess",
+                            subprocess ->
+                                subprocess
+                                    .embeddedSubProcess()
+                                    .startEvent()
+                                    .userTask("B")
+                                    .endEvent())
                         .endEvent())
             .startEvent()
             .userTask("A")
@@ -640,8 +647,16 @@ public class ModifyProcessInstanceTerminationTest {
                 BpmnElementType.EVENT_SUB_PROCESS,
                 "event-subprocess",
                 ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "subprocess",
+                ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(
+                BpmnElementType.SUB_PROCESS,
+                "subprocess",
+                ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(
                 BpmnElementType.EVENT_SUB_PROCESS,
                 "event-subprocess",


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
When we receive a terminate instruction for a subprocess, we have to make sure we terminate all child instances of this subprocess as well as the subprocess itself.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9698

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
