### PR TITLE
build(.github): manage workflow concurrency

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -8,6 +8,11 @@ on:
       - trying
       - staging
   pull_request: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   codeql:
     name: CodeQL

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,12 @@ on:
       - main
   workflow_dispatch: { }
 
+# Sequence deployment of artifacts on pushes to ensure ordering, e.g. SNAPSHOT is always the latest
+# commit
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   tests:
     name: Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ on:
   workflow_dispatch: {}
   workflow_call: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     # use bash shell by default to ensure pipefail behavior is the default


### PR DESCRIPTION
## Description

Modifies the concurrency of the code quality, test, and deploy workflows.

The deploy workflow is sequenced such that every deploy is ran only after the previous push's deploy run is finished. This will avoid having concurrent deployments which could overwrite each other or mess up the ordering, ensuring the latest SNAPSHOT is from the latest successful commit.

For other workflows, these will run and cancel previous runs, such that only one run at the same time is running. Hopefully this cuts down on resource usage and perhaps auto-scaling issues.

This done via the `concurrency` configuration. We use as a key the workflow name and the GitHub reference. For pushes, the reference is the branch or tag which is being pushed, e.g. `deploy-main`, `test-main`, `test-myfeaturebranch`, etc. For pull requests events, this is the PR branch.

This means when working on a feature branch, at most one run per workflow is being done for that branch, which I think is good (and will save resources). For main and bors (staging), these are already supposedly sequenced, so it shouldn't make a difference.

Regarding the deploy workflow, while it won't cancel the previous run, it will wait until it finishes before running. I don't recall us running into an issue with it, but I think we would rarely detect it anyway, so better safe than sorry.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
