### PR TITLE
[Backport stable/8.1] build(docker): update base image to fix CVE-2022-2068

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Override this based on the architecture; this is currently pointing to amd64
-ARG BASE_SHA="fce37e5146419a158c2199c6089fa39b92445fb2e66dc0331f8591891239ea3b"
+ARG BASE_SHA="e7fe469c4e729ff0ed6ff464f41eaff0e4cb9b6fe7efe71754d8935c8118eb87"
 
 # Building builder image
 FROM ubuntu:focal as builder

--- a/docker/test/docker-labels.golden.json
+++ b/docker/test/docker-labels.golden.json
@@ -5,7 +5,7 @@
   "io.openshift.non-scalable": "false",
   "io.openshift.tags": "bpmn,orchestration,workflow",
   "org.opencontainers.image.authors": "zeebe@camunda.com",
-  "org.opencontainers.image.base.digest": "fce37e5146419a158c2199c6089fa39b92445fb2e66dc0331f8591891239ea3b",
+  "org.opencontainers.image.base.digest": "e7fe469c4e729ff0ed6ff464f41eaff0e4cb9b6fe7efe71754d8935c8118eb87",
   "org.opencontainers.image.base.name": "docker.io/library/eclipse-temurin:17-jre-focal",
   "org.opencontainers.image.created": $DATE,
   "org.opencontainers.image.description": "Workflow engine for microservice orchestration",


### PR DESCRIPTION
# Description
Backport of #10810 to `stable/8.1`.

relates to #10800