### PR TITLE
Support user task candidate users 

### DIFF
--- a/bpmn-model/revapi.json
+++ b/bpmn-model/revapi.json
@@ -39,6 +39,18 @@
             "matcher": "java-package",
             "match": "io.camunda.zeebe.model.bpmn.validation.zeebe"
           }
+        },
+        {
+          "ignore": true,
+          "code": "java.method.addedToInterface",
+          "new": "method B io.camunda.zeebe.model.bpmn.builder.ZeebeUserTaskPropertiesBuilder<B extends io.camunda.zeebe.model.bpmn.builder.ZeebeUserTaskPropertiesBuilder<B>>::zeebeCandidateUsers(java.lang.String)",
+          "justification": "Ignore new methods for user task properties builder."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.addedToInterface",
+          "new": "method B io.camunda.zeebe.model.bpmn.builder.ZeebeUserTaskPropertiesBuilder<B extends io.camunda.zeebe.model.bpmn.builder.ZeebeUserTaskPropertiesBuilder<B>>::zeebeCandidateUsersExpression(java.lang.String)",
+          "justification": "Ignore new methods for user task properties builder."
         }
       ]
     }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
@@ -107,6 +107,19 @@ public abstract class AbstractUserTaskBuilder<B extends AbstractUserTaskBuilder<
     return zeebeCandidateGroups(asZeebeExpression(expression));
   }
 
+  @Override
+  public B zeebeCandidateUsers(final String candidateUsers) {
+    final ZeebeAssignmentDefinition assignment =
+        myself.getCreateSingleExtensionElement(ZeebeAssignmentDefinition.class);
+    assignment.setCandidateUsers(candidateUsers);
+    return myself;
+  }
+
+  @Override
+  public B zeebeCandidateUsersExpression(final String expression) {
+    return zeebeCandidateUsers(asZeebeExpression(expression));
+  }
+
   public B zeebeTaskHeader(final String key, final String value) {
     final ZeebeTaskHeaders taskHeaders = getCreateSingleExtensionElement(ZeebeTaskHeaders.class);
     final ZeebeHeader header = createChild(taskHeaders, ZeebeHeader.class);

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeUserTaskPropertiesBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeUserTaskPropertiesBuilder.java
@@ -86,4 +86,20 @@ public interface ZeebeUserTaskPropertiesBuilder<B extends ZeebeUserTaskPropertie
    * @return the builder object
    */
   B zeebeCandidateGroupsExpression(String expression);
+
+  /**
+   * Sets a static candidateUsers for the user task
+   *
+   * @param candidateUsers the candidateUsers of the user task
+   * @return the builder object
+   */
+  B zeebeCandidateUsers(String candidateUsers);
+
+  /**
+   * Sets a dynamic candidateUsers for the user task that is retrieved from the given expression
+   *
+   * @param expression the expression for the candidateUsers of the user task
+   * @return the builder object
+   */
+  B zeebeCandidateUsersExpression(String expression);
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -41,6 +41,7 @@ public class ZeebeConstants {
 
   public static final String ATTRIBUTE_ASSIGNEE = "assignee";
   public static final String ATTRIBUTE_CANDIDATE_GROUPS = "candidateGroups";
+  public static final String ATTRIBUTE_CANDIDATE_USERS = "candidateUsers";
 
   public static final String ATTRIBUTE_DECISION_ID = "decisionId";
 

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeAssignmentDefinitionImpl.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeAssignmentDefinitionImpl.java
@@ -29,6 +29,7 @@ public final class ZeebeAssignmentDefinitionImpl extends BpmnModelElementInstanc
 
   private static Attribute<String> assigneeAttribute;
   private static Attribute<String> candidateGroupsAttribute;
+  private static Attribute<String> candidateUsersAttribute;
 
   public ZeebeAssignmentDefinitionImpl(final ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
@@ -54,6 +55,12 @@ public final class ZeebeAssignmentDefinitionImpl extends BpmnModelElementInstanc
             .namespace(BpmnModelConstants.ZEEBE_NS)
             .build();
 
+    candidateUsersAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_CANDIDATE_USERS)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
     typeBuilder.build();
   }
 
@@ -75,5 +82,15 @@ public final class ZeebeAssignmentDefinitionImpl extends BpmnModelElementInstanc
   @Override
   public void setCandidateGroups(final String candidateGroups) {
     candidateGroupsAttribute.setValue(this, candidateGroups);
+  }
+
+  @Override
+  public String getCandidateUsers() {
+    return candidateUsersAttribute.getValue(this);
+  }
+
+  @Override
+  public void setCandidateUsers(final String candidateUsers) {
+    candidateUsersAttribute.setValue(this, candidateUsers);
   }
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAssignmentDefinition.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAssignmentDefinition.java
@@ -26,4 +26,8 @@ public interface ZeebeAssignmentDefinition extends BpmnModelElementInstance {
   String getCandidateGroups();
 
   void setCandidateGroups(String candidateGroups);
+
+  String getCandidateUsers();
+
+  void setCandidateUsers(String candidateUsers);
 }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAssignmentDefinitionTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAssignmentDefinitionTest.java
@@ -37,6 +37,7 @@ public final class ZeebeAssignmentDefinitionTest extends BpmnModelElementInstanc
   public Collection<AttributeAssumption> getAttributesAssumptions() {
     return Arrays.asList(
         new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "assignee", false, false),
-        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "candidateGroups", false, false));
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "candidateGroups", false, false),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "candidateUsers", false, false));
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/JobWorkerProperties.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/JobWorkerProperties.java
@@ -20,6 +20,7 @@ public class JobWorkerProperties {
   private Expression retries;
   private Expression assignee;
   private Expression candidateGroups;
+  private Expression candidateUsers;
   private Map<String, String> taskHeaders = Map.of();
 
   public Expression getType() {
@@ -52,6 +53,14 @@ public class JobWorkerProperties {
 
   public void setCandidateGroups(final Expression candidateGroups) {
     this.candidateGroups = candidateGroups;
+  }
+
+  public Expression getCandidateUsers() {
+    return candidateUsers;
+  }
+
+  public void setCandidateUsers(final Expression candidateUsers) {
+    this.candidateUsers = candidateUsers;
   }
 
   public Map<String, String> getTaskHeaders() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -88,6 +88,21 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
         jobWorkerProperties.setCandidateGroups(candidateGroupsExpression);
       }
     }
+    final var candidateUsers = assignmentDefinition.getCandidateUsers();
+    if (candidateUsers != null && !candidateUsers.isBlank()) {
+      final var candidateUsersExpression = expressionLanguage.parseExpression(candidateUsers);
+      if (candidateUsersExpression.isStatic()) {
+        // static candidateUsers must be in CSV format, but this is already checked by validator
+        jobWorkerProperties.setCandidateUsers(
+            ExpressionTransformer.parseListOfCsv(candidateUsers)
+                .map(ExpressionTransformer::asListLiteral)
+                .map(ExpressionTransformer::asFeelExpressionString)
+                .map(expressionLanguage::parseExpression)
+                .get());
+      } else {
+        jobWorkerProperties.setCandidateUsers(candidateUsersExpression);
+      }
+    }
   }
 
   private void transformTaskHeaders(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -112,6 +112,14 @@ public final class ZeebeRuntimeValidators {
                         .satisfiesIfStatic(
                             ZeebeExpressionValidator::isListOfCsv,
                             "be a list of comma-separated values, e.g. 'a,b,c'"))
+            .hasValidExpression(
+                ZeebeAssignmentDefinition::getCandidateUsers,
+                expression ->
+                    expression
+                        .isOptional()
+                        .satisfiesIfStatic(
+                            ZeebeExpressionValidator::isListOfCsv,
+                            "be a list of comma-separated values, e.g. 'a,b,c'"))
             .build(expressionLanguage),
         // ----------------------------------------
         new TimerCatchEventExpressionValidator(expressionLanguage, expressionProcessor),

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
@@ -104,5 +104,36 @@ class UserTaskTransformerTest {
         }
       }
     }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class CandidateUsersTests {
+
+      Stream<Arguments> candidateUsers() {
+        return Stream.of(
+            Arguments.of(null, null),
+            Arguments.of("", null),
+            Arguments.of(" ", null),
+            Arguments.of("rose", "[\"rose\"]"),
+            Arguments.of("jack,rose", "[\"jack\",\"rose\"]"),
+            Arguments.of(" jack , rose ", "[\"jack\",\"rose\"]"),
+            Arguments.of("=users", "users"),
+            Arguments.of("=[\"jack\",\"rose\"]", "[\"jack\",\"rose\"]"));
+      }
+
+      @DisplayName("Should transform user task with candidateUsers")
+      @ParameterizedTest
+      @MethodSource("candidateUsers")
+      void shouldTransform(final String candidateUsers, final String parsedExpression) {
+        final var userTask =
+            transformUserTask(processWithUserTask(b -> b.zeebeCandidateUsers(candidateUsers)));
+        if (parsedExpression == null) {
+          assertThat(userTask.getJobWorkerProperties().getCandidateUsers()).isNull();
+        } else {
+          assertThat(userTask.getJobWorkerProperties().getCandidateUsers().getExpression())
+              .isEqualTo(parsedExpression);
+        }
+      }
+    }
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -353,10 +353,29 @@ public final class ZeebeRuntimeValidationTest {
         List.of(expect(ZeebeAssignmentDefinition.class, INVALID_EXPRESSION_MESSAGE))
       },
       {
+        /* invalid candidateUsers expression */
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("task", b -> b.zeebeCandidateUsersExpression(INVALID_EXPRESSION))
+            .done(),
+        List.of(expect(ZeebeAssignmentDefinition.class, INVALID_EXPRESSION_MESSAGE))
+      },
+      {
         /* invalid candidateGroups static value */
         Bpmn.createExecutableProcess("process")
             .startEvent()
             .userTask("task", b -> b.zeebeCandidateGroups("1,,"))
+            .done(),
+        List.of(
+            expect(
+                ZeebeAssignmentDefinition.class,
+                "Expected static value to be a list of comma-separated values, e.g. 'a,b,c', but found '1,,'"))
+      },
+      {
+        /* invalid candidateUsers static value */
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("task", b -> b.zeebeCandidateUsers("1,,"))
             .done(),
         List.of(
             expect(

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
@@ -80,6 +80,10 @@ public final class Protocol {
   public static final String USER_TASK_CANDIDATE_GROUPS_HEADER_NAME =
       RESERVED_HEADER_NAME_PREFIX + "candidateGroups";
 
+  /** Task header key used for candidate users */
+  public static final String USER_TASK_CANDIDATE_USERS_HEADER_NAME =
+      RESERVED_HEADER_NAME_PREFIX + "candidateUsers";
+
   public static long encodePartitionId(final int partitionId, final long key) {
     return ((long) partitionId << KEY_BITS) + key;
   }


### PR DESCRIPTION
## Description
As a user I would like to specify task candidate-users for user tasks.

* candidate users are defined as a string containing a comma-separated list of values (e.g. x,y,z), or a Zeebe-formatted FEEL expression (i.e. prefixed by = ) where the expression should evaluate to a list of strings.

##### Example
```xml
<!-- A user task can have an candidateUsers, specified as static value -->
<bpmn:userTask id="Activity_0l1dt75" name="Cast ring into the fire">
 <bpmn:extensionElements>
   <zeebe:assignmentDefinition candidateUsers="saruman,gandalf" />
 </bpmn:extensionElements>
 <bpmn:incoming>Flow_0ytpx7p</bpmn:incoming>
</bpmn:userTask>
 
<!-- A user task can have an candidateUsers, specified as expression -->
<bpmn:userTask id="Activity_0l1dt75" name="Cast ring into the fire">
 <bpmn:extensionElements>
  <!--
     expression produces bracket formatted list which differs from static value
     example expression evaluates to: ["saruman", "gandalf"]
   -->
   <zeebe:assignmentDefinition candidateUsers="= wizards" />
 </bpmn:extensionElements>
 <bpmn:incoming>Flow_0ytpx7p</bpmn:incoming>
</bpmn:userTask>
 
 
<!-- A user task can have an assignee, candidateGroups and candidateUsers simultaneously -->
<bpmn:userTask id="Activity_0l1dt75" name="Cast ring into the fire">
 <bpmn:extensionElements>
  <zeebe:assignmentDefinition
      assignee="= ring.bearer" 
      candidateUsers="saruman, gandalf"
      candidateGroups="elves, men, dwarfs, hobbits" />
 </bpmn:extensionElements>
 <bpmn:incoming>Flow_0ytpx7p</bpmn:incoming>
</bpmn:userTask>
```

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10346

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
