### PR TITLE
ci(test): run tests ordered by runtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,11 @@ jobs:
           ./agent wait
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
+      - name: Cache test runtimes
+        uses: actions/cache@v3
+        with:
+          path: ./**/.surefire-*
+          key: integration-test-runtimes
       - name: Maven Test Build
         run: >
           mvn -B -T2 --no-snapshot-updates
@@ -108,6 +113,11 @@ jobs:
           ./agent wait
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
+      - name: Cache test runtimes
+        uses: actions/cache@v3
+        with:
+          path: ./**/.surefire-*
+          key: qa-tests-runtimes
       - name: Maven Test Build
         run: >
           mvn -B -T2 --no-snapshot-updates
@@ -142,6 +152,11 @@ jobs:
           maven-extra-args: -T1C
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
+      - name: Cache test runtimes
+        uses: actions/cache@v3
+        with:
+          path: ./**/.surefire-*
+          key: unit-tests-runtimes
       - name: Maven Test Build
         run: >
           mvn -T2 -B --no-snapshot-updates
@@ -209,6 +224,11 @@ jobs:
           maven-extra-args: -T1C
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
+      - name: Cache test runtimes
+        uses: actions/cache@v3
+        with:
+          path: ./**/.surefire-*
+          key: property-test-runtimes
       - name: Maven Test Build
         run: >
           mvn -T1C -B

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1208,6 +1208,7 @@
               </property>
             </properties>
             <reportNameSuffix>${env.SUREFIRE_REPORT_NAME_SUFFIX}</reportNameSuffix>
+            <runOrder>balanced</runOrder>
             <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
               <disable>false</disable>
               <version>3.0</version>
@@ -1236,6 +1237,7 @@
               </property>
             </properties>
             <reportNameSuffix>${env.SUREFIRE_REPORT_NAME_SUFFIX}</reportNameSuffix>
+            <runOrder>balanced</runOrder>
             <!--
               ensure junit5 display names are properly reported; see the documentation for more
               https://maven.apache.org/surefire/maven-failsafe-plugin/examples/junit-platform.html


### PR DESCRIPTION
## Description

This changes the test ordering for unit, integration and qa to [`balanced`](https://maven.apache.org/surefire/maven-failsafe-plugin/integration-test-mojo.html#runOrder). While it officially only achieves even runtime distribution across parallelized class threads, it still orders all tests by their runtime given a `.surefire-<hash>` file exists before these are distributed across forks.
Based on some tests this yields benefits for forkCount>0 runs as [tests are pulled from a shared ordered queue by forks](https://github.com/apache/maven-surefire/blob/master/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ForkStarter.java#L356-L361). This results in tests with similar runtime to get distributed more evenly across forks. The tests passed into this queue get ordered by their runtime by the [`DefaultRunOrderCalculator`](https://github.com/apache/maven-surefire/blob/a4cdc02e0d5d70f86cf3001d69210ad080e97ce7/surefire-api/src/main/java/org/apache/maven/surefire/api/util/DefaultRunOrderCalculator.java#L93) just by setting the runOrder:balanced option. If there is no runtime data the order equals the default ordering being `filesystem`.

Sharing of runtime metrics is achieved using the [cache](https://github.com/actions/cache) action. The [behaviour](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache) of this action across branches seems a good fit to me as it caches based on branch name, and in case no branch specific cache exists yet falls back to base branches/main.