### PR TITLE
DRAFT: ProcessSchedulingService no extra submit

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
@@ -36,7 +36,7 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService 
 
   @Override
   public void runDelayed(final Duration delay, final Runnable followUpTask) {
-    scheduleOnActor(() -> actorControl.runDelayed(delay, followUpTask));
+    actorControl.runDelayed(delay, followUpTask);
   }
 
   @Override
@@ -47,7 +47,7 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService 
   @Override
   public <T> void runOnCompletion(
       final ActorFuture<T> precedingTask, final BiConsumer<T, Throwable> followUpTask) {
-    scheduleOnActor(() -> actorControl.runOnCompletion(precedingTask, followUpTask));
+    actorControl.runOnCompletion(precedingTask, followUpTask);
   }
 
   @Override
@@ -66,10 +66,6 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService 
                 runAtFixedRate(delay, task);
               }
             }));
-  }
-
-  private void scheduleOnActor(final Runnable task) {
-    actorControl.submit(task);
   }
 
   Runnable toRunnable(final Task task) {

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
@@ -136,7 +136,7 @@ public class ActorControl implements ConcurrencyControl {
    * @return
    */
   public ScheduledTimer runDelayed(final Duration delay, final Runnable runnable) {
-    ensureCalledFromWithinActor("runDelayed(...)");
+//    ensureCalledFromWithinActor("runDelayed(...)");
     return scheduleTimer(delay, false, runnable);
   }
 


### PR DESCRIPTION
## Description

@npepinpe I need your input here

I removed the additional submit, but it turns out to be needed for the tests, since Scheduling timers from another Actor is not allowed somehow (?). 

The timer will be added to the timer queue which is part of the ActorThread. Tbh I see not really an issue here, even if this is another thread. When the timer is due the ActorTask will be enqueued and run from some ActorThread :shrug: Maybe I oversee  something. Do you think we can remove the restriction?

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10291 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
