### PR TITLE
ci(gha): disable cache for short stages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -185,7 +185,6 @@ jobs:
           go: false
           # setting up maven often times out on macOS
           maven: ${{ matrix.os != 'macos-latest' }}
-          maven-cache: true
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
@@ -242,8 +241,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zeebe
-        with:
-          maven-cache: true
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
       # Once we're on Go 1.18, use the official gorelease to do this
@@ -389,8 +386,6 @@ jobs:
         with:
           sarif_file: ./hadolint.sarif
       - uses: ./.github/actions/setup-zeebe
-        with:
-          maven-cache: true
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
       - uses: ./.github/actions/build-docker


### PR DESCRIPTION
## Description

`Smoke tests` does not build all modules, thus sharing the cache with other bigger jobs introduces a race condition on
who finishes first, thus the cache might be smaller than needed by other jobs. Furthermore jobs like client tests & Smoke tests are so short it's not worth using limited cache space for them.

