### PR TITLE
Do not take a backup if it already exists

### DIFF
--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -122,17 +122,20 @@ public final class S3BackupStore implements BackupStore {
             status -> {
               final var snapshot = saveSnapshotFiles(backup);
               final var segments = saveSegmentFiles(backup);
-              return CompletableFuture.allOf(snapshot, segments);
+              return CompletableFuture.allOf(snapshot, segments)
+                  .thenComposeAsync(
+                      ignored ->
+                          updateManifestObject(
+                              backup.id(),
+                              Manifest::expectInProgress,
+                              InProgressBackupManifest::asCompleted))
+                  .exceptionallyComposeAsync(
+                      throwable ->
+                          updateManifestObject(
+                                  backup.id(), manifest -> manifest.asFailed(throwable))
+                              // Mark the returned future as failed.
+                              .thenCompose(ignore -> CompletableFuture.failedStage(throwable)));
             })
-        .thenComposeAsync(
-            ignored ->
-                updateManifestObject(
-                    backup.id(), Manifest::expectInProgress, InProgressBackupManifest::asCompleted))
-        .exceptionallyComposeAsync(
-            throwable ->
-                updateManifestObject(backup.id(), manifest -> manifest.asFailed(throwable))
-                    // Mark the returned future as failed.
-                    .thenCompose(status -> CompletableFuture.failedStage(throwable)))
         // Discard status, it's either COMPLETED or the future is completed exceptionally
         .thenApply(ignored -> null);
   }

--- a/backup/pom.xml
+++ b/backup/pom.xml
@@ -101,6 +101,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupAlreadyExistsException.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupAlreadyExistsException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.management;
+
+import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupStatus;
+
+public class BackupAlreadyExistsException extends RuntimeException {
+
+  public BackupAlreadyExistsException(final BackupIdentifier id, final BackupStatus status) {
+    super("Backup with id %s already exists, status of the backup is %s".formatted(id, status));
+  }
+}

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -44,34 +44,70 @@ final class BackupServiceImpl {
 
     backupsInProgress.add(inProgressBackup);
 
-    final ActorFuture<Void> snapshotFound = concurrencyControl.createFuture();
-    final ActorFuture<Void> snapshotReserved = concurrencyControl.createFuture();
-    final ActorFuture<Void> snapshotFilesCollected = concurrencyControl.createFuture();
+    final var checkCurrentBackup = backupStore.getStatus(inProgressBackup.id());
+
     final ActorFuture<Void> backupSaved = concurrencyControl.createFuture();
 
-    final ActorFuture<Void> segmentFilesCollected = inProgressBackup.findSegmentFiles();
+    checkCurrentBackup.whenCompleteAsync(
+        (status, error) -> {
+          if (error != null) {
+            backupSaved.completeExceptionally(error);
+          } else {
+            takeBackupIfDoesNotExist(status, inProgressBackup, concurrencyControl, backupSaved);
+          }
+        },
+        concurrencyControl::run);
 
-    segmentFilesCollected.onComplete(
-        proceed(
-            snapshotFound::completeExceptionally,
-            () -> inProgressBackup.findValidSnapshot().onComplete(snapshotFound)));
-
-    snapshotFound.onComplete(
-        proceed(
-            snapshotReserved::completeExceptionally,
-            () -> inProgressBackup.reserveSnapshot().onComplete(snapshotReserved)));
-
-    snapshotReserved.onComplete(
-        proceed(
-            snapshotFilesCollected::completeExceptionally,
-            () -> inProgressBackup.findSnapshotFiles().onComplete(snapshotFilesCollected)));
-
-    snapshotFilesCollected.onComplete(
-        proceed(
-            error -> failBackup(inProgressBackup, backupSaved, error),
-            () -> saveBackup(inProgressBackup, backupSaved)));
-
+    backupSaved.onComplete((ignore, error) -> closeInProgressBackup(inProgressBackup));
     return backupSaved;
+  }
+
+  private void takeBackupIfDoesNotExist(
+      final BackupStatus status,
+      final InProgressBackup inProgressBackup,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<Void> backupSaved) {
+
+    switch (status.statusCode()) {
+      case COMPLETED -> {
+        LOG.debug("Backup {} is already completed, will not take a new one", inProgressBackup.id());
+        backupSaved.complete(null);
+      }
+      case FAILED, IN_PROGRESS -> {
+        LOG.error(
+            "Backup {} already exists with status {}, will not take a new one",
+            inProgressBackup.id(),
+            status);
+        backupSaved.completeExceptionally(
+            new BackupAlreadyExistsException(inProgressBackup.id(), status));
+      }
+      default -> {
+        final ActorFuture<Void> snapshotFound = concurrencyControl.createFuture();
+        final ActorFuture<Void> snapshotReserved = concurrencyControl.createFuture();
+        final ActorFuture<Void> snapshotFilesCollected = concurrencyControl.createFuture();
+        final ActorFuture<Void> segmentFilesCollected = inProgressBackup.findSegmentFiles();
+
+        segmentFilesCollected.onComplete(
+            proceed(
+                snapshotFound::completeExceptionally,
+                () -> inProgressBackup.findValidSnapshot().onComplete(snapshotFound)));
+
+        snapshotFound.onComplete(
+            proceed(
+                snapshotReserved::completeExceptionally,
+                () -> inProgressBackup.reserveSnapshot().onComplete(snapshotReserved)));
+
+        snapshotReserved.onComplete(
+            proceed(
+                snapshotFilesCollected::completeExceptionally,
+                () -> inProgressBackup.findSnapshotFiles().onComplete(snapshotFilesCollected)));
+
+        snapshotFilesCollected.onComplete(
+            proceed(
+                error -> failBackup(inProgressBackup, backupSaved, error),
+                () -> saveBackup(inProgressBackup, backupSaved)));
+      }
+    }
   }
 
   private void saveBackup(
@@ -80,10 +116,7 @@ final class BackupServiceImpl {
         .onComplete(
             proceed(
                 error -> failBackup(inProgressBackup, backupSaved, error),
-                () -> {
-                  backupSaved.complete(null);
-                  closeInProgressBackup(inProgressBackup);
-                }));
+                () -> backupSaved.complete(null)));
   }
 
   private ActorFuture<Void> saveBackup(final InProgressBackup inProgressBackup) {
@@ -108,7 +141,6 @@ final class BackupServiceImpl {
       final Throwable error) {
     backupSaved.completeExceptionally(error);
     backupStore.markFailed(inProgressBackup.id(), error.getMessage());
-    closeInProgressBackup(inProgressBackup);
   }
 
   private void closeInProgressBackup(final InProgressBackup inProgressBackup) {

--- a/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.backup.management;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
@@ -31,6 +32,8 @@ import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -40,12 +43,21 @@ class BackupServiceImplTest {
   @Mock InProgressBackup inProgressBackup;
   @Mock BackupStore backupStore;
 
+  @Mock BackupStatus notExistingBackupStatus;
+
   private BackupServiceImpl backupService;
   private final ConcurrencyControl concurrencyControl = new TestConcurrencyControl();
 
   @BeforeEach
   void setup() {
     backupService = new BackupServiceImpl(backupStore);
+
+    lenient()
+        .when(notExistingBackupStatus.statusCode())
+        .thenReturn(BackupStatusCode.DOES_NOT_EXIST);
+    lenient()
+        .when(backupStore.getStatus(any()))
+        .thenReturn(CompletableFuture.completedFuture(notExistingBackupStatus));
   }
 
   @Test
@@ -273,6 +285,40 @@ class BackupServiceImplTest {
     // then
     verify(backupStore, timeout(1000))
         .markFailed(inProgressBackup, "Backup is cancelled due to leader change.");
+  }
+
+  @Test
+  void shouldNotTakeNewBackupIfBackupAlreadyCompleted() {
+    // given
+    final BackupStatus status = mock(BackupStatus.class);
+    when(status.statusCode()).thenReturn(BackupStatusCode.COMPLETED);
+    when(backupStore.getStatus(any())).thenReturn(CompletableFuture.completedFuture(status));
+
+    // when
+    backupService.takeBackup(inProgressBackup, concurrencyControl).join();
+
+    // then
+    verify(backupStore, never()).save(any());
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = BackupStatusCode.class,
+      names = {"IN_PROGRESS", "FAILED"})
+  void shouldNotTakeNewBackupIfBackupAlreadyExists(final BackupStatusCode statusCode) {
+    // given
+    final BackupStatus status = mock(BackupStatus.class);
+    when(status.statusCode()).thenReturn(statusCode);
+    when(backupStore.getStatus(any())).thenReturn(CompletableFuture.completedFuture(status));
+
+    // when
+    assertThat(backupService.takeBackup(inProgressBackup, concurrencyControl))
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(BackupAlreadyExistsException.class);
+
+    // then
+    verify(backupStore, never()).save(any());
   }
 
   private ActorFuture<Void> failedFuture() {


### PR DESCRIPTION
## Description

After restore, the log is truncated to the checkpoint position. So the checkpoint record is processed again and will trigger a new backup with the same Id of the backup it restored from. With this PR, `BackupService` handles this case gracefully. In addition, we also do not take a new backup if existing backup is failed or in progress. Alternatively, we can delete this backup and take a new one. But chances of it happening (i.e triggering a new backup when one already is in progress/failed) is very low. So we can keep this simple.

## Related issues

closes #10430 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
