### PR TITLE
Do not use DefaultActorClock

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/ActorSchedulerConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/ActorSchedulerConfiguration.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.broker;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ThreadsCfg;
 import io.camunda.zeebe.scheduler.ActorScheduler;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
+import io.camunda.zeebe.shared.ActorClockConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,12 +18,13 @@ import org.springframework.context.annotation.Configuration;
 @Configuration(proxyBeanMethods = false)
 public final class ActorSchedulerConfiguration {
   private final BrokerCfg brokerCfg;
-  private final ActorClock clock;
+  private final ActorClockConfiguration actorClockConfiguration;
 
   @Autowired
-  public ActorSchedulerConfiguration(final BrokerCfg brokerCfg, final ActorClock clock) {
+  public ActorSchedulerConfiguration(
+      final BrokerCfg brokerCfg, final ActorClockConfiguration actorClockConfiguration) {
     this.brokerCfg = brokerCfg;
-    this.clock = clock;
+    this.actorClockConfiguration = actorClockConfiguration;
   }
 
   @Bean(destroyMethod = "close")
@@ -35,7 +36,7 @@ public final class ActorSchedulerConfiguration {
     final boolean metricsEnabled = brokerCfg.getExperimental().getFeatures().isEnableActorMetrics();
 
     return ActorScheduler.newActorScheduler()
-        .setActorClock(clock)
+        .setActorClock(actorClockConfiguration.getClock().orElse(null))
         .setCpuBoundActorThreadCount(cpuThreads)
         .setIoBoundActorThreadCount(ioThreads)
         .setMetricsEnabled(metricsEnabled)

--- a/dist/src/main/java/io/camunda/zeebe/gateway/ActorSchedulerComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/ActorSchedulerComponent.java
@@ -33,7 +33,7 @@ final class ActorSchedulerComponent {
         .setCpuBoundActorThreadCount(config.getThreads().getManagementThreads())
         .setIoBoundActorThreadCount(0)
         .setSchedulerName("gateway-scheduler")
-        .setActorClock(clockConfiguration.getClock())
+        .setActorClock(clockConfiguration.getClock().orElse(null))
         .build();
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/shared/ActorClockConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/ActorClockConfiguration.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.shared;
 
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
-import io.camunda.zeebe.scheduler.clock.DefaultActorClock;
 import io.camunda.zeebe.shared.management.ActorClockService;
 import io.camunda.zeebe.shared.management.ControlledActorClockService;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -31,8 +30,8 @@ public final class ActorClockConfiguration {
       service = new ControlledActorClockService(controlledClock);
       clock = controlledClock;
     } else {
-      clock = new DefaultActorClock();
-      service = clock::getTimeMillis;
+      clock = null;
+      service = System::currentTimeMillis;
     }
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/ActorClockConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/ActorClockConfiguration.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.shared.management.ActorClockService;
 import io.camunda.zeebe.shared.management.ControlledActorClockService;
+import java.util.Optional;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.boot.context.properties.bind.DefaultValue;
@@ -20,7 +21,7 @@ import org.springframework.context.annotation.Bean;
 @ConfigurationProperties("zeebe.clock")
 public final class ActorClockConfiguration {
 
-  private final ActorClock clock;
+  private final Optional<ActorClock> clock;
   private final ActorClockService service;
 
   @ConstructorBinding
@@ -28,15 +29,15 @@ public final class ActorClockConfiguration {
     if (controlled) {
       final var controlledClock = new ControlledActorClock();
       service = new ControlledActorClockService(controlledClock);
-      clock = controlledClock;
+      clock = Optional.of(controlledClock);
     } else {
-      clock = null;
+      clock = Optional.empty();
       service = System::currentTimeMillis;
     }
   }
 
   @Bean
-  public ActorClock getClock() {
+  public Optional<ActorClock> getClock() {
     return clock;
   }
 

--- a/dist/src/test/java/io/camunda/zeebe/shared/ActorClockConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/ActorClockConfigurationTest.java
@@ -25,7 +25,8 @@ public class ActorClockConfigurationTest {
 
     // then
     assertThat(actorClockConfiguration.getClock()).isNotNull();
-    assertThat(actorClockConfiguration.getClock().getClass()).isEqualTo(ControlledActorClock.class);
+    assertThat(actorClockConfiguration.getClock().orElseThrow().getClass())
+        .isEqualTo(ControlledActorClock.class);
     assertThat(actorClockConfiguration.getClockService().epochMilli())
         .isGreaterThanOrEqualTo(currentTimeMillis);
   }

--- a/dist/src/test/java/io/camunda/zeebe/shared/ActorClockConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/ActorClockConfigurationTest.java
@@ -40,7 +40,7 @@ public class ActorClockConfigurationTest {
     final var actorClockConfiguration = new ActorClockConfiguration(controlled);
 
     // then
-    assertThat(actorClockConfiguration.getClock()).isNull();
+    assertThat(actorClockConfiguration.getClock()).isEmpty();
     assertThat(actorClockConfiguration.getClockService()).isNotNull();
     assertThat(actorClockConfiguration.getClockService().epochMilli())
         .isGreaterThanOrEqualTo(currentTimeMillis);

--- a/dist/src/test/java/io/camunda/zeebe/shared/ActorClockConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/ActorClockConfigurationTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
+import org.junit.jupiter.api.Test;
+
+public class ActorClockConfigurationTest {
+
+  @Test
+  void shouldUseControlledClock() {
+    // given
+    final var controlled = true;
+    final var currentTimeMillis = System.currentTimeMillis();
+
+    // when
+    final var actorClockConfiguration = new ActorClockConfiguration(controlled);
+
+    // then
+    assertThat(actorClockConfiguration.getClock()).isNotNull();
+    assertThat(actorClockConfiguration.getClock().getClass()).isEqualTo(ControlledActorClock.class);
+    assertThat(actorClockConfiguration.getClockService().epochMilli()).isGreaterThanOrEqualTo(currentTimeMillis);
+  }
+
+  @Test
+  void shouldUseNoClock() {
+    // given
+    final var controlled = false;
+    final var currentTimeMillis = System.currentTimeMillis();
+
+    // when
+    final var actorClockConfiguration = new ActorClockConfiguration(controlled);
+
+    // then
+    assertThat(actorClockConfiguration.getClock()).isNull();
+    assertThat(actorClockConfiguration.getClockService()).isNotNull();
+    assertThat(actorClockConfiguration.getClockService().epochMilli()).isGreaterThanOrEqualTo(currentTimeMillis);
+  }
+}

--- a/dist/src/test/java/io/camunda/zeebe/shared/ActorClockConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/ActorClockConfigurationTest.java
@@ -26,7 +26,8 @@ public class ActorClockConfigurationTest {
     // then
     assertThat(actorClockConfiguration.getClock()).isNotNull();
     assertThat(actorClockConfiguration.getClock().getClass()).isEqualTo(ControlledActorClock.class);
-    assertThat(actorClockConfiguration.getClockService().epochMilli()).isGreaterThanOrEqualTo(currentTimeMillis);
+    assertThat(actorClockConfiguration.getClockService().epochMilli())
+        .isGreaterThanOrEqualTo(currentTimeMillis);
   }
 
   @Test
@@ -41,6 +42,7 @@ public class ActorClockConfigurationTest {
     // then
     assertThat(actorClockConfiguration.getClock()).isNull();
     assertThat(actorClockConfiguration.getClockService()).isNotNull();
-    assertThat(actorClockConfiguration.getClockService().epochMilli()).isGreaterThanOrEqualTo(currentTimeMillis);
+    assertThat(actorClockConfiguration.getClockService().epochMilli())
+        .isGreaterThanOrEqualTo(currentTimeMillis);
   }
 }


### PR DESCRIPTION
## Description
The default ActorClock is not thread safe and shouldn't be shared with multiple threads. This means we need to set the clock in the ActorClockConfiguration to null.

Creating the ActorScheduler with no clock will cause that each threads gets its own clock.


Note: This is a quick fix, at some point, we want to make DefaultActorClock threadsafe so we can use always the same clock. See #10400 
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related #10400 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
