### PR TITLE
Add terminate end event to randomised tests

### DIFF
--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/ExecutionPathSegment.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/ExecutionPathSegment.java
@@ -101,18 +101,29 @@ public final class ExecutionPathSegment {
   }
 
   /**
-   * Appends the step of the passed execution path segment to the current segment if the current
+   * Appends the steps of the passed execution path segment to the current segment.
    *
-   * @param pathToAdd
-   * @param changesFlowScope
+   * <p>The steps are only appended when the current segment has not reached a terminate end event.
+   * The reasoning behind this is that when a terminate end event has been reached processing must
+   * stop. No more steps should get executed.
+   *
+   * <p>This is only true in some cases. The terminate end event terminate the event's flow scope.
+   * When there is nested flow scopes, for example with a subprocess, only steps of this subprocess
+   * should not be appended. The steps of other flow scopes are not terminated by the end event.
+   * These steps should be appended. Because of this a boolean could be passed to force the steps to
+   * be appended.
+   *
+   * @param pathToAdd execution path segment to append to this segment
+   * @param force forces the path to be appended, even when a terminate end event has already been
+   *     reached
    */
-  public void append(final ExecutionPathSegment pathToAdd, final boolean changesFlowScope) {
+  public void append(final ExecutionPathSegment pathToAdd, final boolean force) {
     mergeVariableDefaults(pathToAdd);
 
-    if (!hasReachedTerminateEndEvent() || changesFlowScope) {
+    if (!hasReachedTerminateEndEvent() || force) {
       pathToAdd.getScheduledSteps().forEach(this::append);
     }
-    reachedTerminateEndEvent = pathToAdd.hasReachedTerminateEndEvent() && !changesFlowScope;
+    reachedTerminateEndEvent = pathToAdd.hasReachedTerminateEndEvent() && !force;
   }
 
   public void append(final ScheduledExecutionStep scheduledExecutionStep) {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/RandomProcessGenerator.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/RandomProcessGenerator.java
@@ -28,6 +28,7 @@ public final class RandomProcessGenerator {
 
   public static final double PROBABILITY_BOUNDARY_TIMER_EVENT = 0.2;
   public static final double PROBABILITY_BOUNDARY_ERROR_EVENT = 0.2;
+  public static final double PROBABILITY_TERMINATE_END_EVENT = 0.2;
 
   private static final BlockSequenceBuilderFactory FACTORY = new BlockSequenceBuilderFactory();
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -88,8 +88,13 @@ public class BlockSequenceBuilder extends AbstractBlockBuilder {
   public ExecutionPathSegment generateRandomExecutionPath(final ExecutionPathContext context) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
-    blockBuilders.forEach(
-        blockBuilder -> result.append(blockBuilder.findRandomExecutionPath(context)));
+    for (final BlockBuilder blockBuilder : blockBuilders) {
+      final var segment = blockBuilder.findRandomExecutionPath(context);
+      result.append(segment);
+      if (result.hasReachedTerminateEndEvent()) {
+        break;
+      }
+    }
 
     return result;
   }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BoundaryEventBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BoundaryEventBuilder.java
@@ -14,11 +14,11 @@ import io.camunda.zeebe.test.util.bpmn.random.RandomProcessGenerator;
 
 public class BoundaryEventBuilder {
 
+  private final boolean timerEventHasTerminateEndEvent;
+  private final boolean errorEventHasTerminateEndEvent;
   private final String taskId;
   private final String joinGatewayId;
   private boolean joinGatewayCreated;
-  private final boolean timerEventHasTerminateEndEvent;
-  private final boolean errorEventHasTerminateEndEvent;
 
   public BoundaryEventBuilder(final ConstructionContext context, final String taskId) {
     this.taskId = taskId;
@@ -71,5 +71,13 @@ public class BoundaryEventBuilder {
     } else {
       return boundaryEventBuilder.connectTo(joinGatewayId);
     }
+  }
+
+  public boolean timerEventHasTerminateEndEvent() {
+    return timerEventHasTerminateEndEvent;
+  }
+
+  public boolean errorEventHasTerminateEndEvent() {
+    return errorEventHasTerminateEndEvent;
   }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BoundaryEventBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BoundaryEventBuilder.java
@@ -40,7 +40,7 @@ public class BoundaryEventBuilder {
       final String errorCode,
       final String boundaryEventId) {
     var builder = taskBuilder;
-    if (!joinGatewayCreated) {
+    if (!joinGatewayCreated && !errorEventHasTerminateEndEvent) {
       builder = connectJoinGateway(taskBuilder);
     }
 
@@ -49,7 +49,7 @@ public class BoundaryEventBuilder {
             .boundaryEvent(boundaryEventId, b -> b.error(errorCode));
 
     if (errorEventHasTerminateEndEvent) {
-      return boundaryEventBuilder.endEvent().terminate().moveToNode(joinGatewayId);
+      return boundaryEventBuilder.endEvent().terminate().moveToNode(taskId);
     } else {
       return boundaryEventBuilder.connectTo(joinGatewayId);
     }
@@ -58,7 +58,7 @@ public class BoundaryEventBuilder {
   public AbstractFlowNodeBuilder<?, ?> connectBoundaryTimerEvent(
       final AbstractFlowNodeBuilder<?, ?> taskBuilder, final String boundaryEventId) {
     var builder = taskBuilder;
-    if (!joinGatewayCreated) {
+    if (!joinGatewayCreated && !timerEventHasTerminateEndEvent) {
       builder = connectJoinGateway(taskBuilder);
     }
 
@@ -67,7 +67,7 @@ public class BoundaryEventBuilder {
             .boundaryEvent(boundaryEventId, b -> b.timerWithDurationExpression(boundaryEventId));
 
     if (timerEventHasTerminateEndEvent) {
-      return boundaryEventBuilder.endEvent().terminate().moveToNode(joinGatewayId);
+      return boundaryEventBuilder.endEvent().terminate().moveToNode(taskId);
     } else {
       return boundaryEventBuilder.connectTo(joinGatewayId);
     }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BoundaryEventBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BoundaryEventBuilder.java
@@ -16,13 +16,13 @@ public class BoundaryEventBuilder {
 
   private final boolean timerEventHasTerminateEndEvent;
   private final boolean errorEventHasTerminateEndEvent;
-  private final String taskId;
+  private final String flowNodeId;
   private final String joinGatewayId;
   private boolean joinGatewayCreated;
 
-  public BoundaryEventBuilder(final ConstructionContext context, final String taskId) {
-    this.taskId = taskId;
-    joinGatewayId = "boundary_join_" + taskId;
+  public BoundaryEventBuilder(final ConstructionContext context, final String flowNodeId) {
+    this.flowNodeId = flowNodeId;
+    joinGatewayId = "boundary_join_" + flowNodeId;
     timerEventHasTerminateEndEvent =
         context.getRandom().nextDouble() < RandomProcessGenerator.PROBABILITY_TERMINATE_END_EVENT;
     errorEventHasTerminateEndEvent =
@@ -30,44 +30,44 @@ public class BoundaryEventBuilder {
   }
 
   private AbstractFlowNodeBuilder<?, ?> connectJoinGateway(
-      final AbstractFlowNodeBuilder<?, ?> taskBuilder) {
+      final AbstractFlowNodeBuilder<?, ?> flowNodeBuilder) {
     joinGatewayCreated = true;
-    return taskBuilder.exclusiveGateway(joinGatewayId);
+    return flowNodeBuilder.exclusiveGateway(joinGatewayId);
   }
 
   public AbstractFlowNodeBuilder<?, ?> connectBoundaryErrorEvent(
-      final AbstractFlowNodeBuilder<?, ?> taskBuilder,
+      final AbstractFlowNodeBuilder<?, ?> flowNodeBuilder,
       final String errorCode,
       final String boundaryEventId) {
-    var builder = taskBuilder;
+    var builder = flowNodeBuilder;
     if (!joinGatewayCreated && !errorEventHasTerminateEndEvent) {
-      builder = connectJoinGateway(taskBuilder);
+      builder = connectJoinGateway(flowNodeBuilder);
     }
 
     final var boundaryEventBuilder =
-        ((AbstractActivityBuilder<?, ?>) builder.moveToNode(taskId))
+        ((AbstractActivityBuilder<?, ?>) builder.moveToNode(flowNodeId))
             .boundaryEvent(boundaryEventId, b -> b.error(errorCode));
 
     if (errorEventHasTerminateEndEvent) {
-      return boundaryEventBuilder.endEvent().terminate().moveToNode(taskId);
+      return boundaryEventBuilder.endEvent().terminate().moveToNode(flowNodeId);
     } else {
       return boundaryEventBuilder.connectTo(joinGatewayId);
     }
   }
 
   public AbstractFlowNodeBuilder<?, ?> connectBoundaryTimerEvent(
-      final AbstractFlowNodeBuilder<?, ?> taskBuilder, final String boundaryEventId) {
-    var builder = taskBuilder;
+      final AbstractFlowNodeBuilder<?, ?> flowNodeBuilder, final String boundaryEventId) {
+    var builder = flowNodeBuilder;
     if (!joinGatewayCreated && !timerEventHasTerminateEndEvent) {
-      builder = connectJoinGateway(taskBuilder);
+      builder = connectJoinGateway(flowNodeBuilder);
     }
 
     final var boundaryEventBuilder =
-        ((AbstractActivityBuilder<?, ?>) builder.moveToNode(taskId))
+        ((AbstractActivityBuilder<?, ?>) builder.moveToNode(flowNodeId))
             .boundaryEvent(boundaryEventId, b -> b.timerWithDurationExpression(boundaryEventId));
 
     if (timerEventHasTerminateEndEvent) {
-      return boundaryEventBuilder.endEvent().terminate().moveToNode(taskId);
+      return boundaryEventBuilder.endEvent().terminate().moveToNode(flowNodeId);
     } else {
       return boundaryEventBuilder.connectTo(joinGatewayId);
     }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
@@ -64,7 +64,7 @@ public class CallActivityBlockBuilder extends AbstractBlockBuilder {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
     if (calledProcessBuilder != null) {
-      result.append(calledProcessBuilder.findRandomExecutionPath(context));
+      result.append(calledProcessBuilder.findRandomExecutionPath(context), true);
     }
 
     return result;

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
@@ -64,7 +64,9 @@ public class CallActivityBlockBuilder extends AbstractBlockBuilder {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
     if (calledProcessBuilder != null) {
-      result.append(calledProcessBuilder.findRandomExecutionPath(context), true);
+      final var calledProcessExecutionPath = calledProcessBuilder.findRandomExecutionPath(context);
+      final var isDifferentFlowScope = true;
+      result.append(calledProcessExecutionPath, isDifferentFlowScope);
     }
 
     return result;

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/JobWorkerTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/JobWorkerTaskBlockBuilder.java
@@ -118,7 +118,7 @@ public class JobWorkerTaskBlockBuilder extends AbstractBlockBuilder {
     result.append(buildStepsForFailedExecutions(context.getRandom()));
 
     result.appendExecutionSuccessor(
-        buildStepForSuccessfulExecution(context.getRandom()), activateStep);
+        buildStepForSuccessfulExecution(context.getRandom(), result), activateStep);
 
     return result;
   }
@@ -147,13 +147,18 @@ public class JobWorkerTaskBlockBuilder extends AbstractBlockBuilder {
    * Successful execution is any execution which moves the token past the service task, so that the
    * process can continue.
    */
-  private AbstractExecutionStep buildStepForSuccessfulExecution(final Random random) {
+  private AbstractExecutionStep buildStepForSuccessfulExecution(
+      final Random random, final ExecutionPathSegment executionPathSegment) {
     final AbstractExecutionStep result;
 
     if (hasBoundaryErrorEvent && random.nextBoolean()) {
       result = new StepActivateJobAndThrowError(jobType, errorCode, getElementId());
+      executionPathSegment.setReachedTerminateEndEvent(
+          boundaryEventBuilder.errorEventHasTerminateEndEvent());
     } else if (hasBoundaryTimerEvent && random.nextBoolean()) {
       result = new StepTriggerTimerBoundaryEvent(boundaryTimerEventId);
+      executionPathSegment.setReachedTerminateEndEvent(
+          boundaryEventBuilder.timerEventHasTerminateEndEvent());
     } else {
       result = new StepActivateAndCompleteJob(jobType, getElementId());
     }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
@@ -128,8 +128,8 @@ public class ParallelGatewayBlockBuilder extends AbstractBlockBuilder {
       final BlockBuilder blockBuilder) {
     final var branchExecutionPath = blockBuilder.findRandomExecutionPath(context);
     executionPathSegment.mergeVariableDefaults(branchExecutionPath);
-    return new BranchPointer(
-        branchExecutionPath.getScheduledSteps(), branchExecutionPath.hasReachedTerminateEndEvent());
+    final boolean shouldStopAfterLastStep = branchExecutionPath.hasReachedTerminateEndEvent();
+    return new BranchPointer(branchExecutionPath.getScheduledSteps(), shouldStopAfterLastStep);
   }
 
   // shuffles the lists together by iteratively taking the first item from one of the lists
@@ -151,7 +151,7 @@ public class ParallelGatewayBlockBuilder extends AbstractBlockBuilder {
       copyAutomaticSteps(tuple, executionPath);
       purgeEmptyBranches(branchPointers);
 
-      if (tuple.isEmpty() && tuple.stopAfterLastStep) {
+      if (tuple.isEmpty() && tuple.shouldStopAfterLastStep) {
         executionPath.setReachedTerminateEndEvent(true);
         break;
       }
@@ -195,12 +195,12 @@ public class ParallelGatewayBlockBuilder extends AbstractBlockBuilder {
   private static final class BranchPointer {
 
     private final List<ScheduledExecutionStep> remainingSteps;
-    private final boolean stopAfterLastStep;
+    private final boolean shouldStopAfterLastStep;
 
     private BranchPointer(
-        final List<ScheduledExecutionStep> remainingSteps, final boolean stopAfterLastStep) {
+        final List<ScheduledExecutionStep> remainingSteps, final boolean shouldStopAfterLastStep) {
       this.remainingSteps = new ArrayList<>(remainingSteps);
-      this.stopAfterLastStep = stopAfterLastStep;
+      this.shouldStopAfterLastStep = shouldStopAfterLastStep;
     }
 
     private List<ScheduledExecutionStep> getRemainingSteps() {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/ParallelGatewayBlockBuilder.java
@@ -145,13 +145,13 @@ public class ParallelGatewayBlockBuilder extends AbstractBlockBuilder {
     purgeEmptyBranches(branchPointers);
 
     while (!branchPointers.isEmpty()) {
-      final var tuple = branchPointers.get(random.nextInt(branchPointers.size()));
+      final var branchpointer = branchPointers.get(random.nextInt(branchPointers.size()));
 
-      takeNextItemAndAppendToExecutionPath(executionPath, tuple);
-      copyAutomaticSteps(tuple, executionPath);
+      takeNextItemAndAppendToExecutionPath(executionPath, branchpointer);
+      copyAutomaticSteps(branchpointer, executionPath);
       purgeEmptyBranches(branchPointers);
 
-      if (tuple.isEmpty() && tuple.shouldStopAfterLastStep) {
+      if (branchpointer.isEmpty() && branchpointer.shouldStopAfterLastStep) {
         executionPath.setReachedTerminateEndEvent(true);
         break;
       }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
@@ -33,6 +33,7 @@ public class SubProcessBlockBuilder extends AbstractBlockBuilder {
   private final String subProcessStartEventId;
   private final String subProcessEndEventId;
   private final String subProcessBoundaryTimerEventId;
+  private final BoundaryEventBuilder boundaryEventBuilder;
 
   private final boolean hasBoundaryEvents;
   private final boolean hasBoundaryTimerEvent;
@@ -50,6 +51,7 @@ public class SubProcessBlockBuilder extends AbstractBlockBuilder {
     subProcessEndEventId = idGenerator.nextId();
 
     subProcessBoundaryTimerEventId = "boundary_timer_" + elementId;
+    boundaryEventBuilder = new BoundaryEventBuilder(context, elementId);
 
     final boolean goDeeper = random.nextInt(maxDepth) > currentDepth;
 
@@ -82,11 +84,10 @@ public class SubProcessBlockBuilder extends AbstractBlockBuilder {
 
     AbstractFlowNodeBuilder result = subProcessBuilderDone;
     if (hasBoundaryEvents) {
-      final BoundaryEventBuilder boundaryEventBuilder =
-          new BoundaryEventBuilder(getElementId(), subProcessBuilderDone);
-
       if (hasBoundaryTimerEvent) {
-        result = boundaryEventBuilder.connectBoundaryTimerEvent(subProcessBoundaryTimerEventId);
+        result =
+            boundaryEventBuilder.connectBoundaryTimerEvent(
+                subProcessBuilderDone, subProcessBoundaryTimerEventId);
       }
     }
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
@@ -115,10 +115,10 @@ public class SubProcessBlockBuilder extends AbstractBlockBuilder {
     final var internalExecutionPath = embeddedSubProcessBuilder.findRandomExecutionPath(context);
 
     if (!hasBoundaryEvents || !internalExecutionPath.canBeInterrupted() || random.nextBoolean()) {
-      result.append(internalExecutionPath);
+      result.append(internalExecutionPath, true);
     } else {
       internalExecutionPath.cutAtRandomPosition(random);
-      result.append(internalExecutionPath);
+      result.append(internalExecutionPath, true);
       if (hasBoundaryTimerEvent) {
         result.appendExecutionSuccessor(
             new StepTriggerTimerBoundaryEvent(subProcessBoundaryTimerEventId), activateSubProcess);

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
@@ -115,10 +115,12 @@ public class SubProcessBlockBuilder extends AbstractBlockBuilder {
     final var internalExecutionPath = embeddedSubProcessBuilder.findRandomExecutionPath(context);
 
     if (!hasBoundaryEvents || !internalExecutionPath.canBeInterrupted() || random.nextBoolean()) {
-      result.append(internalExecutionPath, true);
+      final var isDifferentFlowScope = true;
+      result.append(internalExecutionPath, isDifferentFlowScope);
     } else {
       internalExecutionPath.cutAtRandomPosition(random);
-      result.append(internalExecutionPath, true);
+      final var isDifferentFlowScope = true;
+      result.append(internalExecutionPath, isDifferentFlowScope);
       if (hasBoundaryTimerEvent) {
         result.appendExecutionSuccessor(
             new StepTriggerTimerBoundaryEvent(subProcessBoundaryTimerEventId), activateSubProcess);

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/SubProcessBlockBuilder.java
@@ -122,6 +122,7 @@ public class SubProcessBlockBuilder extends AbstractBlockBuilder {
       if (hasBoundaryTimerEvent) {
         result.appendExecutionSuccessor(
             new StepTriggerTimerBoundaryEvent(subProcessBoundaryTimerEventId), activateSubProcess);
+        result.setReachedTerminateEndEvent(boundaryEventBuilder.timerEventHasTerminateEndEvent());
       } // extend here for other boundary events
     }
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
@@ -87,8 +87,10 @@ public class UserTaskBlockBuilder extends AbstractBlockBuilder {
     if (hasBoundaryTimerEvent && random.nextBoolean()) {
       result.appendExecutionSuccessor(
           new StepTriggerTimerBoundaryEvent(boundaryTimerEventId), activateStep);
+      result.setReachedTerminateEndEvent(boundaryEventBuilder.timerEventHasTerminateEndEvent());
     } else if (hasBoundaryErrorEvent && random.nextBoolean()) {
       result.appendExecutionSuccessor(new StepThrowError(getElementId(), errorCode), activateStep);
+      result.setReachedTerminateEndEvent(boundaryEventBuilder.errorEventHasTerminateEndEvent());
     } else {
       result.appendExecutionSuccessor(new StepCompleteUserTask(getElementId()), activateStep);
     }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/UserTaskBlockBuilder.java
@@ -27,6 +27,7 @@ public class UserTaskBlockBuilder extends AbstractBlockBuilder {
 
   private final String boundaryErrorEventId;
   private final String boundaryTimerEventId;
+  private final BoundaryEventBuilder boundaryEventBuilder;
   private final String errorCode;
   private final boolean hasBoundaryEvents;
   private final boolean hasBoundaryErrorEvent;
@@ -38,6 +39,7 @@ public class UserTaskBlockBuilder extends AbstractBlockBuilder {
 
     boundaryErrorEventId = "boundary_error_" + elementId;
     boundaryTimerEventId = "boundary_timer_" + elementId;
+    boundaryEventBuilder = new BoundaryEventBuilder(context, elementId);
     errorCode = "error_" + elementId;
 
     hasBoundaryErrorEvent =
@@ -54,15 +56,14 @@ public class UserTaskBlockBuilder extends AbstractBlockBuilder {
     AbstractFlowNodeBuilder<?, ?> result = taskBuilder;
 
     if (hasBoundaryEvents) {
-      final BoundaryEventBuilder boundaryEventBuilder =
-          new BoundaryEventBuilder(getElementId(), taskBuilder);
-
       if (hasBoundaryErrorEvent) {
-        result = boundaryEventBuilder.connectBoundaryErrorEvent(boundaryErrorEventId, errorCode);
+        result =
+            boundaryEventBuilder.connectBoundaryErrorEvent(
+                taskBuilder, errorCode, boundaryErrorEventId);
       }
 
       if (hasBoundaryTimerEvent) {
-        result = boundaryEventBuilder.connectBoundaryTimerEvent(boundaryTimerEventId);
+        result = boundaryEventBuilder.connectBoundaryTimerEvent(taskBuilder, boundaryTimerEventId);
       }
     }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR will generate processes containing terminate end events. When a terminate end event is reached the flow scope should be terminated (not that it writes a COMPLETED event for the flow scope itself). If this was the root flow scope the process is completed, otherwise processing will continue as expected.

At this moment this PR only adds terminate end events through boundary events on user tasks, job worker tasks, and sub processes. Just this allows the events to be present in different flow scopes of the process.

Since the randomised tests don't know the concept of flow scopes it's not straightforward to support terminate end events. Generating them is easy, however having to generate an execution path proofs difficult. What we do have is `ExecutionPathSegements`. An `ExecutionPathSegment` is a set of steps that completes a specific part of the process. To understand this PR it is required to know how the execution path generation works.


A randomly generated process consist of `BlockBuilders`. Each `BlockBuilder` is responsible for generating a part of the process. There is many different kinds of `BlockBuilders`, for example `UserTaskBlockBuilder` and `SubProcessBlockBuilder`. When we generate an execution path we will iterate over these `BlockBuilders` and each of them will generate it's own `ExecutionPathSegment`.
These `BlockBuilders` are nested. We always have a root `BlockSequenceBuilder`. Generating an execution path causes this root `BlockBuilder` to iterate over all the `BlockBuilders` nested within it. For each of these it will generate the execution path and append the execution steps of that segment to it's own `ExecutionPathSegment`. Of course generating the path for this nested block builder will result in the nested block builder generating that are nested within that block builder as well.
By doing this the root block builder will end up with an `ExecutionPathSegment` which contains all the execution steps for the entire process.

The tricky part for this PR is that we somehow need to stop appending new execution paths to the `ExecutionPathSegment` when we encounter a terminate end event. For this I've introduced a boolean on the `ExecutionPathSegment`. Because of this flag each `BlockBuilder` will have the freedom to decide what should happen when a terminate end event is reached. Some will prevent the appending of new segments (e.g. `ExclusiveGatewayBlockBuilder`), and some will allow appending new segments after the current (e.g. `SubProcessBlockBuilder`).



As mentioned I've only introduces the terminate end event connected to boundary events. The reasoning for this is that the randomised tests are already complex as-is. There is no straightforward way to have 1 branch of a gateway connect to a terminate end event. Since the boundary events already cover all scenarios I believe it is fine to limit it to this.

## Related issues

<!-- Which issues are closed by this PR or are related -->

blocked by #10590
closes #10476 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
