### PR TITLE
Disable backup by feature flag

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -73,7 +73,8 @@ public final class SystemContext {
 
     validateClusterConfig(cluster);
 
-    validateDataConfig(brokerCfg.getData());
+    validateDataConfig(
+        brokerCfg.getData(), brokerCfg.getExperimental().getFeatures().isEnableBackup());
 
     validateExperimentalConfigs(cluster, brokerCfg.getExperimental());
 
@@ -137,7 +138,7 @@ public final class SystemContext {
     }
   }
 
-  private void validateDataConfig(final DataCfg dataCfg) {
+  private void validateDataConfig(final DataCfg dataCfg, final boolean backupFeatureEnabled) {
     final var snapshotPeriod = dataCfg.getSnapshotPeriod();
     if (snapshotPeriod.isNegative() || snapshotPeriod.minus(MINIMUM_SNAPSHOT_PERIOD).isNegative()) {
       throw new IllegalArgumentException(String.format(SNAPSHOT_PERIOD_ERROR_MSG, snapshotPeriod));
@@ -167,7 +168,9 @@ public final class SystemContext {
               diskUsageCommandWatermark, diskUsageReplicationWatermark));
     }
 
-    validateBackupCfg(dataCfg.getBackup());
+    if (backupFeatureEnabled) {
+      validateBackupCfg(dataCfg.getBackup());
+    }
   }
 
   private void validateBackupCfg(final BackupStoreCfg backup) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
@@ -32,6 +32,7 @@ public final class FeatureFlagsCfg {
 
   private boolean enableYieldingDueDateChecker = DEFAULT_SETTINGS.yieldingDueDateChecker();
   private boolean enableActorMetrics = DEFAULT_SETTINGS.enableActorMetrics();
+  private boolean enableBackup = DEFAULT_SETTINGS.enableBackup();
 
   public boolean isEnableYieldingDueDateChecker() {
     return enableYieldingDueDateChecker;
@@ -49,8 +50,17 @@ public final class FeatureFlagsCfg {
     this.enableActorMetrics = enableActorMetrics;
   }
 
+  public boolean isEnableBackup() {
+    return enableBackup;
+  }
+
+  public void setEnableBackup(final boolean enableBackup) {
+    this.enableBackup = enableBackup;
+  }
+
   public FeatureFlags toFeatureFlags() {
-    return new FeatureFlags(enableYieldingDueDateChecker, enableActorMetrics /*, enableFoo*/);
+    return new FeatureFlags(
+        enableYieldingDueDateChecker, enableActorMetrics, enableBackup /*, enableFoo*/);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStep.java
@@ -69,7 +69,8 @@ public final class BackupApiRequestHandlerStep implements PartitionTransitionSte
             context.getGatewayBrokerTransport(),
             logStreamRecordWriter,
             context.getBackupManager(),
-            context.getPartitionId());
+            context.getPartitionId(),
+            context.getBrokerCfg().getExperimental().getFeatures().isEnableBackup());
     context.getActorSchedulingService().submitActor(requestHandler).onComplete(installed);
     installed.onComplete(
         (ignore, error) -> {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
@@ -71,9 +71,7 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
       backupManagerInstalled.onComplete(
           (ignore, error) -> {
             if (error == null) {
-              if (isBackupFeatureEnabled) {
-                installCheckpointProcessor(context, context.getBackupManager());
-              }
+              installCheckpointProcessor(context, context.getBackupManager());
               installed.complete(null);
             } else {
               installed.completeExceptionally(error);

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -49,8 +49,11 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
     if (shouldInstallOnTransition(context.getCurrentRole(), targetRole)
         || (context.getBackupStore() == null && targetRole != Role.INACTIVE)) {
 
+      final boolean isBackupFeatureDisabled =
+          !context.getBrokerCfg().getExperimental().getFeatures().isEnableBackup();
+
       final var backupCfg = context.getBrokerCfg().getData().getBackup();
-      if (backupCfg.getStore() == BackupStoreType.NONE) {
+      if (backupCfg.getStore() == BackupStoreType.NONE || isBackupFeatureDisabled) {
         // No backup store is installed. BackupManager can handle this case
         context.setBackupStore(null);
         installed.complete(null);

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -401,6 +401,7 @@ final class SystemContextTest {
   void shouldThrowExceptionWhenS3BucketIsNotProvided() {
     // given
     final var brokerCfg = new BrokerCfg();
+    brokerCfg.getExperimental().getFeatures().setEnableBackup(true);
     brokerCfg.getData().getBackup().setStore(BackupStoreType.S3);
 
     // when - then
@@ -415,6 +416,7 @@ final class SystemContextTest {
   void shouldThrowExceptionWhenS3IsNotConfigured() {
     // given
     final var brokerCfg = new BrokerCfg();
+    brokerCfg.getExperimental().getFeatures().setEnableBackup(true);
     final var backupCfg = brokerCfg.getData().getBackup();
     backupCfg.setStore(BackupStoreType.S3);
     backupCfg.getS3().setBucketName("bucket");

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupApiRequestHandlerStepTest.java
@@ -9,10 +9,12 @@ package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.TestPartitionTransitionContext;
 import io.camunda.zeebe.broker.transport.backupapi.BackupApiRequestHandler;
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -42,6 +45,9 @@ final class BackupApiRequestHandlerStepTest {
 
   @Mock ActorSchedulingService actorSchedulingService;
 
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  BrokerCfg brokerCfg;
+
   private final TestPartitionTransitionContext transitionContext =
       new TestPartitionTransitionContext();
   private BackupApiRequestHandlerStep step;
@@ -53,6 +59,9 @@ final class BackupApiRequestHandlerStepTest {
     transitionContext.setConcurrencyControl(new TestConcurrencyControl());
     transitionContext.setDiskSpaceUsageMonitor(diskSpaceUsageMonitor);
     transitionContext.setActorSchedulingService(actorSchedulingService);
+    transitionContext.setBrokerCfg(brokerCfg);
+
+    lenient().when(brokerCfg.getExperimental().getFeatures().isEnableBackup()).thenReturn(true);
 
     step = new BackupApiRequestHandlerStep();
   }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStepTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -49,7 +50,8 @@ class BackupServiceTransitionStepTest {
   @Mock ActorSchedulingService actorSchedulingService;
   @Mock BackupStore backupStore;
 
-  @Mock BrokerCfg brokerCfg;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  BrokerCfg brokerCfg;
 
   @Mock ClusterCfg clusterCfg;
 
@@ -64,8 +66,9 @@ class BackupServiceTransitionStepTest {
     transitionContext.setBrokerCfg(brokerCfg);
     transitionContext.setRaftPartition(raftPartition);
 
-    lenient().when(brokerCfg.getCluster()).thenReturn(clusterCfg);
-    lenient().when(clusterCfg.getPartitionsCount()).thenReturn(3);
+    lenient().when(brokerCfg.getExperimental().getFeatures().isEnableBackup()).thenReturn(true);
+
+    lenient().when(brokerCfg.getCluster().getPartitionsCount()).thenReturn(3);
     lenient()
         .when(raftPartition.members())
         .thenReturn(Set.of(MemberId.from("1"), MemberId.from("2")));

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStepTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -39,7 +40,10 @@ class BackupStoreTransitionStepTest {
 
   private static final TestConcurrencyControl TEST_CONCURRENCY_CONTROL =
       new TestConcurrencyControl();
-  @Mock BrokerCfg brokerCfg;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  BrokerCfg brokerCfg;
+
   @Mock DataCfg dataCfg;
   @Mock BackupStore backupStorePreviousRole;
 
@@ -51,6 +55,8 @@ class BackupStoreTransitionStepTest {
   void setup() {
     transitionContext.setConcurrencyControl(TEST_CONCURRENCY_CONTROL);
     transitionContext.setBrokerCfg(brokerCfg);
+
+    lenient().when(brokerCfg.getExperimental().getFeatures().isEnableBackup()).thenReturn(true);
 
     step = new BackupStoreTransitionStep();
   }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStepTest.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
@@ -94,14 +95,13 @@ class BackupStoreTransitionStepTest {
         .isNotEqualTo(backupStorePreviousRole);
   }
 
-  @ParameterizedTest
-  @ArgumentsSource(TransitionsThatShouldInstallService.class)
+  @Test
   // This test fails if you have AWS configured locally (eg:- ~/.aws/)
-  void shouldFailToInstallWhenS3ConfigurationsAreNotAvailable(
-      final Role currentRole, final Role targetRole) {
+  void shouldFailToInstallWhenS3ConfigurationsAreNotAvailable() {
     // given
-    setUpCurrentRole(currentRole);
+    setUpCurrentRole(null);
     configureStore(BackupStoreType.S3, new S3BackupStoreConfig());
+    final var targetRole = Role.LEADER;
 
     // when
     step.prepareTransition(transitionContext, 1, targetRole).join();

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -64,7 +64,7 @@ final class BackupApiRequestHandlerTest {
 
   @BeforeEach
   void setup() {
-    handler = new BackupApiRequestHandler(transport, logStreamRecordWriter, backupManager, 1);
+    handler = new BackupApiRequestHandler(transport, logStreamRecordWriter, backupManager, 1, true);
     scheduler.submitActor(handler);
     scheduler.workUntilDone();
 

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -800,3 +800,8 @@
         # Controls whether to collect metrics about actor usage such as actor job execution latencies
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEACTORMETRICS
         # enableActorMetrics: false
+
+        # When this feature is disabled, user requests to take backup or query backup will be rejected.
+        # To allow backups, enable this flag and configure zeebe.broker.data.backup.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEBACKUP
+        # enableBackup: false

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -738,3 +738,8 @@
         # Controls whether to collect metrics about actor usage such as actor job execution latencies
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEACTORMETRICS
         # enableActorMetrics: false
+
+        # When this feature is disabled, user requests to take backup or query backup will be rejected.
+        # To allow backups, enable this flag and configure zeebe.broker.data.backup.
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEBACKUP
+        # enableBackup: false

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupIT.java
@@ -48,6 +48,8 @@ class BackupIT {
   private BackupRequestHandler backupRequestHandler;
 
   private void configureBackupStore(final BrokerCfg config) {
+    config.getExperimental().getFeatures().setEnableBackup(true);
+
     final var backupConfig = config.getData().getBackup();
     backupConfig.setStore(BackupStoreType.S3);
 

--- a/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
+++ b/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
@@ -11,7 +11,9 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 public record FeatureFlags(
-    boolean yieldingDueDateChecker, boolean enableActorMetrics /*, boolean foo*/) {
+    boolean yieldingDueDateChecker,
+    boolean enableActorMetrics,
+    boolean enableBackup /*, boolean foo*/) {
 
   /* To add a new feature toggle, please follow these steps:
    *
@@ -43,8 +45,11 @@ public record FeatureFlags(
   private static final boolean YIELDING_DUE_DATE_CHECKER = false;
   private static final boolean ENABLE_ACTOR_METRICS = false;
 
+  private static final boolean ENABLE_BACKUP = false;
+
   public static FeatureFlags createDefault() {
-    return new FeatureFlags(YIELDING_DUE_DATE_CHECKER, ENABLE_ACTOR_METRICS /*, FOO_DEFAULT*/);
+    return new FeatureFlags(
+        YIELDING_DUE_DATE_CHECKER, ENABLE_ACTOR_METRICS, ENABLE_BACKUP /*, FOO_DEFAULT*/);
   }
 
   /**
@@ -54,7 +59,9 @@ public record FeatureFlags(
    */
   public static FeatureFlags createDefaultForTests() {
     return new FeatureFlags(
-        /* YIELDING_DUE_DATE_CHECKER*/ true, /* ENABLE_ACTOR_METRICS */ false /*, FOO_DEFAULT*/);
+        true, /* YIELDING_DUE_DATE_CHECKER*/
+        false, /* ENABLE_ACTOR_METRICS */
+        true /* ENABLE_BACKUP */ /*, FOO_DEFAULT*/);
   }
 
   @Override

--- a/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-public class FeatureFlagsTest {
+class FeatureFlagsTest {
 
   @Test
   void testDefaultValues() {
@@ -20,6 +20,8 @@ public class FeatureFlagsTest {
 
     // then
     assertThat(sut.yieldingDueDateChecker()).isFalse();
+    assertThat(sut.enableActorMetrics()).isFalse();
+    assertThat(sut.enableBackup()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## Description

Since hot backup is a new feature, we release it with the feature disabled by default. When disabled, most of the backup related code will be disabled:
- Backup store is not installed
- `CheckpointRecordProcessor` is not injected to `StreamProcessor`.  So all checkpoint records will be skipped.
- BackupApiRequestHandler  rejects all backup requests from the gateway with an error
- Backup configuration is not validated on startup

Note:- Disabling checkpoint record processor is a bit risky. If you run the cluster with backup enabled, then restart with disabled, and then restart with enabled, the first checkpoint that is created after the restart can be inconsistent. As a result the backup will also be inconsistent. Not disabling the `CheckpointRecordProcessor` would also make this feature flag not very useful. Any errors in this processor can cause StreamProcessor to fail and thus not able to process anything else. So considering the risk of having unhealthy non-recoverable clusters in production due to a bug in this, I would suggest to allow disabling the processor.

The feature flag does not disable backup handling in the gateway. The actuators for the backup api can be turned off independently of this.

## Related issues

closes #10369 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x ] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
