### PR TITLE
PI Modification: Terminate call activity

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -533,10 +533,15 @@ public final class ProcessInstanceModificationProcessor
     // terminate all child instances if the element is an event subprocess
     final BpmnElementType elementType = elementInstance.getValue().getBpmnElementType();
     if (elementType == BpmnElementType.EVENT_SUB_PROCESS
-        || elementType == BpmnElementType.SUB_PROCESS) {
+        || elementType == BpmnElementType.SUB_PROCESS
+        || elementType == BpmnElementType.PROCESS) {
       elementInstanceState.getChildren(elementInstanceKey).stream()
           .filter(ElementInstance::canTerminate)
           .forEach(childInstance -> terminateElement(childInstance, sideEffects));
+    } else if (elementType == BpmnElementType.CALL_ACTIVITY) {
+      final var calledActivityElementInstance =
+          elementInstanceState.getInstance(elementInstance.getCalledChildInstanceKey());
+      terminateElement(calledActivityElementInstance, sideEffects);
     }
 
     stateWriter.appendFollowUpEvent(

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceRecordStream.java
@@ -42,6 +42,14 @@ public final class ProcessInstanceRecordStream
     return valueFilter(v -> v.getProcessInstanceKey() == processInstanceKey);
   }
 
+  public ProcessInstanceRecordStream withProcessInstanceKeyOrParentProcessInstanceKey(
+      final long processInstanceKey) {
+    return valueFilter(
+        v ->
+            v.getProcessInstanceKey() == processInstanceKey
+                || v.getParentProcessInstanceKey() == processInstanceKey);
+  }
+
   public ProcessInstanceRecordStream withElementId(final String elementId) {
     return valueFilter(v -> elementId.equals(v.getElementId()));
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
When a terminate instruction is targetting a call activity we need to make sure this call activity is terminated correctly. Not only must we terminate the element instance of the call activity, we also have to terminate the child process.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9702 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
