### PR TITLE
ci(gha): check for duplicate test runs

### DIFF
--- a/.github/actions/check-duplicate-tests/action.yml
+++ b/.github/actions/check-duplicate-tests/action.yml
@@ -1,0 +1,41 @@
+---
+name: Check for duplicated test runs
+
+description: Check for duplicated test runs from a maven build output file and fail if found.
+
+inputs:
+  buildOutputFilePath:
+    description: 'Path to the build log file.'
+    required: true
+
+runs:
+  using: composite
+  steps:
+
+  - name: Parse the build log output and write duplicate tests to the output file
+    shell: bash
+    env:
+      BUILD_OUTPUT_FILE_PATH: ${{ inputs.buildOutputFilePath }}
+    run: |
+      if [ ! -s "$BUILD_OUTPUT_FILE_PATH" ]; then
+        echo "::error::Build output file does not exist or is empty!"
+        exit 1
+      fi
+      if grep -E -q "^\[(INFO|WARNING|ERROR)\] Tests run: [1-9]" "$BUILD_OUTPUT_FILE_PATH"; then
+        outputFile=$(mktemp)
+        tmpFile=$(mktemp)
+        grep -oP "\[INFO\] Running \K(.*)$" "$BUILD_OUTPUT_FILE_PATH" > "$tmpFile"
+        if [ -s "$tmpFile" ]; then  # found tests
+          sort "$tmpFile" | uniq -d | tee "$outputFile"
+          if [ -s "$outputFile" ]; then
+            echo "::error::Found duplicate test runs!"
+            exit 1
+          fi
+          echo "No duplicate test runs found, all good!"
+          exit 0
+        fi
+        echo "::error::Could not find any tests, duplicate detection is broken."
+        exit 1
+      fi
+      echo "No test execution found in build output, thus nothing to check."
+      exit 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,8 @@ jobs:
           chmod +x agent
           ./agent --private-registry-url=http://localhost:5000 '--private-registry-allowed-image-name-globs=*,*/*' &
           ./agent wait
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
       - run: >
           mvn -B -T2 --no-snapshot-updates
           -D junitThreadCount=12
@@ -52,6 +54,11 @@ jobs:
           -P parallel-tests,extract-flaky-tests
           -pl !:zeebe-elasticsearch-exporter
           verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Duplicate Test Check
+        uses: ./.github/actions/check-duplicate-tests
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
         if: always()
@@ -70,11 +77,18 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
       - run: >
           mvn -B --no-snapshot-updates
           -D skipUTs -D skipChecks -D failsafe.rerunFailingTestsCount=3
           -pl :zeebe-elasticsearch-exporter
           verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Duplicate Test Check
+        uses: ./.github/actions/check-duplicate-tests
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
         if: always()
@@ -112,13 +126,20 @@ jobs:
         with:
           go: false
           maven-extra-args: -am -pl ${{ matrix.project }}
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
       - run: >
           mvn -B --no-snapshot-updates
           -D skipITs -D skipChecks
           -pl ${{ matrix.project }}
           verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Normalize artifact name
         run: echo "ARTIFACT_NAME=$(echo ${{ matrix.project }} | sed 's/\//-/g')" >> $GITHUB_ENV
+      - name: Duplicate Test Check
+        uses: ./.github/actions/check-duplicate-tests
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
         if: always()
@@ -138,11 +159,18 @@ jobs:
         with:
           go: false
           maven-extra-args: -am -pl engine/
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
       - run: >
           mvn -B --no-snapshot-updates
           -D skipITs -D skipChecks
           -pl :zeebe-workflow-engine
           verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Duplicate Test Check
+        uses: ./.github/actions/check-duplicate-tests
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
         if: always()
@@ -193,7 +221,18 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
-      - run: mvn -T1C -B -D skipChecks -P parallel-tests,include-random-tests test
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
+      - run: >
+          mvn -T1C -B
+          -P parallel-tests,include-random-tests
+          -D skipChecks
+          test
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Duplicate Test Check
+        uses: ./.github/actions/check-duplicate-tests
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
         if: always()
@@ -250,6 +289,8 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
           cache: maven
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
       - run: >
           mvn -B
           -P disableCheckstyle,extract-flaky-tests
@@ -257,6 +298,11 @@ jobs:
           -D surefire.rerunFailingTestsCount=3
           -pl clients/java
           verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Duplicate Test Check
+        uses: ./.github/actions/check-duplicate-tests
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
         if: always()


### PR DESCRIPTION
## Description

Adds a GHA that will check for any duplicate test runs from the maven build output of all maven test jobs, except the platform smoke tests.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10260

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
