### PR TITLE
ci(bors): add Docker checks to bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,8 @@
 status = [
     "Test summary",
     "Java checks",
-    "Go linting"
+    "Go linting",
+    "Docker checks"
 ]
 
 required_approvals = 1


### PR DESCRIPTION
## Description

Simply adding the Docker Checks to the bors status going forward.

closes #10301 