### PR TITLE
test(backup-stores/s3): increase timeout

### DIFF
--- a/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/SavingBackup.java
+++ b/backup-stores/testkit/src/main/java/io/camunda/zeebe/backup/testkit/SavingBackup.java
@@ -74,7 +74,7 @@ public interface SavingBackup {
 
     // then
     assertThat(saveAttempt)
-        .failsWithin(Duration.ofSeconds(1))
+        .failsWithin(Duration.ofMinutes(1))
         .withThrowableOfType(ExecutionException.class);
 
     final var status = getStore().getStatus(backup.id()).join();


### PR DESCRIPTION
## Description

The timeout was too low, resulting in flaky tests. Set it to 1 minute. This might be too much for this test, but it is better than encountering flakiness again.

## Related issues

closes #10500 

