### PR TITLE
Preserve output of flaky test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Maven Test Build
         run: >
           mvn -T2 -B --no-snapshot-updates
-          -D skipChecks
+          -D skipChecks -D surefire.rerunFailingTestsCount=3
           -D junitThreadCount=16
           -P skip-random-tests,parallel-tests
           test
@@ -185,7 +185,7 @@ jobs:
       - name: Run smoke test
         run: >
           mvn -B --no-snapshot-updates
-          -DskipUTs -DskipChecks
+          -DskipUTs -DskipChecks -Dsurefire.rerunFailingTestsCount=3
           -pl qa/integration-tests
           -P smoke-test
           verify

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,7 +147,7 @@ jobs:
           mvn -T2 -B --no-snapshot-updates
           -D skipChecks -D surefire.rerunFailingTestsCount=3
           -D junitThreadCount=16
-          -P skip-random-tests,parallel-tests
+          -P skip-random-tests,parallel-tests,extract-flaky-tests
           test
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Normalize artifact name
@@ -187,7 +187,7 @@ jobs:
           mvn -B --no-snapshot-updates
           -DskipUTs -DskipChecks -Dsurefire.rerunFailingTestsCount=3
           -pl qa/integration-tests
-          -P smoke-test
+          -P smoke-test,extract-flaky-tests
           verify
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,7 +211,7 @@ jobs:
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
       - name: Maven Test Build
         run: >
-          mvn -T1C -B
+          mvn -T1C -B --no-snapshot-updates
           -P parallel-tests,include-random-tests
           -D junitThreadCount=16
           -D skipChecks
@@ -281,7 +281,7 @@ jobs:
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
       - name: Maven Test Build
         run: >
-          mvn -B
+          mvn -B --no-snapshot-updates
           -P disableCheckstyle,extract-flaky-tests
           -D skipChecks -D skipITs
           -D surefire.rerunFailingTestsCount=3

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -424,7 +424,6 @@
       <option name="DOWHILE_BRACE_FORCE" value="3" />
       <option name="WHILE_BRACE_FORCE" value="3" />
       <option name="FOR_BRACE_FORCE" value="3" />
-      <option name="PARENT_SETTINGS_INSTALLED" value="true" />
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />
         <option name="TAB_SIZE" value="2" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -424,6 +424,7 @@
       <option name="DOWHILE_BRACE_FORCE" value="3" />
       <option name="WHILE_BRACE_FORCE" value="3" />
       <option name="FOR_BRACE_FORCE" value="3" />
+      <option name="PARENT_SETTINGS_INSTALLED" value="true" />
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />
         <option name="TAB_SIZE" value="2" />

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -31,6 +31,24 @@
       <artifactId>slf4j-api</artifactId>
       <version>1.7.36</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven.surefire</groupId>
+      <artifactId>surefire-extensions-api</artifactId>
+      <version>3.0.0-M7</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven.surefire</groupId>
+      <artifactId>maven-surefire-common</artifactId>
+      <version>3.0.0-M7</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+      <version>1.17.1</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -43,12 +43,6 @@
       <artifactId>maven-surefire-common</artifactId>
       <version>3.0.0-M7</version>
     </dependency>
-
-    <dependency>
-      <groupId>org.agrona</groupId>
-      <artifactId>agrona</artifactId>
-      <version>1.17.1</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/build-tools/src/main/java/io/camunda/zeebe/ZeebeConsoleOutputFileReporter.java
+++ b/build-tools/src/main/java/io/camunda/zeebe/ZeebeConsoleOutputFileReporter.java
@@ -16,7 +16,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.agrona.LangUtil;
 import org.apache.maven.plugin.surefire.booterclient.output.InPluginProcessDumpSingleton;
 import org.apache.maven.plugin.surefire.report.ConsoleOutputFileReporter;
 import org.apache.maven.plugin.surefire.report.FileReporter;
@@ -105,7 +104,7 @@ public final class ZeebeConsoleOutputFileReporter implements ConsoleOutputReport
 
     } catch (final Exception e) {
       dumpException(e);
-      LangUtil.rethrowUnchecked(e);
+      sneakyThrow(e);
     }
   }
 
@@ -154,5 +153,10 @@ public final class ZeebeConsoleOutputFileReporter implements ConsoleOutputReport
   private boolean filterTestOutputFiles(final String fileName, final Path path) {
     return path.getFileName().toString().startsWith(fileName)
         && path.getFileName().toString().endsWith(OUTPUT_FILE_EXTENSION);
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T extends Throwable> void sneakyThrow(final Throwable t) throws T {
+    throw (T) t;
   }
 }

--- a/build-tools/src/main/java/io/camunda/zeebe/ZeebeConsoleOutputFileReporter.java
+++ b/build-tools/src/main/java/io/camunda/zeebe/ZeebeConsoleOutputFileReporter.java
@@ -103,10 +103,7 @@ public final class ZeebeConsoleOutputFileReporter implements ConsoleOutputReport
         Files.move(reportPath, backupPath);
       }
 
-    } catch (final InvocationTargetException
-        | IllegalAccessException
-        | IOException
-        | NoSuchMethodException e) {
+    } catch (final Exception e) {
       dumpException(e);
       LangUtil.rethrowUnchecked(e);
     }

--- a/build-tools/src/main/java/io/camunda/zeebe/ZeebeConsoleOutputFileReporter.java
+++ b/build-tools/src/main/java/io/camunda/zeebe/ZeebeConsoleOutputFileReporter.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.agrona.LangUtil;
+import org.apache.maven.plugin.surefire.booterclient.output.InPluginProcessDumpSingleton;
+import org.apache.maven.plugin.surefire.report.ConsoleOutputFileReporter;
+import org.apache.maven.plugin.surefire.report.FileReporter;
+import org.apache.maven.surefire.api.report.TestOutputReportEntry;
+import org.apache.maven.surefire.api.report.TestSetReportEntry;
+import org.apache.maven.surefire.extensions.ConsoleOutputReportEventListener;
+
+/**
+ * A {@link ConsoleOutputReportEventListener} which will save a test's previous run's output instead
+ * of overwriting it. This is somewhat hacky, as the canonical implementation {@link
+ * ConsoleOutputFileReporter} is not really extensible. So instead we "predict" the output path that
+ * it will use, and if it was present, we copy it in order to preserve it. If we see that the
+ * canonical implementation changes too much, then we could simply make our own to stabilize things,
+ * but for now I think this is acceptable.
+ *
+ * <p>By using this implementation, it now works like this:
+ *
+ * <ul>
+ *   <li>All calls are delegated to an instance of the canonical implementation
+ *   <li>When {@link #writeTestOutput(TestOutputReportEntry)} is called, we predict the path by
+ *       calling {@link FileReporter#getReportFile(File, String, String, String)} via reflection
+ *       just like the canonical implementation does
+ *   <li>If a file exists at this path, extract the latest run count from the other existing files;
+ *       we opted against keeping an in-memory cache, as on long builds this could use too much
+ *       memory
+ */
+public final class ZeebeConsoleOutputFileReporter implements ConsoleOutputReportEventListener {
+
+  private static final Pattern RUN_COUNT_MATCHER = Pattern.compile("^.+?-(\\d)-output\\.txt$");
+  private static final String OUTPUT_FILE_EXTENSION = "-output.txt";
+
+  private final File reportsDirectory;
+  private final String reportNameSuffix;
+  private final boolean usePhrasedFileName;
+  private final Integer forkNumber;
+  private final ConsoleOutputReportEventListener delegate;
+
+  private volatile String reportEntryName;
+
+  public ZeebeConsoleOutputFileReporter(
+      final File reportsDirectory,
+      final String reportNameSuffix,
+      final boolean usePhrasedFileName,
+      final Integer forkNumber,
+      final ConsoleOutputReportEventListener delegate) {
+    this.reportsDirectory = reportsDirectory;
+    this.reportNameSuffix = reportNameSuffix;
+    this.usePhrasedFileName = usePhrasedFileName;
+    this.forkNumber = forkNumber;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public synchronized void testSetStarting(final TestSetReportEntry reportEntry) {
+    reportEntryName =
+        usePhrasedFileName ? reportEntry.getSourceText() : reportEntry.getSourceName();
+    delegate.testSetStarting(reportEntry);
+  }
+
+  @Override
+  public synchronized void testSetCompleted(final TestSetReportEntry report) {
+    delegate.testSetStarting(report);
+  }
+
+  @Override
+  public synchronized void close() {
+    delegate.close();
+  }
+
+  @Override
+  public synchronized void writeTestOutput(final TestOutputReportEntry reportEntry) {
+    try {
+      final Path reportPath = getReportPath();
+      final String fileName =
+          reportPath.getFileName().toString().replace(OUTPUT_FILE_EXTENSION, "");
+      final Path backupPath =
+          reportPath.resolveSibling(
+              fileName + "-" + computeRunCount(reportPath, fileName) + OUTPUT_FILE_EXTENSION);
+
+      // write the report first; if anything was written, we then move it with the appropriate run
+      // count in its name
+      delegate.writeTestOutput(reportEntry);
+      if (Files.exists(reportPath)) {
+        Files.move(reportPath, backupPath);
+      }
+
+    } catch (final InvocationTargetException
+        | IllegalAccessException
+        | IOException
+        | NoSuchMethodException e) {
+      dumpException(e);
+      LangUtil.rethrowUnchecked(e);
+    }
+  }
+
+  private void dumpException(final Exception e) {
+    if (forkNumber == null) {
+      InPluginProcessDumpSingleton.getSingleton()
+          .dumpException(e, e.getLocalizedMessage(), reportsDirectory);
+    } else {
+      InPluginProcessDumpSingleton.getSingleton()
+          .dumpException(e, e.getLocalizedMessage(), reportsDirectory, forkNumber);
+    }
+  }
+
+  private int computeRunCount(final Path path, final String fileName) throws IOException {
+    final Path directory = path.getParent();
+    int latestRunCount = 0;
+
+    try (final DirectoryStream<Path> files =
+        Files.newDirectoryStream(directory, p -> filterTestOutputFiles(fileName, p))) {
+      for (final Path file : files) {
+        final Matcher matcher = RUN_COUNT_MATCHER.matcher(file.getFileName().toString());
+        if (matcher.find()) {
+          final String runCount = matcher.group(1);
+          latestRunCount = Math.max(latestRunCount, Integer.parseInt(runCount));
+        }
+      }
+    }
+
+    return latestRunCount + 1;
+  }
+
+  private Path getReportPath()
+      throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+    final Method delegate =
+        FileReporter.class.getDeclaredMethod(
+            "getReportFile", File.class, String.class, String.class, String.class);
+    delegate.setAccessible(true);
+    final File file =
+        (File)
+            delegate.invoke(
+                null, reportsDirectory, reportEntryName, reportNameSuffix, OUTPUT_FILE_EXTENSION);
+
+    return file.toPath();
+  }
+
+  private boolean filterTestOutputFiles(final String fileName, final Path path) {
+    return path.getFileName().toString().startsWith(fileName)
+        && path.getFileName().toString().endsWith(OUTPUT_FILE_EXTENSION);
+  }
+}

--- a/build-tools/src/main/java/io/camunda/zeebe/ZeebeConsoleOutputReporter.java
+++ b/build-tools/src/main/java/io/camunda/zeebe/ZeebeConsoleOutputReporter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe;
+
+import java.io.File;
+import org.apache.maven.plugin.surefire.extensions.junit5.JUnit5ConsoleOutputReporter;
+import org.apache.maven.surefire.extensions.ConsoleOutputReportEventListener;
+
+public final class ZeebeConsoleOutputReporter extends JUnit5ConsoleOutputReporter {
+
+  @Override
+  public ConsoleOutputReportEventListener createListener(
+      final File reportsDirectory, final String reportNameSuffix, final Integer forkNumber) {
+    return new ZeebeConsoleOutputFileReporter(
+        reportsDirectory,
+        reportNameSuffix,
+        false,
+        forkNumber,
+        super.createListener(reportsDirectory, reportNameSuffix, forkNumber));
+  }
+
+  @Override
+  public String toString() {
+    return "ZeebeConsoleOutputReporter{"
+        + "disable="
+        + isDisable()
+        + ", encoding="
+        + getEncoding()
+        + ", usePhrasedFileName="
+        + isUsePhrasedFileName()
+        + '}';
+  }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1216,8 +1216,16 @@
               <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
               <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
             </statelessTestsetReporter>
+            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter"></consoleOutputReporter>
             <skip>${skipUTs}</skip>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>io.camunda</groupId>
+              <artifactId>zeebe-build-tools</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+          </dependencies>
         </plugin>
 
         <!-- Integration tests -->
@@ -1248,8 +1256,16 @@
               <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
               <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
             </statelessTestsetReporter>
+            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter"></consoleOutputReporter>
             <skip>${skipITs}</skip>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>io.camunda</groupId>
+              <artifactId>zeebe-build-tools</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+          </dependencies>
           <executions>
             <execution>
               <goals>

--- a/protocol/ignored-changes.json
+++ b/protocol/ignored-changes.json
@@ -50,6 +50,14 @@
           "code": "java.class.removed",
           "regex": true,
           "classQualifiedName": "io.camunda.zeebe.protocol.record.Admin(Request|Response)\\w*"
+        },
+        {
+          "justification": "Allowed annotations were fixed to prevent indirect modifications via transitive dependencies, but will not affect existing usage",
+          "code": "java.annotation.attributeAdded",
+          "old": "@interface io.camunda.zeebe.protocol.record.ImmutableProtocol",
+          "new": "@interface io.camunda.zeebe.protocol.record.ImmutableProtocol",
+          "attribute": "allowedClasspathAnnotations",
+          "value": "{org.immutables.value.Generated.class, javax.annotation.ParametersAreNonnullByDefault.class, javax.annotation.concurrent.Immutable.class, edu.umd.cs.findbugs.annotations.SuppressFBWarnings.class, javax.annotation.concurrent.NotThreadSafe.class, javax.annotation.Nullable.class}"
         }
       ]
     }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/ImmutableProtocol.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/ImmutableProtocol.java
@@ -15,14 +15,20 @@
  */
 package io.camunda.zeebe.protocol.record;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.camunda.zeebe.protocol.record.ImmutableProtocol.Builder;
 import io.camunda.zeebe.protocol.record.ImmutableProtocol.Type;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.NotThreadSafe;
 import org.immutables.annotate.InjectAnnotation;
 import org.immutables.annotate.InjectAnnotation.Where;
+import org.immutables.value.Generated;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Style.ValidationMethod;
 
@@ -48,6 +54,16 @@ import org.immutables.value.Value.Style.ValidationMethod;
     // allow null values to be passed; this allows for partial deserialization
     validationMethod = ValidationMethod.NONE,
     clearBuilder = true,
+    // specify annotations that can be passed to adding/removing new annotations due to direct or
+    // transitive dependency changes
+    allowedClasspathAnnotations = {
+      Generated.class,
+      ParametersAreNonnullByDefault.class,
+      Immutable.class,
+      SuppressFBWarnings.class,
+      NotThreadSafe.class,
+      Nullable.class
+    },
     // enables passing other immutable builders as arguments, allowing you to chain multiple
     // builders together which may help reduce the amount of allocations
     attributeBuilderDetection = true,


### PR DESCRIPTION
## Description

This PR numbers the output of all test runs, such that instead of writing to `MyTest-output.txt`, it now writes to `MyTest-1-output.txt`. This will ensure that when we re-run a failing test, the next run will write to `MyTest-2-output.txt`.

In more details:

To ensure that we preserve test output of flaky tests - that is, the output of a test even if it's re-run - we use a custom implementation of the `ConsoleOutputReporter`. This implementation is a simple delegating implementation, except for to return a custom listener which will ensure that all run outputs are numbered (e.g. 1, 2, 3, etc.) for each test. The custom listener is also a delegating one, and simply hooks into the lifecycle of the canonical implementation. After writing the output (e.g. `MyTest-output.txt`), the listener will compute the run count from the file system (to avoid caching an inordinate amount of test files) and move to the file to its proper numbered name, e.g. `MyTest-1-output.txt` or `MyTest-2-output.txt`).

As the canonical implementation is not meant to be extended, we opted for this delegating pattern which is a little hacky (as we "predict" the file name of the report via reflection), but it's a good compromise in terms of keeping up with Surefire improvements and maintaining our complete implementation.

NOTE: since the implementation moves the file after it's originally written to `MyTest-output.txt`, there is a race condition where the last run may still be un-numbered, but I think this is acceptable, and we're still fixing the problem.

## Related issues

closes #10109 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
