### PR TITLE
[Backport stable/8.0] fix(helm): rename podSecurityContext to containerSecurityContext

### DIFF
--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -20,8 +20,8 @@ zeebe:
   # IoThreadCount defines how many threads can be used for the exporting on each broker pod
   ioThreadCount: 4
 
-  # PodSecurityContext defines the security options the broker and gateway container should be run with
-  podSecurityContext:
+  # ContainerSecurityContext defines the security options the Zeebe broker container should be run with
+  containerSecurityContext:
     capabilities:
       add: ["NET_ADMIN"]
 


### PR DESCRIPTION
# Description
Backport of #10556 to `stable/8.0`.

relates to camunda/camunda-platform-helm#374