### PR TITLE
refactor(bpmn-model) Improve error message of BPMN features

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
@@ -89,9 +89,11 @@ public class FlowElementValidator implements ModelElementValidator<FlowElement> 
         && !NON_EXECUTABLE_ELEMENT_TYPES.contains(elementType)) {
       validationResultCollector.addError(
           0,
-          "Elements of type 'elementType.getSimpleName()' are currently not supported. Please refer "
-              + "to the documentation for a list of supported elements: "
-              + "https://docs.camunda.io/docs/reference/bpmn-processes/bpmn-coverage");
+          String.format(
+              "Elements of type '%s' are currently not supported. Please refer "
+                  + "to the documentation for a list of supported elements: "
+                  + "https://docs.camunda.io/docs/reference/bpmn-processes/bpmn-coverage",
+              elementType.getSimpleName()));
     }
   }
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
@@ -87,9 +87,11 @@ public class FlowElementValidator implements ModelElementValidator<FlowElement> 
 
     if (!SUPPORTED_ELEMENT_TYPES.contains(elementType)
         && !NON_EXECUTABLE_ELEMENT_TYPES.contains(elementType)) {
-      validationResultCollector.addError(0, "An un-supported element found. The XML is valid, but "
-          + "currently, just a sub-set of BPMN elements are supported, see the documentation for "
-          + "more details: https://docs.camunda.io/docs/reference/bpmn-processes/bpmn-coverage");
+      validationResultCollector.addError(
+          0,
+          "An un-supported element found. The XML is valid, but "
+              + "currently, just a sub-set of BPMN elements are supported, see the documentation for "
+              + "more details: https://docs.camunda.io/docs/reference/bpmn-processes/bpmn-coverage");
     }
   }
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
@@ -87,7 +87,9 @@ public class FlowElementValidator implements ModelElementValidator<FlowElement> 
 
     if (!SUPPORTED_ELEMENT_TYPES.contains(elementType)
         && !NON_EXECUTABLE_ELEMENT_TYPES.contains(elementType)) {
-      validationResultCollector.addError(0, "Elements of this type are not supported");
+      validationResultCollector.addError(0, "An un-supported element found. The XML is valid, but "
+          + "currently, just a sub-set of BPMN elements are supported, see the documentation for "
+          + "more details: https://docs.camunda.io/docs/reference/bpmn-processes/bpmn-coverage");
     }
   }
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
@@ -89,9 +89,9 @@ public class FlowElementValidator implements ModelElementValidator<FlowElement> 
         && !NON_EXECUTABLE_ELEMENT_TYPES.contains(elementType)) {
       validationResultCollector.addError(
           0,
-          "An un-supported element found. The XML is valid, but "
-              + "currently, just a sub-set of BPMN elements are supported, see the documentation for "
-              + "more details: https://docs.camunda.io/docs/reference/bpmn-processes/bpmn-coverage");
+          "Elements of type 'elementType.getSimpleName()' are currently not supported. Please refer "
+              + "to the documentation for a list of supported elements: "
+              + "https://docs.camunda.io/docs/reference/bpmn-processes/bpmn-coverage");
     }
   }
 }


### PR DESCRIPTION
## Description

Improve error message in case of uncovered BPMN features by linking error message to documentation. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7282

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X ] I've reviewed my own code
* [ X] I've written a clear changelist description
* [ X] I've narrowly scoped my changes
* [ X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
