### PR TITLE
Add a standalone app that can be used to restore a broker from a backup

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -96,9 +96,7 @@ public class RaftPartition implements Partition, HealthMonitorable {
   }
 
   /** Opens the partition. */
-  CompletableFuture<Partition> open(
-      final PartitionMetadata metadata, final PartitionManagementService managementService) {
-    partitionMetadata = metadata;
+  CompletableFuture<Partition> open(final PartitionManagementService managementService) {
     if (partitionMetadata
         .members()
         .contains(managementService.getMembershipService().getLocalMember().id())) {
@@ -250,5 +248,13 @@ public class RaftPartition implements Partition, HealthMonitorable {
 
   public CompletableFuture<Void> goInactive() {
     return server.goInactive();
+  }
+
+  public PartitionMetadata getMetadata() {
+    return partitionMetadata;
+  }
+
+  public void setMetadata(final PartitionMetadata partitionMetadata) {
+    this.partitionMetadata = partitionMetadata;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
@@ -27,9 +27,9 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-final class RaftPartitionGroupFactory {
+public final class RaftPartitionGroupFactory {
 
-  RaftPartitionGroup buildRaftPartitionGroup(
+  public RaftPartitionGroup buildRaftPartitionGroup(
       final BrokerCfg configuration, final ReceivableSnapshotStoreFactory snapshotStoreFactory) {
 
     final DataCfg dataConfiguration = configuration.getData();

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -33,6 +33,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-restore</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-elasticsearch-exporter</artifactId>
     </dependency>
 
@@ -54,6 +59,16 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-atomix-utils</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-backup</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-backup-store-s3</artifactId>
     </dependency>
 
     <dependency>
@@ -203,6 +218,7 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
 
   <build>

--- a/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.broker;
 
 import io.atomix.cluster.AtomixCluster;
-import io.camunda.zeebe.broker.WorkingDirectoryConfiguration.WorkingDirectory;
+import io.camunda.zeebe.broker.shared.WorkingDirectoryConfiguration.WorkingDirectory;
 import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;

--- a/dist/src/main/java/io/camunda/zeebe/broker/shared/BrokerConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/shared/BrokerConfiguration.java
@@ -5,9 +5,9 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker;
+package io.camunda.zeebe.broker.shared;
 
-import io.camunda.zeebe.broker.WorkingDirectoryConfiguration.WorkingDirectory;
+import io.camunda.zeebe.broker.shared.WorkingDirectoryConfiguration.WorkingDirectory;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/dist/src/main/java/io/camunda/zeebe/broker/shared/WorkingDirectoryConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/shared/WorkingDirectoryConfiguration.java
@@ -5,8 +5,9 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker;
+package io.camunda.zeebe.broker.shared;
 
+import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.shared.Profile;
 import java.io.IOException;
 import java.io.UncheckedIOException;

--- a/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.restore;
+
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.s3.S3BackupConfig;
+import io.camunda.zeebe.backup.s3.S3BackupStore;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Component
+final class BackupStoreComponent {
+
+  private final BrokerCfg brokerCfg;
+
+  @Autowired
+  BackupStoreComponent(final BrokerCfg brokerCfg) {
+    this.brokerCfg = brokerCfg;
+  }
+
+  @Bean(destroyMethod = "close")
+  BackupStore backupStore() {
+    return buildBackupStore(brokerCfg.getData().getBackup());
+  }
+
+  private BackupStore buildBackupStore(final BackupStoreCfg backupCfg) {
+    final var store = backupCfg.getStore();
+    if (store == BackupStoreType.NONE) {
+      throw new IllegalArgumentException("No backup store configured, cannot restore from backup.");
+    }
+
+    if (store == BackupStoreType.S3) {
+      final var s3Config = backupCfg.getS3();
+      final S3BackupConfig storeConfig =
+          S3BackupConfig.from(
+              s3Config.getBucketName(),
+              s3Config.getEndpoint(),
+              s3Config.getRegion(),
+              s3Config.getAccessKey(),
+              s3Config.getSecretKey());
+      return new S3BackupStore(storeConfig);
+    } else {
+      throw new IllegalArgumentException(
+          "The configured backup store type (%s) is unsupported. Cannot restore from backup"
+              .formatted(store));
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.restore;
+
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.shared.Profile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+@SpringBootApplication(
+    scanBasePackages = {"io.camunda.zeebe.restore", "io.camunda.zeebe.broker.shared"})
+@ConfigurationPropertiesScan(basePackages = {"io.camunda.zeebe.broker.shared"})
+public class RestoreApp implements ApplicationRunner {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RestoreApp.class);
+  private final BrokerCfg configuration;
+  private final BackupStore backupStore;
+
+  @Value("${backupId}")
+  // Parsed from commandline Eg:-`--backupId=100`
+  private long backupId;
+
+  @Autowired
+  public RestoreApp(final BrokerCfg configuration, final BackupStore backupStore) {
+    this.configuration = configuration;
+    this.backupStore = backupStore;
+  }
+
+  public static void main(final String[] args) {
+    System.setProperty("spring.banner.location", "classpath:/assets/zeebe_broker_banner.txt");
+    final var application =
+        new SpringApplicationBuilder(RestoreApp.class)
+            .logStartupInfo(true)
+            .profiles(Profile.RESTORE.getId())
+            .build();
+
+    application.run(args);
+  }
+
+  @Override
+  public void run(final ApplicationArguments args) {
+    LOG.info("Starting to restore from backup {}", backupId);
+    new RestoreManager(configuration, backupStore).restore(backupId).join();
+    LOG.info("Successfully restored broker from backup {}", backupId);
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -40,7 +40,6 @@ public class RestoreApp implements ApplicationRunner {
   }
 
   public static void main(final String[] args) {
-    System.setProperty("spring.banner.location", "classpath:/assets/zeebe_broker_banner.txt");
     final var application =
         new SpringApplicationBuilder(RestoreApp.class)
             .logStartupInfo(true)

--- a/dist/src/main/java/io/camunda/zeebe/shared/Profile.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/Profile.java
@@ -19,6 +19,7 @@ public enum Profile {
   // application specific profiles
   BROKER("broker"),
   GATEWAY("gateway"),
+  RESTORE("restore"),
 
   // environment profiles
   TEST("test"),

--- a/dist/src/test/java/io/camunda/zeebe/broker/WorkingDirectoryConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/broker/WorkingDirectoryConfigurationTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.broker.shared.WorkingDirectoryConfiguration;
 import io.camunda.zeebe.shared.Profile;
 import java.nio.file.Path;
 import java.util.Properties;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -369,6 +369,11 @@
         <version>${project.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-restore</artifactId>
+        <version>${project.version}</version>
+      </dependency>
       <!-- sibling projects -->
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <module>backup</module>
     <module>backup-stores/testkit</module>
     <module>backup-stores/s3</module>
+    <module>restore</module>
   </modules>
 
   <scm>

--- a/restore/pom.xml
+++ b/restore/pom.xml
@@ -22,4 +22,60 @@
 
   <name>Zeebe Backup Restore</name>
 
+  <dependencies>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-backup</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-atomix-cluster</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-snapshots</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-journal</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-scheduler</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
 </project>

--- a/restore/pom.xml
+++ b/restore/pom.xml
@@ -76,6 +76,10 @@
       <artifactId>zeebe-scheduler</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-broker</artifactId>
+    </dependency>
 
   </dependencies>
 </project>

--- a/restore/pom.xml
+++ b/restore/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Zeebe Community License 1.1. You may not use this file
+  ~ except in compliance with the Zeebe Community License 1.1.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>zeebe-parent</artifactId>
+    <version>8.1.0-SNAPSHOT</version>
+    <relativePath>../parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>zeebe-restore</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Zeebe Backup Restore</name>
+
+</project>

--- a/restore/src/main/java/io/camunda/zeebe/restore/BackupNotFoundException.java
+++ b/restore/src/main/java/io/camunda/zeebe/restore/BackupNotFoundException.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.system.restore;
+package io.camunda.zeebe.restore;
 
 public class BackupNotFoundException extends RuntimeException {
 

--- a/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -5,9 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.system.restore;
-
-import static io.camunda.zeebe.util.FileUtil.ensureDirectoryExists;
+package io.camunda.zeebe.restore;
 
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.backup.api.Backup;
@@ -97,7 +95,7 @@ public class PartitionRestoreService {
       // First download the contents to a temporary directory and then move it to the correct
       // locations.
       final var tempTargetDirectory = rootDirectory.resolve("restoring-" + backupId);
-      ensureDirectoryExists(tempTargetDirectory);
+      FileUtil.ensureDirectoryExists(tempTargetDirectory);
       return CompletableFuture.completedFuture(tempTargetDirectory);
     } catch (final Exception e) {
       return CompletableFuture.failedFuture(e);

--- a/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -89,7 +89,8 @@ public class PartitionRestoreService {
         LOG.error(
             "Partition's data directory {} is not empty. Aborting restore to avoid overwriting data. Please restart with a clean directory.",
             rootDirectory);
-        CompletableFuture.failedFuture(new DirectoryNotEmptyException(rootDirectory.toString()));
+        return CompletableFuture.failedFuture(
+            new DirectoryNotEmptyException(rootDirectory.toString()));
       }
 
       // First download the contents to a temporary directory and then move it to the correct
@@ -108,7 +109,7 @@ public class PartitionRestoreService {
         return entries.findFirst().isEmpty();
       }
     }
-    return false;
+    return !Files.exists(path);
   }
 
   // While taking the backup, we add all log segments. But the backup must only have entries upto

--- a/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -63,11 +63,7 @@ public class RestoreManager {
       final int localBrokerId) {
     return new PartitionRestoreService(backupStore, partition, brokerIds, localBrokerId)
         .restore(backupId)
-        .thenApply(
-            backup -> {
-              logSuccessfulRestore(backup, partition.id().id(), backupId);
-              return null;
-            });
+        .thenAccept(backup -> logSuccessfulRestore(backup, partition.id().id(), backupId));
   }
 
   private Set<RaftPartition> collectPartitions() {

--- a/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.restore;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.partition.RaftPartition;
+import io.camunda.zeebe.backup.api.BackupDescriptor;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.broker.partitioning.RaftPartitionGroupFactory;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RestoreManager {
+  private static final Logger LOG = LoggerFactory.getLogger(RestoreManager.class);
+  private final BrokerCfg configuration;
+  private final BackupStore backupStore;
+
+  public RestoreManager(final BrokerCfg configuration, final BackupStore backupStore) {
+    this.configuration = configuration;
+    this.backupStore = backupStore;
+  }
+
+  public CompletableFuture<Void> restore(final long backupId) {
+    final var brokerIds =
+        IntStream.range(0, configuration.getCluster().getClusterSize())
+            .boxed()
+            .collect(Collectors.toSet());
+    final var partitionToRestore = collectPartitions();
+    final var localBrokerId = configuration.getCluster().getNodeId();
+
+    final var partitionIds = partitionToRestore.stream().map(p -> p.id().id()).toList();
+    LOG.info("Restoring partitions {}", partitionIds);
+
+    return CompletableFuture.allOf(
+        partitionToRestore.stream()
+            .map(partition -> restorePartition(partition, backupId, brokerIds, localBrokerId))
+            .toArray(CompletableFuture[]::new));
+  }
+
+  private void logSuccessfulRestore(
+      final BackupDescriptor backup, final int partitionId, final long backupId) {
+    LOG.info(
+        "Successfully restored partition {} from backup {}. Backup description: {}",
+        partitionId,
+        backupId,
+        backup);
+  }
+
+  private CompletableFuture<Void> restorePartition(
+      final RaftPartition partition,
+      final long backupId,
+      final Set<Integer> brokerIds,
+      final int localBrokerId) {
+    return new PartitionRestoreService(backupStore, partition, brokerIds, localBrokerId)
+        .restore(backupId)
+        .thenApply(
+            backup -> {
+              logSuccessfulRestore(backup, partition.id().id(), backupId);
+              return null;
+            });
+  }
+
+  private Set<RaftPartition> collectPartitions() {
+
+    final var factory = new RaftPartitionGroupFactory();
+    // snapshot store factory can be null because we are not going start the partitions.
+    final var partitionsGroup = factory.buildRaftPartitionGroup(configuration, null);
+
+    final var localBrokerId = configuration.getCluster().getNodeId();
+    final var localMember = MemberId.from(String.valueOf(localBrokerId));
+    return partitionsGroup.getPartitions().stream()
+        .map(RaftPartition.class::cast)
+        .filter(partition -> partition.getMetadata().members().contains(localMember))
+        .collect(Collectors.toSet());
+  }
+}

--- a/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.system.restore;
+package io.camunda.zeebe.restore;
 
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/restore/src/test/java/io/camunda/zeebe/restore/TestRestorableBackupStore.java
+++ b/restore/src/test/java/io/camunda/zeebe/restore/TestRestorableBackupStore.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.broker.system.restore;
+package io.camunda.zeebe.restore;
 
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;


### PR DESCRIPTION
## Description

* Added a new module for restore. 
* Adds a RestoreManager that coordinates restoring of all partitions. It first determines which partitions to restore from based on the given `BrokerCfg`. This configuration must be the same one used by the Broker when it is started after the restore. Because of this, restore module depens on broker module. But since it needs access to the configuration and `RaftPartitionGroupFactory`, there is no other way. There is scope of splitting broker to take these shared configs out of it.
* Added a `RestoreApp` in dist. My plan was to add it in restore module. But it needs access to BrokerConfig, which is built in dist. So the app is added to dist module. Alternative is to copy components `BrokerConfiguration` and `WorkerDirectory` to restore module. 
* The backup id to restore from is passed as a command line argument `--backupId=x`. This is parsed by spring boot. I decided to keep it simple for now, since we are planning to release it as experimental feature anyway. If we decide to support this app long term, then I suggest to switch to something like picocli that we use in zdb.

A basic test to verify a broker can be restored is added. More scenarios should be added later.

PS:- App is not added to the distribution yet.

## Related issues

related #10263 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
