### PR TITLE
fix: actually enable maven cache for GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zeebe
         with:
-          maven-cache: true
+          maven-cache: 'true'
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zeebe
         with:
-          maven-cache: true
+          maven-cache: 'true'
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
@@ -143,7 +143,7 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
-          maven-cache: true
+          maven-cache: 'true'
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
@@ -213,7 +213,7 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
-          maven-cache: true
+          maven-cache: 'true'
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
@@ -276,7 +276,7 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
-          maven-cache: true
+          maven-cache: 'true'
           maven-cache-key-modifier: java-client
       - uses: ./.github/actions/build-zeebe
         with:
@@ -321,7 +321,7 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
-          maven-cache: true
+          maven-cache: 'true'
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
@@ -369,7 +369,7 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
-          maven-cache: true
+          maven-cache: 'true'
           maven-cache-key-modifier: java-checks
       - run: mvn -T1C -B -D skipTests -P !autoFormat,checkFormat,spotbugs verify
   docker-checks:


### PR DESCRIPTION
This fixes the type of the `maven-cache` input parameter to always be a string. Without this, the cache was never used.
I've also tried to just use a proper boolean instead but it seems like GHA [is a bit weird](https://github.com/actions/runner/issues/1483) when it comes to input variables and types so I've just used string everywhere.