### PR TITLE
Fix error handling loop

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -173,7 +173,10 @@ public class Engine implements RecordProcessor {
     LOG.error(errorMessage, processingException);
 
     if (processingException instanceof ExceededBatchRecordSizeException) {
-
+      // Rejection reason is left empty here. This is because we need to make sure we can write the
+      // rejection. The record itself does not exceed the batch record size, but adding a reason
+      // could cause it to cross the limit. When this happens the engine would reach an
+      // exception-loop.
       writers.rejection().appendRejection(record, RejectionType.EXCEEDED_BATCH_RECORD_SIZE, "");
       writers
           .response()

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
 import io.camunda.zeebe.engine.api.RecordProcessor;
 import io.camunda.zeebe.engine.api.RecordProcessorContext;
 import io.camunda.zeebe.engine.api.TypedRecord;
+import io.camunda.zeebe.engine.api.records.RecordBatch.ExceededBatchRecordSizeException;
 import io.camunda.zeebe.engine.processing.streamprocessor.RecordProcessorMap;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor.ProcessingError;
@@ -171,10 +172,15 @@ public class Engine implements RecordProcessor {
             ERROR_MESSAGE_PROCESSING_EXCEPTION_OCCURRED, record, processingException.getMessage());
     LOG.error(errorMessage, processingException);
 
-    writers.rejection().appendRejection(record, RejectionType.PROCESSING_ERROR, errorMessage);
-    writers
-        .response()
-        .writeRejectionOnCommand(record, RejectionType.PROCESSING_ERROR, errorMessage);
+    if (processingException instanceof ExceededBatchRecordSizeException) {
+      writers.rejection().appendRejection(record, RejectionType.EXCEEDED_BATCH, "");
+      writers.response().writeRejectionOnCommand(record, RejectionType.EXCEEDED_BATCH, "");
+    } else {
+      writers.rejection().appendRejection(record, RejectionType.PROCESSING_ERROR, errorMessage);
+      writers
+          .response()
+          .writeRejectionOnCommand(record, RejectionType.PROCESSING_ERROR, errorMessage);
+    }
     errorRecord.initErrorRecord(processingException, record.getPosition());
 
     if (DbBlackListState.shouldBeBlacklisted(record.getIntent())) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -173,8 +173,11 @@ public class Engine implements RecordProcessor {
     LOG.error(errorMessage, processingException);
 
     if (processingException instanceof ExceededBatchRecordSizeException) {
-      writers.rejection().appendRejection(record, RejectionType.EXCEEDED_BATCH, "");
-      writers.response().writeRejectionOnCommand(record, RejectionType.EXCEEDED_BATCH, "");
+
+      writers.rejection().appendRejection(record, RejectionType.EXCEEDED_BATCH_RECORD_SIZE, "");
+      writers
+          .response()
+          .writeRejectionOnCommand(record, RejectionType.EXCEEDED_BATCH_RECORD_SIZE, "");
     } else {
       writers.rejection().appendRejection(record, RejectionType.PROCESSING_ERROR, errorMessage);
       writers

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResultBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/DirectProcessingResultBuilder.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.StringUtil;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -68,7 +69,9 @@ final class DirectProcessingResultBuilder implements ProcessingResultBuilder {
       }
     } else {
       throw new IllegalStateException(
-          String.format("The record value %s is not a UnifiedRecordValue", value));
+          String.format(
+              "The record value %s is not a UnifiedRecordValue",
+              StringUtil.limitString(value.toString(), 1024)));
     }
 
     return Either.right(this);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -217,10 +217,7 @@ public class DeploymentRejectionTest {
 
     // then
     Assertions.assertThat(deploymentRejection)
-        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
-        .hasRejectionReason(
-            "Unable to deploy resources as the size exceeds the maximum batch size. Please split "
-                + "the resources into separate deployments, or reduce the size of the deployed "
-                + "resource.");
+        .hasRejectionType(RejectionType.EXCEEDED_BATCH)
+        .hasRejectionReason("");
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -217,7 +217,7 @@ public class DeploymentRejectionTest {
 
     // then
     Assertions.assertThat(deploymentRejection)
-        .hasRejectionType(RejectionType.EXCEEDED_BATCH)
+        .hasRejectionType(RejectionType.EXCEEDED_BATCH_RECORD_SIZE)
         .hasRejectionReason("");
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceRejectionTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 
 public class CreateProcessInstanceRejectionTest {
 
-  public static final long MAX_MESSAGE_SIZE = ByteValue.ofMegabytes(4);
+  private static final long MAX_MESSAGE_SIZE = ByteValue.ofMegabytes(4);
   private static final String PROCESS_ID = "process-id";
   @Rule public final EngineRule engine = EngineRule.singlePartition();
 
@@ -231,6 +231,6 @@ public class CreateProcessInstanceRejectionTest {
                 .onlyCommandRejections()
                 .getFirst())
         .hasIntent(ProcessInstanceCreationIntent.CREATE)
-        .hasRejectionType(RejectionType.EXCEEDED_BATCH);
+        .hasRejectionType(RejectionType.EXCEEDED_BATCH_RECORD_SIZE);
   }
 }

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -31,6 +31,11 @@
           "justification": "Ignore Enum order for ValueType as ordinal() is not used",
           "code": "java.field.enumConstantOrderChanged",
           "classQualifiedName": "io.camunda.zeebe.protocol.record.ValueType"
+        },
+        {
+          "justification": "Ignore Enum order for RejectionType as ordinal() is not used",
+          "code": "java.field.enumConstantOrderChanged",
+          "match": "io.camunda.zeebe.protocol.record.RejectionType"
         }
       ]
     }

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -60,6 +60,7 @@
       <validValue name="ALREADY_EXISTS">2</validValue>
       <validValue name="INVALID_STATE">3</validValue>
       <validValue name="PROCESSING_ERROR">4</validValue>
+      <validValue name="EXCEEDED_BATCH">5</validValue>
     </enum>
 
     <enum name="PartitionRole" encodingType="uint8">

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -60,7 +60,7 @@
       <validValue name="ALREADY_EXISTS">2</validValue>
       <validValue name="INVALID_STATE">3</validValue>
       <validValue name="PROCESSING_ERROR">4</validValue>
-      <validValue name="EXCEEDED_BATCH">5</validValue>
+      <validValue name="EXCEEDED_BATCH_RECORD_SIZE">5</validValue>
     </enum>
 
     <enum name="PartitionRole" encodingType="uint8">

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateDeploymentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateDeploymentTest.java
@@ -142,9 +142,6 @@ public final class CreateDeploymentTest {
     // then
     assertThatThrownBy(command::join)
         .isInstanceOf(ClientException.class)
-        .hasMessageContaining(
-            "Unable to deploy resources as the size exceeds the maximum batch size. Please split "
-                + "the resources into separate deployments, or reduce the size of the deployed "
-                + "resource.");
+        .hasMessageContaining("rejected with code 'EXCEEDED_BATCH'");
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateDeploymentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateDeploymentTest.java
@@ -142,6 +142,6 @@ public final class CreateDeploymentTest {
     // then
     assertThatThrownBy(command::join)
         .isInstanceOf(ClientException.class)
-        .hasMessageContaining("rejected with code 'EXCEEDED_BATCH'");
+        .hasMessageContaining("rejected with code 'EXCEEDED_BATCH_RECORD_SIZE'");
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
When we exceed the record batch an exception is thrown. When this is done during the handling of an error this would result in the writing of a rejection to fail, in turn resulting in an exception-loop.

By removing the rejection reason from the rejection in the event of an `ExceededBatchRecordSizeException` the rejection should always be able to be written. Unfortunately removing this reason makes it unclear what went wrong. To still be able to identify this a new rejection type has been added.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10199 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
