### PR TITLE
Split `ClusteredSnapshotTest`

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredSnapshotTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredSnapshotTest.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.DataCfg;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
-import io.camunda.zeebe.client.api.response.BrokerInfo;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Context.RecordFilter;
@@ -19,15 +18,12 @@ import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.snapshots.SnapshotId;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
@@ -133,124 +129,6 @@ public class ClusteredSnapshotTest {
     assertThat(clusteringRule.getBroker(followerId)).havingSnapshot();
   }
 
-  @Test
-  public void shouldIncludeExportedPositionInSnapshot() {
-    // given
-    ControllableExporter.updatePosition(true);
-
-    publishMessages();
-    ControllableExporter.updatePosition(false);
-    publishMessages();
-
-    // when - then
-    awaitUntilAsserted(
-        (broker) -> {
-          triggerSnapshotRoutine();
-          assertThat(broker)
-              .havingSnapshot()
-              .withExportedPosition(ControllableExporter.lastUpdatedPosition);
-        });
-  }
-
-  @Test
-  public void shouldTakeSnapshotWhenExporterPositionIsMinusOne() {
-    // given
-    // an exporter is configured, but nothing gets exported
-    ControllableExporter.updatePosition(false);
-    publishMessages();
-
-    // when
-    triggerSnapshotRoutine();
-
-    // then
-    awaitUntilAsserted(
-        (broker) -> {
-          assertThat(broker).havingSnapshot().withIndex(0).withTerm(0).withExportedPosition(0);
-        });
-  }
-
-  @Test
-  public void shouldKeepIndexAndTerm() {
-    // given
-    ControllableExporter.updatePosition(false);
-    removeExporters();
-    restartCluster();
-    publishMessages();
-    triggerSnapshotRoutine();
-
-    // expect - each broker has created a snapshot
-    awaitUntilAsserted(
-        (broker) -> {
-          assertThat(broker).havingSnapshot().withExportedPosition(Long.MAX_VALUE);
-        });
-
-    final Map<Integer, SnapshotId> snapshotsByBroker =
-        clusteringRule.getTopologyFromClient().getBrokers().stream()
-            .collect(Collectors.toMap(BrokerInfo::getNodeId, this::getSnapshot));
-
-    LOG.info("Snapshots before configuring exporters {}", snapshotsByBroker);
-
-    // when
-    configureExporters();
-    restartCluster();
-    publishMessages();
-    triggerSnapshotRoutine();
-
-    // then
-    awaitUntilAsserted(
-        (broker) -> {
-          final SnapshotId expectedSnapshot =
-              snapshotsByBroker.get(broker.getConfig().getCluster().getNodeId());
-          assertThat(broker)
-              .havingSnapshot()
-              .withIndex(expectedSnapshot.getIndex())
-              .withTerm(expectedSnapshot.getTerm())
-              .withExportedPosition(0);
-        });
-  }
-
-  @Test
-  public void shouldNotTakeNewSnapshot() {
-    // given
-    ControllableExporter.updatePosition(false);
-    removeExporters();
-    restartCluster();
-    publishMessages();
-
-    final var leaderId = clusteringRule.getLeaderForPartition(1).getNodeId();
-    final var leaderAdminService =
-        clusteringRule.getBroker(leaderId).getBrokerContext().getBrokerAdminService();
-    final var expectedProcessedPosition =
-        leaderAdminService.getPartitionStatus().get(1).getProcessedPosition();
-
-    // expect
-    awaitUntilAsserted(
-        (broker) -> {
-          triggerSnapshotRoutine();
-          assertThat(broker)
-              .havingSnapshot()
-              .withProcessedPosition(expectedProcessedPosition)
-              .withExportedPosition(Long.MAX_VALUE);
-        });
-
-    final Map<Integer, SnapshotId> snapshotsByBroker =
-        clusteringRule.getTopologyFromClient().getBrokers().stream()
-            .collect(Collectors.toMap(BrokerInfo::getNodeId, this::getSnapshot));
-
-    // when
-    configureExporters();
-    restartCluster();
-    triggerSnapshotRoutine();
-
-    // then
-    awaitUntilAsserted(
-        (broker) -> {
-          final SnapshotId expectedSnapshot =
-              snapshotsByBroker.get(broker.getConfig().getCluster().getNodeId());
-          assertThat(broker).havingSnapshot().isEqualTo(expectedSnapshot);
-        });
-  }
-
   private void awaitUntilAsserted(final Consumer<Broker> consumer) {
     Awaitility.await()
         .pollInterval(Duration.ofSeconds(1))
@@ -273,35 +151,14 @@ public class ClusteredSnapshotTest {
     configureExporter(brokerCfg);
   }
 
-  private void configureExporters() {
-    clusteringRule.getBrokers().stream().map(Broker::getConfig).forEach(this::configureExporter);
-  }
-
   private void configureExporter(final BrokerCfg brokerConfig) {
     final ExporterCfg exporterConfig = new ExporterCfg();
     exporterConfig.setClassName(ControllableExporter.class.getName());
     brokerConfig.setExporters(Collections.singletonMap("snapshot-test-exporter", exporterConfig));
   }
 
-  private void removeExporters() {
-    clusteringRule.getBrokers().forEach(this::removeExporter);
-  }
-
-  private void removeExporter(final Broker broker) {
-    final BrokerCfg brokerConfig = broker.getConfig();
-    brokerConfig.setExporters(Collections.emptyMap());
-  }
-
-  private void restartCluster() {
-    clusteringRule.restartCluster();
-  }
-
   private void triggerSnapshotRoutine() {
     snapshotTrigger.accept(clusteringRule);
-  }
-
-  private SnapshotId getSnapshot(final BrokerInfo brokerInfo) {
-    return clusteringRule.getSnapshot(brokerInfo.getNodeId()).get();
   }
 
   private void publishMessages() {
@@ -379,57 +236,11 @@ public class ClusteredSnapshotTest {
       this.rule = rule;
     }
 
-    public SnapshotAssert havingSnapshot() {
+    public void havingSnapshot() {
       final var snapshot = rule.getSnapshot(actual);
       Assertions.assertThat(snapshot)
           .withFailMessage("No snapshot exists for broker <%s>", actual)
           .isPresent();
-      return new SnapshotAssert(snapshot.orElseThrow());
-    }
-  }
-
-  private static class SnapshotAssert extends AbstractAssert<SnapshotAssert, SnapshotId> {
-
-    protected SnapshotAssert(final SnapshotId actual) {
-      super(actual, SnapshotAssert.class);
-    }
-
-    public SnapshotAssert withIndex(final long expected) {
-      Assertions.assertThat(actual.getIndex())
-          .withFailMessage(
-              "Expecting snapshot index <%s> but was <%s>", expected, actual.getIndex())
-          .isEqualTo(expected);
-      return myself;
-    }
-
-    public SnapshotAssert withTerm(final long expected) {
-      Assertions.assertThat(actual.getTerm())
-          .withFailMessage("Expecting snapshot term <%s> but was <%s>", expected, actual.getTerm())
-          .isEqualTo(expected);
-      return myself;
-    }
-
-    public SnapshotAssert withProcessedPosition(final long expected) {
-      Assertions.assertThat(actual.getProcessedPosition())
-          .withFailMessage(
-              "Expecting snapshot processed position <%s> but was <%s>",
-              expected, actual.getProcessedPosition())
-          .isEqualTo(expected);
-      return myself;
-    }
-
-    public SnapshotAssert withExportedPosition(final long expected) {
-      Assertions.assertThat(actual.getExportedPosition())
-          .withFailMessage(
-              "Expecting snapshot exported position <%s> but was <%s>",
-              expected, actual.getExportedPosition())
-          .isEqualTo(expected);
-      return myself;
-    }
-
-    @Override
-    public SnapshotAssert isEqualTo(final Object expected) {
-      return super.isEqualTo(expected);
     }
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredSnapshotTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredSnapshotTest.java
@@ -20,72 +20,59 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.unit.DataSize;
 
-@RunWith(Parameterized.class)
-public class ClusteredSnapshotTest {
+final class ClusteredSnapshotTest {
 
   public static final Logger LOG = LoggerFactory.getLogger("ClusteredSnapshotTest");
   private static final Duration SNAPSHOT_INTERVAL = Duration.ofMinutes(5);
 
-  @Rule
-  public final ClusteringRule clusteringRule = new ClusteringRule(1, 3, 3, this::configureBroker);
+  @RegisterExtension
+  private final ClusteringRuleExtension clusteringRule =
+      new ClusteringRuleExtension(1, 3, 3, this::configureBroker);
 
-  @Parameter(0)
-  public Consumer<ClusteringRule> snapshotTrigger;
-
-  @Parameter(1)
-  public String description;
-
-  @Parameters(name = "{index}: {1}")
-  public static Object[][] snapshotTriggers() {
-    return new Object[][] {
-      new Object[] {
-        (Consumer<ClusteringRule>)
-            (rule) -> {
-              LOG.info("Triggerring snapshots using admin api");
-              rule.triggerAndWaitForSnapshots();
-            },
-        "explicit trigger snapshot"
-      },
-      new Object[] {
-        (Consumer<ClusteringRule>)
-            (rule) -> {
-              LOG.info("Increasing clock by snapshot interval {}", SNAPSHOT_INTERVAL);
-              rule.getClock().addTime(SNAPSHOT_INTERVAL);
-            },
-        "implicit snapshot by advancing the clock"
-      }
-    };
+  public static Stream<Arguments> snapshotTriggers() {
+    return Stream.of(
+        Arguments.of(
+            Named.of(
+                "explicit trigger snapshot",
+                (Consumer<ClusteringRule>)
+                    (rule) -> {
+                      LOG.info("Triggering snapshots using admin api");
+                      rule.triggerAndWaitForSnapshots();
+                    })),
+        Arguments.of(
+            Named.of(
+                "implicit snapshot by advancing the clock",
+                (Consumer<ClusteringRule>)
+                    (rule) -> {
+                      LOG.info("Increasing clock by snapshot interval {}", SNAPSHOT_INTERVAL);
+                      rule.getClock().addTime(SNAPSHOT_INTERVAL);
+                    })));
   }
 
-  @After
-  public void cleanUp() {
+  @AfterEach
+  void cleanUp() {
     ControllableExporter.updatePosition(true);
-    ControllableExporter.EXPORTED_RECORDS.set(0);
-    ControllableExporter.RECORD_TYPE_FILTER.set(r -> true);
-    ControllableExporter.VALUE_TYPE_FILTER.set(r -> true);
   }
 
-  @Test
-  public void shouldTakeSnapshotsOnAllNodes() {
+  @ParameterizedTest
+  @MethodSource("snapshotTriggers")
+  void shouldTakeSnapshotsOnAllNodes(final Consumer<ClusteringRule> snapshotTrigger) {
     // given
     ControllableExporter.updatePosition(true);
 
@@ -96,13 +83,14 @@ public class ClusteredSnapshotTest {
     // when - then
     awaitUntilAsserted(
         (broker) -> {
-          triggerSnapshotRoutine();
+          snapshotTrigger.accept(clusteringRule);
           assertThat(broker).havingSnapshot();
         });
   }
 
-  @Test
-  public void shouldSendSnapshotOnReconnect() {
+  @ParameterizedTest()
+  @MethodSource("snapshotTriggers")
+  void shouldSendSnapshotOnReconnect(final Consumer<ClusteringRule> snapshotTrigger) {
     // given
     final var followerId = clusteringRule.stopAnyFollower();
     final var leaderId = clusteringRule.getLeaderForPartition(1).getNodeId();
@@ -135,9 +123,7 @@ public class ClusteredSnapshotTest {
         .timeout(Duration.ofSeconds(60))
         .ignoreExceptions()
         .untilAsserted(
-            () -> {
-              Assertions.assertThat(clusteringRule.getBrokers()).allSatisfy(consumer);
-            });
+            () -> Assertions.assertThat(clusteringRule.getBrokers()).allSatisfy(consumer));
   }
 
   private void configureBroker(final BrokerCfg brokerCfg) {
@@ -155,10 +141,6 @@ public class ClusteredSnapshotTest {
     final ExporterCfg exporterConfig = new ExporterCfg();
     exporterConfig.setClassName(ControllableExporter.class.getName());
     brokerConfig.setExporters(Collections.singletonMap("snapshot-test-exporter", exporterConfig));
-  }
-
-  private void triggerSnapshotRoutine() {
-    snapshotTrigger.accept(clusteringRule);
   }
 
   private void publishMessages() {
@@ -181,14 +163,6 @@ public class ClusteredSnapshotTest {
 
   public static class ControllableExporter implements Exporter {
     static volatile boolean shouldExport = true;
-    static volatile long lastUpdatedPosition = -1;
-
-    static final AtomicLong EXPORTED_RECORDS = new AtomicLong(0);
-    static final AtomicReference<Predicate<RecordType>> RECORD_TYPE_FILTER =
-        new AtomicReference<>(r -> true);
-    static final AtomicReference<Predicate<ValueType>> VALUE_TYPE_FILTER =
-        new AtomicReference<>(r -> true);
-
     private Controller controller;
 
     static void updatePosition(final boolean flag) {
@@ -201,12 +175,12 @@ public class ClusteredSnapshotTest {
           new RecordFilter() {
             @Override
             public boolean acceptType(final RecordType recordType) {
-              return RECORD_TYPE_FILTER.get().test(recordType);
+              return true;
             }
 
             @Override
             public boolean acceptValue(final ValueType valueType) {
-              return VALUE_TYPE_FILTER.get().test(valueType);
+              return true;
             }
           });
     }
@@ -219,11 +193,8 @@ public class ClusteredSnapshotTest {
     @Override
     public void export(final Record<?> record) {
       if (shouldExport) {
-        lastUpdatedPosition = record.getPosition();
-        controller.updateLastExportedRecordPosition(lastUpdatedPosition);
+        controller.updateLastExportedRecordPosition(record.getPosition());
       }
-
-      EXPORTED_RECORDS.incrementAndGet();
     }
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SnapshotWithExportersTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SnapshotWithExportersTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering;
+
+import static io.camunda.zeebe.test.StableValuePredicate.hasStableValue;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
+import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.zeebe.containers.ZeebeContainer;
+import io.zeebe.containers.ZeebeVolume;
+import io.zeebe.containers.exporter.DebugReceiver;
+import java.time.Duration;
+import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+final class SnapshotWithExportersTest {
+
+  @Test
+  void shouldIncludeExportedPositionInSnapshot() {
+    // given
+    try (final var debugReceiver =
+        new DebugReceiver((record) -> {}, SocketUtil.getNextAddress(), true).start()) {
+      try (final var zeebe =
+          new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
+              .withDebugExporter(debugReceiver.serverAddress().getPort())) {
+        zeebe.start();
+
+        final var partitions = PartitionsActuator.of(zeebe);
+
+        try (final var client =
+            ZeebeClient.newClientBuilder()
+                .gatewayAddress(zeebe.getExternalGatewayAddress())
+                .usePlaintext()
+                .build()) {
+
+          publishMessages(client);
+          final var exporterPosition =
+              Awaitility.await("Exported position is stable")
+                  .atMost(Duration.ofSeconds(30))
+                  .during(Duration.ofSeconds(5))
+                  .until(() -> partitions.query().get(1).exportedPosition(), hasStableValue());
+          assertThat(exporterPosition).isPositive();
+
+          // when
+          partitions.takeSnapshot();
+
+          // then
+          final var exportedPositionInSnapshot =
+              Awaitility.await("Snapshot is taken")
+                  .atMost(Duration.ofSeconds(60))
+                  .during(Duration.ofSeconds(5))
+                  .until(
+                      () ->
+                          FileBasedSnapshotId.ofFileName(partitions.query().get(1).snapshotId())
+                              .orElseThrow()
+                              .getExportedPosition(),
+                      hasStableValue());
+
+          assertThat(exportedPositionInSnapshot).isEqualTo(exporterPosition);
+        }
+      }
+    }
+  }
+
+  @Test
+  void shouldTakeSnapshotWhenExporterPositionIsMinusOne() {
+    // given -- broker with exporter that does not acknowledge anything
+    try (final var unresponsiveExporterTarget = new DebugReceiver((record) -> {}, false).start()) {
+      try (final var zeebe =
+          new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
+              .withDebugExporter(unresponsiveExporterTarget.serverAddress().getPort())) {
+        zeebe.start();
+
+        try (final var client =
+            ZeebeClient.newClientBuilder()
+                .gatewayAddress(zeebe.getExternalGatewayAddress())
+                .usePlaintext()
+                .build()) {
+          publishMessages(client);
+        }
+
+        final var partitions = PartitionsActuator.of(zeebe);
+        Awaitility.await("Processed position is stable")
+            .atMost(Duration.ofSeconds(60))
+            .during(Duration.ofSeconds(5))
+            .until(() -> partitions.query().get(1).processedPosition(), hasStableValue());
+
+        partitions.takeSnapshot();
+
+        // then -- snapshot has exported position 0
+        final var snapshotWithExporters =
+            Awaitility.await("Snapshot is taken")
+                .atMost(Duration.ofSeconds(60))
+                .during(Duration.ofSeconds(5))
+                .until(
+                    () ->
+                        FileBasedSnapshotId.ofFileName(partitions.query().get(1).snapshotId())
+                            .orElseThrow(),
+                    hasStableValue());
+
+        assertThat(snapshotWithExporters).returns(0L, FileBasedSnapshotId::getExportedPosition);
+      }
+    }
+  }
+
+  @Test
+  void shouldNotTakeNewSnapshotWhenAddingNewExporter() {
+    // given -- snapshot taken by broker without exporters
+    final var dataVolume = ZeebeVolume.newVolume();
+    final FileBasedSnapshotId snapshotWithoutExporters;
+    final FileBasedSnapshotId snapshotWithExporters;
+    try (final var zeebeWithoutExporter =
+        new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
+            .withZeebeData(dataVolume)) {
+      zeebeWithoutExporter.start();
+
+      try (final var client =
+          ZeebeClient.newClientBuilder()
+              .gatewayAddress(zeebeWithoutExporter.getExternalGatewayAddress())
+              .usePlaintext()
+              .build()) {
+        publishMessages(client);
+      }
+
+      final var partitions = PartitionsActuator.of(zeebeWithoutExporter);
+
+      partitions.takeSnapshot();
+      snapshotWithoutExporters =
+          Awaitility.await("Snapshot is taken")
+              .atMost(Duration.ofSeconds(60))
+              .during(Duration.ofSeconds(5))
+              .until(
+                  () ->
+                      FileBasedSnapshotId.ofFileName(partitions.query().get(1).snapshotId())
+                          .orElseThrow(),
+                  hasStableValue());
+    }
+
+    // when -- taking snapshot on broker with exporters configured
+    try (final var debugReceiver =
+        new DebugReceiver((record) -> {}, SocketUtil.getNextAddress()).start()) {
+      try (final var zeebeWithExporter =
+          new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
+              .withZeebeData(dataVolume)
+              .withDebugExporter(debugReceiver.serverAddress().getPort())) {
+        zeebeWithExporter.start();
+
+        final var partitions = PartitionsActuator.of(zeebeWithExporter);
+
+        partitions.takeSnapshot();
+        snapshotWithExporters =
+            Awaitility.await("Snapshot is taken")
+                .atMost(Duration.ofSeconds(60))
+                .during(Duration.ofSeconds(5))
+                .until(
+                    () ->
+                        FileBasedSnapshotId.ofFileName(partitions.query().get(1).snapshotId())
+                            .orElseThrow(),
+                    hasStableValue());
+      }
+    }
+
+    // then -- broker with exporter configured should not have taken a new backup
+    assertThat(snapshotWithExporters).isEqualTo(snapshotWithoutExporters);
+  }
+
+  private void publishMessages(final ZeebeClient client) {
+    IntStream.range(0, 10)
+        .forEach(
+            (i) ->
+                client
+                    .newPublishMessageCommand()
+                    .messageName("msg")
+                    .correlationKey("msg-" + i)
+                    .send()
+                    .join());
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.it.management;
 
-import static io.camunda.zeebe.it.management.ExportingEndpointIT.StableValuePredicate.hasStableValue;
+import static io.camunda.zeebe.test.StableValuePredicate.hasStableValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.client.ZeebeClient;
@@ -21,8 +21,6 @@ import io.zeebe.containers.cluster.ZeebeCluster;
 import io.zeebe.containers.exporter.DebugReceiver;
 import java.time.Duration;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Predicate;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -157,28 +155,6 @@ final class ExportingEndpointIT {
               status ->
                   status.exporterPhase() == null || status.exporterPhase().equals("EXPORTING"),
               "All exporters should be running");
-    }
-  }
-
-  static final class StableValuePredicate<T> implements Predicate<T> {
-
-    final AtomicReference<T> lastSeen = new AtomicReference<>();
-
-    /**
-     * Used in combination with {@link Awaitility}'s {@link
-     * org.awaitility.core.ConditionFactory#during(Duration)} to ensure that an expression maintains
-     * an arbitrary value over time.
-     *
-     * @return a predicate that accepts a value if it is the same value that was checked in the
-     *     previous call to this predicate.
-     */
-    static <T> StableValuePredicate<T> hasStableValue() {
-      return new StableValuePredicate<>();
-    }
-
-    @Override
-    public boolean test(final T t) {
-      return t == lastSeen.getAndSet(t);
     }
   }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/StableValuePredicate.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/StableValuePredicate.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import org.awaitility.Awaitility;
+
+public final class StableValuePredicate<T> implements Predicate<T> {
+
+  final AtomicReference<T> lastSeen = new AtomicReference<>();
+
+  /**
+   * Used in combination with {@link Awaitility}'s {@link
+   * org.awaitility.core.ConditionFactory#during(Duration)} to ensure that an expression maintains
+   * an arbitrary value over time.
+   *
+   * @return a predicate that accepts a value if it is the same value that was checked in the
+   *     previous call to this predicate.
+   */
+  public static <T> StableValuePredicate<T> hasStableValue() {
+    return new StableValuePredicate<>();
+  }
+
+  @Override
+  public boolean test(final T t) {
+    return Objects.equals(t, lastSeen.getAndSet(t));
+  }
+}


### PR DESCRIPTION
`ClusteredSnapshotTest` is one of our longest running tests, running for roughly 6 minutes on GHA. Here we split this class into two, moving all tests related to exporting into `SnapshotWithExportersTest`. We also migrate `ClusteredSnapshotTest` to JUnit5.

`SnapshotWithExportersTest` work a bit differently than before but I think test coverage is the same:
* `shouldIncludeExportedPositionInSnapshot` tests that snapshots taken by a broker with a running exporter have the correct exporter position.
* `shouldTakeSnapshotWhenExporterPositionIsMinusOne` tests that snapshots taken by a broker with a non-functioning exporter can take snapshots
* `shouldNotTakeNewSnapshotWhenAddingNewExporter` tests that taking a new snapshot after adding an exporter will not trigger a new snapshot and instead reuse the previous one taken without any exporters.

The remaining `ClusteredSnapshotTest` are essentially untouched but I'd say this PR should close existing issues regarding flaky tests too as it is unclear if they were failing on GHA, and if they will fail again after this refactoring.

closes #10560
closes #10484
closes #8669