### PR TITLE
[Backport stable/8.1] fix(raft): do not handle response if role is already closed

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -208,16 +208,16 @@ final class LeaderAppender {
         .append(member.getMember().memberId(), request)
         .whenCompleteAsync(
             (response, error) -> {
-              // Complete the append to the member.
-              final long appendLatency = System.currentTimeMillis() - timestamp;
-              metrics.appendComplete(appendLatency, member.getMember().memberId().id());
-              if (!request.entries().isEmpty()) {
-                member.completeAppend(appendLatency);
-              } else {
-                member.completeAppend();
-              }
-
               if (open) {
+                // Complete the append to the member.
+                final long appendLatency = System.currentTimeMillis() - timestamp;
+                metrics.appendComplete(appendLatency, member.getMember().memberId().id());
+                if (!request.entries().isEmpty()) {
+                  member.completeAppend(appendLatency);
+                } else {
+                  member.completeAppend();
+                }
+
                 if (error == null) {
                   log.trace("Received {} from {}", response, member.getMember().memberId());
                   handleAppendResponse(member, request, response, timestamp);
@@ -300,10 +300,10 @@ final class LeaderAppender {
         .configure(member.getMember().memberId(), request)
         .whenCompleteAsync(
             (response, error) -> {
-              // Complete the configure to the member.
-              member.completeConfigure();
-
               if (open) {
+                // Complete the configure to the member.
+                member.completeConfigure();
+
                 if (error == null) {
                   log.trace("Received {} from {}", response, member.getMember().memberId());
                   handleConfigureResponse(member, request, response, timestamp);
@@ -413,10 +413,10 @@ final class LeaderAppender {
         .install(member.getMember().memberId(), request)
         .whenCompleteAsync(
             (response, error) -> {
-              // Complete the install to the member.
-              member.completeInstall();
-
               if (open) {
+                // Complete the install to the member.
+                member.completeInstall();
+
                 if (error == null) {
                   log.trace("Received {} from {}", response, member.getMember().memberId());
                   handleInstallResponse(member, request, response, timestamp);

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -513,7 +513,13 @@ public final class ControllableRaftContexts {
   }
 
   public void assertAllMembersAreReady() {
-    raftServers.values().forEach(raft -> assertThat(raft.getState()).isEqualTo(State.READY));
+    raftServers
+        .values()
+        .forEach(
+            raft ->
+                assertThat(raft.getState())
+                    .describedAs("Raft %s must be ready".formatted(raft.getName()))
+                    .isEqualTo(State.READY));
   }
 
   public void assertNoJournalAppendErrors() {


### PR DESCRIPTION
# Description
Backport of #10640 to `stable/8.1`.

closes #10545