### PR TITLE
Remove the extra submit from ProcessingScheduleServiceImpl

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
@@ -92,7 +92,7 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService,
     openFuture = new CompletableActorFuture<>();
     writeRetryStrategy = new AbortableRetryStrategy(control);
     final var writerFuture = writerAsyncSupplier.get();
-    control.runOnCompletionBlockingCurrentPhase(
+    control.runOnCompletion(
         writerFuture,
         (writer, failure) -> {
           if (failure == null) {

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
@@ -10,33 +10,45 @@ package io.camunda.zeebe.streamprocessor;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.api.Task;
+import io.camunda.zeebe.logstreams.log.LogStreamBatchWriter;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.retry.AbortableRetryStrategy;
 import io.camunda.zeebe.streamprocessor.StreamProcessor.Phase;
 import java.time.Duration;
 import java.util.function.BiConsumer;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
 
 /**
  * Here the implementation is just a suggestion to amke the engine abstraction work. Can be whatever
  * PDT team thinks is best to work with
  */
-public class ProcessingScheduleServiceImpl implements ProcessingScheduleService {
+public class ProcessingScheduleServiceImpl implements ProcessingScheduleService, AutoCloseable {
 
-  private final ActorControl actorControl;
-  private final StreamProcessorContext streamProcessorContext;
-  private final AbortableRetryStrategy writeRetryStrategy;
+  private static final Logger LOG = Loggers.STREAM_PROCESSING;
+  private final Supplier<StreamProcessor.Phase> streamProcessorPhaseSupplier;
+  private final BooleanSupplier abortCondition;
+  private final Supplier<ActorFuture<LogStreamBatchWriter>> writerAsyncSupplier;
+  private LogStreamBatchWriter logStreamBatchWriter;
+  private ActorControl actorControl;
+  private AbortableRetryStrategy writeRetryStrategy;
+  private CompletableActorFuture<Void> openFuture;
 
-  // todo remove context from CTOR; will be cleaned up after engine abstraction is done
-  public ProcessingScheduleServiceImpl(final StreamProcessorContext streamProcessorContext) {
-    actorControl = streamProcessorContext.getActor();
-    this.streamProcessorContext = streamProcessorContext;
-    writeRetryStrategy = new AbortableRetryStrategy(actorControl);
+  public ProcessingScheduleServiceImpl(
+      final Supplier<Phase> streamProcessorPhaseSupplier,
+      final BooleanSupplier abortCondition,
+      final Supplier<ActorFuture<LogStreamBatchWriter>> writerAsyncSupplier) {
+    this.streamProcessorPhaseSupplier = streamProcessorPhaseSupplier;
+    this.abortCondition = abortCondition;
+    this.writerAsyncSupplier = writerAsyncSupplier;
   }
 
   @Override
   public void runDelayed(final Duration delay, final Runnable followUpTask) {
-    scheduleOnActor(() -> actorControl.runDelayed(delay, followUpTask));
+    useActorControl(() -> actorControl.runDelayed(delay, followUpTask));
   }
 
   @Override
@@ -47,15 +59,11 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService 
   @Override
   public <T> void runOnCompletion(
       final ActorFuture<T> precedingTask, final BiConsumer<T, Throwable> followUpTask) {
-    scheduleOnActor(() -> actorControl.runOnCompletion(precedingTask, followUpTask));
+    useActorControl(() -> actorControl.runOnCompletion(precedingTask, followUpTask));
   }
 
   @Override
   public void runAtFixedRate(final Duration delay, final Task task) {
-    /* TODO preliminary implementation; with the direct access
-     * this only works because this class is scheduled on the same actor as the
-     * stream processor.
-     */
     runDelayed(
         delay,
         toRunnable(
@@ -68,18 +76,52 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService 
             }));
   }
 
-  private void scheduleOnActor(final Runnable task) {
+  private void useActorControl(final Runnable task) {
+    if (actorControl == null) {
+      LOG.debug("ProcessingScheduleService hasn't been opened yet, ignore scheduled task.");
+      return;
+    }
     actorControl.submit(task);
+  }
+
+  public ActorFuture<Void> open(final ActorControl control) {
+    if (openFuture != null) {
+      return openFuture;
+    }
+
+    openFuture = new CompletableActorFuture<>();
+    writeRetryStrategy = new AbortableRetryStrategy(control);
+    final var writerFuture = writerAsyncSupplier.get();
+    control.runOnCompletionBlockingCurrentPhase(
+        writerFuture,
+        (writer, failure) -> {
+          if (failure == null) {
+            logStreamBatchWriter = writer;
+            actorControl = control;
+            openFuture.complete(null);
+          } else {
+            openFuture.completeExceptionally(failure);
+          }
+        });
+    return openFuture;
+  }
+
+  @Override
+  public void close() {
+    actorControl = null;
+    logStreamBatchWriter = null;
+    writeRetryStrategy = null;
+    openFuture = null;
   }
 
   Runnable toRunnable(final Task task) {
     return () -> {
-      if (streamProcessorContext.getAbortCondition().getAsBoolean()) {
+      if (abortCondition.getAsBoolean()) {
         // it might be that we are closing, then we should just stop
         return;
       }
 
-      final var currentStreamProcessorPhase = streamProcessorContext.getStreamProcessorPhase();
+      final var currentStreamProcessorPhase = streamProcessorPhaseSupplier.get();
       if (currentStreamProcessorPhase != Phase.PROCESSING) {
 
         // We want to execute the scheduled tasks only if the StreamProcessor is in the PROCESSING
@@ -90,13 +132,12 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService 
         //  * we are not running during replay/init phase (the state might not be up-to-date yet)
         //  * we are not running during suspending
         //
-        Loggers.PROCESS_PROCESSOR_LOGGER.trace(
+        LOG.trace(
             "Not able to execute scheduled task right now. [streamProcessorPhase: {}]",
             currentStreamProcessorPhase);
         actorControl.submit(toRunnable(task));
         return;
       }
-      final var logStreamBatchWriter = streamProcessorContext.getLogStreamBatchWriter();
       final var builder =
           new DirectTaskResultBuilder(logStreamBatchWriter::canWriteAdditionalEvent);
       final var result = task.execute(builder);
@@ -108,7 +149,7 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService 
       final var writeFuture =
           writeRetryStrategy.runWithRetry(
               () -> {
-                Loggers.PROCESS_PROCESSOR_LOGGER.trace("Write scheduled TaskResult to dispatcher!");
+                LOG.trace("Write scheduled TaskResult to dispatcher!");
                 logStreamBatchWriter.reset();
                 result
                     .getRecordBatch()
@@ -124,7 +165,7 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService 
 
                 return logStreamBatchWriter.tryWrite() >= 0;
               },
-              streamProcessorContext.getAbortCondition());
+              abortCondition);
 
       writeFuture.onComplete(
           (v, t) -> {
@@ -133,7 +174,7 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService 
               //   can happen if we tried to write a too big batch of records
               //   this should resolve if we use the buffered writer were we detect these errors
               // earlier
-              Loggers.PROCESS_PROCESSOR_LOGGER.warn("Writing of scheduled TaskResult failed!", t);
+              LOG.warn("Writing of scheduled TaskResult failed!", t);
             }
           });
     };

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorContext.java
@@ -60,7 +60,11 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   public StreamProcessorContext actor(final ActorControl actor) {
     this.actor = actor;
-    processingScheduleService = new ProcessingScheduleServiceImpl(this);
+    return this;
+  }
+
+  public StreamProcessorContext scheduleService(final ProcessingScheduleService scheduleService) {
+    processingScheduleService = scheduleService;
     return this;
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
@@ -55,7 +55,7 @@ import org.mockito.Mockito;
 import org.mockito.verification.VerificationWithTimeout;
 
 @ExtendWith(StreamPlatformExtension.class)
-public class ProcessingScheduleServiceTest {
+public class ProcessingScheduleServiceIntegrationTest {
 
   private static final long TIMEOUT_MILLIS = 2_000L;
   private static final VerificationWithTimeout TIMEOUT = timeout(TIMEOUT_MILLIS);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
@@ -69,7 +69,6 @@ public class ProcessingScheduleServiceIntegrationTest {
   @AfterEach
   public void clean() {
     dummyProcessor.continueReplay();
-    dummyProcessor.continueProcessing();
     streamPlatform = null;
   }
 
@@ -205,7 +204,6 @@ public class ProcessingScheduleServiceIntegrationTest {
   private static final class DummyProcessor implements RecordProcessor {
 
     private ProcessingScheduleService scheduleService;
-    private CountDownLatch processingLatch;
     private CountDownLatch replayLatch;
 
     @Override
@@ -232,13 +230,6 @@ public class ProcessingScheduleServiceIntegrationTest {
     @Override
     public ProcessingResult process(
         final TypedRecord record, final ProcessingResultBuilder processingResultBuilder) {
-      if (processingLatch != null) {
-        try {
-          processingLatch.await();
-        } catch (final InterruptedException e) {
-          throw new RuntimeException(e);
-        }
-      }
       return EmptyProcessingResult.INSTANCE;
     }
 
@@ -248,16 +239,6 @@ public class ProcessingScheduleServiceIntegrationTest {
         final TypedRecord record,
         final ProcessingResultBuilder processingResultBuilder) {
       return EmptyProcessingResult.INSTANCE;
-    }
-
-    public void blockProcessing() {
-      processingLatch = new CountDownLatch(1);
-    }
-
-    public void continueProcessing() {
-      if (processingLatch != null) {
-        processingLatch.countDown();
-      }
     }
 
     public void blockReplay() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
@@ -11,17 +11,13 @@ import static io.camunda.zeebe.engine.util.RecordToWrite.command;
 import static io.camunda.zeebe.engine.util.RecordToWrite.event;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.api.EmptyProcessingResult;
 import io.camunda.zeebe.engine.api.ProcessingResult;
 import io.camunda.zeebe.engine.api.ProcessingResultBuilder;
@@ -36,17 +32,12 @@ import io.camunda.zeebe.engine.api.records.RecordBatch;
 import io.camunda.zeebe.engine.util.Records;
 import io.camunda.zeebe.engine.util.StreamPlatform;
 import io.camunda.zeebe.engine.util.StreamPlatformExtension;
-import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
-import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicInteger;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -202,73 +193,6 @@ public class ProcessingScheduleServiceIntegrationTest {
     // then
     verify(dummyProcessorSpy, TIMEOUT.times(5))
         .process(Mockito.argThat(record -> record.getKey() == 1), any());
-  }
-
-  @RegressionTest("https://github.com/camunda/zeebe/issues/10240")
-  void shouldPreserveOrderingOfWritesEvenWithRetries() {
-    // given
-    final var dummyProcessorSpy = spy(dummyProcessor);
-    final var syncLogStream = spy(streamPlatform.getLogStream());
-    final var logStream = spy(syncLogStream.getAsyncLogStream());
-    final var batchWriter = spy(syncLogStream.newLogStreamBatchWriter());
-
-    when(syncLogStream.getAsyncLogStream()).thenReturn(logStream);
-    doReturn(CompletableActorFuture.completed(batchWriter))
-        .when(logStream)
-        .newLogStreamBatchWriter();
-    streamPlatform
-        .withRecordProcessors(List.of(dummyProcessorSpy))
-        .buildStreamProcessor(syncLogStream, true);
-
-    // when - in order to make sure we would interleave tasks without the fix for #10240, we need to
-    // make sure we retry at least twice, such that the second task can be executed in between both
-    // invocations. ensure both tasks have an expiry far away enough such that they expire on
-    // different ticks, as tasks expiring on the same tick will be submitted in a non-deterministic
-    // order
-    final var counter = new AtomicInteger(0);
-    when(batchWriter.tryWrite())
-        .then(
-            i -> {
-              final var invocationCount = counter.incrementAndGet();
-              // wait a sufficiently high enough invocation count to ensure the second timer is
-              // expired, gets scheduled, and then the executions are interleaved. this is quite
-              // hard to do in a deterministic controlled way because of the way our timers are
-              // scheduled
-              if (invocationCount < 5000) {
-                return -1L;
-              }
-
-              Loggers.PROCESS_PROCESSOR_LOGGER.debug("Calling real method");
-              return i.callRealMethod();
-            });
-
-    // we need to schedule first the longer delayed task, otherwise we might get race conditions
-    // with the scheduling and clock adjustment
-    dummyProcessorSpy.scheduleService.runDelayed(
-        Duration.ofMinutes(1),
-        builder -> {
-          Loggers.PROCESS_PROCESSOR_LOGGER.debug("Running second timer");
-          builder.appendCommandRecord(2, ACTIVATE_ELEMENT, RECORD);
-          return builder.build();
-        });
-    dummyProcessorSpy.scheduleService.runDelayed(
-        Duration.ZERO,
-        builder -> {
-          Loggers.PROCESS_PROCESSOR_LOGGER.debug("Running first timer");
-          // force trigger second task
-          clock.addTime(Duration.ofMinutes(1));
-          builder.appendCommandRecord(1, ACTIVATE_ELEMENT, RECORD);
-          return builder.build();
-        });
-
-    // then
-    Awaitility.await("until both records are written to the stream")
-        .atMost(Duration.ofSeconds(10))
-        .untilAsserted(() -> assertThat(streamPlatform.events()).hasSize(2));
-    assertThat(streamPlatform.events())
-        .as("records were written in order of submitted tasks")
-        .extracting(LoggedEvent::getKey)
-        .containsExactly(1L, 2L);
   }
 
   private static final class DummyTask implements Task {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
@@ -96,38 +96,6 @@ public class ProcessingScheduleServiceIntegrationTest {
   }
 
   @Test
-  public void shouldNotExecuteScheduledTaskIfProcessingIsOngoing() {
-    // given
-    dummyProcessor.blockProcessing();
-    streamPlatform.writeBatch(command().processInstance(ACTIVATE_ELEMENT, RECORD));
-    streamPlatform.withRecordProcessors(List.of(dummyProcessor)).startStreamProcessor();
-    final var mockedTask = spy(new DummyTask());
-
-    // when
-    dummyProcessor.scheduleService.runDelayed(Duration.ZERO, mockedTask);
-
-    // then
-    verify(mockedTask, never()).execute(any());
-  }
-
-  @Test
-  public void shouldExecuteScheduledTaskAfterProcessing() {
-    // given
-    dummyProcessor.blockProcessing();
-    streamPlatform.writeBatch(command().processInstance(ACTIVATE_ELEMENT, RECORD));
-    streamPlatform.withRecordProcessors(List.of(dummyProcessor)).startStreamProcessor();
-    final var mockedTask = spy(new DummyTask());
-
-    // when
-    dummyProcessor.scheduleService.runDelayed(Duration.ZERO, mockedTask);
-    verify(mockedTask, never()).execute(any());
-    dummyProcessor.continueProcessing();
-
-    // then
-    verify(mockedTask, TIMEOUT).execute(any());
-  }
-
-  @Test
   public void shouldNotExecuteScheduledTaskIfOnReplay() {
     // given
     dummyProcessor.blockReplay();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
@@ -12,7 +12,6 @@ import static io.camunda.zeebe.engine.util.RecordToWrite.event;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
@@ -120,11 +119,9 @@ public class ProcessingScheduleServiceIntegrationTest {
     processor.continueReplay();
 
     // then
-    final var inOrder = inOrder(processor, mockedTask);
-    inOrder.verify(processor, TIMEOUT).init(any());
-    inOrder.verify(processor, TIMEOUT).replay(any());
-    inOrder.verify(mockedTask, never()).execute(any());
-    inOrder.verifyNoMoreInteractions();
+    verify(processor, TIMEOUT).init(any());
+    verify(processor, TIMEOUT).replay(any());
+    verify(mockedTask, never()).execute(any());
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
@@ -147,7 +147,7 @@ public class ProcessingScheduleServiceTest {
   }
 
   @Test
-  public void shouldExecuteScheduledTaskAfterReplay() {
+  public void shouldNotExecuteTaskWhichAreScheduledDuringReplay() {
     // given
     final var processor = spy(dummyProcessor);
     processor.blockReplay();
@@ -165,7 +165,7 @@ public class ProcessingScheduleServiceTest {
     final var inOrder = inOrder(processor, mockedTask);
     inOrder.verify(processor, TIMEOUT).init(any());
     inOrder.verify(processor, TIMEOUT).replay(any());
-    inOrder.verify(mockedTask, TIMEOUT).execute(any());
+    inOrder.verify(mockedTask, never()).execute(any());
     inOrder.verifyNoMoreInteractions();
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.api.ProcessingScheduleService;
+import io.camunda.zeebe.engine.api.Task;
+import io.camunda.zeebe.engine.api.TaskResult;
+import io.camunda.zeebe.engine.api.TaskResultBuilder;
+import io.camunda.zeebe.engine.api.records.RecordBatch;
+import io.camunda.zeebe.engine.util.Records;
+import io.camunda.zeebe.logstreams.log.LogStreamBatchWriter;
+import io.camunda.zeebe.logstreams.log.LogStreamBatchWriter.LogEntryBuilder;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.streamprocessor.ProcessingScheduleServiceImpl;
+import io.camunda.zeebe.streamprocessor.StreamProcessor.Phase;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+import org.agrona.LangUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.verification.VerificationWithTimeout;
+
+public class ProcessingScheduleServiceTest {
+
+  private static final long TIMEOUT_MILLIS = 2_000L;
+  private static final VerificationWithTimeout TIMEOUT = timeout(TIMEOUT_MILLIS);
+
+  private static final ProcessInstanceRecord RECORD = Records.processInstance(1);
+
+  private ControlledActorClock clock;
+  private ActorScheduler actorScheduler;
+  private LifecycleSupplier lifecycleSupplier;
+  private WriterAsyncSupplier writerAsyncSupplier;
+  private TestScheduleServiceActorDecorator scheduleService;
+
+  @BeforeEach
+  public void before() {
+    clock = new ControlledActorClock();
+    final var builder =
+        ActorScheduler.newActorScheduler()
+            .setCpuBoundActorThreadCount(
+                Math.max(1, Runtime.getRuntime().availableProcessors() - 2))
+            .setIoBoundActorThreadCount(2)
+            .setActorClock(clock);
+
+    actorScheduler = builder.build();
+    actorScheduler.start();
+
+    lifecycleSupplier = new LifecycleSupplier();
+    writerAsyncSupplier = new WriterAsyncSupplier();
+    final var processingScheduleService =
+        new ProcessingScheduleServiceImpl(
+            lifecycleSupplier, lifecycleSupplier, writerAsyncSupplier);
+
+    scheduleService = new TestScheduleServiceActorDecorator(processingScheduleService);
+    actorScheduler.submitActor(scheduleService);
+  }
+
+  @AfterEach
+  public void clean() {
+    try {
+      actorScheduler.close();
+    } catch (final Exception e) {
+      LangUtil.rethrowUnchecked(e);
+    }
+
+    actorScheduler = null;
+  }
+
+  @Test
+  public void shouldExecuteScheduledTask() {
+    // given
+    final var mockedTask = spy(new DummyTask());
+
+    // when
+    scheduleService.runDelayed(Duration.ZERO, mockedTask);
+
+    // then
+    verify(mockedTask, TIMEOUT).execute(any());
+  }
+
+  @Test
+  public void shouldExecuteScheduledTaskInRightOrder() {
+    // given
+    final var mockedTask = spy(new DummyTask());
+    final var mockedTask2 = spy(new DummyTask());
+
+    // when
+    scheduleService.runDelayed(Duration.ZERO, mockedTask);
+    scheduleService.runDelayed(Duration.ZERO, mockedTask2);
+
+    // then
+    final var inOrder = inOrder(mockedTask, mockedTask2);
+    inOrder.verify(mockedTask, TIMEOUT).execute(any());
+    inOrder.verify(mockedTask2, TIMEOUT).execute(any());
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldNotExecuteScheduledTaskIfNotInProcessingPhase() {
+    // given
+    lifecycleSupplier.currentPhase = Phase.INITIAL;
+    final var mockedTask = spy(new DummyTask());
+
+    // when
+    scheduleService.runDelayed(Duration.ZERO, mockedTask);
+
+    // then
+    verify(mockedTask, never()).execute(any());
+  }
+
+  @Test
+  public void shouldNotExecuteScheduledTaskIfAborted() {
+    // given
+    lifecycleSupplier.isAborted = true;
+    final var mockedTask = spy(new DummyTask());
+
+    // when
+    scheduleService.runDelayed(Duration.ZERO, mockedTask);
+
+    // then
+    verify(mockedTask, never()).execute(any());
+  }
+
+  @Test
+  public void shouldExecuteScheduledTaskInProcessing() {
+    // given
+    lifecycleSupplier.currentPhase = Phase.PAUSED;
+    final var mockedTask = spy(new DummyTask());
+
+    // when
+    scheduleService.runDelayed(Duration.ZERO, mockedTask);
+    verify(mockedTask, never()).execute(any());
+    lifecycleSupplier.currentPhase = Phase.PROCESSING;
+
+    // then
+    verify(mockedTask, TIMEOUT).execute(any());
+  }
+
+  @Test
+  public void shouldNotExecuteTasksWhenScheduledOnClosedActor() {
+    // given
+    lifecycleSupplier.currentPhase = Phase.PAUSED;
+    final var notOpenScheduleService =
+        new ProcessingScheduleServiceImpl(
+            lifecycleSupplier, lifecycleSupplier, writerAsyncSupplier);
+    final var mockedTask = spy(new DummyTask());
+
+    // when
+    notOpenScheduleService.runDelayed(Duration.ZERO, mockedTask);
+
+    // then
+    verify(mockedTask, never()).execute(any());
+  }
+
+  @Test
+  public void shouldFailActorIfWriterCantBeRetrieved() {
+    // given
+    writerAsyncSupplier.writerFutureRef.set(
+        CompletableActorFuture.completedExceptionally(new RuntimeException("expected")));
+    final var notOpenScheduleService =
+        new TestScheduleServiceActorDecorator(
+            new ProcessingScheduleServiceImpl(
+                lifecycleSupplier, lifecycleSupplier, writerAsyncSupplier));
+
+    // when
+    final var actorFuture = actorScheduler.submitActor(notOpenScheduleService);
+
+    // then
+    assertThatThrownBy(actorFuture::join).hasMessageContaining("expected");
+  }
+
+  @Test
+  public void shouldWriteRecordAfterTaskWasExecuted() {
+    // given
+    final var batchWriter = writerAsyncSupplier.get().join();
+    when(batchWriter.canWriteAdditionalEvent(anyInt(), anyInt())).thenReturn(true);
+    final var logEntryBuilder = mock(LogEntryBuilder.class, Mockito.RETURNS_DEEP_STUBS);
+    when(batchWriter.event()).thenReturn(logEntryBuilder);
+
+    // when
+    scheduleService.runDelayed(
+        Duration.ZERO,
+        (builder) -> {
+          builder.appendCommandRecord(1, ACTIVATE_ELEMENT, RECORD);
+          return builder.build();
+        });
+
+    // then
+    verify(batchWriter, TIMEOUT).event();
+    verify(logEntryBuilder, TIMEOUT).key(1);
+    verify(batchWriter, TIMEOUT).tryWrite();
+  }
+
+  @Test
+  public void shouldScheduleOnFixedRate() {
+    // given
+    final var mockedTask = spy(new DummyTask());
+
+    // when
+    scheduleService.runAtFixedRate(Duration.ofMillis(10), mockedTask);
+
+    // then
+    verify(mockedTask, TIMEOUT.times(5)).execute(any());
+  }
+
+  @Test
+  public void shouldNotRunScheduledTasksAfterClosed() {
+    // given
+    final var mockedTask = spy(new DummyTask());
+    scheduleService.runDelayed(Duration.ofMillis(200), mockedTask);
+
+    // when
+    scheduleService.close();
+
+    // then
+    verify(mockedTask, never()).execute(any());
+  }
+
+  /**
+   * This decorator is an actor and implements {@link ProcessingScheduleService} and delegates to
+   * {@link ProcessingScheduleServiceImpl}, on each call it will submit an extra job to the related
+   * Actor in order to schedule the work on the same ActorThread. This is needed since we are not
+   * allowed to schedule timers from outside to the actor.
+   *
+   * <p>Note: This is an actor scheduler limitation, since the used way how we schedule timers are
+   * not thread safe, so this need to happen on the same thread, meaning on the same actor.
+   */
+  private static final class TestScheduleServiceActorDecorator extends Actor
+      implements ProcessingScheduleService {
+    private final ProcessingScheduleServiceImpl processingScheduleService;
+
+    public TestScheduleServiceActorDecorator(
+        final ProcessingScheduleServiceImpl processingScheduleService) {
+      this.processingScheduleService = processingScheduleService;
+    }
+
+    @Override
+    public void runDelayed(final Duration delay, final Runnable task) {
+      actor.submit(() -> processingScheduleService.runDelayed(delay, task));
+    }
+
+    @Override
+    public void runDelayed(final Duration delay, final Task task) {
+      actor.submit(() -> processingScheduleService.runDelayed(delay, task));
+    }
+
+    @Override
+    public void runAtFixedRate(final Duration delay, final Task task) {
+      actor.submit(() -> processingScheduleService.runAtFixedRate(delay, task));
+    }
+
+    @Override
+    protected void onActorStarting() {
+      final var openFuture = processingScheduleService.open(actor);
+      actor.runOnCompletionBlockingCurrentPhase(
+          openFuture,
+          (v, t) -> {
+            if (t != null) {
+              actor.fail(t);
+            }
+          });
+    }
+  }
+
+  private static final class WriterAsyncSupplier
+      implements Supplier<ActorFuture<LogStreamBatchWriter>> {
+    AtomicReference<ActorFuture<LogStreamBatchWriter>> writerFutureRef =
+        new AtomicReference<>(CompletableActorFuture.completed(mock(LogStreamBatchWriter.class)));
+
+    @Override
+    public ActorFuture<LogStreamBatchWriter> get() {
+      return writerFutureRef.get();
+    }
+  }
+
+  private static final class LifecycleSupplier implements Supplier<Phase>, BooleanSupplier {
+
+    volatile Phase currentPhase = Phase.PROCESSING;
+    volatile boolean isAborted = false;
+
+    @Override
+    public boolean getAsBoolean() {
+      return isAborted;
+    }
+
+    @Override
+    public Phase get() {
+      return currentPhase;
+    }
+  }
+
+  private static final class DummyTask implements Task {
+    @Override
+    public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
+      return RecordBatch::empty;
+    }
+  }
+}


### PR DESCRIPTION
## Description


And another round! :grin: After https://github.com/camunda/zeebe/pull/10414 and https://github.com/camunda/zeebe/pull/10390 
I think I found a good way to replace the additional Actor#submit from the production code and move it to where it is necessary in tests.

As described here https://github.com/camunda/zeebe/pull/10414#issuecomment-1252400461 it is not easily possible to create a separate Actor for the ScheduleService, due to concurrency issues and further work we would need to do here.

## Details

In this PR I iterate over the ProcessingScheduleServiceImpl and remove the StreamProcessorContext from the constructor.
The service gets all necessary dependencies injected on the constructor (except the actor), mostly as suppliers. This allows to lazy load dependencies and reduce dependencies for tests. It allowed to write some more unit-test like tests.

The service gets an open method to initialize the service with the actor control and create its own writer. This allows us to no longer share the writer with the StreamProcessor, since this might lead to issues especially if we now run in between (during processing phases).

Due to the later initializing of the writers we reduce resources on followers, if the service is never scheduled we don't need to create a writer.

When the StreamProcessor is in the closing phase it will close the scheduled service as well.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/pull/10414
closes https://github.com/camunda/zeebe/pull/10390 
closes https://github.com/camunda/zeebe/issues/10291

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
