### PR TITLE
[Backport release-8.1.0] Reorganize stream processor and engine tests

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/ContinuouslyReplayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/ContinuouslyReplayTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.engine.processing.streamprocessor;
+package io.camunda.zeebe.engine.processing;
 
 import io.camunda.zeebe.engine.state.ZbColumnFamilies;
 import io.camunda.zeebe.engine.util.EngineRule;

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/FailedPropertyBasedTestDataPrinter.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/FailedPropertyBasedTestDataPrinter.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.engine.processing.streamprocessor;
+package io.camunda.zeebe.engine.processing.randomized;
 
 import io.camunda.zeebe.test.util.bpmn.random.TestDataGenerator.TestDataRecord;
 import java.util.function.Supplier;

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ProcessExecutionRandomizedPropertyTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ProcessExecutionRandomizedPropertyTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.engine.processing.streamprocessor;
+package io.camunda.zeebe.engine.processing.randomized;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.ProcessExecutor;

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ReplayStateRandomizedPropertyTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ReplayStateRandomizedPropertyTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.engine.processing.streamprocessor;
+package io.camunda.zeebe.engine.processing.randomized;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/BlacklistInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/BlacklistInstanceTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.engine.processing.streamprocessor;
+package io.camunda.zeebe.engine.state;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/ReplayStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/ReplayStateTest.java
@@ -5,12 +5,11 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.engine.processing.streamprocessor;
+package io.camunda.zeebe.engine.state;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.processing.message.MessageObserver;
-import io.camunda.zeebe.engine.state.ZbColumnFamilies;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/EventFilterTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/EventFilterTest.java
@@ -5,13 +5,12 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.engine.processing.streamprocessor;
+package io.camunda.zeebe.streamprocessor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
-import io.camunda.zeebe.streamprocessor.EventFilter;
 import org.junit.Test;
 
 public final class EventFilterTest {

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/NewStreamProcessorReplayModeTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/NewStreamProcessorReplayModeTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.engine.processing.streamprocessor;
+package io.camunda.zeebe.streamprocessor;
 
 import static io.camunda.zeebe.engine.util.RecordToWrite.command;
 import static io.camunda.zeebe.engine.util.RecordToWrite.event;

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceIntegrationTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.engine.processing.streamprocessor;
+package io.camunda.zeebe.streamprocessor;
 
 import static io.camunda.zeebe.engine.util.RecordToWrite.command;
 import static io.camunda.zeebe.engine.util.RecordToWrite.event;

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.engine.processing.streamprocessor;
+package io.camunda.zeebe.streamprocessor;
 
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -34,7 +34,6 @@ import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.streamprocessor.ProcessingScheduleServiceImpl;
 import io.camunda.zeebe.streamprocessor.StreamProcessor.Phase;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.time.Duration;

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/TypedEventSerializationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/TypedEventSerializationTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.streamprocessor;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.api.TypedRecord;
+import io.camunda.zeebe.logstreams.log.LoggedEvent;
+import io.camunda.zeebe.protocol.impl.record.CopiedRecord;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.test.util.JsonUtil;
+import io.camunda.zeebe.util.collection.Tuple;
+import org.agrona.DirectBuffer;
+import org.junit.Test;
+
+public final class TypedEventSerializationTest {
+
+  private static Tuple<TypedRecord, CopiedRecord> createRecordTuple() {
+    final RecordMetadata recordMetadata = new RecordMetadata();
+
+    final DeploymentIntent intent = DeploymentIntent.CREATE;
+    final int protocolVersion = 1;
+    final ValueType valueType = ValueType.DEPLOYMENT;
+
+    final RecordType recordType = RecordType.COMMAND;
+    final String rejectionReason = "fails";
+    final RejectionType rejectionType = RejectionType.INVALID_ARGUMENT;
+    final int requestId = 23;
+    final int requestStreamId = 1;
+
+    recordMetadata
+        .intent(intent)
+        .protocolVersion(protocolVersion)
+        .valueType(valueType)
+        .recordType(recordType)
+        .rejectionReason(rejectionReason)
+        .rejectionType(rejectionType)
+        .requestId(requestId)
+        .requestStreamId(requestStreamId);
+
+    final String resourceName = "resource";
+    final DirectBuffer resource = wrapString("contents");
+    final String bpmnProcessId = "testProcess";
+    final long processDefinitionKey = 123;
+    final int processVersion = 12;
+    final DeploymentRecord record = new DeploymentRecord();
+    record.resources().add().setResourceName(wrapString(resourceName)).setResource(resource);
+    record
+        .processesMetadata()
+        .add()
+        .setBpmnProcessId(wrapString(bpmnProcessId))
+        .setKey(processDefinitionKey)
+        .setResourceName(wrapString(resourceName))
+        .setVersion(processVersion)
+        .setChecksum(wrapString("checksum"));
+
+    final long key = 1234;
+    final long position = 4321;
+    final long sourcePosition = 231;
+    final long timestamp = 2191L;
+
+    final LoggedEvent loggedEvent = mock(LoggedEvent.class);
+    when(loggedEvent.getPosition()).thenReturn(position);
+    when(loggedEvent.getKey()).thenReturn(key);
+    when(loggedEvent.getSourceEventPosition()).thenReturn(sourcePosition);
+    when(loggedEvent.getTimestamp()).thenReturn(timestamp);
+
+    final TypedRecordImpl typedEvent = new TypedRecordImpl(0);
+    typedEvent.wrap(loggedEvent, recordMetadata, record);
+
+    final CopiedRecord copiedRecord =
+        new CopiedRecord<>(record, recordMetadata, key, 0, position, sourcePosition, timestamp);
+
+    return new Tuple<>(typedEvent, copiedRecord);
+  }
+
+  @Test
+  public void shouldCreateSameJson() {
+    // given
+    final Tuple<TypedRecord, CopiedRecord> records = createRecordTuple();
+    final String expectedJson = records.getRight().toJson();
+
+    // when
+    final String actualJson = records.getLeft().toJson();
+
+    // then
+    JsonUtil.assertEquality(actualJson, expectedJson);
+  }
+}


### PR DESCRIPTION
# Description
Backport of #10458 to `release-8.1.0`.

relates to #10455 #10130 #10455 #10130