### PR TITLE
Improve s3 backup store client reliability

### DIFF
--- a/backup-stores/s3/pom.xml
+++ b/backup-stores/s3/pom.xml
@@ -46,6 +46,16 @@
     </dependency>
 
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>aws-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>netty-nio-client</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.s3;
 
+import java.time.Duration;
 import java.util.Optional;
 
 /**
@@ -19,6 +20,8 @@ import java.util.Optional;
  *     try to discover an appropriate value from the environment.
  * @param credentials If no value is provided, the AWS SDK will try to discover appropriate values
  *     from the environment.
+ * @param apiCallTimeout Used as the overall api call timeout for the AWS SDK. API calls that exceed
+ *     the timeout may fail and result in failed backups.
  * @see <a
  *     href=https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html#automatically-determine-the-aws-region-from-the-environment>
  *     Automatically determine the Region from the environment</a>
@@ -28,17 +31,18 @@ public record S3BackupConfig(
     String bucketName,
     Optional<String> endpoint,
     Optional<String> region,
-    Optional<Credentials> credentials) {
+    Optional<Credentials> credentials,
+    Optional<Duration> apiCallTimeout) {
 
   /**
    * Creates a config without setting the region and credentials.
    *
    * @param bucketName Name of the backup that will be used for storing backups
    * @see S3BackupConfig#S3BackupConfig(String bucketName, Optional endpoint, Optional region,
-   *     Optional credentials)
+   *     Optional credentials, Optional apiCallTimeout)
    */
   public S3BackupConfig(final String bucketName) {
-    this(bucketName, Optional.empty(), Optional.empty(), Optional.empty());
+    this(bucketName, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
   }
 
   public static S3BackupConfig from(
@@ -46,7 +50,8 @@ public record S3BackupConfig(
       final String endpoint,
       final String region,
       final String accessKey,
-      final String secretKey) {
+      final String secretKey,
+      final Duration apiCallTimeoutMs) {
     Credentials credentials = null;
     if (accessKey != null && secretKey != null) {
       credentials = new Credentials(accessKey, secretKey);
@@ -55,7 +60,8 @@ public record S3BackupConfig(
         bucketName,
         Optional.ofNullable(endpoint),
         Optional.ofNullable(region),
-        Optional.ofNullable(credentials));
+        Optional.ofNullable(credentials),
+        Optional.ofNullable(apiCallTimeoutMs));
   }
 
   record Credentials(String accessKey, String secretKey) {

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.backup.s3.manifest.ValidBackupManifest;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -438,6 +439,9 @@ public final class S3BackupStore implements BackupStore {
                     StaticCredentialsProvider.create(
                         AwsBasicCredentials.create(
                             credentials.accessKey(), credentials.secretKey()))));
+    config
+        .apiCallTimeout()
+        .ifPresent(timeout -> builder.overrideConfiguration(cfg -> cfg.apiCallTimeout(timeout)));
     return builder.build();
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -188,7 +188,8 @@ public final class SystemContext {
               s3Config.getEndpoint(),
               s3Config.getRegion(),
               s3Config.getAccessKey(),
-              s3Config.getSecretKey());
+              s3Config.getSecretKey(),
+              s3Config.getApiCallTimeout());
       try {
         S3BackupStore.validateConfig(storeConfig);
       } catch (final Exception e) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.configuration.backup;
 
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import java.time.Duration;
 import java.util.Objects;
 
 public class S3BackupStoreConfig implements ConfigurationEntry {
@@ -17,6 +18,7 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
   private String region;
   private String accessKey;
   private String secretKey;
+  private Duration apiCallTimeout;
 
   public String getBucketName() {
     return bucketName;
@@ -58,6 +60,14 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
     this.secretKey = secretKey;
   }
 
+  public Duration getApiCallTimeout() {
+    return apiCallTimeout;
+  }
+
+  public void setApiCallTimeout(final Duration apiCallTimeout) {
+    this.apiCallTimeout = apiCallTimeout;
+  }
+
   @Override
   public int hashCode() {
     int result = bucketName != null ? bucketName.hashCode() : 0;
@@ -65,6 +75,7 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
     result = 31 * result + (region != null ? region.hashCode() : 0);
     result = 31 * result + (accessKey != null ? accessKey.hashCode() : 0);
     result = 31 * result + (secretKey != null ? secretKey.hashCode() : 0);
+    result = 31 * result + (apiCallTimeout != null ? apiCallTimeout.hashCode() : 0);
     return result;
   }
 
@@ -91,7 +102,10 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
     if (!Objects.equals(accessKey, that.accessKey)) {
       return false;
     }
-    return Objects.equals(secretKey, that.secretKey);
+    if (!Objects.equals(secretKey, that.secretKey)) {
+      return false;
+    }
+    return Objects.equals(apiCallTimeout, that.apiCallTimeout);
   }
 
   @Override
@@ -111,6 +125,9 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
         + '\''
         + ", secretKey='"
         + "<redacted>"
+        + '\''
+        + ", apiCallTimeout='"
+        + apiCallTimeout
         + '\''
         + '}';
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
@@ -18,7 +18,7 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
   private String region;
   private String accessKey;
   private String secretKey;
-  private Duration apiCallTimeout;
+  private Duration apiCallTimeout = Duration.ofSeconds(180);
 
   public String getBucketName() {
     return bucketName;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -87,7 +87,8 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
               s3Config.getEndpoint(),
               s3Config.getRegion(),
               s3Config.getAccessKey(),
-              s3Config.getSecretKey());
+              s3Config.getSecretKey(),
+              s3Config.getApiCallTimeout());
       final S3BackupStore backupStore = new S3BackupStore(storeConfig);
       context.setBackupStore(backupStore);
       installed.complete(null);

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -264,6 +264,12 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_SECRETKEY
           # secretKey:
 
+          # Configure a maximum duration for all S3 client API calls.
+          # Lower values will ensure that failed or slow API calls don't block other backups but may increase the risk
+          # that backups can't be stored if uploading parts of the backup takes longer than the configured timeout.
+          # See https://github.com/aws/aws-sdk-java-v2/blob/master/docs/BestPractices.md#utilize-timeout-configurations
+          # apiCallTimeout: PT180S
+
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
 

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -204,6 +204,12 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_SECRETKEY
           # secretKey:
 
+          # Configure a maximum duration for all S3 client API calls.
+          # Lower values will ensure that failed or slow API calls don't block other backups but may increase the risk
+          # that backups can't be stored if uploading parts of the backup takes longer than the configured timeout.
+          # See https://github.com/aws/aws-sdk-java-v2/blob/master/docs/BestPractices.md#utilize-timeout-configurations
+          # apiCallTimeout: PT180S
+
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
 

--- a/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
@@ -46,7 +46,8 @@ final class BackupStoreComponent {
               s3Config.getEndpoint(),
               s3Config.getRegion(),
               s3Config.getAccessKey(),
-              s3Config.getSecretKey());
+              s3Config.getSecretKey(),
+              s3Config.getApiCallTimeout());
       return new S3BackupStore(storeConfig);
     } else {
       throw new IllegalArgumentException(

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupAcceptanceIT.java
@@ -99,7 +99,8 @@ final class BackupAcceptanceIT {
             minio.externalEndpoint(),
             minio.region(),
             minio.accessKey(),
-            minio.secretKey());
+            minio.secretKey(),
+            Duration.ofSeconds(25));
     store = new S3BackupStore(config);
 
     try (final var client = S3BackupStore.buildClient(config)) {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupMultiPartitionTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupMultiPartitionTest.java
@@ -107,7 +107,12 @@ class BackupMultiPartitionTest {
     // Create bucket before for storing backups
     s3ClientConfig =
         S3BackupConfig.from(
-            bucketName, S3.externalEndpoint(), S3.region(), S3.accessKey(), S3.secretKey());
+            bucketName,
+            S3.externalEndpoint(),
+            S3.region(),
+            S3.accessKey(),
+            S3.secretKey(),
+            Duration.ofSeconds(15));
     s3BackupStore = new S3BackupStore(s3ClientConfig);
     try (final var s3Client = S3BackupStore.buildClient(s3ClientConfig)) {
       s3Client.createBucket(builder -> builder.bucket(bucketName).build()).join();


### PR DESCRIPTION
This adds the ability to set an overall api call timeout which appears to be the only thing that fixes #10547. Additionally, some other configuration for the client is updated to smooth out load spikes when taking backups and to automatically adjust various other parameters based on the detected environment.