### PR TITLE
[Backport stable/8.0] Ensure retries are not interleaved even on multiple sequential calls

### DIFF
--- a/util/src/main/java/io/camunda/zeebe/util/retry/AbortableRetryStrategy.java
+++ b/util/src/main/java/io/camunda/zeebe/util/retry/AbortableRetryStrategy.java
@@ -21,7 +21,7 @@ public final class AbortableRetryStrategy implements RetryStrategy {
 
   public AbortableRetryStrategy(final ActorControl actor) {
     this.actor = actor;
-    retryMechanism = new ActorRetryMechanism(actor);
+    retryMechanism = new ActorRetryMechanism();
   }
 
   @Override
@@ -44,7 +44,7 @@ public final class AbortableRetryStrategy implements RetryStrategy {
     try {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
-        actor.submit(this::run);
+        actor.run(this::run);
       }
     } catch (final Exception exception) {
       currentFuture.completeExceptionally(exception);

--- a/util/src/main/java/io/camunda/zeebe/util/retry/ActorRetryMechanism.java
+++ b/util/src/main/java/io/camunda/zeebe/util/retry/ActorRetryMechanism.java
@@ -7,21 +7,13 @@
  */
 package io.camunda.zeebe.util.retry;
 
-import io.camunda.zeebe.util.sched.ActorControl;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import java.util.function.BooleanSupplier;
 
 public final class ActorRetryMechanism {
-
-  private final ActorControl actor;
-
   private OperationToRetry currentCallable;
   private BooleanSupplier currentTerminateCondition;
   private ActorFuture<Boolean> currentFuture;
-
-  public ActorRetryMechanism(final ActorControl actor) {
-    this.actor = actor;
-  }
 
   void wrap(
       final OperationToRetry callable,

--- a/util/src/main/java/io/camunda/zeebe/util/retry/EndlessRetryStrategy.java
+++ b/util/src/main/java/io/camunda/zeebe/util/retry/EndlessRetryStrategy.java
@@ -26,7 +26,7 @@ public final class EndlessRetryStrategy implements RetryStrategy {
 
   public EndlessRetryStrategy(final ActorControl actor) {
     this.actor = actor;
-    retryMechanism = new ActorRetryMechanism(actor);
+    retryMechanism = new ActorRetryMechanism();
   }
 
   @Override
@@ -50,13 +50,13 @@ public final class EndlessRetryStrategy implements RetryStrategy {
     try {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
-        actor.submit(this::run);
+        actor.run(this::run);
       }
     } catch (final Exception exception) {
       if (terminateCondition.getAsBoolean()) {
         currentFuture.complete(false);
       } else {
-        actor.submit(this::run);
+        actor.run(this::run);
         LOG.error(
             "Caught exception {} with message {}, will retry...",
             exception.getClass(),

--- a/util/src/main/java/io/camunda/zeebe/util/retry/RecoverableRetryStrategy.java
+++ b/util/src/main/java/io/camunda/zeebe/util/retry/RecoverableRetryStrategy.java
@@ -23,7 +23,7 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
 
   public RecoverableRetryStrategy(final ActorControl actor) {
     this.actor = actor;
-    retryMechanism = new ActorRetryMechanism(actor);
+    retryMechanism = new ActorRetryMechanism();
   }
 
   @Override
@@ -47,11 +47,11 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
     try {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
-        actor.submit(this::run);
+        actor.run(this::run);
       }
     } catch (final RecoverableException ex) {
       if (!terminateCondition.getAsBoolean()) {
-        actor.submit(this::run);
+        actor.run(this::run);
       }
     } catch (final Exception exception) {
       currentFuture.completeExceptionally(exception);

--- a/util/src/test/java/io/camunda/zeebe/util/retry/RetryStrategyTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/retry/RetryStrategyTest.java
@@ -14,7 +14,9 @@ import io.camunda.zeebe.util.sched.ActorControl;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.testing.ControlledActorSchedulerRule;
 import java.lang.reflect.Constructor;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -114,6 +116,25 @@ public final class RetryStrategyTest {
     assertThat(resultFuture.isDone()).isTrue();
     assertThat(resultFuture.isCompletedExceptionally()).isTrue();
     assertThat(resultFuture.getException()).isExactlyInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  public void shouldNotInterleaveRetry() {
+    // given
+    final AtomicReference<ActorFuture<Boolean>> firstFuture = new AtomicReference<>();
+    final AtomicBoolean retryToggle = new AtomicBoolean();
+    final AtomicReference<ActorFuture<Boolean>> secondFuture = new AtomicReference<>();
+
+    // when
+    actorControl.run(
+        () -> firstFuture.set(retryStrategy.runWithRetry(() -> retryToggle.getAndSet(true))));
+    actorControl.run(() -> secondFuture.set(retryStrategy.runWithRetry(() -> true)));
+
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(firstFuture.get()).isDone().isNotEqualTo(secondFuture.get());
+    assertThat(secondFuture.get()).isDone();
   }
 
   private static final class ControllableActor extends Actor {


### PR DESCRIPTION
## Description

This PR backports part of the changes found in #10289, notably the ones in the scheduler about the retry strategies (skipping the engine ones which are all around new 8.1.0 code). It seems I forgot to backport that part, as we did remove `runUntilDone` in 8.0 as well, so we should fix the retry strategies.

## Related issues

backports #10289 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
