### PR TITLE
fix(helm): rename podSecurityContext to containerSecurityContext

### DIFF
--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -20,8 +20,8 @@ zeebe:
   # IoThreadCount defines how many threads can be used for the exporting on each broker pod
   ioThreadCount: 4
 
-  # PodSecurityContext defines the security options the broker and gateway container should be run with
-  podSecurityContext:
+  # ContainerSecurityContext defines the security options the Zeebe broker container should be run with
+  containerSecurityContext:
     capabilities:
       add: ["NET_ADMIN"]
 


### PR DESCRIPTION
## Description

The recent v8.0.14 release introduced containerSecurityContext, see https://github.com/camunda/camunda-platform-helm/issues/374 and was actually failing now with the format `podSecurityContext` was set.
```
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(StatefulSet.spec.template.spec.securityContext): unknown field "capabilities" in io.k8s.api.core.v1.PodSecurityContext
```

//cc @aabouzaid 