### PR TITLE
Add support for restoring a partition from a backup

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/restore/BackupNotFoundException.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/restore/BackupNotFoundException.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.restore;
+
+public class BackupNotFoundException extends RuntimeException {
+
+  public BackupNotFoundException(final long backupId) {
+    super("Could not find a completed backup with id %d.".formatted(backupId));
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/restore/PartitionRestoreService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/restore/PartitionRestoreService.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.restore;
+
+import static io.camunda.zeebe.util.FileUtil.ensureDirectoryExists;
+
+import io.atomix.raft.partition.RaftPartition;
+import io.camunda.zeebe.backup.api.Backup;
+import io.camunda.zeebe.backup.api.BackupDescriptor;
+import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.journal.JournalReader;
+import io.camunda.zeebe.journal.file.SegmentedJournal;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
+import java.io.IOException;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Restores a backup from the given {@link io.camunda.zeebe.backup.api.BackupStore}. */
+public class PartitionRestoreService {
+  private static final Logger LOG = LoggerFactory.getLogger(PartitionRestoreService.class);
+  final BackupStore backupStore;
+  final int partitionId;
+
+  // All members of the cluster. A backup could have been taken by any broker. So we have to iterate
+  // over all of them to find a valid backup for this partition with the given id.
+  final Set<Integer> brokerIds;
+  final Path rootDirectory;
+  private final RaftPartition partition;
+  private final int localBrokerId;
+
+  public PartitionRestoreService(
+      final BackupStore backupStore,
+      final RaftPartition partition,
+      final Set<Integer> brokerIds,
+      final int localNodeId) {
+    this.backupStore = backupStore;
+    partitionId = partition.id().id();
+    rootDirectory = partition.dataDirectory().toPath();
+    this.partition = partition;
+    this.brokerIds = brokerIds;
+    localBrokerId = localNodeId;
+  }
+
+  /**
+   * Downloads backup from the backup file, restore it to the partition's data directory. After
+   * restoring, it truncates the journal to the checkpointPosition so that the last record in the
+   * journal will be the checkpoint record at checkpointPosition.
+   *
+   * @param backupId id of the backup to restore from
+   * @return the descriptor of the backup it restored
+   */
+  public CompletableFuture<BackupDescriptor> restore(final long backupId) {
+    return getTargetDirectory(backupId)
+        .thenCompose(targetDirectory -> download(backupId, targetDirectory))
+        .thenApply(this::moveFilesToDataDirectory)
+        .thenApply(
+            backup -> {
+              resetLogToCheckpointPosition(backup.descriptor().checkpointPosition(), rootDirectory);
+              return backup.descriptor();
+            })
+        .toCompletableFuture();
+
+    // TODO: As an additional consistency check:
+    // - Validate journal.firstIndex <= snapshotIndex + 1
+    // - Verify journal.lastEntry.asqn == checkpointPosition
+  }
+
+  private CompletionStage<Path> getTargetDirectory(final long backupId) {
+    try {
+      if (!isEmpty(rootDirectory)) {
+        LOG.error(
+            "Partition's data directory {} is not empty. Aborting restore to avoid overwriting data. Please restart with a clean directory.",
+            rootDirectory);
+        CompletableFuture.failedFuture(new DirectoryNotEmptyException(rootDirectory.toString()));
+      }
+
+      // First download the contents to a temporary directory and then move it to the correct
+      // locations.
+      final var tempTargetDirectory = rootDirectory.resolve("restoring-" + backupId);
+      ensureDirectoryExists(tempTargetDirectory);
+      return CompletableFuture.completedFuture(tempTargetDirectory);
+    } catch (final Exception e) {
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
+  private boolean isEmpty(final Path path) throws IOException {
+    if (Files.isDirectory(path)) {
+      try (final Stream<Path> entries = Files.list(path)) {
+        return entries.findFirst().isEmpty();
+      }
+    }
+    return false;
+  }
+
+  // While taking the backup, we add all log segments. But the backup must only have entries upto
+  // the checkpoint position. So after restoring, we truncate the journal until the
+  // checkpointPosition.
+  private void resetLogToCheckpointPosition(
+      final long checkpointPosition, final Path dataDirectory) {
+
+    try (final var journal =
+        SegmentedJournal.builder()
+            .withDirectory(dataDirectory.toFile())
+            .withName(partition.name())
+            .withLastWrittenIndex(-1)
+            .build()) {
+
+      resetJournal(checkpointPosition, journal);
+    }
+  }
+
+  private void resetJournal(final long checkpointPosition, final SegmentedJournal journal) {
+    try (final var reader = journal.openReader()) {
+      reader.seekToAsqn(checkpointPosition);
+      if (reader.hasNext()) {
+        final var checkpointRecord = reader.next();
+        // Here the assumption is the checkpointRecord is the only entry in the journal record. So
+        // the checkpointPosition will be the asqn of the record.
+        if (checkpointRecord.asqn() != checkpointPosition) {
+          failedToFindCheckpointRecord(checkpointPosition, reader);
+        }
+        journal.deleteAfter(checkpointRecord.index());
+      } else {
+        failedToFindCheckpointRecord(checkpointPosition, reader);
+      }
+    }
+  }
+
+  private static void failedToFindCheckpointRecord(
+      final long checkpointPosition, final JournalReader reader) {
+    reader.seekToFirst();
+    final var firstEntry = reader.hasNext() ? reader.next() : null;
+    reader.seekToLast();
+    final var lastEntry = reader.hasNext() ? reader.next() : null;
+    LOG.error(
+        "Cannot find the checkpoint record at position {}. Log contains first record: (index = {}, position= {}) last record: (index = {}, position= {}). Restoring from this state can lead to inconsistent state. Aborting restore.",
+        checkpointPosition,
+        firstEntry != null ? firstEntry.index() : -1,
+        firstEntry != null ? firstEntry.asqn() : -1,
+        lastEntry != null ? lastEntry.index() : -1,
+        lastEntry != null ? lastEntry.asqn() : -1);
+    throw new IllegalStateException(
+        "Failed to restore from backup. Cannot find a record at checkpoint position %d in the log."
+            .formatted(checkpointPosition));
+  }
+  // Move contents of restored backup from the temp directory to partition's root data directory.
+  // After this is done, the contents of the data directory follow the expected directory
+  // structure. That is - segments in rootDirectory, snapshot in
+  // rootDirectory/snapshots/<snapshotId>/
+  private Backup moveFilesToDataDirectory(final Backup backup) {
+    moveSegmentFiles(backup);
+    moveSnapshotFiles(backup);
+    return backup;
+  }
+
+  private void moveSegmentFiles(final Backup backup) {
+    LOG.info("Moving journal segment files to {}", rootDirectory);
+    final var segmentFileSet = backup.segments().namedFiles();
+    final var segmentFileNames = segmentFileSet.keySet();
+    segmentFileNames.forEach(
+        name -> copyNamedFileToDirectory(name, segmentFileSet.get(name), rootDirectory));
+  }
+
+  private void moveSnapshotFiles(final Backup backup) {
+    if (backup.descriptor().snapshotId().isEmpty()) {
+      return;
+    }
+
+    final var snapshotStore =
+        FileBasedSnapshotStoreFactory.createRestorableSnapshotStore(
+            partition.dataDirectory().toPath(), partition.id().id(), localBrokerId);
+
+    try {
+      snapshotStore.restore(
+          backup.descriptor().snapshotId().orElseThrow(), backup.snapshot().namedFiles());
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void copyNamedFileToDirectory(
+      final String name, final Path source, final Path targetDirectory) {
+    final var targetFilePath = targetDirectory.resolve(name);
+    try {
+      Files.move(source, targetFilePath);
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private CompletionStage<Backup> download(
+      final long checkpointId, final Path tempRestoringDirectory) {
+    return findValidBackup(checkpointId)
+        .thenCompose(
+            backup -> {
+              LOG.info("Downloading backup {} to {}", backup, tempRestoringDirectory);
+              return backupStore.restore(backup, tempRestoringDirectory);
+            });
+  }
+
+  private CompletionStage<BackupIdentifier> findValidBackup(final long checkpointId) {
+    LOG.info("Searching for a completed backup with id {}", checkpointId);
+    final var futures =
+        brokerIds.stream()
+            .map(brokerId -> new BackupIdentifierImpl(brokerId, partitionId, checkpointId))
+            .map(backupStore::getStatus)
+            .toList();
+
+    return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
+        .thenApply(
+            ignore -> {
+              final var backupStatuses = futures.stream().map(CompletableFuture::join).toList();
+              return findCompletedBackup(backupStatuses)
+                  .orElseThrow(
+                      () -> {
+                        LOG.error(
+                            "Could not find a valid backup with id {}. Found {}",
+                            checkpointId,
+                            backupStatuses);
+                        return new BackupNotFoundException(checkpointId);
+                      });
+            });
+  }
+
+  private Optional<BackupIdentifier> findCompletedBackup(final List<BackupStatus> backupStatuses) {
+    return backupStatuses.stream()
+        .filter(s -> s.statusCode() == BackupStatusCode.COMPLETED)
+        .findFirst()
+        .map(BackupStatus::id);
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/restore/PartitionRestoreServiceTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/restore/PartitionRestoreServiceTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.restore;
+
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.raft.partition.RaftPartition;
+import io.camunda.zeebe.backup.api.Backup;
+import io.camunda.zeebe.backup.management.BackupService;
+import io.camunda.zeebe.journal.file.SegmentedJournal;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.snapshots.SnapshotException.CorruptedSnapshotException;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
+import io.camunda.zeebe.util.FileUtil;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PartitionRestoreServiceTest {
+
+  private static TestRestorableBackupStore backupStore;
+  private static ActorScheduler actorScheduler;
+  private static final String SNAPSHOT_FILE_NAME = "file1";
+  @TempDir Path dataDirectory;
+  @TempDir Path dataDirectoryToRestore;
+  private SegmentedJournal journal;
+  private PartitionRestoreService restoreService;
+  private FileBasedSnapshotStore snapshotStore;
+  private BackupService backupService;
+
+  @BeforeAll
+  static void beforeAll() {
+    actorScheduler = ActorScheduler.newActorScheduler().build();
+    actorScheduler.start();
+    backupStore = new TestRestorableBackupStore();
+  }
+
+  @AfterAll
+  static void afterAll() throws ExecutionException, InterruptedException {
+    actorScheduler.stop().get();
+  }
+
+  @BeforeEach
+  void setUp() {
+
+    final int nodeId = 1;
+    final int partitionId = 1;
+    snapshotStore =
+        (FileBasedSnapshotStore)
+            new FileBasedSnapshotStoreFactory(actorScheduler, nodeId)
+                .createReceivableSnapshotStore(dataDirectory, partitionId);
+
+    backupService =
+        new BackupService(
+            nodeId,
+            partitionId,
+            1,
+            List.of(1, 2),
+            backupStore,
+            snapshotStore,
+            dataDirectory,
+            path -> path.toString().endsWith(".log"));
+    actorScheduler.submitActor(backupService);
+
+    final var raftPartition =
+        new RaftPartition(
+            PartitionId.from("raft", partitionId), null, dataDirectoryToRestore.toFile());
+    restoreService = new PartitionRestoreService(backupStore, raftPartition, Set.of(1, 2), nodeId);
+
+    journal =
+        SegmentedJournal.builder()
+            .withDirectory(dataDirectory.toFile())
+            .withName(raftPartition.name())
+            .build();
+  }
+
+  @AfterEach
+  void afterEach() {
+    backupService.close();
+    snapshotStore.close();
+  }
+
+  @Test
+  void shouldRestoreToDataDirectory() throws IOException {
+    // given
+    // write something to the journal
+    appendRecord(1, "data");
+    appendRecord(2, "data");
+    appendRecord(3, "data");
+    appendRecord(4, "checkpoint");
+    appendRecord(5, "data");
+    appendRecord(6, "data");
+
+    // take a snapshot
+    final var snapshot = takeSnapshot(2, 3);
+
+    // take backup
+    final long backupId = 2;
+    final var backup = takeBackup(backupId, 4);
+
+    // when
+    restoreService.restore(backupId).join();
+
+    // then
+    assertThat(dataDirectoryToRestore).isNotEmptyDirectory();
+
+    final Set<String> restoredSegmentFiles = getRegularFiles(dataDirectoryToRestore);
+    assertThat(restoredSegmentFiles)
+        .describedAs("All segment files has been restored")
+        .containsExactlyInAnyOrderElementsOf(backup.segments().names());
+
+    final Path snapshotsDirectory = dataDirectoryToRestore.resolve("snapshots");
+    assertThat(snapshotsDirectory.toFile())
+        .describedAs("Snapshot directory is created and snapshot checksum is restored.")
+        .exists()
+        .isDirectoryContaining("regex:.*/" + backup.descriptor().snapshotId().orElseThrow())
+        .isDirectoryContaining("regex:.*/" + snapshot.getId() + ".checksum");
+
+    final Set<String> expectedSnapshotFiles = getRegularFiles(snapshot.getPath());
+    final Set<String> restoredSnapshotFiles =
+        getRegularFiles(snapshotsDirectory.resolve(snapshot.getId()));
+    assertThat(restoredSnapshotFiles)
+        .describedAs("All snapshot files has been restored")
+        .containsExactlyInAnyOrderElementsOf(expectedSnapshotFiles);
+  }
+
+  @Test
+  void shouldFailToRestoreWhenCheckpointPositionNotFound() {
+    // given
+    // journal without record at checkpointPosition
+    appendRecord(1, "data");
+    appendRecord(2, "data");
+
+    takeSnapshot(1, 2);
+
+    final long backupId = 1;
+    takeBackup(backupId, 5);
+
+    // when - then
+    assertThat(restoreService.restore(backupId))
+        .failsWithin(Duration.ofSeconds(1))
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(IllegalStateException.class)
+        .withMessageContaining("Cannot find a record at checkpoint position");
+  }
+
+  @Test
+  void shouldFailToRestoreWhenSnapshotIsCorrupted() throws IOException {
+    // given
+    appendRecord(1, "data");
+    appendRecord(2, "data");
+    appendRecord(4, "checkpoint");
+
+    takeSnapshot(1, 2);
+
+    final long backupId = 2;
+    final var backup = takeBackup(backupId, 4);
+
+    // corrupt backup snapshot
+    Files.write(
+        backup.snapshot().namedFiles().get(SNAPSHOT_FILE_NAME),
+        "corrupted".getBytes(),
+        StandardOpenOption.APPEND);
+
+    // when - then
+    assertThat(restoreService.restore(backupId))
+        .failsWithin(Duration.ofSeconds(1))
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(CorruptedSnapshotException.class);
+  }
+
+  private Set<String> getRegularFiles(final Path directory) throws IOException {
+    final Set<String> restoredSegmentFiles;
+    try (final var stream = Files.list(directory)) {
+      restoredSegmentFiles =
+          stream
+              .filter(Files::isRegularFile)
+              .map(path -> path.getFileName().toString())
+              .collect(Collectors.toSet());
+    }
+    return restoredSegmentFiles;
+  }
+
+  private Backup takeBackup(final long backupId, final long checkpointPosition) {
+    backupStore.setBackupFuture(new CompletableFuture<>());
+    backupService.takeBackup(backupId, checkpointPosition);
+    return backupStore.getBackupFuture().join();
+  }
+
+  private void appendRecord(final long asqn, final String data) {
+    journal.append(asqn, new UnsafeBuffer(data.getBytes()));
+  }
+
+  private PersistedSnapshot takeSnapshot(final long index, final long lastWrittenPosition) {
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(index, 1, 1, 1).get();
+    transientSnapshot.take(
+        path -> {
+          try {
+            FileUtil.ensureDirectoryExists(path);
+
+            Files.write(
+                path.resolve(SNAPSHOT_FILE_NAME),
+                "This is the content".getBytes(),
+                CREATE_NEW,
+                StandardOpenOption.WRITE);
+          } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        });
+
+    return transientSnapshot.withLastFollowupEventPosition(lastWrittenPosition).persist().join();
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/restore/PartitionRestoreServiceTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/restore/PartitionRestoreServiceTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.snapshots.SnapshotException.CorruptedSnapshotException;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
 import io.camunda.zeebe.util.FileUtil;
+import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -212,7 +213,7 @@ class PartitionRestoreServiceTest {
   }
 
   private void appendRecord(final long asqn, final String data) {
-    journal.append(asqn, new UnsafeBuffer(data.getBytes()));
+    journal.append(asqn, new DirectBufferWriter().wrap(new UnsafeBuffer(data.getBytes())));
   }
 
   private PersistedSnapshot takeSnapshot(final long index, final long lastWrittenPosition) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/restore/TestRestorableBackupStore.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/restore/TestRestorableBackupStore.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.restore;
+
+import io.camunda.zeebe.backup.api.Backup;
+import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.api.NamedFileSet;
+import io.camunda.zeebe.backup.common.BackupImpl;
+import io.camunda.zeebe.backup.common.BackupStatusImpl;
+import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+final class TestRestorableBackupStore implements BackupStore {
+
+  final Map<BackupIdentifier, Backup> backups = new HashMap<>();
+  CompletableFuture<Backup> backupFuture;
+
+  CompletableFuture<Backup> getBackupFuture() {
+    return backupFuture;
+  }
+
+  void setBackupFuture(final CompletableFuture<Backup> backupFuture) {
+    this.backupFuture = backupFuture;
+  }
+
+  @Override
+  public CompletableFuture<Void> save(final Backup backup) {
+    backups.put(backup.id(), backup);
+    if (backupFuture != null) {
+      backupFuture.complete(backup);
+    }
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<BackupStatus> getStatus(final BackupIdentifier id) {
+    final var backup = backups.get(id);
+    final BackupStatus backupStatus;
+    if (backup != null) {
+      backupStatus =
+          new BackupStatusImpl(
+              id,
+              Optional.of(backup.descriptor()),
+              BackupStatusCode.COMPLETED,
+              Optional.empty(),
+              Optional.empty(),
+              Optional.empty());
+    } else {
+      backupStatus =
+          new BackupStatusImpl(
+              id,
+              Optional.empty(),
+              BackupStatusCode.DOES_NOT_EXIST,
+              Optional.empty(),
+              Optional.empty(),
+              Optional.empty());
+    }
+    return CompletableFuture.completedFuture(backupStatus);
+  }
+
+  @Override
+  public CompletableFuture<Void> delete(final BackupIdentifier id) {
+    return null;
+  }
+
+  @Override
+  public CompletableFuture<Backup> restore(final BackupIdentifier id, final Path targetFolder) {
+    final var backup = backups.get(id);
+    final var snapshotFiles = copyNamedFileSet(targetFolder, backup.snapshot().namedFiles());
+
+    final var segmentFiles = copyNamedFileSet(targetFolder, backup.segments().namedFiles());
+    final var restoredBackup = new BackupImpl(id, backup.descriptor(), snapshotFiles, segmentFiles);
+    return CompletableFuture.completedFuture(restoredBackup);
+  }
+
+  @Override
+  public CompletableFuture<BackupStatusCode> markFailed(
+      final BackupIdentifier id, final String failureReason) {
+    return null;
+  }
+
+  @Override
+  public CompletableFuture<Void> closeAsync() {
+    return null;
+  }
+
+  private NamedFileSet copyNamedFileSet(
+      final Path targetFolder, final Map<String, Path> snapshotFiles) {
+    return new NamedFileSetImpl(
+        snapshotFiles.keySet().stream()
+            .map(
+                name -> {
+                  try {
+                    Files.copy(snapshotFiles.get(name), targetFolder.resolve(name));
+                    return Map.entry(name, targetFolder.resolve(name));
+                  } catch (final IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue)));
+  }
+}

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/RestorableSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/RestorableSnapshotStore.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.snapshots;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+
+public interface RestorableSnapshotStore {
+
+  /**
+   * Restores the snapshot by moving the snapshotFiles to the snapshotDirectory.
+   *
+   * <p>WARN. Implementation of this method can be not thread safe.
+   *
+   * @param snapshotId
+   * @param snapshotFiles
+   * @throws IOException
+   */
+  void restore(String snapshotId, Map<String, Path> snapshotFiles) throws IOException;
+}

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotException.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotException.java
@@ -30,4 +30,10 @@ public class SnapshotException extends RuntimeException {
       super(message);
     }
   }
+
+  public static class CorruptedSnapshotException extends SnapshotException {
+    public CorruptedSnapshotException(final String message) {
+      super(message);
+    }
+  }
 }

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -727,6 +727,10 @@ public final class FileBasedSnapshotStore extends Actor
 
     Files.copy(checksumFile, checksumPath);
 
+    // Flush directory of this snapshot as well as root snapshot directory
+    FileUtil.flushDirectory(snapshotPath);
+    FileUtil.flushDirectory(snapshotsDirectory);
+
     LOGGER.info("Moved snapshot {} to {}", snapshotId, snapshotPath);
 
     // verify snapshot is not corrupted
@@ -743,7 +747,7 @@ public final class FileBasedSnapshotStore extends Actor
     try {
       Files.move(source, targetFilePath);
     } catch (final IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
   }
 }


### PR DESCRIPTION
## Description

This PR adds a `PartitionRestoreService` which can restore data of a single partition. This is expected to be used only during restore, which happens when other processes are not running. Hence it is not designed to be thread safe. This service will be used by a coordinator that manages restore of all partition owned by this broker. In addition, as this is a standalone class, we would be also able to use this in integration testing backups.

I have left some TODOs for adding more the verification after restoring. They will be added later, as this PR is already huge.

## Related issues

related #10263 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
