### PR TITLE
ci(gha): cache m2 repo

### DIFF
--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -22,6 +22,14 @@ inputs:
     description: If true, will set up Maven; defaults to true
     default: "true"
     required: false
+  maven-cache:
+    description: A modifier key used to toggle the usage of a maven repo cache.
+    default: "false"
+    required: false
+  maven-cache-key-modifier:
+    description: A modifier key used for the maven cache, can be used to create isolated caches for certain jobs.
+    default: "default"
+    required: false
 
 outputs: {}
 
@@ -37,6 +45,14 @@ runs:
       uses: stCarolas/setup-maven@v4.4
       with:
         maven-version: '3.8.5'
+    - if: ${{ inputs.maven-cache == 'true' }}
+      name: Cache local Maven repository
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-${{ inputs.maven-cache-key-modifier }}-
     - if: ${{ inputs.go == 'true' }}
       uses: actions/setup-go@v3
       with:

--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -44,7 +44,7 @@ runs:
     - if: ${{ inputs.java == 'true' && inputs.maven == 'true' }}
       uses: stCarolas/setup-maven@v4.4
       with:
-        maven-version: '3.8.5'
+        maven-version: '3.8.6'
     - if: ${{ inputs.maven-cache == 'true' }}
       name: Cache local Maven repository
       uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zeebe
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-integration-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-integration-
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
@@ -91,6 +98,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zeebe
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-qa-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-qa-
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
@@ -138,6 +152,13 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-unit-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-unit-
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
@@ -180,6 +201,13 @@ jobs:
           go: false
           # setting up maven often times out on macOS
           maven: ${{ matrix.os != 'macos-latest' }}
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-smoke-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-smoke-
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
@@ -205,6 +233,13 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-property-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-property-
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
@@ -267,6 +302,13 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-client-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-client-
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
@@ -315,6 +357,13 @@ jobs:
         with:
           languages: java
           queries: +security-and-quality
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-codeql-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-codeql-
       - uses: ./.github/actions/build-zeebe
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
@@ -355,6 +404,13 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-java-checks-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-java-checks-
       - run: mvn -T1C -B -D skipTests -P !autoFormat,checkFormat,spotbugs verify
   docker-checks:
     name: Docker checks
@@ -373,6 +429,13 @@ jobs:
         with:
           sarif_file: ./hadolint.sarif
       - uses: ./.github/actions/setup-zeebe
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-docker-checks-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-docker-checks-
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
       - uses: ./.github/actions/build-docker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,13 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zeebe
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-integration-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-integration-
+          maven-cache: true
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
@@ -98,13 +93,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zeebe
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-qa-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-qa-
+          maven-cache: true
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
@@ -152,13 +142,7 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-unit-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-unit-
+          maven-cache: true
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
@@ -201,13 +185,7 @@ jobs:
           go: false
           # setting up maven often times out on macOS
           maven: ${{ matrix.os != 'macos-latest' }}
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-smoke-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-smoke-
+          maven-cache: true
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
@@ -233,13 +211,7 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-property-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-property-
+          maven-cache: true
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
@@ -270,6 +242,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zeebe
+        with:
+          maven-cache: true
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
       # Once we're on Go 1.18, use the official gorelease to do this
@@ -302,13 +276,8 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-client-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-client-
+          maven-cache: true
+          maven-cache-key-modifier: java-client
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
@@ -352,19 +321,15 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
+          maven-cache: true
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
           languages: java
           queries: +security-and-quality
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-codeql-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-codeql-
       - uses: ./.github/actions/build-zeebe
+        with:
+          maven-extra-args: -T1C
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
         with:
@@ -404,13 +369,8 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-java-checks-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-java-checks-
+          maven-cache: true
+          maven-cache-key-modifier: java-checks
       - run: mvn -T1C -B -D skipTests -P !autoFormat,checkFormat,spotbugs verify
   docker-checks:
     name: Docker checks
@@ -429,13 +389,8 @@ jobs:
         with:
           sarif_file: ./hadolint.sarif
       - uses: ./.github/actions/setup-zeebe
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-docker-checks-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-docker-checks-
+          maven-cache: true
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
       - uses: ./.github/actions/build-docker

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,56 @@
+# Continuous Integration Guide
+
+This is a small guide for things useful around our continuos integration setup.
+
+## Github Action
+
+### Maven repository cache
+
+Within
+our [Github action to setup zeebe](/Users/megglos/git/zeebe/.github/actions/setup-zeebe/action.yml)
+we make use of [action/cache](https://github.com/actions/cache) to store the content of
+the maven repository and share it across jobs and even branches. Primarily to speedup builds and
+reduce the
+risks of failures due to network hiccups to remote repositories (rare but happened).
+
+#### Delete Maven repository caches
+
+In case you encounter a corrupted cache which you suspect to be the cause of a build failure you may
+delete that cache to force a clean rebuild of it.
+
+[Github Actions Cache](https://github.com/actions/gh-actions-cache) provides convenient tooling for
+doing so.
+
+You can easily list existing caches with:
+
+```bash
+gh actions-cache list
+
+Linux-maven-default-dddf7912807d96783a168b6dda5c5b639c6eb183bfedaab524c6e34f695afba4        586.20 MB  refs/pull/10550/merge     10 minutes ago
+```
+
+and delete them via:
+
+```bash
+gh actions-cache delete Linux-maven-default-dddf7912807d96783a168b6dda5c5b639c6eb183bfedaab524c6e34f695afba4
+```
+
+To determine the key of the cache used you can take a look into the log of the setup-zeebe job.
+
+```
+...
+Run actions/cache@v3
+  with:
+    path: ~/.m2/repository
+    key: Linux-maven-default-dddf7912807d96783a168b6dda5c5b639c6eb183bfedaab524c6e34f695afba4
+    restore-keys: Linux-maven-default-
+
+  env:
+    TC_CLOUD_TOKEN: ***
+    TC_CLOUD_CONCURRENCY: 4
+    ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
+    JAVA_HOME: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.4-101/x64
+Received 0 of 614674276 (0.0%), 0.0 MBs/sec
+...
+```
+


### PR DESCRIPTION
## Description

Saves us network io for redownloading most deps + occasional hiccups we sometimes experience (timeout, network error etc.). I based the setup on the [maven sample](https://github.com/actions/cache/blob/main/examples.md#java---maven) by github. In overall we will have[ 10GB of cache space](https://github.com/actions/cache#cache-limits) until eviction happens, in worst case maven just downloads everything again.

[runtime of 7 runs without cache](https://github.com/camunda/zeebe/actions/runs/3146313420/jobs/5120133089)
17m37s
22m30s
17m22s
17m40s
19m24s
17m47s
20m44s
22m15s

MIN 17m22s AVG 19m24s MAX 22m30s
TOTAL TIME 2h35m19s

[runtime of 8 runs with cache](https://github.com/camunda/zeebe/actions/runs/3146699966)
19m26s (cold cache)
18m49s
16m39s
17m08s
16m49s
16m57s
17m32s
17m27s

with warm cache (7 runs):
MIN 16m39s AVG 17m20s MAX 18m49s
TOTAL TIME 2h01m21s

including cold cache:
MIN 16m39s AVG 17m35s MAX 19m26s

So it saves us roughly 1-2 minutes per run + way less variance between min/max.

