### PR TITLE
refactor(snapshots): remove unnecessary close in snapshot

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
@@ -166,9 +166,6 @@ public class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapshot {
   }
 
   @Override
-  public void close() {}
-
-  @Override
   public long index() {
     return index;
   }

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshot.java
@@ -8,11 +8,10 @@
 package io.camunda.zeebe.snapshots;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.util.CloseableSilently;
 import java.nio.file.Path;
 
 /** Represents a snapshot, which was persisted at the {@link PersistedSnapshotStore}. */
-public interface PersistedSnapshot extends CloseableSilently {
+public interface PersistedSnapshot {
 
   /**
    * Returns the snapshot format version.

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
@@ -161,11 +161,6 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
   }
 
   @Override
-  public void close() {
-    // nothing to be done
-  }
-
-  @Override
   public int hashCode() {
     int result = getDirectory().hashCode();
     result = 31 * result + checksumFile.hashCode();


### PR DESCRIPTION
## Description

`PersistedSnapshot` implemented `CloseableSilently`. This was creating warnings in several places that a snapshot is not used with try-with-resources. But all implementations of `close` did nothing. There is no need to close a snapshot as it is not holding any resources.

