### PR TITLE
test(restore): recreate backup store for each test

### DIFF
--- a/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -46,11 +46,11 @@ import org.junit.jupiter.api.io.TempDir;
 @Timeout(value = 60)
 class PartitionRestoreServiceTest {
 
-  private static TestRestorableBackupStore backupStore;
   private static ActorScheduler actorScheduler;
   private static final String SNAPSHOT_FILE_NAME = "file1";
   @TempDir Path dataDirectory;
   @TempDir Path dataDirectoryToRestore;
+  private TestRestorableBackupStore backupStore;
   private SegmentedJournal journal;
   private PartitionRestoreService restoreService;
   private FileBasedSnapshotStore snapshotStore;
@@ -62,7 +62,6 @@ class PartitionRestoreServiceTest {
   static void beforeAll() {
     actorScheduler = ActorScheduler.newActorScheduler().build();
     actorScheduler.start();
-    backupStore = new TestRestorableBackupStore();
   }
 
   @AfterAll
@@ -72,6 +71,7 @@ class PartitionRestoreServiceTest {
 
   @BeforeEach
   void setUp() {
+    backupStore = new TestRestorableBackupStore();
 
     snapshotStore =
         (FileBasedSnapshotStore)


### PR DESCRIPTION
## Description

The test was failing because the backup already exists, when it attempts to take a backup. It was only failing when trying to merge #10443, because that PR introduced this check. Previously, the backup was overwritten, so the test always succeeded.

