### PR TITLE
[Backport stable/8.1] test: don't fail test if scheduled task runs more often than expected

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceTest.java
@@ -288,7 +288,7 @@ public class ProcessingScheduleServiceTest {
     scheduleService.runAtFixedRate(Duration.ofMillis(10), mockedTask);
 
     // then
-    verify(mockedTask, TIMEOUT.times(5)).execute(any());
+    verify(mockedTask, TIMEOUT.atLeast(5)).execute(any());
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #10746 to `stable/8.1`.

relates to #10745