### PR TITLE
feat: support terminate end events

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractEndEventBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractEndEventBuilder.java
@@ -19,6 +19,7 @@ package io.camunda.zeebe.model.bpmn.builder;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.TerminateEventDefinition;
 
 /**
  * @author Sebastian Menski
@@ -70,5 +71,18 @@ public abstract class AbstractEndEventBuilder<B extends AbstractEndEventBuilder<
     final ErrorEventDefinition errorEventDefinition = createEmptyErrorEventDefinition();
     element.getEventDefinitions().add(errorEventDefinition);
     return new ErrorEventDefinitionBuilder(modelInstance, errorEventDefinition);
+  }
+
+  /**
+   * Creates a terminate event definition and add it to the end event. It morphs the end event into
+   * a terminate end event.
+   *
+   * @return the builder object
+   */
+  public B terminate() {
+    final TerminateEventDefinition terminateEventDefinition =
+        createInstance(TerminateEventDefinition.class);
+    element.getEventDefinitions().add(terminateEventDefinition);
+    return myself;
   }
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EndEventValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EndEventValidator.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.TerminateEventDefinition;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -28,7 +29,8 @@ import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 public class EndEventValidator implements ModelElementValidator<EndEvent> {
 
   private static final List<Class<? extends EventDefinition>> SUPPORTED_EVENT_DEFINITIONS =
-      Arrays.asList(ErrorEventDefinition.class, MessageEventDefinition.class);
+      Arrays.asList(
+          ErrorEventDefinition.class, MessageEventDefinition.class, TerminateEventDefinition.class);
 
   @Override
   public Class<EndEvent> getElementType() {
@@ -59,7 +61,7 @@ public class EndEventValidator implements ModelElementValidator<EndEvent> {
         def -> {
           if (SUPPORTED_EVENT_DEFINITIONS.stream().noneMatch(type -> type.isInstance(def))) {
             validationResultCollector.addError(
-                0, "End events must be one of: none, error or message");
+                0, "End events must be one of: none, error, message, or terminate");
           }
         });
   }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EventDefinitionValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EventDefinitionValidator.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.model.bpmn.validation.zeebe;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.TerminateEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.TimerEventDefinition;
 import java.util.Arrays;
 import java.util.List;
@@ -28,7 +29,10 @@ public class EventDefinitionValidator implements ModelElementValidator<EventDefi
 
   private static final List<Class<? extends EventDefinition>> SUPPORTED_EVENT_DEFINITIONS =
       Arrays.asList(
-          MessageEventDefinition.class, TimerEventDefinition.class, ErrorEventDefinition.class);
+          MessageEventDefinition.class,
+          TimerEventDefinition.class,
+          ErrorEventDefinition.class,
+          TerminateEventDefinition.class);
 
   @Override
   public Class<EventDefinition> getElementType() {

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEndEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEndEventValidationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation;
+
+import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.EndEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ZeebeEndEventValidationTest {
+
+  @Test
+  @DisplayName("Should not support signal end events")
+  void signalEventEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .endEvent("end")
+            .signalEventDefinition("foo")
+            .id("eventDefinition")
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect("end", "End events must be one of: none, error or message"),
+        expect("eventDefinition", "Event definition of this type is not supported"));
+  }
+
+  @Test
+  @DisplayName("An end event should not have an outgoing sequence flow")
+  void outgoingSequenceFlow() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .endEvent("end")
+            // an activity after the end event
+            .manualTask()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            EndEvent.class, "End events must not have outgoing sequence flows to other elements."));
+  }
+}

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEndEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEndEventValidationTest.java
@@ -20,43 +20,50 @@ import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.ex
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.EndEventBuilder;
+import io.camunda.zeebe.model.bpmn.builder.StartEventBuilder;
+import io.camunda.zeebe.model.bpmn.instance.CancelEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.CompensateEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EndEvent;
+import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.SignalEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.TerminateEventDefinition;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class ZeebeEndEventValidationTest {
 
-  @Test
-  @DisplayName("Should support terminate end events")
-  void terminateEndEvent() {
+  private static final String END_EVENT_ID = "end";
+
+  @ParameterizedTest(name = "[{index}] event type = {0}")
+  @MethodSource("supportedEndEventTypes")
+  @DisplayName("Should support end event of the given type")
+  void supportedEndEventTypes(final EndEventTypeBuilder endEventTypeBuilder) {
     // given
-    final BpmnModelInstance process =
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .endEvent("end", EndEventBuilder::terminate)
-            .done();
+    final BpmnModelInstance process = createProcessWithEndEvent(endEventTypeBuilder);
 
     // when/then
     ProcessValidationUtil.assertThatProcessIsValid(process);
   }
 
-  @Test
-  @DisplayName("Should not support signal end events")
-  void signalEventEvent() {
+  @ParameterizedTest(name = "[{index}] event type = {0}")
+  @MethodSource("unsupportedEndEventTypes")
+  @DisplayName("Should not support end event of the given type")
+  void unsupportedEndEventTypes(final EndEventTypeBuilder endEventTypeBuilder) {
     // given
-    final BpmnModelInstance process =
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .endEvent("end")
-            .signalEventDefinition("foo")
-            .id("eventDefinition")
-            .done();
+    final BpmnModelInstance process = createProcessWithEndEvent(endEventTypeBuilder);
 
     // when/then
     ProcessValidationUtil.assertThatProcessHasViolations(
         process,
-        expect("end", "End events must be one of: none, error, message, or terminate"),
-        expect("eventDefinition", "Event definition of this type is not supported"));
+        expect(END_EVENT_ID, "End events must be one of: none, error, message, or terminate"),
+        expect(endEventTypeBuilder.eventType, "Event definition of this type is not supported"));
   }
 
   @Test
@@ -66,7 +73,7 @@ class ZeebeEndEventValidationTest {
     final BpmnModelInstance process =
         Bpmn.createExecutableProcess("process")
             .startEvent()
-            .endEvent("end")
+            .endEvent(END_EVENT_ID)
             // an activity after the end event
             .manualTask()
             .done();
@@ -76,5 +83,66 @@ class ZeebeEndEventValidationTest {
         process,
         expect(
             EndEvent.class, "End events must not have outgoing sequence flows to other elements."));
+  }
+
+  private static BpmnModelInstance createProcessWithEndEvent(
+      final EndEventTypeBuilder endEventTypeBuilder) {
+    final StartEventBuilder processBuilder = Bpmn.createExecutableProcess("process").startEvent();
+    endEventTypeBuilder.build(processBuilder.endEvent(END_EVENT_ID));
+    return processBuilder.done();
+  }
+
+  private static Stream<EndEventTypeBuilder> supportedEndEventTypes() {
+    return Stream.of(
+        new EndEventTypeBuilder(null, endEvent -> endEvent),
+        new EndEventTypeBuilder(
+            ErrorEventDefinition.class, endEvent -> endEvent.error("error-code")),
+        new EndEventTypeBuilder(
+            MessageEventDefinition.class,
+            endEvent -> endEvent.message("message-name").zeebeJobType("job-type")),
+        new EndEventTypeBuilder(TerminateEventDefinition.class, EndEventBuilder::terminate));
+  }
+
+  private static Stream<EndEventTypeBuilder> unsupportedEndEventTypes() {
+    return Stream.of(
+        new EndEventTypeBuilder(
+            SignalEventDefinition.class, endEvent -> endEvent.signal("signal-name")),
+        new EndEventTypeBuilder(
+            EscalationEventDefinition.class, endEvent -> endEvent.escalation("escalation-code")),
+        new EndEventTypeBuilder(
+            CompensateEventDefinition.class,
+            endEvent -> endEvent.compensateEventDefinition().compensateEventDefinitionDone()),
+        new EndEventTypeBuilder(
+            CancelEventDefinition.class,
+            endEvent -> {
+              // currently, we don't have a builder for cancel events
+              final CancelEventDefinition cancelEventDefinition =
+                  endEvent.getElement().getModelInstance().newInstance(CancelEventDefinition.class);
+              endEvent.getElement().getEventDefinitions().add(cancelEventDefinition);
+              return endEvent;
+            }));
+  }
+
+  private static final class EndEventTypeBuilder {
+    private final String eventTypeName;
+    private final Class<? extends EventDefinition> eventType;
+    private final UnaryOperator<EndEventBuilder> elementModifier;
+
+    private EndEventTypeBuilder(
+        final Class<? extends EventDefinition> eventType,
+        final UnaryOperator<EndEventBuilder> elementModifier) {
+      this.eventType = eventType;
+      eventTypeName = eventType == null ? "none" : eventType.getSimpleName();
+      this.elementModifier = elementModifier;
+    }
+
+    public EndEventBuilder build(final EndEventBuilder endEventBuilder) {
+      return elementModifier.apply(endEventBuilder);
+    }
+
+    @Override
+    public String toString() {
+      return eventTypeName;
+    }
   }
 }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEndEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEndEventValidationTest.java
@@ -19,11 +19,26 @@ import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.ex
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.EndEventBuilder;
 import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class ZeebeEndEventValidationTest {
+
+  @Test
+  @DisplayName("Should support terminate end events")
+  void terminateEndEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .endEvent("end", EndEventBuilder::terminate)
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
 
   @Test
   @DisplayName("Should not support signal end events")
@@ -40,7 +55,7 @@ class ZeebeEndEventValidationTest {
     // when/then
     ProcessValidationUtil.assertThatProcessHasViolations(
         process,
-        expect("end", "End events must be one of: none, error or message"),
+        expect("end", "End events must be one of: none, error, message, or terminate"),
         expect("eventDefinition", "Event definition of this type is not supported"));
   }
 

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeValidationTest.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.AbstractCatchEventBuilder;
 import io.camunda.zeebe.model.bpmn.builder.ProcessBuilder;
 import io.camunda.zeebe.model.bpmn.instance.CompensateEventDefinition;
-import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.IntermediateCatchEvent;
 import io.camunda.zeebe.model.bpmn.instance.SignalEventDefinition;
 import java.util.Arrays;
@@ -37,28 +36,6 @@ public class ZeebeValidationTest extends AbstractZeebeValidationTest {
       {
         Bpmn.createExecutableProcess("process").done(),
         singletonList(expect("process", "Must have at least one start event"))
-      },
-      {
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .endEvent("end")
-            .signalEventDefinition("foo")
-            .id("eventDefinition")
-            .done(),
-        Arrays.asList(
-            expect("end", "End events must be one of: none, error or message"),
-            expect("eventDefinition", "Event definition of this type is not supported"))
-      },
-      {
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .endEvent()
-            .serviceTask("task", tb -> tb.zeebeJobType("task"))
-            .done(),
-        singletonList(
-            expect(
-                EndEvent.class,
-                "End events must not have outgoing sequence flows to other elements."))
       },
       {
         Bpmn.createExecutableProcess("process")

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -148,10 +148,19 @@ public final class ProcessProcessor
                       flowScopeContext));
 
     } else if (stateBehavior.canBeTerminated(childContext)) {
-      transitionTo(
-          element,
-          flowScopeContext,
-          context -> Either.right(stateTransitionBehavior.transitionToTerminated(context)));
+
+      final var flowScopeInstance = stateBehavior.getElementInstance(flowScopeContext);
+      if (flowScopeInstance.isTerminating()) {
+        // the process instance was canceled, or interrupted by a parent process instance
+        transitionTo(
+            element,
+            flowScopeContext,
+            context -> Either.right(stateTransitionBehavior.transitionToTerminated(context)));
+
+      } else if (flowScopeInstance.isActive()) {
+        // the child element instances were terminated by a terminate end event in the process
+        stateTransitionBehavior.completeElement(flowScopeContext);
+      }
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -100,9 +100,7 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
 
     @Override
     public boolean isSuitableForEvent(final ExecutableEndEvent element) {
-      return !element.hasError()
-          && element.getJobWorkerProperties() == null
-          && !element.isTerminateEndEvent();
+      return element.isNoneEndEvent();
     }
 
     @Override
@@ -119,7 +117,7 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
 
     @Override
     public boolean isSuitableForEvent(final ExecutableEndEvent element) {
-      return element.hasError();
+      return element.isErrorEndEvent();
     }
 
     @Override
@@ -149,7 +147,7 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
 
     @Override
     public boolean isSuitableForEvent(final ExecutableEndEvent element) {
-      return element.getJobWorkerProperties() != null;
+      return element.isMessageEventEvent();
     }
 
     @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableEndEvent.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableEndEvent.java
@@ -26,10 +26,6 @@ public class ExecutableEndEvent extends ExecutableFlowNode implements Executable
     this.error = error;
   }
 
-  public boolean hasError() {
-    return error != null;
-  }
-
   @Override
   public JobWorkerProperties getJobWorkerProperties() {
     return jobWorkerProperties;
@@ -38,6 +34,18 @@ public class ExecutableEndEvent extends ExecutableFlowNode implements Executable
   @Override
   public void setJobWorkerProperties(final JobWorkerProperties jobWorkerProperties) {
     this.jobWorkerProperties = jobWorkerProperties;
+  }
+
+  public boolean isNoneEndEvent() {
+    return !isErrorEndEvent() && !isMessageEventEvent() && !isTerminateEndEvent;
+  }
+
+  public boolean isErrorEndEvent() {
+    return error != null;
+  }
+
+  public boolean isMessageEventEvent() {
+    return jobWorkerProperties != null;
   }
 
   public boolean isTerminateEndEvent() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableEndEvent.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableEndEvent.java
@@ -12,6 +12,8 @@ public class ExecutableEndEvent extends ExecutableFlowNode implements Executable
   private JobWorkerProperties jobWorkerProperties;
   private ExecutableError error;
 
+  private boolean isTerminateEndEvent;
+
   public ExecutableEndEvent(final String id) {
     super(id);
   }
@@ -36,5 +38,13 @@ public class ExecutableEndEvent extends ExecutableFlowNode implements Executable
   @Override
   public void setJobWorkerProperties(final JobWorkerProperties jobWorkerProperties) {
     this.jobWorkerProperties = jobWorkerProperties;
+  }
+
+  public boolean isTerminateEndEvent() {
+    return isTerminateEndEvent;
+  }
+
+  public void setTerminateEndEvent(final boolean isTerminateEndEvent) {
+    this.isTerminateEndEvent = isTerminateEndEvent;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/EndEventTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/EndEventTransformer.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.transformation.Transf
 import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.TerminateEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 
 public final class EndEventTransformer implements ModelElementTransformer<EndEvent> {
@@ -49,6 +50,9 @@ public final class EndEventTransformer implements ModelElementTransformer<EndEve
     if (eventDefinition instanceof ErrorEventDefinition) {
       transformErrorEventDefinition(
           context, executableElement, (ErrorEventDefinition) eventDefinition);
+
+    } else if (eventDefinition instanceof TerminateEventDefinition) {
+      executableElement.setTerminateEndEvent(true);
     }
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/TerminateEndEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/TerminateEndEventTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.activity;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.EndEventBuilder;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.groups.Tuple;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class TerminateEndEventTest {
+
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
+  private static final String PROCESS_ID = "process";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCompleteProcessInstance() {
+    // given
+    ENGINE_RULE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .endEvent("terminate-end", EndEventBuilder::terminate)
+                .done())
+        .deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE_RULE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .describedAs(
+            "Expect to complete the process instance when reaching the terminate end event")
+        .containsSubsequence(
+            Tuple.tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            Tuple.tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/TerminateEndEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/TerminateEndEventTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.activity;
 
+import static org.assertj.core.groups.Tuple.tuple;
+
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.builder.EndEventBuilder;
@@ -18,7 +20,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.function.Consumer;
 import org.assertj.core.api.Assertions;
-import org.assertj.core.groups.Tuple;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -57,8 +58,8 @@ public final class TerminateEndEventTest {
         .describedAs(
             "Expect to complete the process instance when reaching the terminate end event")
         .containsSubsequence(
-            Tuple.tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
-            Tuple.tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
   @Test
@@ -93,10 +94,10 @@ public final class TerminateEndEventTest {
         .describedAs(
             "Expect to terminate all element instances when reaching the terminate end event")
         .containsSubsequence(
-            Tuple.tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
-            Tuple.tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
-            Tuple.tuple(BpmnElementType.USER_TASK, ProcessInstanceIntent.ELEMENT_TERMINATED),
-            Tuple.tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.USER_TASK, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
   @Test
@@ -146,29 +147,28 @@ public final class TerminateEndEventTest {
         .describedAs(
             "Expect to terminate all element instances in the subprocess when reaching the terminate end event")
         .containsSubsequence(
-            Tuple.tuple(BpmnElementType.SERVICE_TASK, "C", ProcessInstanceIntent.ELEMENT_COMPLETED),
-            Tuple.tuple(
+            tuple(BpmnElementType.SERVICE_TASK, "C", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(
                 BpmnElementType.END_EVENT,
                 "terminate-end",
                 ProcessInstanceIntent.ELEMENT_COMPLETED),
-            Tuple.tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED))
+            tuple(BpmnElementType.USER_TASK, "B", ProcessInstanceIntent.ELEMENT_TERMINATED))
         .describedAs("Expect to complete the subprocess and take the outgoing sequence flow")
         .containsSubsequence(
-            Tuple.tuple(
+            tuple(
                 BpmnElementType.SUB_PROCESS, "subprocess", ProcessInstanceIntent.ELEMENT_COMPLETED),
-            Tuple.tuple(
+            tuple(
                 BpmnElementType.SEQUENCE_FLOW,
                 "to_end_after_subprocess",
                 ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
-            Tuple.tuple(
+            tuple(
                 BpmnElementType.END_EVENT,
                 "end_after_subprocess",
                 ProcessInstanceIntent.ELEMENT_COMPLETED))
         .describedAs(
             "Expect that the element instances outside of the subprocess are not terminated")
         .doesNotContain(
-            Tuple.tuple(
-                BpmnElementType.SERVICE_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED));
+            tuple(BpmnElementType.SERVICE_TASK, "A", ProcessInstanceIntent.ELEMENT_TERMINATED));
 
     ENGINE_RULE.job().ofInstance(processInstanceKey).withType("A").complete();
 
@@ -183,10 +183,9 @@ public final class TerminateEndEventTest {
         .describedAs(
             "Expect to complete the process instance after all element instances are completed")
         .containsSubsequence(
-            Tuple.tuple(BpmnElementType.SERVICE_TASK, "A", ProcessInstanceIntent.ELEMENT_COMPLETED),
-            Tuple.tuple(
+            tuple(BpmnElementType.SERVICE_TASK, "A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(
                 BpmnElementType.END_EVENT, "end_after_A", ProcessInstanceIntent.ELEMENT_COMPLETED),
-            Tuple.tuple(
-                BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+            tuple(BpmnElementType.PROCESS, PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 }


### PR DESCRIPTION
## Description

Add support for BPMN terminate end events. See https://github.com/camunda/zeebe/issues/8789#issuecomment-1253338375 on how the BPMN element should work.

The implementation doesn't follow the BPMN spec in one point: the flow scope that contains the terminate end event is not terminated but completed. Reasoning:
- The state of the flow scope is a detail that doesn't influence the core behavior. In both cases, the process instance should continue, for example, by taking the outgoing sequence flow. The difference is not visible to process participants but only when monitoring the process instance, for example, in Operate.
- It fits better with the existing implementation. It would be a bigger effort to continue the process instance (e.g. taking the outgoing sequence flow) when the flow scope is terminated. As a result, we would end up in more complex code.
- It aligns with the behavior of Camunda Platform 7. 

Side note: I implemented the major parts during a [Live Hacking session](https://www.twitch.tv/videos/1584245006). :movie_camera: 

## Related issues

closes #8789

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
