### PR TITLE
Remove interrupted state on event subprocess activation

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -185,6 +185,11 @@ public final class ProcessInstanceModificationProcessor
                                   processInstance,
                                   process,
                                   instruction));
+
+                  activatedElementKeys
+                      .getFlowScopeKeys()
+                      .forEach(value::addActivatedElementInstanceKey);
+
                   return activatedElementKeys.getFlowScopeKeys().stream();
                 })
             .collect(Collectors.toSet());

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
@@ -50,6 +51,7 @@ public final class EventAppliers implements EventApplier {
   public EventAppliers(final MutableZeebeState state) {
     registerProcessInstanceEventAppliers(state);
     registerProcessInstanceCreationAppliers(state);
+    registerProcessInstanceModificationAppliers(state);
 
     register(ProcessIntent.CREATED, new ProcessCreatedApplier(state));
     register(ErrorIntent.CREATED, new ErrorCreatedApplier(state.getBlackListState()));
@@ -145,6 +147,12 @@ public final class EventAppliers implements EventApplier {
     register(
         ProcessInstanceCreationIntent.CREATED,
         new ProcessInstanceCreationCreatedApplier(processState, elementInstanceState));
+  }
+
+  private void registerProcessInstanceModificationAppliers(final MutableZeebeState state) {
+    register(
+        ProcessInstanceModificationIntent.MODIFIED,
+        new ProcessInstanceModifiedEventApplier(state.getElementInstanceState()));
   }
 
   private void registerJobIntentEventAppliers(final MutableZeebeState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceModifiedEventApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceModifiedEventApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+
+final class ProcessInstanceModifiedEventApplier
+    implements TypedEventApplier<
+        ProcessInstanceModificationIntent, ProcessInstanceModificationRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+
+  public ProcessInstanceModifiedEventApplier(
+      final MutableElementInstanceState elementInstanceState) {
+    this.elementInstanceState = elementInstanceState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceModificationRecord value) {}
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceModifiedEventApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceModifiedEventApplier.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
@@ -24,5 +25,13 @@ final class ProcessInstanceModifiedEventApplier
   }
 
   @Override
-  public void applyState(final long key, final ProcessInstanceModificationRecord value) {}
+  public void applyState(final long key, final ProcessInstanceModificationRecord value) {
+    value.getActivatedElementInstanceKeys().stream()
+        .map(elementInstanceState::getInstance)
+        .filter(ElementInstance::isInterrupted)
+        .forEach(
+            instance ->
+                elementInstanceState.updateInstance(
+                    instance.getKey(), ElementInstance::clearInterruptedState));
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -188,6 +188,10 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
     return getInterruptingElementId().capacity() > 0;
   }
 
+  public void clearInterruptedState() {
+    interruptingEventKeyProp.setValue("");
+  }
+
   public long getParentKey() {
     return parentKeyProp.getValue();
   }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
@@ -10,10 +10,13 @@ package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
     implements ProcessInstanceModificationRecordValue {
@@ -27,11 +30,14 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
       activateInstructionsProperty =
           new ArrayProperty<>(
               "activateInstructions", new ProcessInstanceModificationActivateInstruction());
+  private final ArrayProperty<LongValue> activatedElementInstanceKeys =
+      new ArrayProperty<>("activatedElementInstanceKeys", new LongValue());
 
   public ProcessInstanceModificationRecord() {
     declareProperty(processInstanceKeyProperty)
         .declareProperty(terminateInstructionsProperty)
-        .declareProperty(activateInstructionsProperty);
+        .declareProperty(activateInstructionsProperty)
+        .declareProperty(activatedElementInstanceKeys);
   }
 
   /**
@@ -95,6 +101,17 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
   public ProcessInstanceModificationRecord addActivateInstruction(
       final ProcessInstanceModificationActivateInstruction activateInstruction) {
     activateInstructionsProperty.add().copy(activateInstruction);
+    return this;
+  }
+
+  public Set<Long> getActivatedElementInstanceKeys() {
+    return activatedElementInstanceKeys.stream()
+        .map(LongValue::getValue)
+        .collect(Collectors.toSet());
+  }
+
+  public ProcessInstanceModificationRecord addActivatedElementInstanceKey(final long key) {
+    activatedElementInstanceKeys.add().setValue(key);
     return this;
   }
 

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -787,7 +787,8 @@ final class JsonSerializableToJsonTest {
               }
             }],
             "elementId": "activity"
-          }]
+          }],
+          "activatedElementInstanceKeys": []
         }
         """
       },
@@ -803,7 +804,8 @@ final class JsonSerializableToJsonTest {
         {
           "processInstanceKey": 1,
           "terminateInstructions": [],
-          "activateInstructions": []
+          "activateInstructions": [],
+          "activatedElementInstanceKeys": []
         }
         """
       },


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
When an interrupting event sub process gets triggered it will terminate all active element in its flow scope and mark the flow scope as interrupted. With process instance modification it should be possible to re-activate element within the interrupted scope. Because of the interrupted state any activate commands get rejected, making this currently impossible.

With this change we will check if any of the activated elements is currently in an interrupted state. If this is the case we will remove this state, allowing elements within to be activated through a modification.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10477 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
