### PR TITLE
Verify broker can take backup

### DIFF
--- a/backup-stores/s3/pom.xml
+++ b/backup-stores/s3/pom.xml
@@ -14,18 +14,6 @@
 
   <name>Zeebe Backup Store for S3</name>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>bom</artifactId>
-        <version>2.17.275</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>io.camunda</groupId>

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -348,7 +348,7 @@ public final class S3BackupStore implements BackupStore {
         AsyncRequestBody.fromFile(filePath));
   }
 
-  private static S3AsyncClient buildClient(final S3BackupConfig config) {
+  public static S3AsyncClient buildClient(final S3BackupConfig config) {
     final var builder = S3AsyncClient.builder();
     config.endpoint().ifPresent(endpoint -> builder.endpointOverride(URI.create(endpoint)));
     config.region().ifPresent(region -> builder.region(Region.of(region)));

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionFactory.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.broker.system.partitions.impl.PartitionTransitionImpl;
 import io.camunda.zeebe.broker.system.partitions.impl.StateControllerImpl;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.BackupApiRequestHandlerStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.BackupServiceTransitionStep;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.BackupStoreTransitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.ExporterDirectorPartitionTransitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.InterPartitionCommandServiceStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.LogDeletionPartitionStartupStep;
@@ -73,6 +74,7 @@ final class PartitionFactory {
           new LogStreamPartitionTransitionStep(),
           new ZeebeDbPartitionTransitionStep(),
           new QueryServicePartitionTransitionStep(),
+          new BackupStoreTransitionStep(),
           new BackupServiceTransitionStep(),
           new InterPartitionCommandServiceStep(),
           new StreamProcessorTransitionStep(),

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -52,7 +52,7 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
       final var backupCfg = context.getBrokerCfg().getData().getBackup();
       if (backupCfg.getStore() == BackupStoreType.NONE) {
         // No backup store is installed. BackupManager can handle this case
-        context.setBackupManager(null);
+        context.setBackupStore(null);
         installed.complete(null);
       } else if (backupCfg.getStore() == BackupStoreType.S3) {
         installS3Store(context, backupCfg, installed);

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -65,7 +65,7 @@ public final class BackupApiRequestHandler
 
   @Override
   protected ActorFuture<Either<ErrorResponseWriter, BackupApiResponseWriter>> handleAsync(
-      final int partitionId,
+      final int requestStreamId,
       final long requestId,
       final BackupApiRequestReader requestReader,
       final BackupApiResponseWriter responseWriter,
@@ -73,7 +73,8 @@ public final class BackupApiRequestHandler
 
     return switch (requestReader.type()) {
       case TAKE_BACKUP -> CompletableActorFuture.completed(
-          handleTakeBackupRequest(requestReader, responseWriter, errorWriter));
+          handleTakeBackupRequest(
+              requestStreamId, requestId, requestReader, responseWriter, errorWriter));
       case QUERY_STATUS -> handleQueryStatusHandler(requestReader, responseWriter, errorWriter);
       default -> CompletableActorFuture.completed(
           unknownRequest(errorWriter, requestReader.getMessageDecoder().type()));
@@ -81,6 +82,8 @@ public final class BackupApiRequestHandler
   }
 
   private Either<ErrorResponseWriter, BackupApiResponseWriter> handleTakeBackupRequest(
+      final int requestStreamId,
+      final long requestId,
       final BackupApiRequestReader requestReader,
       final BackupApiResponseWriter responseWriter,
       final ErrorResponseWriter errorWriter) {
@@ -92,7 +95,9 @@ public final class BackupApiRequestHandler
         new RecordMetadata()
             .recordType(RecordType.COMMAND)
             .valueType(ValueType.CHECKPOINT)
-            .intent(CheckpointIntent.CREATE);
+            .intent(CheckpointIntent.CREATE)
+            .requestId(requestId)
+            .requestStreamId(requestStreamId);
     final CheckpointRecord checkpointRecord =
         new CheckpointRecord().setCheckpointId(requestReader.backupId());
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiResponseWriter.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.broker.transport.backupapi;
 
 import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.ResponseWriter;
 import io.camunda.zeebe.protocol.impl.encoding.BackupStatusResponse;
-import io.camunda.zeebe.protocol.management.BackupStatusResponseEncoder;
 import io.camunda.zeebe.protocol.management.MessageHeaderEncoder;
 import io.camunda.zeebe.transport.ServerOutput;
 import io.camunda.zeebe.transport.impl.ServerResponseImpl;
@@ -55,7 +54,7 @@ public final class BackupApiResponseWriter implements ResponseWriter {
   @Override
   public int getLength() {
     if (hasResponse) {
-      return MessageHeaderEncoder.ENCODED_LENGTH + BackupStatusResponseEncoder.BLOCK_LENGTH;
+      return MessageHeaderEncoder.ENCODED_LENGTH + status.getLength();
     } else {
       return 0;
     }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupStatusRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupStatusRequest.java
@@ -11,7 +11,8 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerRequest;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.camunda.zeebe.protocol.impl.encoding.BackupRequest;
 import io.camunda.zeebe.protocol.impl.encoding.BackupStatusResponse;
-import io.camunda.zeebe.protocol.management.BackupRequestEncoder;
+import io.camunda.zeebe.protocol.management.BackupRequestType;
+import io.camunda.zeebe.protocol.management.BackupStatusResponseDecoder;
 import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
@@ -23,7 +24,8 @@ public class BackupStatusRequest extends BrokerRequest<BackupStatusResponse> {
   protected final BackupStatusResponse response = new BackupStatusResponse();
 
   public BackupStatusRequest() {
-    super(BackupRequestEncoder.SCHEMA_ID, BackupRequestEncoder.TEMPLATE_ID);
+    super(BackupStatusResponseDecoder.SCHEMA_ID, BackupStatusResponseDecoder.TEMPLATE_ID);
+    request.setType(BackupRequestType.QUERY_STATUS);
   }
 
   public long getBackupId() {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BrokerBackupRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BrokerBackupRequest.java
@@ -15,8 +15,8 @@ import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.camunda.zeebe.protocol.impl.encoding.BackupRequest;
 import io.camunda.zeebe.protocol.impl.encoding.ExecuteCommandResponse;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
-import io.camunda.zeebe.protocol.management.BackupRequestEncoder;
 import io.camunda.zeebe.protocol.management.BackupRequestType;
+import io.camunda.zeebe.protocol.record.ExecuteCommandResponseDecoder;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
@@ -32,7 +32,7 @@ public final class BrokerBackupRequest extends BrokerRequest<CheckpointRecord> {
   final ExecuteCommandResponse response = new ExecuteCommandResponse();
 
   public BrokerBackupRequest() {
-    super(BackupRequestEncoder.SCHEMA_ID, BackupRequestEncoder.TEMPLATE_ID);
+    super(ExecuteCommandResponseDecoder.SCHEMA_ID, ExecuteCommandResponseDecoder.TEMPLATE_ID);
     request.setType(BackupRequestType.TAKE_BACKUP);
   }
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/PartitionBackupDescriptor.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/PartitionBackupDescriptor.java
@@ -7,5 +7,5 @@
  */
 package io.camunda.zeebe.gateway.admin.backup;
 
-record PartitionBackupDescriptor(
+public record PartitionBackupDescriptor(
     String snapshotId, long checkpointPosition, int brokerId, String brokerVersion) {}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/PartitionBackupStatus.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/PartitionBackupStatus.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.protocol.impl.encoding.BackupStatusResponse;
 import io.camunda.zeebe.protocol.management.BackupStatusCode;
 import java.util.Optional;
 
-record PartitionBackupStatus(
+public record PartitionBackupStatus(
     int partitionId,
     BackupStatusCode status,
     Optional<PartitionBackupDescriptor> description,

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -112,6 +112,7 @@
     <version.jnr-posix>3.1.15</version.jnr-posix>
     <version.zpt>8.0.6</version.zpt>
     <version.feign>11.9.1</version.feign>
+    <version.awssdk>2.17.275</version.awssdk>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.1.0</plugin.version.antrun>
@@ -985,6 +986,15 @@
         <artifactId>cron-utils</artifactId>
         <version>${version.cron-utils}</version>
       </dependency>
+
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${version.awssdk}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -246,6 +246,26 @@
     </dependency>
 
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Sad workaround for https://github.com/testcontainers/testcontainers-java/issues/4279 -->
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
+      <version>1.12.304</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -229,6 +229,24 @@
 
     <dependency>
       <groupId>org.testcontainers</groupId>
+      <artifactId>localstack</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-backup-store-s3</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupIT.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.backup.s3.S3BackupStore;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.gateway.admin.backup.BackupRequestHandler;
+import io.camunda.zeebe.gateway.admin.backup.BackupStatus;
+import io.camunda.zeebe.it.clustering.ClusteringRuleExtension;
+import io.camunda.zeebe.it.util.GrpcClientRule;
+import io.camunda.zeebe.protocol.management.BackupStatusCode;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer.Service;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class BackupIT {
+  @Container
+  private static final LocalStackContainer S3 =
+      new LocalStackContainer(DockerImageName.parse("localstack/localstack:0.14.5"))
+          .withServices(Service.S3);
+
+  private GrpcClientRule client;
+
+  @RegisterExtension
+  private final ClusteringRuleExtension clusteringRule =
+      new ClusteringRuleExtension(1, 1, 1, this::configureBackupStore);
+
+  private BackupRequestHandler backupRequestHandler;
+
+  private void configureBackupStore(final BrokerCfg config) {
+    final var backupConfig = config.getData().getBackup();
+    backupConfig.setStore(BackupStoreType.S3);
+
+    final var s3Config = backupConfig.getS3();
+    final String bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    s3Config.setBucketName(bucketName);
+    s3Config.setEndpoint(S3.getEndpointOverride(Service.S3).toString());
+    s3Config.setRegion(S3.getRegion());
+    s3Config.setAccessKey(S3.getAccessKey());
+    s3Config.setSecretKey(S3.getSecretKey());
+
+    // Create bucket before for storing backups
+    final var s3ClientConfig =
+        io.camunda.zeebe.backup.s3.S3BackupConfig.from(
+            bucketName,
+            s3Config.getEndpoint(),
+            S3.getRegion(),
+            S3.getAccessKey(),
+            S3.getSecretKey());
+    try (final var s3Client = S3BackupStore.buildClient(s3ClientConfig)) {
+      s3Client.createBucket(builder -> builder.bucket(bucketName).build()).join();
+    }
+  }
+
+  @BeforeEach
+  void setup() {
+    client = new GrpcClientRule(clusteringRule.getClient());
+    backupRequestHandler = new BackupRequestHandler(clusteringRule.getGateway().getBrokerClient());
+  }
+
+  @Test
+  void shouldBackup() {
+    // given
+    client.createSingleJob("test");
+
+    final long backupId = 2;
+
+    // when
+    backup(backupId);
+
+    // then
+    Awaitility.await("Backup must be completed.")
+        .timeout(Duration.ofMinutes(2))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var status = getBackupStatus(backupId);
+              assertThat(status.status()).isEqualTo(BackupStatusCode.COMPLETED);
+              assertThat(status.backupId()).isEqualTo(backupId);
+              assertThat(status.partitions()).hasSize(clusteringRule.getPartitionCount());
+            });
+  }
+
+  private BackupStatus getBackupStatus(final long backupId)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    // TODO: This should be replaced by the Gateway rest api when it is available
+    return backupRequestHandler.getStatus(backupId).toCompletableFuture().get(30, TimeUnit.SECONDS);
+  }
+
+  private void backup(final long backupId) {
+    // TODO: This should be replaced by the Gateway rest api when it is available
+    assertThat(backupRequestHandler.takeBackup(backupId).toCompletableFuture())
+        .succeedsWithin(Duration.ofSeconds(30));
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -102,7 +102,7 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-public final class ClusteringRule extends ExternalResource {
+public class ClusteringRule extends ExternalResource {
 
   private static final AtomicLong CLUSTER_COUNT = new AtomicLong(0);
   private static final boolean ENABLE_DEBUG_EXPORTER = false;
@@ -360,7 +360,7 @@ public final class ClusteringRule extends ExternalResource {
     return brokerCfg;
   }
 
-  private File getBrokerBase(final int nodeId) {
+  protected File getBrokerBase(final int nodeId) {
     final var base = new File(temporaryFolder.getRoot(), String.valueOf(nodeId));
     if (!base.exists()) {
       base.mkdir();
@@ -682,6 +682,10 @@ public final class ClusteringRule extends ExternalResource {
 
   public InetSocketAddress getGatewayAddress() {
     return gateway.getGatewayCfg().getNetwork().toSocketAddress();
+  }
+
+  public Gateway getGateway() {
+    return gateway;
   }
 
   public ZeebeClient getClient() {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRuleExtension.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRuleExtension.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.util.FileUtil;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * This is a wrapper over {@link ClusteringRule}. NOTE: {@link
+ * io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher} is not available when using this
+ * extension.
+ */
+public class ClusteringRuleExtension extends ClusteringRule
+    implements BeforeEachCallback, AfterEachCallback {
+
+  private Path tempDir;
+
+  public ClusteringRuleExtension(
+      final int partitionCount,
+      final int replicationFactor,
+      final int clusterSize,
+      final Consumer<BrokerCfg> configurator) {
+    super(partitionCount, replicationFactor, clusterSize, configurator);
+  }
+
+  @Override
+  public void afterEach(final ExtensionContext context) throws Exception {
+    FileUtil.deleteFolderIfExists(tempDir);
+    super.after();
+  }
+
+  @Override
+  public void beforeEach(final ExtensionContext context) throws Exception {
+    tempDir = Files.createTempDirectory("clustered-tests");
+    super.before();
+  }
+
+  @Override
+  protected File getBrokerBase(final int nodeId) {
+    final Path base;
+    try {
+      base = Files.createDirectory(tempDir.resolve(String.valueOf(nodeId)));
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    return base.toFile();
+  }
+
+  public ClusteringRule getCluster() {
+    return this;
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/GrpcClientRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/GrpcClientRule.java
@@ -69,6 +69,15 @@ public final class GrpcClientRule extends ExternalResource {
     this.configurator = configurator;
   }
 
+  /**
+   * This is a hacky way to allow us to use this class in {@link
+   * io.camunda.zeebe.it.clustering.ClusteringRuleExtension}
+   */
+  public GrpcClientRule(final ZeebeClient client) {
+    this.client = client;
+    configurator = config -> {};
+  }
+
   @Override
   public void before() {
     startTime = System.currentTimeMillis();

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -66,6 +66,16 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <dep>com.amazonaws:aws-java-sdk-core</dep>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
## Description

- Add a simple test to verify broker can take backup.
- Fixed several minor bugs that were found with this test. 

This PR only adds a basic test to verify backup. More scenarios should be tested later.

Also added a Junit5 extension to replace `ClusteringRule`. Now it is a wrapper around `ClusteringRule`. Once all tests have been migrated to junit5, we would be able to replace it.

## Related issues

closes #10262 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
