### PR TITLE
Use PAT as checkout token in backport-action workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,6 +23,9 @@ jobs:
       )
     steps:
       - uses: actions/checkout@v3
+        with:
+          # Token for git actions, e.g. git push
+          token: ${{ secrets.BACKPORT_ACTION_PAT }}
       - name: Create backport PRs
         uses: zeebe-io/backport-action@v0.0.8
         with:


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

In order to allow the backport-action to backport accepted changes to workflows, we need to provide the `workflow` permission to the token used in the git checkout.

The PAT used as `github_token` has this permission. By using the same PAT as the github_token, we also make sure that the git commits are no longer produced by `github-action` but by `backport-action` itself.

For more details, see: https://github.com/orgs/community/discussions/27072#discussioncomment-3254515

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #10666

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
