### PR TITLE
fix: take snapshot if nothing was exported since last snapshot

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/NoEntryAtSnapshotPosition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/NoEntryAtSnapshotPosition.java
@@ -11,7 +11,7 @@ package io.camunda.zeebe.broker.system.partitions;
  * Used when there is no entry at the determined snapshot position while taking a transient
  * snapshot.
  */
-public class NoEntryAtSnapshotPosition extends RuntimeException {
+public class NoEntryAtSnapshotPosition extends Exception {
 
   public NoEntryAtSnapshotPosition(final String message) {
     super(message);

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -199,6 +199,33 @@ public final class StateControllerImplTest {
   }
 
   @Test
+  public void shouldTakeSnapshotWithoutIndexedEntryWhenProcessedPositionChanged() {
+    // given
+    final var snapshotPosition = 2;
+    exporterPosition.set(snapshotPosition - 1);
+    snapshotController.recover().join();
+    final var firstSnapshot =
+        snapshotController.takeTransientSnapshot(snapshotPosition).join().persist().join();
+    atomixRecordEntrySupplier.set(emptyEntrySupplier);
+
+    // when
+    final var snapshot =
+        snapshotController.takeTransientSnapshot(snapshotPosition + 1).join().persist().join();
+
+    // then
+    assertThat(snapshot)
+        .extracting(PersistedSnapshot::getCompactionBound)
+        .isEqualTo(firstSnapshot.getCompactionBound());
+    assertThat(snapshot.getId()).isNotEqualTo(firstSnapshot.getId());
+    final var newSnapshotId = FileBasedSnapshotId.ofFileName(snapshot.getId()).orElseThrow();
+    final var firstSnapshotId = FileBasedSnapshotId.ofFileName(firstSnapshot.getId()).orElseThrow();
+    assertThat(newSnapshotId.getExportedPosition())
+        .isEqualTo(firstSnapshotId.getExportedPosition());
+    assertThat(newSnapshotId.getProcessedPosition())
+        .isGreaterThan(firstSnapshotId.getProcessedPosition());
+  }
+
+  @Test
   public void shouldTakeSnapshotWhenProcessorPositionNotChanged() {
     // given
     final var snapshotPosition = 2;


### PR DESCRIPTION
When figuring out where to take the next snapshot, we determine the snapshot position as the minimum of processing and exporter positions.

There was an edge case where a leader could process but no export.
In that case it'd use the exporter position as snapshot position and tryand find a log entry at that position.
If the log starts with the exporter position, for example because the same broker previously received a snapshot and compacted the log, no entry could be found which led to a failed snapshot.

We now try and use the latest snapshot's term and index if the log entry could not be found. This ensures that new snapshots can be taken even if nothing was exported since the last snapshot.

closes #9761 