### PR TITLE
Run ScheduledTasks during processing

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
@@ -80,22 +80,19 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService 
       }
 
       final var currentStreamProcessorPhase = streamProcessorContext.getStreamProcessorPhase();
-      if (currentStreamProcessorPhase != Phase.PROCESSING
-          || streamProcessorContext.isInProcessing()) {
+      if (currentStreamProcessorPhase != Phase.PROCESSING) {
 
         // We want to execute the scheduled tasks only if the StreamProcessor is in the PROCESSING
-        // PHASE, but no processing is currently happening.
+        // PHASE
         //
         // To make sure that:
         //
         //  * we are not running during replay/init phase (the state might not be up-to-date yet)
         //  * we are not running during suspending
-        //  * we are not interfering with the current ongoing processing,
-        //    such that all transaction changes are available during our task execution
+        //
         Loggers.PROCESS_PROCESSOR_LOGGER.trace(
-            "Not able to execute scheduled task right now. [streamProcessorPhase: {}, inProcessing: {}]",
-            currentStreamProcessorPhase,
-            streamProcessorContext.isInProcessing());
+            "Not able to execute scheduled task right now. [streamProcessorPhase: {}]",
+            currentStreamProcessorPhase);
         actorControl.submit(toRunnable(task));
         return;
       }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
@@ -55,10 +55,6 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private CommandResponseWriter commandResponseWriter;
   private InterPartitionCommandSender partitionCommandSender;
 
-  // this is always accessed by the same actor; which means we don't need to use a concurrent/thread
-  // safe structure here
-  private boolean inProcessing;
-
   // this is accessed outside, which is why we need to make sure that it is thread-safe
   private volatile StreamProcessor.Phase phase = Phase.INITIAL;
 
@@ -105,23 +101,6 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   public StreamProcessorContext logStreamReader(final LogStreamReader logStreamReader) {
     this.logStreamReader = logStreamReader;
     return this;
-  }
-
-  /**
-   * @return allows to determine whether there is a current processing is on going
-   */
-  boolean isInProcessing() {
-    return inProcessing;
-  }
-
-  /**
-   * Sets the state of the processing. This is useful to show between different actor jobs whether a
-   * processing is going on or not, and to determine whether certain actions can be taken.
-   *
-   * @param inProcessing the state of processing
-   */
-  void setInProcessing(final boolean inProcessing) {
-    this.inProcessing = inProcessing;
   }
 
   public StreamProcessorContext eventCache(final RecordValues recordValues) {


### PR DESCRIPTION
## Description

Removes the guarantee that scheduled Tasks are only executed after commit and only if no inProcessing is going on. This is not necessary, since all actions we want to execute after a commit are executed via PostcommitTasks which are added to the ProcessingResult.

See related comment and discussion https://github.com/camunda/zeebe/issues/9723#issuecomment-1239767498

Future improvements:

 * We can create our own actor for the SchedulingService this would decouple better than scheduling and processing
 * We can remove the multiple scheduling in the SchedulingService https://github.com/camunda/zeebe/issues/10291

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/9723
related https://github.com/camunda/zeebe/issues/10272

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
