### PR TITLE
fix(backup/s3): use latest available versions of minio and localstack

### DIFF
--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/LocalstackBackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/LocalstackBackupStoreIT.java
@@ -26,7 +26,7 @@ final class LocalstackBackupStoreIT implements S3BackupStoreTests {
 
   @Container
   private static final LocalStackContainer S3 =
-      new LocalStackContainer(DockerImageName.parse("localstack/localstack:0.14.5"))
+      new LocalStackContainer(DockerImageName.parse("localstack/localstack"))
           .withServices(Service.S3);
 
   private static S3AsyncClient client;

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/MinioBackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/MinioBackupStoreIT.java
@@ -32,7 +32,7 @@ final class MinioBackupStoreIT implements S3BackupStoreTests {
   @SuppressWarnings("resource")
   @Container
   private static final GenericContainer<?> S3 =
-      new GenericContainer<>(DockerImageName.parse("minio/minio:edge"))
+      new GenericContainer<>(DockerImageName.parse("minio/minio"))
           .withCommand("server /data")
           .withExposedPorts(DEFAULT_PORT)
           .withEnv("MINIO_ACCESS_KEY", ACCESS_KEY)


### PR DESCRIPTION
Use latest versions of localstack and minio for running backup integration tests. Both versions were very outdated.