### PR TITLE
feat(engine): Apply output mappings for none end events

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/NoneEndEventOutputMappingTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/NoneEndEventOutputMappingTest.java
@@ -7,95 +7,211 @@
  */
 package io.camunda.zeebe.engine.processing.variable.mapping;
 
+import static io.camunda.zeebe.engine.processing.variable.mapping.VariableValue.variable;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.model.bpmn.builder.EndEventBuilder;
+import io.camunda.zeebe.model.bpmn.builder.ZeebeVariablesMappingBuilder;
 import io.camunda.zeebe.protocol.record.Record;
-import io.camunda.zeebe.protocol.record.intent.VariableIntent;
-import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
+@RunWith(Parameterized.class)
 public final class NoneEndEventOutputMappingTest {
 
   @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
+
   private static final String PROCESS_ID = "process";
+
+  private static final String A_TIME_VALUE = "\"04:20:00@Europe/Berlin\"";
+  private static final String A_LOCAL_TIME_VALUE = "\"04:20\"";
+  private static final String A_DATE_VALUE = "\"2021-02-24\"";
+  private static final String A_LOCAL_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20\"";
+  private static final String A_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20+01:00\"";
+  private static final String A_DAY_TIME_DURATION_VALUE = "\"PT42H56M33S\"";
+  private static final String A_YEAR_MONTH_DURATION_VALUE = "\"P2Y3M\"";
+  private static final String A_STRING = "\"foobar\"";
+  private static final String A_SUB_STRING = "\"bar\"";
+  private static final String A_UPPER_STRING = "\"FOOBAR\"";
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
 
-  @Test
-  public void shouldCreateVariableForNoneEndEvent() {
-    // given
-    final BpmnModelInstance processDefinition =
-        Bpmn.createExecutableProcess(PROCESS_ID)
-            .startEvent("start")
-            .zeebeOutputExpression("1", "x")
-            .manualTask()
-            .endEvent("end")
-            .zeebeOutputExpression("x+1", "y")
-            .done();
+  @Parameter(0)
+  public String initialVariables;
 
-    ENGINE_RULE.deployment().withXmlResource(processDefinition).deploy();
+  @Parameter(1)
+  public Consumer<EndEventBuilder> mappings;
 
-    // when
-    final long processInstanceKey =
-        ENGINE_RULE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+  @Parameter(2)
+  public List<VariableValue> expectedScopeVariables;
 
-    // then
-    final Record<VariableRecordValue> variableRecord =
-        RecordingExporter.variableRecords(VariableIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withName("y")
-            .getFirst();
-
-    Assertions.assertThat(variableRecord.getValue())
-        .hasScopeKey(processInstanceKey)
-        .hasName("y")
-        .hasValue("2");
+  @Parameters(name = "from {0} to {2}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {
+        "{'x': 1}",
+        mapping(b -> b.zeebeOutputExpression("x", "y")),
+        scopeVariables(variable("y", "1"))
+      },
+      {
+        "{'x': 1}",
+        mapping(b -> b.zeebeOutputExpression("decimal(x / 3, 2)", "y")),
+        scopeVariables(variable("y", "0.33"))
+      },
+      {
+        "{'x': 1, 'y': 2}",
+        mapping(b -> b.zeebeOutputExpression("y", "z")),
+        scopeVariables(variable("z", "2"))
+      },
+      {
+        "{'x': 1}",
+        mapping(b -> b.zeebeInputExpression("x", "y").zeebeOutputExpression("x", "z")),
+        scopeVariables(variable("z", "1"))
+      },
+      {
+        "{'x': {'y': 2}}",
+        mapping(b -> b.zeebeOutputExpression("x", "z")),
+        scopeVariables(variable("z", "{\"y\":2}"))
+      },
+      {
+        "{'x': {'y': 2}}",
+        mapping(b -> b.zeebeOutputExpression("x.y", "z")),
+        scopeVariables(variable("z", "2"))
+      },
+      {
+        "{'z': {'x': 1}, 'y': 2}",
+        mapping(b -> b.zeebeOutputExpression("y", "z.y")),
+        scopeVariables(variable("z", "{\"x\":1,\"y\":2}"))
+      },
+      {
+        "{'x': 1, 'y': 2}",
+        mapping(b -> b.zeebeOutputExpression("x", "z.x").zeebeOutputExpression("y", "z.y")),
+        scopeVariables(variable("z", "{\"x\":1,\"y\":2}"))
+      },
+      {
+        "{'x': %s}".formatted(A_STRING),
+        mapping(b -> b.zeebeOutputExpression("contains(x, \"of\")", "y")),
+        scopeVariables(variable("y", "false"))
+      },
+      {
+        "{'x': %s}".formatted(A_STRING),
+        mapping(b -> b.zeebeOutputExpression("starts with(x, \"fo\")", "y")),
+        scopeVariables(variable("y", "true"))
+      },
+      {
+        "{'x': %s}".formatted(A_STRING),
+        mapping(b -> b.zeebeOutputExpression("substring(x, 4)", "y")),
+        scopeVariables(variable("y", A_SUB_STRING))
+      },
+      {
+        "{'x': %s}".formatted(A_STRING),
+        mapping(b -> b.zeebeOutputExpression("upper case(x)", "y")),
+        scopeVariables(variable("y", A_UPPER_STRING))
+      },
+      {
+        "{'x': %s}".formatted(A_TIME_VALUE),
+        mapping(b -> b.zeebeOutputExpression("time(x)", "y")),
+        scopeVariables(variable("y", A_TIME_VALUE))
+      },
+      {
+        "{'x': %s}".formatted(A_LOCAL_TIME_VALUE),
+        mapping(b -> b.zeebeOutputExpression("time(x)", "y")),
+        scopeVariables(variable("y", A_LOCAL_TIME_VALUE))
+      },
+      {
+        "{'x': %s}".formatted(A_DATE_VALUE),
+        mapping(b -> b.zeebeOutputExpression("date(x)", "y")),
+        scopeVariables(variable("y", A_DATE_VALUE))
+      },
+      {
+        "{'x': %s}".formatted(A_LOCAL_DATE_AND_TIME_VALUE),
+        mapping(b -> b.zeebeOutputExpression("date and time(x)", "y")),
+        scopeVariables(variable("y", A_LOCAL_DATE_AND_TIME_VALUE))
+      },
+      {
+        "{'x': %s}".formatted(A_DATE_AND_TIME_VALUE),
+        mapping(b -> b.zeebeOutputExpression("date and time(x)", "y")),
+        scopeVariables(variable("y", A_DATE_AND_TIME_VALUE))
+      },
+      {
+        "{'x': %s}".formatted(A_DAY_TIME_DURATION_VALUE),
+        mapping(b -> b.zeebeOutputExpression("duration(x)", "y")),
+        scopeVariables(variable("y", A_DAY_TIME_DURATION_VALUE))
+      },
+      {
+        "{'x': %s}".formatted(A_YEAR_MONTH_DURATION_VALUE),
+        mapping(b -> b.zeebeOutputExpression("duration(x)", "y")),
+        scopeVariables(variable("y", A_YEAR_MONTH_DURATION_VALUE))
+      }
+    };
   }
 
   @Test
-  public void shouldCreateVariableForSubProcessNoneEndEvent() {
+  public void shouldApplyOutputMappings() {
     // given
-    final BpmnModelInstance processDefinition =
-        Bpmn.createExecutableProcess(PROCESS_ID)
-            .startEvent()
-            .zeebeOutputExpression("1", "x")
-            .subProcess(
-                "sub",
-                b -> {
-                  b.embeddedSubProcess()
-                      .startEvent()
-                      .zeebeOutputExpression("x + 1", "sub_x")
-                      .endEvent()
-                      .zeebeOutputExpression("sub_x + 1", "sub_y");
-                })
-            .endEvent()
-            .zeebeOutputExpression("sub_y + 1", "y")
-            .done();
-
-    ENGINE_RULE.deployment().withXmlResource(processDefinition).deploy();
+    ENGINE_RULE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .endEvent(
+                    "end",
+                    builder -> {
+                      mappings.accept(builder);
+                    })
+                .done())
+        .deploy();
 
     // when
     final long processInstanceKey =
-        ENGINE_RULE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+        ENGINE_RULE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariables(initialVariables)
+            .create();
 
     // then
-    final Record<VariableRecordValue> variableRecord =
-        RecordingExporter.variableRecords(VariableIntent.CREATED)
+    final long endEventActivatePosition =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
             .withProcessInstanceKey(processInstanceKey)
-            .withName("y")
-            .getFirst();
+            .withElementId("end")
+            .limit(1)
+            .getFirst()
+            .getPosition();
 
-    Assertions.assertThat(variableRecord.getValue())
-        .hasScopeKey(processInstanceKey)
-        .hasName("y")
-        .hasValue("4");
+    assertThat(
+            RecordingExporter.variableRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .skipUntil(r -> r.getPosition() > endEventActivatePosition)
+                .withScopeKey(processInstanceKey)
+                .limit(expectedScopeVariables.size()))
+        .extracting(Record::getValue)
+        .extracting(v -> variable(v.getName(), v.getValue()))
+        .hasSameSizeAs(expectedScopeVariables)
+        .containsAll(expectedScopeVariables);
+  }
+
+  private static Consumer<ZeebeVariablesMappingBuilder<EndEventBuilder>> mapping(
+      final Consumer<ZeebeVariablesMappingBuilder<EndEventBuilder>> mappingBuilder) {
+    return mappingBuilder;
+  }
+
+  private static List<VariableValue> scopeVariables(final VariableValue... variables) {
+    return Arrays.asList(variables);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/NoneEndEventOutputMappingTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/NoneEndEventOutputMappingTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.variable.mapping;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class NoneEndEventOutputMappingTest {
+
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
+  private static final String PROCESS_ID = "process";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCreateVariableForNoneEndEvent() {
+    // given
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent("start")
+            .zeebeOutputExpression("1", "x")
+            .manualTask()
+            .endEvent("end")
+            .zeebeOutputExpression("x+1", "y")
+            .done();
+
+    final Record<DeploymentRecordValue> deployment =
+        ENGINE_RULE.deployment().withXmlResource(processDefinition).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE_RULE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<VariableRecordValue> variableRecord =
+        RecordingExporter.variableRecords(VariableIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withName("y")
+            .getFirst();
+
+    Assertions.assertThat(variableRecord.getValue())
+        .hasScopeKey(processInstanceKey)
+        .hasName("y")
+        .hasValue("2");
+  }
+
+  @Test
+  public void shouldCreateVariableForSubProcessNoneEndEvent() {
+    // given
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .zeebeOutputExpression("1", "x")
+            .subProcess(
+                "sub",
+                b -> {
+                  b.embeddedSubProcess()
+                      .startEvent()
+                      .zeebeOutputExpression("x + 1", "sub_x")
+                      .endEvent()
+                      .zeebeOutputExpression("sub_x + 1", "sub_y");
+                })
+            .endEvent()
+            .zeebeOutputExpression("sub_y + 1", "y")
+            .done();
+
+    final Record<DeploymentRecordValue> deployment =
+        ENGINE_RULE.deployment().withXmlResource(processDefinition).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE_RULE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<VariableRecordValue> variableRecord =
+        RecordingExporter.variableRecords(VariableIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withName("y")
+            .getFirst();
+
+    Assertions.assertThat(variableRecord.getValue())
+        .hasScopeKey(processInstanceKey)
+        .hasName("y")
+        .hasValue("4");
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/NoneEndEventOutputMappingTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/NoneEndEventOutputMappingTest.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
-import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -42,8 +41,7 @@ public final class NoneEndEventOutputMappingTest {
             .zeebeOutputExpression("x+1", "y")
             .done();
 
-    final Record<DeploymentRecordValue> deployment =
-        ENGINE_RULE.deployment().withXmlResource(processDefinition).deploy();
+    ENGINE_RULE.deployment().withXmlResource(processDefinition).deploy();
 
     // when
     final long processInstanceKey =
@@ -82,8 +80,7 @@ public final class NoneEndEventOutputMappingTest {
             .zeebeOutputExpression("sub_y + 1", "y")
             .done();
 
-    final Record<DeploymentRecordValue> deployment =
-        ENGINE_RULE.deployment().withXmlResource(processDefinition).deploy();
+    ENGINE_RULE.deployment().withXmlResource(processDefinition).deploy();
 
     // when
     final long processInstanceKey =


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Support none end event outputs.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10613 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
