### PR TITLE
Add additional status info to the status query

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -144,8 +144,11 @@ public final class BackupApiRequestHandler
                 response
                     .setCheckpointPosition(backupDescriptor.checkpointPosition())
                     .setSnapshotId(backupDescriptor.snapshotId().orElse(""))
-                    .setNumberOfPartitions(backupDescriptor.numberOfPartitions()));
+                    .setNumberOfPartitions(backupDescriptor.numberOfPartitions())
+                    .setBrokerVersion(backupDescriptor.brokerVersion()));
     status.failureReason().ifPresent(response::setFailureReason);
+    status.created().ifPresent(instant -> response.setCreatedAt(instant.toString()));
+    status.lastModified().ifPresent(instant -> response.setLastUpdated(instant.toString()));
     return response;
   }
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/PartitionBackupDescriptor.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/PartitionBackupDescriptor.java
@@ -7,4 +7,5 @@
  */
 package io.camunda.zeebe.gateway.admin.backup;
 
-record PartitionBackupDescriptor(String snapshotId, long checkpointPosition, int brokerId) {}
+record PartitionBackupDescriptor(
+    String snapshotId, long checkpointPosition, int brokerId, String brokerVersion) {}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/PartitionBackupStatus.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/PartitionBackupStatus.java
@@ -15,7 +15,9 @@ record PartitionBackupStatus(
     int partitionId,
     BackupStatusCode status,
     Optional<PartitionBackupDescriptor> description,
-    Optional<String> failureReason) {
+    Optional<String> failureReason,
+    Optional<String> createdAt,
+    Optional<String> lastUpdatedAt) {
 
   static PartitionBackupStatus from(final BackupStatusResponse response) {
 
@@ -31,15 +33,25 @@ record PartitionBackupStatus(
   private static PartitionBackupStatus validStatus(final BackupStatusResponse response) {
     final var descriptor =
         new PartitionBackupDescriptor(
-            response.getSnapshotId(), response.getCheckpointPosition(), response.getBrokerId());
+            response.getSnapshotId(),
+            response.getCheckpointPosition(),
+            response.getBrokerId(),
+            response.getBrokerVersion());
     return new PartitionBackupStatus(
-        response.getPartitionId(), response.getStatus(), Optional.of(descriptor), Optional.empty());
+        response.getPartitionId(),
+        response.getStatus(),
+        Optional.of(descriptor),
+        Optional.empty(),
+        Optional.ofNullable(response.getCreatedAt()),
+        Optional.ofNullable(response.getLastUpdated()));
   }
 
   private static PartitionBackupStatus notExistingStatus(final BackupStatusResponse response) {
     return new PartitionBackupStatus(
         response.getPartitionId(),
         BackupStatusCode.DOES_NOT_EXIST,
+        Optional.empty(),
+        Optional.empty(),
         Optional.empty(),
         Optional.empty());
   }
@@ -49,6 +61,8 @@ record PartitionBackupStatus(
         response.getPartitionId(),
         BackupStatusCode.FAILED,
         Optional.empty(),
-        Optional.of(response.getFailureReason()));
+        Optional.of(response.getFailureReason()),
+        Optional.ofNullable(response.getCreatedAt()),
+        Optional.ofNullable(response.getLastUpdated()));
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupQueryStub.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupQueryStub.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.camunda.zeebe.protocol.impl.encoding.BackupStatusResponse;
 import io.camunda.zeebe.protocol.management.BackupStatusCode;
 import io.camunda.zeebe.protocol.record.ErrorCode;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -46,7 +47,10 @@ public class BackupQueryStub
         .setFailureReason("")
         .setCheckpointPosition(100)
         .setBrokerId(1)
-        .setPartitionId(request.getPartitionId());
+        .setPartitionId(request.getPartitionId())
+        .setBrokerVersion("test")
+        .setCreatedAt(Instant.now().toString())
+        .setLastUpdated(Instant.now().toString());
   }
 
   private BackupStatusResponse getFailedStatus(final BackupStatusRequest request) {
@@ -66,7 +70,9 @@ public class BackupQueryStub
         .setFailureReason("")
         .setCheckpointPosition(100)
         .setBrokerId(1)
-        .setPartitionId(request.getPartitionId());
+        .setPartitionId(request.getPartitionId())
+        .setCreatedAt(Instant.now().toString())
+        .setLastUpdated(Instant.now().toString());
   }
 
   private BackupStatusResponse getDoesNotExistStatus(final BackupStatusRequest request) {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupStatusResponse.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupStatusResponse.java
@@ -39,6 +39,12 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
   private byte[] encodedSnapshotId = EMPTY_BYTE_ARRAY;
   private String failureReason = "";
   private byte[] encodedFailureReason = EMPTY_BYTE_ARRAY;
+  private String brokerVersion = "";
+  private byte[] encodedBrokerVersion = EMPTY_BYTE_ARRAY;
+  private String createdAt = "";
+  private byte[] encodedCreatedAt = EMPTY_BYTE_ARRAY;
+  private String lastUpdated = "";
+  private byte[] encodedLastUpdated = EMPTY_BYTE_ARRAY;
 
   public long getBackupId() {
     return backupId;
@@ -116,6 +122,39 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
     return this;
   }
 
+  public String getBrokerVersion() {
+    return brokerVersion;
+  }
+
+  public BackupStatusResponse setBrokerVersion(final String brokerVersion) {
+    this.brokerVersion = brokerVersion;
+    encodedBrokerVersion =
+        encodeString(brokerVersion, BackupStatusResponseEncoder.brokerVersionCharacterEncoding());
+    return this;
+  }
+
+  public String getCreatedAt() {
+    return createdAt;
+  }
+
+  public BackupStatusResponse setCreatedAt(final String createdAt) {
+    this.createdAt = createdAt;
+    encodedCreatedAt =
+        encodeString(createdAt, BackupStatusResponseEncoder.createdAtCharacterEncoding());
+    return this;
+  }
+
+  public String getLastUpdated() {
+    return lastUpdated;
+  }
+
+  public BackupStatusResponse setLastUpdated(final String lastUpdated) {
+    this.lastUpdated = lastUpdated;
+    encodedLastUpdated =
+        encodeString(lastUpdated, BackupStatusResponseEncoder.lastUpdatedCharacterEncoding());
+    return this;
+  }
+
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
     bodyDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
@@ -137,6 +176,23 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
     failureReason =
         decodeString(
             encodedFailureReason, BackupStatusResponseDecoder.failureReasonCharacterEncoding());
+
+    encodedBrokerVersion = new byte[bodyDecoder.brokerVersionLength()];
+    bodyDecoder.getBrokerVersion(encodedBrokerVersion, 0, encodedBrokerVersion.length);
+    brokerVersion =
+        decodeString(
+            encodedBrokerVersion, BackupStatusResponseDecoder.brokerVersionCharacterEncoding());
+
+    encodedCreatedAt = new byte[bodyDecoder.createdAtLength()];
+    bodyDecoder.getCreatedAt(encodedCreatedAt, 0, encodedCreatedAt.length);
+    createdAt =
+        decodeString(encodedCreatedAt, BackupStatusResponseDecoder.createdAtCharacterEncoding());
+
+    encodedLastUpdated = new byte[bodyDecoder.lastUpdatedLength()];
+    bodyDecoder.getLastUpdated(encodedLastUpdated, 0, encodedLastUpdated.length);
+    lastUpdated =
+        decodeString(
+            encodedLastUpdated, BackupStatusResponseDecoder.lastUpdatedCharacterEncoding());
   }
 
   private String decodeString(final byte[] encodedSnapshotId, final String charsetName) {
@@ -154,7 +210,13 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
         + BackupStatusResponseEncoder.snapshotIdHeaderLength()
         + encodedSnapshotId.length
         + BackupStatusResponseEncoder.failureReasonHeaderLength()
-        + encodedFailureReason.length;
+        + encodedFailureReason.length
+        + BackupStatusResponseEncoder.brokerVersionHeaderLength()
+        + encodedBrokerVersion.length
+        + BackupStatusResponseEncoder.createdAtHeaderLength()
+        + encodedCreatedAt.length
+        + BackupStatusResponseEncoder.lastUpdatedHeaderLength()
+        + encodedLastUpdated.length;
   }
 
   @Override
@@ -169,7 +231,10 @@ public class BackupStatusResponse implements BufferReader, BufferWriter {
         .numberOfPartitions(numberOfPartitions)
         .status(status)
         .putSnapshotId(encodedSnapshotId, 0, encodedSnapshotId.length)
-        .putFailureReason(encodedFailureReason, 0, encodedFailureReason.length);
+        .putFailureReason(encodedFailureReason, 0, encodedFailureReason.length)
+        .putBrokerVersion(encodedBrokerVersion, 0, encodedBrokerVersion.length)
+        .putCreatedAt(encodedCreatedAt, 0, encodedCreatedAt.length)
+        .putLastUpdated(encodedLastUpdated, 0, encodedLastUpdated.length);
   }
 
   private byte[] encodeString(final String value, final String charsetName) {

--- a/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/protocol/src/main/resources/cluster-management-protocol.xml
@@ -45,11 +45,17 @@
     <field name="status" id="2" type="BackupStatusCode"/>
     <field name="partitionId" id="3" type="uint16"/>
     <field name="brokerId" id="4" type="uint16"/>
+    <!-- Following fields will have a valid value if status == COMPLETED or status == INPROGRESS -->
     <field name="checkpointPosition" id="5" type="int64"/>
     <field name="numberOfPartitions" id="6" type="uint16"/>
     <data name="snapshotId" id="7" type="varDataEncoding"/>
+    <!-- failure reason will have a valid value if status == FAILED -->
     <data name="failureReason" id="8" type="varDataEncoding"/>
+    <!-- Following fields will have a valid value if status == COMPLETED or status == INPROGRESS -->
+    <data name="createdAt" id="9" type="varDataEncoding"/>
+    <data name="lastUpdated" id="10" type="varDataEncoding"/>
+    <!-- Broker version which created this backup -->
+    <data name="brokerVersion" id="11" type="varDataEncoding"/>
   </sbe:message>
-
 
 </sbe:messageSchema>


### PR DESCRIPTION
## Description

#10237  #10239 added new fields (brokerVersion, created and lastUpdated timestamps) to the backup status. But they were not sent to the Gateway as part of the status query. This PR fixes this by adding additional fields to the sbe message that is sent from broker to the gateway. It also updates the `BackupStatus` in gateway that will be sent back to the user. The created and lastUpdated timestamps are encoded as string for human readability.

## Related issues

related #10235 #10238

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
