### PR TITLE
Add client integration tests for process instance modification

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ModifyProcessInstanceTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ModifyProcessInstanceTest.java
@@ -115,4 +115,35 @@ public class ModifyProcessInstanceTest {
                 "Expected to modify process instance but no process instance found with key '%d'",
                 processDefinitionKey));
   }
+
+  @Test
+  public void shouldRejectCommandForUnknownTerminationTarget() {
+    // given
+    final var processInstance =
+        CLIENT_RULE
+            .getClient()
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId2)
+            .latestVersion()
+            .send()
+            .join();
+
+    // when
+    final var command =
+        CLIENT_RULE
+            .getClient()
+            .newModifyProcessInstanceCommand(processInstance.getProcessInstanceKey())
+            .terminateElement(123)
+            .send();
+
+    // then
+    assertThatThrownBy(command::join)
+        .isInstanceOf(ClientStatusException.class)
+        .hasMessageContaining(
+            """
+            Expected to modify instance of process \
+            'process-shouldRejectCommandForUnknownTerminationTarget' but it contains one or \
+            more terminate instructions with an element instance that could not be found: \
+            '123'""");
+  }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ModifyProcessInstanceTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ModifyProcessInstanceTest.java
@@ -7,13 +7,17 @@
  */
 package io.camunda.zeebe.it.client.command;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
 import io.camunda.zeebe.client.api.command.ClientStatusException;
 import io.camunda.zeebe.it.util.GrpcClientRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -30,14 +34,65 @@ public class ModifyProcessInstanceTest {
 
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
   private String processId;
+  private String processId2;
   private long processDefinitionKey;
 
   @Before
   public void deploy() {
     processId = helper.getBpmnProcessId();
+    processId2 = helper.getBpmnProcessId();
     processDefinitionKey =
         CLIENT_RULE.deployProcess(
             Bpmn.createExecutableProcess(processId).startEvent().endEvent().done());
+    CLIENT_RULE.deployProcess(
+        Bpmn.createExecutableProcess(processId2)
+            .startEvent()
+            .userTask("A")
+            .parallelGateway()
+            .userTask("B")
+            .moveToLastGateway()
+            .userTask("C")
+            .endEvent()
+            .done());
+  }
+
+  @Test
+  public void shouldModifyExistingProcessInstance() {
+    // given
+    final var processInstance =
+        CLIENT_RULE
+            .getClient()
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId2)
+            .latestVersion()
+            .send()
+            .join();
+    final var processInstanceKey = processInstance.getProcessInstanceKey();
+
+    final var activatedUserTask =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .limit("A", ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .getFirst();
+
+    // when
+    final var command =
+        CLIENT_RULE
+            .getClient()
+            .newModifyProcessInstanceCommand(processInstanceKey)
+            .activateElement("B")
+            .withVariables(Map.of("foo", "bar"), "B")
+            .and()
+            .activateElement("C")
+            .withVariables(Map.of("fizz", "buzz"), "C")
+            .and()
+            .terminateElement(activatedUserTask.getKey())
+            .send();
+
+    // then
+    assertThatNoException()
+        .describedAs("Expect that modification command is not rejected")
+        .isThrownBy(command::join);
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This adds end-to-end integration tests for process instance modification, which showcases that the integration between the java client and the engine works as expected. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10010

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
