### PR TITLE
ci: fix dependabot PR approval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,6 +571,7 @@ jobs:
       checks: read
       pull-requests: write
     steps:
+      - uses: actions/checkout@v3
       - id: metadata
         name: Fetch dependency metadata
         uses: dependabot/fetch-metadata@v1.3.4


### PR DESCRIPTION
The gh cli requires a repo to function so we need to re-add the checkout step again.