### PR TITLE
Add activatedElementInstanceKeys to modification record template

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
@@ -2,7 +2,9 @@
   "index_patterns": [
     "zeebe-record_process-instance-modification_*"
   ],
-  "composed_of": ["zeebe-record"],
+  "composed_of": [
+    "zeebe-record"
+  ],
   "priority": 20,
   "version": 1,
   "template": {
@@ -48,6 +50,9 @@
                   }
                 }
               }
+            },
+            "activatedElementInstanceKeys": {
+              "type": "long"
             }
           }
         }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
@@ -80,6 +80,13 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
         .toList();
   }
 
+  @Override
+  public Set<Long> getActivatedElementInstanceKeys() {
+    return activatedElementInstanceKeys.stream()
+        .map(LongValue::getValue)
+        .collect(Collectors.toSet());
+  }
+
   /** Returns true if this record has terminate instructions, otherwise false. */
   @JsonIgnore
   public boolean hasTerminateInstructions() {
@@ -102,12 +109,6 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
       final ProcessInstanceModificationActivateInstruction activateInstruction) {
     activateInstructionsProperty.add().copy(activateInstruction);
     return this;
-  }
-
-  public Set<Long> getActivatedElementInstanceKeys() {
-    return activatedElementInstanceKeys.stream()
-        .map(LongValue::getValue)
-        .collect(Collectors.toSet());
   }
 
   public ProcessInstanceModificationRecord addActivatedElementInstanceKey(final long key) {

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceModificationRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceModificationRecordValue.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -31,6 +32,8 @@ public interface ProcessInstanceModificationRecordValue
 
   /** Returns a list of activate instructions (if available), or an empty list. */
   List<ProcessInstanceModificationActivateInstructionValue> getActivateInstructions();
+
+  Set<Long> getActivatedElementInstanceKeys();
 
   @Value.Immutable
   @ImmutableProtocol(


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Adds the new `activatedElementInstanceKeys` to the modification record template for ElasticSearch.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10732 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
