### PR TITLE
feat(backup): add metrics for checkpoints

### DIFF
--- a/backup/pom.xml
+++ b/backup/pom.xml
@@ -66,6 +66,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/backup/src/main/java/io/camunda/zeebe/backup/metrics/CheckpointMetrics.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/metrics/CheckpointMetrics.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.metrics;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+
+public class CheckpointMetrics {
+
+  private static final String NAMESPACE = "zeebe";
+  private static final String LABEL_NAME_PARTITION = "partition";
+  private static final String LABEL_NAME_RESULT = "result";
+
+  private static final Counter CHECKPOINT_RECORDS =
+      Counter.build()
+          .namespace(NAMESPACE)
+          .name("checkpoint_records_total")
+          .help(
+              "Number of checkpoint records processed by stream processor. Processing can result in either creating a new checkpoint or ignoring the record. This can be observed by filtering for label 'result'.")
+          .labelNames(LABEL_NAME_RESULT, LABEL_NAME_PARTITION)
+          .register();
+
+  private static final Gauge CHECKPOINT_POSITION =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("checkpoint_position")
+          .help("Position of the last checkpoint")
+          .labelNames(LABEL_NAME_PARTITION)
+          .register();
+
+  private static final Gauge CHECKPOINT_ID =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("checkpoint_id")
+          .help("Id of the last checkpoint")
+          .labelNames(LABEL_NAME_PARTITION)
+          .register();
+
+  final String partitionId;
+
+  public CheckpointMetrics(final int partitionId) {
+    this.partitionId = String.valueOf(partitionId);
+  }
+
+  public void created(final long checkpointId, final long checkpointPosition) {
+    setCheckpointId(checkpointId, checkpointPosition);
+    CHECKPOINT_RECORDS.labels("created", partitionId).inc();
+  }
+
+  public void setCheckpointId(final long checkpointId, final long checkpointPosition) {
+    CHECKPOINT_ID.labels(partitionId).set(checkpointId);
+    CHECKPOINT_POSITION.labels(partitionId).set(checkpointPosition);
+  }
+
+  public void ignored() {
+    CHECKPOINT_RECORDS.labels("ignored", partitionId).inc();
+  }
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreatedEventApplier.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.processing;
 
 import io.camunda.zeebe.backup.api.CheckpointListener;
+import io.camunda.zeebe.backup.metrics.CheckpointMetrics;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import java.util.Set;
@@ -17,10 +18,15 @@ public final class CheckpointCreatedEventApplier {
   private final CheckpointState checkpointState;
   private final Set<CheckpointListener> checkpointListeners;
 
+  private final CheckpointMetrics metrics;
+
   public CheckpointCreatedEventApplier(
-      final CheckpointState checkpointState, final Set<CheckpointListener> checkpointListeners) {
+      final CheckpointState checkpointState,
+      final Set<CheckpointListener> checkpointListeners,
+      final CheckpointMetrics metrics) {
     this.checkpointState = checkpointState;
     this.checkpointListeners = checkpointListeners;
+    this.metrics = metrics;
   }
 
   public void apply(final CheckpointRecord checkpointRecord) {

--- a/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -58,7 +58,7 @@ final class CheckpointRecordsProcessorTest {
     final RecordProcessorContextImpl context = createContext(executor, zeebedb);
 
     resultBuilder = new MockProcessingResultBuilder();
-    processor = new CheckpointRecordsProcessor(backupManager);
+    processor = new CheckpointRecordsProcessor(backupManager, 1);
     processor.init(context);
 
     state = new DbCheckpointState(zeebedb, zeebedb.createContext());
@@ -236,7 +236,7 @@ final class CheckpointRecordsProcessorTest {
   void shouldNotifyListenerOnInit() {
     // given
     final RecordProcessorContextImpl context = createContext(null, zeebedb);
-    processor = new CheckpointRecordsProcessor(backupManager);
+    processor = new CheckpointRecordsProcessor(backupManager, 1);
     final long checkpointId = 3;
     final long checkpointPosition = 30;
     state.setCheckpointInfo(checkpointId, checkpointPosition);

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
@@ -140,7 +140,7 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
   private static void installCheckpointProcessor(
       final PartitionTransitionContext context, final BackupManager backupManager) {
     final CheckpointRecordsProcessor checkpointRecordsProcessor =
-        new CheckpointRecordsProcessor(backupManager);
+        new CheckpointRecordsProcessor(backupManager, context.getPartitionId());
     context.setCheckpointProcessor(checkpointRecordsProcessor);
   }
 


### PR DESCRIPTION
## Description

Added following metrics:
- number of checkpoint records processed per partition. Can be filtered by `result = created` or `result = ignored`.
- last checkpoint id and last checkpoint position per partition. It is updated in both leader and followers.

PS:- This PR does not add panels to grafana dashboard. 

## Related issues

closes #10385 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
