### PR TITLE
Fix NPE during PI modification

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -198,6 +198,12 @@ public final class ProcessInstanceModificationProcessor
             instruction -> {
               final var elementInstance =
                   elementInstanceState.getInstance(instruction.getElementInstanceKey());
+              if (elementInstance == null) {
+                // at this point this element instance has already been terminated as a result of
+                // one of the previous terminate instructions. As a result we no longer need to
+                // terminate it.
+                return;
+              }
               final var flowScopeKey = elementInstance.getValue().getFlowScopeKey();
 
               terminateElement(elementInstance, sideEffectQueue);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTerminationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTerminationTest.java
@@ -1004,13 +1004,14 @@ public class ModifyProcessInstanceTerminationTest {
             .withElementId("A")
             .withElementType(BpmnElementType.MULTI_INSTANCE_BODY)
             .getFirst();
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withElementId("B")
-        .withElementType(BpmnElementType.USER_TASK)
-        .limit(3)
-        .map(Record::getKey)
-        .toList();
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("B")
+                .withElementType(BpmnElementType.USER_TASK)
+                .limit(3))
+        .describedAs("Expect that all 3 user tasks are activated")
+        .hasSize(3);
     final var elements =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
             .withProcessInstanceKey(processInstanceKey)


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Multiple terminate instructions could result in the termination of a specific element instance multiple times. When this happened a NPE would occur, rolling back the modification. When we encounter this issue we can just ignore the second termination of this specific element instance, as we've already processed it as part of a different instruction.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10537 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
