### PR TITLE
test: wait for exporter to close to prevent flaky test

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorPauseTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorPauseTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import java.util.List;
 import java.util.Map;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -94,6 +95,13 @@ public final class ExporterDirectorPauseTest {
   public void canPauseAndResumeWithoutAnyExporter() {
     // given
     activeExporter.startExporterDirector(List.of());
+
+    // when -- exporter is closed
+    // Wait for exporter to properly close before submitting pause/resume jobs.
+    // Needed to prevent flaky test https://github.com/camunda/zeebe/issues/10439
+    Awaitility.await()
+        .alias("Exporter is closed")
+        .until(() -> activeExporter.getDirector().getPhase().join() == ExporterPhase.CLOSED);
 
     // then
     assertThatCode(() -> activeExporter.getDirector().pauseExporting().join())


### PR DESCRIPTION
Here we await for the correct exporter phase before submitting resume/pause requests to the exporter director. This is to prevent cases where these jobs were submitted before the director had the chance to close the actor, resulting in an unexpected failure when the pause/resume jobs ran.

closes #10439
