### PR TITLE
ci: fix test result publishing

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -3,7 +3,7 @@
 name: Publish Test Results
 on:
   workflow_run:
-    workflows: [Tests]
+    workflows: [CI]
     types:
       - completed
 jobs:


### PR DESCRIPTION
After merging and renaming the workflows, the trigger for the publish test results workflow needs to be updated too.
