### PR TITLE
[Backport stable/8.1] deps(maven): bump commons-text from 1.9 to 1.10.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -45,7 +45,7 @@
     <version.commons-logging>1.2</version.commons-logging>
     <version.commons-math>3.6.1</version.commons-math>
     <version.commons-codec>1.15</version.commons-codec>
-    <version.commons-text>1.9</version.commons-text>
+    <version.commons-text>1.10.0</version.commons-text>
     <version.cron-utils>9.2.0</version.cron-utils>
     <version.docker-java-api>3.2.13</version.docker-java-api>
     <version.elasticsearch>7.17.5</version.elasticsearch>


### PR DESCRIPTION
# Description
Backport of #10559 to `stable/8.1`.

relates to 