### PR TITLE
[Backport stable/8.0] Split `ClusteredSnapshotTest`

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -92,7 +92,7 @@
     <version.asm>9.2</version.asm>
     <version.testcontainers>1.16.3</version.testcontainers>
     <version.netflix.concurrency>0.3.6</version.netflix.concurrency>
-    <version.zeebe-test-container>3.3.0</version.zeebe-test-container>
+    <version.zeebe-test-container>3.5.2</version.zeebe-test-container>
     <version.feel-scala>1.14.3</version.feel-scala>
     <version.dmn-scala>1.7.2</version.dmn-scala>
     <version.rest-assured>4.5.1</version.rest-assured>

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SnapshotWithExportersTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SnapshotWithExportersTest.java
@@ -19,6 +19,7 @@ import io.zeebe.containers.ZeebeContainer;
 import io.zeebe.containers.ZeebeVolume;
 import io.zeebe.containers.exporter.DebugReceiver;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
@@ -53,19 +54,14 @@ final class SnapshotWithExportersTest {
 
           // when
           partitions.takeSnapshot();
+          final var snapshotId =
+              Awaitility.await("Snapshot is taken")
+                  .atMost(Duration.ofSeconds(60))
+                  .until(() -> partitions.query().get(1).snapshotId(), Objects::nonNull);
 
           // then
           final var exportedPositionInSnapshot =
-              Awaitility.await("Snapshot is taken")
-                  .atMost(Duration.ofSeconds(60))
-                  .during(Duration.ofSeconds(5))
-                  .until(
-                      () ->
-                          FileBasedSnapshotId.ofFileName(partitions.query().get(1).snapshotId())
-                              .orElseThrow()
-                              .getExportedPosition(),
-                      hasStableValue());
-
+              FileBasedSnapshotMetadata.ofFileName(snapshotId).orElseThrow().getExportedPosition();
           assertThat(exportedPositionInSnapshot).isEqualTo(exporterPosition);
         }
       }
@@ -108,7 +104,8 @@ final class SnapshotWithExportersTest {
                             .orElseThrow(),
                     hasStableValue());
 
-        assertThat(snapshotWithExporters).returns(0L, FileBasedSnapshotMetadata::getExportedPosition);
+        assertThat(snapshotWithExporters)
+            .returns(0L, FileBasedSnapshotMetadata::getExportedPosition);
       }
     }
   }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SnapshotWithExportersTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SnapshotWithExportersTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering;
+
+import static io.camunda.zeebe.test.StableValuePredicate.hasStableValue;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
+import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotMetadata;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.zeebe.containers.ZeebeContainer;
+import io.zeebe.containers.ZeebeVolume;
+import io.zeebe.containers.exporter.DebugReceiver;
+import java.time.Duration;
+import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+final class SnapshotWithExportersTest {
+
+  @Test
+  void shouldIncludeExportedPositionInSnapshot() {
+    // given
+    try (final var debugReceiver =
+        new DebugReceiver((record) -> {}, SocketUtil.getNextAddress(), true).start()) {
+      try (final var zeebe =
+          new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
+              .withDebugExporter(debugReceiver.serverAddress().getPort())) {
+        zeebe.start();
+
+        final var partitions = PartitionsActuator.of(zeebe);
+
+        try (final var client =
+            ZeebeClient.newClientBuilder()
+                .gatewayAddress(zeebe.getExternalGatewayAddress())
+                .usePlaintext()
+                .build()) {
+
+          publishMessages(client);
+          final var exporterPosition =
+              Awaitility.await("Exported position is stable")
+                  .atMost(Duration.ofSeconds(30))
+                  .during(Duration.ofSeconds(5))
+                  .until(() -> partitions.query().get(1).exportedPosition(), hasStableValue());
+          assertThat(exporterPosition).isPositive();
+
+          // when
+          partitions.takeSnapshot();
+
+          // then
+          final var exportedPositionInSnapshot =
+              Awaitility.await("Snapshot is taken")
+                  .atMost(Duration.ofSeconds(60))
+                  .during(Duration.ofSeconds(5))
+                  .until(
+                      () ->
+                          FileBasedSnapshotId.ofFileName(partitions.query().get(1).snapshotId())
+                              .orElseThrow()
+                              .getExportedPosition(),
+                      hasStableValue());
+
+          assertThat(exportedPositionInSnapshot).isEqualTo(exporterPosition);
+        }
+      }
+    }
+  }
+
+  @Test
+  void shouldTakeSnapshotWhenExporterPositionIsMinusOne() {
+    // given -- broker with exporter that does not acknowledge anything
+    try (final var unresponsiveExporterTarget = new DebugReceiver((record) -> {}, false).start()) {
+      try (final var zeebe =
+          new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
+              .withDebugExporter(unresponsiveExporterTarget.serverAddress().getPort())) {
+        zeebe.start();
+
+        try (final var client =
+            ZeebeClient.newClientBuilder()
+                .gatewayAddress(zeebe.getExternalGatewayAddress())
+                .usePlaintext()
+                .build()) {
+          publishMessages(client);
+        }
+
+        final var partitions = PartitionsActuator.of(zeebe);
+        Awaitility.await("Processed position is stable")
+            .atMost(Duration.ofSeconds(60))
+            .during(Duration.ofSeconds(5))
+            .until(() -> partitions.query().get(1).processedPosition(), hasStableValue());
+
+        partitions.takeSnapshot();
+
+        // then -- snapshot has exported position 0
+        final var snapshotWithExporters =
+            Awaitility.await("Snapshot is taken")
+                .atMost(Duration.ofSeconds(60))
+                .during(Duration.ofSeconds(5))
+                .until(
+                    () ->
+                        FileBasedSnapshotMetadata.ofFileName(partitions.query().get(1).snapshotId())
+                            .orElseThrow(),
+                    hasStableValue());
+
+        assertThat(snapshotWithExporters).returns(0L, FileBasedSnapshotMetadata::getExportedPosition);
+      }
+    }
+  }
+
+  @Test
+  void shouldNotTakeNewSnapshotWhenAddingNewExporter() {
+    // given -- snapshot taken by broker without exporters
+    final var dataVolume = ZeebeVolume.newVolume();
+    final FileBasedSnapshotMetadata snapshotWithoutExporters;
+    final FileBasedSnapshotMetadata snapshotWithExporters;
+    try (final var zeebeWithoutExporter =
+        new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
+            .withZeebeData(dataVolume)) {
+      zeebeWithoutExporter.start();
+
+      try (final var client =
+          ZeebeClient.newClientBuilder()
+              .gatewayAddress(zeebeWithoutExporter.getExternalGatewayAddress())
+              .usePlaintext()
+              .build()) {
+        publishMessages(client);
+      }
+
+      final var partitions = PartitionsActuator.of(zeebeWithoutExporter);
+
+      partitions.takeSnapshot();
+      snapshotWithoutExporters =
+          Awaitility.await("Snapshot is taken")
+              .atMost(Duration.ofSeconds(60))
+              .during(Duration.ofSeconds(5))
+              .until(
+                  () ->
+                      FileBasedSnapshotMetadata.ofFileName(partitions.query().get(1).snapshotId())
+                          .orElseThrow(),
+                  hasStableValue());
+    }
+
+    // when -- taking snapshot on broker with exporters configured
+    try (final var debugReceiver =
+        new DebugReceiver((record) -> {}, SocketUtil.getNextAddress()).start()) {
+      try (final var zeebeWithExporter =
+          new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
+              .withZeebeData(dataVolume)
+              .withDebugExporter(debugReceiver.serverAddress().getPort())) {
+        zeebeWithExporter.start();
+
+        final var partitions = PartitionsActuator.of(zeebeWithExporter);
+
+        partitions.takeSnapshot();
+        snapshotWithExporters =
+            Awaitility.await("Snapshot is taken")
+                .atMost(Duration.ofSeconds(60))
+                .during(Duration.ofSeconds(5))
+                .until(
+                    () ->
+                        FileBasedSnapshotMetadata.ofFileName(partitions.query().get(1).snapshotId())
+                            .orElseThrow(),
+                    hasStableValue());
+      }
+    }
+
+    // then -- broker with exporter configured should not have taken a new backup
+    assertThat(snapshotWithExporters).isEqualTo(snapshotWithoutExporters);
+  }
+
+  private void publishMessages(final ZeebeClient client) {
+    IntStream.range(0, 10)
+        .forEach(
+            (i) ->
+                client
+                    .newPublishMessageCommand()
+                    .messageName("msg")
+                    .correlationKey("msg-" + i)
+                    .send()
+                    .join());
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/StableValuePredicate.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/StableValuePredicate.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import org.awaitility.Awaitility;
+
+public final class StableValuePredicate<T> implements Predicate<T> {
+
+  final AtomicReference<T> lastSeen = new AtomicReference<>();
+
+  /**
+   * Used in combination with {@link Awaitility}'s {@link
+   * org.awaitility.core.ConditionFactory#during(Duration)} to ensure that an expression maintains
+   * an arbitrary value over time.
+   *
+   * @return a predicate that accepts a value if it is the same value that was checked in the
+   *     previous call to this predicate.
+   */
+  public static <T> StableValuePredicate<T> hasStableValue() {
+    return new StableValuePredicate<>();
+  }
+
+  @Override
+  public boolean test(final T t) {
+    return Objects.equals(t, lastSeen.getAndSet(t));
+  }
+}


### PR DESCRIPTION
manual backport of #10716 without the commit to migrate to JUnit5