### PR TITLE
[Backport stable/8.1] fix: don't fail on startup if disk usage monitor is disabled

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -48,10 +48,9 @@ public final class BrokerStartupProcess {
 
     result.add(new ClusterServicesStep());
 
-    if (config.getData().isDiskUsageMonitoringEnabled()) {
-      // must be executed before any disk space usage listeners are registered
-      result.add(new DiskSpaceUsageMonitorStep());
-    }
+    // must be executed before any disk space usage listeners are registered
+    result.add(new DiskSpaceUsageMonitorStep());
+
     result.add(new MonitoringServerStep());
     result.add(new BrokerAdminServiceStep());
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/DiskSpaceUsageMonitorStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/DiskSpaceUsageMonitorStep.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
-import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitorActor;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.FileUtil;
@@ -30,7 +30,7 @@ class DiskSpaceUsageMonitorStep extends AbstractBrokerStartupStep {
       return;
     }
 
-    final var diskSpaceUsageMonitor = new DiskSpaceUsageMonitor(data);
+    final var diskSpaceUsageMonitor = new DiskSpaceUsageMonitorActor(data);
 
     final var actorStartFuture =
         brokerStartupContext.getActorSchedulingService().submitActor(diskSpaceUsageMonitor);
@@ -57,9 +57,8 @@ class DiskSpaceUsageMonitorStep extends AbstractBrokerStartupStep {
       final ActorFuture<BrokerStartupContext> shutdownFuture) {
 
     final var diskSpaceUsageMonitor = brokerShutdownContext.getDiskSpaceUsageMonitor();
-
-    if (diskSpaceUsageMonitor != null) {
-      final var closeFuture = diskSpaceUsageMonitor.closeAsync();
+    if (diskSpaceUsageMonitor instanceof DiskSpaceUsageMonitorActor actor) {
+      final var closeFuture = actor.closeAsync();
       concurrencyControl.runOnCompletion(
           closeFuture,
           (ok, error) -> {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/DiskSpaceUsageMonitor.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/DiskSpaceUsageMonitor.java
@@ -7,78 +7,14 @@
  */
 package io.camunda.zeebe.broker.system.monitoring;
 
-import static io.camunda.zeebe.broker.Broker.LOG;
-
-import io.camunda.zeebe.broker.system.configuration.DataCfg;
-import io.camunda.zeebe.scheduler.Actor;
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.time.Duration;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.function.LongSupplier;
 
-public class DiskSpaceUsageMonitor extends Actor {
+public interface DiskSpaceUsageMonitor {
 
-  private final Set<DiskSpaceUsageListener> diskSpaceUsageListeners = new HashSet<>();
-  private boolean currentDiskAvailableStatus = true;
-  private LongSupplier freeDiskSpaceSupplier;
-  private final Duration monitoringDelay;
-  private final long minFreeDiskSpaceRequired;
+  void addDiskUsageListener(DiskSpaceUsageListener listener);
 
-  public DiskSpaceUsageMonitor(final DataCfg dataCfg) {
-    monitoringDelay = dataCfg.getDiskUsageMonitoringInterval();
-    minFreeDiskSpaceRequired = dataCfg.getFreeDiskSpaceCommandWatermark();
-    final var directory = new File(dataCfg.getDirectory());
-
-    if (!directory.exists()) {
-      throw new UncheckedIOException(new IOException("Folder '" + directory + "' does not exist."));
-    }
-    freeDiskSpaceSupplier = directory::getUsableSpace;
-  }
-
-  @Override
-  protected void onActorStarted() {
-    checkDiskUsageAndNotifyListeners();
-    actor.runAtFixedRate(monitoringDelay, this::checkDiskUsageAndNotifyListeners);
-  }
-
-  private void checkDiskUsageAndNotifyListeners() {
-    final long freeDiskSpaceAvailable = freeDiskSpaceSupplier.getAsLong();
-    final boolean previousStatus = currentDiskAvailableStatus;
-    currentDiskAvailableStatus = freeDiskSpaceAvailable >= minFreeDiskSpaceRequired;
-    if (currentDiskAvailableStatus != previousStatus) {
-      if (!currentDiskAvailableStatus) {
-        LOG.warn(
-            "Out of disk space. Current available {} bytes. Minimum needed {} bytes.",
-            freeDiskSpaceAvailable,
-            minFreeDiskSpaceRequired);
-        diskSpaceUsageListeners.forEach(DiskSpaceUsageListener::onDiskSpaceNotAvailable);
-      } else {
-        LOG.info("Disk space available again. Current available {} bytes", freeDiskSpaceAvailable);
-        diskSpaceUsageListeners.forEach(DiskSpaceUsageListener::onDiskSpaceAvailable);
-      }
-    }
-  }
-
-  public void addDiskUsageListener(final DiskSpaceUsageListener listener) {
-    actor.call(
-        () -> {
-          diskSpaceUsageListeners.add(listener);
-          // Listeners always assumes diskspace is available on start. So notify them if it is not.
-          if (!currentDiskAvailableStatus) {
-            listener.onDiskSpaceNotAvailable();
-          }
-        });
-  }
-
-  public void removeDiskUsageListener(final DiskSpaceUsageListener listener) {
-    actor.call(() -> diskSpaceUsageListeners.remove(listener));
-  }
+  void removeDiskUsageListener(DiskSpaceUsageListener listener);
 
   // Used only for testing
-  public void setFreeDiskSpaceSupplier(final LongSupplier freeDiskSpaceSupplier) {
-    this.freeDiskSpaceSupplier = freeDiskSpaceSupplier;
-  }
+  void setFreeDiskSpaceSupplier(LongSupplier freeDiskSpaceSupplier);
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/DiskSpaceUsageMonitor.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/DiskSpaceUsageMonitor.java
@@ -7,9 +7,10 @@
  */
 package io.camunda.zeebe.broker.system.monitoring;
 
+import io.camunda.zeebe.scheduler.AsyncClosable;
 import java.util.function.LongSupplier;
 
-public interface DiskSpaceUsageMonitor {
+public interface DiskSpaceUsageMonitor extends AsyncClosable {
 
   void addDiskUsageListener(DiskSpaceUsageListener listener);
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/DiskSpaceUsageMonitorActor.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/DiskSpaceUsageMonitorActor.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.monitoring;
+
+import static io.camunda.zeebe.broker.Broker.LOG;
+
+import io.camunda.zeebe.broker.system.configuration.DataCfg;
+import io.camunda.zeebe.scheduler.Actor;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.LongSupplier;
+
+public class DiskSpaceUsageMonitorActor extends Actor implements DiskSpaceUsageMonitor {
+
+  private final Set<DiskSpaceUsageListener> diskSpaceUsageListeners = new HashSet<>();
+  private boolean currentDiskAvailableStatus = true;
+  private LongSupplier freeDiskSpaceSupplier;
+  private final Duration monitoringDelay;
+  private final long minFreeDiskSpaceRequired;
+
+  public DiskSpaceUsageMonitorActor(final DataCfg dataCfg) {
+    monitoringDelay = dataCfg.getDiskUsageMonitoringInterval();
+    minFreeDiskSpaceRequired = dataCfg.getFreeDiskSpaceCommandWatermark();
+    final var directory = new File(dataCfg.getDirectory());
+
+    if (!directory.exists()) {
+      throw new UncheckedIOException(new IOException("Folder '" + directory + "' does not exist."));
+    }
+    freeDiskSpaceSupplier = directory::getUsableSpace;
+  }
+
+  @Override
+  protected void onActorStarted() {
+    checkDiskUsageAndNotifyListeners();
+    actor.runAtFixedRate(monitoringDelay, this::checkDiskUsageAndNotifyListeners);
+  }
+
+  private void checkDiskUsageAndNotifyListeners() {
+    final long freeDiskSpaceAvailable = freeDiskSpaceSupplier.getAsLong();
+    final boolean previousStatus = currentDiskAvailableStatus;
+    currentDiskAvailableStatus = freeDiskSpaceAvailable >= minFreeDiskSpaceRequired;
+    if (currentDiskAvailableStatus != previousStatus) {
+      if (!currentDiskAvailableStatus) {
+        LOG.warn(
+            "Out of disk space. Current available {} bytes. Minimum needed {} bytes.",
+            freeDiskSpaceAvailable,
+            minFreeDiskSpaceRequired);
+        diskSpaceUsageListeners.forEach(DiskSpaceUsageListener::onDiskSpaceNotAvailable);
+      } else {
+        LOG.info("Disk space available again. Current available {} bytes", freeDiskSpaceAvailable);
+        diskSpaceUsageListeners.forEach(DiskSpaceUsageListener::onDiskSpaceAvailable);
+      }
+    }
+  }
+
+  @Override
+  public void addDiskUsageListener(final DiskSpaceUsageListener listener) {
+    actor.call(
+        () -> {
+          diskSpaceUsageListeners.add(listener);
+          // Listeners always assumes diskspace is available on start. So notify them if it is not.
+          if (!currentDiskAvailableStatus) {
+            listener.onDiskSpaceNotAvailable();
+          }
+        });
+  }
+
+  @Override
+  public void removeDiskUsageListener(final DiskSpaceUsageListener listener) {
+    actor.call(() -> diskSpaceUsageListeners.remove(listener));
+  }
+
+  // Used only for testing
+  @Override
+  public void setFreeDiskSpaceSupplier(final LongSupplier freeDiskSpaceSupplier) {
+    this.freeDiskSpaceSupplier = freeDiskSpaceSupplier;
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
-import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitorActor;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorScheduler;
@@ -68,7 +68,7 @@ class CommandApiServiceStepTest {
             mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
             Collections.emptyList());
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
-    testBrokerStartupContext.setDiskSpaceUsageMonitor(mock(DiskSpaceUsageMonitor.class));
+    testBrokerStartupContext.setDiskSpaceUsageMonitor(mock(DiskSpaceUsageMonitorActor.class));
     testBrokerStartupContext.setGatewayBrokerTransport(mock(AtomixServerTransport.class));
   }
 
@@ -135,7 +135,7 @@ class CommandApiServiceStepTest {
     @Test
     void shouldAddCommandApiServiceAsDiskSpaceUsageListener() {
       // given
-      final var mockDiskSpaceUsageMonitor = mock(DiskSpaceUsageMonitor.class);
+      final var mockDiskSpaceUsageMonitor = mock(DiskSpaceUsageMonitorActor.class);
       testBrokerStartupContext.setDiskSpaceUsageMonitor(mockDiskSpaceUsageMonitor);
 
       // when
@@ -171,7 +171,7 @@ class CommandApiServiceStepTest {
       testBrokerStartupContext.setGatewayBrokerTransport(mockAtomixServerTransport);
       testBrokerStartupContext.setCommandApiService(mockCommandApiService);
       testBrokerStartupContext.addPartitionListener(mockCommandApiService);
-      testBrokerStartupContext.setDiskSpaceUsageMonitor(mock(DiskSpaceUsageMonitor.class));
+      testBrokerStartupContext.setDiskSpaceUsageMonitor(mock(DiskSpaceUsageMonitorActor.class));
       testBrokerStartupContext
           .getDiskSpaceUsageMonitor()
           .addDiskUsageListener(mockCommandApiService);
@@ -182,7 +182,7 @@ class CommandApiServiceStepTest {
     @Test
     void shouldRemoveCommandApiFromDiskSpaceUsageListenerList() {
       // given
-      final var mockDiskSpaceUsageMonitor = mock(DiskSpaceUsageMonitor.class);
+      final var mockDiskSpaceUsageMonitor = mock(DiskSpaceUsageMonitorActor.class);
       testBrokerStartupContext.setDiskSpaceUsageMonitor(mockDiskSpaceUsageMonitor);
 
       // when

--- a/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/DiskSpaceUsageMonitorStepTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/DiskSpaceUsageMonitorStepTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
+import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitorActor;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
@@ -31,7 +31,7 @@ class DiskSpaceUsageMonitorStepTest {
 
   private BrokerStartupContext mockBrokerStartupContext;
   private ActorSchedulingService mockActorSchedulingService;
-  private DiskSpaceUsageMonitor mockDiskSpaceUsageMonitor;
+  private DiskSpaceUsageMonitorActor mockDiskSpaceUsageMonitor;
 
   private ActorFuture<BrokerStartupContext> future;
 
@@ -41,7 +41,7 @@ class DiskSpaceUsageMonitorStepTest {
   void setUp() {
     mockBrokerStartupContext = mock(BrokerStartupContext.class);
     mockActorSchedulingService = mock(ActorSchedulingService.class);
-    mockDiskSpaceUsageMonitor = mock(DiskSpaceUsageMonitor.class);
+    mockDiskSpaceUsageMonitor = mock(DiskSpaceUsageMonitorActor.class);
 
     when(mockBrokerStartupContext.getBrokerConfiguration()).thenReturn(TEST_BROKER_CONFIG);
     when(mockBrokerStartupContext.getConcurrencyControl()).thenReturn(CONCURRENCY_CONTROL);
@@ -73,7 +73,7 @@ class DiskSpaceUsageMonitorStepTest {
     sut.startupInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
 
     // then
-    final var argumentCaptor = ArgumentCaptor.forClass(DiskSpaceUsageMonitor.class);
+    final var argumentCaptor = ArgumentCaptor.forClass(DiskSpaceUsageMonitorActor.class);
     verify(mockBrokerStartupContext).setDiskSpaceUsageMonitor(argumentCaptor.capture());
     verify(mockActorSchedulingService).submitActor(argumentCaptor.getValue());
   }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/DiskSpaceUsageMonitorTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/DiskSpaceUsageMonitorTest.java
@@ -22,7 +22,7 @@ public class DiskSpaceUsageMonitorTest {
     dataCfg.setDirectory("something-that-does-not-exist");
 
     // when + then
-    assertThatThrownBy(() -> new DiskSpaceUsageMonitor(dataCfg))
+    assertThatThrownBy(() -> new DiskSpaceUsageMonitorActor(dataCfg))
         .isInstanceOf(UncheckedIOException.class)
         .hasMessage("java.io.IOException: Folder 'something-that-does-not-exist' does not exist.");
   }


### PR DESCRIPTION
# Description
Backport of #10749 to `stable/8.1`.

relates to #10735