### PR TITLE
Setup benchmark GHA workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: merge branch into medic-cw-benchmarks
         run: |
+          git fetch origin medic-cw-benchmarks
           git checkout medic-cw-benchmarks
           git merge ${{ github.event.inputs.branch }} --no-edit
           # git push origin medic-cw-benchmarks

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,46 @@
+# Creates and starts a benchmark cluster
+name: Benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Specifies the branch to benchmark'
+        default: 'main'
+        required: false
+
+jobs:
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:    
+      - uses: actions/checkout@v3
+        with:
+          ref: "${{ github.event.inputs.branch }}"
+      
+      - name: determine current calendar week
+        run: export CURRENT_CW=$(date +%V)
+      - name: determine currently checked out commit sha
+        run: export CURRENT_SHA=$(git rev-parse --short HEAD)
+
+      - name: merge branch into medic-cw-benchmarks
+        run: |
+          git checkout medic-cw-benchmarks
+          git merge ${{ github.event.inputs.branch }} --no-edit
+          # git push origin medic-cw-benchmarks
+      
+      - uses: ./.github/actions/setup-zeebe
+        with:
+          maven-cache: 'true'
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C
+      - uses: ./.github/actions/build-docker
+        with:
+          repository: gcr.io/zeebe-io/zeebe
+          version: medic-cw-${{ env.CURRENT_CW }}-${{ env.CURRENT_SHA }}-benchmark
+          push: false
+          distball: ${{ steps.build-zeebe.outputs.distball }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,9 +23,9 @@ jobs:
       
       - name: determine benchmark name
         run: |
-          echo "CURRENT_CW=$(date +%V)" >> $GITHUB_ENV
-          echo "CURRENT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-          echo "BENCHMARK_NAME=medic-cw-$CURRENT_CW-$CURRENT_SHA-benchmark" >> $GITHUB_ENV
+          export CURRENT_CW=$(date +%V)
+          export CURRENT_SHA=$(git rev-parse --short HEAD)
+          echo "BENCHMARK_NAME=medic-cw-${CURRENT_CW}-${CURRENT_SHA}-benchmark" >> $GITHUB_ENV
 
       - name: merge branch into medic-cw-benchmarks
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,9 +22,9 @@ jobs:
           ref: "${{ github.event.inputs.branch }}"
       
       - name: determine current calendar week
-        run: export CURRENT_CW=$(date +%V)
+        run: echo "CURRENT_CW=$(date +%V)" >> $GITHUB_ENV
       - name: determine currently checked out commit sha
-        run: export CURRENT_SHA=$(git rev-parse --short HEAD)
+        run: echo "CURRENT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: merge branch into medic-cw-benchmarks
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,10 +21,11 @@ jobs:
         with:
           ref: "${{ github.event.inputs.branch }}"
       
-      - name: determine current calendar week
-        run: echo "CURRENT_CW=$(date +%V)" >> $GITHUB_ENV
-      - name: determine currently checked out commit sha
-        run: echo "CURRENT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - name: determine benchmark name
+        run: |
+          echo "CURRENT_CW=$(date +%V)" >> $GITHUB_ENV
+          echo "CURRENT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "BENCHMARK_NAME=medic-cw-$CURRENT_CW-$CURRENT_SHA-benchmark" >> $GITHUB_ENV
 
       - name: merge branch into medic-cw-benchmarks
         run: |
@@ -43,6 +44,16 @@ jobs:
       - uses: ./.github/actions/build-docker
         with:
           repository: gcr.io/zeebe-io/zeebe
-          version: medic-cw-${{ env.CURRENT_CW }}-${{ env.CURRENT_SHA }}-benchmark
+          version: ${{ env.BENCHMARK_NAME }}
           push: false
           distball: ${{ steps.build-zeebe.outputs.distball }}
+
+      - name: build benchmark project
+        run: |
+          cd benchmarks/project
+          sed -i -e "s/:SNAPSHOT/:$BENCHMARK_NAME/" docker-compose.yml
+          # Use --no-cache to force re-build the application.
+          # Without this flag, changes to zeebe-client were not picked up.
+          # This can take longer to build than usual.
+          docker-compose build --no-cache
+          # docker-compose push

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           repository: gcr.io/zeebe-io/zeebe
           version: ${{ env.BENCHMARK_NAME }}
-          push: false
+          push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
 
       - name: build benchmark project
@@ -56,4 +56,4 @@ jobs:
           # Without this flag, changes to zeebe-client were not picked up.
           # This can take longer to build than usual.
           docker compose build --no-cache
-          # docker-compose push
+          docker compose push

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,6 +8,7 @@ on:
         description: 'Specifies the branch to benchmark'
         default: 'main'
         required: false
+  pull_request:
 
 jobs:
   benchmark:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,5 +55,5 @@ jobs:
           # Use --no-cache to force re-build the application.
           # Without this flag, changes to zeebe-client were not picked up.
           # This can take longer to build than usual.
-          docker-compose build --no-cache
+          docker compose build --no-cache
           # docker-compose push


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Introduces a benchmark workflow that can create and start the weekly medic benchmark.

Creating and starting this medic benchmark was always a tedious task. Luckily most of it was scripted away, so all we have to do is run that script locally. However, then you have to hope it works on your machine and wait for everything to complete before you can really continue with other tasks.

By moving this work into a GitHub action workflow, we can make this process more reliable (it will only run on a GitHub runner that is pretty much a clean-slate). 

Later we can remove the human step to run the script and wait for it to finish, by calling this GHA workflow from our medic process, e.g. using a REST connector.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to https://github.com/zeebe-io/zeebe-medic-process/issues/73
relates to https://github.com/camunda/zeebe/issues/7491

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
