### PR TITLE
[Backport stable/8.1] Reset active sequence flows upon terminate end event activation

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
@@ -91,8 +91,6 @@ final class ProcessInstanceElementActivatingApplier
       // (Tetris principle)
       elementInstanceState.decrementNumberOfTakenSequenceFlows(
           value.getFlowScopeKey(), gateway.getId());
-    } else {
-      return;
     }
   }
 


### PR DESCRIPTION
# Description
Backport of #10789 to `stable/8.1`.

relates to #10590