### PR TITLE
ci: run go client tests on github hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
           name: Property Tests
   go-client:
     name: Go client tests
-    runs-on: "n1-standard-8-netssd-preempt"
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Go client tests should be able to run ob github hosted runners which are more reliable than the `n1-standard-8-netssd-preempt` runners used before.