### PR TITLE
Add record and intent for escalation

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -587,6 +587,7 @@
         #     deployment: true
         #     deploymentDistribution: true
         #     error: true
+        #     escalation: true
         #     incident: true
         #     job: true
         #     jobBatch: false

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -525,6 +525,7 @@
         #     deployment: true
         #     deploymentDistribution: true
         #     error: true
+        #     escalation: true
         #     incident: true
         #     job: true
         #     jobBatch: false

--- a/exporters/elasticsearch-exporter/README.md
+++ b/exporters/elasticsearch-exporter/README.md
@@ -124,15 +124,21 @@ More specifically, each option configures the following:
   exported; if false, ignored.
 * `deployment` (`boolean`): if true, records related to deployments will be exported; if false,
   ignored.
+* `deploymentDistribution` (`boolean`): if true, records related to deployment distributions will be exported; if false,
+  ignored.
 * `error` (`boolean`): if true, records related to errors will be exported; if false, ignored.
+* `escalation` (`boolean`): if true, records related to escalations will be exported; if false, ignored.
 * `incident` (`boolean`): if true, records related to incidents will be exported; if false, ignored.
 * `job` (`boolean`): if true, records related to jobs will be exported; if false, ignored.
 * `jobBatch` (`boolean`): if true, records related to job batches will be exported; if false,
   ignored.
 * `message` (`boolean`): if true, records related to messages will be exported; if false, ignored.
 * `messageSubscription` (`boolean`): if true, records related to message subscriptions will be
+* `messageStartSubscription` (`boolean`): if true, records related to message start subscriptions will be
   exported; if false, ignored.
 * `process` (`boolean`): if true, records related to processes will be exported; if false, ignored.
+* `processEvent` (`boolean`): if true, records related to process events will be exported; if
+  false, ignored.
 * `processInstance` (`boolean`): if true, records related to process instances will be exported; if
   false, ignored.
 * `processInstanceCreation` (`boolean`): if true, records related to process instance creations will
@@ -141,6 +147,7 @@ More specifically, each option configures the following:
   be exported; if false, ignored.
 * `processMessageSubscription` (`boolean`): if true, records related to process message
   subscriptions will be exported; if false, ignored.
+* `timer` (`boolean`): if true, records related to timers will be exported; if false, ignored.
 * `variable` (`boolean`): if true, records related to variables will be exported; if false, ignored.
 * `variableDocument` (`boolean`): if true, records related to variable documents will be exported;
    if false, ignored.
@@ -188,6 +195,7 @@ exporters:
         deployment: true
         deploymentDistribution: true
         error: true
+        escalation: true
         incident: true
         job: true
         jobBatch: false

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -212,6 +212,9 @@ public class ElasticsearchExporter implements Exporter {
       if (index.deploymentDistribution) {
         createValueIndexTemplate(ValueType.DEPLOYMENT_DISTRIBUTION);
       }
+      if (index.escalation) {
+        createValueIndexTemplate(ValueType.ESCALATION);
+      }
     }
 
     indexTemplatesCreated = true;

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -97,6 +97,8 @@ public class ElasticsearchExporterConfiguration {
         return index.processEvent;
       case DEPLOYMENT_DISTRIBUTION:
         return index.deploymentDistribution;
+      case ESCALATION:
+        return index.escalation;
       default:
         return false;
     }
@@ -151,6 +153,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean messageStartEventSubscription = true;
     public boolean processEvent = false;
     public boolean deploymentDistribution = true;
+    public boolean escalation = true;
 
     // index settings
     private Integer numberOfShards = null;
@@ -228,6 +231,8 @@ public class ElasticsearchExporterConfiguration {
           + processEvent
           + ", deploymentDistribution="
           + deploymentDistribution
+          + ", escalation="
+          + escalation
           + '}';
     }
   }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-escalation-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-escalation-template.json
@@ -1,0 +1,39 @@
+{
+  "index_patterns": [
+    "zeebe-record_escalation_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-escalation": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "processInstanceKey": {
+              "type": "long"
+            },
+            "escalationCode": {
+              "type": "keyword"
+            },
+            "throwElementId": {
+              "type": "keyword"
+            },
+            "catchElementId": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -71,6 +71,7 @@ final class TestSupport {
       case MESSAGE_START_EVENT_SUBSCRIPTION -> config.messageStartEventSubscription = value;
       case PROCESS_EVENT -> config.processEvent = value;
       case DEPLOYMENT_DISTRIBUTION -> config.deploymentDistribution = value;
+      case ESCALATION -> config.escalation = value;
       default -> throw new IllegalArgumentException(
           "No known indexing configuration option for value type " + valueType);
     }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/escalation/EscalationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/escalation/EscalationRecord.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.escalation;
+
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.EscalationRecordValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+
+public class EscalationRecord extends UnifiedRecordValue implements EscalationRecordValue {
+
+  private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
+  private final StringProperty escalationCodeProp = new StringProperty("escalationCode", "");
+  private final StringProperty throwElementIdProp = new StringProperty("throwElementId", "");
+  private final StringProperty catchElementIdProp = new StringProperty("catchElementId", "");
+
+  public EscalationRecord() {
+    declareProperty(processInstanceKeyProp)
+        .declareProperty(escalationCodeProp)
+        .declareProperty(throwElementIdProp)
+        .declareProperty(catchElementIdProp);
+  }
+
+  public void wrap(final EscalationRecord record) {
+    processInstanceKeyProp.setValue(record.getProcessInstanceKey());
+    escalationCodeProp.setValue(record.getEscalationCode());
+    throwElementIdProp.setValue(record.getThrowElementId());
+    catchElementIdProp.setValue(record.getCatchElementId());
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
+  }
+
+  @Override
+  public String getEscalationCode() {
+    return BufferUtil.bufferAsString(escalationCodeProp.getValue());
+  }
+
+  public EscalationRecord setEscalationCode(final String escalationCode) {
+    escalationCodeProp.setValue(escalationCode);
+    return this;
+  }
+
+  @Override
+  public String getThrowElementId() {
+    return BufferUtil.bufferAsString(throwElementIdProp.getValue());
+  }
+
+  @Override
+  public String getCatchElementId() {
+    return BufferUtil.bufferAsString(catchElementIdProp.getValue());
+  }
+
+  public EscalationRecord setCatchElementId(final DirectBuffer catchElementId) {
+    catchElementIdProp.setValue(catchElementId);
+    return this;
+  }
+
+  public EscalationRecord setThrowElementId(final DirectBuffer throwElementId) {
+    throwElementIdProp.setValue(throwElementId);
+    return this;
+  }
+
+  public EscalationRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProp.setValue(processInstanceKey);
+    return this;
+  }
+}

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentDistribu
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
+import io.camunda.zeebe.protocol.impl.record.value.escalation.EscalationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -1038,6 +1039,43 @@ final class JsonSerializableToJsonTest {
           {
               "checkpointId":1,
               "checkpointPosition":10
+          }
+          """
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// Escalation record /////////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Escalation record",
+        (Supplier<UnifiedRecordValue>)
+            () ->
+                new EscalationRecord()
+                    .setProcessInstanceKey(4L)
+                    .setEscalationCode("escalation")
+                    .setThrowElementId(wrapString("throw"))
+                    .setCatchElementId(wrapString("catch")),
+        """
+          {
+              "processInstanceKey":4,
+              "escalationCode": "escalation",
+              "throwElementId": "throw",
+              "catchElementId": "catch"
+          }
+          """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// Empty EscalationRecord ////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty EscalationRecord",
+        (Supplier<UnifiedRecordValue>) EscalationRecord::new,
+        """
+          {
+              "processInstanceKey":-1,
+              "escalationCode": "",
+              "throwElementId": "",
+              "catchElementId": ""
           }
           """
       },

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
+import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
@@ -43,6 +44,7 @@ import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
+import io.camunda.zeebe.protocol.record.value.EscalationRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
@@ -172,6 +174,8 @@ public final class ValueTypeMapping {
         new Mapping<>(VariableDocumentRecordValue.class, VariableDocumentIntent.class));
     mapping.put(
         ValueType.CHECKPOINT, new Mapping<>(CheckpointRecordValue.class, CheckpointIntent.class));
+    mapping.put(
+        ValueType.ESCALATION, new Mapping<>(EscalationRecordValue.class, EscalationIntent.class));
 
     return mapping;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/EscalationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/EscalationIntent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum EscalationIntent implements Intent {
+  ESCALATED((short) 0),
+
+  NOT_ESCALATED((short) 1);
+
+  private final short value;
+
+  EscalationIntent(final short value) {
+    this.value = value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return ESCALATED;
+      case 1:
+        return NOT_ESCALATED;
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -24,6 +24,7 @@ public interface Intent {
   Collection<Class<? extends Intent>> INTENT_CLASSES =
       Arrays.asList(
           DeploymentIntent.class,
+          EscalationIntent.class,
           IncidentIntent.class,
           JobIntent.class,
           ProcessInstanceIntent.class,
@@ -111,6 +112,8 @@ public interface Intent {
         return DecisionEvaluationIntent.from(intent);
       case CHECKPOINT:
         return CheckpointIntent.from(intent);
+      case ESCALATION:
+        return EscalationIntent.from(intent);
       case PROCESS_INSTANCE_MODIFICATION:
         return ProcessInstanceModificationIntent.from(intent);
       case NULL_VAL:
@@ -170,6 +173,8 @@ public interface Intent {
         return DecisionEvaluationIntent.valueOf(intent);
       case CHECKPOINT:
         return CheckpointIntent.valueOf(intent);
+      case ESCALATION:
+        return EscalationIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EscalationRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EscalationRecordValue.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
+import org.immutables.value.Value;
+
+/**
+ * Represents an escalation event
+ *
+ * <p>See {@link EscalationIntent} for intents.
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableEscalationRecordValue.Builder.class)
+public interface EscalationRecordValue extends RecordValue {
+
+  /**
+   * @return the key of the process instance
+   */
+  long getProcessInstanceKey();
+
+  /**
+   * @return the code of the escalation
+   */
+  String getEscalationCode();
+
+  /**
+   * @return the id of the escalation throw event
+   */
+  String getThrowElementId();
+
+  /**
+   * @return the id of the escalation catch event
+   */
+  String getCatchElementId();
+}

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -43,6 +43,7 @@
       <validValue name="DECISION_REQUIREMENTS">26</validValue>
       <validValue name="DECISION_EVALUATION">27</validValue>
       <validValue name="PROCESS_INSTANCE_MODIFICATION">28</validValue>
+      <validValue name="ESCALATION">29</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="CHECKPOINT">254</validValue>

--- a/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
+++ b/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
@@ -72,6 +72,7 @@ final class IntentEncodingDecodingTest {
     result.addAll(buildParameterSets(VariableDocumentIntent.class, VariableDocumentIntent::from));
     result.addAll(buildParameterSets(VariableIntent.class, VariableIntent::from));
     result.addAll(buildParameterSets(CheckpointIntent.class, CheckpointIntent::from));
+    result.addAll(buildParameterSets(EscalationIntent.class, EscalationIntent::from));
 
     return result.stream();
   }


### PR DESCRIPTION
## Description
Add record and intent for escalation and export escalation record to ES.

## Related issues
closes #10762 
closes #10767

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
