### PR TITLE
Fix backwards compatibility of ProcessInstanceModificationRecordValue

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -147,7 +147,7 @@
     <extension.version.os-maven-plugin>1.7.0</extension.version.os-maven-plugin>
 
     <!-- version against which backwards compatibility is checked -->
-    <backwards.compat.version>8.1.0</backwards.compat.version>
+    <backwards.compat.version>8.1.2</backwards.compat.version>
     <ignored.changes.file>ignored-changes.json</ignored.changes.file>
 
     <!--

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -36,6 +36,54 @@
           "justification": "Ignore Enum order for RejectionType as ordinal() is not used",
           "code": "java.field.enumConstantOrderChanged",
           "match": "io.camunda.zeebe.protocol.record.RejectionType"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue.Builder io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue.Builder::addActivatedElementInstanceKey(java.lang.Long)",
+          "justification": "This method had a wrong name. It was only used internally as it provides no value for others."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue.Builder io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue.Builder::addActivatedElementInstanceKeys(java.lang.Long[])",
+          "justification": "This method had a wrong name. It was only used internally as it provides no value for others."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue.Builder io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue.Builder::addAllActivatedElementInstanceKeys(java.lang.Iterable<? extends java.lang.Long>)",
+          "justification": "This method had a wrong name. It was only used internally as it provides no value for others."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue.Builder io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue.Builder::withActivatedElementInstanceKeys(java.lang.Iterable<? extends java.lang.Long>)",
+          "justification": "This method had a wrong name. It was only used internally as it provides no value for others."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method java.util.Set<java.lang.Long> io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue::getActivatedElementInstanceKeys()",
+          "justification": "This method had a wrong name. It was only used internally as it provides no value for others."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue::withActivatedElementInstanceKeys(java.lang.Iterable<? extends java.lang.Long>)",
+          "justification": "This method had a wrong name. It was only used internally as it provides no value for others."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue::withActivatedElementInstanceKeys(java.lang.Long[])",
+          "justification": "This method had a wrong name. It was only used internally as it provides no value for others."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method java.util.Set<java.lang.Long> io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue::getActivatedElementInstanceKeys()",
+          "justification": "This method had a wrong name. It was only used internally as it provides no value for others."
         }
       ]
     }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The changes in https://github.com/camunda/zeebe/pull/10779 renamed a method. We had discussed this before in the team and decided it was fine, however revapi doesn't like it. Because of this the backport failed. I'm not entirely sure why the regular merge did not have any problems.
This PR restored this method and deprecates it.

## Related issues

<!-- Which issues are closed by this PR or are related -->

Related to https://github.com/camunda/zeebe/pull/10779

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
