### PR TITLE
Fix error on writing cache file in the Java client

### DIFF
--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
@@ -152,7 +152,7 @@ public final class OAuthCredentialsCacheTest {
   }
 
   @Test
-  public void shouldCreateFileOnlyIfParentIsSymbolicLinkToDirectory() throws IOException {
+  public void shouldCreateFileOnlyIfParentIsDirectory() throws IOException {
     final File root = new File(temporaryFolder.getRoot(), "/some/root");
     Files.createDirectories(root.toPath());
     assertThat(root.exists()).isTrue();

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
@@ -17,6 +17,8 @@ package io.camunda.zeebe.client.impl.oauth;
 
 import static io.camunda.zeebe.client.OAuthCredentialsProviderTest.EXPIRY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertTrue;
 
 import io.camunda.zeebe.client.impl.ZeebeClientCredentials;
 import java.io.File;
@@ -29,6 +31,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public final class OAuthCredentialsCacheTest {
+
   private static final String WOMBAT_ENDPOINT = "wombat.cloud.camunda.io";
   private static final String AARDVARK_ENDPOINT = "aardvark.cloud.camunda.io";
   private static final String GOLDEN_FILE = "/oauth/credentialsCache.yml";
@@ -38,6 +41,7 @@ public final class OAuthCredentialsCacheTest {
       new ZeebeClientCredentials("aardvark", EXPIRY, "Bearer");
 
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
   private File cacheFile;
 
   @Before
@@ -46,6 +50,143 @@ public final class OAuthCredentialsCacheTest {
     try (final InputStream input = getClass().getResourceAsStream(GOLDEN_FILE)) {
       Files.copy(input, cacheFile.toPath());
     }
+  }
+
+  @Test
+  public void shouldCreateFileOnlyIfParentIsSymbolicLinkToFolder() throws IOException {
+    final File root = new File(temporaryFolder.getRoot(), "/some/root");
+    Files.createDirectories(root.toPath());
+    assertThat(root.exists()).isTrue();
+
+    final File target = new File(root, "target");
+    Files.createDirectories(target.toPath());
+    assertThat(target.exists()).isTrue();
+
+    final File container = new File(root, ".camunda");
+    assertThat(container.exists()).isFalse();
+    Files.createSymbolicLink(container.toPath(), target.toPath());
+    assertThat(container.exists()).isTrue();
+
+    final File fileInContainer = new File(container, "/credentials");
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache(fileInContainer);
+    cache.writeCache();
+
+    assertThat(fileInContainer.exists()).isTrue();
+  }
+
+  @Test
+  public void shouldFailIfParentIsSymbolicLinkToFile() throws IOException {
+    final File root = new File(temporaryFolder.getRoot(), "/some/root");
+    Files.createDirectories(root.toPath());
+    assertThat(root.exists()).isTrue();
+
+    final File target = new File(root, "target");
+    Files.createFile(target.toPath());
+    assertThat(target.exists()).isTrue();
+
+    final File container = new File(root, ".camunda");
+    assertThat(container.exists()).isFalse();
+    Files.createSymbolicLink(container.toPath(), target.toPath());
+    assertThat(container.exists()).isTrue();
+
+    final File fileInContainer = new File(container, "/credentials");
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache(fileInContainer);
+
+    assertThatThrownBy(cache::writeCache)
+        .hasMessage(
+            "Expected "
+                + container.getAbsolutePath()
+                + " to be a directory, but it was a symbolic link pointing to a regular file.");
+    assertThat(fileInContainer.exists()).isFalse();
+  }
+
+  @Test
+  public void shouldFailIfParentIsFile() throws IOException {
+    final File root = new File(temporaryFolder.getRoot(), "/some/root");
+    Files.createDirectories(root.toPath());
+    assertThat(root.exists()).isTrue();
+
+    final File target = new File(root, "target");
+    Files.createFile(target.toPath());
+    assertThat(target.exists()).isTrue();
+
+    final File fileInContainer = new File(target, "/credentials");
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache(fileInContainer);
+
+    assertThatThrownBy(cache::writeCache)
+        .hasMessage(
+            "Expected "
+                + target.getAbsolutePath()
+                + " to be a directory, but it was a regular file.");
+    assertThat(fileInContainer.exists()).isFalse();
+  }
+
+  @Test
+  public void shouldFailIfParentIsBrokenSymbolicLink() throws IOException {
+    final File root = new File(temporaryFolder.getRoot(), "/some/root");
+    Files.createDirectories(root.toPath());
+    assertThat(root.exists()).isTrue();
+
+    final File target = new File(root, "target");
+    Files.createDirectories(target.toPath());
+    assertThat(target.exists()).isTrue();
+
+    final File container = new File(root, ".camunda");
+    assertThat(container.exists()).isFalse();
+    Files.createSymbolicLink(container.toPath(), target.toPath());
+    assertThat(container.exists()).isTrue();
+
+    // now /some/root/.camunda -> /some/root/target
+    // we will delete target, creating a dead link.
+    assertTrue(target.delete());
+
+    final File fileInContainer = new File(container, "/credentials");
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache(fileInContainer);
+
+    assertThatThrownBy(cache::writeCache)
+        .hasMessage(
+            "Expected "
+                + container.getAbsolutePath()
+                + " to be a directory, but it was a symbolic link to unresolvable path.");
+    assertThat(fileInContainer.exists()).isFalse();
+  }
+
+  @Test
+  public void shouldCreateFileOnlyIfParentIsSymbolicLinkToDirectory() throws IOException {
+    final File root = new File(temporaryFolder.getRoot(), "/some/root");
+    Files.createDirectories(root.toPath());
+    assertThat(root.exists()).isTrue();
+
+    final File target = new File(root, "target");
+    Files.createDirectories(target.toPath());
+    assertThat(target.exists()).isTrue();
+
+    final File fileInContainer = new File(target, "/credentials");
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache(fileInContainer);
+    cache.writeCache();
+
+    assertThat(target.exists()).isTrue();
+    assertThat(fileInContainer.exists()).isTrue();
+  }
+
+  @Test
+  public void shouldCreateDirectoryIfMissing() throws IOException {
+    final File root = new File(temporaryFolder.getRoot(), "/some/root");
+    Files.createDirectories(root.toPath());
+    assertThat(root.exists()).isTrue();
+
+    final File target = new File(root, "target");
+    Files.createFile(target.toPath());
+    assertThat(target.exists()).isTrue();
+
+    final File container = new File(root, ".camunda");
+    assertThat(container.exists()).isFalse();
+    final File fileInContainer = new File(container, "/credentials");
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache(fileInContainer);
+
+    cache.writeCache();
+    assertThat(container.exists()).isTrue();
+    assertThat(fileInContainer.exists()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This is a recreation of #10642, as I had to rebase the branch.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/10641

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
