### PR TITLE
ci: re-publish test results when re-running failed jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,9 @@ on:
       - release-*
       - trying
       - staging
-  pull_request: {}
-  workflow_dispatch: {}
-  workflow_call: {}
+  pull_request: { }
+  workflow_dispatch: { }
+  workflow_call: { }
 
 defaults:
   run:
@@ -347,10 +347,19 @@ jobs:
   event_file:
     name: "Event File"
     runs-on: ubuntu-latest
+    needs: # Add dependencies so that the event file is republished on retry
+      - integration-tests
+      - exporter-tests
+      - unit-tests
+      - slow-unit-tests
+      - smoke-tests
+      - java-randomized-tests
+      - go-client
+      - java-client
+    if: always()
     steps:
       - name: Upload
         uses: actions/upload-artifact@v3
-        if: always()
         with:
           name: Event File
           path: ${{ github.event_path }}


### PR DESCRIPTION
The publish-test-results workflow runs after retrying failed jobs in a workflow run. Previously it used the same event file and didn't get access to new test reports. With this change here, we regenerate the event file on whenever a failed job is retried.