### PR TITLE
PI Modification: Reject direct termination of child process

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -89,6 +89,12 @@ public final class ProcessInstanceModificationProcessor
       for an element that has a flow scope with more than one active instance: '%s'. Can't decide \
       in which instance of the flow scope the element should be activated.""";
 
+  private static final String ERROR_MESSAGE_CHILD_PROCESS_INSTANCE_TERMINATED =
+      """
+      Expected to modify instance of process '%s' but the given instructions would terminate \
+      the instance. A different process started this process. To terminate this instance \
+      please modify the parent process instead.""";
+
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       Set.of(
           BpmnElementType.UNSPECIFIED,
@@ -233,6 +239,13 @@ public final class ProcessInstanceModificationProcessor
           typedCommand,
           RejectionType.INVALID_ARGUMENT,
           ERROR_COMMAND_TOO_LARGE.formatted(typedCommand.getValue().getProcessInstanceKey()));
+      return ProcessingError.EXPECTED_ERROR;
+
+    } else if (error instanceof TerminatedChildProcessException exception) {
+      rejectionWriter.appendRejection(
+          typedCommand, RejectionType.INVALID_ARGUMENT, exception.getMessage());
+      responseWriter.writeRejectionOnCommand(
+          typedCommand, RejectionType.INVALID_ARGUMENT, exception.getMessage());
       return ProcessingError.EXPECTED_ERROR;
     }
     return ProcessingError.UNEXPECTED_ERROR;
@@ -521,6 +534,7 @@ public final class ProcessInstanceModificationProcessor
       final ElementInstance elementInstance, final SideEffects sideEffects) {
     final var elementInstanceKey = elementInstance.getKey();
     final var elementInstanceRecord = elementInstance.getValue();
+    final BpmnElementType elementType = elementInstance.getValue().getBpmnElementType();
 
     stateWriter.appendFollowUpEvent(
         elementInstanceKey, ProcessInstanceIntent.ELEMENT_TERMINATING, elementInstanceRecord);
@@ -531,7 +545,6 @@ public final class ProcessInstanceModificationProcessor
     catchEventBehavior.unsubscribeFromEvents(elementInstanceKey, sideEffects);
 
     // terminate all child instances if the element is an event subprocess
-    final BpmnElementType elementType = elementInstance.getValue().getBpmnElementType();
     if (elementType == BpmnElementType.EVENT_SUB_PROCESS
         || elementType == BpmnElementType.SUB_PROCESS
         || elementType == BpmnElementType.PROCESS
@@ -556,6 +569,17 @@ public final class ProcessInstanceModificationProcessor
     var currentElementInstance = elementInstanceState.getInstance(elementInstanceKey);
 
     while (canTerminateElementInstance(currentElementInstance, requiredKeysForActivation)) {
+
+      // Reject the command by throwing an exception if the process is being terminated, but it was
+      // started by a call activity.
+      final var currentElementInstanceRecord = currentElementInstance.getValue();
+      if (currentElementInstanceRecord.getBpmnElementType() == BpmnElementType.PROCESS
+          && currentElementInstanceRecord.hasParentProcess()) {
+        throw new TerminatedChildProcessException(
+            ERROR_MESSAGE_CHILD_PROCESS_INSTANCE_TERMINATED.formatted(
+                currentElementInstanceRecord.getBpmnProcessId()));
+      }
+
       final var flowScopeKey = currentElementInstance.getValue().getFlowScopeKey();
 
       terminateElement(currentElementInstance, sideEffects);
@@ -576,4 +600,20 @@ public final class ProcessInstanceModificationProcessor
   }
 
   private record Rejection(RejectionType type, String reason) {}
+
+  /**
+   * Exception that can be thrown when child instance is being modified. If all active element
+   * instances of this process are being terminated this exception is thrown. The reason for this is
+   * that it's unclear what the expected behavior of the parent process would be in these cases.
+   * Terminating the parent process could be unintended. Creating an incident is an alternative, but
+   * there would be no way to resolve this incident.
+   *
+   * <p>In order to terminate the child process a modification should be performed on the parent
+   * process instead.
+   */
+  private static class TerminatedChildProcessException extends RuntimeException {
+    TerminatedChildProcessException(final String message) {
+      super(message);
+    }
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -92,8 +92,8 @@ public final class ProcessInstanceModificationProcessor
   private static final String ERROR_MESSAGE_CHILD_PROCESS_INSTANCE_TERMINATED =
       """
       Expected to modify instance of process '%s' but the given instructions would terminate \
-      the instance. A different process started this process. To terminate this instance \
-      please modify the parent process instead.""";
+      the instance. The instance was created by a call activity in the parent process. \
+      To terminate this instance please modify the parent process instead.""";
 
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       Set.of(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceRejectionTest.java
@@ -430,8 +430,8 @@ public class ModifyProcessInstanceRejectionTest {
             String.format(
                 """
                 Expected to modify instance of process '%s' but the given instructions would terminate \
-                the instance. A different process started this process. To terminate this instance \
-                please modify the parent process instead.""",
+                the instance. The instance was created by a call activity in the parent process. \
+                To terminate this instance please modify the parent process instead.""",
                 callActivityProcessId));
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -84,16 +84,6 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     return elementIdProp.getValue();
   }
 
-  @Override
-  public long getProcessInstanceKey() {
-    return processInstanceKeyProp.getValue();
-  }
-
-  public ProcessInstanceRecord setProcessInstanceKey(final long processInstanceKey) {
-    processInstanceKeyProp.setValue(processInstanceKey);
-    return this;
-  }
-
   public ProcessInstanceRecord setBpmnProcessId(
       final DirectBuffer directBuffer, final int offset, final int length) {
     bpmnProcessIdProp.setValue(directBuffer, offset, length);
@@ -113,6 +103,16 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   @Override
   public long getProcessDefinitionKey() {
     return processDefinitionKeyProp.getValue();
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
+  }
+
+  public ProcessInstanceRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProp.setValue(processInstanceKey);
+    return this;
   }
 
   @Override
@@ -187,6 +187,10 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   public ProcessInstanceRecord setBpmnProcessId(final DirectBuffer directBuffer) {
     bpmnProcessIdProp.setValue(directBuffer);
     return this;
+  }
+
+  public boolean hasParentProcess() {
+    return getParentProcessInstanceKey() != -1L;
   }
 
   public ProcessInstanceRecord setElementId(


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
It is possible to terminate a process instance using a modification command. This is done by adding terminate instructions for all of the active element instances of the process. When this happens the process will be fully terminated.

However, it could be the case that a process is started with a call activity. This causes a complex situation. Terminating the child process would mean the parent process is "stuck". There is a few ways around this.

1. We could terminate the parent process. This could have unintended consequence for the user.
2. An incident is created on the parent process. The problem here is that the current incident logic makes it impossible to resolve these incidents. These could be worked around by doing another modification. That leaves the question why the user wouldn't modify the parent process in the first place.
3. We reject the command and advice the user to modify the parent process if the child process needs to be terminated.

The option we are going for is option 3. When we detect that we are trying to terminate a process which is called by a parent process, the command will be rejected. The user received a message with the advice to modify the parent process instead.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10347 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
