### PR TITLE
[Backport stable/8.0] deps(maven): bump commons-text from 1.9 to 1.10.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -50,7 +50,7 @@
     <version.commons-logging>1.2</version.commons-logging>
     <version.commons-math>3.6.1</version.commons-math>
     <version.commons-codec>1.15</version.commons-codec>
-    <version.commons-text>1.9</version.commons-text>
+    <version.commons-text>1.10.0</version.commons-text>
     <version.docker-java-api>3.2.13</version.docker-java-api>
     <version.elasticsearch>7.17.0</version.elasticsearch>
     <version.error-prone>2.11.0</version.error-prone>


### PR DESCRIPTION
# Description
Backport of #10559 to `stable/8.0`.

