### PR TITLE
test: `PartitionRestoreServiceTest` does not block on taking a backup

### DIFF
--- a/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterAll;
@@ -209,7 +210,11 @@ class PartitionRestoreServiceTest {
   private Backup takeBackup(final long backupId, final long checkpointPosition) {
     backupStore.setBackupFuture(new CompletableFuture<>());
     backupService.takeBackup(backupId, checkpointPosition);
-    return backupStore.getBackupFuture().join();
+    try {
+      return backupStore.getBackupFuture().get(30, TimeUnit.SECONDS);
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private void appendRecord(final long asqn, final String data) {

--- a/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -40,8 +40,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
+@Timeout(value = 60)
 class PartitionRestoreServiceTest {
 
   private static TestRestorableBackupStore backupStore;

--- a/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.backup.api.Backup;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.management.BackupService;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
 import io.camunda.zeebe.scheduler.ActorScheduler;
@@ -30,7 +31,6 @@ import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -53,6 +53,8 @@ class PartitionRestoreServiceTest {
   private PartitionRestoreService restoreService;
   private FileBasedSnapshotStore snapshotStore;
   private BackupService backupService;
+  private final int nodeId = 1;
+  private final int partitionId = 1;
 
   @BeforeAll
   static void beforeAll() {
@@ -69,8 +71,6 @@ class PartitionRestoreServiceTest {
   @BeforeEach
   void setUp() {
 
-    final int nodeId = 1;
-    final int partitionId = 1;
     snapshotStore =
         (FileBasedSnapshotStore)
             new FileBasedSnapshotStoreFactory(actorScheduler, nodeId)
@@ -208,13 +208,10 @@ class PartitionRestoreServiceTest {
   }
 
   private Backup takeBackup(final long backupId, final long checkpointPosition) {
-    backupStore.setBackupFuture(new CompletableFuture<>());
+    final var backup =
+        backupStore.waitForBackup(new BackupIdentifierImpl(nodeId, partitionId, backupId));
     backupService.takeBackup(backupId, checkpointPosition);
-    try {
-      return backupStore.getBackupFuture().get(30, TimeUnit.SECONDS);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
-    }
+    return backup.orTimeout(30, TimeUnit.SECONDS).join();
   }
 
   private void appendRecord(final long asqn, final String data) {

--- a/restore/src/test/java/io/camunda/zeebe/restore/TestRestorableBackupStore.java
+++ b/restore/src/test/java/io/camunda/zeebe/restore/TestRestorableBackupStore.java
@@ -113,6 +113,9 @@ final class TestRestorableBackupStore implements BackupStore {
   @Override
   public CompletableFuture<BackupStatusCode> markFailed(
       final BackupIdentifier id, final String failureReason) {
+    backupFuture.completeExceptionally(
+        new RuntimeException(
+            "Backup was explicitly marked as failed: %s".formatted(failureReason)));
     return null;
   }
 


### PR DESCRIPTION
We saw some unit tests timing out in `PartitionRestoreServiceTest`:

```
"ForkJoinPool-1-worker-1" #19 daemon prio=5 os_prio=0 cpu=1567.91ms elapsed=914.45s tid=0x00007facfca78b60 nid=0x15ab5 waiting on condition  [0x00007facb83df000]
   java.lang.Thread.State: WAITING (parking)
	at jdk.internal.misc.Unsafe.park(java.base@17.0.4.1/Native Method)
	- parking to wait for  <0x0000000511f04c68> (a java.util.concurrent.CompletableFuture$Signaller)
	at java.util.concurrent.locks.LockSupport.park(java.base@17.0.4.1/LockSupport.java:211)
	at java.util.concurrent.CompletableFuture$Signaller.block(java.base@17.0.4.1/CompletableFuture.java:1864)
	at java.util.concurrent.ForkJoinPool.compensatedBlock(java.base@17.0.4.1/ForkJoinPool.java:3449)
	at java.util.concurrent.ForkJoinPool.managedBlock(java.base@17.0.4.1/ForkJoinPool.java:3432)
	at java.util.concurrent.CompletableFuture.waitingGet(java.base@17.0.4.1/CompletableFuture.java:1898)
	at java.util.concurrent.CompletableFuture.join(java.base@17.0.4.1/CompletableFuture.java:2117)
	at io.camunda.zeebe.restore.PartitionRestoreServiceTest.takeBackup(PartitionRestoreServiceTest.java:212)
	at io.camunda.zeebe.restore.PartitionRestoreServiceTest.shouldFailToRestoreWhenSnapshotIsCorrupted(PartitionRestoreServiceTest.java:182)
```

With these changes here we ensure that the test does not wait forever on a backup, instead setting a maximum of 30 seconds. Additionally, `TestRestorableBackupStore` now fails the future when a backup is marked as failed.