### PR TITLE
ci: require update tests to pass

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -393,6 +393,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - integration-tests
+      - qa-update-tests
       - unit-tests
       - smoke-tests
       - property-tests
@@ -413,6 +414,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - integration-tests
+      - qa-update-tests
       - unit-tests
       - smoke-tests
       - property-tests


### PR DESCRIPTION
QA update tests were split off from other integration tests but haven't been added to the list of required checks, causing bors to potentially merge PRs with failing update tests.