### PR TITLE
Introduce take backup management API

### DIFF
--- a/backup-stores/s3/pom.xml
+++ b/backup-stores/s3/pom.xml
@@ -118,18 +118,10 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Sad workaround for https://github.com/testcontainers/testcontainers-java/issues/4279 -->
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>1.12.307</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -97,11 +97,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-actuator</artifactId>
     </dependency>

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.shared.management;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -52,7 +52,7 @@ public class ActorClockEndpoint {
   @ReadOperation
   public WebEndpointResponse<Response> getCurrentClock() {
     final var instant = Instant.ofEpochMilli(service.epochMilli());
-    return new WebEndpointResponse<>(new Response(instant));
+    return new WebEndpointResponse<>(new Response(instant.toEpochMilli(), instant));
   }
 
   /**
@@ -109,7 +109,7 @@ public class ActorClockEndpoint {
    *
    * @return 200 and the current clock time
    */
-  @SuppressWarnings("unused")
+  @SuppressWarnings({"unused", "UnusedReturnValue"})
   @DeleteOperation
   public WebEndpointResponse<?> resetTime() {
     final var clock = service.mutable();
@@ -156,22 +156,6 @@ public class ActorClockEndpoint {
   }
 
   /** A response type for future proofing, in case the format needs to be changed in the future. */
-  protected static final class Response {
-    @JsonProperty("epochMilli")
-    protected final long epochMilli;
-
-    @JsonProperty("instant")
-    protected final Instant instant;
-
-    public Response(final Instant instant) {
-      this.instant = instant;
-      epochMilli = instant.toEpochMilli();
-    }
-
-    @SuppressWarnings("unused") // Used by Jackson deserialization
-    private Response() {
-      this.epochMilli = 0;
-      this.instant = null;
-    }
-  }
+  @VisibleForTesting
+  record Response(long epochMilli, Instant instant) {}
 }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -17,13 +17,11 @@ import org.springframework.boot.actuate.endpoint.annotation.Selector;
 import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
 @Component
 @WebEndpoint(id = "backups", enableByDefault = false)
-@ConditionalOnProperty(prefix = "zeebe.broker.experimental.features", name = "enableBackup")
 final class BackupEndpoint {
   private final BackupApi api;
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared.management;
+
+import io.camunda.zeebe.gateway.admin.backup.BackupApi;
+import io.camunda.zeebe.gateway.admin.backup.BackupRequestHandler;
+import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
+import io.camunda.zeebe.util.VisibleForTesting;
+import java.util.concurrent.CompletionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.annotation.Selector;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
+import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+@Component
+@WebEndpoint(id = "backups", enableByDefault = false)
+@ConditionalOnProperty(prefix = "zeebe.broker.experimental.features", name = "enableBackup")
+final class BackupEndpoint {
+  private final BackupApi api;
+
+  @SuppressWarnings("unused") // used by Spring
+  @Autowired
+  public BackupEndpoint(final BrokerClient client) {
+    this(new BackupRequestHandler(client));
+  }
+
+  BackupEndpoint(final BackupApi api) {
+    this.api = api;
+  }
+
+  @WriteOperation
+  public WebEndpointResponse<?> take(@Selector @NonNull final long id) {
+    try {
+      final long backupId = api.takeBackup(id).toCompletableFuture().join();
+      return new WebEndpointResponse<>(new TakeBackupResponse(backupId));
+    } catch (final CompletionException e) {
+      return new WebEndpointResponse<>(
+          new TakeBackupError(id, e.getCause().getMessage()),
+          WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR);
+    } catch (final Exception e) {
+      return new WebEndpointResponse<>(
+          new TakeBackupError(id, e.getMessage()),
+          WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @VisibleForTesting
+  record TakeBackupResponse(long id) {}
+
+  @VisibleForTesting
+  record TakeBackupError(long id, String failure) {}
+}

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -23,6 +23,11 @@ management.endpoint.prometheus.enabled=true
 management.metrics.export.prometheus.enabled=true
 # Allow runtime configuration of log levels
 management.endpoint.loggers.enabled=true
+# Backups endpoint; as this is an experimental feature, it should be enabled only with care. The API
+# is subject to change in the future. To fully enable online backups, you will need to enable this
+# management endpoint, and also enable the backups feature flag by setting the following property
+# zeebe.broker.experimental.features.enableBackup=true.
+management.endpoint.backups.enabled=false
 # Disable specific autoconfiguration classes which are triggered automatically (e.g. creating an
 # Elastic client which spawns 16 threads)
 spring.autoconfigure.exclude=\

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.zeebe.gateway.admin.backup.BackupApi;
+import io.camunda.zeebe.shared.management.BackupEndpoint.TakeBackupError;
+import io.camunda.zeebe.shared.management.BackupEndpoint.TakeBackupResponse;
+import java.util.concurrent.CompletableFuture;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
+
+@Execution(ExecutionMode.CONCURRENT)
+final class BackupEndpointTest {
+  @Test
+  void shouldReturnErrorOnCompletionException() {
+    // given
+    final var api = mock(BackupApi.class);
+    final var endpoint = new BackupEndpoint(api);
+    final var failure = new RuntimeException("failure");
+    doReturn(CompletableFuture.failedFuture(failure)).when(api).takeBackup(anyLong());
+
+    // when
+    final WebEndpointResponse<?> response = endpoint.take(1);
+
+    // then
+    assertThat(response.getBody())
+        .asInstanceOf(InstanceOfAssertFactories.type(TakeBackupError.class))
+        .isEqualTo(new TakeBackupError(1, "failure"));
+  }
+
+  @Test
+  void shouldReturnErrorOnException() {
+    // given
+    final var api = mock(BackupApi.class);
+    final var endpoint = new BackupEndpoint(api);
+    final var failure = new RuntimeException("failure");
+    doThrow(failure).when(api).takeBackup(anyLong());
+
+    // when
+    final WebEndpointResponse<?> response = endpoint.take(1);
+
+    // then
+    assertThat(response.getBody())
+        .asInstanceOf(InstanceOfAssertFactories.type(TakeBackupError.class))
+        .isEqualTo(new TakeBackupError(1, "failure"));
+  }
+
+  @Test
+  void shouldReturnNewBackupIdOnSuccess() {
+    // given
+    final var api = mock(BackupApi.class);
+    final var endpoint = new BackupEndpoint(api);
+    doReturn(CompletableFuture.completedFuture(3L)).when(api).takeBackup(anyLong());
+
+    // when
+    final WebEndpointResponse<?> response = endpoint.take(1);
+
+    // then
+    assertThat(response.getBody())
+        .asInstanceOf(InstanceOfAssertFactories.type(TakeBackupResponse.class))
+        .isEqualTo(new TakeBackupResponse(3));
+  }
+}

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ControlledActorClockEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ControlledActorClockEndpointTest.java
@@ -51,7 +51,7 @@ final class ControlledActorClockEndpointTest {
     assertThat(response.getStatus()).isEqualTo(200);
     assertThat(response.getBody())
         .asInstanceOf(responseType)
-        .satisfies((body) -> assertThat(body.epochMilli).isEqualTo(millis))
+        .satisfies((body) -> assertThat(body.epochMilli()).isEqualTo(millis))
         .isNotNull();
   }
 
@@ -77,7 +77,7 @@ final class ControlledActorClockEndpointTest {
         .asInstanceOf(responseType)
         // This can be flaky, but only if the test thread is sleeping for more than the margin of
         // error.
-        .satisfies((body) -> assertThat(body.instant).isBetween(offsetMinimum, offsetMaximum));
+        .satisfies((body) -> assertThat(body.instant()).isBetween(offsetMinimum, offsetMaximum));
   }
 
   @Test
@@ -86,13 +86,13 @@ final class ControlledActorClockEndpointTest {
     final var offset = 10000L;
     final var firstResponse = endpoint.modify("add", null, offset);
     assertThat(firstResponse.getBody()).isNotNull();
-    final var firstMillis = ((Response) firstResponse.getBody()).epochMilli;
+    final var firstMillis = ((Response) firstResponse.getBody()).epochMilli();
 
     // when
     Thread.sleep(100);
     final var secondResponse = endpoint.getCurrentClock();
     assertThat(secondResponse.getBody()).isNotNull();
-    final var secondMillis = secondResponse.getBody().epochMilli;
+    final var secondMillis = secondResponse.getBody().epochMilli();
 
     // then
     assertThat(firstMillis).isLessThan(secondMillis);
@@ -107,7 +107,7 @@ final class ControlledActorClockEndpointTest {
     assertThat(firstResponse.getBody())
         .isNotNull()
         .asInstanceOf(responseType)
-        .satisfies((body) -> assertThat(body.epochMilli).isEqualTo(millis));
+        .satisfies((body) -> assertThat(body.epochMilli()).isEqualTo(millis));
 
     // when
     Thread.sleep(100);
@@ -115,7 +115,7 @@ final class ControlledActorClockEndpointTest {
 
     // then
     assertThat(secondResponse.getBody()).isNotNull();
-    assertThat(secondResponse.getBody().epochMilli).isEqualTo(millis);
+    assertThat(secondResponse.getBody().epochMilli()).isEqualTo(millis);
   }
 
   @Test
@@ -123,8 +123,8 @@ final class ControlledActorClockEndpointTest {
     // when
     final var response = endpoint.getCurrentClock();
     assertThat(response.getBody()).isNotNull();
-    final var millis = response.getBody().epochMilli;
-    final var instant = response.getBody().instant;
+    final var millis = response.getBody().epochMilli();
+    final var instant = response.getBody().instant();
 
     // then
     assertThat(Instant.ofEpochMilli(millis)).isEqualTo(instant);

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
@@ -16,6 +16,9 @@ public interface BackupApi {
    * partitions have processed the request. Returned future fails if the request was not processed
    * by at least one partition.
    *
+   * <p>TODO: check if it makes more sense to return a {@link java.util.concurrent.Future} if we're
+   * always blocking on the result and never combining.
+   *
    * @param backupId the id of the backup to be taken
    * @return the backupId
    */
@@ -24,6 +27,9 @@ public interface BackupApi {
   /**
    * Returns the status of the backup. The future fails if the request was not processed by at least
    * one partition.
+   *
+   * <p>TODO: check if it makes more sense to return a {@link java.util.concurrent.Future} if we're
+   * always blocking on the result and never combining.
    *
    * @return the status of the backup
    */

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandler.java
@@ -41,11 +41,7 @@ public final class BackupRequestHandler implements BackupApi {
                             .map(partitionId -> getBackupRequestForPartition(backupId, partitionId))
                             .map(brokerClient::sendRequestWithRetry)
                             .toArray(CompletableFuture[]::new))
-                    .thenApply(ignore -> backupId))
-        .exceptionallyCompose(
-            error ->
-                CompletableFuture.failedFuture(
-                    new BackupOperationFailedException("take", backupId, error.getCause())));
+                    .thenApply(ignore -> backupId));
   }
 
   @Override
@@ -61,11 +57,7 @@ public final class BackupRequestHandler implements BackupApi {
 
               return CompletableFuture.allOf(statusesReceived.toArray(CompletableFuture[]::new))
                   .thenApply(ignore -> aggregatePartitionStatus(backupId, statusesReceived));
-            })
-        .exceptionallyCompose(
-            error ->
-                CompletableFuture.failedFuture(
-                    new BackupOperationFailedException("query", backupId, error.getCause())));
+            });
   }
 
   private CompletionStage<BrokerClusterState> checkTopologyComplete() {

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandlerTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandlerTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.admin.backup;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
+import io.camunda.zeebe.gateway.cmd.BrokerErrorException;
 import io.camunda.zeebe.protocol.management.BackupStatusCode;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
@@ -52,7 +53,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
     assertThat(future)
         .failsWithin(Duration.ofMillis(500))
         .withThrowableOfType(ExecutionException.class)
-        .withCauseInstanceOf(BackupOperationFailedException.class);
+        .withCauseInstanceOf(BrokerErrorException.class);
   }
 
   @Test
@@ -149,6 +150,6 @@ public class BackupRequestHandlerTest extends GatewayTest {
     assertThat(future)
         .failsWithin(Duration.ofMillis(500))
         .withThrowableOfType(ExecutionException.class)
-        .withCauseInstanceOf(BackupOperationFailedException.class);
+        .withCauseInstanceOf(BrokerErrorException.class);
   }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -929,6 +929,32 @@
         <version>${version.jnr-posix}</version>
       </dependency>
 
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${version.awssdk}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!--
+        Sad workaround for https://github.com/testcontainers/testcontainers-java/issues/4279; when
+        this is not needed and removed, make sure to remove it from child modules including this as
+        well
+      -->
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-core</artifactId>
+        <version>1.12.306</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
       <!-- Dependencies present for convergence only -->
       <!-- between log4j2 and commons-compress (from testcontainers) -->
       <dependency>
@@ -985,14 +1011,6 @@
         <groupId>com.cronutils</groupId>
         <artifactId>cron-utils</artifactId>
         <version>${version.cron-utils}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>bom</artifactId>
-        <version>${version.awssdk}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
 
     </dependencies>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -228,12 +228,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>localstack</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <scope>test</scope>
@@ -251,23 +245,15 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Sad workaround for https://github.com/testcontainers/testcontainers-java/issues/4279 -->
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-      <version>1.12.307</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -406,6 +392,13 @@
       <artifactId>jackson-datatype-jsr310</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-backup</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <profiles>

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupApiIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupApiIT.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.s3.S3BackupConfig;
+import io.camunda.zeebe.backup.s3.S3BackupStore;
+import io.camunda.zeebe.qa.util.actuator.BackupActuator;
+import io.camunda.zeebe.qa.util.actuator.BackupActuator.TakeBackupResponse;
+import io.camunda.zeebe.qa.util.testcontainers.ContainerLogsDumper;
+import io.camunda.zeebe.qa.util.testcontainers.MinioContainer;
+import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.zeebe.containers.ZeebeBrokerNode;
+import io.zeebe.containers.ZeebeNode;
+import io.zeebe.containers.ZeebePort;
+import io.zeebe.containers.cluster.ZeebeCluster;
+import io.zeebe.containers.engine.ContainerEngine;
+import java.time.Duration;
+import org.agrona.CloseHelper;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Acceptance tests for the backup management API. Tests here should interact with the backups
+ * primarily via the management API, and occasionally assert results on the configured backup store.
+ *
+ * <p>The tests run against a cluster of 2 brokers and 1 gateway, no embedded gateways, two
+ * partitions and replication factor of 1. This allows us to test that requests are correctly fanned
+ * out across the gateway, since each broker is guaranteed to be leader of a partition.
+ *
+ * <p>NOTE: this does not test the consistency of backups, nor that partition leaders correctly
+ * maintain consistency via checkpoint records. Other test suites should be set up for this.
+ */
+@Testcontainers
+final class BackupApiIT {
+  private static final Network NETWORK = Network.newNetwork();
+
+  private final String bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+
+  @Container
+  private final MinioContainer minio =
+      new MinioContainer().withNetwork(NETWORK).withDomain("minio.local", bucketName);
+
+  private final ZeebeCluster cluster =
+      ZeebeCluster.builder()
+          .withImage(ZeebeTestContainerDefaults.defaultTestImage())
+          .withNetwork(NETWORK)
+          .withBrokersCount(2)
+          .withGatewaysCount(1)
+          .withReplicationFactor(1)
+          .withPartitionsCount(2)
+          .withEmbeddedGateway(false)
+          .withBrokerConfig(this::configureBroker)
+          .withNodeConfig(this::configureNode)
+          .build();
+
+  @RegisterExtension
+  @SuppressWarnings("unused")
+  final ContainerLogsDumper logsWatcher = new ContainerLogsDumper(cluster::getNodes);
+
+  @Container
+  private final ContainerEngine engine =
+      ContainerEngine.builder().withAutoAcknowledge(true).withCluster(cluster).build();
+
+  private S3BackupStore store;
+
+  @AfterAll
+  static void afterAll() {
+    CloseHelper.quietCloseAll(NETWORK);
+  }
+
+  @BeforeEach
+  void beforeEach() {
+    final var config =
+        S3BackupConfig.from(
+            bucketName,
+            minio.externalEndpoint(),
+            minio.region(),
+            minio.accessKey(),
+            minio.secretKey());
+    store = new S3BackupStore(config);
+
+    try (final var s3Client = S3BackupStore.buildClient(config)) {
+      s3Client.createBucket(builder -> builder.bucket(config.bucketName()).build()).join();
+    }
+  }
+
+  @AfterEach
+  void afterEach() {
+    CloseHelper.quietCloseAll(() -> store.closeAsync().join());
+  }
+
+  @Test
+  void shouldTakeBackup() {
+    // given
+    final var actuator = BackupActuator.of(cluster.getAvailableGateway());
+    try (final var client = engine.createClient()) {
+      client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
+    }
+
+    // when
+    final var response = actuator.take(1L);
+
+    // then
+    assertThat(response).isEqualTo(new TakeBackupResponse(1L));
+    Awaitility.await("until a backup exists with the given ID")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(this::assertBackupCompleteOnAllPartitions);
+  }
+
+  private void assertBackupCompleteOnAllPartitions() {
+    // TODO: this will be replaced by the status API later
+    for (int partitionId = 1; partitionId < 2; partitionId++) {
+      assertBackupCompleteForPartition(partitionId);
+    }
+  }
+
+  private void assertBackupCompleteForPartition(final int partitionId) {
+    final var backupId = new BackupIdentifierImpl(0, partitionId, 1);
+    final var status = store.getStatus(backupId);
+
+    assertThat(status)
+        .succeedsWithin(Duration.ofSeconds(30))
+        .extracting(BackupStatus::id, BackupStatus::statusCode)
+        .containsExactly(backupId, BackupStatusCode.COMPLETED);
+  }
+
+  private void configureBroker(final ZeebeBrokerNode<?> broker) {
+    broker
+        .withEnv("ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEBACKUP", "true")
+        .withEnv("ZEEBE_BROKER_DATA_BACKUP_STORE", "S3")
+        .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_BUCKETNAME", bucketName)
+        .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_ENDPOINT", minio.internalEndpoint())
+        .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_REGION", minio.region())
+        .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_ACCESSKEY", minio.accessKey())
+        .withEnv("ZEEBE_BROKER_DATA_BACKUP_S3_SECRETKEY", minio.secretKey());
+  }
+
+  private void configureNode(final ZeebeNode<?> node) {
+    node.withEnv("MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE", "*")
+        .withEnv("MANAGEMENT_ENDPOINTS_BACKUPS_ENABLED", "true")
+        .dependsOn(minio);
+    node.addExposedPort(ZeebePort.MONITORING.getPort());
+  }
+}

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -50,5 +50,10 @@
       <groupId>io.github.openfeign</groupId>
       <artifactId>feign-jackson</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java-api</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.actuator;
+
+import feign.Feign;
+import feign.FeignException;
+import feign.FeignException.InternalServerError;
+import feign.Headers;
+import feign.Param;
+import feign.Request;
+import feign.RequestLine;
+import feign.Response;
+import feign.Retryer;
+import feign.Target.HardCodedTarget;
+import feign.codec.ErrorDecoder;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import io.camunda.zeebe.qa.util.actuator.BackupActuator.TakeBackupError.Payload;
+import io.zeebe.containers.ZeebeNode;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Java interface for the node's backup actuator. To instantiate this interface, you can use {@link
+ * Feign}; see {@link #of(String)} as an example.
+ *
+ * <p>You can use one of {@link #of(String)} or {@link #of(ZeebeNode)} to create a new client to use
+ * for yourself.
+ */
+public interface BackupActuator {
+
+  /**
+   * Returns a {@link BackupActuator} instance using the given node as upstream.
+   *
+   * @param node the node to connect to
+   * @return a new instance of {@link BackupActuator}
+   */
+  static BackupActuator of(final ZeebeNode<?> node) {
+    final var endpoint =
+        String.format("http://%s/actuator/backups", node.getExternalMonitoringAddress());
+    return of(endpoint);
+  }
+
+  /**
+   * Returns a {@link BackupActuator} instance using the given endpoint as upstream. The endpoint is
+   * expected to be a complete absolute URL, e.g. "http://localhost:9600/actuator/backups".
+   *
+   * @param endpoint the actuator URL to connect to
+   * @return a new instance of {@link BackupActuator}
+   */
+  @SuppressWarnings("JavadocLinkAsPlainText")
+  static BackupActuator of(final String endpoint) {
+    final var target = new HardCodedTarget<>(BackupActuator.class, endpoint);
+    final var decoder = new JacksonDecoder();
+
+    return Feign.builder()
+        .encoder(new JacksonEncoder())
+        .decoder(decoder)
+        .errorDecoder(new ErrorHandler(decoder))
+        .retryer(Retryer.NEVER_RETRY)
+        .target(target);
+  }
+
+  /**
+   * Triggers taking a backup of the cluster.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("POST /{id}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  TakeBackupResponse take(@Param final long id);
+
+  /**
+   * Custom error handler, mapping errors with body to custom types for easier
+   * verification/handling. This is somewhat verbose, so any suggestions for improvements are
+   * welcome.
+   */
+  final class ErrorHandler implements ErrorDecoder {
+    private final JacksonDecoder decoder;
+
+    public ErrorHandler(final JacksonDecoder decoder) {
+      this.decoder = decoder;
+    }
+
+    @Override
+    public Exception decode(final String methodKey, final Response response) {
+      if (response.status() == 500) {
+        try {
+          final var payload = (Payload) decoder.decode(response, Payload.class);
+          return new TakeBackupError(
+              payload.failure(),
+              response.request(),
+              response.body().asInputStream().readAllBytes(),
+              response.headers(),
+              payload);
+        } catch (final IOException e) {
+          throw new UncheckedIOException(e);
+        }
+      }
+
+      return FeignException.errorStatus(methodKey, response);
+    }
+  }
+
+  record TakeBackupResponse(long id) {}
+
+  final class TakeBackupError extends InternalServerError {
+    private final Payload payload;
+
+    private TakeBackupError(
+        final String message,
+        final Request request,
+        final byte[] body,
+        final Map<String, Collection<String>> headers,
+        final Payload payload) {
+      super(message, request, body, headers);
+      this.payload = payload;
+    }
+
+    public String failure() {
+      return payload.failure();
+    }
+
+    public long id() {
+      return payload.id();
+    }
+
+    record Payload(long id, String failure) {}
+  }
+}

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/RebalanceActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/RebalanceActuator.java
@@ -14,14 +14,14 @@ import feign.Retryer;
 import feign.Target.HardCodedTarget;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
-import io.zeebe.containers.ZeebeGatewayNode;
+import io.zeebe.containers.ZeebeNode;
 
 /**
- * Java interface for the gateway's rebalance actuator. To instantiate this interface, you can use
+ * Java interface for the node's rebalance actuator. To instantiate this interface, you can use
  * {@link Feign}; see {@link #of(String)} as an example.
  *
- * <p>You can use one of {@link #of(String)} or {@link #of(ZeebeGatewayNode)} to create a new client
- * to use for yourself.
+ * <p>You can use one of {@link #of(String)} or {@link #of(ZeebeNode)} to create a new client to use
+ * for yourself.
  *
  * <p>Adding a new method is simple: simply define the input/output here as you normally would, and
  * make sure to add the correct JSON encoding headers (`Accept` for the response type,
@@ -31,14 +31,12 @@ import io.zeebe.containers.ZeebeGatewayNode;
 public interface RebalanceActuator {
 
   /**
-   * Returns a {@link RebalanceActuator} instance using the given node as upstream. This only
-   * accepts {@link ZeebeGatewayNode} at the moment, as only a node with a gateway can use this
-   * actuator.
+   * Returns a {@link RebalanceActuator} instance using the given node as upstream.
    *
    * @param node the node to connect to
    * @return a new instance of {@link RebalanceActuator}
    */
-  static RebalanceActuator of(final ZeebeGatewayNode<?> node) {
+  static RebalanceActuator of(final ZeebeNode<?> node) {
     final var endpoint =
         String.format("http://%s/actuator/rebalance", node.getExternalMonitoringAddress());
     return of(endpoint);

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/MinioContainer.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/MinioContainer.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.testcontainers;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Objects;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Minio is a S3 compatible high performance object storage. See <a href="https://min.io/">their
+ * official page</a> for more.
+ *
+ * <p>We use it primarily to test compatibility with our S3 backup store, as it's lightweight and
+ * popular.
+ *
+ * <p>When using this, keep in mind that you will need to add a network alias per bucket that you
+ * want to create. You should use {@link #withDomain(String, String...)} for this, and read the
+ * method's documentation.
+ *
+ * <p>In most cases, it's expected you will configure the domain as above.
+ */
+public final class MinioContainer extends GenericContainer<MinioContainer> {
+
+  private static final DockerImageName IMAGE = DockerImageName.parse("minio/minio");
+  private static final int PORT = 9000;
+  private static final String DEFAULT_REGION = "us-east-1";
+  private static final String DEFAULT_ACCESS_KEY = "accessKey";
+  private static final String DEFAULT_SECRET_KEY = "secretKey";
+
+  private String domain;
+
+  /**
+   * Creates a default container with a pinned image version. It's unlikely we ever need to change
+   * this.
+   */
+  public MinioContainer() {
+    this("RELEASE.2022-09-17T00-09-45Z");
+  }
+
+  /**
+   * Creates a new container with the specific image version.
+   *
+   * @param version the minio version to use
+   */
+  @SuppressWarnings("resource")
+  public MinioContainer(final String version) {
+    super(IMAGE.withTag(version));
+
+    withCommand("server /data")
+        .withExposedPorts(PORT)
+        .withEnv("MINIO_ACCESS_KEY", DEFAULT_ACCESS_KEY)
+        .withEnv("MINIO_SECRET_KEY", DEFAULT_SECRET_KEY)
+        .withEnv("MINIO_REGION", DEFAULT_REGION)
+        .waitingFor(defaultWaitStrategy());
+  }
+
+  public WaitStrategy defaultWaitStrategy() {
+    return new HttpWaitStrategy()
+        .forPath("/minio/health/ready")
+        .forPort(PORT)
+        .withStartupTimeout(Duration.ofMinutes(1));
+  }
+
+  /**
+   * Returns the S3 accessible endpoint for a client running on the host machine. Note that this may
+   * use a hostname. If you wish to use path-style access (e.g. you don't know your buckets
+   * beforehand), then you can format the endpoint yourself using 127.0.0.1 as the IP address
+   * instead of the host.
+   *
+   * <p>NOTE: if this is a common use case, we can add a method here that does so.
+   */
+  public String externalEndpoint() {
+    return "http://%s:%d".formatted(getHost(), getMappedPort(PORT));
+  }
+
+  /**
+   * Returns the internal endpoint, i.e. the S3 accessible endpoint used when your client is running
+   * in a container in the same network as this one. If you wish to use path-style access (e.g. you
+   * don't know your buckets beforehand), then you can format the endpoint yourself using the
+   * container's internal IP address. You can fetch that by inspecting the container via {@link
+   * #getContainerInfo()} and checking the network settings for the IP address.
+   *
+   * <p>NOTE: if this is a common use case, we can add a method here that does so.
+   */
+  public String internalEndpoint() {
+    return "http://%s:%d".formatted(internalHost(), PORT);
+  }
+
+  /** Returns the configured Minio region. You can pass this to your S3 client builder. */
+  public String region() {
+    return getEnvMap().getOrDefault("MINIO_REGION", DEFAULT_REGION);
+  }
+
+  /** Returns the configured Minio access key. You can pass this to your S3 client builder. */
+  public String accessKey() {
+    return getEnvMap().getOrDefault("MINIO_ACCESS_KEY", DEFAULT_ACCESS_KEY);
+  }
+
+  /** Returns the configured Minio secret key. You can pass this to your S3 client builder. */
+  public String secretKey() {
+    return getEnvMap().getOrDefault("MINIO_SECRET_KEY", DEFAULT_SECRET_KEY);
+  }
+
+  /**
+   * Configures Minio to use the specific domain as its internal hostname and virtual wild card
+   * host, allowing subdomain access for buckets. In order for the bucket subdomain to be
+   * resolvable, you must provide them here, so they can be added as routes to the network.
+   *
+   * <p>So if you pass, say, {@code minio.local}, and two buckets called {@code bucketA} and {@code
+   * bucketB}, you can access the following domains: {@code http://minio.local}, {@code
+   * http://bucketA.minio.local}, and {@code http://bucketB.minio.local}. This is the default
+   * operating mode for an S3 client.
+   *
+   * <p>If you do not know your bucket names in advance, then you will need to find to use the
+   * container's IP address as the endpoint; this will force your client to use the path-style
+   * access to access your buckets.
+   *
+   * @param domain the root domain accessible from the container's network
+   * @param buckets a list of bucket names which will be added as subdomains for the root domain
+   * @return this container for chaining
+   */
+  public MinioContainer withDomain(final String domain, final String... buckets) {
+    this.domain = Objects.requireNonNull(domain, "must specify a domain");
+    withEnv("MINIO_DOMAIN", domain).withNetworkAliases(domain);
+    Arrays.stream(buckets)
+        .map(name -> "%s.%s".formatted(name, domain))
+        .forEach(this::withNetworkAliases);
+
+    if (buckets.length == 0) {
+      logger()
+          .warn(
+              "Configured minio with a domain but no buckets; make sure to use the container's IP"
+                  + " address when accessing S3 via a client to enforce path-style access to your buckets");
+    }
+
+    return this;
+  }
+
+  private String internalHost() {
+    if (domain != null) {
+      return domain;
+    }
+
+    final var networkAliases = getNetworkAliases();
+    if (networkAliases.isEmpty()) {
+      return getContainerInfo().getName();
+    }
+
+    return networkAliases.get(networkAliases.size() - 1);
+  }
+}

--- a/util/src/main/java/io/camunda/zeebe/util/VisibleForTesting.java
+++ b/util/src/main/java/io/camunda/zeebe/util/VisibleForTesting.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the visibility was strengthened purely for testing purposes.
+ *
+ * <p>NOTE: this should not be used on public members, but is meant only to highlight
+ * package-private or protected fields, types, etc., which aren't private in order to allow
+ * comprehensive tests. In general, you should try to avoid this, but at times there is no other
+ * way.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.SOURCE)
+@Documented
+public @interface VisibleForTesting {}


### PR DESCRIPTION
## Description

This PR adds a new backup management endpoint, currently only implementing taking a backup. As such, the acceptance test rely on inspecting the backing store (S3) - this can be changed/dropped later to mostly focus on using the API for observability.

As discussed before, we went with a simpler user API, mostly because of time constraints. This API is subject to change in the future to the documented OpenAPI spec.

The PR also adds a new annotation, `@VisibileForTesting`. There were here two cases (and in other places) where we want to reuse some types/functionality which is not exposed normally. I would advise this as acceptable for unit tests, and for identifying types/fields/methods with strengthened visibility up to package-private or protected. While it's a smell in itself, it's much weaker than if it were annotating, say, a public field, which would be a clear design issue. However, I'm happy to drop this and we can find workaround for the two cases here (notably re-implementing the types ourselves).

## Related issues

closes #9901 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
