### PR TITLE
feat(client-java): support set variables when failing a job

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/FailJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/FailJobCommandStep1.java
@@ -16,7 +16,9 @@
 package io.camunda.zeebe.client.api.command;
 
 import io.camunda.zeebe.client.api.response.FailJobResponse;
+import java.io.InputStream;
 import java.time.Duration;
+import java.util.Map;
 
 public interface FailJobCommandStep1 {
 
@@ -56,5 +58,41 @@ public interface FailJobCommandStep1 {
      *     it to the broker.
      */
     FailJobCommandStep2 errorMessage(String errorMsg);
+
+    /**
+     * Set the variables of this job.
+     *
+     * @param variables the variables (JSON) as stream
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    FailJobCommandStep2 variables(InputStream variables);
+
+    /**
+     * Set the variables of this job.
+     *
+     * @param variables the variables (JSON) as String
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    FailJobCommandStep2 variables(String variables);
+
+    /**
+     * Set the variables of this job.
+     *
+     * @param variables the variables as map
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    FailJobCommandStep2 variables(Map<String, Object> variables);
+
+    /**
+     * Set the variables of this job.
+     *
+     * @param variables the variables as object
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    FailJobCommandStep2 variables(Object variables);
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/FailJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/FailJobCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1.FailJobCommandStep2;
@@ -31,7 +32,8 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
-public final class FailJobCommandImpl implements FailJobCommandStep1, FailJobCommandStep2 {
+public final class FailJobCommandImpl extends CommandWithVariables<FailJobCommandStep2>
+    implements FailJobCommandStep1, FailJobCommandStep2 {
 
   private final GatewayStub asyncStub;
   private final Builder builder;
@@ -40,9 +42,11 @@ public final class FailJobCommandImpl implements FailJobCommandStep1, FailJobCom
 
   public FailJobCommandImpl(
       final GatewayStub asyncStub,
+      final JsonMapper jsonMapper,
       final long key,
       final Duration requestTimeout,
       final Predicate<Throwable> retryPredicate) {
+    super(jsonMapper);
     this.asyncStub = asyncStub;
     this.requestTimeout = requestTimeout;
     this.retryPredicate = retryPredicate;
@@ -65,6 +69,12 @@ public final class FailJobCommandImpl implements FailJobCommandStep1, FailJobCom
   @Override
   public FailJobCommandStep2 errorMessage(final String errorMsg) {
     builder.setErrorMessage(errorMsg);
+    return this;
+  }
+
+  @Override
+  public FailJobCommandStep2 setVariablesInternal(final String variables) {
+    builder.setVariables(variables);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobClientImpl.java
@@ -60,7 +60,7 @@ public final class JobClientImpl implements JobClient {
   @Override
   public FailJobCommandStep1 newFailCommand(final long jobKey) {
     return new FailJobCommandImpl(
-        asyncStub, jobKey, config.getDefaultRequestTimeout(), retryPredicate);
+        asyncStub, jsonMapper, jobKey, config.getDefaultRequestTimeout(), retryPredicate);
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/FailJobTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/FailJobTest.java
@@ -21,8 +21,10 @@ import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.response.FailJobResponse;
 import io.camunda.zeebe.client.util.ClientTest;
+import io.camunda.zeebe.client.util.JsonUtil;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobRequest;
 import java.time.Duration;
+import java.util.Collections;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -145,6 +147,25 @@ public final class FailJobTest extends ClientTest {
         command.retries(0).errorMessage("This failed oops.").send().join();
 
     // then
+    assertThat(response).isNotNull();
+  }
+
+  @Test
+  public void shouldFailJobWithJsonStringVariables() {
+    // given
+    final long jobKey = 12;
+    final int newRetries = 0;
+
+    final String json = JsonUtil.toJson(Collections.singletonMap("key", "val"));
+
+    // when
+    final FailJobResponse response =
+        client.newFailCommand(jobKey).retries(newRetries).variables(json).send().join();
+
+    // then
+    final FailJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getJobKey()).isEqualTo(jobKey);
+    JsonUtil.assertEquality(request.getVariables(), json);
     assertThat(response).isNotNull();
   }
 }


### PR DESCRIPTION
## Description

Add support set variables when failing a job.

`client.newFailCommand(...).variables(...) `

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9404 

depends on #10701, #10702 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
