### PR TITLE
Backup manager can delete backup

### DIFF
--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import java.nio.file.Path;
 import java.util.List;
@@ -104,8 +103,7 @@ public final class BackupService extends Actor implements BackupManager {
 
   @Override
   public ActorFuture<Void> deleteBackup(final long checkpointId) {
-    return CompletableActorFuture.completedExceptionally(
-        new UnsupportedOperationException("Not implemented"));
+    return internalBackupManager.deleteBackup(getBackupId(checkpointId), actor);
   }
 
   @Override

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -145,6 +145,24 @@ final class BackupServiceImpl {
     return future;
   }
 
+  ActorFuture<Void> deleteBackup(
+      final BackupIdentifier backupId, final ConcurrencyControl executor) {
+    final var future = new CompletableActorFuture<Void>();
+    executor.run(
+        () ->
+            backupStore
+                .delete(backupId)
+                .whenComplete(
+                    (status, error) -> {
+                      if (error == null) {
+                        future.complete(null);
+                      } else {
+                        future.completeExceptionally(error);
+                      }
+                    }));
+    return future;
+  }
+
   void failInProgressBackups(
       final int partitionId,
       final long lastCheckpointId,


### PR DESCRIPTION
## Description

This PR forwards requests for the backup manager to delete backups to the underlying backup store. There's no special logic to it: on success the future completes successfully, and on failure the error from the store is returned.

## Related issues

closes #10208 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
