### PR TITLE
feat(bpmn-model): support escalation events

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBaseElementBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBaseElementBuilder.java
@@ -293,6 +293,10 @@ public abstract class AbstractBaseElementBuilder<
     return escalation;
   }
 
+  protected EscalationEventDefinition createEmptyEscalationEventDefinition() {
+    return createInstance(EscalationEventDefinition.class);
+  }
+
   protected EscalationEventDefinition createEscalationEventDefinition(final String escalationCode) {
     final Escalation escalation = findEscalationForCode(escalationCode);
     final EscalationEventDefinition escalationEventDefinition =

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractEscalationEventDefinitionBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractEscalationEventDefinitionBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.Event;
+
+public abstract class AbstractEscalationEventDefinitionBuilder<
+        B extends AbstractEscalationEventDefinitionBuilder<B>>
+    extends AbstractRootElementBuilder<B, EscalationEventDefinition> {
+
+  public AbstractEscalationEventDefinitionBuilder(
+      final BpmnModelInstance modelInstance,
+      final EscalationEventDefinition element,
+      final Class<?> selfType) {
+    super(modelInstance, element, selfType);
+  }
+
+  @Override
+  public B id(final String identifier) {
+    return super.id(identifier);
+  }
+
+  /** Sets the escalation attribute with escalationCode. */
+  public B escalationCode(final String escalationCode) {
+    element.setEscalation(findEscalationForCode(escalationCode));
+    return myself;
+  }
+
+  /**
+   * Finishes the building of a escalation event definition.
+   *
+   * @param <T>
+   * @return the parent event builder
+   */
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public <T extends AbstractFlowNodeBuilder> T escalationEventDefinitionDone() {
+    return (T) ((Event) element.getParentElement()).builder();
+  }
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractThrowEventBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractThrowEventBuilder.java
@@ -138,6 +138,36 @@ public abstract class AbstractThrowEventBuilder<
     return myself;
   }
 
+  /**
+   * Creates an escalation event definition with an unique id and returns a builder for the
+   * escalation event definition.
+   *
+   * @return the escalation event definition builder object
+   */
+  public EscalationEventDefinitionBuilder escalationEventDefinition(final String id) {
+    final EscalationEventDefinition escalationEventDefinition =
+        createEmptyEscalationEventDefinition();
+    if (id != null) {
+      escalationEventDefinition.setId(id);
+    }
+
+    element.getEventDefinitions().add(escalationEventDefinition);
+    return new EscalationEventDefinitionBuilder(modelInstance, escalationEventDefinition);
+  }
+
+  /**
+   * Creates an escalation event definition and returns a builder for the escalation event
+   * definition.
+   *
+   * @return the escalation event definition builder object
+   */
+  public EscalationEventDefinitionBuilder escalationEventDefinition() {
+    final EscalationEventDefinition escalationEventDefinition =
+        createEmptyEscalationEventDefinition();
+    element.getEventDefinitions().add(escalationEventDefinition);
+    return new EscalationEventDefinitionBuilder(modelInstance, escalationEventDefinition);
+  }
+
   public CompensateEventDefinitionBuilder compensateEventDefinition() {
     return compensateEventDefinition(null);
   }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/EscalationEventDefinitionBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/EscalationEventDefinitionBuilder.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
+
+public class EscalationEventDefinitionBuilder
+    extends AbstractEscalationEventDefinitionBuilder<EscalationEventDefinitionBuilder> {
+
+  public EscalationEventDefinitionBuilder(
+      final BpmnModelInstance modelInstance, final EscalationEventDefinition element) {
+    super(modelInstance, element, EscalationEventDefinitionBuilder.class);
+  }
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/BoundaryEventValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/BoundaryEventValidator.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
 import io.camunda.zeebe.model.bpmn.instance.BoundaryEvent;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.SignalEventDefinition;
@@ -35,7 +36,8 @@ public class BoundaryEventValidator implements ModelElementValidator<BoundaryEve
           TimerEventDefinition.class,
           MessageEventDefinition.class,
           ErrorEventDefinition.class,
-          SignalEventDefinition.class);
+          SignalEventDefinition.class,
+          EscalationEventDefinition.class);
 
   @Override
   public Class<BoundaryEvent> getElementType() {
@@ -72,7 +74,7 @@ public class BoundaryEventValidator implements ModelElementValidator<BoundaryEve
         def -> {
           if (SUPPORTED_EVENT_DEFINITIONS.stream().noneMatch(type -> type.isInstance(def))) {
             validationResultCollector.addError(
-                0, "Boundary events must be one of: timer, message, error, signal");
+                0, "Boundary events must be one of: timer, message, error, signal, escalation");
           }
         });
 

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EndEventValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EndEventValidator.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
 import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.SignalEventDefinition;
@@ -34,7 +35,8 @@ public class EndEventValidator implements ModelElementValidator<EndEvent> {
           ErrorEventDefinition.class,
           MessageEventDefinition.class,
           TerminateEventDefinition.class,
-          SignalEventDefinition.class);
+          SignalEventDefinition.class,
+          EscalationEventDefinition.class);
 
   @Override
   public Class<EndEvent> getElementType() {
@@ -65,7 +67,8 @@ public class EndEventValidator implements ModelElementValidator<EndEvent> {
         def -> {
           if (SUPPORTED_EVENT_DEFINITIONS.stream().noneMatch(type -> type.isInstance(def))) {
             validationResultCollector.addError(
-                0, "End events must be one of: none, error, message, terminate, or signal");
+                0,
+                "End events must be one of: none, error, message, terminate, signal, or escalation");
           }
         });
   }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EscalationEventDefinitionValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EscalationEventDefinitionValidator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.EndEvent;
+import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.IntermediateThrowEvent;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class EscalationEventDefinitionValidator
+    implements ModelElementValidator<EscalationEventDefinition> {
+
+  @Override
+  public Class<EscalationEventDefinition> getElementType() {
+    return EscalationEventDefinition.class;
+  }
+
+  @Override
+  public void validate(
+      final EscalationEventDefinition element,
+      final ValidationResultCollector validationResultCollector) {
+
+    if (isEscalationThrowEvent(element) && element.getEscalation() == null) {
+      validationResultCollector.addError(0, "Must reference an escalation");
+    }
+  }
+
+  private boolean isEscalationThrowEvent(final EscalationEventDefinition element) {
+    final ModelElementInstance parentElement = element.getParentElement();
+    return parentElement instanceof IntermediateThrowEvent || parentElement instanceof EndEvent;
+  }
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EscalationValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EscalationValidator.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.Escalation;
+import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.Process;
+import io.camunda.zeebe.model.bpmn.instance.ThrowEvent;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.camunda.bpm.model.xml.impl.ModelInstanceImpl;
+import org.camunda.bpm.model.xml.impl.util.ModelUtil;
+import org.camunda.bpm.model.xml.instance.DomElement;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class EscalationValidator implements ModelElementValidator<Escalation> {
+
+  @Override
+  public Class<Escalation> getElementType() {
+    return Escalation.class;
+  }
+
+  @Override
+  public void validate(
+      final Escalation element, final ValidationResultCollector validationResultCollector) {
+    if (isReferredByThrowEvent(element)) {
+      validateEscalationCode(element, validationResultCollector);
+    }
+  }
+
+  private void validateEscalationCode(
+      final Escalation element, final ValidationResultCollector validationResultCollector) {
+    if (element.getEscalationCode() == null || element.getEscalationCode().isEmpty()) {
+      validationResultCollector.addError(0, "EscalationCode must be present and not empty");
+    }
+  }
+
+  private boolean isReferredByThrowEvent(final Escalation element) {
+
+    final Collection<ThrowEvent> throwEvents = getAllElementsByType(element, ThrowEvent.class);
+
+    return throwEvents.stream()
+        .flatMap(i -> i.getEventDefinitions().stream())
+        .anyMatch(
+            e ->
+                e instanceof EscalationEventDefinition
+                    && ((EscalationEventDefinition) e).getEscalation() == element);
+  }
+
+  private <T extends ModelElementInstance> Collection<T> getAllElementsByType(
+      final Escalation element, final Class<T> type) {
+    return element.getParentElement().getChildElementsByType(Process.class).stream()
+        .flatMap(p -> getAllElementsByTypeRecursive(p, type).stream())
+        .collect(Collectors.toList());
+  }
+
+  private <T extends ModelElementInstance> Collection<T> getAllElementsByTypeRecursive(
+      final ModelElementInstance element, final Class<T> type) {
+
+    // look for immediate children
+    final Collection<T> result = element.getChildElementsByType(type);
+
+    // look for children in subtree
+    final List<DomElement> childDomElements = element.getDomElement().getChildElements();
+    final Collection<ModelElementInstance> childModelElements =
+        ModelUtil.getModelElementCollection(
+            childDomElements, (ModelInstanceImpl) element.getModelInstance());
+
+    result.addAll(
+        childModelElements.stream()
+            .flatMap(child -> getAllElementsByTypeRecursive(child, type).stream())
+            .collect(Collectors.toList()));
+
+    return result;
+  }
+}

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EventDefinitionValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EventDefinitionValidator.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.LinkEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
@@ -36,7 +37,8 @@ public class EventDefinitionValidator implements ModelElementValidator<EventDefi
           ErrorEventDefinition.class,
           TerminateEventDefinition.class,
           SignalEventDefinition.class,
-          LinkEventDefinition.class);
+          LinkEventDefinition.class,
+          EscalationEventDefinition.class);
 
   @Override
   public Class<EventDefinition> getElementType() {

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SubProcessValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SubProcessValidator.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.SignalEventDefinition;
@@ -36,7 +37,8 @@ public class SubProcessValidator implements ModelElementValidator<SubProcess> {
           TimerEventDefinition.class,
           MessageEventDefinition.class,
           ErrorEventDefinition.class,
-          SignalEventDefinition.class);
+          SignalEventDefinition.class,
+          EscalationEventDefinition.class);
 
   @Override
   public Class<SubProcess> getElementType() {
@@ -78,7 +80,8 @@ public class SubProcessValidator implements ModelElementValidator<SubProcess> {
     final Collection<EventDefinition> eventDefinitions = start.getEventDefinitions();
     if (eventDefinitions.isEmpty()) {
       validationResultCollector.addError(
-          0, "Start events in event subprocesses must be one of: message, timer, error, signal");
+          0,
+          "Start events in event subprocesses must be one of: message, timer, error, signal, escalation");
     }
 
     eventDefinitions.forEach(
@@ -86,7 +89,7 @@ public class SubProcessValidator implements ModelElementValidator<SubProcess> {
           if (SUPPORTED_START_TYPES.stream().noneMatch(type -> type.isInstance(def))) {
             validationResultCollector.addError(
                 0,
-                "Start events in event subprocesses must be one of: message, timer, error, signal");
+                "Start events in event subprocesses must be one of: message, timer, error, signal, escalation");
           }
         });
 

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -111,6 +111,8 @@ public final class ZeebeDesignTimeValidators {
     validators.add(new SignalEventDefinitionValidator());
     validators.add(new SignalValidator());
     validators.add(new LinkEventDefinitionValidator());
+    validators.add(new EscalationEventDefinitionValidator());
+    validators.add(new EscalationValidator());
 
     VALIDATORS = Collections.unmodifiableList(validators);
   }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEndEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEndEventValidationTest.java
@@ -63,7 +63,8 @@ class ZeebeEndEventValidationTest {
     ProcessValidationUtil.assertThatProcessHasViolations(
         process,
         expect(
-            END_EVENT_ID, "End events must be one of: none, error, message, terminate, or signal"),
+            END_EVENT_ID,
+            "End events must be one of: none, error, message, terminate, signal, or escalation"),
         expect(endEventTypeBuilder.eventType, "Event definition of this type is not supported"));
   }
 
@@ -101,6 +102,8 @@ class ZeebeEndEventValidationTest {
         new EndEventTypeBuilder(
             ErrorEventDefinition.class, endEvent -> endEvent.error("error-code")),
         new EndEventTypeBuilder(
+            EscalationEventDefinition.class, endEvent -> endEvent.escalation("escalation-code")),
+        new EndEventTypeBuilder(
             MessageEventDefinition.class,
             endEvent -> endEvent.message("message-name").zeebeJobType("job-type")),
         new EndEventTypeBuilder(TerminateEventDefinition.class, EndEventBuilder::terminate));
@@ -108,8 +111,6 @@ class ZeebeEndEventValidationTest {
 
   private static Stream<EndEventTypeBuilder> unsupportedEndEventTypes() {
     return Stream.of(
-        new EndEventTypeBuilder(
-            EscalationEventDefinition.class, endEvent -> endEvent.escalation("escalation-code")),
         new EndEventTypeBuilder(
             CompensateEventDefinition.class,
             endEvent -> endEvent.compensateEventDefinition().compensateEventDefinitionDone()),

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEscalationValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEscalationValidationTest.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation;
+
+import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractThrowEventBuilder;
+import io.camunda.zeebe.model.bpmn.builder.SubProcessBuilder;
+import io.camunda.zeebe.model.bpmn.instance.BoundaryEvent;
+import io.camunda.zeebe.model.bpmn.instance.CallActivity;
+import io.camunda.zeebe.model.bpmn.instance.Escalation;
+import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.Process;
+import io.camunda.zeebe.model.bpmn.instance.SubProcess;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ZeebeEscalationValidationTest {
+
+  private BpmnModelInstance process(final Consumer<SubProcessBuilder> builder) {
+    return Bpmn.createExecutableProcess().startEvent().subProcess("sp", builder).endEvent().done();
+  }
+
+  @Test
+  @DisplayName(
+      "An escalation boundary event should only allow attaching to sub-process or call-activity")
+  void verifyEscalationBoundaryEventOnlyAllowAttachingToSubProcessOrCallActivity() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
+            .boundaryEvent("catch", b -> b.escalation("escalation-1"))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            BoundaryEvent.class,
+            "An escalation boundary event should only be attached to a subprocess, or a call activity"));
+  }
+
+  @Test
+  @DisplayName("An escalation boundary event should allow attaching to sub-process")
+  void verifyEscalationBoundaryEventAttachingToSubProcess() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .subProcess(
+                "sp",
+                s -> {
+                  s.embeddedSubProcess()
+                      .startEvent()
+                      .endEvent("end", e -> e.escalation("escalation"));
+                })
+            .boundaryEvent("catch", b -> b.escalation("escalation"))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  @DisplayName("An escalation boundary event should allow attaching to call-activity")
+  void verifyEscalationBoundaryEventAttachingToCallActivity() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity("call", c -> c.zeebeProcessId("child"))
+            .boundaryEvent("catch-1", b -> b.escalation().endEvent())
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  @DisplayName(
+      "Multiple escalation boundary event definitions without escalation code are not allowed")
+  void verifyMultipleEscalationBoundaryEventsWithoutEscalationCode() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .callActivity("call", c -> c.zeebeProcessId("child"))
+            .boundaryEvent("catch-1", b -> b.escalation().endEvent())
+            .moveToActivity("call")
+            .boundaryEvent("catch-2", b -> b.escalation().endEvent())
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            CallActivity.class,
+            "The same scope can not contain more than one escalation catch event without escalation code. An escalation catch event without escalation code catches all escalations."));
+  }
+
+  @Test
+  @DisplayName("Multiple escalation boundary events with the same escalationCode are not allowed")
+  void verifyMultipleEscalationBoundaryEventsWithSameEscalationCode() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity("call", c -> c.zeebeProcessId("child"))
+            .boundaryEvent("catch-1", b -> b.escalation("escalation").endEvent())
+            .moveToActivity("call")
+            .boundaryEvent("catch-2", b -> b.escalation("escalation").endEvent())
+            .moveToNode("call")
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            CallActivity.class,
+            "Multiple escalation catch events with the same escalation code 'escalation' are not supported on the same scope."));
+  }
+
+  @Test
+  @DisplayName(
+      "The same scope can not contains an escalation boundary event without escalation code and another one with escalation code.")
+  void verifyMultipleEscalationBoundaryEventsWithAndWithOutEscalationCode() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity("call", c -> c.zeebeProcessId("child"))
+            .boundaryEvent("catch-1", b -> b.escalation().endEvent())
+            .moveToActivity("call")
+            .boundaryEvent("catch-2", b -> b.escalation("escalation").endEvent())
+            .moveToNode("call")
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            CallActivity.class,
+            "The same scope can not contain an escalation catch event without escalation code and another one with escalation code. An escalation catch event without escalation code catches all escalations."));
+  }
+
+  @Test
+  @DisplayName("A sub-process with multiple escalation start event definitions are not allowed")
+  void verifyMultipleEscalationEventSubprocessWithoutEscalationCode() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            sp -> {
+              sp.embeddedSubProcess()
+                  .eventSubProcess()
+                  .startEvent()
+                  .interrupting(false)
+                  .escalation("")
+                  .endEvent();
+              sp.embeddedSubProcess()
+                  .eventSubProcess()
+                  .startEvent()
+                  .interrupting(false)
+                  .escalation("")
+                  .endEvent();
+              sp.embeddedSubProcess().startEvent().endEvent();
+            });
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            SubProcess.class,
+            "The same scope can not contain more than one escalation catch event without escalation code. An escalation catch event without escalation code catches all escalations."));
+  }
+
+  @Test
+  @DisplayName("A sub-process with multiple escalation start event definitions are not allowed")
+  void verifyMultipleEscalationEventSubprocessWithAndWithoutEscalationCode() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            sp -> {
+              sp.embeddedSubProcess()
+                  .eventSubProcess()
+                  .startEvent()
+                  .interrupting(false)
+                  .escalation()
+                  .endEvent();
+              sp.embeddedSubProcess()
+                  .eventSubProcess()
+                  .startEvent()
+                  .interrupting(false)
+                  .escalation("escalation")
+                  .endEvent();
+              sp.embeddedSubProcess().startEvent().endEvent();
+            });
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            SubProcess.class,
+            "The same scope can not contain an escalation catch event without escalation code and another one with escalation code. An escalation catch event without escalation code catches all escalations."));
+  }
+
+  @Test
+  @DisplayName("Multiple event subprocess with the same escalationCode are not allowed")
+  void verifyMultipleEscalationEventSubprocessWithSameEscalationCode() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .eventSubProcess(
+                "sub-1", s -> s.startEvent().interrupting(true).escalation("escalation").endEvent())
+            .eventSubProcess(
+                "sub-2", s -> s.startEvent().interrupting(true).escalation("escalation").endEvent())
+            .startEvent()
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            Process.class,
+            "Multiple escalation catch events with the same escalation code 'escalation' are not supported on the same scope."));
+  }
+
+  @Test
+  @DisplayName("An escalation throw event definition cannot omit escalationRef")
+  void verifyMissingEscalationRefOnIntermediateThrowingEscalationEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateThrowEvent()
+            .escalationEventDefinition()
+            .escalationEventDefinitionDone()
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process, expect(EscalationEventDefinition.class, "Must reference an escalation"));
+  }
+
+  @Test
+  @DisplayName("An escalation throw event definition cannot omit escalationCode")
+  void verifyMissingEscalationCodeOnIntermediateThrowingEscalationEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateThrowEvent()
+            .escalation("")
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process, expect(Escalation.class, "EscalationCode must be present and not empty"));
+  }
+
+  @Test
+  @DisplayName("An escalation end event definition cannot omit escalationRef")
+  void verifyMissingEscalationRefOnEscalationEndEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .endEvent("escalation", AbstractThrowEventBuilder::escalationEventDefinition)
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process, expect(EscalationEventDefinition.class, "Must reference an escalation"));
+  }
+
+  @Test
+  @DisplayName(
+      "An escalation end event definition cannot omit escalationCode of referenced escalation")
+  void verifyMissingEscalationCodeOnEscalationEndEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .endEvent("escalation", e -> e.escalation(""))
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process, expect(Escalation.class, "EscalationCode must be present and not empty"));
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/EscalationEventValidationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/EscalationEventValidationTest.java
@@ -1,0 +1,458 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractBoundaryEventBuilder;
+import io.camunda.zeebe.model.bpmn.builder.AbstractThrowEventBuilder;
+import io.camunda.zeebe.model.bpmn.builder.SubProcessBuilder;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.function.Consumer;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class EscalationEventValidationTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private BpmnModelInstance process(final Consumer<SubProcessBuilder> builder) {
+    return Bpmn.createExecutableProcess().startEvent().subProcess("sp", builder).endEvent().done();
+  }
+
+  @Test
+  public void shouldDeployProcessModelWithEscalationThrowEvent() {
+    // given
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .intermediateThrowEvent()
+            .escalation("escalationCode")
+            .endEvent()
+            .done();
+
+    // when
+    final Record<DeploymentRecordValue> result =
+        ENGINE.deployment().withXmlResource(processDefinition).deploy();
+
+    // then
+    assertThat(result.getKey()).isGreaterThan(0);
+    assertThat(result.getValue().getProcessesMetadata()).hasSize(1);
+    final ProcessMetadataValue deployedProcess = result.getValue().getProcessesMetadata().get(0);
+    assertThat(deployedProcess.getVersion()).isEqualTo(1);
+    assertThat(deployedProcess.getProcessDefinitionKey()).isGreaterThan(0);
+  }
+
+  @Test
+  public void shouldDeployProcessModelWithEscalationStartEvent() {
+    // given
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess()
+            .eventSubProcess(
+                "sub", s -> s.startEvent("start-1").escalation("escalationCode").endEvent())
+            .startEvent()
+            .endEvent()
+            .done();
+
+    // when
+    final Record<DeploymentRecordValue> result =
+        ENGINE.deployment().withXmlResource(processDefinition).deploy();
+
+    // then
+    assertThat(result.getKey()).isGreaterThan(0);
+    assertThat(result.getValue().getProcessesMetadata()).hasSize(1);
+    final ProcessMetadataValue deployedProcess = result.getValue().getProcessesMetadata().get(0);
+    assertThat(deployedProcess.getVersion()).isEqualTo(1);
+    assertThat(deployedProcess.getProcessDefinitionKey()).isGreaterThan(0);
+  }
+
+  @Test
+  public void shouldDeployProcessModelWithEscalationEndEvent() {
+    // given
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .endEvent("end", builder -> builder.escalation("escalationCode"))
+            .done();
+
+    // when
+    final Record<DeploymentRecordValue> result =
+        ENGINE.deployment().withXmlResource(processDefinition).deploy();
+
+    // then
+    assertThat(result.getKey()).isGreaterThan(0);
+    assertThat(result.getValue().getProcessesMetadata()).hasSize(1);
+    final ProcessMetadataValue deployedProcess = result.getValue().getProcessesMetadata().get(0);
+    assertThat(deployedProcess.getVersion()).isEqualTo(1);
+    assertThat(deployedProcess.getProcessDefinitionKey()).isGreaterThan(0);
+  }
+
+  @Test
+  public void shouldDeployProcessModelWithEscalationBoundaryEvent() {
+    // given
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .callActivity("call", builder -> builder.zeebeProcessId("sub"))
+            .boundaryEvent("catch", builder -> builder.escalation("escalationCode"))
+            .endEvent()
+            .done();
+
+    // when
+    final Record<DeploymentRecordValue> result =
+        ENGINE.deployment().withXmlResource(processDefinition).deploy();
+
+    // then
+    assertThat(result.getKey()).isGreaterThan(0);
+    assertThat(result.getValue().getProcessesMetadata()).hasSize(1);
+    final ProcessMetadataValue deployedProcess = result.getValue().getProcessesMetadata().get(0);
+    assertThat(deployedProcess.getVersion()).isEqualTo(1);
+    assertThat(deployedProcess.getProcessDefinitionKey()).isGreaterThan(0);
+  }
+
+  @Test
+  public void
+      shouldRejectDeploymentIfEscalationBoundaryEventIsNotAttachedToChildProcessOrCallActivity() {
+    // given
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .serviceTask("task", builder -> builder.zeebeJobType("type"))
+            .boundaryEvent("catch", AbstractBoundaryEventBuilder::escalation)
+            .endEvent()
+            .done();
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(processDefinition).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains(
+            "An escalation boundary event should only be attached to a subprocess, or a call activity.");
+  }
+
+  @Test
+  public void shouldRejectDeploymentIfMissingEscalationRefOnIntermediateThrowingEvent() {
+    // given
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .intermediateThrowEvent()
+            .escalationEventDefinition("escalation")
+            .escalationEventDefinitionDone()
+            .endEvent()
+            .done();
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(processDefinition).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(rejectedDeployment.getRejectionReason()).contains("Must reference an escalation");
+  }
+
+  @Test
+  public void shouldRejectDeploymentIfEscalationThrowEventWithoutEscalationCode() {
+    // given
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .intermediateThrowEvent()
+            .escalationEventDefinition("escalation")
+            .escalationCode("")
+            .escalationEventDefinitionDone()
+            .endEvent()
+            .done();
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(processDefinition).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains("ERROR: EscalationCode must be present and not empty");
+  }
+
+  @Test
+  public void shouldRejectDeploymentIfMultipleEscalationBoundaryEventsWithoutEscalationCode() {
+    // given
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .callActivity("call", c -> c.zeebeProcessId("child"))
+            .boundaryEvent("catch-1", b -> b.escalation().endEvent())
+            .moveToActivity("call")
+            .boundaryEvent("catch-2", b -> b.escalation().endEvent())
+            .endEvent()
+            .done();
+
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(processDefinition).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains(
+            "The same scope can not contain more than one escalation catch event without escalation code. An escalation catch event without escalation code catches all escalations.");
+  }
+
+  @Test
+  public void shouldRejectDeploymentIfMultipleEscalationBoundaryEventsWithSameEscalationCode() {
+    // given
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .callActivity("call", c -> c.zeebeProcessId("child"))
+            .boundaryEvent("catch-1", b -> b.escalation("escalationCode").endEvent())
+            .moveToActivity("call")
+            .boundaryEvent("catch-2", b -> b.escalation("escalationCode").endEvent())
+            .endEvent()
+            .done();
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(processDefinition).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains(
+            "Multiple escalation catch events with the same escalation code 'escalationCode' are not supported on the same scope.");
+  }
+
+  @Test
+  public void
+      shouldRejectDeploymentIfMultipleEscalationBoundaryEventsWithAndWithoutEscalationCode() {
+    // given
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .callActivity("call", c -> c.zeebeProcessId("child"))
+            .boundaryEvent("catch-1", b -> b.escalation().endEvent())
+            .moveToActivity("call")
+            .boundaryEvent("catch-2", b -> b.escalation("escalationCode").endEvent())
+            .endEvent()
+            .done();
+
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(processDefinition).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains(
+            "The same scope can not contain an escalation catch event without escalation code and another one with escalation code. An escalation catch event without escalation code catches all escalations.");
+  }
+
+  @Test
+  public void shouldRejectDeploymentIfMissingEscalationRefOnEscalationEndEvent() {
+    // given
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .endEvent("end", AbstractThrowEventBuilder::escalationEventDefinition)
+            .done();
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(processDefinition).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains("ERROR: Must reference an escalation");
+  }
+
+  @Test
+  public void shouldRejectDeploymentIfEscalationEndEventWithoutEscalationCode() {
+    // given
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .endEvent("end", builder -> builder.escalation(""))
+            .done();
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(processDefinition).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains("ERROR: EscalationCode must be present and not empty");
+  }
+
+  @Test
+  public void shouldRejectDeploymentIfEscalationEndEventWithSameEscalationCode() {
+    // given
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .callActivity("call", c -> c.zeebeProcessId("child"))
+            .boundaryEvent("catch-1", b -> b.escalation("escalationCode").endEvent())
+            .moveToActivity("call")
+            .boundaryEvent("catch-2", b -> b.escalation("escalationCode").endEvent())
+            .done();
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(processDefinition).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains(
+            "Multiple escalation catch events with the same escalation code 'escalationCode' are not supported on the same scope.");
+  }
+
+  @Test
+  public void shouldRejectDeploymentIfMultipleEscalationEventSubprocessWithoutEscalationCode() {
+    // given
+    final BpmnModelInstance processDefinition =
+        process(
+            sp -> {
+              sp.embeddedSubProcess()
+                  .eventSubProcess()
+                  .startEvent()
+                  .interrupting(false)
+                  .escalation("")
+                  .endEvent();
+              sp.embeddedSubProcess()
+                  .eventSubProcess()
+                  .startEvent()
+                  .interrupting(false)
+                  .escalation("")
+                  .endEvent();
+              sp.embeddedSubProcess().startEvent().endEvent();
+            });
+
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(processDefinition).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains(
+            "The same scope can not contain more than one escalation catch event without escalation code. An escalation catch event without escalation code catches all escalations.");
+  }
+
+  @Test
+  public void shouldRejectDeploymentIfMultipleEscalationEventSubprocessWithSameEscalationCode() {
+    // given
+    final BpmnModelInstance processDefinition =
+        process(
+            sp -> {
+              sp.embeddedSubProcess()
+                  .eventSubProcess()
+                  .startEvent()
+                  .interrupting(false)
+                  .escalation("escalation")
+                  .endEvent();
+              sp.embeddedSubProcess()
+                  .eventSubProcess()
+                  .startEvent()
+                  .interrupting(false)
+                  .escalation("escalation")
+                  .endEvent();
+              sp.embeddedSubProcess().startEvent().endEvent();
+            });
+
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(processDefinition).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains(
+            "Multiple escalation catch events with the same escalation code 'escalation' are not supported on the same scope.");
+  }
+
+  @Test
+  public void
+      shouldRejectDeploymentIfMultipleEscalationEventSubprocessWithAndWithoutEscalationCode() {
+    // given
+    final BpmnModelInstance processDefinition =
+        process(
+            sp -> {
+              sp.embeddedSubProcess()
+                  .eventSubProcess()
+                  .startEvent()
+                  .interrupting(false)
+                  .escalation()
+                  .endEvent();
+              sp.embeddedSubProcess()
+                  .eventSubProcess()
+                  .startEvent()
+                  .interrupting(false)
+                  .escalation("escalation")
+                  .endEvent();
+              sp.embeddedSubProcess().startEvent().endEvent();
+            });
+
+    // when
+    final Record<DeploymentRecordValue> rejectedDeployment =
+        ENGINE.deployment().withXmlResource(processDefinition).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(rejectedDeployment.getRejectionReason())
+        .contains(
+            "The same scope can not contain an escalation catch event without escalation code and another one with escalation code. An escalation catch event without escalation code catches all escalations.");
+  }
+}


### PR DESCRIPTION
## Description
As a user I can deploy a process definition with escalation event.

## Related issues
closes #10688 

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
