### PR TITLE
[Backport stable/8.1] ci: fix dependabot PR approval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,6 +565,7 @@ jobs:
       checks: read
       pull-requests: write
     steps:
+      - uses: actions/checkout@v3
       - id: metadata
         name: Fetch dependency metadata
         uses: dependabot/fetch-metadata@v1.3.4


### PR DESCRIPTION
# Description
Backport of #10666 to `stable/8.1`.

relates to 