### PR TITLE
fix(journal): reset writer asqn on truncate

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
@@ -55,15 +55,15 @@ final class Segment implements AutoCloseable {
       final SegmentFile file,
       final SegmentDescriptor descriptor,
       final MappedByteBuffer buffer,
-      final long maxWrittenIndex,
-      final long highestAsqn,
+      final long lastWrittenIndex,
+      final long lastWrittenAsqn,
       final JournalIndex index) {
     this.file = file;
     this.descriptor = descriptor;
     this.buffer = buffer;
     this.index = index;
 
-    writer = createWriter(maxWrittenIndex, highestAsqn);
+    writer = createWriter(lastWrittenIndex, lastWrittenAsqn);
   }
 
   /**
@@ -94,12 +94,12 @@ final class Segment implements AutoCloseable {
   }
 
   /**
-   * Returns the highest/last application sequence number in the segment.
+   * Returns the last application sequence number in the segment.
    *
-   * @return The highest/last application sequence number in the segment.
+   * @return The last application sequence number in the segment.
    */
-  public long highestAsqn() {
-    return writer.getHighestAsqn();
+  public long lastAsqn() {
+    return writer.getLastAsqn();
   }
 
   /**
@@ -161,8 +161,8 @@ final class Segment implements AutoCloseable {
     return reader;
   }
 
-  private SegmentWriter createWriter(final long lastWrittenIndex, final long highestAsqn) {
-    return new SegmentWriter(buffer, this, index, lastWrittenIndex, highestAsqn);
+  private SegmentWriter createWriter(final long lastWrittenIndex, final long lastWrittenAsqn) {
+    return new SegmentWriter(buffer, this, index, lastWrittenIndex, lastWrittenAsqn);
   }
 
   /**

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentLoader.java
@@ -42,7 +42,7 @@ final class SegmentLoader {
       final Path segmentFile,
       final SegmentDescriptor descriptor,
       final long lastWrittenIndex,
-      final long highestAsqn,
+      final long lastWrittenAsqn,
       final JournalIndex journalIndex) {
     final MappedByteBuffer mappedSegment;
 
@@ -76,13 +76,13 @@ final class SegmentLoader {
     }
 
     return loadSegment(
-        segmentFile, mappedSegment, descriptor, lastWrittenIndex, highestAsqn, journalIndex);
+        segmentFile, mappedSegment, descriptor, lastWrittenIndex, lastWrittenAsqn, journalIndex);
   }
 
   Segment loadExistingSegment(
       final Path segmentFile,
       final long lastWrittenIndex,
-      final long highestAsqn,
+      final long lastWrittenAsqn,
       final JournalIndex journalIndex) {
     final var descriptor = readDescriptor(segmentFile);
     final MappedByteBuffer mappedSegment;
@@ -96,7 +96,7 @@ final class SegmentLoader {
     }
 
     return loadSegment(
-        segmentFile, mappedSegment, descriptor, lastWrittenIndex, highestAsqn, journalIndex);
+        segmentFile, mappedSegment, descriptor, lastWrittenIndex, lastWrittenAsqn, journalIndex);
   }
 
   /* ---- Internal methods ------ */
@@ -105,11 +105,11 @@ final class SegmentLoader {
       final MappedByteBuffer buffer,
       final SegmentDescriptor descriptor,
       final long lastWrittenIndex,
-      final long highestAsqn,
+      final long lastWrittenAsqn,
       final JournalIndex journalIndex) {
     final SegmentFile segmentFile = new SegmentFile(file.toFile());
     return new Segment(
-        segmentFile, descriptor, buffer, lastWrittenIndex, highestAsqn, journalIndex);
+        segmentFile, descriptor, buffer, lastWrittenIndex, lastWrittenAsqn, journalIndex);
   }
 
   private MappedByteBuffer mapSegment(final FileChannel channel, final long segmentSize)


### PR DESCRIPTION
## Description

On truncate the current lastAsqn of the segment writer is reset to allow overwriting non-committed records afterwards.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6217

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
