### PR TITLE
Resolve OutOfDirectMemory when running Test in loop

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
@@ -13,6 +13,8 @@ import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTI
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -38,12 +40,14 @@ import io.camunda.zeebe.engine.util.StreamPlatformExtension;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
@@ -247,8 +251,7 @@ public class ProcessingScheduleServiceTest {
     final var batchWriter = spy(syncLogStream.newLogStreamBatchWriter());
 
     when(syncLogStream.getAsyncLogStream()).thenReturn(logStream);
-    when(logStream.newLogStreamBatchWriter())
-        .thenReturn(CompletableActorFuture.completed(batchWriter));
+    doReturn(CompletableActorFuture.completed(batchWriter)).when(logStream).newLogStreamBatchWriter();
     streamPlatform
         .withRecordProcessors(List.of(dummyProcessorSpy))
         .buildStreamProcessor(syncLogStream, true);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
@@ -242,7 +242,7 @@ public class ProcessingScheduleServiceTest {
   void shouldPreserveOrderingOfWritesEvenWithRetries() {
     // given
     final var dummyProcessorSpy = spy(dummyProcessor);
-    final var syncLogStream = spy(streamPlatform.createLogStream("stream", 1));
+    final var syncLogStream = spy(streamPlatform.getLogStream("stream-1"));
     final var logStream = spy(syncLogStream.getAsyncLogStream());
     final var batchWriter = spy(syncLogStream.newLogStreamBatchWriter());
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
@@ -79,6 +79,8 @@ public class ProcessingScheduleServiceTest {
   public void clean() {
     dummyProcessor.continueReplay();
     dummyProcessor.continueProcessing();
+    streamPlatform = null;
+
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
@@ -13,7 +13,6 @@ import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTI
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
@@ -40,14 +39,12 @@ import io.camunda.zeebe.engine.util.StreamPlatformExtension;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
@@ -84,7 +81,6 @@ public class ProcessingScheduleServiceTest {
     dummyProcessor.continueReplay();
     dummyProcessor.continueProcessing();
     streamPlatform = null;
-
   }
 
   @Test
@@ -251,7 +247,9 @@ public class ProcessingScheduleServiceTest {
     final var batchWriter = spy(syncLogStream.newLogStreamBatchWriter());
 
     when(syncLogStream.getAsyncLogStream()).thenReturn(logStream);
-    doReturn(CompletableActorFuture.completed(batchWriter)).when(logStream).newLogStreamBatchWriter();
+    doReturn(CompletableActorFuture.completed(batchWriter))
+        .when(logStream)
+        .newLogStreamBatchWriter();
     streamPlatform
         .withRecordProcessors(List.of(dummyProcessorSpy))
         .buildStreamProcessor(syncLogStream, true);

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
@@ -107,6 +107,7 @@ public final class StreamPlatform {
         .thenReturn(EmptyProcessingResult.INSTANCE);
     when(defaultRecordProcessor.accepts(any())).thenReturn(true);
     recordProcessors = List.of(defaultRecordProcessor);
+    closeables.add(() -> recordProcessors.clear());
   }
 
   public SynchronousLogStream createLogStream(final String name, final int partitionId) {
@@ -135,8 +136,7 @@ public final class StreamPlatform {
 
     final LogContext logContext = LogContext.createLogContext(logStream);
     logContextMap.put(name, logContext);
-    closeables.add(logContext);
-    closeables.add(() -> logContextMap.remove(name));
+    closeables.add(() -> logContextMap.remove(name).close());
     return logStream;
   }
 
@@ -253,7 +253,7 @@ public final class StreamPlatform {
     final ProcessorContext processorContext =
         ProcessorContext.createStreamContext(streamProcessor, zeebeDb, storage, snapshot);
     streamContextMap.put(logName, processorContext);
-    closeables.add(processorContext);
+    closeables.add(() -> streamContextMap.remove(logName).close());
 
     return streamProcessor;
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatformExtension.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatformExtension.java
@@ -124,6 +124,7 @@ public class StreamPlatformExtension implements BeforeEachCallback {
       Collections.reverse(closables);
       CloseHelper.quietCloseAll(closables);
       closables.clear();
+      streamPlatform = null;
     }
   }
 }

--- a/util/src/main/java/io/camunda/zeebe/util/allocation/DirectBufferAllocator.java
+++ b/util/src/main/java/io/camunda/zeebe/util/allocation/DirectBufferAllocator.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.util.allocation;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicLong;
+import org.agrona.BufferUtil;
 
 public final class DirectBufferAllocator implements BufferAllocator {
   private static final AtomicLong ALLOCATED_MEMORY = new AtomicLong();
@@ -26,6 +27,7 @@ public final class DirectBufferAllocator implements BufferAllocator {
 
   private static void onFree(final AllocatedDirectBuffer buffer) {
     ALLOCATED_MEMORY.addAndGet(-buffer.capacity());
+    BufferUtil.free(buffer.rawBuffer);
   }
 
   public static long getAllocatedMemoryInKb() {


### PR DESCRIPTION
## Description

Running `shouldPreserveOrderingOfWritesEvenWithRetries` in a loop ended quite quick in a OutOfDirectMemory error.

One issue I found was that the spy creation and mocking, created new resources which haven't been closed. More information here https://stackoverflow.com/a/29394497/2165134

Furthermore, the Dispatcher buffers are not freed. This was a decision a while ago, because we don't wanted to rely on the hacky free method. But this is not also supported by Agrona, so we should think about it again. Otherwise freeing happens only in the finalizer (on gc) which is not 100% guaranteed to be called. This is an issue when running tests in a loop OR when we have many role transitions (this can also lead to oom). Happy to discuss this further @npepinpe 

Furthermore, I closed and freed some other resources in the extension etc.


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related https://github.com/camunda/zeebe/issues/10306#issuecomment-1243624970

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
