### PR TITLE
Stop raft server when going inactive due to unrecoverable errors

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -247,7 +247,7 @@ public class RaftPartition implements Partition, HealthMonitorable {
   }
 
   public CompletableFuture<Void> goInactive() {
-    return server.goInactive();
+    return server.stop();
   }
 
   public PartitionMetadata getMetadata() {

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -246,7 +246,7 @@ public class RaftPartition implements Partition, HealthMonitorable {
         && primary.get() != server.getMemberId();
   }
 
-  public CompletableFuture<Void> goInactive() {
+  public CompletableFuture<Void> stop() {
     return server.stop();
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -374,7 +374,6 @@ public final class ZeebePartition extends Actor
     final var report = HealthReport.dead(this).withIssue(error);
     healthMetrics.setDead();
     zeebePartitionHealth.onUnrecoverableFailure(error);
-    transitionToInactive();
     context.getRaftPartition().goInactive();
     failureListeners.forEach((l) -> l.onUnrecoverableFailure(report));
     context.notifyListenersOfBecomingInactive();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -366,7 +366,7 @@ public final class ZeebePartition extends Actor
           context.getPartitionId(),
           context.getCurrentRole(),
           context.getCurrentTerm());
-      context.getRaftPartition().goInactive();
+      context.getRaftPartition().stop();
     }
   }
 
@@ -374,7 +374,7 @@ public final class ZeebePartition extends Actor
     final var report = HealthReport.dead(this).withIssue(error);
     healthMetrics.setDead();
     zeebePartitionHealth.onUnrecoverableFailure(error);
-    context.getRaftPartition().goInactive();
+    context.getRaftPartition().stop();
     failureListeners.forEach((l) -> l.onUnrecoverableFailure(report));
     context.notifyListenersOfBecomingInactive();
   }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -232,7 +232,7 @@ public class ZeebePartitionTest {
     order.verify(transition).toLeader(2);
     // after failing leader transition no other
     // transitions are triggered
-    order.verify(raft, times(0)).goInactive();
+    order.verify(raft, times(0)).stop();
     order.verify(transition, times(0)).toFollower(anyLong());
   }
 
@@ -251,7 +251,7 @@ public class ZeebePartitionTest {
             });
     when(raft.getRole()).thenReturn(Role.FOLLOWER);
     when(ctx.getCurrentRole()).thenReturn(Role.FOLLOWER);
-    when(raft.goInactive())
+    when(raft.stop())
         .then(
             invocation -> {
               partition.onNewRole(Role.INACTIVE, 2);
@@ -267,7 +267,7 @@ public class ZeebePartitionTest {
     // then
     final InOrder order = inOrder(transition, raft);
     order.verify(transition).toFollower(0L);
-    order.verify(raft).goInactive();
+    order.verify(raft).stop();
     order.verify(transition).toInactive(anyLong());
   }
 
@@ -288,7 +288,7 @@ public class ZeebePartitionTest {
     // then
     final InOrder order = inOrder(transition, raft);
     order.verify(transition).toLeader(0L);
-    order.verify(raft).goInactive();
+    order.verify(raft).stop();
   }
 
   @Test


### PR DESCRIPTION
## Description

Previously, it was transitioning to inactive. But, in the configuration the member is still marked as active. As a result, the member transition back to active when it gets a new message from the leader. We cannot change the configuration, and mark this member as inactive because that would mean we are changing the quorum. What we really requires is that this partition is "dead" (atleast temporarily) so that it doesn't become leader again. We also don't want it to become a follower because this can also lead to partial functionality which can cause problems. For example, in follower role, raft is replicating events, but the streamprocessor or snapshotting is not working because of this error. So it is not able to compact the logs. This will eventually leads to disk space full and thus affecting other possibly healthy partitions.

To fix this, in this PR we stop the raft server instead of only transitioning to inactive. The replication factor and quorum remains the same. But this node cannot become leader again until the member is restarted.

## Related issues

closes #9924

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
