### PR TITLE
ci: disable Jenkins Github & Slack notifications

### DIFF
--- a/.ci/jobs/github_camunda.dsl
+++ b/.ci/jobs/github_camunda.dsl
@@ -57,9 +57,9 @@ organizationFolder('camunda') {
     properties {
         // Avoid automatically build jobs on non-prod envs by org indexing.
         // Note: The DSL name here is misleading. This config is for the branches that WILL be built automatically.
-        // So on prod env all branches will be built automatically but for non-prod no automatic builds.
+        // So on prod env main will be built automatically but for non-prod no automatic builds.
         noTriggerOrganizationFolderProperty {
-            branches (ENVIRONMENT == 'prod' ? '.*' : '')
+            branches (ENVIRONMENT == 'prod' ? 'main' : '')
         }
     }
 

--- a/.ci/jobs/github_camunda.dsl
+++ b/.ci/jobs/github_camunda.dsl
@@ -28,10 +28,8 @@ organizationFolder('camunda') {
                   excludes('')
                 }
 
-                // Disable sending Github status notifications in non-prod envs.
-                if (ENVIRONMENT != 'prod') {
-                    notificationsSkip()
-                }
+                // Disable sending Github status notifications as GHA CI is default
+                notificationsSkip()
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -428,30 +428,6 @@ pipeline {
             }
         }
 
-        failure {
-            script {
-                if (env.BRANCH_NAME != mainBranchName || agentDisconnected()) {
-                    return
-                }
-                sendZeebeSlackMessage()
-            }
-        }
-
-        changed {
-            script {
-                if (env.BRANCH_NAME != mainBranchName || agentDisconnected()) {
-                    return
-                }
-                if (currentBuild.currentResult == 'FAILURE') {
-                    return // already handled above
-                }
-                if (!hasBuildResultChanged()) {
-                    return
-                }
-
-                sendZeebeSlackMessage()
-            }
-        }
     }
 }
 
@@ -488,14 +464,6 @@ def setHumanReadableBuildDisplayName(int maximumLength = 45) {
             currentBuild.displayName = displayStringHardTruncate.take(displayStringHardTruncate.lastIndexOf(' '))
         }
     }
-}
-
-// TODO: can be extracted to zeebe-jenkins-shared-library
-def sendZeebeSlackMessage() {
-    echo "Send slack message"
-    slackSend(
-        channel: "#zeebe-ci${jenkins.model.JenkinsLocationConfiguration.get()?.getUrl()?.contains('stage') ? '-stage' : ''}",
-        message: "Zeebe ${env.BRANCH_NAME} build ${currentBuild.absoluteUrl} changed status to ${currentBuild.currentResult}")
 }
 
 def isBorsStagingBranch() {


### PR DESCRIPTION
## Description

As discussed on Slack we want to remove the Jenkins build status from Github and the #zeebe-ci Slack channel going forward given that the GHA CI reached a state that satisfies all needs relevant for PR merges.

Jenkins still builds the `main` branch to populate code coverage  #9130 and flaky test statistics  #9132 , that haven't been migrated yet. It doesn't send notifications to slack about its state anymore though. Once these are completed the Jenkins branch builds can get completely removed to save resources. 

## Related issues

relates #9137