### PR TITLE
Accept Process Instance cancelling and new deployment when backpressure is high

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backpressure/CommandRateLimiter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backpressure/CommandRateLimiter.java
@@ -9,9 +9,11 @@ package io.camunda.zeebe.broker.transport.backpressure;
 
 import com.netflix.concurrency.limits.limiter.AbstractLimiter;
 import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import java.util.EnumSet;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -26,7 +28,13 @@ public final class CommandRateLimiter extends AbstractLimiter<Intent>
   private static final Logger LOG =
       LoggerFactory.getLogger("io.camunda.zeebe.broker.transport.backpressure");
   private static final Set<? extends Intent> WHITE_LISTED_COMMANDS =
-      EnumSet.of(JobIntent.COMPLETE, JobIntent.FAIL);
+      Set.of(
+          JobIntent.COMPLETE,
+          JobIntent.FAIL,
+          ProcessInstanceIntent.CANCEL,
+          DeploymentIntent.CREATE,
+          DeploymentIntent.DISTRIBUTE,
+          DeploymentDistributionIntent.COMPLETE);
   private final Map<ListenerId, Listener> responseListeners = new ConcurrentHashMap<>();
   private final int partitionId;
   private final BackpressureMetrics metrics = new BackpressureMetrics();

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/backpressure/CommandRateLimiterTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/backpressure/CommandRateLimiterTest.java
@@ -14,9 +14,9 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import java.util.stream.IntStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public final class CommandRateLimiterTest {
+class CommandRateLimiterTest {
 
   private static final int INITIAL_LIMIT = 5;
   private final SettableLimit limit = new SettableLimit(INITIAL_LIMIT);
@@ -25,12 +25,12 @@ public final class CommandRateLimiterTest {
   private final Intent context = ProcessInstanceCreationIntent.CREATE;
 
   @Test
-  public void shouldAcquire() {
+  void shouldAcquire() {
     assertThat(rateLimiter.tryAcquire(0, 1, context)).isTrue();
   }
 
   @Test
-  public void shouldNotAcquireAfterLimit() {
+  void shouldNotAcquireAfterLimit() {
     // given
     IntStream.range(0, limit.getLimit())
         .forEach(i -> assertThat(rateLimiter.tryAcquire(0, 1, context)).isTrue());
@@ -39,7 +39,7 @@ public final class CommandRateLimiterTest {
   }
 
   @Test
-  public void shouldCompleteRequestOnResponse() {
+  void shouldCompleteRequestOnResponse() {
     // given
     IntStream.range(0, limit.getLimit())
         .forEach(i -> assertThat(rateLimiter.tryAcquire(0, i, context)));
@@ -53,7 +53,7 @@ public final class CommandRateLimiterTest {
   }
 
   @Test
-  public void shouldCompleteAllRequests() {
+  void shouldCompleteAllRequests() {
     // given
     IntStream.range(0, limit.getLimit())
         .forEach(i -> assertThat(rateLimiter.tryAcquire(0, i, context)));
@@ -69,7 +69,7 @@ public final class CommandRateLimiterTest {
   }
 
   @Test
-  public void shouldAcquireWhenJobCompleteCommandAfterLimit() {
+  void shouldAcquireWhenJobCompleteCommandAfterLimit() {
     // given
     IntStream.range(0, limit.getLimit())
         .forEach(i -> assertThat(rateLimiter.tryAcquire(0, 1, context)).isTrue());
@@ -79,7 +79,7 @@ public final class CommandRateLimiterTest {
   }
 
   @Test
-  public void shouldAcquireWhenJobFailCommandAfterLimit() {
+  void shouldAcquireWhenJobFailCommandAfterLimit() {
     // given
     IntStream.range(0, limit.getLimit())
         .forEach(i -> assertThat(rateLimiter.tryAcquire(0, 1, context)).isTrue());
@@ -89,7 +89,7 @@ public final class CommandRateLimiterTest {
   }
 
   @Test
-  public void shouldReleaseRequestOnIgnore() {
+  void shouldReleaseRequestOnIgnore() {
     // given
     rateLimiter.tryAcquire(0, 1, context);
     assertThat(rateLimiter.getInflightCount()).isEqualTo(1);

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/backpressure/CommandRateLimiterTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/backpressure/CommandRateLimiterTest.java
@@ -41,8 +41,7 @@ class CommandRateLimiterTest {
   @Test
   void shouldCompleteRequestOnResponse() {
     // given
-    IntStream.range(0, limit.getLimit())
-        .forEach(i -> assertThat(rateLimiter.tryAcquire(0, i, context)));
+    IntStream.range(0, limit.getLimit()).forEach(i -> rateLimiter.tryAcquire(0, i, context));
     assertThat(rateLimiter.tryAcquire(0, 100, context)).isFalse();
 
     // when
@@ -55,8 +54,7 @@ class CommandRateLimiterTest {
   @Test
   void shouldCompleteAllRequests() {
     // given
-    IntStream.range(0, limit.getLimit())
-        .forEach(i -> assertThat(rateLimiter.tryAcquire(0, i, context)));
+    IntStream.range(0, limit.getLimit()).forEach(i -> rateLimiter.tryAcquire(0, i, context));
     assertThat(rateLimiter.tryAcquire(0, 100, context)).isFalse();
 
     // when


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Allow cancelling of process instances and deployments of new processes when the back pressure is high.

It could occur that a cluster has a high back pressure because of a faulty process. This could be resolved by cancelling the instance, or by creating a new deployment. When these commands get rejected because of this high backpressure it becomes unrecoverable.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9283

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
