### PR TITLE
[Backport stable/8.1] Remove interrupted state on event subprocess activation

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -185,6 +185,11 @@ public final class ProcessInstanceModificationProcessor
                                   processInstance,
                                   process,
                                   instruction));
+
+                  activatedElementKeys
+                      .getFlowScopeKeys()
+                      .forEach(value::addActivatedElementInstanceKey);
+
                   return activatedElementKeys.getFlowScopeKeys().stream();
                 })
             .collect(Collectors.toSet());

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
@@ -50,6 +51,7 @@ public final class EventAppliers implements EventApplier {
   public EventAppliers(final MutableZeebeState state) {
     registerProcessInstanceEventAppliers(state);
     registerProcessInstanceCreationAppliers(state);
+    registerProcessInstanceModificationAppliers(state);
 
     register(ProcessIntent.CREATED, new ProcessCreatedApplier(state));
     register(ErrorIntent.CREATED, new ErrorCreatedApplier(state.getBlackListState()));
@@ -145,6 +147,12 @@ public final class EventAppliers implements EventApplier {
     register(
         ProcessInstanceCreationIntent.CREATED,
         new ProcessInstanceCreationCreatedApplier(processState, elementInstanceState));
+  }
+
+  private void registerProcessInstanceModificationAppliers(final MutableZeebeState state) {
+    register(
+        ProcessInstanceModificationIntent.MODIFIED,
+        new ProcessInstanceModifiedEventApplier(state.getElementInstanceState()));
   }
 
   private void registerJobIntentEventAppliers(final MutableZeebeState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceModifiedEventApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceModifiedEventApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+
+final class ProcessInstanceModifiedEventApplier
+    implements TypedEventApplier<
+        ProcessInstanceModificationIntent, ProcessInstanceModificationRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+
+  public ProcessInstanceModifiedEventApplier(
+      final MutableElementInstanceState elementInstanceState) {
+    this.elementInstanceState = elementInstanceState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceModificationRecord value) {}
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceModifiedEventApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceModifiedEventApplier.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
@@ -24,5 +25,13 @@ final class ProcessInstanceModifiedEventApplier
   }
 
   @Override
-  public void applyState(final long key, final ProcessInstanceModificationRecord value) {}
+  public void applyState(final long key, final ProcessInstanceModificationRecord value) {
+    value.getActivatedElementInstanceKeys().stream()
+        .map(elementInstanceState::getInstance)
+        .filter(ElementInstance::isInterrupted)
+        .forEach(
+            instance ->
+                elementInstanceState.updateInstance(
+                    instance.getKey(), ElementInstance::clearInterruptedState));
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -188,6 +188,10 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
     return getInterruptingElementId().capacity() > 0;
   }
 
+  public void clearInterruptedState() {
+    interruptingEventKeyProp.setValue("");
+  }
+
   public long getParentKey() {
     return parentKeyProp.getValue();
   }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
@@ -10,10 +10,13 @@ package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
     implements ProcessInstanceModificationRecordValue {
@@ -27,11 +30,14 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
       activateInstructionsProperty =
           new ArrayProperty<>(
               "activateInstructions", new ProcessInstanceModificationActivateInstruction());
+  private final ArrayProperty<LongValue> activatedElementInstanceKeys =
+      new ArrayProperty<>("activatedElementInstanceKeys", new LongValue());
 
   public ProcessInstanceModificationRecord() {
     declareProperty(processInstanceKeyProperty)
         .declareProperty(terminateInstructionsProperty)
-        .declareProperty(activateInstructionsProperty);
+        .declareProperty(activateInstructionsProperty)
+        .declareProperty(activatedElementInstanceKeys);
   }
 
   /**
@@ -95,6 +101,17 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
   public ProcessInstanceModificationRecord addActivateInstruction(
       final ProcessInstanceModificationActivateInstruction activateInstruction) {
     activateInstructionsProperty.add().copy(activateInstruction);
+    return this;
+  }
+
+  public Set<Long> getActivatedElementInstanceKeys() {
+    return activatedElementInstanceKeys.stream()
+        .map(LongValue::getValue)
+        .collect(Collectors.toSet());
+  }
+
+  public ProcessInstanceModificationRecord addActivatedElementInstanceKey(final long key) {
+    activatedElementInstanceKeys.add().setValue(key);
     return this;
   }
 

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -787,7 +787,8 @@ final class JsonSerializableToJsonTest {
               }
             }],
             "elementId": "activity"
-          }]
+          }],
+          "activatedElementInstanceKeys": []
         }
         """
       },
@@ -803,7 +804,8 @@ final class JsonSerializableToJsonTest {
         {
           "processInstanceKey": 1,
           "terminateInstructions": [],
-          "activateInstructions": []
+          "activateInstructions": [],
+          "activatedElementInstanceKeys": []
         }
         """
       },


### PR DESCRIPTION
# Description
Backport of #10609 to `stable/8.1`.

relates to #10477