### PR TITLE
Do not copy ResultBatch everytime

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
@@ -142,6 +142,18 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService,
           new BufferedTaskResultBuilder(logStreamBatchWriter::canWriteAdditionalEvent);
       final var result = task.execute(builder);
 
+      logStreamBatchWriter.reset();
+      result
+          .getRecordBatch()
+          .forEach(
+              entry ->
+                  logStreamBatchWriter
+                      .event()
+                      .key(entry.key())
+                      .metadataWriter(entry.recordMetadata())
+                      .sourceIndex(entry.sourceIndex())
+                      .valueWriter(entry.recordValue())
+                      .done());
       // we need to retry the writing if the dispatcher return zero or negative position (this means
       // it was full during writing)
       // it will be freed from the LogStorageAppender concurrently, which means we might be able to
@@ -150,19 +162,6 @@ public class ProcessingScheduleServiceImpl implements ProcessingScheduleService,
           writeRetryStrategy.runWithRetry(
               () -> {
                 LOG.trace("Write scheduled TaskResult to dispatcher!");
-                logStreamBatchWriter.reset();
-                result
-                    .getRecordBatch()
-                    .forEach(
-                        entry ->
-                            logStreamBatchWriter
-                                .event()
-                                .key(entry.key())
-                                .metadataWriter(entry.recordMetadata())
-                                .sourceIndex(entry.sourceIndex())
-                                .valueWriter(entry.recordValue())
-                                .done());
-
                 return logStreamBatchWriter.tryWrite() >= 0;
               },
               abortCondition);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ProcessingScheduleServiceTest.java
@@ -273,7 +273,7 @@ public class ProcessingScheduleServiceTest {
 
     inOrder.verify(batchWriter, TIMEOUT).event();
     inOrder.verify(logEntryBuilder, TIMEOUT).key(1);
-    inOrder.verify(batchWriter, TIMEOUT).tryWrite();
+    inOrder.verify(batchWriter, TIMEOUT.times(5000)).tryWrite();
     inOrder.verify(batchWriter, TIMEOUT).event();
     inOrder.verify(logEntryBuilder, TIMEOUT).key(2);
     inOrder.verify(batchWriter, TIMEOUT).tryWrite();


### PR DESCRIPTION
## Description

I have seen when running shouldPreserveOrderingOfWritesEvenWithRetries that it sometimes can happen that the writing (retry loop) can take up to 3 seconds, where the timeout is 2 seconds. I think this is related to the that we always copy again in the loop (which is not necessary).

I also have observed in https://github.com/camunda/zeebe/issues/10526#issuecomment-1260510043

Related to https://github.com/camunda/zeebe/pull/10458
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda/zeebe/pull/10458
related to #10526 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
