### PR TITLE
Backup manager can delete backup

### DIFF
--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
@@ -26,7 +26,11 @@ public interface BackupStore {
    */
   CompletableFuture<Collection<BackupStatus>> list(BackupIdentifierWildcard wildcard);
 
-  /** Delete all state related to the backup from the storage */
+  /**
+   * Delete all state related to the backup from the storage. Backups with status{@link
+   * BackupStatusCode#IN_PROGRESS} is not deleted. The caller of this method must first mark it as
+   * failed.
+   */
   CompletableFuture<Void> delete(BackupIdentifier id);
 
   /** Restores the backup */

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -137,9 +137,7 @@ public final class BackupService extends Actor implements BackupManager {
   public ActorFuture<Void> deleteBackup(final long checkpointId) {
     final var operationMetrics = metrics.startDeleting();
 
-    final CompletableActorFuture<Void> backupDeleted =
-        CompletableActorFuture.completedExceptionally(
-            new UnsupportedOperationException("Not implemented"));
+    final var backupDeleted = internalBackupManager.deleteBackup(partitionId, checkpointId, actor);
 
     backupDeleted.onComplete(operationMetrics::complete);
 


### PR DESCRIPTION
## Description

- Backup manager delete the backup for the partition with the given checkpointId. The backup could have created by another broker. So it has to iterate over all possible backups and delete it. Also in rare cases, there can be more than one backup with the same checkpointId.

## Related issues

closes #10208 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
