### PR TITLE
build(.github): configure Maven for CI timeouts

### DIFF
--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -59,12 +59,7 @@ runs:
     - if: ${{ inputs.java == 'true' && inputs.maven == 'true' }}
       name: Set default maven options
       shell: bash
-      run: echo "MAVEN_OPTS=-Dhttp.keepAlive=false
-          -Dmaven.wagon.http.pool=false
-          -Dmaven.wagon.http.retryHandler.class=standard
-          -Dmaven.wagon.http.retryHandler.count=3
-          -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
-          ${MAVEN_OPTS}" >> "${GITHUB_ENV}"
+      run: echo "MAVEN_OPTS=-Dmaven.wagon.httpconnectionManager.ttlSeconds=60 ${MAVEN_OPTS}" >> "${GITHUB_ENV}"
     - if: ${{ inputs.java == 'true' && inputs.maven == 'true' && inputs.nexus-cache == 'true' }}
       name: Use Camunda Nexus cache
       uses: ./.github/actions/use-ci-nexus-cache

--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -59,9 +59,7 @@ runs:
     - if: ${{ inputs.java == 'true' && inputs.maven == 'true' }}
       name: Set default maven options
       shell: bash
-      run: echo "MAVEN_OPTS=-Dhttp.keepAlive=false
-          -Dmaven.wagon.http.pool=false
-          -Dmaven.wagon.http.retryHandler.class=standard
+      run: echo "MAVEN_OPTS=-Dmaven.wagon.http.retryHandler.class=standard
           -Dmaven.wagon.http.retryHandler.count=3
           -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
           ${MAVEN_OPTS}" >> "${GITHUB_ENV}"

--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -59,7 +59,9 @@ runs:
     - if: ${{ inputs.java == 'true' && inputs.maven == 'true' }}
       name: Set default maven options
       shell: bash
-      run: echo "MAVEN_OPTS=-Dmaven.wagon.http.retryHandler.class=standard
+      run: echo "MAVEN_OPTS=-Dhttp.keepAlive=false
+          -Dmaven.wagon.http.pool=false
+          -Dmaven.wagon.http.retryHandler.class=standard
           -Dmaven.wagon.http.retryHandler.count=3
           -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
           ${MAVEN_OPTS}" >> "${GITHUB_ENV}"

--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -22,6 +22,22 @@ inputs:
     description: If true, will set up Maven; defaults to true
     default: "true"
     required: false
+  nexus-cache:
+    description: If true, sets up Maven to use the internal Nexus cache; only usable on self-hosted runners
+    default: 'false'
+    required: false
+  maven-server-id:
+    description: 'ID of the distributionManagement repository in the pom.xml file. Default is `github`'
+    default: 'github'
+    required: false
+  maven-server-username:
+    description: 'Environment variable name for the username for authentication to the Apache Maven repository. Default is $GITHUB_ACTOR'
+    default: GITHUB_ACTOR
+    required: false
+  maven-server-password:
+    description: 'Environment variable name for password or token for authentication to the Apache Maven repository. Default is $GITHUB_TOKEN'
+    default: GITHUB_TOKEN
+    required: false
 
 outputs: {}
 
@@ -33,10 +49,25 @@ runs:
       with:
         distribution: 'temurin'
         java-version: ${{ inputs.java-version }}
+        server-id: ${{ inputs.maven-server-id }}
+        server-username: ${{ inputs.maven-server-username }}
+        server-password: ${{ inputs.maven-server-password }}
     - if: ${{ inputs.java == 'true' && inputs.maven == 'true' }}
       uses: stCarolas/setup-maven@v4.4
       with:
         maven-version: '3.8.5'
+    - if: ${{ inputs.java == 'true' && inputs.maven == 'true' }}
+      name: Set default maven options
+      shell: bash
+      run: echo "MAVEN_OPTS=-Dhttp.keepAlive=false
+          -Dmaven.wagon.http.pool=false
+          -Dmaven.wagon.http.retryHandler.class=standard
+          -Dmaven.wagon.http.retryHandler.count=3
+          -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
+          ${MAVEN_OPTS}" >> "${GITHUB_ENV}"
+    - if: ${{ inputs.java == 'true' && inputs.maven == 'true' && inputs.nexus-cache == 'true' }}
+      name: Use Camunda Nexus cache
+      uses: ./.github/actions/use-ci-nexus-cache
     - if: ${{ inputs.go == 'true' }}
       uses: actions/setup-go@v3
       with:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -20,8 +20,7 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
-      - name: Use CI Nexus cache
-        uses: ./.github/actions/use-ci-nexus-cache
+          nexus-cache: true
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,13 +31,12 @@ jobs:
           secrets: |
             secret/data/products/zeebe/ci/zeebe ARTIFACTS_USR;
             secret/data/products/zeebe/ci/zeebe ARTIFACTS_PSW;
-      - uses: actions/setup-java@v3.5.0
+      - uses: ./.github/actions/setup-zeebe
         with:
-          distribution: 'temurin'
-          java-version: '17'
-          server-id: camunda-nexus
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
+          go: 'false'
+          maven-server-id: camunda-nexus
+          maven-server-username: MAVEN_USERNAME
+          maven-server-password: MAVEN_PASSWORD
       # compile and generate-sources to ensure that the Javadoc can be properly generated; compile is
       # necessary when using annotation preprocessors for code generation, as otherwise the symbols are
       # not resolve-able by the Javadoc generator

--- a/.github/workflows/qa-testbench.yaml
+++ b/.github/workflows/qa-testbench.yaml
@@ -48,10 +48,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: "${{ github.event.inputs.branch }}"
-      - uses: actions/setup-java@v3.5.0
+      - uses: ./.github/actions/setup-zeebe
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          go: false
       # Set further environment variables, which are needed for the QA Testbench run
       - id: set-env
         name: Set environment variables

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zeebe
-      - uses: ./.github/actions/use-ci-nexus-cache
+        with:
+          nexus-cache: true
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
       - uses: ./.github/actions/build-docker
@@ -80,7 +81,7 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
-      - uses: ./.github/actions/use-ci-nexus-cache
+          nexus-cache: true
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
@@ -165,7 +166,7 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
-      - uses: ./.github/actions/use-ci-nexus-cache
+          nexus-cache: true
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
@@ -297,11 +298,11 @@ jobs:
       # This is a workaround for java 8, which does not support the --add-exports options
       - run: rm .mvn/jvm.config
       # Then run client tests with JDK 8
-      - uses: actions/setup-java@v3.5.0
+      - uses: ./.github/actions/setup-zeebe
         with:
+          go: 'false'
+          maven: 'false'
           java-version: '8'
-          distribution: 'temurin'
-          cache: maven
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
       - name: Maven Test Build


### PR DESCRIPTION
## Description

Sets sane defaults to configure Maven to be more resilient when it comes to timeouts when downloading dependencies. This is a problem which primarily affects CI, and notably GitHub Actions runners.

To set the options globally, a new step is added in `setup-zeebe` iff maven is being set up there, setting the environment variable for further workflow steps.

To make sure this is used everywhere, all usages of setup-maven and setup-java must thus be replaced with setup-zeebe itself. To solve deployment, we now allow specifying the server ID, password, and username, exactly as it's done with the `setup-java` action, and add a flag to use the internal Camunda Nexus cache for self hosted runners.

## Related issues

closes #10447 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
