### PR TITLE
Allow broker to handle resume exporting request from gateway

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
@@ -199,6 +199,83 @@ final class AdminApiRequestHandlerTest {
 
   @Nested
   @ExtendWith(MockitoExtension.class)
+  final class ResumeExportingRequest {
+    @RegisterExtension
+    final ControlledActorSchedulerExtension scheduler = new ControlledActorSchedulerExtension();
+
+    final AdminRequest request;
+    private final PartitionAdminAccess adminAccess;
+    private final AdminApiRequestHandler handler;
+
+    public ResumeExportingRequest(
+        @Mock final PartitionAdminAccess adminAccess,
+        @Mock final PartitionManagerImpl partitionManager,
+        @Mock final AtomixServerTransport transport) {
+      this.adminAccess = adminAccess;
+      final int partitionId = 1;
+      when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
+      when(partitionManager.getPartitionGroup()).thenReturn(mock(ManagedPartitionGroup.class));
+      when(partitionManager.getPartitions()).thenReturn(List.of());
+      when(partitionManager.createAdminAccess(any())).thenReturn(adminAccess);
+      handler = new AdminApiRequestHandler(transport, partitionManager);
+
+      request = new AdminRequest();
+      request.setPartitionId(partitionId);
+      request.setType(AdminRequestType.RESUME_EXPORTING);
+    }
+
+    @BeforeEach
+    void startHandler() {
+      scheduler.submitActor(handler);
+      scheduler.workUntilDone();
+    }
+
+    @Test
+    void shouldResumeExportingForGivenPartition() {
+      when(adminAccess.resumeExporting()).thenReturn(CompletableActorFuture.completed(null));
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertThat(responseFuture).succeedsWithin(Duration.ofMinutes(1)).matches(Either::isRight);
+      verify(adminAccess).forPartition(request.getPartitionId());
+      verify(adminAccess).resumeExporting();
+    }
+
+    @Test
+    void shouldRespondWithFailureIfPausingFails() {
+      // given
+      when(adminAccess.resumeExporting())
+          .thenReturn(
+              CompletableActorFuture.completedExceptionally(
+                  new RuntimeException("Exporting fails")));
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertErrorCode(responseFuture, ErrorCode.INTERNAL_ERROR);
+    }
+
+    @Test
+    void shouldRespondWithFailureIfPartitionNotFound() {
+      // given
+      request.setPartitionId(5);
+
+      // when
+      final var responseFuture = handleRequest(request, handler);
+      scheduler.workUntilDone();
+
+      // then
+      assertErrorCode(responseFuture, ErrorCode.INTERNAL_ERROR);
+    }
+  }
+
+  @Nested
+  @ExtendWith(MockitoExtension.class)
   final class StepdownRequest {
     @RegisterExtension
     final ControlledActorSchedulerExtension scheduler = new ControlledActorSchedulerExtension();

--- a/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/protocol/src/main/resources/cluster-management-protocol.xml
@@ -10,6 +10,7 @@
     <enum name="AdminRequestType" encodingType="uint8">
       <validValue name="STEP_DOWN_IF_NOT_PRIMARY">0</validValue>
       <validValue name="PAUSE_EXPORTING">1</validValue>
+      <validValue name="RESUME_EXPORTING">2</validValue>
     </enum>
 
     <enum name="BackupRequestType" encodingType="uint8">


### PR DESCRIPTION
## Description

Adds RESUME_EXPORTING to the admin requests types. `AdminApiRequestHandler` receives resume exporting request from gateway and process it similar to how it handles pause request. 
Note: The processing of this request in the Gateway is not part of this PR.

## Related issues

related #9633 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
