### PR TITLE
[Backport stable/8.1] ci: run go client tests on github hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
           name: Property Tests
   go-client:
     name: Go client tests
-    runs-on: "n1-standard-8-netssd-preempt"
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# Description
Backport of #10833 to `stable/8.1`.

relates to 