### PR TITLE
ci(macos): set code cache size of 64m

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,7 +170,7 @@ jobs:
       matrix:
         os: [ macos-latest, windows-latest, ubuntu-latest ]
     env:
-      JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+      JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64M
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zeebe


### PR DESCRIPTION
To counter occasional out of code cache errors observed on macos builds.