### PR TITLE
[Backport stable/8.0] deps(maven): bump scala-library from 2.13.8 to 2.13.9

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -83,7 +83,7 @@
     <version.rocksdbjni>6.28.2</version.rocksdbjni>
     <version.sbe>1.25.2</version.sbe>
     <version.scala-parser>2.1.1</version.scala-parser>
-    <version.scala>2.13.8</version.scala>
+    <version.scala>2.13.9</version.scala>
     <version.slf4j>1.7.36</version.slf4j>
     <version.snakeyaml>1.30</version.snakeyaml>
     <version.javax>1.3.2</version.javax>


### PR DESCRIPTION
## Description

Manual backport of https://github.com/camunda/zeebe/pull/10405 to `stable/8.0`.

closes #10801