### PR TITLE
fix(ci): do not verify docker image

### DIFF
--- a/.ci/pipelines/release_zeebe.groovy
+++ b/.ci/pipelines/release_zeebe.groovy
@@ -152,7 +152,8 @@ spec:
                         string(name: 'BRANCH', value: env.RELEASE_BRANCH),
                         string(name: 'VERSION', value: params.RELEASE_VERSION),
                         booleanParam(name: 'IS_LATEST', value: params.IS_LATEST),
-                        booleanParam(name: 'PUSH', value: true)
+                        booleanParam(name: 'PUSH', value: true),
+                        booleanParam(name: 'VERIFY', value: false)
                 ]
             }
         }


### PR DESCRIPTION
## Description

While releasing 8.0.7, docker job failed because it was trying to verify the image, but the script `verify.sh` is not available. The script was added only in 8.1.*  

