### PR TITLE
Fix activation of Parallel Gateway through Process Instance Modification

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -190,9 +190,6 @@ public final class ProcessInstanceModificationProcessor
                                   process,
                                   instruction));
 
-                  activatedElementKeys
-                      .getFlowScopeKeys()
-                      .forEach(value::addActivatedElementInstanceKey);
                   extendedRecord.addActivateInstruction(
                       ((ProcessInstanceModificationActivateInstruction) instruction)
                           .addAncestorScopeKeys(activatedElementKeys.getFlowScopeKeys()));

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -152,7 +152,8 @@ public final class EventAppliers implements EventApplier {
   private void registerProcessInstanceModificationAppliers(final MutableZeebeState state) {
     register(
         ProcessInstanceModificationIntent.MODIFIED,
-        new ProcessInstanceModifiedEventApplier(state.getElementInstanceState()));
+        new ProcessInstanceModifiedEventApplier(
+            state.getElementInstanceState(), state.getProcessState()));
   }
 
   private void registerJobIntentEventAppliers(final MutableZeebeState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceModifiedEventApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceModifiedEventApplier.java
@@ -7,25 +7,39 @@
  */
 package io.camunda.zeebe.engine.state.appliers;
 
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.util.Collections;
 
 final class ProcessInstanceModifiedEventApplier
     implements TypedEventApplier<
         ProcessInstanceModificationIntent, ProcessInstanceModificationRecord> {
 
   private final MutableElementInstanceState elementInstanceState;
+  private final MutableProcessState processState;
 
   public ProcessInstanceModifiedEventApplier(
-      final MutableElementInstanceState elementInstanceState) {
+      final MutableElementInstanceState elementInstanceState,
+      final MutableProcessState processState) {
     this.elementInstanceState = elementInstanceState;
+    this.processState = processState;
   }
 
   @Override
   public void applyState(final long key, final ProcessInstanceModificationRecord value) {
+    if (value.hasActivateInstructions()) {
+      clearInterruptedState(value);
+      incrementNumberOfTakenSequenceFlows(value);
+    }
+  }
+
+  private void clearInterruptedState(final ProcessInstanceModificationRecord value) {
     value.getActivatedElementInstanceKeys().stream()
         .map(elementInstanceState::getInstance)
         .filter(ElementInstance::isInterrupted)
@@ -33,5 +47,35 @@ final class ProcessInstanceModifiedEventApplier
             instance ->
                 elementInstanceState.updateInstance(
                     instance.getKey(), ElementInstance::clearInterruptedState));
+  }
+
+  private void incrementNumberOfTakenSequenceFlows(final ProcessInstanceModificationRecord value) {
+    final ElementInstance processInstance =
+        elementInstanceState.getInstance(value.getProcessInstanceKey());
+    final var process =
+        processState
+            .getProcessByKey(processInstance.getValue().getProcessDefinitionKey())
+            .getProcess();
+    value
+        .getActivateInstructions()
+        .forEach(
+            instruction -> {
+              final var element =
+                  process.getElementById(instruction.getElementId(), ExecutableFlowNode.class);
+              if (!element.getElementType().equals(BpmnElementType.PARALLEL_GATEWAY)) {
+                return;
+              }
+
+              // Parent scopes are created in order from outer scope to inner scope. This means that
+              // the parent flow scope of the element that must be activated will always be the
+              // highest key in the set.
+              final var parentFlowScopeKey = Collections.max(instruction.getAncestorScopeKeys());
+              element
+                  .getIncoming()
+                  .forEach(
+                      incoming ->
+                          elementInstanceState.incrementNumberOfTakenSequenceFlows(
+                              parentFlowScopeKey, element.getId(), incoming.getId()));
+            });
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceModifiedEventApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceModifiedEventApplier.java
@@ -40,7 +40,7 @@ final class ProcessInstanceModifiedEventApplier
   }
 
   private void clearInterruptedState(final ProcessInstanceModificationRecord value) {
-    value.getActivatedElementInstanceKeys().stream()
+    value.getAncestorScopeKeys().stream()
         .map(elementInstanceState::getInstance)
         .filter(ElementInstance::isInterrupted)
         .forEach(

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
@@ -48,6 +48,9 @@
                       "type": "keyword"
                     }
                   }
+                },
+                "ancestorScopeKeys": {
+                  "type": "long"
                 }
               }
             },

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-modification-template.json
@@ -54,7 +54,7 @@
                 }
               }
             },
-            "activatedElementInstanceKeys": {
+            "ancestorScopeKeys": {
               "type": "long"
             }
           }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
@@ -30,6 +30,8 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
       activateInstructionsProperty =
           new ArrayProperty<>(
               "activateInstructions", new ProcessInstanceModificationActivateInstruction());
+
+  @Deprecated(since = "8.1.3")
   private final ArrayProperty<LongValue> activatedElementInstanceKeys =
       new ArrayProperty<>("activatedElementInstanceKeys", new LongValue());
 
@@ -81,10 +83,20 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
   }
 
   @Override
-  public Set<Long> getActivatedElementInstanceKeys() {
-    return activatedElementInstanceKeys.stream()
-        .map(LongValue::getValue)
-        .collect(Collectors.toSet());
+  public Set<Long> getAncestorScopeKeys() {
+    final Set<Long> activatedElementInstanceKeys =
+        this.activatedElementInstanceKeys.stream()
+            .map(LongValue::getValue)
+            .collect(Collectors.toSet());
+    // For backwards compatibility's sake we have to add the ancestor scope keys of all activate
+    // instructions, as from version 8.1.3 on the activatedElementInstanceKeys property is no longer
+    // filled.
+    activatedElementInstanceKeys.addAll(
+        getActivateInstructions().stream()
+            .map(ProcessInstanceModificationActivateInstructionValue::getAncestorScopeKeys)
+            .flatMap(Set::stream)
+            .collect(Collectors.toSet()));
+    return activatedElementInstanceKeys;
   }
 
   /** Returns true if this record has terminate instructions, otherwise false. */
@@ -108,11 +120,6 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
   public ProcessInstanceModificationRecord addActivateInstruction(
       final ProcessInstanceModificationActivateInstruction activateInstruction) {
     activateInstructionsProperty.add().copy(activateInstruction);
-    return this;
-  }
-
-  public ProcessInstanceModificationRecord addActivatedElementInstanceKey(final long key) {
-    activatedElementInstanceKeys.add().setValue(key);
     return this;
   }
 

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -57,6 +57,7 @@ import java.io.StringWriter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -770,7 +771,8 @@ final class JsonSerializableToJsonTest {
                           .addVariableInstruction(
                               new ProcessInstanceModificationVariableInstruction()
                                   .setVariables(VARIABLES_MSGPACK)
-                                  .setElementId(variableInstructionElementId)));
+                                  .setElementId(variableInstructionElementId))
+                          .addAncestorScopeKeys(Set.of(key, ancestorScopeKey)));
             },
         """
         {
@@ -786,9 +788,10 @@ final class JsonSerializableToJsonTest {
                 "foo": "bar"
               }
             }],
-            "elementId": "activity"
+            "elementId": "activity",
+            "ancestorScopeKeys": [1,3]
           }],
-          "activatedElementInstanceKeys": []
+          "ancestorScopeKeys": [1,3]
         }
         """
       },
@@ -805,7 +808,7 @@ final class JsonSerializableToJsonTest {
           "processInstanceKey": 1,
           "terminateInstructions": [],
           "activateInstructions": [],
-          "activatedElementInstanceKeys": []
+          "ancestorScopeKeys": []
         }
         """
       },

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceModificationRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceModificationRecordValue.java
@@ -33,7 +33,15 @@ public interface ProcessInstanceModificationRecordValue
   /** Returns a list of activate instructions (if available), or an empty list. */
   List<ProcessInstanceModificationActivateInstructionValue> getActivateInstructions();
 
-  Set<Long> getActivatedElementInstanceKeys();
+  /**
+   * Returns a list of all ancestor keys of all activate instructions. The property is set in the
+   * event only after the modification is applied.
+   *
+   * @deprecated since 8.1.3, replaced by {@link
+   *     ProcessInstanceModificationActivateInstructionValue#getAncestorScopeKeys()}
+   */
+  @Deprecated
+  Set<Long> getAncestorScopeKeys();
 
   @Value.Immutable
   @ImmutableProtocol(
@@ -77,7 +85,10 @@ public interface ProcessInstanceModificationRecordValue
     /** Returns a list of variable instructions (if available), or an empty list. */
     List<ProcessInstanceModificationVariableInstructionValue> getVariableInstructions();
 
-    /** Returns all ancestor scope keys of the element that will be activated. */
+    /**
+     * Returns all ancestor scope keys of the element that will be activated. The property is set in
+     * the event only after the modification is applied.
+     */
     Set<Long> getAncestorScopeKeys();
   }
 

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceModificationRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceModificationRecordValue.java
@@ -76,6 +76,9 @@ public interface ProcessInstanceModificationRecordValue
 
     /** Returns a list of variable instructions (if available), or an empty list. */
     List<ProcessInstanceModificationVariableInstructionValue> getVariableInstructions();
+
+    /** Returns all ancestor scope keys of the element that will be activated. */
+    Set<Long> getAncestorScopeKeys();
   }
 
   @Value.Immutable


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Activating a Parallel Gateway was not possible due to a failing check if the correct amount of active sequence have been taken. This PR will increment the amount of taken sequence upon when the activate instructions contain a parallel gateway. This is done in the `ProcessInstance.MODIFIED` event applier.

One edge case that is not supported with this change is the following scenario:
<img width="684" alt="image" src="https://user-images.githubusercontent.com/5787702/196986426-bdff96b0-e47f-4063-956e-c007e1aa2a13.png">
If I want to modify this process by putting an activation on task A and on the joining gateway, the gateway will be activated immediately. Task A will be executed and will start waiting at the gateway again, meaning the process will be stuck). The gateway will not wait for task A before continuing. I could not think of a simple solution to solve this problem.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10518

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
