### PR TITLE
feat(engine): set the variables locally when failling a job with variables

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -51,7 +51,11 @@ public final class JobEventProcessors {
             ValueType.JOB,
             JobIntent.FAIL,
             new JobFailProcessor(
-                zeebeState, zeebeState.getKeyGenerator(), jobMetrics, jobBackoffChecker))
+                zeebeState,
+                zeebeState.getKeyGenerator(),
+                jobMetrics,
+                jobBackoffChecker,
+                bpmnBehaviors.variableBehavior()))
         .onCommand(
             ValueType.JOB,
             JobIntent.THROW_ERROR,

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
@@ -311,6 +311,8 @@ public final class FailJobTest {
             .withName("foo")
             .getFirst();
 
-    assertThat(variableRecord.getValue().getValue()).isEqualTo("\"bar\"");
+    assertThat(variableRecord.getValue().getValue())
+        .describedAs("check set failing job variables locally")
+        .isEqualTo("\"bar\"");
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
@@ -307,12 +307,12 @@ public final class FailJobTest {
     final Record<VariableRecordValue> variableRecord =
         RecordingExporter.variableRecords()
             .withProcessInstanceKey(job.getProcessInstanceKey())
-            .withScopeKey(failRecord.getValue().getElementInstanceKey())
-            .withName("foo")
             .getFirst();
 
-    assertThat(variableRecord.getValue().getValue())
+    Assertions.assertThat(variableRecord.getValue())
         .describedAs("check set failing job variables locally")
-        .isEqualTo("\"bar\"");
+        .hasScopeKey(failRecord.getValue().getElementInstanceKey())
+        .hasName("foo")
+        .hasValue("\"bar\"");
   }
 }


### PR DESCRIPTION
## Description

If a failing job has variables, then the variables will be set locally.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10698 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
