### PR TITLE
feat(gateway): add fail job variables support

### DIFF
--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -273,6 +273,12 @@ message FailJobRequest {
   string errorMessage = 3;
   // the backoff timeout (in ms) for the next retry
   int64 retryBackOff = 4;
+  // JSON document that will instantiate the variables for the root variable scope of the
+  // process instance; it must be a JSON object, as variables will be mapped in a
+  // key-value fashion. e.g. { "a": 1, "b": 2 } will create two variables, named "a" and
+  // "b" respectively, with their associated values. [{ "a": 1, "b": 2 }] would not be a
+  // valid argument, as the root of the JSON document is an array and not an object.
+  string variables = 5;
 }
 
 message FailJobResponse {

--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -273,8 +273,8 @@ message FailJobRequest {
   string errorMessage = 3;
   // the backoff timeout (in ms) for the next retry
   int64 retryBackOff = 4;
-  // JSON document that will instantiate the variables for the root variable scope of the
-  // process instance; it must be a JSON object, as variables will be mapped in a
+  // JSON document that will instantiate the variables at the local scope of the
+  // job's associated task; it must be a JSON object, as variables will be mapped in a
   // key-value fashion. e.g. { "a": 1, "b": 2 } will create two variables, named "a" and
   // "b" respectively, with their associated values. [{ "a": 1, "b": 2 }] would not be a
   // valid argument, as the root of the JSON document is an array and not an object.

--- a/gateway-protocol/src/main/proto/proto.lock
+++ b/gateway-protocol/src/main/proto/proto.lock
@@ -537,6 +537,11 @@
                 "id": 4,
                 "name": "retryBackOff",
                 "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "variables",
+                "type": "string"
               }
             ]
           },

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -89,7 +89,8 @@ public final class RequestMapper {
   public static BrokerFailJobRequest toFailJobRequest(final FailJobRequest grpcRequest) {
     return new BrokerFailJobRequest(
             grpcRequest.getJobKey(), grpcRequest.getRetries(), grpcRequest.getRetryBackOff())
-        .setErrorMessage(grpcRequest.getErrorMessage());
+        .setErrorMessage(grpcRequest.getErrorMessage())
+        .setVariables(ensureJsonSet(grpcRequest.getVariables()));
   }
 
   public static BrokerThrowErrorRequest toThrowErrorRequest(final ThrowErrorRequest grpcRequest) {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerFailJobRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerFailJobRequest.java
@@ -28,6 +28,11 @@ public final class BrokerFailJobRequest extends BrokerExecuteCommand<JobRecord> 
     return this;
   }
 
+  public BrokerFailJobRequest setVariables(final DirectBuffer variables) {
+    requestDto.setVariables(variables);
+    return this;
+  }
+
   @Override
   public JobRecord getRequestWriter() {
     return requestDto;

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/FailJobTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/FailJobTest.java
@@ -17,6 +17,9 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobResponse;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.test.util.JsonUtil;
+import io.camunda.zeebe.test.util.MsgPackUtil;
+import java.util.Collections;
 import org.junit.Test;
 
 public final class FailJobTest extends GatewayTest {
@@ -30,12 +33,15 @@ public final class FailJobTest extends GatewayTest {
     final int retries = 123;
     final int retryBackOff = 100;
 
+    final String variables = JsonUtil.toJson(Collections.singletonMap("foo", "bar"));
+
     final FailJobRequest request =
         FailJobRequest.newBuilder()
             .setJobKey(stub.getKey())
             .setRetries(retries)
             .setRetryBackOff(retryBackOff)
             .setErrorMessage("failed")
+            .setVariables(variables)
             .build();
 
     // when
@@ -53,5 +59,8 @@ public final class FailJobTest extends GatewayTest {
     assertThat(brokerRequestValue.getRetries()).isEqualTo(retries);
     assertThat(brokerRequestValue.getRetryBackoff()).isEqualTo(retryBackOff);
     assertThat(brokerRequestValue.getErrorMessageBuffer()).isEqualTo(wrapString("failed"));
+
+    MsgPackUtil.assertEqualityExcluding(brokerRequestValue.getVariablesBuffer(), variables);
+    assertThat(brokerRequestValue.getVariables().get("foo")).isEqualTo("bar");
   }
 }


### PR DESCRIPTION
## Description

Add variables param for FailJob api and transfer variables from gateway to broker.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10700 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
