### PR TITLE
Use ClusteringRule for SecureClusteredMessagingIT

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/gateway/ActorSchedulerComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/ActorSchedulerComponent.java
@@ -10,25 +10,27 @@ package io.camunda.zeebe.gateway;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.shared.ActorClockConfiguration;
+import io.camunda.zeebe.util.VisibleForTesting;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 
 @Component
-final class ActorSchedulerComponent {
+@VisibleForTesting
+public final class ActorSchedulerComponent {
 
   private final GatewayCfg config;
   private final ActorClockConfiguration clockConfiguration;
 
   @Autowired
-  ActorSchedulerComponent(
+  public ActorSchedulerComponent(
       final GatewayCfg config, final ActorClockConfiguration clockConfiguration) {
     this.config = config;
     this.clockConfiguration = clockConfiguration;
   }
 
   @Bean(destroyMethod = "close")
-  ActorScheduler actorScheduler() {
+  public ActorScheduler actorScheduler() {
     return ActorScheduler.newActorScheduler()
         .setCpuBoundActorThreadCount(config.getThreads().getManagementThreads())
         .setIoBoundActorThreadCount(0)

--- a/dist/src/main/java/io/camunda/zeebe/gateway/BrokerClientComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/BrokerClientComponent.java
@@ -12,18 +12,20 @@ import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.util.VisibleForTesting;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 
 @Component
-final class BrokerClientComponent {
+@VisibleForTesting
+public final class BrokerClientComponent {
   final GatewayCfg config;
   final AtomixCluster atomixCluster;
   final ActorScheduler actorScheduler;
 
   @Autowired
-  BrokerClientComponent(
+  public BrokerClientComponent(
       final GatewayCfg config,
       final AtomixCluster atomixCluster,
       final ActorScheduler actorScheduler) {
@@ -33,7 +35,7 @@ final class BrokerClientComponent {
   }
 
   @Bean(destroyMethod = "close")
-  BrokerClient brokerClient() {
+  public BrokerClient brokerClient() {
     return new BrokerClientImpl(
         config.getCluster().getRequestTimeout(),
         atomixCluster.getMessagingService(),

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRuleExtension.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRuleExtension.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.it.clustering;
 
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.test.util.record.RecordLogger;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.FileUtil;
@@ -33,6 +34,15 @@ public class ClusteringRuleExtension extends ClusteringRule
       final int clusterSize,
       final Consumer<BrokerCfg> configurator) {
     super(partitionCount, replicationFactor, clusterSize, configurator);
+  }
+
+  public ClusteringRuleExtension(
+      final int partitionCount,
+      final int replicationFactor,
+      final int clusterSize,
+      final Consumer<BrokerCfg> brokerConfigurator,
+      final Consumer<GatewayCfg> gatewayConfigurator) {
+    super(partitionCount, replicationFactor, clusterSize, brokerConfigurator, gatewayConfigurator);
   }
 
   @Override

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/SecureClusteredMessagingIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/SecureClusteredMessagingIT.java
@@ -46,13 +46,15 @@ final class SecureClusteredMessagingIT {
     assertAddressIsSecured("gateway", getGatewayAddress());
   }
 
+  /** Verifies that both the command and internal APIs of the broker are correctly secured. */
   private void assertBrokerMessagingServicesAreSecured(final Broker broker) {
-    assertAddressIsSecured(
-        broker.getConfig().getCluster().getNodeId(),
-        broker.getConfig().getNetwork().getCommandApi().getAdvertisedAddress());
-    assertAddressIsSecured(
-        broker.getConfig().getCluster().getNodeId(),
-        broker.getConfig().getNetwork().getInternalApi().getAdvertisedAddress());
+    final var commandApiAddress =
+        broker.getConfig().getNetwork().getCommandApi().getAdvertisedAddress();
+    final var internalApiAddress =
+        broker.getConfig().getNetwork().getInternalApi().getAdvertisedAddress();
+
+    assertAddressIsSecured(broker.getConfig().getCluster().getNodeId(), commandApiAddress);
+    assertAddressIsSecured(broker.getConfig().getCluster().getNodeId(), internalApiAddress);
   }
 
   private InetSocketAddress getGatewayAddress() {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/SecureClusteredMessagingIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/SecureClusteredMessagingIT.java
@@ -8,108 +8,83 @@
 package io.camunda.zeebe.it.network;
 
 import io.atomix.utils.net.Address;
+import io.camunda.zeebe.broker.Broker;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.client.api.response.Topology;
-import io.camunda.zeebe.qa.util.testcontainers.ContainerLogsDumper;
-import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.gateway.impl.configuration.ClusterCfg;
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.camunda.zeebe.it.clustering.ClusteringRuleExtension;
 import io.camunda.zeebe.test.util.asserts.SslAssert;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
-import io.zeebe.containers.ZeebeNode;
-import io.zeebe.containers.cluster.ZeebeCluster;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.security.cert.CertificateException;
 import java.util.concurrent.TimeUnit;
-import org.agrona.CloseHelper;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.Network;
-import org.testcontainers.utility.MountableFile;
 
 final class SecureClusteredMessagingIT {
-  private static final Logger LOGGER = LoggerFactory.getLogger(SecureClusteredMessagingIT.class);
+  private final SelfSignedCertificate certificate = newCertificate();
 
-  private Network network;
-  private ZeebeCluster cluster;
-
-  @SuppressWarnings("unused")
   @RegisterExtension
-  final ContainerLogsDumper logsWatcher =
-      new ContainerLogsDumper(() -> cluster.getBrokers(), LOGGER);
-
-  private SelfSignedCertificate certificate;
-
-  @BeforeEach
-  void beforeEach() throws CertificateException {
-    network = Network.newNetwork();
-    certificate = new SelfSignedCertificate();
-  }
-
-  @AfterEach
-  void afterEach() {
-    CloseHelper.quietCloseAll(cluster, network);
-  }
+  private final ClusteringRuleExtension cluster =
+      new ClusteringRuleExtension(1, 2, 2, this::configureBroker, this::configureGateway);
 
   @Test
   void shouldFormAClusterWithTls() {
     // given - a cluster with 2 standalone brokers, and 1 standalone gateway
-    cluster =
-        ZeebeCluster.builder()
-            .withGatewaysCount(1)
-            .withBrokersCount(2)
-            .withReplicationFactor(2)
-            .withEmbeddedGateway(false)
-            .build();
-    cluster.getBrokers().forEach((nodeId, broker) -> configureNode(broker));
-    cluster.getGateways().forEach((nodeId, gateway) -> configureNode(gateway));
-    cluster.start();
 
     // when - note the client is using plaintext since we only care about inter-cluster TLS
-    final Topology topology;
-    try (final var client = cluster.newClientBuilder().usePlaintext().build()) {
-      topology = client.newTopologyRequest().send().join(15, TimeUnit.SECONDS);
-    }
+    final Topology topology =
+        cluster.getClient().newTopologyRequest().send().join(15, TimeUnit.SECONDS);
 
     // then - ensure the cluster is formed correctly and all inter-cluster communication endpoints
     // are secured using the expected certificate
     TopologyAssert.assertThat(topology).hasBrokersCount(2).isComplete(2, 1, 2);
-    cluster
-        .getBrokers()
-        .forEach(
-            (id, broker) -> {
-              assertAddressIsSecured(id, broker.getExternalCommandAddress());
-              assertAddressIsSecured(id, broker.getExternalClusterAddress());
-            });
-    cluster
-        .getGateways()
-        .forEach((id, gateway) -> assertAddressIsSecured(id, gateway.getExternalClusterAddress()));
+    cluster.getBrokers().forEach(this::assertBrokerMessagingServicesAreSecured);
+    assertAddressIsSecured("gateway", getGatewayAddress());
   }
 
-  private void configureNode(final ZeebeNode<?> node) {
-    final var certChainPath = "/tmp/certChain.crt";
-    final var privateKeyPath = "/tmp/private.key";
-
-    // configure both the broker and gateway; it doesn't really matter if one sees the environment
-    // variables of the other
-    node.setDockerImageName(ZeebeTestContainerDefaults.defaultTestImage().asCanonicalNameString());
-    node.withEnv("ZEEBE_BROKER_NETWORK_SECURITY_ENABLED", "true")
-        .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_CERTIFICATECHAINPATH", certChainPath)
-        .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_PRIVATEKEYPATH", privateKeyPath)
-        .withEnv("ZEEBE_GATEWAY_CLUSTER_SECURITY_ENABLED", "true")
-        .withEnv("ZEEBE_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH", certChainPath)
-        .withEnv("ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH", privateKeyPath)
-        .withCopyFileToContainer(
-            MountableFile.forHostPath(certificate.certificate().toPath()), certChainPath)
-        .withCopyFileToContainer(
-            MountableFile.forHostPath(certificate.privateKey().toPath()), privateKeyPath);
+  private void assertBrokerMessagingServicesAreSecured(final Broker broker) {
+    assertAddressIsSecured(
+        broker.getConfig().getCluster().getNodeId(),
+        broker.getConfig().getNetwork().getCommandApi().getAdvertisedAddress());
+    assertAddressIsSecured(
+        broker.getConfig().getCluster().getNodeId(),
+        broker.getConfig().getNetwork().getInternalApi().getAdvertisedAddress());
   }
 
-  private void assertAddressIsSecured(final Object nodeId, final String address) {
-    final var socketAddress = Address.from(address).socketAddress();
-    SslAssert.assertThat(socketAddress)
-        .as("node %s is not secured correctly", nodeId)
+  private InetSocketAddress getGatewayAddress() {
+    final ClusterCfg clusterConfig = cluster.getGateway().getGatewayCfg().getCluster();
+    final var address =
+        Address.from(clusterConfig.getAdvertisedHost(), clusterConfig.getAdvertisedPort());
+    return address.socketAddress();
+  }
+
+  private void assertAddressIsSecured(final Object nodeId, final SocketAddress address) {
+    SslAssert.assertThat(address)
+        .as("node %s is not secured correctly at address %s", nodeId, address)
         .isSecuredBy(certificate);
+  }
+
+  private SelfSignedCertificate newCertificate() {
+    try {
+      return new SelfSignedCertificate();
+    } catch (final CertificateException e) {
+      throw new IllegalStateException("Failed to create self-signed certificate", e);
+    }
+  }
+
+  private void configureGateway(final GatewayCfg config) {
+    config.getCluster().getSecurity().setEnabled(true);
+    config.getCluster().getSecurity().setCertificateChainPath(certificate.certificate());
+    config.getCluster().getSecurity().setPrivateKeyPath(certificate.privateKey());
+  }
+
+  private void configureBroker(final BrokerCfg config) {
+    config.getNetwork().getSecurity().setEnabled(true);
+    config.getNetwork().getSecurity().setCertificateChainPath(certificate.certificate());
+    config.getNetwork().getSecurity().setPrivateKeyPath(certificate.privateKey());
   }
 }


### PR DESCRIPTION
## Description

This PR rewrites the existing `SecureClusteredMessagingIT` to use the `ClusteringRule` instead of containers. This is in attempt to fix the the flakiness where, every once in a while, the gateway's messaging service is not accessible from the outside (and only in CI).

The assumption is that, since we've verified the nodes are still talking to each other fine, this is not a production issue but an environmental one, so rewriting the test to modify the environment is a valid solution (if incomplete, as root causing the problem would have been preferable of course). As we've already spent too much time on this, however, root causing was shelved in favor of this approach.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10655 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
