### PR TITLE
fix(raft): do not handle response if role is already closed

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -208,16 +208,16 @@ final class LeaderAppender {
         .append(member.getMember().memberId(), request)
         .whenCompleteAsync(
             (response, error) -> {
-              // Complete the append to the member.
-              final long appendLatency = System.currentTimeMillis() - timestamp;
-              metrics.appendComplete(appendLatency, member.getMember().memberId().id());
-              if (!request.entries().isEmpty()) {
-                member.completeAppend(appendLatency);
-              } else {
-                member.completeAppend();
-              }
-
               if (open) {
+                // Complete the append to the member.
+                final long appendLatency = System.currentTimeMillis() - timestamp;
+                metrics.appendComplete(appendLatency, member.getMember().memberId().id());
+                if (!request.entries().isEmpty()) {
+                  member.completeAppend(appendLatency);
+                } else {
+                  member.completeAppend();
+                }
+
                 if (error == null) {
                   log.trace("Received {} from {}", response, member.getMember().memberId());
                   handleAppendResponse(member, request, response, timestamp);
@@ -300,10 +300,10 @@ final class LeaderAppender {
         .configure(member.getMember().memberId(), request)
         .whenCompleteAsync(
             (response, error) -> {
-              // Complete the configure to the member.
-              member.completeConfigure();
-
               if (open) {
+                // Complete the configure to the member.
+                member.completeConfigure();
+
                 if (error == null) {
                   log.trace("Received {} from {}", response, member.getMember().memberId());
                   handleConfigureResponse(member, request, response, timestamp);
@@ -413,10 +413,10 @@ final class LeaderAppender {
         .install(member.getMember().memberId(), request)
         .whenCompleteAsync(
             (response, error) -> {
-              // Complete the install to the member.
-              member.completeInstall();
-
               if (open) {
+                // Complete the install to the member.
+                member.completeInstall();
+
                 if (error == null) {
                   log.trace("Received {} from {}", response, member.getMember().memberId());
                   handleInstallResponse(member, request, response, timestamp);

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -513,7 +513,13 @@ public final class ControllableRaftContexts {
   }
 
   public void assertAllMembersAreReady() {
-    raftServers.values().forEach(raft -> assertThat(raft.getState()).isEqualTo(State.READY));
+    raftServers
+        .values()
+        .forEach(
+            raft ->
+                assertThat(raft.getState())
+                    .describedAs("Raft %s must be ready".formatted(raft.getName()))
+                    .isEqualTo(State.READY));
   }
 
   public void assertNoJournalAppendErrors() {


### PR DESCRIPTION
## Description

The response to a request send when the node was in leader in a specific term, was processed even if the response was received in a later term. This resulted in following behavior:

1. Leader sends an AppendRequest to follower, before sending it updates `RaftMemberContext#inFlightAppendCount` to 1. 
3. Leader steps down and becomes leader again
5. Leader resets the member context of follower. So `inFlightAppendCount` is reset to 0
6. Leader sends a new append request to the follower,` inFlightAppendCount` is set to 1
7. The first request times out. On handling the response it decrements the inFlightAppendCount to 0.
8. The second request times out. On handling the response it decrements the inFlightAppendCount to -1. 
9. Next time, when the leader attempts to send an append request `RaftMemberContext#canAppend` returns false because inFlightAppendCount != 0. As a result leader will never sent a heartbeat or new append request to the follower. 

To fix this, the check for if the role is open is done before processing the response. As a precaution, other requests where the response is handled without checking for open is also updated.

## Related issues

closes #10545 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
