### PR TITLE
test: close manually to avoid leaks in `ClusteringRuleExtension`

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -63,7 +63,6 @@ import io.camunda.zeebe.shared.ActorClockConfiguration;
 import io.camunda.zeebe.shared.management.ActorClockService.MutableClock;
 import io.camunda.zeebe.snapshots.SnapshotId;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
-import io.camunda.zeebe.test.util.AutoCloseableRule;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
@@ -78,6 +77,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -111,7 +111,7 @@ public class ClusteringRule extends ExternalResource {
 
   private final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
-  private final AutoCloseableRule closeables = new AutoCloseableRule();
+  private final ArrayDeque<AutoCloseable> closeables = new ArrayDeque<>();
   private final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   // configuration
@@ -207,8 +207,7 @@ public class ClusteringRule extends ExternalResource {
 
   @Override
   public Statement apply(final Statement base, final Description description) {
-    Statement statement = recordingExporterTestWatcher.apply(base, description);
-    statement = closeables.apply(statement, description);
+    final var statement = recordingExporterTestWatcher.apply(base, description);
     return temporaryFolder.apply(super.apply(statement, description), description);
   }
 
@@ -260,6 +259,16 @@ public class ClusteringRule extends ExternalResource {
   @Override
   protected void after() {
     LOG.debug("Closing ClusteringRule...");
+    closeables
+        .descendingIterator()
+        .forEachRemaining(
+            autoCloseable -> {
+              try {
+                autoCloseable.close();
+              } catch (final Exception e) {
+                LOG.error("Failed to close managed resource {}", autoCloseable, e);
+              }
+            });
 
     // Previously we used `Collection#parallelStream` in an attempt to achieve the same but
     // that didn't work because requesting a parallel stream does not guarantee that
@@ -443,10 +452,10 @@ public class ClusteringRule extends ExternalResource {
             actorScheduler);
     brokerClient.start();
     final Gateway gateway = new Gateway(gatewayCfg, brokerClient, actorScheduler);
-    closeables.manage(actorScheduler);
-    closeables.manage(gateway::stop);
-    closeables.manage(() -> atomixCluster.stop().join());
-    closeables.manage(brokerClient);
+    closeables.add(actorScheduler);
+    closeables.add(gateway::stop);
+    closeables.add(() -> atomixCluster.stop().join());
+    closeables.add(brokerClient);
     return gateway;
   }
 
@@ -459,7 +468,7 @@ public class ClusteringRule extends ExternalResource {
     clientConfigurator.accept(zeebeClientBuilder);
 
     final ZeebeClient client = zeebeClientBuilder.build();
-    closeables.manage(client);
+    closeables.add(client);
     return client;
   }
 


### PR DESCRIPTION
`ClusteringRule` uses rule chaining to ensure that gateway and client resources will be closed when tests are finished. We wrapped the `ClusteringRule` in `ClusteringRuleExtension` for use in JUnit5. The extension calls `after` and `before` callbacks of the rule, but it does not call `apply` which is responsible for making sure that inner rules such as the `AutoCloseableRule` are also informed about the test lifecycle.

This was already an issue for the recording exporter and that's why the extension had to implement this part again and couldn't rely on `ClusteringRule`. With this change, we let `ClusteringRule` handle closeables directly, without relying on the `AutoCloseableRule`. This ensures that the `after` callback from the extension will actually close all resources created by `ClusteringRule`.

First noticed here: https://github.com/camunda/zeebe/pull/10722#issuecomment-1280694839