### PR TITLE
refactor: marking in-progress backups as failed uses `BackupStore#list`

### DIFF
--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import org.slf4j.Logger;
@@ -36,14 +35,12 @@ public final class BackupService extends Actor implements BackupManager {
   private final PersistedSnapshotStore snapshotStore;
   private final Path segmentsDirectory;
   private final Predicate<Path> isSegmentsFile;
-  private final List<Integer> partitionMembers;
   private final BackupManagerMetrics metrics;
 
   public BackupService(
       final int nodeId,
       final int partitionId,
       final int numberOfPartitions,
-      final List<Integer> partitionMembers,
       final BackupStore backupStore,
       final PersistedSnapshotStore snapshotStore,
       final Path segmentsDirectory,
@@ -51,7 +48,6 @@ public final class BackupService extends Actor implements BackupManager {
     this.nodeId = nodeId;
     this.partitionId = partitionId;
     this.numberOfPartitions = numberOfPartitions;
-    this.partitionMembers = partitionMembers;
     this.snapshotStore = snapshotStore;
     this.segmentsDirectory = segmentsDirectory;
     this.isSegmentsFile = isSegmentsFile;
@@ -152,8 +148,7 @@ public final class BackupService extends Actor implements BackupManager {
 
   @Override
   public void failInProgressBackup(final long lastCheckpointId) {
-    internalBackupManager.failInProgressBackups(
-        partitionId, lastCheckpointId, partitionMembers, actor);
+    internalBackupManager.failInProgressBackups(partitionId, lastCheckpointId, actor);
   }
 
   private BackupIdentifierImpl getBackupId(final long checkpointId) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
-import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.backup.api.BackupManager;
 import io.camunda.zeebe.backup.management.BackupService;
@@ -19,7 +18,6 @@ import io.camunda.zeebe.journal.file.SegmentFile;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.function.Predicate;
 
 public final class BackupServiceTransitionStep implements PartitionTransitionStep {
@@ -115,7 +113,6 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
             context.getNodeId(),
             context.getPartitionId(),
             context.getBrokerCfg().getCluster().getPartitionsCount(),
-            getPartitionMembers(context),
             context.getBackupStore(),
             context.getPersistedSnapshotStore(),
             context.getRaftPartition().dataDirectory().toPath(),
@@ -142,14 +139,6 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
     final CheckpointRecordsProcessor checkpointRecordsProcessor =
         new CheckpointRecordsProcessor(backupManager, context.getPartitionId());
     context.setCheckpointProcessor(checkpointRecordsProcessor);
-  }
-
-  // Brokers which are members of this partition's replication group
-  private static List<Integer> getPartitionMembers(final PartitionTransitionContext context) {
-    return context.getRaftPartition().members().stream()
-        .map(MemberId::id)
-        .map(Integer::parseInt)
-        .toList();
   }
 
   private boolean shouldInstallOnTransition(final Role newRole, final Role currentRole) {

--- a/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -29,7 +29,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -83,7 +82,6 @@ class PartitionRestoreServiceTest {
             nodeId,
             partitionId,
             1,
-            List.of(1, 2),
             backupStore,
             snapshotStore,
             dataDirectory,


### PR DESCRIPTION
Instead of iterating over all known brokers, we can simply ask the backup store to list backups regardless of which broker took the backup.

closes #10444 