### PR TITLE
Add restore app to the distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,8 @@ LABEL io.openshift.min-cpu="1"
 
 ENV ZB_HOME=/usr/local/zeebe \
     ZEEBE_BROKER_GATEWAY_NETWORK_HOST=0.0.0.0 \
-    ZEEBE_STANDALONE_GATEWAY=false
+    ZEEBE_STANDALONE_GATEWAY=false \
+    ZEEBE_RESTORE=false
 ENV PATH "${ZB_HOME}/bin:${PATH}"
 
 WORKDIR ${ZB_HOME}

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -248,6 +248,10 @@
               <id>gateway</id>
               <mainClass>io.camunda.zeebe.gateway.StandaloneGateway</mainClass>
             </program>
+            <program>
+              <id>restore</id>
+              <mainClass>io.camunda.zeebe.restore.RestoreApp</mainClass>
+            </program>
           </programs>
           <repositoryLayout>flat</repositoryLayout>
           <repositoryName>lib</repositoryName>

--- a/docker/utils/startup.sh
+++ b/docker/utils/startup.sh
@@ -7,6 +7,8 @@ if [ "$ZEEBE_STANDALONE_GATEWAY" = "true" ]; then
     export ZEEBE_GATEWAY_CLUSTER_HOST=${ZEEBE_GATEWAY_CLUSTER_HOST:-${ZEEBE_GATEWAY_NETWORK_HOST}}
 
     exec /usr/local/zeebe/bin/gateway
+elif [ "$ZEEBE_RESTORE" = "true" ]; then
+    exec /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID}
 else
     export ZEEBE_BROKER_NETWORK_HOST=${ZEEBE_BROKER_NETWORK_HOST:-${HOST}}
     export ZEEBE_BROKER_GATEWAY_CLUSTER_HOST=${ZEEBE_BROKER_GATEWAY_CLUSTER_HOST:-${ZEEBE_BROKER_NETWORK_HOST}}

--- a/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,7 +84,7 @@ public class PartitionRestoreService {
 
   private CompletionStage<Path> getTargetDirectory(final long backupId) {
     try {
-      if (!isEmpty(rootDirectory)) {
+      if (!FileUtil.isEmpty(rootDirectory)) {
         LOG.error(
             "Partition's data directory {} is not empty. Aborting restore to avoid overwriting data. Please restart with a clean directory.",
             rootDirectory);
@@ -101,15 +100,6 @@ public class PartitionRestoreService {
     } catch (final Exception e) {
       return CompletableFuture.failedFuture(e);
     }
-  }
-
-  private boolean isEmpty(final Path path) throws IOException {
-    if (Files.isDirectory(path)) {
-      try (final Stream<Path> entries = Files.list(path)) {
-        return entries.findFirst().isEmpty();
-      }
-    }
-    return !Files.exists(path);
   }
 
   // While taking the backup, we add all log segments. But the backup must only have entries upto

--- a/util/src/main/java/io/camunda/zeebe/util/FileUtil.java
+++ b/util/src/main/java/io/camunda/zeebe/util/FileUtil.java
@@ -23,6 +23,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Objects;
+import java.util.stream.Stream;
 import org.agrona.SystemUtil;
 import org.slf4j.Logger;
 
@@ -123,6 +124,19 @@ public final class FileUtil {
   public static void copySnapshot(final Path snapshotDirectory, final Path runtimeDirectory)
       throws Exception {
     Files.walkFileTree(snapshotDirectory, new SnapshotCopier(snapshotDirectory, runtimeDirectory));
+  }
+
+  /**
+   * Return true if directory does not exists, or if it is empty. Returns false if the path is not a
+   * directory
+   */
+  public static boolean isEmpty(final Path path) throws IOException {
+    if (Files.isDirectory(path)) {
+      try (final Stream<Path> entries = Files.list(path)) {
+        return entries.findFirst().isEmpty();
+      }
+    }
+    return !Files.exists(path);
   }
 
   public static final class SnapshotCopier extends SimpleFileVisitor<Path> {

--- a/util/src/test/java/io/camunda/zeebe/util/FileUtilTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/FileUtilTest.java
@@ -90,4 +90,31 @@ final class FileUtilTest {
     // then
     assertThat(Files.list(target)).contains(target.resolve(snapshotFile));
   }
+
+  @Test
+  void isEmptyReturnsTrueWhenDirectoryEmpty() throws IOException {
+    // given
+    final Path emptyDirectory = Files.createDirectory(tmpDir.resolve("src"));
+
+    // when - then
+    assertThat(FileUtil.isEmpty(emptyDirectory)).isTrue();
+  }
+
+  @Test
+  void isEmptyReturnsTrueWhenDirectoryDoesNotExist() throws IOException {
+    // given
+    final Path notExistingDirectory = tmpDir.resolve("src");
+
+    // when - then
+    assertThat(FileUtil.isEmpty(notExistingDirectory)).isTrue();
+  }
+
+  @Test
+  void isEmptyReturnsFalseWhenPathIsNotDirectory() throws IOException {
+    // given
+    final Path regularFile = Files.createFile(tmpDir.resolve("file"));
+
+    // when - then
+    assertThat(FileUtil.isEmpty(regularFile)).isFalse();
+  }
 }


### PR DESCRIPTION
## Description

* Create a binary `bin/restore` when building the project. 
* Configure docker image to run restore, when a specific env variable is set. This is done similarly to chose between broker and gateway.
* In addition, extended the restore app to delete data directory if restore failed.

Depends on #10412 

## Related issues

closes #10263 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
