### PR TITLE
fix: querying backup status considers backups from other nodes

### DIFF
--- a/backup-stores/s3/pom.xml
+++ b/backup-stores/s3/pom.xml
@@ -71,6 +71,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.reactivestreams</groupId>
+      <artifactId>reactive-streams</artifactId>
+      <version>1.0.3</version>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-backup-testkit</artifactId>
       <scope>test</scope>

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/AsyncAggregatingSubscriber.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/AsyncAggregatingSubscriber.java
@@ -87,7 +87,7 @@ public class AsyncAggregatingSubscriber<T> implements Subscriber<CompletableFutu
     return CompletableFuture.supplyAsync(phaser::arriveAndAwaitAdvance)
         .thenApply(
             ignored -> {
-              LOG.debug("");
+              LOG.trace("Result is available: {}", results);
               return results;
             });
   }

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/AsyncAggregatingSubscriber.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/AsyncAggregatingSubscriber.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.Phaser;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Aggregates the results of futures published by a {@link
+ * org.reactivestreams.Publisher<CompletableFuture>}.
+ *
+ * <p>Once the subscription is started, multiple futures are requested from the publisher. New
+ * futures are requested whenever a future completes. The maximum number of requested futures must
+ * be provided in {@link AsyncAggregatingSubscriber#AsyncAggregatingSubscriber(long parallelism)}}
+ *
+ * <p>Futures that complete exceptionally are omitted from the result!
+ */
+@SuppressWarnings("ReactiveStreamsSubscriberImplementation")
+public class AsyncAggregatingSubscriber<T> implements Subscriber<CompletableFuture<T>> {
+  private static final Logger LOG = LoggerFactory.getLogger(AsyncAggregatingSubscriber.class);
+
+  final ConcurrentLinkedDeque<T> results = new ConcurrentLinkedDeque<>();
+
+  // Phaser used to await for all results. New parties are registered for every new future in
+  // onNext().
+  final Phaser phaser = new Phaser(1); // arrives in result()
+  private Subscription subscription;
+  private final long parallelism;
+
+  public AsyncAggregatingSubscriber(final long parallelism) {
+    this.parallelism = parallelism;
+  }
+
+  @Override
+  public void onSubscribe(final Subscription subscription) {
+    LOG.trace("Subscription started");
+    phaser.register(); // arrives in onComplete()
+    this.subscription = subscription;
+    subscription.request(parallelism);
+  }
+
+  @Override
+  public void onNext(final CompletableFuture<T> future) {
+    LOG.trace("Received next future: {}", future);
+    phaser.register(); // arrives in handleAsync
+    future.handleAsync(
+        (result, throwable) -> {
+          if (throwable == null) {
+            LOG.trace("Completed: {}", result);
+            results.add(result);
+          } else {
+            LOG.warn("Future failed, omitted from result", throwable);
+          }
+          phaser.arrive();
+          subscription.request(1); // one future completed, request a new one
+          return null;
+        });
+  }
+
+  @Override
+  public void onError(final Throwable t) {
+    LOG.warn("Subscription failed, result might be incomplete", t);
+    phaser.forceTermination();
+  }
+
+  @Override
+  public void onComplete() {
+    LOG.trace("Completed subscription");
+    phaser.arrive();
+  }
+
+  /**
+   * @return A future that is completed with the results once all of them have been collected.
+   */
+  CompletableFuture<Collection<T>> result() {
+    return CompletableFuture.supplyAsync(phaser::arriveAndAwaitAdvance)
+        .thenApply(
+            ignored -> {
+              LOG.debug("");
+              return results;
+            });
+  }
+}

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -185,6 +185,9 @@ public final class S3BackupStore implements BackupStore {
     return readManifestObject(id).thenApply(Manifest::toStatus);
   }
 
+  /**
+   * @implNote Even if S3 is unavailable, the returned future may complete successfully.
+   */
   @Override
   public CompletableFuture<Collection<BackupStatus>> list(final BackupIdentifierWildcard wildcard) {
     LOG.info("Querying status of {}", wildcard);

--- a/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/BackupStoreTestKit.java
+++ b/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/BackupStoreTestKit.java
@@ -12,4 +12,5 @@ public interface BackupStoreTestKit
         DeletingBackup,
         RestoringBackup,
         UpdatingBackupStatus,
-        QueryingBackupStatus {}
+        QueryingBackupStatus,
+        ListingBackups {}

--- a/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/ListingBackups.java
+++ b/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/ListingBackups.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.testkit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
+import io.camunda.zeebe.backup.testkit.support.WildcardBackupProvider;
+import io.camunda.zeebe.backup.testkit.support.WildcardBackupProvider.WildcardTestParameter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+public interface ListingBackups {
+
+  BackupStore getStore();
+
+  @ParameterizedTest
+  @ArgumentsSource(WildcardBackupProvider.class)
+  default void canFindBackupByWildcard(final WildcardTestParameter parameter) {
+    // given
+    final var provider = new TestBackupProvider();
+
+    final var backups =
+        Stream.concat(parameter.unexpectedIds().stream(), parameter.expectedIds().stream())
+            .map(
+                id -> {
+                  try {
+                    return provider.minimalBackupWithId(id);
+                  } catch (final IOException e) {
+                    throw new UncheckedIOException(e);
+                  }
+                });
+    backups.map(backup -> getStore().save(backup)).forEach(CompletableFuture::join);
+
+    // when
+    final var status = getStore().list(parameter.wildcard());
+
+    assertThat(status).succeedsWithin(Duration.ofSeconds(20));
+    final var result = status.join();
+    assertThat(result)
+        .map(BackupStatus::id)
+        .containsExactlyInAnyOrderElementsOf(parameter.expectedIds());
+  }
+}

--- a/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/support/TestBackupProvider.java
+++ b/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/support/TestBackupProvider.java
@@ -35,7 +35,7 @@ public final class TestBackupProvider implements ArgumentsProvider {
         arguments(named("stub without snapshot", backupWithoutSnapshot())));
   }
 
-  private Backup backupWithoutSnapshot() throws IOException {
+  public Backup backupWithoutSnapshot() throws IOException {
     final var tempDir = Files.createTempDirectory("backup");
     Files.createDirectory(tempDir.resolve("segments/"));
     final var seg1 = Files.createFile(tempDir.resolve("segments/segment-file-1"));
@@ -50,7 +50,11 @@ public final class TestBackupProvider implements ArgumentsProvider {
         new NamedFileSetImpl(Map.of("segment-file-1", seg1, "segment-file-2", seg2)));
   }
 
-  private Backup simpleBackup() throws IOException {
+  public Backup simpleBackup() throws IOException {
+    return simpleBackupWithId(new BackupIdentifierImpl(1, 2, 3));
+  }
+
+  public Backup simpleBackupWithId(final BackupIdentifierImpl id) throws IOException {
     final var tempDir = Files.createTempDirectory("backup");
     Files.createDirectory(tempDir.resolve("segments/"));
     final var seg1 = Files.createFile(tempDir.resolve("segments/segment-file-1"));
@@ -65,9 +69,22 @@ public final class TestBackupProvider implements ArgumentsProvider {
     Files.write(s2, RandomUtils.nextBytes(1024));
 
     return new BackupImpl(
-        new BackupIdentifierImpl(1, 2, 3),
+        id,
         new BackupDescriptorImpl(Optional.of("test-snapshot-id"), 4, 5, "test"),
         new NamedFileSetImpl(Map.of("segment-file-1", seg1, "segment-file-2", seg2)),
         new NamedFileSetImpl(Map.of("snapshot-file-1", s1, "snapshot-file-2", s2)));
+  }
+
+  public Backup minimalBackupWithId(final BackupIdentifierImpl id) throws IOException {
+    final var tempDir = Files.createTempDirectory("backup");
+    Files.createDirectory(tempDir.resolve("segments/"));
+    final var seg1 = Files.createFile(tempDir.resolve("segments/segment-file-1"));
+    Files.write(seg1, RandomUtils.nextBytes(1));
+
+    return new BackupImpl(
+        id,
+        new BackupDescriptorImpl(Optional.empty(), 4, 5, "test"),
+        new NamedFileSetImpl(Map.of()),
+        new NamedFileSetImpl(Map.of("segment-file-1", seg1)));
   }
 }

--- a/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/support/WildcardBackupProvider.java
+++ b/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/support/WildcardBackupProvider.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.testkit.support;
+
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+public class WildcardBackupProvider implements ArgumentsProvider {
+
+  @Override
+  public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
+    return Stream.of(
+        Arguments.of(
+            Named.of(
+                "Backups of arbitrary nodes",
+                new WildcardTestParameter(
+                    new BackupIdentifierWildcardImpl(
+                        Optional.empty(), Optional.of(1), Optional.of(1L)),
+                    List.of(
+                        new BackupIdentifierImpl(1, 1, 1),
+                        new BackupIdentifierImpl(2, 1, 1),
+                        new BackupIdentifierImpl(3, 1, 1)),
+                    List.of(
+                        new BackupIdentifierImpl(1, 2, 1), new BackupIdentifierImpl(2, 1, 2))))),
+        Arguments.of(
+            Named.of(
+                "Backups of arbitrary partitions",
+                new WildcardTestParameter(
+                    new BackupIdentifierWildcardImpl(
+                        Optional.of(1), Optional.empty(), Optional.of(1L)),
+                    List.of(
+                        new BackupIdentifierImpl(1, 1, 1),
+                        new BackupIdentifierImpl(1, 2, 1),
+                        new BackupIdentifierImpl(1, 3, 1)),
+                    List.of(
+                        new BackupIdentifierImpl(2, 1, 1), new BackupIdentifierImpl(1, 1, 3))))),
+        Arguments.of(
+            Named.of(
+                "Backups of arbitrary checkpoints",
+                new WildcardTestParameter(
+                    new BackupIdentifierWildcardImpl(
+                        Optional.of(1), Optional.of(1), Optional.empty()),
+                    List.of(
+                        new BackupIdentifierImpl(1, 1, 1),
+                        new BackupIdentifierImpl(1, 1, 2),
+                        new BackupIdentifierImpl(1, 1, 3)),
+                    List.of(
+                        new BackupIdentifierImpl(1, 2, 1), new BackupIdentifierImpl(2, 1, 3))))),
+        Arguments.of(
+            Named.of(
+                "Backups of arbitrary partitions and checkpoints",
+                new WildcardTestParameter(
+                    new BackupIdentifierWildcardImpl(
+                        Optional.of(1), Optional.empty(), Optional.empty()),
+                    List.of(
+                        new BackupIdentifierImpl(1, 1, 3),
+                        new BackupIdentifierImpl(1, 2, 2),
+                        new BackupIdentifierImpl(1, 3, 1)),
+                    List.of(
+                        new BackupIdentifierImpl(2, 2, 1), new BackupIdentifierImpl(3, 1, 3))))),
+        Arguments.of(
+            Named.of(
+                "Backups of arbitrary nodes and partitions",
+                new WildcardTestParameter(
+                    new BackupIdentifierWildcardImpl(
+                        Optional.empty(), Optional.empty(), Optional.of(1L)),
+                    List.of(
+                        new BackupIdentifierImpl(1, 3, 1),
+                        new BackupIdentifierImpl(2, 2, 1),
+                        new BackupIdentifierImpl(3, 1, 1)),
+                    List.of(
+                        new BackupIdentifierImpl(1, 2, 2), new BackupIdentifierImpl(2, 1, 3))))),
+        Arguments.of(
+            Named.of(
+                "Backups of arbitrary nodes and checkpoints",
+                new WildcardTestParameter(
+                    new BackupIdentifierWildcardImpl(
+                        Optional.empty(), Optional.of(1), Optional.empty()),
+                    List.of(
+                        new BackupIdentifierImpl(1, 1, 3),
+                        new BackupIdentifierImpl(2, 1, 2),
+                        new BackupIdentifierImpl(3, 1, 1)),
+                    List.of(
+                        new BackupIdentifierImpl(1, 2, 2), new BackupIdentifierImpl(2, 3, 3))))),
+        Arguments.of(
+            Named.of(
+                "All backups",
+                new WildcardTestParameter(
+                    new BackupIdentifierWildcardImpl(
+                        Optional.empty(), Optional.empty(), Optional.empty()),
+                    List.of(
+                        new BackupIdentifierImpl(1, 1, 1),
+                        new BackupIdentifierImpl(2, 2, 2),
+                        new BackupIdentifierImpl(3, 3, 3)),
+                    List.of()))));
+  }
+
+  public record WildcardTestParameter(
+      BackupIdentifierWildcard wildcard,
+      List<BackupIdentifierImpl> expectedIds,
+      List<BackupIdentifierImpl> unexpectedIds) {}
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIdentifierWildcard.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupIdentifierWildcard.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.api;
+
+import java.util.Optional;
+
+/**
+ * Similar to {@link BackupIdentifier} but fields that are omitted should be interpreted as a
+ * wildcard.
+ */
+public interface BackupIdentifierWildcard {
+  /**
+   * @return id of the broker which took this backup.
+   */
+  Optional<Integer> nodeId();
+
+  /**
+   * @return id of the partition of which the backup is taken
+   */
+  Optional<Integer> partitionId();
+
+  /**
+   * @return id of the checkpoint included in the backup
+   */
+  Optional<Long> checkpointId();
+
+  /**
+   * Predicate that tries to match an id to this wildcard.
+   *
+   * @return true if the given id matches the wildcard, otherwise false.
+   */
+  boolean matches(BackupIdentifier id);
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStatusCode.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStatusCode.java
@@ -12,9 +12,10 @@ import java.util.Comparator;
 public enum BackupStatusCode {
   // WARNING! Must be ordered from "worst" to "best" for comparator below!
   DOES_NOT_EXIST,
+  FAILED,
+
   IN_PROGRESS,
-  COMPLETED,
-  FAILED;
+  COMPLETED;
 
   public static final Comparator<BackupStatus> BY_STATUS =
       Comparator.comparing(BackupStatus::statusCode);

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStatusCode.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStatusCode.java
@@ -7,9 +7,15 @@
  */
 package io.camunda.zeebe.backup.api;
 
+import java.util.Comparator;
+
 public enum BackupStatusCode {
+  // WARNING! Must be ordered from "worst" to "best" for comparator below!
   DOES_NOT_EXIST,
   IN_PROGRESS,
   COMPLETED,
-  FAILED,
+  FAILED;
+
+  public static final Comparator<BackupStatus> BY_STATUS =
+      Comparator.comparing(BackupStatus::statusCode);
 }

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.api;
 
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 /** A store where the backup is stored * */
@@ -18,6 +19,12 @@ public interface BackupStore {
 
   /** Returns the status of the backup */
   CompletableFuture<BackupStatus> getStatus(BackupIdentifier id);
+
+  /**
+   * Uses the given wildcard to list all backups matching this wildcard. The result may be
+   * incomplete.
+   */
+  CompletableFuture<Collection<BackupStatus>> list(BackupIdentifierWildcard wildcard);
 
   /** Delete all state related to the backup from the storage */
   CompletableFuture<Void> delete(BackupIdentifier id);

--- a/backup/src/main/java/io/camunda/zeebe/backup/common/BackupIdentifierWildcardImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/common/BackupIdentifierWildcardImpl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.common;
+
+import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
+import java.util.Optional;
+
+public record BackupIdentifierWildcardImpl(
+    Optional<Integer> nodeId, Optional<Integer> partitionId, Optional<Long> checkpointId)
+    implements BackupIdentifierWildcard {
+
+  @Override
+  public boolean matches(final BackupIdentifier id) {
+    return (nodeId.isEmpty() || nodeId.get().equals(id.nodeId()))
+        && (partitionId.isEmpty() || partitionId.get().equals(id.partitionId()))
+        && (checkpointId.isEmpty() || checkpointId.get().equals(id.checkpointId()));
+  }
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -129,7 +129,7 @@ final class BackupServiceImpl {
     };
   }
 
-  public ActorFuture<Optional<BackupStatus>> getBackupStatus(
+  ActorFuture<Optional<BackupStatus>> getBackupStatus(
       final int partitionId, final long checkpointId, final ConcurrencyControl executor) {
     final var future = new CompletableActorFuture<Optional<BackupStatus>>();
     executor.run(

--- a/restore/src/test/java/io/camunda/zeebe/restore/TestRestorableBackupStore.java
+++ b/restore/src/test/java/io/camunda/zeebe/restore/TestRestorableBackupStore.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.restore;
 
 import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
@@ -19,6 +20,7 @@ import io.camunda.zeebe.backup.common.NamedFileSetImpl;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -72,6 +74,25 @@ final class TestRestorableBackupStore implements BackupStore {
               Optional.empty());
     }
     return CompletableFuture.completedFuture(backupStatus);
+  }
+
+  @Override
+  public CompletableFuture<Collection<BackupStatus>> list(final BackupIdentifierWildcard wildcard) {
+    final var matchingBackups =
+        backups.values().stream()
+            .filter(backup -> wildcard.matches(backup.id()))
+            .map(
+                backup ->
+                    (BackupStatus)
+                        new BackupStatusImpl(
+                            backup.id(),
+                            Optional.of(backup.descriptor()),
+                            BackupStatusCode.COMPLETED,
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.empty()))
+            .toList();
+    return CompletableFuture.completedFuture(matchingBackups);
   }
 
   @Override


### PR DESCRIPTION
This fixes #10380, allowing brokers to return the best backup status, regardless of which broker took the backup.

To do this, I implemented support for listing backups based on wildcards (e.g. all backups with a given partition and checkpoint id).