### PR TITLE
Migrate ProcessingScheduleService to own actor

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
@@ -55,14 +55,15 @@ public class ProcessingScheduleServiceImpl extends Actor implements ProcessingSc
   protected void onActorStarting() {
     writeRetryStrategy = new AbortableRetryStrategy(actor);
     final var writerFuture = writerAsyncSupplier.get();
-    actor.runOnCompletionBlockingCurrentPhase(writerFuture, (writer, failure) -> {
-      if (failure == null) {
-        logStreamBatchWriter = writer;
-      }
-      else {
-        actor.fail(failure);
-      }
-    });
+    actor.runOnCompletionBlockingCurrentPhase(
+        writerFuture,
+        (writer, failure) -> {
+          if (failure == null) {
+            logStreamBatchWriter = writer;
+          } else {
+            actor.fail(failure);
+          }
+        });
   }
 
   @Override
@@ -154,7 +155,8 @@ public class ProcessingScheduleServiceImpl extends Actor implements ProcessingSc
                                 .done());
 
                 return logStreamBatchWriter.tryWrite() >= 0;
-              }, abortCondition);
+              },
+              abortCondition);
 
       writeFuture.onComplete(
           (v, t) -> {

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
@@ -111,6 +111,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   private final List<RecordProcessor> recordProcessors = new ArrayList<>();
   private StreamProcessorDbState streamProcessorDbState;
+  private ProcessingScheduleServiceImpl scheduleService;
 
   protected StreamProcessor(final StreamProcessorBuilder processorBuilder) {
     actorSchedulingService = processorBuilder.getActorSchedulingService();
@@ -165,6 +166,14 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
       LOG.debug("Recovering state of partition {} from snapshot", partitionId);
       final var startRecoveryTimer = metrics.startRecoveryTimer();
       final long snapshotPosition = recoverFromSnapshot();
+
+      // the schedule service actor is only submitted to the scheduler if the replay is done,
+      // until then it is an unusable and closed actor
+      scheduleService = new ProcessingScheduleServiceImpl(
+          streamProcessorContext::getStreamProcessorPhase,
+          streamProcessorContext.getAbortCondition(),
+          logStream::newLogStreamBatchWriter);
+      streamProcessorContext.scheduleService(scheduleService);
 
       initRecordProcessors();
 
@@ -253,6 +262,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   }
 
   private void tearDown() {
+    scheduleService.closeAsync();
     streamProcessorContext.getLogStreamReader().close();
     logStream.removeRecordAvailableListener(this);
     replayStateMachine.close();
@@ -270,23 +280,34 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
     if (errorOnReceivingWriter == null) {
       streamProcessorContext.logStreamBatchWriter(batchWriter);
-
       streamProcessorContext.streamProcessorPhase(Phase.PROCESSING);
 
-      processingStateMachine =
-          new ProcessingStateMachine(
-              streamProcessorContext, this::shouldProcessNext, recordProcessors);
-
-      logStream.registerRecordAvailableListener(this);
-
-      // start reading
-      lifecycleAwareListeners.forEach(l -> l.onRecovered(streamProcessorContext));
-      processingStateMachine.startProcessing(lastProcessingPositions);
-      if (!shouldProcess) {
-        setStateToPausedAndNotifyListeners();
-      }
+      final var processingScheduleServiceFuture = actorSchedulingService.submitActor(scheduleService);
+      processingScheduleServiceFuture.onComplete((v, failure) -> {
+        if (failure == null) {
+          startProcessing(lastProcessingPositions);
+        }
+        else {
+          onFailure(failure);
+        }
+      });
     } else {
       onFailure(errorOnReceivingWriter);
+    }
+  }
+
+  private void startProcessing(final LastProcessingPositions lastProcessingPositions) {
+    processingStateMachine =
+        new ProcessingStateMachine(
+            streamProcessorContext, this::shouldProcessNext, recordProcessors);
+
+    logStream.registerRecordAvailableListener(this);
+
+    // start reading
+    lifecycleAwareListeners.forEach(l -> l.onRecovered(streamProcessorContext));
+    processingStateMachine.startProcessing(lastProcessingPositions);
+    if (!shouldProcess) {
+      setStateToPausedAndNotifyListeners();
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
@@ -99,6 +99,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   // processing
   private final StreamProcessorContext streamProcessorContext;
   private final String actorName;
+  private final String scheduleServiceActorName;
   private LogStreamReader logStreamReader;
   private ProcessingStateMachine processingStateMachine;
   private ReplayStateMachine replayStateMachine;
@@ -129,6 +130,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     logStream = streamProcessorContext.getLogStream();
     partitionId = logStream.getPartitionId();
     actorName = buildActorName(processorBuilder.getNodeId(), "StreamProcessor", partitionId);
+    scheduleServiceActorName = buildActorName(processorBuilder.getNodeId(), "ProcessingScheduleService", partitionId);
     metrics = new StreamProcessorMetrics(partitionId);
     recordProcessors.addAll(processorBuilder.getRecordProcessors());
   }
@@ -170,6 +172,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
       // the schedule service actor is only submitted to the scheduler if the replay is done,
       // until then it is an unusable and closed actor
       scheduleService = new ProcessingScheduleServiceImpl(
+          scheduleServiceActorName,
           streamProcessorContext::getStreamProcessorPhase,
           streamProcessorContext.getAbortCondition(),
           logStream::newLogStreamBatchWriter);

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
@@ -130,7 +130,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     logStream = streamProcessorContext.getLogStream();
     partitionId = logStream.getPartitionId();
     actorName = buildActorName(processorBuilder.getNodeId(), "StreamProcessor", partitionId);
-    scheduleServiceActorName = buildActorName(processorBuilder.getNodeId(), "ProcessingScheduleService", partitionId);
+    scheduleServiceActorName =
+        buildActorName(processorBuilder.getNodeId(), "ProcessingScheduleService", partitionId);
     metrics = new StreamProcessorMetrics(partitionId);
     recordProcessors.addAll(processorBuilder.getRecordProcessors());
   }
@@ -171,11 +172,12 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
       // the schedule service actor is only submitted to the scheduler if the replay is done,
       // until then it is an unusable and closed actor
-      scheduleService = new ProcessingScheduleServiceImpl(
-          scheduleServiceActorName,
-          streamProcessorContext::getStreamProcessorPhase,
-          streamProcessorContext.getAbortCondition(),
-          logStream::newLogStreamBatchWriter);
+      scheduleService =
+          new ProcessingScheduleServiceImpl(
+              scheduleServiceActorName,
+              streamProcessorContext::getStreamProcessorPhase,
+              streamProcessorContext.getAbortCondition(),
+              logStream::newLogStreamBatchWriter);
       streamProcessorContext.scheduleService(scheduleService);
 
       initRecordProcessors();
@@ -285,15 +287,16 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
       streamProcessorContext.logStreamBatchWriter(batchWriter);
       streamProcessorContext.streamProcessorPhase(Phase.PROCESSING);
 
-      final var processingScheduleServiceFuture = actorSchedulingService.submitActor(scheduleService);
-      processingScheduleServiceFuture.onComplete((v, failure) -> {
-        if (failure == null) {
-          startProcessing(lastProcessingPositions);
-        }
-        else {
-          onFailure(failure);
-        }
-      });
+      final var processingScheduleServiceFuture =
+          actorSchedulingService.submitActor(scheduleService);
+      processingScheduleServiceFuture.onComplete(
+          (v, failure) -> {
+            if (failure == null) {
+              startProcessing(lastProcessingPositions);
+            } else {
+              onFailure(failure);
+            }
+          });
     } else {
       onFailure(errorOnReceivingWriter);
     }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
@@ -60,7 +60,11 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   public StreamProcessorContext actor(final ActorControl actor) {
     this.actor = actor;
-    processingScheduleService = new ProcessingScheduleServiceImpl(this);
+    return this;
+  }
+
+  public StreamProcessorContext scheduleService(final ProcessingScheduleService processingScheduleService) {
+    this.processingScheduleService = processingScheduleService;
     return this;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
@@ -63,7 +63,8 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
     return this;
   }
 
-  public StreamProcessorContext scheduleService(final ProcessingScheduleService processingScheduleService) {
+  public StreamProcessorContext scheduleService(
+      final ProcessingScheduleService processingScheduleService) {
     this.processingScheduleService = processingScheduleService;
     return this;
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
@@ -97,38 +97,6 @@ public class ProcessingScheduleServiceIntegrationTest {
   }
 
   @Test
-  public void shouldNotExecuteScheduledTaskIfProcessingIsOngoing() {
-    // given
-    dummyProcessor.blockProcessing();
-    streamPlatform.writeBatch(command().processInstance(ACTIVATE_ELEMENT, RECORD));
-    streamPlatform.withRecordProcessors(List.of(dummyProcessor)).startStreamProcessor();
-    final var mockedTask = spy(new DummyTask());
-
-    // when
-    dummyProcessor.scheduleService.runDelayed(Duration.ZERO, mockedTask);
-
-    // then
-    verify(mockedTask, never()).execute(any());
-  }
-
-  @Test
-  public void shouldExecuteScheduledTaskAfterProcessing() {
-    // given
-    dummyProcessor.blockProcessing();
-    streamPlatform.writeBatch(command().processInstance(ACTIVATE_ELEMENT, RECORD));
-    streamPlatform.withRecordProcessors(List.of(dummyProcessor)).startStreamProcessor();
-    final var mockedTask = spy(new DummyTask());
-
-    // when
-    dummyProcessor.scheduleService.runDelayed(Duration.ZERO, mockedTask);
-    verify(mockedTask, never()).execute(any());
-    dummyProcessor.continueProcessing();
-
-    // then
-    verify(mockedTask, TIMEOUT).execute(any());
-  }
-
-  @Test
   public void shouldNotExecuteScheduledTaskIfOnReplay() {
     // given
     dummyProcessor.blockReplay();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
@@ -56,7 +56,7 @@ import org.mockito.Mockito;
 import org.mockito.verification.VerificationWithTimeout;
 
 @ExtendWith(StreamPlatformExtension.class)
-public class ProcessingScheduleServiceTest {
+public class ProcessingScheduleServiceIntegrationTest {
 
   private static final long TIMEOUT_MILLIS = 2_000L;
   private static final VerificationWithTimeout TIMEOUT = timeout(TIMEOUT_MILLIS);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
@@ -71,7 +71,6 @@ public class ProcessingScheduleServiceIntegrationTest {
   @AfterEach
   public void clean() {
     dummyProcessor.continueReplay();
-    dummyProcessor.continueProcessing();
     streamPlatform = null;
   }
 
@@ -221,7 +220,6 @@ public class ProcessingScheduleServiceIntegrationTest {
   private static final class DummyProcessor implements RecordProcessor {
 
     private ProcessingScheduleService scheduleService;
-    private CountDownLatch processingLatch;
     private CountDownLatch replayLatch;
 
     @Override
@@ -248,13 +246,6 @@ public class ProcessingScheduleServiceIntegrationTest {
     @Override
     public ProcessingResult process(
         final TypedRecord record, final ProcessingResultBuilder processingResultBuilder) {
-      if (processingLatch != null) {
-        try {
-          processingLatch.await();
-        } catch (final InterruptedException e) {
-          throw new RuntimeException(e);
-        }
-      }
       return EmptyProcessingResult.INSTANCE;
     }
 
@@ -264,16 +255,6 @@ public class ProcessingScheduleServiceIntegrationTest {
         final TypedRecord record,
         final ProcessingResultBuilder processingResultBuilder) {
       return EmptyProcessingResult.INSTANCE;
-    }
-
-    public void blockProcessing() {
-      processingLatch = new CountDownLatch(1);
-    }
-
-    public void continueProcessing() {
-      if (processingLatch != null) {
-        processingLatch.countDown();
-      }
     }
 
     public void blockReplay() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
@@ -201,8 +201,7 @@ public class ProcessingScheduleServiceIntegrationTest {
   public void shouldCloseWhenStreamProcessorClosed() throws Exception {
     // given
     final var dummyProcessorSpy = spy(dummyProcessor);
-    streamPlatform.withRecordProcessors(List.of(dummyProcessorSpy))
-        .startStreamProcessor();
+    streamPlatform.withRecordProcessors(List.of(dummyProcessorSpy)).startStreamProcessor();
 
     // when
     streamPlatform.closeStreamProcessor();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
@@ -13,15 +13,12 @@ import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTI
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.api.EmptyProcessingResult;
 import io.camunda.zeebe.engine.api.ProcessingResult;
 import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
@@ -36,18 +33,13 @@ import io.camunda.zeebe.engine.api.records.RecordBatch;
 import io.camunda.zeebe.engine.util.Records;
 import io.camunda.zeebe.engine.util.StreamPlatform;
 import io.camunda.zeebe.engine.util.StreamPlatformExtension;
-import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
-import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicInteger;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -218,73 +210,6 @@ public class ProcessingScheduleServiceIntegrationTest {
     // then
     assertThat(streamPlatform.getStreamProcessor().isClosed()).isTrue();
     assertThat(((Actor) dummyProcessorSpy.scheduleService).isActorClosed()).isTrue();
-  }
-
-  @RegressionTest("https://github.com/camunda/zeebe/issues/10240")
-  void shouldPreserveOrderingOfWritesEvenWithRetries() {
-    // given
-    final var dummyProcessorSpy = spy(dummyProcessor);
-    final var syncLogStream = spy(streamPlatform.getLogStream());
-    final var logStream = spy(syncLogStream.getAsyncLogStream());
-    final var batchWriter = spy(syncLogStream.newLogStreamBatchWriter());
-
-    when(syncLogStream.getAsyncLogStream()).thenReturn(logStream);
-    doReturn(CompletableActorFuture.completed(batchWriter))
-        .when(logStream)
-        .newLogStreamBatchWriter();
-    streamPlatform
-        .withRecordProcessors(List.of(dummyProcessorSpy))
-        .buildStreamProcessor(syncLogStream, true);
-
-    // when - in order to make sure we would interleave tasks without the fix for #10240, we need to
-    // make sure we retry at least twice, such that the second task can be executed in between both
-    // invocations. ensure both tasks have an expiry far away enough such that they expire on
-    // different ticks, as tasks expiring on the same tick will be submitted in a non-deterministic
-    // order
-    final var counter = new AtomicInteger(0);
-    when(batchWriter.tryWrite())
-        .then(
-            i -> {
-              final var invocationCount = counter.incrementAndGet();
-              // wait a sufficiently high enough invocation count to ensure the second timer is
-              // expired, gets scheduled, and then the executions are interleaved. this is quite
-              // hard to do in a deterministic controlled way because of the way our timers are
-              // scheduled
-              if (invocationCount < 5000) {
-                return -1L;
-              }
-
-              Loggers.PROCESS_PROCESSOR_LOGGER.debug("Calling real method");
-              return i.callRealMethod();
-            });
-
-    // we need to schedule first the longer delayed task, otherwise we might get race conditions
-    // with the scheduling and clock adjustment
-    dummyProcessorSpy.scheduleService.runDelayed(
-        Duration.ofMinutes(1),
-        builder -> {
-          Loggers.PROCESS_PROCESSOR_LOGGER.debug("Running second timer");
-          builder.appendCommandRecord(2, ACTIVATE_ELEMENT, RECORD);
-          return builder.build();
-        });
-    dummyProcessorSpy.scheduleService.runDelayed(
-        Duration.ZERO,
-        builder -> {
-          Loggers.PROCESS_PROCESSOR_LOGGER.debug("Running first timer");
-          // force trigger second task
-          clock.addTime(Duration.ofMinutes(1));
-          builder.appendCommandRecord(1, ACTIVATE_ELEMENT, RECORD);
-          return builder.build();
-        });
-
-    // then
-    Awaitility.await("until both records are written to the stream")
-        .atMost(Duration.ofSeconds(10))
-        .untilAsserted(() -> assertThat(streamPlatform.events()).hasSize(2));
-    assertThat(streamPlatform.events())
-        .as("records were written in order of submitted tasks")
-        .extracting(LoggedEvent::getKey)
-        .containsExactly(1L, 2L);
   }
 
   private static final class DummyTask implements Task {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
@@ -65,7 +65,8 @@ public class ProcessingScheduleServiceTest {
     clock = new ControlledActorClock();
     final var builder =
         ActorScheduler.newActorScheduler()
-            .setCpuBoundActorThreadCount(Math.max(1, Runtime.getRuntime().availableProcessors() - 2))
+            .setCpuBoundActorThreadCount(
+                Math.max(1, Runtime.getRuntime().availableProcessors() - 2))
             .setIoBoundActorThreadCount(2)
             .setActorClock(clock);
 
@@ -74,8 +75,9 @@ public class ProcessingScheduleServiceTest {
 
     lifecycleSupplier = new LifecycleSupplier();
     writerAsyncSupplier = new WriterAsyncSupplier();
-    processingScheduleService = new ProcessingScheduleServiceImpl("actorName", lifecycleSupplier,
-        lifecycleSupplier, writerAsyncSupplier);
+    processingScheduleService =
+        new ProcessingScheduleServiceImpl(
+            "actorName", lifecycleSupplier, lifecycleSupplier, writerAsyncSupplier);
     actorScheduler.submitActor(processingScheduleService);
   }
 
@@ -164,8 +166,9 @@ public class ProcessingScheduleServiceTest {
   public void shouldNotExecuteTasksWhenScheduledOnClosedActor() {
     // given
     lifecycleSupplier.currentPhase = Phase.PAUSED;
-    final var notOpenScheduleService = new ProcessingScheduleServiceImpl("actorName", lifecycleSupplier,
-        lifecycleSupplier, writerAsyncSupplier);
+    final var notOpenScheduleService =
+        new ProcessingScheduleServiceImpl(
+            "actorName", lifecycleSupplier, lifecycleSupplier, writerAsyncSupplier);
     final var mockedTask = spy(new DummyTask());
 
     // when
@@ -178,9 +181,11 @@ public class ProcessingScheduleServiceTest {
   @Test
   public void shouldFailActorIfWriterCantBeRetrieved() {
     // given
-    writerAsyncSupplier.writerFutureRef.set(CompletableActorFuture.completedExceptionally(new RuntimeException("expected")));
-    final var notOpenScheduleService = new ProcessingScheduleServiceImpl("actorName", lifecycleSupplier,
-        lifecycleSupplier, writerAsyncSupplier);
+    writerAsyncSupplier.writerFutureRef.set(
+        CompletableActorFuture.completedExceptionally(new RuntimeException("expected")));
+    final var notOpenScheduleService =
+        new ProcessingScheduleServiceImpl(
+            "actorName", lifecycleSupplier, lifecycleSupplier, writerAsyncSupplier);
 
     // when
     final var actorFuture = actorScheduler.submitActor(notOpenScheduleService);
@@ -276,8 +281,7 @@ public class ProcessingScheduleServiceTest {
     final var mockedTask = spy(new DummyTask());
 
     // when
-    processingScheduleService.runAtFixedRate(
-        Duration.ofMillis(10), mockedTask);
+    processingScheduleService.runAtFixedRate(Duration.ofMillis(10), mockedTask);
 
     // then
     verify(mockedTask, TIMEOUT.times(5)).execute(any());
@@ -296,8 +300,10 @@ public class ProcessingScheduleServiceTest {
     verify(mockedTask, never()).execute(any());
   }
 
-  private static final class WriterAsyncSupplier implements Supplier<ActorFuture<LogStreamBatchWriter>> {
-    AtomicReference<ActorFuture<LogStreamBatchWriter>> writerFutureRef = new AtomicReference<>(CompletableActorFuture.completed(mock(LogStreamBatchWriter.class)));
+  private static final class WriterAsyncSupplier
+      implements Supplier<ActorFuture<LogStreamBatchWriter>> {
+    AtomicReference<ActorFuture<LogStreamBatchWriter>> writerFutureRef =
+        new AtomicReference<>(CompletableActorFuture.completed(mock(LogStreamBatchWriter.class)));
 
     @Override
     public ActorFuture<LogStreamBatchWriter> get() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
@@ -147,7 +147,7 @@ public class ProcessingScheduleServiceTest {
   }
 
   @Test
-  public void shouldExecuteScheduledTaskAfterReplay() {
+  public void shouldNotExecuteTaskWhichAreScheduledDuringReplay() {
     // given
     final var processor = spy(dummyProcessor);
     processor.blockReplay();
@@ -165,7 +165,7 @@ public class ProcessingScheduleServiceTest {
     final var inOrder = inOrder(processor, mockedTask);
     inOrder.verify(processor, TIMEOUT).init(any());
     inOrder.verify(processor, TIMEOUT).replay(any());
-    inOrder.verify(mockedTask, TIMEOUT).execute(any());
+    inOrder.verify(mockedTask, never()).execute(any());
     inOrder.verifyNoMoreInteractions();
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.api.Task;
+import io.camunda.zeebe.engine.api.TaskResult;
+import io.camunda.zeebe.engine.api.TaskResultBuilder;
+import io.camunda.zeebe.engine.api.records.RecordBatch;
+import io.camunda.zeebe.engine.util.Records;
+import io.camunda.zeebe.logstreams.log.LogStreamBatchWriter;
+import io.camunda.zeebe.logstreams.log.LogStreamBatchWriter.LogEntryBuilder;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.streamprocessor.ProcessingScheduleServiceImpl;
+import io.camunda.zeebe.streamprocessor.StreamProcessor.Phase;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+import org.agrona.LangUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.verification.VerificationWithTimeout;
+
+public class ProcessingScheduleServiceTest {
+
+  private static final long TIMEOUT_MILLIS = 2_000L;
+  private static final VerificationWithTimeout TIMEOUT = timeout(TIMEOUT_MILLIS);
+
+  private static final ProcessInstanceRecord RECORD = Records.processInstance(1);
+
+  private ControlledActorClock clock;
+  private ActorScheduler actorScheduler;
+  private LifecycleSupplier lifecycleSupplier;
+  private WriterAsyncSupplier writerAsyncSupplier;
+  private ProcessingScheduleServiceImpl processingScheduleService;
+
+  @BeforeEach
+  public void before() {
+    clock = new ControlledActorClock();
+    final var builder =
+        ActorScheduler.newActorScheduler()
+            .setCpuBoundActorThreadCount(Math.max(1, Runtime.getRuntime().availableProcessors() - 2))
+            .setIoBoundActorThreadCount(2)
+            .setActorClock(clock);
+
+    actorScheduler = builder.build();
+    actorScheduler.start();
+
+    lifecycleSupplier = new LifecycleSupplier();
+    writerAsyncSupplier = new WriterAsyncSupplier();
+    processingScheduleService = new ProcessingScheduleServiceImpl("actorName", lifecycleSupplier,
+        lifecycleSupplier, writerAsyncSupplier);
+    actorScheduler.submitActor(processingScheduleService);
+  }
+
+  @AfterEach
+  public void clean() {
+    try {
+      actorScheduler.close();
+    } catch (final Exception e) {
+      LangUtil.rethrowUnchecked(e);
+    }
+
+    actorScheduler = null;
+  }
+
+  @Test
+  public void shouldExecuteScheduledTask() {
+    // given
+    final var mockedTask = spy(new DummyTask());
+
+    // when
+    processingScheduleService.runDelayed(Duration.ZERO, mockedTask);
+
+    // then
+    verify(mockedTask, TIMEOUT).execute(any());
+  }
+
+  @Test
+  public void shouldExecuteScheduledTaskInRightOrder() {
+    // given
+    final var mockedTask = spy(new DummyTask());
+    final var mockedTask2 = spy(new DummyTask());
+
+    // when
+    processingScheduleService.runDelayed(Duration.ZERO, mockedTask);
+    processingScheduleService.runDelayed(Duration.ZERO, mockedTask2);
+
+    // then
+    final var inOrder = inOrder(mockedTask, mockedTask2);
+    inOrder.verify(mockedTask, TIMEOUT).execute(any());
+    inOrder.verify(mockedTask2, TIMEOUT).execute(any());
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldNotExecuteScheduledTaskIfNotInProcessingPhase() {
+    // given
+    lifecycleSupplier.currentPhase = Phase.INITIAL;
+    final var mockedTask = spy(new DummyTask());
+
+    // when
+    processingScheduleService.runDelayed(Duration.ZERO, mockedTask);
+
+    // then
+    verify(mockedTask, never()).execute(any());
+  }
+
+  @Test
+  public void shouldNotExecuteScheduledTaskIfAborted() {
+    // given
+    lifecycleSupplier.isAborted = true;
+    final var mockedTask = spy(new DummyTask());
+
+    // when
+    processingScheduleService.runDelayed(Duration.ZERO, mockedTask);
+
+    // then
+    verify(mockedTask, never()).execute(any());
+  }
+
+  @Test
+  public void shouldExecuteScheduledTaskInProcessing() {
+    // given
+    lifecycleSupplier.currentPhase = Phase.PAUSED;
+    final var mockedTask = spy(new DummyTask());
+
+    // when
+    processingScheduleService.runDelayed(Duration.ZERO, mockedTask);
+    verify(mockedTask, never()).execute(any());
+    lifecycleSupplier.currentPhase = Phase.PROCESSING;
+
+    // then
+    verify(mockedTask, TIMEOUT).execute(any());
+  }
+
+  @Test
+  public void shouldNotExecuteTasksWhenScheduledOnClosedActor() {
+    // given
+    lifecycleSupplier.currentPhase = Phase.PAUSED;
+    final var notOpenScheduleService = new ProcessingScheduleServiceImpl("actorName", lifecycleSupplier,
+        lifecycleSupplier, writerAsyncSupplier);
+    final var mockedTask = spy(new DummyTask());
+
+    // when
+    notOpenScheduleService.runDelayed(Duration.ZERO, mockedTask);
+
+    // then
+    verify(mockedTask, never()).execute(any());
+  }
+
+  @Test
+  public void shouldFailActorIfWriterCantBeRetrieved() {
+    // given
+    writerAsyncSupplier.writerFutureRef.set(CompletableActorFuture.completedExceptionally(new RuntimeException("expected")));
+    final var notOpenScheduleService = new ProcessingScheduleServiceImpl("actorName", lifecycleSupplier,
+        lifecycleSupplier, writerAsyncSupplier);
+
+    // when
+    final var actorFuture = actorScheduler.submitActor(notOpenScheduleService);
+
+    // then
+    assertThatThrownBy(actorFuture::join).hasMessageContaining("expected");
+  }
+
+  @Test
+  public void shouldWriteRecordAfterTaskWasExecuted() {
+    // given
+    final var batchWriter = writerAsyncSupplier.get().join();
+    when(batchWriter.canWriteAdditionalEvent(anyInt(), anyInt())).thenReturn(true);
+    final var logEntryBuilder = mock(LogEntryBuilder.class, Mockito.RETURNS_DEEP_STUBS);
+    when(batchWriter.event()).thenReturn(logEntryBuilder);
+
+    // when
+    processingScheduleService.runDelayed(
+        Duration.ZERO,
+        (builder) -> {
+          builder.appendCommandRecord(1, ACTIVATE_ELEMENT, RECORD);
+          return builder.build();
+        });
+
+    // then
+    verify(batchWriter, TIMEOUT).event();
+    verify(logEntryBuilder, TIMEOUT).key(1);
+    verify(batchWriter, TIMEOUT).tryWrite();
+  }
+
+  @Test
+  public void shouldScheduleOnFixedRate() {
+    // given
+    final var mockedTask = spy(new DummyTask());
+
+    // when
+    processingScheduleService.runAtFixedRate(
+        Duration.ofMillis(10), mockedTask);
+
+    // then
+    verify(mockedTask, TIMEOUT.times(5)).execute(any());
+  }
+
+  @Test
+  public void shouldNotRunScheduledTasksAfterClosed() {
+    // given
+    final var mockedTask = spy(new DummyTask());
+    processingScheduleService.runDelayed(Duration.ofMillis(200), mockedTask);
+
+    // when
+    processingScheduleService.close();
+
+    // then
+    verify(mockedTask, never()).execute(any());
+  }
+
+  private static final class WriterAsyncSupplier implements Supplier<ActorFuture<LogStreamBatchWriter>> {
+    AtomicReference<ActorFuture<LogStreamBatchWriter>> writerFutureRef = new AtomicReference<>(CompletableActorFuture.completed(mock(LogStreamBatchWriter.class)));
+
+    @Override
+    public ActorFuture<LogStreamBatchWriter> get() {
+      return writerFutureRef.get();
+    }
+  }
+
+  private static final class LifecycleSupplier implements Supplier<Phase>, BooleanSupplier {
+
+    volatile Phase currentPhase = Phase.PROCESSING;
+    volatile boolean isAborted = false;
+
+    @Override
+    public boolean getAsBoolean() {
+      return isAborted;
+    }
+
+    @Override
+    public Phase get() {
+      return currentPhase;
+    }
+  }
+
+  private static final class DummyTask implements Task {
+    @Override
+    public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
+      return RecordBatch::empty;
+    }
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.api.Task;
 import io.camunda.zeebe.engine.api.TaskResult;
 import io.camunda.zeebe.engine.api.TaskResultBuilder;
@@ -33,7 +34,9 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.streamprocessor.ProcessingScheduleServiceImpl;
 import io.camunda.zeebe.streamprocessor.StreamProcessor.Phase;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
@@ -206,6 +209,65 @@ public class ProcessingScheduleServiceTest {
     verify(batchWriter, TIMEOUT).event();
     verify(logEntryBuilder, TIMEOUT).key(1);
     verify(batchWriter, TIMEOUT).tryWrite();
+  }
+
+  @RegressionTest("https://github.com/camunda/zeebe/issues/10240")
+  public void shouldPreserveOrderingOfWritesEvenWithRetries() {
+    // given
+    final var batchWriter = writerAsyncSupplier.get().join();
+    when(batchWriter.canWriteAdditionalEvent(anyInt(), anyInt())).thenReturn(true);
+    final var logEntryBuilder = mock(LogEntryBuilder.class, Mockito.RETURNS_DEEP_STUBS);
+    when(batchWriter.event()).thenReturn(logEntryBuilder);
+
+    // when - in order to make sure we would interleave tasks without the fix for #10240, we need to
+    // make sure we retry at least twice, such that the second task can be executed in between both
+    // invocations. ensure both tasks have an expiry far away enough such that they expire on
+    // different ticks, as tasks expiring on the same tick will be submitted in a non-deterministic
+    // order
+    final var counter = new AtomicInteger(0);
+    when(batchWriter.tryWrite())
+        .then(
+            i -> {
+              final var invocationCount = counter.incrementAndGet();
+              // wait a sufficiently high enough invocation count to ensure the second timer is
+              // expired, gets scheduled, and then the executions are interleaved. this is quite
+              // hard to do in a deterministic controlled way because of the way our timers are
+              // scheduled
+              if (invocationCount < 5000) {
+                return -1L;
+              }
+
+              Loggers.PROCESS_PROCESSOR_LOGGER.debug("End tryWrite loop");
+              return 0L;
+            });
+
+    processingScheduleService.runDelayed(
+        Duration.ofMinutes(1),
+        builder -> {
+          Loggers.PROCESS_PROCESSOR_LOGGER.debug("Running second timer");
+          builder.appendCommandRecord(2, ACTIVATE_ELEMENT, RECORD);
+          return builder.build();
+        });
+    processingScheduleService.runDelayed(
+        Duration.ZERO,
+        builder -> {
+          Loggers.PROCESS_PROCESSOR_LOGGER.debug("Running first timer");
+          // force trigger second task
+          clock.addTime(Duration.ofMinutes(1));
+          builder.appendCommandRecord(1, ACTIVATE_ELEMENT, RECORD);
+          return builder.build();
+        });
+
+    // then
+    final var inOrder = inOrder(batchWriter, logEntryBuilder);
+
+    inOrder.verify(batchWriter, TIMEOUT).event();
+    inOrder.verify(logEntryBuilder, TIMEOUT).key(1);
+    inOrder.verify(batchWriter, TIMEOUT).tryWrite();
+    inOrder.verify(batchWriter, TIMEOUT).event();
+    inOrder.verify(logEntryBuilder, TIMEOUT).key(2);
+    inOrder.verify(batchWriter, TIMEOUT).tryWrite();
+    inOrder.verifyNoMoreInteractions();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
@@ -281,6 +281,10 @@ public final class StreamPlatform {
     return writeActor.submit(batchWriter::tryWrite).join();
   }
 
+  public void closeStreamProcessor() throws Exception {
+    processorContext.close();
+  }
+
   /** Used to run writes within an actor thread. */
   private static final class WriteActor extends Actor {
     public ActorFuture<Long> submit(final Callable<Long> write) {


### PR DESCRIPTION
## Description


> @npepinpe another idea. What do you think of we keep the additional submit, to keep it thread-safe, but create an own actor for the PRocessingScheduleService. This might reduce the potential delays (since the actor only has to schedule and execute timers). This would also solve other issues, like blocking processing actor when having many timers or timeouts. If you agree then I would create another PR where I migrate the ProcessingScheduleService to an own actor with own

As discussed here https://github.com/camunda/zeebe/pull/10390#discussion_r975008485

### Details 
This PR migrates the `ProcessingScheduleServiceImpl` to an own actor this means:

The actor between `StreamProcessor` and `ProcessingScheduleServiceImpl` is no longer shared. `ProcessingScheduleServiceImpl` is scheduled as own actor.

`ProcessingScheduleServiceImpl` is created before the `RecordProcessors` are initialized. This allows to initialize all processors already correctly on `init`.

The `ProcessingScheduleServiceImpl` actor is submitted to the scheduler AFTER replay is done. Only after that scheduled tasks are accepted.

The `ProcessingScheduleServiceImpl` gets on the creation some suppliers which are used during the actor's lifetime. For example an `LogStreamWriter` supplier, which is used to create an own writer AFTER the actor is scheduled. This reduces the consumed resources on followers, if the service is never scheduled we don't need to create a writer.

When the StreamProcessor is in the closing phase it will close the scheduled service as well.

I created some new unit tests, and renamed the old tests to "integration" tests. The existing regression test was ported to the unit tests, since the setup was easier. We can discuss whether we need all of the integration tests since mostly it is now tested in the unit tests. 


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10291 
closes https://github.com/camunda/zeebe/issues/8991
closes https://github.com/camunda/zeebe/pull/10390

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
