### PR TITLE
feat(bpmn-model): added link events model api support

### DIFF
--- a/bpmn-model/revapi.json
+++ b/bpmn-model/revapi.json
@@ -51,6 +51,19 @@
           "code": "java.method.addedToInterface",
           "new": "method B io.camunda.zeebe.model.bpmn.builder.ZeebeUserTaskPropertiesBuilder<B extends io.camunda.zeebe.model.bpmn.builder.ZeebeUserTaskPropertiesBuilder<B>>::zeebeCandidateUsersExpression(java.lang.String)",
           "justification": "Ignore new methods for user task properties builder."
+        },{
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method void io.camunda.zeebe.model.bpmn.builder.AbstractBaseElementBuilder<B extends io.camunda.zeebe.model.bpmn.builder.AbstractBaseElementBuilder<B, E>, E extends io.camunda.zeebe.model.bpmn.instance.BaseElement>::resizeSubProcess(io.camunda.zeebe.model.bpmn.instance.bpmndi.BpmnShape)",
+          "justification": "change the name to reuse for SubProcess and Link Events"
+
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method void io.camunda.zeebe.model.bpmn.builder.ProcessBuilder::setEventSubProcessCoordinates(io.camunda.zeebe.model.bpmn.instance.bpmndi.BpmnShape)",
+          "justification": "change the name to reuse for EventSubProcess and Link Events"
+
         }
       ]
     }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBaseElementBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBaseElementBuilder.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.FlowElement;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.model.bpmn.instance.Gateway;
+import io.camunda.zeebe.model.bpmn.instance.IntermediateCatchEvent;
 import io.camunda.zeebe.model.bpmn.instance.Message;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.Process;
@@ -586,6 +587,57 @@ public abstract class AbstractBaseElementBuilder<
 
         innerElement = (SubProcess) parent;
         innerShapeBounds = subProcessBounds;
+        parent = innerElement.getParentElement();
+      } else {
+        break;
+      }
+    }
+  }
+
+  protected void resizeLinkCatchEvent(final BpmnShape innerShape) {
+
+    BaseElement innerElement = innerShape.getBpmnElement();
+    Bounds innerShapeBounds = innerShape.getBounds();
+
+    ModelElementInstance parent = innerElement.getParentElement();
+
+    while (parent instanceof IntermediateCatchEvent) {
+
+      final BpmnShape catchEventShape = findBpmnShape((IntermediateCatchEvent) parent);
+
+      if (catchEventShape != null) {
+
+        final Bounds catchEventBounds = catchEventShape.getBounds();
+        final double innerX = innerShapeBounds.getX();
+        final double innerWidth = innerShapeBounds.getWidth();
+        final double innerY = innerShapeBounds.getY();
+        final double innerHeight = innerShapeBounds.getHeight();
+
+        final double catchEventY = catchEventBounds.getY();
+        final double catchEventHeight = catchEventBounds.getHeight();
+        final double catchEventX = catchEventBounds.getX();
+        final double catchEventWidth = catchEventBounds.getWidth();
+
+        final double tmpWidth = innerX + innerWidth + SPACE;
+        final double tmpHeight = innerY + innerHeight + SPACE;
+
+        if (innerY == catchEventY) {
+          catchEventBounds.setY(catchEventY - SPACE);
+          catchEventBounds.setHeight(catchEventHeight + SPACE);
+        }
+
+        if (tmpWidth >= catchEventX + catchEventWidth) {
+          final double newWidth = tmpWidth - catchEventX;
+          catchEventBounds.setWidth(newWidth);
+        }
+
+        if (tmpHeight >= catchEventY + catchEventHeight) {
+          final double newHeight = tmpHeight - catchEventY;
+          catchEventBounds.setHeight(newHeight);
+        }
+
+        innerElement = (SubProcess) parent;
+        innerShapeBounds = catchEventBounds;
         parent = innerElement.getParentElement();
       } else {
         break;

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBaseElementBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBaseElementBuilder.java
@@ -543,7 +543,7 @@ public abstract class AbstractBaseElementBuilder<
     return null;
   }
 
-  protected void resizeSubProcess(final BpmnShape innerShape) {
+  protected void resizeBpmnShape(final BpmnShape innerShape) {
 
     BaseElement innerElement = innerShape.getBpmnElement();
     Bounds innerShapeBounds = innerShape.getBounds();
@@ -592,14 +592,6 @@ public abstract class AbstractBaseElementBuilder<
         break;
       }
     }
-  }
-
-  protected void resizeLinkCatchEvent(final BpmnShape innerShape) {
-
-    BaseElement innerElement = innerShape.getBpmnElement();
-    Bounds innerShapeBounds = innerShape.getBounds();
-
-    ModelElementInstance parent = innerElement.getParentElement();
 
     while (parent instanceof IntermediateCatchEvent) {
 
@@ -636,7 +628,7 @@ public abstract class AbstractBaseElementBuilder<
           catchEventBounds.setHeight(newHeight);
         }
 
-        innerElement = (SubProcess) parent;
+        innerElement = (IntermediateCatchEvent) parent;
         innerShapeBounds = catchEventBounds;
         parent = innerElement.getParentElement();
       } else {

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractCatchEventBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractCatchEventBuilder.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.model.bpmn.builder.zeebe.SignalBuilder;
 import io.camunda.zeebe.model.bpmn.instance.CatchEvent;
 import io.camunda.zeebe.model.bpmn.instance.CompensateEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.ConditionalEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.LinkEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.Message;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.Signal;
@@ -249,6 +250,20 @@ public abstract class AbstractCatchEventBuilder<
   public B condition(final String condition) {
     conditionalEventDefinition().condition(condition);
     return myself;
+  }
+
+  public LinkEventDefinitionBuilder linkEventDefinition() {
+    return linkEventDefinition(null);
+  }
+
+  public LinkEventDefinitionBuilder linkEventDefinition(final String id) {
+    final LinkEventDefinition eventDefinition = createInstance(LinkEventDefinition.class);
+    if (id != null) {
+      eventDefinition.setId(id);
+    }
+
+    element.getEventDefinitions().add(eventDefinition);
+    return new LinkEventDefinitionBuilder(modelInstance, eventDefinition);
   }
 
   @Override

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractCatchEventBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractCatchEventBuilder.java
@@ -252,6 +252,17 @@ public abstract class AbstractCatchEventBuilder<
     return myself;
   }
 
+  /**
+   * Sets a link event definition for the given link name.
+   *
+   * @param linkName the name of the link
+   * @return the builder object
+   */
+  public B link(final String linkName) {
+    linkEventDefinition().name(linkName);
+    return myself;
+  }
+
   public LinkEventDefinitionBuilder linkEventDefinition() {
     return linkEventDefinition(null);
   }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractFlowNodeBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractFlowNodeBuilder.java
@@ -153,7 +153,7 @@ public abstract class AbstractFlowNodeBuilder<
     final BpmnShape targetBpmnShape = createBpmnShape(target);
     setCoordinates(targetBpmnShape);
     connectTarget(target);
-    resizeSubProcess(targetBpmnShape);
+    resizeBpmnShape(targetBpmnShape);
     return target;
   }
 

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractLinkEventDefinitionBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractLinkEventDefinitionBuilder.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.Event;
+import io.camunda.zeebe.model.bpmn.instance.LinkEventDefinition;
+
+public abstract class AbstractLinkEventDefinitionBuilder<
+        B extends AbstractLinkEventDefinitionBuilder<B>>
+    extends AbstractRootElementBuilder<B, LinkEventDefinition> {
+
+  public AbstractLinkEventDefinitionBuilder(
+      final BpmnModelInstance modelInstance,
+      final LinkEventDefinition element,
+      final Class<?> selfType) {
+    super(modelInstance, element, selfType);
+  }
+
+  @Override
+  public B id(final String identifier) {
+    return super.id(identifier);
+  }
+
+  /**
+   * Sets the link attribute.
+   *
+   * @param name the link for the message event definition
+   * @return the builder object
+   */
+  public B name(final String name) {
+    element.setName(name);
+    return myself;
+  }
+
+  /**
+   * Finishes the building of a link event definition.
+   *
+   * @param <T>
+   * @return the parent event builder
+   */
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public <T extends AbstractFlowNodeBuilder> T linkEventDefinitionDone() {
+    return (T) ((Event) element.getParentElement()).builder();
+  }
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractThrowEventBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractThrowEventBuilder.java
@@ -19,6 +19,7 @@ package io.camunda.zeebe.model.bpmn.builder;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.CompensateEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.LinkEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.SignalEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.ThrowEvent;
@@ -150,6 +151,32 @@ public abstract class AbstractThrowEventBuilder<
 
     element.getEventDefinitions().add(eventDefinition);
     return new CompensateEventDefinitionBuilder(modelInstance, eventDefinition);
+  }
+  /**
+   * Creates an empty link event definition with a unique id and returns a builder for the link
+   * event definition.
+   *
+   * @return the link event definition builder object
+   */
+  public LinkEventDefinitionBuilder linkEventDefinition() {
+    return linkEventDefinition(null);
+  }
+
+  /**
+   * Creates an empty link event definition with the given id and returns a builder for the link
+   * event definition.
+   *
+   * @param id the id of the link event definition
+   * @return the link event definition builder object
+   */
+  public LinkEventDefinitionBuilder linkEventDefinition(final String id) {
+    final LinkEventDefinition eventDefinition = createInstance(LinkEventDefinition.class);
+    if (id != null) {
+      eventDefinition.setId(id);
+    }
+
+    element.getEventDefinitions().add(eventDefinition);
+    return new LinkEventDefinitionBuilder(modelInstance, eventDefinition);
   }
 
   @Override

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractThrowEventBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractThrowEventBuilder.java
@@ -152,6 +152,18 @@ public abstract class AbstractThrowEventBuilder<
     element.getEventDefinitions().add(eventDefinition);
     return new CompensateEventDefinitionBuilder(modelInstance, eventDefinition);
   }
+
+  /**
+   * Sets a link event definition for the given link name.
+   *
+   * @param linkName the name of the link
+   * @return the builder object
+   */
+  public B link(final String linkName) {
+    linkEventDefinition().name(linkName);
+    return myself;
+  }
+
   /**
    * Creates an empty link event definition with a unique id and returns a builder for the link
    * event definition.

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/EmbeddedSubProcessBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/EmbeddedSubProcessBuilder.java
@@ -77,7 +77,7 @@ public class EmbeddedSubProcessBuilder
     // place event sub process underneath
     setCoordinates(targetBpmnShape);
 
-    subProcessBuilder.resizeSubProcess(targetBpmnShape);
+    subProcessBuilder.resizeBpmnShape(targetBpmnShape);
 
     // Return the eventSubProcessBuilder
     final EventSubProcessBuilder eventSubProcessBuilder =

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/LinkEventDefinitionBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/LinkEventDefinitionBuilder.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.LinkEventDefinition;
+
+public class LinkEventDefinitionBuilder
+    extends AbstractLinkEventDefinitionBuilder<LinkEventDefinitionBuilder> {
+
+  public LinkEventDefinitionBuilder(
+      final BpmnModelInstance modelInstance, final LinkEventDefinition element) {
+    super(modelInstance, element, LinkEventDefinitionBuilder.class);
+  }
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilder.java
@@ -59,9 +59,9 @@ public class ProcessBuilder extends AbstractProcessBuilder<ProcessBuilder> {
     final BpmnShape targetBpmnShape = createBpmnShape(subProcess);
     // find the lowest shape in the process
     // place event sub process underneath
-    setEventSubProcessCoordinates(targetBpmnShape);
+    setEventCoordinates(targetBpmnShape);
 
-    resizeSubProcess(targetBpmnShape);
+    resizeBpmnShape(targetBpmnShape);
 
     return new EventSubProcessBuilder(modelInstance, subProcess);
   }
@@ -80,8 +80,8 @@ public class ProcessBuilder extends AbstractProcessBuilder<ProcessBuilder> {
   public IntermediateCatchEventBuilder linkCatchEvent(final String id) {
     final IntermediateCatchEvent catchEvent = createChild(IntermediateCatchEvent.class, id);
     final BpmnShape bpmnShape = createBpmnShape(catchEvent);
-    setLinkCatchEventCoordinates(bpmnShape);
-    resizeLinkCatchEvent(bpmnShape);
+    setEventCoordinates(bpmnShape);
+    resizeBpmnShape(bpmnShape);
     return catchEvent.builder();
   }
 
@@ -92,30 +92,7 @@ public class ProcessBuilder extends AbstractProcessBuilder<ProcessBuilder> {
     bounds.setY(100);
   }
 
-  protected void setEventSubProcessCoordinates(final BpmnShape targetBpmnShape) {
-    final SubProcess eventSubProcess = (SubProcess) targetBpmnShape.getBpmnElement();
-    final Bounds targetBounds = targetBpmnShape.getBounds();
-    double lowestheight = 0;
-
-    // find the lowest element in the model
-    final Collection<BpmnShape> allShapes = modelInstance.getModelElementsByType(BpmnShape.class);
-    for (final BpmnShape shape : allShapes) {
-      final Bounds bounds = shape.getBounds();
-      final double bottom = bounds.getY() + bounds.getHeight();
-      if (bottom > lowestheight) {
-        lowestheight = bottom;
-      }
-    }
-
-    final double ycoord = lowestheight + 50.0;
-    final double xcoord = 100.0;
-
-    // move target
-    targetBounds.setY(ycoord);
-    targetBounds.setX(xcoord);
-  }
-
-  protected void setLinkCatchEventCoordinates(final BpmnShape targetBpmnShape) {
+  protected void setEventCoordinates(final BpmnShape targetBpmnShape) {
     final Bounds targetBounds = targetBpmnShape.getBounds();
     double lowestheight = 0;
 

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilder.java
@@ -17,6 +17,7 @@
 package io.camunda.zeebe.model.bpmn.builder;
 
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.IntermediateCatchEvent;
 import io.camunda.zeebe.model.bpmn.instance.Process;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
 import io.camunda.zeebe.model.bpmn.instance.SubProcess;
@@ -72,6 +73,18 @@ public class ProcessBuilder extends AbstractProcessBuilder<ProcessBuilder> {
     return this;
   }
 
+  public IntermediateCatchEventBuilder linkCatchEvent() {
+    return linkCatchEvent(null);
+  }
+
+  public IntermediateCatchEventBuilder linkCatchEvent(final String id) {
+    final IntermediateCatchEvent catchEvent = createChild(IntermediateCatchEvent.class, id);
+    final BpmnShape bpmnShape = createBpmnShape(catchEvent);
+    setLinkCatchEventCoordinates(bpmnShape);
+    resizeLinkCatchEvent(bpmnShape);
+    return catchEvent.builder();
+  }
+
   @Override
   protected void setCoordinates(final BpmnShape targetBpmnShape) {
     final Bounds bounds = targetBpmnShape.getBounds();
@@ -81,6 +94,28 @@ public class ProcessBuilder extends AbstractProcessBuilder<ProcessBuilder> {
 
   protected void setEventSubProcessCoordinates(final BpmnShape targetBpmnShape) {
     final SubProcess eventSubProcess = (SubProcess) targetBpmnShape.getBpmnElement();
+    final Bounds targetBounds = targetBpmnShape.getBounds();
+    double lowestheight = 0;
+
+    // find the lowest element in the model
+    final Collection<BpmnShape> allShapes = modelInstance.getModelElementsByType(BpmnShape.class);
+    for (final BpmnShape shape : allShapes) {
+      final Bounds bounds = shape.getBounds();
+      final double bottom = bounds.getY() + bounds.getHeight();
+      if (bottom > lowestheight) {
+        lowestheight = bottom;
+      }
+    }
+
+    final double ycoord = lowestheight + 50.0;
+    final double xcoord = 100.0;
+
+    // move target
+    targetBounds.setY(ycoord);
+    targetBounds.setX(xcoord);
+  }
+
+  protected void setLinkCatchEventCoordinates(final BpmnShape targetBpmnShape) {
     final Bounds targetBounds = targetBpmnShape.getBounds();
     double lowestheight = 0;
 

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/ModelUtil.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/ModelUtil.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -130,22 +131,18 @@ public class ModelUtil {
     final List<EventDefinition> linkThrowEvents = getEventDefinitionsForLinkThrowEvents(element);
 
     // get link catch events names
-    final Stream<String> catchEventNames =
+    final Set<String> linkCatchList =
         getEventDefinition(linkCatchEvents, LinkEventDefinition.class)
             .filter(def -> def.getName() != null && !def.getName().isEmpty())
-            .map(LinkEventDefinition::getName);
+            .map(LinkEventDefinition::getName)
+            .collect(Collectors.toSet());
 
     // get link throw events names
-    final Stream<String> throwsEventNames =
+    final Set<String> linkThrowList =
         getEventDefinition(linkThrowEvents, LinkEventDefinition.class)
             .filter(def -> def.getName() != null && !def.getName().isEmpty())
-            .map(LinkEventDefinition::getName);
-
-    // get distinct link catch events names
-    final List<String> linkCatchList = catchEventNames.distinct().collect(Collectors.toList());
-
-    // get distinct link throw events names
-    final List<String> linkThrowList = throwsEventNames.distinct().collect(Collectors.toList());
+            .map(LinkEventDefinition::getName)
+            .collect(Collectors.toSet());
 
     linkThrowList.forEach(
         item -> {

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/ModelUtil.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/ModelUtil.java
@@ -118,19 +118,13 @@ public class ModelUtil {
     verifyNoDuplicatedEventDefinition(definitions, errorCollector);
   }
 
-  public static void verifyNoDuplicatedLinkCatchEvents(
-      final ModelElementInstance element, final Consumer<String> errorCollector) {
-
-    final List<EventDefinition> definitions = getEventDefinitionsForLinkCatchEvents(element);
-
-    verifyNoDuplicatedEventDefinition(definitions, errorCollector);
-  }
-
-  public static void verifyPairsLinkEvents(
+  public static void verifyLinkIntermediateEvents(
       final ModelElementInstance element, final Consumer<String> errorCollector) {
 
     // get link catch events definition
     final List<EventDefinition> linkCatchEvents = getEventDefinitionsForLinkCatchEvents(element);
+
+    verifyNoDuplicatedEventDefinition(linkCatchEvents, errorCollector);
 
     // get link throw events definition
     final List<EventDefinition> linkThrowEvents = getEventDefinitionsForLinkThrowEvents(element);
@@ -153,21 +147,12 @@ public class ModelUtil {
     // get distinct link throw events names
     final List<String> linkThrowList = throwsEventNames.distinct().collect(Collectors.toList());
 
-    // intersection with linkCatchList and linkThrowList
-    final List<String> intersection =
-        linkCatchList.stream()
-            .filter(item -> linkThrowList.contains(item))
-            .collect(Collectors.toList());
-
-    // check if intermediate throw and catch link event definitions are appears in pairs.
-    if (!(linkCatchEvents.size() == 0 && linkThrowEvents.size() == 0)) {
-      if ((linkCatchEvents.size() == 0 && linkThrowEvents.size() > 0)
-          || (linkCatchEvents.size() > 0 && linkThrowEvents.size() == 0)
-          || intersection.size() == 0) {
-        errorCollector.accept(
-            "Intermediate throw and catch link event definitions must appear in pairs.");
-      }
-    }
+    linkThrowList.forEach(
+        item -> {
+          if (!linkCatchList.contains(item)) {
+            errorCollector.accept(noPairedLinkNames(item));
+          }
+        });
   }
 
   public static void verifyEventDefinition(
@@ -269,6 +254,11 @@ public class ModelUtil {
     return String.format(
         "Multiple intermediate catch link event definitions with the same name '%s' are not allowed.",
         linkName);
+  }
+
+  private static String noPairedLinkNames(final String linkName) {
+    return String.format(
+        "Can't find an catch link event for the throw link event with the name '%s'.", linkName);
   }
 
   private static void verifyEventDefinition(

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EventDefinitionValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EventDefinitionValidator.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.LinkEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.SignalEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.TerminateEventDefinition;
@@ -34,7 +35,8 @@ public class EventDefinitionValidator implements ModelElementValidator<EventDefi
           TimerEventDefinition.class,
           ErrorEventDefinition.class,
           TerminateEventDefinition.class,
-          SignalEventDefinition.class);
+          SignalEventDefinition.class,
+          LinkEventDefinition.class);
 
   @Override
   public Class<EventDefinition> getElementType() {

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/IntermediateCatchEventValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/IntermediateCatchEventValidator.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.IntermediateCatchEvent;
+import io.camunda.zeebe.model.bpmn.instance.LinkEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.SignalEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.TimerEventDefinition;
@@ -30,7 +31,10 @@ public class IntermediateCatchEventValidator
     implements ModelElementValidator<IntermediateCatchEvent> {
   private static final List<Class<? extends EventDefinition>> SUPPORTED_EVENTS =
       Arrays.asList(
-          MessageEventDefinition.class, TimerEventDefinition.class, SignalEventDefinition.class);
+          MessageEventDefinition.class,
+          TimerEventDefinition.class,
+          SignalEventDefinition.class,
+          LinkEventDefinition.class);
 
   @Override
   public Class<IntermediateCatchEvent> getElementType() {
@@ -51,7 +55,7 @@ public class IntermediateCatchEventValidator
 
       if (SUPPORTED_EVENTS.stream().noneMatch(c -> c.isAssignableFrom(type))) {
         validationResultCollector.addError(
-            0, "Event definition must be one of: message, timer, signal");
+            0, "Event definition must be one of: message, timer, signal, or link");
 
       } else if (eventDefinition instanceof TimerEventDefinition) {
         final TimerEventDefinition timerEventDefinition = (TimerEventDefinition) eventDefinition;

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/LinkEventDefinitionValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/LinkEventDefinitionValidator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.LinkEventDefinition;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class LinkEventDefinitionValidator implements ModelElementValidator<LinkEventDefinition> {
+
+  @Override
+  public Class<LinkEventDefinition> getElementType() {
+    return LinkEventDefinition.class;
+  }
+
+  @Override
+  public void validate(
+      final LinkEventDefinition element,
+      final ValidationResultCollector validationResultCollector) {
+    if (element.getName() == null || element.getName().isEmpty()) {
+      validationResultCollector.addError(0, "Link name must be present and not empty.");
+    }
+  }
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ProcessValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ProcessValidator.java
@@ -47,10 +47,8 @@ public class ProcessValidator implements ModelElementValidator<Process> {
     ModelUtil.verifyNoDuplicateSignalStartEvents(
         element, error -> validationResultCollector.addError(0, error));
 
-    ModelUtil.verifyNoDuplicatedLinkCatchEvents(
+    ModelUtil.verifyLinkIntermediateEvents(
         element, error -> validationResultCollector.addError(0, error));
-
-    ModelUtil.verifyPairsLinkEvents(element, error -> validationResultCollector.addError(0, error));
   }
 
   private boolean isNoneEvent(final StartEvent startEvent) {

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ProcessValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ProcessValidator.java
@@ -46,6 +46,11 @@ public class ProcessValidator implements ModelElementValidator<Process> {
 
     ModelUtil.verifyNoDuplicateSignalStartEvents(
         element, error -> validationResultCollector.addError(0, error));
+
+    ModelUtil.verifyNoDuplicatedLinkCatchEvents(
+        element, error -> validationResultCollector.addError(0, error));
+
+    ModelUtil.verifyPairsLinkEvents(element, error -> validationResultCollector.addError(0, error));
   }
 
   private boolean isNoneEvent(final StartEvent startEvent) {

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -108,6 +108,7 @@ public final class ZeebeDesignTimeValidators {
                 ZeebeCalledDecision::getResultVariable, ZeebeConstants.ATTRIBUTE_RESULT_VARIABLE));
     validators.add(new SignalEventDefinitionValidator());
     validators.add(new SignalValidator());
+    validators.add(new LinkEventDefinitionValidator());
 
     VALIDATORS = Collections.unmodifiableList(validators);
   }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeLinkEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeLinkEventValidationTest.java
@@ -175,52 +175,22 @@ public class ZeebeLinkEventValidationTest {
 
   public static BpmnModelInstance getLinkEventProcess() {
     final ProcessBuilder process = Bpmn.createExecutableProcess("process");
-    process
-        .startEvent()
-        .manualTask("manualTask1")
-        .intermediateThrowEvent()
-        .linkEventDefinition()
-        .name("LinkA")
-        .linkEventDefinitionDone();
-    return process
-        .linkCatchEvent()
-        .linkEventDefinition()
-        .name("LinkB")
-        .linkEventDefinitionDone()
-        .manualTask("manualTask2")
-        .endEvent()
-        .done();
+    process.startEvent().manualTask("manualTask1").intermediateThrowEvent().link("LinkA");
+    return process.linkCatchEvent().link("LinkB").manualTask("manualTask2").endEvent().done();
   }
 
   public static BpmnModelInstance getOnlyTargetLinkEventProcess() {
     final ProcessBuilder process = Bpmn.createExecutableProcess("process");
     process.startEvent().endEvent();
-    return process
-        .linkCatchEvent()
-        .linkEventDefinition()
-        .name("LinkB")
-        .linkEventDefinitionDone()
-        .endEvent()
-        .done();
+    return process.linkCatchEvent().link("LinkB").endEvent().done();
   }
 
   public static BpmnModelInstance getOnlyManyTargetLinkEventProcess() {
     final ProcessBuilder process = Bpmn.createExecutableProcess("process");
     process.startEvent().endEvent();
-    process
-        .linkCatchEvent()
-        .linkEventDefinition()
-        .name("LinkB")
-        .linkEventDefinitionDone()
-        .endEvent();
+    process.linkCatchEvent().link("LinkB").endEvent();
 
-    return process
-        .linkCatchEvent()
-        .linkEventDefinition()
-        .name("LinkC")
-        .linkEventDefinitionDone()
-        .endEvent()
-        .done();
+    return process.linkCatchEvent().link("LinkC").endEvent().done();
   }
 
   public static BpmnModelInstance getManyLinkEventProcess() {
@@ -229,27 +199,14 @@ public class ZeebeLinkEventValidationTest {
         .startEvent()
         .manualTask("manualTask1")
         .intermediateThrowEvent("linkThrow1")
-        .linkEventDefinition()
-        .name("LinkA")
-        .linkEventDefinitionDone();
+        .link("LinkA");
     process
         .linkCatchEvent()
-        .linkEventDefinition()
-        .name("LinkA")
-        .linkEventDefinitionDone()
+        .link("LinkA")
         .manualTask("manualTask2")
         .intermediateThrowEvent("linkThrow2")
-        .linkEventDefinition()
-        .name("LinkB")
-        .linkEventDefinitionDone();
-    return process
-        .linkCatchEvent()
-        .linkEventDefinition()
-        .name("LinkA")
-        .linkEventDefinitionDone()
-        .manualTask("manualTask3")
-        .endEvent()
-        .done();
+        .link("LinkB");
+    return process.linkCatchEvent().link("LinkA").manualTask("manualTask3").endEvent().done();
   }
 
   public static BpmnModelInstance getGoToLinkEventProcess() {
@@ -266,15 +223,7 @@ public class ZeebeLinkEventValidationTest {
         .moveToLastExclusiveGateway()
         .conditionExpression("condition_link")
         .intermediateThrowEvent("linkThrow")
-        .linkEventDefinition()
-        .name("LinkA")
-        .linkEventDefinitionDone();
-    return process
-        .linkCatchEvent()
-        .linkEventDefinition()
-        .name("LinkA")
-        .linkEventDefinitionDone()
-        .connectTo("exclusive1")
-        .done();
+        .link("LinkA");
+    return process.linkCatchEvent().link("LinkA").connectTo("exclusive1").done();
   }
 }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeLinkEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeLinkEventValidationTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.camunda.zeebe.model.bpmn.validation;
+
+import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.ProcessBuilder;
+import io.camunda.zeebe.model.bpmn.instance.EventBasedGateway;
+import io.camunda.zeebe.model.bpmn.instance.Process;
+import org.camunda.bpm.model.xml.impl.util.ReflectUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ZeebeLinkEventValidationTest {
+
+  @Test
+  @DisplayName("A link throw and a catch event appear in pairs are allowed")
+  void testValidEventLink() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.readModelFromStream(
+            ReflectUtil.getResourceAsStream(
+                "io/camunda/zeebe/model/bpmn/validation/LinkEventTest.testValidEventLink.bpmn"));
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  @DisplayName("Two link throw and one catch event appear in pairs are allowed")
+  void testEventLinkMultipleSources() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.readModelFromStream(
+            ReflectUtil.getResourceAsStream(
+                "io/camunda/zeebe/model/bpmn/validation/LinkEventTest.testEventLinkMultipleSources.bpmn"));
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  @DisplayName("Link Name must be present and not empty and must appear in pairs")
+  void testInvalidEventLink() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateThrowEvent()
+            .linkEventDefinition("linkEvent")
+            .name("")
+            .linkEventDefinitionDone()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect("linkEvent", "Link name must be present and not empty."),
+        expect(
+            "process",
+            "Intermediate throw and catch link event definitions must appear in pairs."));
+  }
+
+  @Test
+  @DisplayName("Intermediate throw and catch link event definitions must appear in pairs")
+  void testNotPairsEventLink() {
+    // given
+    final BpmnModelInstance process = getLinkEventProcess();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            "process",
+            "Intermediate throw and catch link event definitions must appear in pairs."));
+  }
+
+  @Test
+  @DisplayName(
+      "Intermediate throw and catch link event definitions with the same link name are not allowed")
+  void testInvalidEventLinkMultipleTarget() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.readModelFromStream(
+            ReflectUtil.getResourceAsStream(
+                "io/camunda/zeebe/model/bpmn/validation/LinkEventTest.testInvalidEventLinkMultipleTarget.bpmn"));
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            Process.class,
+            "Multiple intermediate catch link event definitions with the same name 'LinkA' are not allowed."));
+  }
+
+  @Test
+  @DisplayName("Intermediate catch link event after event-based gateway is not allowed")
+  void testCatchLinkEventAfterEventBasedGatewayNotAllowed() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.readModelFromStream(
+            ReflectUtil.getResourceAsStream(
+                "io/camunda/zeebe/model/bpmn/validation/LinkEventTest.testCatchLinkEventAfterEventBasedGatewayNotAllowed.bpmn"));
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            EventBasedGateway.class,
+            "Event-based gateway must have at least 2 outgoing sequence flows."),
+        expect(
+            EventBasedGateway.class,
+            "Event-based gateway must not have an outgoing sequence flow to other elements than message/timer intermediate catch events."),
+        expect(
+            Process.class,
+            "Intermediate throw and catch link event definitions must appear in pairs."));
+  }
+
+  public static BpmnModelInstance getLinkEventProcess() {
+    final ProcessBuilder process = Bpmn.createExecutableProcess("process");
+    process
+        .startEvent()
+        .manualTask("manualTask1")
+        .intermediateThrowEvent()
+        .linkEventDefinition()
+        .name("LinkA")
+        .linkEventDefinitionDone();
+    return process
+        .linkCatchEvent()
+        .linkEventDefinition()
+        .name("LinkB")
+        .linkEventDefinitionDone()
+        .manualTask("manualTask2")
+        .endEvent()
+        .done();
+  }
+}

--- a/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/LinkEventTest.testCatchLinkEventAfterEventBasedGatewayNotAllowed.bpmn
+++ b/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/LinkEventTest.testCatchLinkEventAfterEventBasedGatewayNotAllowed.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1xsz6dc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.3.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_05x4y1u" name="Process_05x4y1u" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_1678uq1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1678uq1" sourceRef="StartEvent_1" targetRef="Gateway_1wpt3ke" />
+    <bpmn:eventBasedGateway id="Gateway_1wpt3ke" name="Event Based Gateway">
+      <bpmn:incoming>Flow_1678uq1</bpmn:incoming>
+      <bpmn:outgoing>Flow_0c62udf</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:intermediateCatchEvent id="Event_1xpudal" name="LinkA">
+      <bpmn:incoming>Flow_0c62udf</bpmn:incoming>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0wf27ve" name="LinkA" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_0c62udf" sourceRef="Gateway_1wpt3ke" targetRef="Event_1xpudal" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_05x4y1u">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="142" width="25" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0nyzmm1_di" bpmnElement="Gateway_1wpt3ke">
+        <dc:Bounds x="285" y="92" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="281" y="149" width="63" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1kqbsfb_di" bpmnElement="Event_1xpudal">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="436" y="142" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1678uq1_di" bpmnElement="Flow_1678uq1">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="285" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0c62udf_di" bpmnElement="Flow_0c62udf">
+        <di:waypoint x="335" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/LinkEventTest.testEventLinkMultipleSources.bpmn
+++ b/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/LinkEventTest.testEventLinkMultipleSources.bpmn
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1xsz6dc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.3.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_05x4y1u" name="Process_05x4y1u" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="start">
+      <bpmn:outgoing>Flow_1678uq1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1678uq1" sourceRef="StartEvent_1" targetRef="Activity_1k5srs3" />
+    <bpmn:sequenceFlow id="Flow_1in1tnj" sourceRef="Activity_1k5srs3" targetRef="Gateway_1e58sx7" />
+    <bpmn:intermediateThrowEvent id="Event_1xpudal" name="LinkA">
+      <bpmn:incoming>Flow_1cu30ia</bpmn:incoming>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0kys4cl" name="LinkA" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0b2w3o4" sourceRef="Event_1l6b80w" targetRef="Activity_0khevjp" />
+    <bpmn:endEvent id="Event_18wuva8" name="end">
+      <bpmn:incoming>Flow_1goh8c0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:manualTask id="Activity_1k5srs3" name="M1">
+      <bpmn:incoming>Flow_1678uq1</bpmn:incoming>
+      <bpmn:outgoing>Flow_1in1tnj</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_1goh8c0" sourceRef="Activity_0khevjp" targetRef="Event_18wuva8" />
+    <bpmn:manualTask id="Activity_0khevjp" name="M2">
+      <bpmn:incoming>Flow_0b2w3o4</bpmn:incoming>
+      <bpmn:outgoing>Flow_1goh8c0</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:intermediateCatchEvent id="Event_1l6b80w" name="LinkA">
+      <bpmn:outgoing>Flow_0b2w3o4</bpmn:outgoing>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0wf27ve" name="LinkA" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_1cu30ia" sourceRef="Gateway_1e58sx7" targetRef="Event_1xpudal" />
+    <bpmn:parallelGateway id="Gateway_1e58sx7">
+      <bpmn:incoming>Flow_1in1tnj</bpmn:incoming>
+      <bpmn:outgoing>Flow_1cu30ia</bpmn:outgoing>
+      <bpmn:outgoing>Flow_09g0rd8</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:intermediateThrowEvent id="Event_03p4awe" name="LinkA">
+      <bpmn:incoming>Flow_09g0rd8</bpmn:incoming>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0gx4d12" name="LinkA" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_09g0rd8" sourceRef="Gateway_1e58sx7" targetRef="Event_03p4awe" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_05x4y1u">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="186" y="142" width="23" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_18wuva8_di" bpmnElement="Event_18wuva8">
+        <dc:Bounds x="432" y="232" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="441" y="275" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0s5mdjr_di" bpmnElement="Activity_1k5srs3">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1glopn0_di" bpmnElement="Activity_0khevjp">
+        <dc:Bounds x="270" y="210" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00wbmrv_di" bpmnElement="Event_1l6b80w">
+        <dc:Bounds x="179" y="232" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="183" y="275" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_15zdo6m_di" bpmnElement="Gateway_1e58sx7">
+        <dc:Bounds x="425" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1i71kqu_di" bpmnElement="Event_1xpudal">
+        <dc:Bounds x="612" y="52" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="616" y="95" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0ze6iio" bpmnElement="Event_03p4awe">
+        <dc:Bounds x="612" y="172" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="616" y="215" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1678uq1_di" bpmnElement="Flow_1678uq1">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1in1tnj_di" bpmnElement="Flow_1in1tnj">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="425" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0b2w3o4_di" bpmnElement="Flow_0b2w3o4">
+        <di:waypoint x="215" y="250" />
+        <di:waypoint x="270" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1goh8c0_di" bpmnElement="Flow_1goh8c0">
+        <di:waypoint x="370" y="250" />
+        <di:waypoint x="432" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1cu30ia_di" bpmnElement="Flow_1cu30ia">
+        <di:waypoint x="450" y="92" />
+        <di:waypoint x="450" y="70" />
+        <di:waypoint x="612" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09g0rd8_di" bpmnElement="Flow_09g0rd8">
+        <di:waypoint x="450" y="142" />
+        <di:waypoint x="450" y="190" />
+        <di:waypoint x="612" y="190" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/LinkEventTest.testInvalidEventLinkMultipleTarget.bpmn
+++ b/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/LinkEventTest.testInvalidEventLinkMultipleTarget.bpmn
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1xsz6dc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.3.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_05x4y1u" name="Process_05x4y1u" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="start">
+      <bpmn:outgoing>Flow_1678uq1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1678uq1" sourceRef="StartEvent_1" targetRef="Activity_1k5srs3" />
+    <bpmn:sequenceFlow id="Flow_1in1tnj" sourceRef="Activity_1k5srs3" targetRef="Event_1xpudal" />
+    <bpmn:intermediateThrowEvent id="Event_1xpudal" name="LinkA">
+      <bpmn:incoming>Flow_1in1tnj</bpmn:incoming>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0kys4cl" name="LinkA" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0b2w3o4" sourceRef="Event_1l6b80w" targetRef="Activity_0khevjp" />
+    <bpmn:endEvent id="Event_18wuva8" name="end">
+      <bpmn:incoming>Flow_1goh8c0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:manualTask id="Activity_1k5srs3" name="M1">
+      <bpmn:incoming>Flow_1678uq1</bpmn:incoming>
+      <bpmn:outgoing>Flow_1in1tnj</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_1goh8c0" sourceRef="Activity_0khevjp" targetRef="Event_18wuva8" />
+    <bpmn:manualTask id="Activity_0khevjp" name="M2">
+      <bpmn:incoming>Flow_0b2w3o4</bpmn:incoming>
+      <bpmn:outgoing>Flow_1goh8c0</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:intermediateCatchEvent id="Event_1l6b80w" name="LinkA1">
+      <bpmn:outgoing>Flow_0b2w3o4</bpmn:outgoing>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0wf27ve" name="LinkA" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_19tuemi" name="LinkA">
+      <bpmn:outgoing>Flow_0g5rele</bpmn:outgoing>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0gcopxk" name="LinkA" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_0g5rele" sourceRef="Event_19tuemi" targetRef="Activity_1g8s3yi" />
+    <bpmn:endEvent id="Event_14hvjps" name="end">
+      <bpmn:incoming>Flow_123b93b</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_123b93b" sourceRef="Activity_1g8s3yi" targetRef="Event_14hvjps" />
+    <bpmn:manualTask id="Activity_1g8s3yi" name="M3">
+      <bpmn:incoming>Flow_0g5rele</bpmn:incoming>
+      <bpmn:outgoing>Flow_123b93b</bpmn:outgoing>
+    </bpmn:manualTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_05x4y1u">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="186" y="142" width="23" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0s5mdjr_di" bpmnElement="Activity_1k5srs3">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1glopn0_di" bpmnElement="Activity_0khevjp">
+        <dc:Bounds x="270" y="210" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00wbmrv_di" bpmnElement="Event_1l6b80w">
+        <dc:Bounds x="179" y="232" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="183" y="275" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1i71kqu_di" bpmnElement="Event_1xpudal">
+        <dc:Bounds x="472" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="476" y="142" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1dbyri8" bpmnElement="Event_19tuemi">
+        <dc:Bounds x="179" y="352" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="183" y="395" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_18wuva8_di" bpmnElement="Event_18wuva8">
+        <dc:Bounds x="472" y="232" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="482" y="275" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_14hvjps_di" bpmnElement="Event_14hvjps">
+        <dc:Bounds x="472" y="352" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="481" y="395" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0bs7l5g_di" bpmnElement="Activity_1g8s3yi">
+        <dc:Bounds x="270" y="330" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1678uq1_di" bpmnElement="Flow_1678uq1">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1in1tnj_di" bpmnElement="Flow_1in1tnj">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="472" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0b2w3o4_di" bpmnElement="Flow_0b2w3o4">
+        <di:waypoint x="215" y="250" />
+        <di:waypoint x="270" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1goh8c0_di" bpmnElement="Flow_1goh8c0">
+        <di:waypoint x="370" y="250" />
+        <di:waypoint x="472" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0g5rele_di" bpmnElement="Flow_0g5rele">
+        <di:waypoint x="215" y="370" />
+        <di:waypoint x="270" y="370" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_123b93b_di" bpmnElement="Flow_123b93b">
+        <di:waypoint x="370" y="370" />
+        <di:waypoint x="472" y="370" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/LinkEventTest.testValidEventLink.bpmn
+++ b/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/LinkEventTest.testValidEventLink.bpmn
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1xsz6dc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.3.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_05x4y1u" name="Process_05x4y1u" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="start">
+      <bpmn:outgoing>Flow_1678uq1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1678uq1" sourceRef="StartEvent_1" targetRef="Activity_1k5srs3" />
+    <bpmn:sequenceFlow id="Flow_1in1tnj" sourceRef="Activity_1k5srs3" targetRef="Event_1xpudal" />
+    <bpmn:intermediateThrowEvent id="Event_1xpudal" name="LinkA">
+      <bpmn:incoming>Flow_1in1tnj</bpmn:incoming>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0kys4cl" name="LinkA" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0b2w3o4" sourceRef="Event_1l6b80w" targetRef="Activity_0khevjp" />
+    <bpmn:endEvent id="Event_18wuva8" name="end">
+      <bpmn:incoming>Flow_1goh8c0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:manualTask id="Activity_1k5srs3" name="M1">
+      <bpmn:incoming>Flow_1678uq1</bpmn:incoming>
+      <bpmn:outgoing>Flow_1in1tnj</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_1goh8c0" sourceRef="Activity_0khevjp" targetRef="Event_18wuva8" />
+    <bpmn:manualTask id="Activity_0khevjp" name="M2">
+      <bpmn:incoming>Flow_0b2w3o4</bpmn:incoming>
+      <bpmn:outgoing>Flow_1goh8c0</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:intermediateCatchEvent id="Event_1l6b80w" name="LinkA">
+      <bpmn:outgoing>Flow_0b2w3o4</bpmn:outgoing>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0wf27ve" name="LinkA" />
+    </bpmn:intermediateCatchEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_05x4y1u">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="186" y="142" width="23" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1i71kqu_di" bpmnElement="Event_1xpudal">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="436" y="142" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_18wuva8_di" bpmnElement="Event_18wuva8">
+        <dc:Bounds x="432" y="232" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="441" y="275" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0s5mdjr_di" bpmnElement="Activity_1k5srs3">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1glopn0_di" bpmnElement="Activity_0khevjp">
+        <dc:Bounds x="270" y="210" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00wbmrv_di" bpmnElement="Event_1l6b80w">
+        <dc:Bounds x="179" y="232" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="183" y="275" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1678uq1_di" bpmnElement="Flow_1678uq1">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1in1tnj_di" bpmnElement="Flow_1in1tnj">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0b2w3o4_di" bpmnElement="Flow_0b2w3o4">
+        <di:waypoint x="215" y="250" />
+        <di:waypoint x="270" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1goh8c0_di" bpmnElement="Flow_1goh8c0">
+        <di:waypoint x="370" y="250" />
+        <di:waypoint x="432" y="250" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/LinkEventDefinitionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/LinkEventDefinitionTest.java
@@ -90,9 +90,6 @@ public class LinkEventDefinitionTest {
         .hasIntent(DeploymentIntent.CREATE)
         .hasRejectionType(RejectionType.INVALID_ARGUMENT);
     assertThat(rejectedDeployment.getRejectionReason())
-        .contains("Element: process")
-        .contains(
-            "ERROR: Intermediate throw and catch link event definitions must appear in pairs.")
         .contains("Element: linkEvent")
         .contains("ERROR: Link name must be present and not empty.");
   }
@@ -119,13 +116,10 @@ public class LinkEventDefinitionTest {
         .hasIntent(DeploymentIntent.CREATE)
         .hasRejectionType(RejectionType.INVALID_ARGUMENT);
     assertThat(rejectedDeployment.getRejectionReason())
-        .contains("Element: Process_05x4y1u")
+        .contains("Element: Gateway_")
         .contains("ERROR: Event-based gateway must have at least 2 outgoing sequence flows.")
         .contains(
-            "ERROR: Event-based gateway must not have an outgoing sequence flow to other elements than message/timer intermediate catch events.")
-        .contains("Element: Process_05x4y1u")
-        .contains(
-            "ERROR: Intermediate throw and catch link event definitions must appear in pairs.");
+            "ERROR: Event-based gateway must not have an outgoing sequence flow to other elements than message/timer intermediate catch events.");
   }
 
   @Test
@@ -209,7 +203,7 @@ public class LinkEventDefinitionTest {
     assertThat(rejectedDeployment.getRejectionReason())
         .contains("Element: process")
         .contains(
-            "ERROR: Intermediate throw and catch link event definitions must appear in pairs.");
+            "ERROR: Can't find an catch link event for the throw link event with the name 'LinkA'.");
   }
 
   public static BpmnModelInstance getLinkEventProcess() {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/LinkEventDefinitionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/LinkEventDefinitionTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.ProcessBuilder;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.ExecuteCommandResponseDecoder;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class LinkEventDefinitionTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRejectDeploymentIfCatchLinkEventHaveTheSameLinkName() throws Exception {
+    // given
+    final Path path =
+        Paths.get(
+            getClass()
+                .getResource("/processes/LinkEventTest.testInvalidEventLinkMultipleTarget.bpmn")
+                .toURI());
+    final byte[] resource = Files.readAllBytes(path);
+
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(resource).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains("Element: Process_05x4y1u")
+        .contains(
+            "ERROR: Multiple intermediate catch link event definitions with the same name 'LinkA' are not allowed.");
+  }
+
+  @Test
+  public void shouldRejectDeploymentIfNoLinkNameAndNotAppearInPairs() throws Exception {
+    // given
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateThrowEvent()
+            .linkEventDefinition("linkEvent")
+            .name("")
+            .linkEventDefinitionDone()
+            .done();
+
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(processDefinition).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains("Element: process")
+        .contains(
+            "ERROR: Intermediate throw and catch link event definitions must appear in pairs.")
+        .contains("Element: linkEvent")
+        .contains("ERROR: Link name must be present and not empty.");
+  }
+
+  @Test
+  public void shouldRejectDeploymentIfCatchLinkEventAfterEventBasedGatewa() throws Exception {
+    // given
+    final Path path =
+        Paths.get(
+            getClass()
+                .getResource(
+                    "/processes/LinkEventTest.testCatchLinkEventAfterEventBasedGatewayNotAllowed.bpmn")
+                .toURI());
+    final byte[] resource = Files.readAllBytes(path);
+
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(resource).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains("Element: Process_05x4y1u")
+        .contains("ERROR: Event-based gateway must have at least 2 outgoing sequence flows.")
+        .contains(
+            "ERROR: Event-based gateway must not have an outgoing sequence flow to other elements than message/timer intermediate catch events.")
+        .contains("Element: Process_05x4y1u")
+        .contains(
+            "ERROR: Intermediate throw and catch link event definitions must appear in pairs.");
+  }
+
+  @Test
+  public void shouldAcceptDeploymentValidEventLink() throws Exception {
+    // given
+    final Path path =
+        Paths.get(
+            getClass().getResource("/processes/LinkEventTest.testValidEventLink.bpmn").toURI());
+    final byte[] resource = Files.readAllBytes(path);
+
+    // when
+    final Record<DeploymentRecordValue> deployment =
+        ENGINE.deployment().withXmlResource(resource).deploy();
+
+    // then
+    assertThat(deployment.getKey())
+        .describedAs("Should accept deployment valid event link process")
+        .isNotNegative();
+  }
+
+  @Test
+  public void shouldAcceptDeploymentValidEventLinkMultipleSources() throws Exception {
+    // given
+    final Path path =
+        Paths.get(
+            getClass()
+                .getResource("/processes/LinkEventTest.testEventLinkMultipleSources.bpmn")
+                .toURI());
+    final byte[] resource = Files.readAllBytes(path);
+
+    // when
+    final Record<DeploymentRecordValue> deployment =
+        ENGINE.deployment().withXmlResource(resource).deploy();
+
+    // then
+    assertThat(deployment.getKey())
+        .describedAs("Should accept deployment valid event link multiple sources process")
+        .isNotNegative();
+  }
+
+  @Test
+  public void shouldExecuteValidEventLink() throws Exception {
+    // given
+    final Path path =
+        Paths.get(
+            getClass().getResource("/processes/LinkEventTest.testValidEventLink.bpmn").toURI());
+    final byte[] resource = Files.readAllBytes(path);
+
+    ENGINE.deployment().withXmlResource(resource).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("Process_05x4y1u").create();
+
+    // then
+    final List<Record<ProcessInstanceRecordValue>> processInstanceEvents =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .limitToProcessInstanceCompleted()
+            .asList();
+
+    assertThat(processInstanceEvents)
+        .extracting(e -> e.getValue().getElementId(), Record::getIntent)
+        .contains(tuple("Process_05x4y1u", ProcessInstanceIntent.COMPLETE_ELEMENT));
+  }
+
+  @Test
+  public void shouldRejectDeployMultipleStartEventsWithSameSignal() {
+    // given
+    final BpmnModelInstance processDefinition = getLinkEventProcess();
+
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(processDefinition).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains("Element: process")
+        .contains(
+            "ERROR: Intermediate throw and catch link event definitions must appear in pairs.");
+  }
+
+  public static BpmnModelInstance getLinkEventProcess() {
+    final ProcessBuilder process = Bpmn.createExecutableProcess("process");
+    process
+        .startEvent()
+        .manualTask("manualTask1")
+        .intermediateThrowEvent()
+        .linkEventDefinition()
+        .name("LinkA")
+        .linkEventDefinitionDone();
+    return process
+        .linkCatchEvent()
+        .linkEventDefinition()
+        .name("LinkB")
+        .linkEventDefinitionDone()
+        .manualTask("manualTask2")
+        .endEvent()
+        .done();
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/LinkEventDefinitionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/LinkEventDefinitionTest.java
@@ -68,15 +68,13 @@ public class LinkEventDefinitionTest {
   }
 
   @Test
-  public void shouldRejectDeploymentIfNoLinkNameAndNotAppearInPairs() throws Exception {
+  public void shouldRejectDeploymentIfNoLinkName() throws Exception {
     // given
     final BpmnModelInstance processDefinition =
         Bpmn.createExecutableProcess("process")
             .startEvent()
             .intermediateThrowEvent()
-            .linkEventDefinition("linkEvent")
-            .name("")
-            .linkEventDefinitionDone()
+            .link("")
             .done();
 
     // when
@@ -95,7 +93,7 @@ public class LinkEventDefinitionTest {
   }
 
   @Test
-  public void shouldRejectDeploymentIfCatchLinkEventAfterEventBasedGatewa() throws Exception {
+  public void shouldRejectDeploymentIfCatchLinkEventAfterEventBasedGateway() throws Exception {
     // given
     final Path path =
         Paths.get(
@@ -187,7 +185,7 @@ public class LinkEventDefinitionTest {
   }
 
   @Test
-  public void shouldRejectDeployMultipleStartEventsWithSameSignal() {
+  public void shouldRejectDeploymentIfLinkEventNotAppearInPairs() {
     // given
     final BpmnModelInstance processDefinition = getLinkEventProcess();
 
@@ -208,20 +206,7 @@ public class LinkEventDefinitionTest {
 
   public static BpmnModelInstance getLinkEventProcess() {
     final ProcessBuilder process = Bpmn.createExecutableProcess("process");
-    process
-        .startEvent()
-        .manualTask("manualTask1")
-        .intermediateThrowEvent()
-        .linkEventDefinition()
-        .name("LinkA")
-        .linkEventDefinitionDone();
-    return process
-        .linkCatchEvent()
-        .linkEventDefinition()
-        .name("LinkB")
-        .linkEventDefinitionDone()
-        .manualTask("manualTask2")
-        .endEvent()
-        .done();
+    process.startEvent().manualTask("manualTask1").intermediateThrowEvent().link("LinkA");
+    return process.linkCatchEvent().link("LinkB").manualTask("manualTask2").endEvent().done();
   }
 }

--- a/engine/src/test/resources/processes/LinkEventTest.testCatchLinkEventAfterEventBasedGatewayNotAllowed.bpmn
+++ b/engine/src/test/resources/processes/LinkEventTest.testCatchLinkEventAfterEventBasedGatewayNotAllowed.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1xsz6dc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.3.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_05x4y1u" name="Process_05x4y1u" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_1678uq1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1678uq1" sourceRef="StartEvent_1" targetRef="Gateway_1wpt3ke" />
+    <bpmn:eventBasedGateway id="Gateway_1wpt3ke" name="Event Based Gateway">
+      <bpmn:incoming>Flow_1678uq1</bpmn:incoming>
+      <bpmn:outgoing>Flow_0c62udf</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:intermediateCatchEvent id="Event_1xpudal" name="LinkA">
+      <bpmn:incoming>Flow_0c62udf</bpmn:incoming>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0wf27ve" name="LinkA" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_0c62udf" sourceRef="Gateway_1wpt3ke" targetRef="Event_1xpudal" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_05x4y1u">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="142" width="25" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0nyzmm1_di" bpmnElement="Gateway_1wpt3ke">
+        <dc:Bounds x="285" y="92" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="281" y="149" width="63" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1kqbsfb_di" bpmnElement="Event_1xpudal">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="436" y="142" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1678uq1_di" bpmnElement="Flow_1678uq1">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="285" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0c62udf_di" bpmnElement="Flow_0c62udf">
+        <di:waypoint x="335" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/engine/src/test/resources/processes/LinkEventTest.testEventLinkMultipleSources.bpmn
+++ b/engine/src/test/resources/processes/LinkEventTest.testEventLinkMultipleSources.bpmn
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1xsz6dc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.3.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_05x4y1u" name="Process_05x4y1u" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="start">
+      <bpmn:outgoing>Flow_1678uq1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1678uq1" sourceRef="StartEvent_1" targetRef="Activity_1k5srs3" />
+    <bpmn:sequenceFlow id="Flow_1in1tnj" sourceRef="Activity_1k5srs3" targetRef="Gateway_1e58sx7" />
+    <bpmn:intermediateThrowEvent id="Event_1xpudal" name="LinkA">
+      <bpmn:incoming>Flow_1cu30ia</bpmn:incoming>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0kys4cl" name="LinkA" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0b2w3o4" sourceRef="Event_1l6b80w" targetRef="Activity_0khevjp" />
+    <bpmn:endEvent id="Event_18wuva8" name="end">
+      <bpmn:incoming>Flow_1goh8c0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:manualTask id="Activity_1k5srs3" name="M1">
+      <bpmn:incoming>Flow_1678uq1</bpmn:incoming>
+      <bpmn:outgoing>Flow_1in1tnj</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_1goh8c0" sourceRef="Activity_0khevjp" targetRef="Event_18wuva8" />
+    <bpmn:manualTask id="Activity_0khevjp" name="M2">
+      <bpmn:incoming>Flow_0b2w3o4</bpmn:incoming>
+      <bpmn:outgoing>Flow_1goh8c0</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:intermediateCatchEvent id="Event_1l6b80w" name="LinkA">
+      <bpmn:outgoing>Flow_0b2w3o4</bpmn:outgoing>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0wf27ve" name="LinkA" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_1cu30ia" sourceRef="Gateway_1e58sx7" targetRef="Event_1xpudal" />
+    <bpmn:parallelGateway id="Gateway_1e58sx7">
+      <bpmn:incoming>Flow_1in1tnj</bpmn:incoming>
+      <bpmn:outgoing>Flow_1cu30ia</bpmn:outgoing>
+      <bpmn:outgoing>Flow_09g0rd8</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:intermediateThrowEvent id="Event_03p4awe" name="LinkA">
+      <bpmn:incoming>Flow_09g0rd8</bpmn:incoming>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0gx4d12" name="LinkA" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_09g0rd8" sourceRef="Gateway_1e58sx7" targetRef="Event_03p4awe" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_05x4y1u">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="186" y="142" width="23" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_18wuva8_di" bpmnElement="Event_18wuva8">
+        <dc:Bounds x="432" y="232" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="441" y="275" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0s5mdjr_di" bpmnElement="Activity_1k5srs3">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1glopn0_di" bpmnElement="Activity_0khevjp">
+        <dc:Bounds x="270" y="210" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00wbmrv_di" bpmnElement="Event_1l6b80w">
+        <dc:Bounds x="179" y="232" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="183" y="275" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_15zdo6m_di" bpmnElement="Gateway_1e58sx7">
+        <dc:Bounds x="425" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1i71kqu_di" bpmnElement="Event_1xpudal">
+        <dc:Bounds x="612" y="52" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="616" y="95" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0ze6iio" bpmnElement="Event_03p4awe">
+        <dc:Bounds x="612" y="172" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="616" y="215" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1678uq1_di" bpmnElement="Flow_1678uq1">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1in1tnj_di" bpmnElement="Flow_1in1tnj">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="425" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0b2w3o4_di" bpmnElement="Flow_0b2w3o4">
+        <di:waypoint x="215" y="250" />
+        <di:waypoint x="270" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1goh8c0_di" bpmnElement="Flow_1goh8c0">
+        <di:waypoint x="370" y="250" />
+        <di:waypoint x="432" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1cu30ia_di" bpmnElement="Flow_1cu30ia">
+        <di:waypoint x="450" y="92" />
+        <di:waypoint x="450" y="70" />
+        <di:waypoint x="612" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09g0rd8_di" bpmnElement="Flow_09g0rd8">
+        <di:waypoint x="450" y="142" />
+        <di:waypoint x="450" y="190" />
+        <di:waypoint x="612" y="190" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/engine/src/test/resources/processes/LinkEventTest.testInvalidEventLinkMultipleTarget.bpmn
+++ b/engine/src/test/resources/processes/LinkEventTest.testInvalidEventLinkMultipleTarget.bpmn
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1xsz6dc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.3.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_05x4y1u" name="Process_05x4y1u" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="start">
+      <bpmn:outgoing>Flow_1678uq1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1678uq1" sourceRef="StartEvent_1" targetRef="Activity_1k5srs3" />
+    <bpmn:sequenceFlow id="Flow_1in1tnj" sourceRef="Activity_1k5srs3" targetRef="Event_1xpudal" />
+    <bpmn:intermediateThrowEvent id="Event_1xpudal" name="LinkA">
+      <bpmn:incoming>Flow_1in1tnj</bpmn:incoming>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0kys4cl" name="LinkA" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0b2w3o4" sourceRef="Event_1l6b80w" targetRef="Activity_0khevjp" />
+    <bpmn:endEvent id="Event_18wuva8" name="end">
+      <bpmn:incoming>Flow_1goh8c0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:manualTask id="Activity_1k5srs3" name="M1">
+      <bpmn:incoming>Flow_1678uq1</bpmn:incoming>
+      <bpmn:outgoing>Flow_1in1tnj</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_1goh8c0" sourceRef="Activity_0khevjp" targetRef="Event_18wuva8" />
+    <bpmn:manualTask id="Activity_0khevjp" name="M2">
+      <bpmn:incoming>Flow_0b2w3o4</bpmn:incoming>
+      <bpmn:outgoing>Flow_1goh8c0</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:intermediateCatchEvent id="Event_1l6b80w" name="LinkA1">
+      <bpmn:outgoing>Flow_0b2w3o4</bpmn:outgoing>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0wf27ve" name="LinkA" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_19tuemi" name="LinkA">
+      <bpmn:outgoing>Flow_0g5rele</bpmn:outgoing>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0gcopxk" name="LinkA" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_0g5rele" sourceRef="Event_19tuemi" targetRef="Activity_1g8s3yi" />
+    <bpmn:endEvent id="Event_14hvjps" name="end">
+      <bpmn:incoming>Flow_123b93b</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_123b93b" sourceRef="Activity_1g8s3yi" targetRef="Event_14hvjps" />
+    <bpmn:manualTask id="Activity_1g8s3yi" name="M3">
+      <bpmn:incoming>Flow_0g5rele</bpmn:incoming>
+      <bpmn:outgoing>Flow_123b93b</bpmn:outgoing>
+    </bpmn:manualTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_05x4y1u">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="186" y="142" width="23" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0s5mdjr_di" bpmnElement="Activity_1k5srs3">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1glopn0_di" bpmnElement="Activity_0khevjp">
+        <dc:Bounds x="270" y="210" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00wbmrv_di" bpmnElement="Event_1l6b80w">
+        <dc:Bounds x="179" y="232" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="183" y="275" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1i71kqu_di" bpmnElement="Event_1xpudal">
+        <dc:Bounds x="472" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="476" y="142" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1dbyri8" bpmnElement="Event_19tuemi">
+        <dc:Bounds x="179" y="352" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="183" y="395" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_18wuva8_di" bpmnElement="Event_18wuva8">
+        <dc:Bounds x="472" y="232" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="482" y="275" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_14hvjps_di" bpmnElement="Event_14hvjps">
+        <dc:Bounds x="472" y="352" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="481" y="395" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0bs7l5g_di" bpmnElement="Activity_1g8s3yi">
+        <dc:Bounds x="270" y="330" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1678uq1_di" bpmnElement="Flow_1678uq1">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1in1tnj_di" bpmnElement="Flow_1in1tnj">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="472" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0b2w3o4_di" bpmnElement="Flow_0b2w3o4">
+        <di:waypoint x="215" y="250" />
+        <di:waypoint x="270" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1goh8c0_di" bpmnElement="Flow_1goh8c0">
+        <di:waypoint x="370" y="250" />
+        <di:waypoint x="472" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0g5rele_di" bpmnElement="Flow_0g5rele">
+        <di:waypoint x="215" y="370" />
+        <di:waypoint x="270" y="370" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_123b93b_di" bpmnElement="Flow_123b93b">
+        <di:waypoint x="370" y="370" />
+        <di:waypoint x="472" y="370" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/engine/src/test/resources/processes/LinkEventTest.testValidEventLink.bpmn
+++ b/engine/src/test/resources/processes/LinkEventTest.testValidEventLink.bpmn
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1xsz6dc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.3.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_05x4y1u" name="Process_05x4y1u" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="start">
+      <bpmn:outgoing>Flow_1678uq1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1678uq1" sourceRef="StartEvent_1" targetRef="Activity_1k5srs3" />
+    <bpmn:sequenceFlow id="Flow_1in1tnj" sourceRef="Activity_1k5srs3" targetRef="Event_1xpudal" />
+    <bpmn:intermediateThrowEvent id="Event_1xpudal" name="LinkA">
+      <bpmn:incoming>Flow_1in1tnj</bpmn:incoming>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0kys4cl" name="LinkA" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0b2w3o4" sourceRef="Event_1l6b80w" targetRef="Activity_0khevjp" />
+    <bpmn:endEvent id="Event_18wuva8" name="end">
+      <bpmn:incoming>Flow_1goh8c0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:manualTask id="Activity_1k5srs3" name="M1">
+      <bpmn:incoming>Flow_1678uq1</bpmn:incoming>
+      <bpmn:outgoing>Flow_1in1tnj</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_1goh8c0" sourceRef="Activity_0khevjp" targetRef="Event_18wuva8" />
+    <bpmn:manualTask id="Activity_0khevjp" name="M2">
+      <bpmn:incoming>Flow_0b2w3o4</bpmn:incoming>
+      <bpmn:outgoing>Flow_1goh8c0</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:intermediateCatchEvent id="Event_1l6b80w" name="LinkA">
+      <bpmn:outgoing>Flow_0b2w3o4</bpmn:outgoing>
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0wf27ve" name="LinkA" />
+    </bpmn:intermediateCatchEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_05x4y1u">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="186" y="142" width="23" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1i71kqu_di" bpmnElement="Event_1xpudal">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="436" y="142" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_18wuva8_di" bpmnElement="Event_18wuva8">
+        <dc:Bounds x="432" y="232" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="441" y="275" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0s5mdjr_di" bpmnElement="Activity_1k5srs3">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1glopn0_di" bpmnElement="Activity_0khevjp">
+        <dc:Bounds x="270" y="210" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00wbmrv_di" bpmnElement="Event_1l6b80w">
+        <dc:Bounds x="179" y="232" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="183" y="275" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1678uq1_di" bpmnElement="Flow_1678uq1">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1in1tnj_di" bpmnElement="Flow_1in1tnj">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0b2w3o4_di" bpmnElement="Flow_0b2w3o4">
+        <di:waypoint x="215" y="250" />
+        <di:waypoint x="270" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1goh8c0_di" bpmnElement="Flow_1goh8c0">
+        <di:waypoint x="370" y="250" />
+        <di:waypoint x="432" y="250" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Added link events model api support, including link throw and catch events.

![image](https://user-images.githubusercontent.com/26370117/194534796-a0b30b09-98aa-4fbd-a011-6ba7e6d1e7c2.png)


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10563 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [x] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
