### PR TITLE
Fix timer scheduling

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -51,6 +51,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
       if (!checkerRunning) {
         scheduleService.runDelayed(delay, triggerEntitiesTask);
         nextDueDate = dueDate;
+        checkerRunning = true;
       } else if (nextDueDate - dueDate > timerResolution) {
         scheduleService.runDelayed(delay, triggerEntitiesTask);
         nextDueDate = dueDate;

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateCheckerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateCheckerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.timer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.api.ProcessingScheduleService;
+import io.camunda.zeebe.engine.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.engine.api.Task;
+import io.camunda.zeebe.engine.processing.scheduled.DueDateChecker;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class DueDateCheckerTest {
+
+  @Test
+  public void shouldNotScheduleTwoTasks() {
+    // given
+    final var dueDateChecker = new DueDateChecker(100, (builder) -> 0L);
+    final var mockContext = mock(ReadonlyStreamProcessorContext.class);
+    final var mockScheduleService = mock(ProcessingScheduleService.class);
+
+    when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
+    dueDateChecker.onRecovered(mockContext);
+    verify(mockScheduleService, timeout(1000)).runDelayed(eq(Duration.ZERO), any(Task.class));
+    Mockito.clearInvocations(mockScheduleService);
+
+    // when
+    final var currentTimeMillis = System.currentTimeMillis();
+    dueDateChecker.schedule(currentTimeMillis + 1000); // in one second
+    dueDateChecker.schedule(currentTimeMillis + 1000); // in one second
+
+    // then
+    verify(mockScheduleService, timeout(1000)).runDelayed(any(), any(Task.class));
+  }
+
+  @Test
+  public void shouldScheduleForAnEarlierTasks() {
+    // given
+    final var dueDateChecker = new DueDateChecker(100, (builder) -> 0L);
+    final var mockContext = mock(ReadonlyStreamProcessorContext.class);
+    final var mockScheduleService = mock(ProcessingScheduleService.class);
+
+    when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
+    dueDateChecker.onRecovered(mockContext);
+    verify(mockScheduleService, timeout(1000)).runDelayed(eq(Duration.ZERO), any(Task.class));
+    Mockito.clearInvocations(mockScheduleService);
+
+    // when
+    final var currentTimeMillis = System.currentTimeMillis();
+    dueDateChecker.schedule(currentTimeMillis + 1000); // in one second
+    dueDateChecker.schedule(currentTimeMillis + 100); // in 100 millis
+
+    // then
+    verify(mockScheduleService, timeout(1000).times(2)).runDelayed(any(), any(Task.class));
+  }
+}


### PR DESCRIPTION
## Description

If we already scheduled a Task for a created Timer, we shouldn't schedule another Task on next timer creation. This PR fixes that.

The previous behavior could cause severe issues, like exponential increasing backlog if a lot of timers are created per second etc. see https://github.com/camunda/zeebe/issues/10532 and https://github.com/camunda/zeebe/issues/10526

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/10532

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
