### PR TITLE
feat(bpmn-model): add script tasks extension element zeebe:script model api support

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
@@ -222,6 +222,7 @@ import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeLoopCharacteristicsI
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeOutputImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebePropertiesImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebePropertyImpl;
+import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeScriptImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeSubscriptionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeTaskDefinitionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeTaskHeadersImpl;
@@ -647,6 +648,7 @@ public class Bpmn {
     ZeebeCalledDecisionImpl.registerType(bpmnModelBuilder);
     ZeebePropertyImpl.registerType(bpmnModelBuilder);
     ZeebePropertiesImpl.registerType(bpmnModelBuilder);
+    ZeebeScriptImpl.registerType(bpmnModelBuilder);
   }
 
   /**

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractScriptTaskBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractScriptTaskBuilder.java
@@ -19,6 +19,7 @@ package io.camunda.zeebe.model.bpmn.builder;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.Script;
 import io.camunda.zeebe.model.bpmn.instance.ScriptTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeScript;
 
 /**
  * @author Sebastian Menski
@@ -56,6 +57,30 @@ public abstract class AbstractScriptTaskBuilder<B extends AbstractScriptTaskBuil
   public B scriptText(final String scriptText) {
     final Script script = createChild(Script.class);
     script.setTextContent(scriptText);
+    return myself;
+  }
+
+  /**
+   * Sets feel script text of the script task that is called
+   *
+   * @param expression the feel expression for the script task
+   * @return the builder object
+   */
+  public B zeebeExpression(final String expression) {
+    final ZeebeScript zeebeScript = getCreateSingleExtensionElement(ZeebeScript.class);
+    zeebeScript.setExpression(asZeebeExpression(expression));
+    return myself;
+  }
+
+  /**
+   * Sets the name of the result variable.
+   *
+   * @param resultVariable the name of the result variable
+   * @return the builder object
+   */
+  public B zeebeResultVariable(final String resultVariable) {
+    final ZeebeScript zeebeScript = getCreateSingleExtensionElement(ZeebeScript.class);
+    zeebeScript.setResultVariable(resultVariable);
     return myself;
   }
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -45,6 +45,8 @@ public class ZeebeConstants {
 
   public static final String ATTRIBUTE_DECISION_ID = "decisionId";
 
+  public static final String ATTRIBUTE_EXPRESSION = "expression";
+
   public static final String ATTRIBUTE_RESULT_VARIABLE = "resultVariable";
 
   public static final String ELEMENT_HEADER = "header";
@@ -52,6 +54,7 @@ public class ZeebeConstants {
   public static final String ELEMENT_IO_MAPPING = "ioMapping";
   public static final String ELEMENT_OUTPUT = "output";
 
+  public static final String ELEMENT_SCRIPT = "script";
   public static final String ELEMENT_SUBSCRIPTION = "subscription";
 
   public static final String ELEMENT_TASK_DEFINITION = "taskDefinition";

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeScriptImpl.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeScriptImpl.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.impl.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeScript;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.attribute.Attribute;
+
+public class ZeebeScriptImpl extends BpmnModelElementInstanceImpl implements ZeebeScript {
+
+  private static Attribute<String> expressionAttribute;
+  private static Attribute<String> resultVariableAttribute;
+
+  public ZeebeScriptImpl(final ModelTypeInstanceContext instanceContext) {
+    super(instanceContext);
+  }
+
+  public static void registerType(final ModelBuilder modelBuilder) {
+    final ModelElementTypeBuilder typeBuilder =
+        modelBuilder
+            .defineType(ZeebeScript.class, ZeebeConstants.ELEMENT_SCRIPT)
+            .namespaceUri(BpmnModelConstants.ZEEBE_NS)
+            .instanceProvider(ZeebeScriptImpl::new);
+
+    expressionAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_EXPRESSION)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .required()
+            .build();
+
+    resultVariableAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_RESULT_VARIABLE)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .required()
+            .build();
+
+    typeBuilder.build();
+  }
+
+  @Override
+  public String getExpression() {
+    return expressionAttribute.getValue(this);
+  }
+
+  @Override
+  public void setExpression(final String expression) {
+    expressionAttribute.setValue(this, expression);
+  }
+
+  @Override
+  public String getResultVariable() {
+    return resultVariableAttribute.getValue(this);
+  }
+
+  @Override
+  public void setResultVariable(final String resultVariable) {
+    resultVariableAttribute.setValue(this, resultVariable);
+  }
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeScript.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeScript.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+
+/** Zeebe extension element for feel script. It can be used for script tasks. */
+public interface ZeebeScript extends BpmnModelElementInstance {
+
+  /**
+   * @return the feel script expression of the script task
+   */
+  String getExpression();
+
+  /**
+   * Sets the feel script expression of the script task.
+   *
+   * @param expression the expression of the script task
+   */
+  void setExpression(String expression);
+
+  /**
+   * @return the name of the result variable
+   */
+  String getResultVariable();
+
+  /**
+   * Sets the name of the result variable.
+   *
+   * @param resultVariable the name of the result variable
+   */
+  void setResultVariable(String resultVariable);
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ScriptTaskValidation.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ScriptTaskValidation.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import io.camunda.zeebe.model.bpmn.instance.ScriptTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeScript;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
+import java.util.Collection;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public final class ScriptTaskValidation implements ModelElementValidator<ScriptTask> {
+
+  @Override
+  public Class<ScriptTask> getElementType() {
+    return ScriptTask.class;
+  }
+
+  @Override
+  public void validate(
+      final ScriptTask element, final ValidationResultCollector validationResultCollector) {
+
+    if (!hasExactlyOneExtension(element)) {
+      validationResultCollector.addError(
+          0,
+          String.format(
+              "Must have either one 'zeebe:%s' or one 'zeebe:%s' extension element",
+              ZeebeConstants.ELEMENT_SCRIPT, ZeebeConstants.ELEMENT_TASK_DEFINITION));
+    }
+  }
+
+  private boolean hasExactlyOneExtension(final ScriptTask element) {
+    final ExtensionElements extensionElements = element.getExtensionElements();
+
+    if (extensionElements == null) {
+      return false;
+    }
+
+    final Collection<ZeebeScript> scriptExtensions =
+        extensionElements.getChildElementsByType(ZeebeScript.class);
+    final Collection<ZeebeTaskDefinition> taskDefinitionExtensions =
+        extensionElements.getChildElementsByType(ZeebeTaskDefinition.class);
+
+    return scriptExtensions.size() == 1 && taskDefinitionExtensions.isEmpty()
+        || scriptExtensions.isEmpty() && taskDefinitionExtensions.size() == 1;
+  }
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -18,13 +18,13 @@ package io.camunda.zeebe.model.bpmn.validation.zeebe;
 import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.model.bpmn.instance.CallActivity;
 import io.camunda.zeebe.model.bpmn.instance.MultiInstanceLoopCharacteristics;
-import io.camunda.zeebe.model.bpmn.instance.ScriptTask;
 import io.camunda.zeebe.model.bpmn.instance.SendTask;
 import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeScript;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeSubscription;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 import java.util.ArrayList;
@@ -64,10 +64,7 @@ public final class ZeebeDesignTimeValidators {
             .hasSingleExtensionElement(
                 ZeebeLoopCharacteristics.class, ZeebeConstants.ELEMENT_LOOP_CHARACTERISTICS));
     validators.add(new ProcessValidator());
-    validators.add(
-        ExtensionElementsValidator.verifyThat(ScriptTask.class)
-            .hasSingleExtensionElement(
-                ZeebeTaskDefinition.class, ZeebeConstants.ELEMENT_TASK_DEFINITION));
+    validators.add(new ScriptTaskValidation());
     validators.add(new SequenceFlowValidator());
     validators.add(
         ExtensionElementsValidator.verifyThat(SendTask.class)
@@ -106,6 +103,11 @@ public final class ZeebeDesignTimeValidators {
                 ZeebeCalledDecision::getDecisionId, ZeebeConstants.ATTRIBUTE_DECISION_ID)
             .hasNonEmptyAttribute(
                 ZeebeCalledDecision::getResultVariable, ZeebeConstants.ATTRIBUTE_RESULT_VARIABLE));
+    validators.add(
+        ZeebeElementValidator.verifyThat(ZeebeScript.class)
+            .hasNonEmptyAttribute(ZeebeScript::getExpression, ZeebeConstants.ATTRIBUTE_EXPRESSION)
+            .hasNonEmptyAttribute(
+                ZeebeScript::getResultVariable, ZeebeConstants.ATTRIBUTE_RESULT_VARIABLE));
     validators.add(new SignalEventDefinitionValidator());
     validators.add(new SignalValidator());
     validators.add(new LinkEventDefinitionValidator());

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ScriptTaskBuilderTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ScriptTaskBuilderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeScript;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+import org.junit.jupiter.api.Test;
+
+public class ScriptTaskBuilderTest {
+
+  @Test
+  void shouldSetExpression() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .scriptTask("task", task -> task.zeebeExpression("true"))
+            .done();
+
+    // then
+    final ModelElementInstance scriptTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) scriptTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeScript.class))
+        .hasSize(1)
+        .extracting(ZeebeScript::getExpression)
+        .containsExactly("=true");
+  }
+
+  @Test
+  void shouldSetResultVariable() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .scriptTask("task", task -> task.zeebeResultVariable("result"))
+            .done();
+
+    // then
+    final ModelElementInstance scriptTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) scriptTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeScript.class))
+        .hasSize(1)
+        .extracting(ZeebeScript::getResultVariable)
+        .containsExactly("result");
+  }
+
+  @Test
+  void shouldSetExpressionAndResultVariable() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .scriptTask(
+                "task", task -> task.zeebeExpression("expression").zeebeResultVariable("result"))
+            .done();
+
+    // then
+    final ModelElementInstance scriptTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) scriptTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeScript.class))
+        .hasSize(1)
+        .extracting(ZeebeScript::getExpression, ZeebeScript::getResultVariable)
+        .containsExactly(tuple("=expression", "result"));
+  }
+}

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeScriptTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeScriptTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+public class ZeebeScriptTest extends BpmnModelElementInstanceTest {
+
+  @Override
+  public TypeAssumption getTypeAssumption() {
+    return new TypeAssumption(BpmnModelConstants.ZEEBE_NS, false);
+  }
+
+  @Override
+  public Collection<ChildElementAssumption> getChildElementAssumptions() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Collection<AttributeAssumption> getAttributesAssumptions() {
+    return Arrays.asList(
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "expression", false, true),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "resultVariable", false, true));
+  }
+}

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeJobWorkerElementValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeJobWorkerElementValidationTest.java
@@ -111,7 +111,6 @@ public class ZeebeJobWorkerElementValidationTest {
   private static Stream<JobWorkerElementBuilder> jobWorkerElementBuilderProvider() {
     return Stream.of(
         JobWorkerElementBuilder.of("serviceTask", AbstractFlowNodeBuilder::serviceTask),
-        JobWorkerElementBuilder.of("scriptTask", AbstractFlowNodeBuilder::scriptTask),
         JobWorkerElementBuilder.of("sendTask", AbstractFlowNodeBuilder::sendTask),
         JobWorkerElementBuilder.of(
             "message end event",

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeScriptTaskValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeScriptTaskValidationTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation;
+
+import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.ScriptTaskBuilder;
+import io.camunda.zeebe.model.bpmn.instance.ScriptTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeScript;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+class ZeebeScriptTaskValidationTest {
+
+  @Test
+  void emptyExpression() {
+    // when
+    final BpmnModelInstance process =
+        process(task -> task.zeebeExpression("").zeebeResultVariable("result"));
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process, expect(ZeebeScript.class, "Attribute 'expression' must be present and not empty"));
+  }
+
+  @Test
+  void emptyResultVariable() {
+    // when
+    final BpmnModelInstance process =
+        process(task -> task.zeebeExpression("true").zeebeResultVariable(""));
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(ZeebeScript.class, "Attribute 'resultVariable' must be present and not empty"));
+  }
+
+  @Test
+  void emptyJobType() {
+    // when
+    final BpmnModelInstance process = process(task -> task.zeebeJobType(""));
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(ZeebeTaskDefinition.class, "Attribute 'type' must be present and not empty"));
+  }
+
+  @Test
+  void noExpressionAndTaskDefinitionExtension() {
+    // when
+    final BpmnModelInstance process = process(task -> {});
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        ExpectedValidationResult.expect(
+            ScriptTask.class,
+            "Must have either one 'zeebe:script' or one 'zeebe:taskDefinition' extension element"));
+  }
+
+  @Test
+  void bothExpressionAndTaskDefinitionExtension() {
+    // when
+    final BpmnModelInstance process =
+        process(
+            task ->
+                task.zeebeExpression("true").zeebeResultVariable("result").zeebeJobType("jobType"));
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        ExpectedValidationResult.expect(
+            ScriptTask.class,
+            "Must have either one 'zeebe:script' or one 'zeebe:taskDefinition' extension element"));
+  }
+
+  private BpmnModelInstance process(final Consumer<ScriptTaskBuilder> taskBuilder) {
+    return Bpmn.createExecutableProcess("process")
+        .startEvent()
+        .scriptTask("task", taskBuilder)
+        .done();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Add new script tasks extension element zeebe:script model api, to support script tasks run in the engine, different from the job type.


```
<bpmn:scriptTask id="Activity_1f7zluu">
    <bpmn:extensionElements>
        <zeebe:script expression="=today()" resultVariable="result"/>
    </bpmn:extensionElements>
</bpmn:scriptTask>
```



## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10692 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [x] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
