### PR TITLE
Revert "Use PAT as checkout token in backport-action workflow"

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,9 +23,6 @@ jobs:
       )
     steps:
       - uses: actions/checkout@v3
-        with:
-          # Token for git actions, e.g. git push
-          token: ${{ secrets.BACKPORT_ACTION_PAT }}
       - name: Create backport PRs
         uses: zeebe-io/backport-action@v0.0.8
         with:


### PR DESCRIPTION
It did not work because the backport-action user does not have write access (i.e. permission to push commits) to the repo.

Reverts camunda/zeebe#10670