### PR TITLE
feat(engine): support link events

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
@@ -15,9 +15,16 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnVariableMappingBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableIntermediateThrowEvent;
+import java.util.List;
 
 public class IntermediateThrowEventProcessor
     implements BpmnElementProcessor<ExecutableIntermediateThrowEvent> {
+
+  private final List<IntermediateThrowEventBehavior> throwEventBehaviors =
+      List.of(
+          new NoneIntermediateThrowEventBehavior(),
+          new MessageIntermediateThrowEventBehavior(),
+          new LinkIntermediateThrowEventBehavior());
 
   private final BpmnVariableMappingBehavior variableMappingBehavior;
   private final BpmnStateTransitionBehavior stateTransitionBehavior;
@@ -40,43 +47,143 @@ public class IntermediateThrowEventProcessor
 
   @Override
   public void onActivate(
-      final ExecutableIntermediateThrowEvent element, final BpmnElementContext context) {
-
-    if (element.getJobWorkerProperties() != null) {
-      variableMappingBehavior
-          .applyInputMappings(context, element)
-          .flatMap(ok -> jobBehavior.createNewJob(context, element))
-          .ifRightOrLeft(
-              ok -> stateTransitionBehavior.transitionToActivated(context),
-              failure -> incidentBehavior.createIncident(failure, context));
-
-    } else {
-      final var activated = stateTransitionBehavior.transitionToActivated(context);
-      stateTransitionBehavior.completeElement(activated);
-    }
+      final ExecutableIntermediateThrowEvent element, final BpmnElementContext activating) {
+    eventBehaviorOf(element).onActivate(element, activating);
   }
 
   @Override
   public void onComplete(
-      final ExecutableIntermediateThrowEvent element, final BpmnElementContext context) {
-    variableMappingBehavior
-        .applyOutputMappings(context, element)
-        .flatMap(ok -> stateTransitionBehavior.transitionToCompleted(element, context))
-        .ifRightOrLeft(
-            completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed),
-            failure -> incidentBehavior.createIncident(failure, context));
+      final ExecutableIntermediateThrowEvent element, final BpmnElementContext completing) {
+    eventBehaviorOf(element).onComplete(element, completing);
   }
 
   @Override
   public void onTerminate(
-      final ExecutableIntermediateThrowEvent element, final BpmnElementContext context) {
+      final ExecutableIntermediateThrowEvent element, final BpmnElementContext terminating) {
+    eventBehaviorOf(element).onTerminate(element, terminating);
 
-    if (element.getJobWorkerProperties() != null) {
-      jobBehavior.cancelJob(context);
-    }
-
-    final var terminated = stateTransitionBehavior.transitionToTerminated(context);
+    // common behavior for all intermediate throw events
+    final var terminated = stateTransitionBehavior.transitionToTerminated(terminating);
     incidentBehavior.resolveIncidents(terminated);
     stateTransitionBehavior.onElementTerminated(element, terminated);
+  }
+
+  private IntermediateThrowEventBehavior eventBehaviorOf(
+      final ExecutableIntermediateThrowEvent element) {
+    return throwEventBehaviors.stream()
+        .filter(behavior -> behavior.isSuitableForEvent(element))
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new UnsupportedOperationException(
+                    "This kind of intermediate throw event is not supported."));
+  }
+
+  private interface IntermediateThrowEventBehavior {
+
+    boolean isSuitableForEvent(final ExecutableIntermediateThrowEvent element);
+
+    void onActivate(
+        final ExecutableIntermediateThrowEvent element, final BpmnElementContext activating);
+
+    default void onComplete(
+        final ExecutableIntermediateThrowEvent element, final BpmnElementContext completing) {}
+
+    default void onTerminate(
+        final ExecutableIntermediateThrowEvent element, final BpmnElementContext terminating) {}
+  }
+
+  private class NoneIntermediateThrowEventBehavior implements IntermediateThrowEventBehavior {
+
+    @Override
+    public boolean isSuitableForEvent(final ExecutableIntermediateThrowEvent element) {
+      return element.isNoneThrowEvent();
+    }
+
+    @Override
+    public void onActivate(
+        final ExecutableIntermediateThrowEvent element, final BpmnElementContext activating) {
+      final var activated = stateTransitionBehavior.transitionToActivated(activating);
+      stateTransitionBehavior.completeElement(activated);
+    }
+
+    @Override
+    public void onComplete(
+        final ExecutableIntermediateThrowEvent element, final BpmnElementContext completing) {
+      variableMappingBehavior
+          .applyOutputMappings(completing, element)
+          .flatMap(ok -> stateTransitionBehavior.transitionToCompleted(element, completing))
+          .ifRightOrLeft(
+              completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed),
+              failure -> incidentBehavior.createIncident(failure, completing));
+    }
+  }
+
+  private class MessageIntermediateThrowEventBehavior implements IntermediateThrowEventBehavior {
+
+    @Override
+    public boolean isSuitableForEvent(final ExecutableIntermediateThrowEvent element) {
+      return element.isMessageThrowEvent();
+    }
+
+    @Override
+    public void onActivate(
+        final ExecutableIntermediateThrowEvent element, final BpmnElementContext activating) {
+      if (element.getJobWorkerProperties() != null) {
+        variableMappingBehavior
+            .applyInputMappings(activating, element)
+            .flatMap(ok -> jobBehavior.createNewJob(activating, element))
+            .ifRightOrLeft(
+                ok -> stateTransitionBehavior.transitionToActivated(activating),
+                failure -> incidentBehavior.createIncident(failure, activating));
+      }
+    }
+
+    @Override
+    public void onComplete(
+        final ExecutableIntermediateThrowEvent element, final BpmnElementContext completing) {
+      variableMappingBehavior
+          .applyOutputMappings(completing, element)
+          .flatMap(ok -> stateTransitionBehavior.transitionToCompleted(element, completing))
+          .ifRightOrLeft(
+              completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed),
+              failure -> incidentBehavior.createIncident(failure, completing));
+    }
+
+    @Override
+    public void onTerminate(
+        final ExecutableIntermediateThrowEvent element, final BpmnElementContext terminating) {
+      if (element.getJobWorkerProperties() != null) {
+        jobBehavior.cancelJob(terminating);
+      }
+    }
+  }
+
+  private class LinkIntermediateThrowEventBehavior implements IntermediateThrowEventBehavior {
+    @Override
+    public boolean isSuitableForEvent(final ExecutableIntermediateThrowEvent element) {
+      return element.isLinkThrowEvent();
+    }
+
+    @Override
+    public void onActivate(
+        final ExecutableIntermediateThrowEvent element, final BpmnElementContext activating) {
+      final var activated = stateTransitionBehavior.transitionToActivated(activating);
+      stateTransitionBehavior.completeElement(activated);
+    }
+
+    @Override
+    public void onComplete(
+        final ExecutableIntermediateThrowEvent element, final BpmnElementContext completing) {
+      final var link = element.getLink();
+      variableMappingBehavior
+          .applyOutputMappings(completing, element)
+          .flatMap(ok -> stateTransitionBehavior.transitionToCompleted(element, completing))
+          .ifRightOrLeft(
+              completed ->
+                  stateTransitionBehavior.activateElementInstanceInFlowScope(
+                      completed, link.getCatchEventElement()),
+              failure -> incidentBehavior.createIncident(failure, completing));
+    }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEvent.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEvent.java
@@ -21,8 +21,10 @@ public interface ExecutableCatchEvent extends ExecutableFlowElement {
 
   boolean isError();
 
+  boolean isLink();
+
   default boolean isNone() {
-    return !isTimer() && !isMessage() && !isError();
+    return !isTimer() && !isMessage() && !isError() && !isLink();
   }
 
   ExecutableMessage getMessage();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEventElement.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEventElement.java
@@ -28,6 +28,8 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
 
   private boolean isConnectedToEventBasedGateway;
 
+  private boolean isLink;
+
   public ExecutableCatchEventElement(final String id) {
     super(id);
   }
@@ -45,6 +47,11 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
   @Override
   public boolean isError() {
     return error != null;
+  }
+
+  @Override
+  public boolean isLink() {
+    return isLink;
   }
 
   @Override
@@ -73,6 +80,10 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
 
   public void setError(final ExecutableError error) {
     this.error = error;
+  }
+
+  public void setLink(final boolean isLink) {
+    this.isLink = isLink;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableIntermediateThrowEvent.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableIntermediateThrowEvent.java
@@ -12,6 +12,8 @@ public class ExecutableIntermediateThrowEvent extends ExecutableFlowNode
 
   private JobWorkerProperties jobWorkerProperties;
 
+  private ExecutableLink link;
+
   public ExecutableIntermediateThrowEvent(final String id) {
     super(id);
   }
@@ -24,5 +26,25 @@ public class ExecutableIntermediateThrowEvent extends ExecutableFlowNode
   @Override
   public void setJobWorkerProperties(final JobWorkerProperties jobWorkerProperties) {
     this.jobWorkerProperties = jobWorkerProperties;
+  }
+
+  public ExecutableLink getLink() {
+    return link;
+  }
+
+  public void setLink(final ExecutableLink link) {
+    this.link = link;
+  }
+
+  public boolean isNoneThrowEvent() {
+    return !isMessageThrowEvent() && !isLinkThrowEvent();
+  }
+
+  public boolean isMessageThrowEvent() {
+    return jobWorkerProperties != null;
+  }
+
+  public boolean isLinkThrowEvent() {
+    return link != null;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableLink.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableLink.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.element;
+
+import org.agrona.DirectBuffer;
+
+public class ExecutableLink extends AbstractFlowElement {
+
+  private DirectBuffer name;
+
+  private ExecutableCatchEventElement catchEventElement;
+
+  public ExecutableLink(final String id) {
+    super(id);
+  }
+
+  public DirectBuffer getName() {
+    return name;
+  }
+
+  public void setName(final DirectBuffer name) {
+    this.name = name;
+  }
+
+  public void setCatchEvent(final ExecutableCatchEventElement catchEventElement) {
+    this.catchEventElement = catchEventElement;
+  }
+
+  public ExecutableCatchEventElement getCatchEventElement() {
+    return catchEventElement;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableReceiveTask.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableReceiveTask.java
@@ -40,6 +40,11 @@ public class ExecutableReceiveTask extends ExecutableActivity implements Executa
   }
 
   @Override
+  public boolean isLink() {
+    return false;
+  }
+
+  @Override
   public ExecutableMessage getMessage() {
     return message;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
@@ -80,7 +80,6 @@ public final class BpmnTransformer {
     step2Visitor.registerHandler(new ContextProcessTransformer());
     step2Visitor.registerHandler(new EndEventTransformer());
     step2Visitor.registerHandler(new FlowNodeTransformer());
-    step2Visitor.registerHandler(new IntermediateThrowEventTransformer());
     step2Visitor.registerHandler(new JobWorkerElementTransformer<>(ServiceTask.class));
     step2Visitor.registerHandler(new JobWorkerElementTransformer<>(ScriptTask.class));
     step2Visitor.registerHandler(new JobWorkerElementTransformer<>(SendTask.class));
@@ -98,6 +97,7 @@ public final class BpmnTransformer {
     step3Visitor.registerHandler(new SubProcessTransformer());
 
     step4Visitor = new TransformationVisitor();
+    step4Visitor.registerHandler(new IntermediateThrowEventTransformer());
     step4Visitor.registerHandler(new MultiInstanceActivityTransformer());
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/TransformContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/TransformContext.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableError;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableLink;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMessage;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import java.util.ArrayList;
@@ -24,6 +25,7 @@ public final class TransformContext {
   private final Map<DirectBuffer, ExecutableProcess> processes = new HashMap<>();
   private final Map<DirectBuffer, ExecutableMessage> messages = new HashMap<>();
   private final Map<DirectBuffer, ExecutableError> errors = new HashMap<>();
+  private final Map<DirectBuffer, ExecutableLink> links = new HashMap<>();
 
   private ExpressionLanguage expressionLanguage;
 
@@ -66,6 +68,14 @@ public final class TransformContext {
 
   public ExecutableError getError(final String id) {
     return errors.get(wrapString(id));
+  }
+
+  public void addLink(final ExecutableLink link) {
+    links.put(link.getName(), link);
+  }
+
+  public ExecutableLink getLink(final String name) {
+    return links.get(wrapString(name));
   }
 
   public ExpressionLanguage getExpressionLanguage() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/IntermediateThrowEventTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/IntermediateThrowEventTransformer.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.transformer;
 
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableIntermediateThrowEvent;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
 import io.camunda.zeebe.model.bpmn.instance.IntermediateThrowEvent;
+import io.camunda.zeebe.model.bpmn.instance.LinkEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 
@@ -29,6 +31,8 @@ public final class IntermediateThrowEventTransformer
 
     if (isMessageEvent(element) && hasTaskDefinition(element)) {
       jobWorkerElementTransformer.transform(element, context);
+    } else if (isLinkEvent(element)) {
+      transformLinkEventDefinition(element, context);
     }
   }
 
@@ -37,7 +41,25 @@ public final class IntermediateThrowEventTransformer
         .anyMatch(MessageEventDefinition.class::isInstance);
   }
 
+  private boolean isLinkEvent(final IntermediateThrowEvent element) {
+    return element.getEventDefinitions().stream().anyMatch(LinkEventDefinition.class::isInstance);
+  }
+
   private boolean hasTaskDefinition(final IntermediateThrowEvent element) {
     return element.getSingleExtensionElement(ZeebeTaskDefinition.class) != null;
+  }
+
+  private void transformLinkEventDefinition(
+      final IntermediateThrowEvent element, final TransformContext context) {
+    final var process = context.getCurrentProcess();
+    final var executableThrowEventElement =
+        process.getElementById(element.getId(), ExecutableIntermediateThrowEvent.class);
+
+    final var eventDefinition =
+        (LinkEventDefinition) element.getEventDefinitions().iterator().next();
+
+    final var name = eventDefinition.getName();
+    final var executableLink = context.getLink(name);
+    executableThrowEventElement.setLink(executableLink);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/link/LinkEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/link/LinkEventTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.link;
+
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_COMPLETED;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_COMPLETING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.ProcessBuilder;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class LinkEventTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "wf";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldTriggerEvent() {
+    // given
+    final ProcessBuilder processBuilder = Bpmn.createExecutableProcess(PROCESS_ID);
+    processBuilder.startEvent().intermediateThrowEvent("throw", b -> b.link("linkA"));
+    final BpmnModelInstance process =
+        processBuilder.linkCatchEvent("catch").link("linkA").manualTask().endEvent().done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.INTERMEDIATE_THROW_EVENT, ELEMENT_COMPLETING),
+            tuple(BpmnElementType.INTERMEDIATE_THROW_EVENT, ELEMENT_COMPLETED),
+            tuple(BpmnElementType.INTERMEDIATE_CATCH_EVENT, ELEMENT_COMPLETING),
+            tuple(BpmnElementType.INTERMEDIATE_CATCH_EVENT, ELEMENT_COMPLETED),
+            tuple(BpmnElementType.MANUAL_TASK, ELEMENT_COMPLETING),
+            tuple(BpmnElementType.MANUAL_TASK, ELEMENT_COMPLETED),
+            tuple(BpmnElementType.END_EVENT, ELEMENT_COMPLETING),
+            tuple(BpmnElementType.END_EVENT, ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldTriggerEventFromMultipleSources() {
+    // given
+    final ProcessBuilder processBuilder = Bpmn.createExecutableProcess(PROCESS_ID);
+    processBuilder
+        .startEvent()
+        .parallelGateway("parallel")
+        .intermediateThrowEvent("throwA", b -> b.link("link"))
+        .moveToLastGateway()
+        .intermediateThrowEvent("throwB", b -> b.link("link"));
+
+    final BpmnModelInstance process =
+        processBuilder.linkCatchEvent("catch").link("link").manualTask().endEvent().done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ELEMENT_COMPLETED)
+                .limitToProcessInstanceCompleted()
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
+                .count())
+        .isEqualTo(2);
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .describedAs("Expect to complete the process instance")
+        .isTrue();
+  }
+
+  @Test
+  public void shouldTriggerEventWithDifferentLinkEvents() {
+    // given
+    final ProcessBuilder processBuilder = Bpmn.createExecutableProcess(PROCESS_ID);
+    processBuilder.startEvent().intermediateThrowEvent("throwA", b -> b.link("linkA"));
+    processBuilder
+        .linkCatchEvent("catchA")
+        .link("linkA")
+        .intermediateThrowEvent("throwB", b -> b.link("linkB"));
+
+    final BpmnModelInstance process =
+        processBuilder.linkCatchEvent("catchB").link("linkB").endEvent("end").done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("throwA", ELEMENT_COMPLETING),
+            tuple("throwA", ELEMENT_COMPLETED),
+            tuple("catchA", ELEMENT_COMPLETING),
+            tuple("catchA", ELEMENT_COMPLETED),
+            tuple("throwB", ELEMENT_COMPLETING),
+            tuple("throwB", ELEMENT_COMPLETED),
+            tuple("catchB", ELEMENT_COMPLETING),
+            tuple("catchB", ELEMENT_COMPLETED),
+            tuple("end", ELEMENT_COMPLETING),
+            tuple("end", ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ELEMENT_COMPLETING),
+            tuple(PROCESS_ID, ELEMENT_COMPLETED));
+  }
+}


### PR DESCRIPTION
## Description

I can deploy a process that contains link throw or catch events.

I can create an instance of the process. When the process instance enters the link throw event, it activates and completes the throw event in a pass-through semantic.

## Related issues

closes #10563 


## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
