### PR TITLE
Periodically log the progress while partition is waiting to be ready

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftCommitListener.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftCommitListener.java
@@ -16,6 +16,11 @@
  */
 package io.atomix.raft;
 
+/**
+ * Will be notified when a new batch is committed. It is not guaranteed to get notified for each
+ * index. For example, if records at index 1 to 5 are committed together, the listener can be
+ * invoked just once with index 5.
+ */
 @FunctionalInterface
 public interface RaftCommitListener {
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -120,7 +120,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private volatile long term;
   private MemberId lastVotedFor;
   private long commitIndex;
-  private volatile long firstCommitIndex;
+  private long firstCommitIndex;
   private volatile boolean started;
   private EntryValidator entryValidator;
   // Used for randomizing election timeout

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -413,8 +413,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
    *
    * @param committedEntry the most recently committed entry
    */
-  public void notifyCommitListeners(final IndexedRaftLogEntry committedEntry) {
-    commitListeners.forEach(listener -> listener.onCommit(committedEntry.index()));
+  public void notifyCommittedEntryListeners(final IndexedRaftLogEntry committedEntry) {
     committedEntryListeners.forEach(listener -> listener.onCommit(committedEntry));
   }
 
@@ -447,6 +446,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
         stateChangeListeners.forEach(l -> l.accept(state));
       }
       replicationMetrics.setCommitIndex(commitIndex);
+      notifyCommitListeners(commitIndex);
     }
     return previousCommitIndex;
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -1157,7 +1157,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   /** Commit listener is active only until the server is ready * */
-  class AwaitingReadyCommitListener implements RaftCommitListener {
+  final class AwaitingReadyCommitListener implements RaftCommitListener {
     private final Logger throttledLogger = new ThrottledLogger(log, Duration.ofSeconds(30));
 
     @Override

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -599,7 +599,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
               // entries properly on fail over
               if (commitError == null) {
                 appendListener.onCommit(indexed);
-                raft.notifyCommitListeners(indexed);
+                raft.notifyCommittedEntryListeners(indexed);
               } else {
                 appendListener.onCommitError(indexed, commitError);
                 // replicating the entry will be retried on the next append request

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -532,7 +532,6 @@ public class PassiveRole extends InactiveRole {
     final long previousCommitIndex = raft.setCommitIndex(commitIndex);
     if (previousCommitIndex < commitIndex) {
       log.trace("Committed entries up to index {}", commitIndex);
-      raft.notifyCommitListeners(commitIndex);
     }
 
     // Make sure all entries are flushed before ack to ensure we have persisted what we acknowledge

--- a/util/src/main/java/io/camunda/zeebe/util/logging/ThrottledLogger.java
+++ b/util/src/main/java/io/camunda/zeebe/util/logging/ThrottledLogger.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util.logging;
+
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+
+/**
+ * Logger that logs only once every configured interval.
+ *
+ * <p>Example:
+ *
+ * <pre>
+ * while(condition) {
+ *     log.info("repeated log");
+ * }
+ * </pre>
+ *
+ * When ThrottledLogger is used, this is not logged in every loop. Instead, it will be logged once
+ * in every configured interval.
+ */
+public class ThrottledLogger implements Logger {
+
+  private long lastLogTime = 0;
+  private final Logger log;
+  private final long intervalMillis;
+
+  public ThrottledLogger(final Logger log, final Duration interval) {
+    this.log = log;
+    intervalMillis = interval.toMillis();
+  }
+
+  @Override
+  public String getName() {
+    return log.getName();
+  }
+
+  @Override
+  public boolean isTraceEnabled() {
+    return log.isTraceEnabled();
+  }
+
+  @Override
+  public void trace(final String s) {
+    checkAndLog(() -> log.trace(s));
+  }
+
+  @Override
+  public void trace(final String s, final Object o) {
+    checkAndLog(() -> log.trace(s, o));
+  }
+
+  @Override
+  public void trace(final String s, final Object o, final Object o1) {
+    checkAndLog(() -> log.trace(s, o, o1));
+  }
+
+  @Override
+  public void trace(final String s, final Object... objects) {
+    checkAndLog(() -> log.trace(s, objects));
+  }
+
+  @Override
+  public void trace(final String s, final Throwable throwable) {
+    checkAndLog(() -> log.trace(s, throwable));
+  }
+
+  @Override
+  public boolean isTraceEnabled(final Marker marker) {
+    return log.isTraceEnabled(marker);
+  }
+
+  @Override
+  public void trace(final Marker marker, final String s) {
+    checkAndLog(() -> log.trace(marker, s));
+  }
+
+  @Override
+  public void trace(final Marker marker, final String s, final Object o) {
+    checkAndLog(() -> log.trace(marker, s, o));
+  }
+
+  @Override
+  public void trace(final Marker marker, final String s, final Object o, final Object o1) {
+    checkAndLog(() -> log.trace(marker, s, o, o1));
+  }
+
+  @Override
+  public void trace(final Marker marker, final String s, final Object... objects) {
+    checkAndLog(() -> log.trace(marker, s, objects));
+  }
+
+  @Override
+  public void trace(final Marker marker, final String s, final Throwable throwable) {
+    checkAndLog(() -> log.trace(marker, s, throwable));
+  }
+
+  @Override
+  public boolean isDebugEnabled() {
+    return log.isDebugEnabled();
+  }
+
+  @Override
+  public void debug(final String s) {
+    checkAndLog(() -> log.debug(s));
+  }
+
+  @Override
+  public void debug(final String s, final Object o) {
+    checkAndLog(() -> log.debug(s, o));
+  }
+
+  @Override
+  public void debug(final String s, final Object o, final Object o1) {
+    checkAndLog(() -> log.debug(s, o, o1));
+  }
+
+  @Override
+  public void debug(final String s, final Object... objects) {
+    checkAndLog(() -> log.debug(s, objects));
+  }
+
+  @Override
+  public void debug(final String s, final Throwable throwable) {
+    checkAndLog(() -> log.debug(s, throwable));
+  }
+
+  @Override
+  public boolean isDebugEnabled(final Marker marker) {
+    return log.isDebugEnabled(marker);
+  }
+
+  @Override
+  public void debug(final Marker marker, final String s) {
+    checkAndLog(() -> log.debug(marker, s));
+  }
+
+  @Override
+  public void debug(final Marker marker, final String s, final Object o) {
+    checkAndLog(() -> log.debug(marker, s, o));
+  }
+
+  @Override
+  public void debug(final Marker marker, final String s, final Object o, final Object o1) {
+    checkAndLog(() -> log.debug(marker, s, o, o1));
+  }
+
+  @Override
+  public void debug(final Marker marker, final String s, final Object... objects) {
+    checkAndLog(() -> log.debug(marker, s, objects));
+  }
+
+  @Override
+  public void debug(final Marker marker, final String s, final Throwable throwable) {
+    checkAndLog(() -> log.debug(marker, s, throwable));
+  }
+
+  @Override
+  public boolean isInfoEnabled() {
+    return log.isInfoEnabled();
+  }
+
+  @Override
+  public void info(final String s) {
+    checkAndLog(() -> log.info(s));
+  }
+
+  @Override
+  public void info(final String s, final Object o) {
+    checkAndLog(() -> log.info(s, o));
+  }
+
+  @Override
+  public void info(final String s, final Object o, final Object o1) {
+    checkAndLog(() -> log.info(s, o, o1));
+  }
+
+  @Override
+  public void info(final String s, final Object... objects) {
+    checkAndLog(() -> log.info(s, objects));
+  }
+
+  @Override
+  public void info(final String s, final Throwable throwable) {
+    checkAndLog(() -> log.info(s, throwable));
+  }
+
+  @Override
+  public boolean isInfoEnabled(final Marker marker) {
+    return log.isInfoEnabled(marker);
+  }
+
+  @Override
+  public void info(final Marker marker, final String s) {
+    checkAndLog(() -> log.info(marker, s));
+  }
+
+  @Override
+  public void info(final Marker marker, final String s, final Object o) {
+    checkAndLog(() -> log.info(marker, s, o));
+  }
+
+  @Override
+  public void info(final Marker marker, final String s, final Object o, final Object o1) {
+    checkAndLog(() -> log.info(marker, s, o, o1));
+  }
+
+  @Override
+  public void info(final Marker marker, final String s, final Object... objects) {
+    checkAndLog(() -> log.info(marker, s, objects));
+  }
+
+  @Override
+  public void info(final Marker marker, final String s, final Throwable throwable) {
+    checkAndLog(() -> log.info(marker, s, throwable));
+  }
+
+  @Override
+  public boolean isWarnEnabled() {
+    return log.isWarnEnabled();
+  }
+
+  @Override
+  public void warn(final String s) {
+    checkAndLog(() -> log.warn(s));
+  }
+
+  @Override
+  public void warn(final String s, final Object o) {
+    checkAndLog(() -> log.warn(s, o));
+  }
+
+  @Override
+  public void warn(final String s, final Object... objects) {
+    checkAndLog(() -> log.warn(s, objects));
+  }
+
+  @Override
+  public void warn(final String s, final Object o, final Object o1) {
+    checkAndLog(() -> log.warn(s, o, o1));
+  }
+
+  @Override
+  public void warn(final String s, final Throwable throwable) {
+    checkAndLog(() -> log.warn(s, throwable));
+  }
+
+  @Override
+  public boolean isWarnEnabled(final Marker marker) {
+    return log.isWarnEnabled(marker);
+  }
+
+  @Override
+  public void warn(final Marker marker, final String s) {
+    checkAndLog(() -> log.warn(marker, s));
+  }
+
+  @Override
+  public void warn(final Marker marker, final String s, final Object o) {
+    checkAndLog(() -> log.warn(marker, s, o));
+  }
+
+  @Override
+  public void warn(final Marker marker, final String s, final Object o, final Object o1) {
+    checkAndLog(() -> log.warn(marker, s, o, o1));
+  }
+
+  @Override
+  public void warn(final Marker marker, final String s, final Object... objects) {
+    checkAndLog(() -> log.warn(marker, s, objects));
+  }
+
+  @Override
+  public void warn(final Marker marker, final String s, final Throwable throwable) {
+    checkAndLog(() -> log.warn(marker, s, throwable));
+  }
+
+  @Override
+  public boolean isErrorEnabled() {
+    return log.isErrorEnabled();
+  }
+
+  @Override
+  public void error(final String s) {
+    checkAndLog(() -> log.error(s));
+  }
+
+  @Override
+  public void error(final String s, final Object o) {
+    checkAndLog(() -> log.error(s, o));
+  }
+
+  @Override
+  public void error(final String s, final Object o, final Object o1) {
+    checkAndLog(() -> log.error(s, o, o1));
+  }
+
+  @Override
+  public void error(final String s, final Object... objects) {
+    checkAndLog(() -> log.error(s, objects));
+  }
+
+  @Override
+  public void error(final String s, final Throwable throwable) {
+    checkAndLog(() -> log.error(s, throwable));
+  }
+
+  @Override
+  public boolean isErrorEnabled(final Marker marker) {
+    return log.isErrorEnabled(marker);
+  }
+
+  @Override
+  public void error(final Marker marker, final String s) {
+    checkAndLog(() -> log.error(marker, s));
+  }
+
+  @Override
+  public void error(final Marker marker, final String s, final Object o) {
+    checkAndLog(() -> log.error(marker, s, o));
+  }
+
+  @Override
+  public void error(final Marker marker, final String s, final Object o, final Object o1) {
+    checkAndLog(() -> log.error(marker, s, o, o1));
+  }
+
+  @Override
+  public void error(final Marker marker, final String s, final Object... objects) {
+    checkAndLog(() -> log.error(marker, s, objects));
+  }
+
+  @Override
+  public void error(final Marker marker, final String s, final Throwable throwable) {
+    checkAndLog(() -> log.error(marker, s, throwable));
+  }
+
+  private void checkAndLog(final Runnable logger) {
+    final var currentTime = System.currentTimeMillis();
+    if (currentTime - lastLogTime >= intervalMillis) {
+      logger.run();
+      lastLogTime = currentTime;
+    }
+  }
+}


### PR DESCRIPTION
## Description

Introduced a throttled logger that logs only once every configured interval. Used this logger to log when new entries are committed while a node is waiting to be ready. Since using the thtrottle logger, it will not flood the log by logging each commit. 

To enable this, this PR also refactored `setCommitIndex`. Previously, setting first commit index and check if node is ready is done for every commit. This is unnecessary, as it is relevant only until the node is ready. So this is moved to a commit listener which is only  active while the node is waiting to be ready. So that path is not executed unnecessarily during normal execution. 

Also remove "volatile" from firstCommitIndex. It is not accessed outside of raft context. There are also other volatile fields, which I think can be removed. But they need to be done carefully. So I will leave it out of this PR. 

## Related issues

closes #9963 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
