### PR TITLE
test: don't fail test if scheduled task runs more often than expected

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceTest.java
@@ -288,7 +288,7 @@ public class ProcessingScheduleServiceTest {
     scheduleService.runAtFixedRate(Duration.ofMillis(10), mockedTask);
 
     // then
-    verify(mockedTask, TIMEOUT.times(5)).execute(any());
+    verify(mockedTask, TIMEOUT.atLeast(5)).execute(any());
   }
 
   @Test


### PR DESCRIPTION
If the test thread was blocked for a while, for example due to garbage collection, verifying that the task ran exactly 5 times within 2 seconds would fail because it ran more often than that.

With this change we just verify that the task ran at least 5 times within 2 seconds.

closes #10745 