### PR TITLE
Add documentation on how to build Docker images for other platforms and make Dockerfile platform independent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Override this based on the architecture; this is currently pointing to amd64
-ARG BASE_SHA="00a5775f5eb7c24a19cb76ded742cbfcc50c61f062105af9730dadde217e4390"
+ARG BASE_DIGEST="sha256:00a5775f5eb7c24a19cb76ded742cbfcc50c61f062105af9730dadde217e4390"
+ARG BASE_SHA="${BASE_SHA:-@$BASE_DIGEST}"
 
 # Building builder image
 FROM ubuntu:focal as builder
@@ -24,16 +25,16 @@ RUN chmod +x -R ${TMP_DIR}/bin/ && \
 
 # Building application image
 # hadolint ignore=DL3006
-FROM eclipse-temurin:17-jre-focal@sha256:${BASE_SHA} as app
+FROM eclipse-temurin:17-jre-focal${BASE_SHA} as app
 
 # leave unset to use the default value at the top of the file
-ARG BASE_SHA
+ARG BASE_DIGEST
 ARG VERSION=""
 ARG DATE=""
 ARG REVISION=""
 
 # OCI labels: https://github.com/opencontainers/image-spec/blob/main/annotations.md
-LABEL org.opencontainers.image.base.digest="${BASE_SHA}"
+LABEL org.opencontainers.image.base.digest="${BASE_DIGEST}"
 LABEL org.opencontainers.image.base.name="docker.io/library/eclipse-temurin:17-jre-focal"
 LABEL org.opencontainers.image.created="${DATE}"
 LABEL org.opencontainers.image.authors="zeebe@camunda.com"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ To learn more about what we're currently working on, check the [GitHub issues](h
 ## Helpful Links
 
 * [Releases](https://github.com/camunda/zeebe/releases)
-* [Docker images](https://hub.docker.com/r/camunda/zeebe/tags?page=1&ordering=last_updated)
+* [Pre-built Docker images](https://hub.docker.com/r/camunda/zeebe/tags?page=1&ordering=last_updated)
+* [Building Docker images for other platforms](/docs/building_docker_images.md)
 * [Blog](https://camunda.com/blog/category/process-automation-as-a-service/)
 * [Documentation Home](https://docs.camunda.io)
 * [Issue Tracker](https://github.com/camunda/zeebe/issues)

--- a/docker/test/docker-labels.golden.json
+++ b/docker/test/docker-labels.golden.json
@@ -5,7 +5,7 @@
   "io.openshift.non-scalable": "false",
   "io.openshift.tags": "bpmn,orchestration,workflow",
   "org.opencontainers.image.authors": "zeebe@camunda.com",
-  "org.opencontainers.image.base.digest": "00a5775f5eb7c24a19cb76ded742cbfcc50c61f062105af9730dadde217e4390",
+  "org.opencontainers.image.base.digest": "sha256:00a5775f5eb7c24a19cb76ded742cbfcc50c61f062105af9730dadde217e4390",
   "org.opencontainers.image.base.name": "docker.io/library/eclipse-temurin:17-jre-focal",
   "org.opencontainers.image.created": $DATE,
   "org.opencontainers.image.description": "Workflow engine for microservice orchestration",

--- a/docs/building_docker_images.md
+++ b/docs/building_docker_images.md
@@ -1,0 +1,38 @@
+# Building Docker Images
+
+This document contains information on how to build native zeebe docker images for other platforms than the default amd64 architecture (e.g. for Apple Silicon/M1 based Macs).
+
+> **Note**  
+> These instructions are meant for local development and testing (especially on ARM-based machines), not for production use.
+
+## Get the Distball
+
+Either build the project yourself or download an existing artifact, specifying the desired version:
+
+```bash
+mvn dependency:get -B \
+    -DremoteRepositories="https://artifacts.camunda.com/artifactory/zeebe-io/" \
+    -DgroupId="io.camunda" -DartifactId="camunda-zeebe" \
+    -Dversion="8.1.2" -Dpackaging="tar.gz" -Dtransitive=false
+
+mvn dependency:copy -B \
+    -Dartifact="io.camunda:camunda-zeebe:8.1.2:tar.gz" \
+    -DoutputDirectory=./ \
+    -Dmdep.stripVersion=true
+```
+
+## Build the Image
+
+Now build the image for your local platform:
+
+```bash
+docker build --build-arg DISTBALL=camunda-zeebe.tar.gz --build-arg BASE_SHA="" -t my-zeebe:latest .
+```
+
+By default, the BASE_SHA argument in the Dockerfile points to an amd64 base image. Overriding the argument with an empty string - like in the above command - will automatically use your local system architecture for the base image.
+
+If you need a specific version of the [`eclipse-temurin:17-jre-focal`](https://hub.docker.com/layers/library/eclipse-temurin/17-jre-focal/images/sha256-e7fe469c4e729ff0ed6ff464f41eaff0e4cb9b6fe7efe71754d8935c8118eb87?context=explore) base image, you can override the default BASE_DIGEST like that: `--build-arg BASE_DIGEST="@sha256:fce37e5146419a158c2199c6089fa39b92445fb2e66dc0331f8591891239ea3b"`
+
+## Use it
+
+In your [docker-compose.yaml](../docker/compose/docker-compose.yaml), change `camunda/zeebe` to `my-zeebe` to use the newly created image.


### PR DESCRIPTION
## Description

At our company we have an increasing number of ARM-based development machines. Currently there are no pre-built multiarch zeebe docker images and no instructions on building one yourself, this makes getting started with zeebe more difficult than it needs to be.

In this regard, we would like to contribute two things:
* instructions on how to build your own docker image for any platform (placed in `/docs` and linked from the `Helpful Links` section in the readme)
* a slight modification to the Dockerfile that makes it platform independent by removing the SHA version pinning of the base image, so users don't need to look up a fitting SHA for their platform

View the second point as a basis for discussion, we know that there probably is a reason for this solution and we would love to hear your thoughts on why you think that it is needed.

Thanks!

## Related issues

<!-- Which issues are closed by this PR or are related -->

See also: #6155

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
