### PR TITLE
Minimize usage of uninitialized BrokerCfg objects

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/BrokerCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/BrokerCfg.java
@@ -33,11 +33,18 @@ public final class BrokerCfg {
 
   private boolean executionMetricsExporterEnabled;
 
-  public void init(final String brokerBase) {
-    init(brokerBase, new Environment());
+  /** TODO: prevent callers from using an uninitialized broker configuration */
+  public BrokerCfg() {}
+
+  public BrokerCfg(final String brokerBase) {
+    this(brokerBase, new Environment());
   }
 
-  public void init(final String brokerBase, final Environment environment) {
+  public BrokerCfg(final String brokerBase, final Environment environment) {
+    init(brokerBase, environment);
+  }
+
+  private void init(final String brokerBase, final Environment environment) {
     applyEnvironment(environment);
 
     if (isExecutionMetricsExporterEnabled()) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -45,9 +45,8 @@ public final class SimpleBrokerStartTest {
   @Test
   public void shouldFailToCreateBrokerWithSmallSnapshotPeriod() {
     // given
-    final var brokerCfg = new BrokerCfg();
+    final var brokerCfg = new BrokerCfg(newTemporaryFolder.getAbsolutePath());
     brokerCfg.getData().setSnapshotPeriod(Duration.ofMillis(1));
-    brokerCfg.init(newTemporaryFolder.getAbsolutePath());
 
     // when
 
@@ -67,9 +66,8 @@ public final class SimpleBrokerStartTest {
   @Test
   public void shouldCallPartitionListenerAfterStart() throws Exception {
     // given
-    final var brokerCfg = new BrokerCfg();
+    final var brokerCfg = new BrokerCfg(newTemporaryFolder.getAbsolutePath());
     assignSocketAddresses(brokerCfg);
-    brokerCfg.init(newTemporaryFolder.getAbsolutePath());
 
     final var systemContext =
         new SystemContext(

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImplTest.java
@@ -101,9 +101,6 @@ public final class PartitionManagerImplTest {
   }
 
   private BrokerCfg newConfig() {
-    final var config = new BrokerCfg();
-    config.init(temporaryFolder.getRoot().getAbsolutePath(), environment);
-
-    return config;
+    return new BrokerCfg(temporaryFolder.getRoot().getAbsolutePath(), environment);
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -183,17 +183,14 @@ public final class BrokerCfgTest {
     exporterCfgInternal1.setJarPath("");
 
     final ExporterCfg exporterCfgInternal2 = new ExporterCfg();
-
-    final BrokerCfg config = new BrokerCfg();
-    config.getExporters().put("external", exporterCfgExternal);
-    config.getExporters().put("internal-1", exporterCfgInternal1);
-    config.getExporters().put("internal-2", exporterCfgInternal2);
-
     final String base = temporaryFolder.getRoot().getAbsolutePath();
     final String jarFile = Paths.get(base, "exporters", "exporter.jar").toAbsolutePath().toString();
 
     // when
-    config.init(base);
+    final BrokerCfg config = new BrokerCfg(base);
+    config.getExporters().put("external", exporterCfgExternal);
+    config.getExporters().put("internal-1", exporterCfgInternal1);
+    config.getExporters().put("internal-2", exporterCfgInternal2);
 
     // then
     assertThat(config.getExporters()).hasSize(3);

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/TestConfigReader.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/TestConfigReader.java
@@ -17,14 +17,14 @@ public final class TestConfigReader {
 
   public static BrokerCfg readConfig(final String name, final Map<String, String> environment) {
     final String configPath = "/system/" + name + ".yaml";
-
     final Environment environmentVariables = new Environment(environment);
 
-    final BrokerCfg config =
-        new TestConfigurationFactory()
-            .create(environmentVariables, "zeebe.broker", configPath, BrokerCfg.class);
-    config.init(BROKER_BASE, environmentVariables);
-
-    return config;
+    return new TestConfigurationFactory()
+        .create(
+            environmentVariables,
+            "zeebe.broker",
+            configPath,
+            BrokerCfg.class,
+            new BrokerCfg(BROKER_BASE, environmentVariables));
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerConfiguration.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.broker;
 
 import io.camunda.zeebe.broker.WorkingDirectoryConfiguration.WorkingDirectory;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,21 +26,10 @@ import org.springframework.web.context.annotation.ApplicationScope;
  */
 @Configuration(proxyBeanMethods = false)
 public final class BrokerConfiguration {
-
-  @Bean("uninitializedBrokerCfg")
+  @Bean
   @ConfigurationProperties(prefix = "zeebe.broker")
   @ApplicationScope(proxyMode = ScopedProxyMode.NO)
-  private BrokerCfg rawBrokerConfig() {
-    return new BrokerCfg();
-  }
-
-  @Bean("initializedBrokerCfg")
-  @ApplicationScope(proxyMode = ScopedProxyMode.NO)
-  @Primary
-  public BrokerCfg brokerConfig(
-      @Qualifier("uninitializedBrokerCfg") final BrokerCfg config,
-      final WorkingDirectory workingDirectory) {
-    config.init(workingDirectory.path().toString());
-    return config;
+  public BrokerCfg brokerConfig(final WorkingDirectory workingDirectory) {
+    return new BrokerCfg(workingDirectory.path().toString());
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -285,9 +285,7 @@ public final class ClusteringRule extends ExternalResource {
   }
 
   private Broker createBroker(final int nodeId) {
-    final var brokerBase = getBrokerBase(nodeId);
     final var brokerCfg = getBrokerCfg(nodeId);
-    brokerCfg.init(brokerBase.getAbsolutePath());
 
     final var atomixCluster = new BrokerClusterConfiguration().atomixCluster(brokerCfg);
     final var scheduler = new ActorSchedulerConfiguration(brokerCfg, controlledClock).scheduler();
@@ -322,7 +320,8 @@ public final class ClusteringRule extends ExternalResource {
   }
 
   private BrokerCfg createBrokerCfg(final int nodeId) {
-    final BrokerCfg brokerCfg = new BrokerCfg();
+    final File brokerBase = getBrokerBase(nodeId);
+    final BrokerCfg brokerCfg = new BrokerCfg(brokerBase.getAbsolutePath());
 
     // build-in exporters
     if (ENABLE_DEBUG_EXPORTER) {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/TestConfigurationFactory.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/TestConfigurationFactory.java
@@ -9,20 +9,22 @@ package io.camunda.zeebe.test.util;
 
 import io.camunda.zeebe.util.Environment;
 import io.camunda.zeebe.util.Loggers;
+import io.camunda.zeebe.util.ReflectUtil;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.BindContext;
+import org.springframework.boot.context.properties.bind.BindHandler;
 import org.springframework.boot.context.properties.bind.BindResult;
+import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
 import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
 import org.springframework.core.env.MapPropertySource;
@@ -54,27 +56,6 @@ public final class TestConfigurationFactory {
   public static final Logger LOG = Loggers.CONFIG_LOGGER;
 
   /**
-   * Reads the configuration from the input stream and binds it to an object
-   *
-   * @param configurationInputStream input stream of the configuration file; must not be {@code
-   *     null}
-   * @param type type of object to be created; it is assumed that this object has a public no arg
-   *     constructor; must not be {@code null}; must have a {@link ConfigurationProperties}
-   *     annotation with a {@code prefix} attribute
-   */
-  public <T> T create(final InputStream configurationInputStream, final Class<T> type) {
-    final ConfigurationProperties annotation = type.getAnnotation(ConfigurationProperties.class);
-    final String prefix;
-    if (annotation != null && annotation.prefix() != null) {
-      prefix = annotation.prefix();
-    } else {
-      throw new IllegalArgumentException(
-          "Unable to identify prefix for type" + type.getSimpleName());
-    }
-    return create(null, prefix, configurationInputStream, type);
-  }
-
-  /**
    * Reads the configuration file from the class path and binds it to an object
    *
    * @param environment environment to simulate environment variables that can be overlayed; may be
@@ -90,31 +71,42 @@ public final class TestConfigurationFactory {
       final String prefix,
       final String fileName,
       final Class<T> type) {
-    LOG.debug("Reading configuration for {} from file {}", type, fileName);
-
-    try (InputStream inputStream = new ClassPathResource(fileName).getInputStream()) {
-
-      return create(environment, prefix, inputStream, type);
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
+    return create(environment, prefix, fileName, type, ReflectUtil.newInstance(type));
   }
 
   /**
-   * Reads the configuration from the input stream and binds it to an object
+   * Reads the configuration file from the class path and binds it to an object
    *
    * @param environment environment to simulate environment variables that can be overlayed; may be
    *     {@code} null
    * @param prefix the top level element in the configuration that should be mapped to the object
-   * @param inputStream input stream of the configuration file; must not be {@code null}
+   * @param fileName filename of the configuration file; must be available on the classpath; must
+   *     not be {@code null}
    * @param type type of object to be created; it is assumed that this object has a public no arg
    *     constructor; must not be {@code null}
+   * @param instance instance which will be populated with the configuration
    */
   public <T> T create(
       final Environment environment,
       final String prefix,
+      final String fileName,
+      final Class<T> type,
+      final T instance) {
+    LOG.debug("Reading configuration for {} from file {}", type, fileName);
+
+    try (final InputStream inputStream = new ClassPathResource(fileName).getInputStream()) {
+      return create(environment, prefix, inputStream, type, instance);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private <T> T create(
+      final Environment environment,
+      final String prefix,
       final InputStream inputStream,
-      final Class<T> type) {
+      final Class<T> type,
+      final T instance) {
     LOG.debug("Reading configuration for {} from input stream", type);
 
     final Map<String, Object> propertiesFromEnvironment = convertEnvironmentIntoMap(environment);
@@ -127,28 +119,30 @@ public final class TestConfigurationFactory {
     propertySources.addLast(
         new PropertiesPropertySource("properties from file", propertiesFromFile));
 
-    final Constructor<T> constructor;
-    final T target;
-    try {
-      constructor = type.getConstructor();
-      target = constructor.newInstance();
-    } catch (NoSuchMethodException
-        | InstantiationException
-        | IllegalAccessException
-        | InvocationTargetException e) {
-      throw new IllegalStateException(e);
-    }
-
     final Iterable<ConfigurationPropertySource> configPropertySource =
         ConfigurationPropertySources.from(propertySources);
 
-    final BindResult<T> bindResult = new Binder(configPropertySource).bind(prefix, type);
+    final BindResult<T> bindResult =
+        new Binder(configPropertySource)
+            .bind(
+                prefix,
+                Bindable.of(type),
+                new BindHandler() {
+                  @Override
+                  public Object onCreate(
+                      final ConfigurationPropertyName name,
+                      final Bindable<?> target,
+                      final BindContext context,
+                      final Object result) {
+                    return instance;
+                  }
+                });
 
     if (!bindResult.isBound()) {
       LOG.warn(
           "No binding result parsing the configuration. This is normal if the configuration is empty."
               + " Otherwise it is a configuration or programming error.");
-      return target;
+      return instance;
     } else {
       return bindResult.get();
     }
@@ -166,7 +160,7 @@ public final class TestConfigurationFactory {
 
     if (environment != null) {
       final Set<String> propertyKeys = environment.getPropertyKeys();
-      for (String propertyKey : propertyKeys) {
+      for (final String propertyKey : propertyKeys) {
         result.put(propertyKey, environment.get(propertyKey).orElse(null));
       }
     }


### PR DESCRIPTION
## Description

This PR attempts to minimize usages of uninitialized `BrokerCfg` objects. Previously, you would create a configuration, then have to call init for it to be usable. The idea here is to try and enforce that you cannot create an unusable `BrokerCfg` object in general.

Unfortunately many, many places in tests do so, and sometimes create instances via reflection. I've left these for now, but open to suggestions on how best to tackle this.

This also removes the usage of two beans to initialize the `BrokerCfg` as introduced in #10354.

## Related issues

related #9996 
depends on #10354

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
