### PR TITLE
Yield actor thread between retries

### DIFF
--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -51,6 +51,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/AbortableRetryStrategy.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/AbortableRetryStrategy.java
@@ -45,6 +45,7 @@ public final class AbortableRetryStrategy implements RetryStrategy {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
         actor.run(this::run);
+        actor.yieldThread();
       }
     } catch (final Exception exception) {
       currentFuture.completeExceptionally(exception);

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/EndlessRetryStrategy.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/EndlessRetryStrategy.java
@@ -51,12 +51,14 @@ public final class EndlessRetryStrategy implements RetryStrategy {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
         actor.run(this::run);
+        actor.yieldThread();
       }
     } catch (final Exception exception) {
       if (terminateCondition.getAsBoolean()) {
         currentFuture.complete(false);
       } else {
         actor.run(this::run);
+        actor.yieldThread();
         LOG.error(
             "Caught exception {} with message {}, will retry...",
             exception.getClass(),

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RecoverableRetryStrategy.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RecoverableRetryStrategy.java
@@ -48,10 +48,12 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
         actor.run(this::run);
+        actor.yieldThread();
       }
     } catch (final RecoverableException ex) {
       if (!terminateCondition.getAsBoolean()) {
         actor.run(this::run);
+        actor.yieldThread();
       }
     } catch (final Exception exception) {
       currentFuture.completeExceptionally(exception);

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/retry/RetryStrategyTest.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/retry/RetryStrategyTest.java
@@ -12,140 +12,129 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerRule;
-import java.lang.reflect.Constructor;
+import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
-public final class RetryStrategyTest {
+final class RetryStrategyTest {
 
-  @Rule
-  public final ControlledActorSchedulerRule schedulerRule = new ControlledActorSchedulerRule();
+  @RegisterExtension
+  private final ControlledActorSchedulerExtension schedulerRule =
+      new ControlledActorSchedulerExtension();
 
-  @Parameter public Class<RetryStrategy> retryStrategyClass;
-  private RetryStrategy retryStrategy;
-  private ActorControl actorControl;
   private ActorFuture<Boolean> resultFuture;
 
-  @Parameters(name = "{index}: {0}")
-  public static Object[][] reprocessingTriggers() {
-    return new Object[][] {
-      new Object[] {RecoverableRetryStrategy.class}, new Object[] {AbortableRetryStrategy.class}
-    };
-  }
-
-  @Before
-  public void setUp() {
-    final ControllableActor actor = new ControllableActor();
-    actorControl = actor.getActor();
-
-    try {
-      final Constructor<RetryStrategy> constructor =
-          retryStrategyClass.getConstructor(ActorControl.class);
-      retryStrategy = constructor.newInstance(actorControl);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
-    }
-
+  @ParameterizedTest(name = "{0}")
+  @MethodSource({
+    "provideEndlessStrategy",
+    "provideRecoverableStrategy",
+    "provideAbortableStrategy",
+    "provideBackOffStrategy"
+  })
+  void shouldRunUntilDone(final RetryStrategy strategy, final ControllableActor actor) {
+    // given
+    final var count = new AtomicInteger(0);
     schedulerRule.submitActor(actor);
-  }
-
-  @Test
-  public void shouldRunUntilDone() throws Exception {
-    // given
-    final AtomicInteger count = new AtomicInteger(0);
 
     // when
-    actorControl.run(
-        () -> {
-          resultFuture = retryStrategy.runWithRetry(() -> count.incrementAndGet() == 10);
-        });
-
+    actor.run(() -> resultFuture = strategy.runWithRetry(() -> count.incrementAndGet() == 10));
     schedulerRule.workUntilDone();
 
     // then
     assertThat(count.get()).isEqualTo(10);
-    assertThat(resultFuture.isDone()).isTrue();
-    assertThat(resultFuture.get()).isTrue();
+    assertThat(resultFuture).succeedsWithin(Duration.ZERO).isEqualTo(true);
   }
 
-  @Test
-  public void shouldStopWhenAbortConditionReturnsTrue() throws Exception {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource({
+    "provideEndlessStrategy",
+    "provideRecoverableStrategy",
+    "provideAbortableStrategy",
+    "provideBackOffStrategy"
+  })
+  void shouldStopWhenAbortConditionReturnsTrue(
+      final RetryStrategy strategy, final ControllableActor actor) {
     // given
     final AtomicInteger count = new AtomicInteger(0);
+    schedulerRule.submitActor(actor);
 
     // when
-    actorControl.run(
-        () -> {
-          resultFuture =
-              retryStrategy.runWithRetry(() -> false, () -> count.incrementAndGet() == 10);
-        });
-
+    actor.run(
+        () ->
+            resultFuture = strategy.runWithRetry(() -> false, () -> count.incrementAndGet() == 10));
     schedulerRule.workUntilDone();
 
     // then
     assertThat(count.get()).isEqualTo(10);
-    assertThat(resultFuture.isDone()).isTrue();
-    assertThat(resultFuture.get()).isFalse();
+    assertThat(resultFuture).succeedsWithin(Duration.ZERO).isEqualTo(false);
   }
 
-  @Test
-  public void shouldAbortOnOtherException() {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource({"provideRecoverableStrategy", "provideAbortableStrategy"})
+  void shouldAbortOnOtherException(final RetryStrategy strategy, final ControllableActor actor) {
     // given
+    final RuntimeException failure = new RuntimeException("expected");
+    schedulerRule.submitActor(actor);
+
     // when
-    actorControl.run(
+    actor.run(
         () ->
             resultFuture =
-                retryStrategy.runWithRetry(
+                strategy.runWithRetry(
                     () -> {
-                      throw new RuntimeException("expected");
+                      throw failure;
                     }));
-
     schedulerRule.workUntilDone();
 
     // then
-    assertThat(resultFuture.isDone()).isTrue();
-    assertThat(resultFuture.isCompletedExceptionally()).isTrue();
-    assertThat(resultFuture.getException()).isExactlyInstanceOf(RuntimeException.class);
+    assertThat(resultFuture)
+        .failsWithin(Duration.ZERO)
+        .withThrowableOfType(ExecutionException.class)
+        .withCause(failure);
   }
 
-  @Test
-  public void shouldNotInterleaveRetry() {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource({
+    "provideEndlessStrategy",
+    "provideRecoverableStrategy",
+    "provideAbortableStrategy"
+  })
+  void shouldNotInterleaveRetry(final RetryStrategy strategy, final ControllableActor actor) {
     // given
     final AtomicReference<ActorFuture<Boolean>> firstFuture = new AtomicReference<>();
     final AtomicReference<ActorFuture<Boolean>> secondFuture = new AtomicReference<>();
-
     final AtomicInteger executionAttempt = new AtomicInteger(0);
     final AtomicInteger firstResult = new AtomicInteger();
     final AtomicInteger secondResult = new AtomicInteger();
+    schedulerRule.submitActor(actor);
 
     // when
     final var retryCounts = 5;
-    actorControl.run(
+    actor.run(
         () ->
             firstFuture.set(
-                retryStrategy.runWithRetry(
+                strategy.runWithRetry(
                     () -> {
                       firstResult.set(executionAttempt.getAndIncrement());
                       return executionAttempt.get() >= retryCounts;
                     })));
-    actorControl.run(
+    actor.run(
         () ->
             secondFuture.set(
-                retryStrategy.runWithRetry(
+                strategy.runWithRetry(
                     () -> {
                       secondResult.set(executionAttempt.getAndIncrement());
                       return true;
                     })));
-
     schedulerRule.workUntilDone();
 
     // then
@@ -155,9 +144,52 @@ public final class RetryStrategyTest {
     assertThat(secondResult).hasValue(retryCounts);
   }
 
+  private static Stream<Arguments> provideRecoverableStrategy() {
+    return Stream.of(TestCase.of(RecoverableRetryStrategy::new));
+  }
+
+  private static Stream<Arguments> provideAbortableStrategy() {
+    return Stream.of(TestCase.of(AbortableRetryStrategy::new));
+  }
+
+  private static Stream<Arguments> provideEndlessStrategy() {
+    return Stream.of(TestCase.of(EndlessRetryStrategy::new));
+  }
+
+  private static Stream<Arguments> provideBackOffStrategy() {
+    return Stream.of(
+        TestCase.of(
+            // it's important to use a zero delay as otherwise workUntilDone will not wait for
+            // all timers to be triggered
+            actor -> new BackOffRetryStrategy(actor, Duration.ZERO)));
+  }
+
+  private record TestCase<T extends RetryStrategy>(ControllableActor actor, T strategy)
+      implements Arguments {
+
+    private static <T extends RetryStrategy> TestCase<T> of(
+        final Function<ActorControl, T> provider) {
+      final var actor = new ControllableActor();
+      final var strategy = provider.apply(actor.getActor());
+      return new TestCase<>(actor, strategy);
+    }
+
+    @Override
+    public Object[] get() {
+      return new Object[] {Named.of(strategy.getClass().getSimpleName(), strategy), actor};
+    }
+  }
+
   private static final class ControllableActor extends Actor {
     public ActorControl getActor() {
       return actor;
+    }
+
+    @Override
+    public void close() {
+      // do not wait for the close, as the scheduler is already closed by the time the
+      // actor is closed
+      closeAsync();
     }
   }
 }

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/retry/RetryStrategyTest.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/retry/RetryStrategyTest.java
@@ -14,19 +14,24 @@ import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 final class RetryStrategyTest {
 
+  /** Ensure we use a single thread to better control the scheduling in the tests. */
   @RegisterExtension
   private final ControlledActorSchedulerExtension schedulerRule =
-      new ControlledActorSchedulerExtension();
+      new ControlledActorSchedulerExtension(
+          builder -> builder.setIoBoundActorThreadCount(0).setCpuBoundActorThreadCount(1));
 
   private ActorFuture<Boolean> resultFuture;
 
@@ -66,6 +71,11 @@ final class RetryStrategyTest {
     assertThat(resultFuture).succeedsWithin(Duration.ZERO).isEqualTo(false);
   }
 
+  /**
+   * Only the {@link RecoverableRetryStrategy} and {@link AbortableRetryStrategy} stop retrying when
+   * an unrecoverable exception occurs; the others will always retry. We may want to extract this to
+   * specific class tests?
+   */
   @ParameterizedTest
   @ValueSource(strings = {"recoverable", "abortable"})
   void shouldAbortOnOtherException(final TestCase<?> test) {
@@ -90,6 +100,11 @@ final class RetryStrategyTest {
         .withCause(failure);
   }
 
+  /**
+   * The {@link BackOffRetryStrategy} is excluded here because its usage of timers necessarily allow
+   * interleaving calls. If we decide to fix it, then we should refactor the strategy and add it as
+   * a test case here.
+   */
   @ParameterizedTest
   @ValueSource(strings = {"endless", "recoverable", "abortable"})
   void shouldNotInterleaveRetry(final TestCase<?> test) {
@@ -128,13 +143,52 @@ final class RetryStrategyTest {
     assertThat(secondResult).hasValue(retryCounts);
   }
 
+  /**
+   * The {@link BackOffRetryStrategy} is excluded here as it is already yielding implicitly by using
+   * timers for scheduling.
+   */
   @ParameterizedTest
-  @ValueSource(strings = {"endless", "recoverable", "abortable", "backoff"})
-  void shouldYieldThreadOnRetry() {}
+  @ValueSource(strings = {"endless", "recoverable", "abortable"})
+  void shouldYieldThreadOnRetry(final TestCase<?> test) {
+    // given - all actors share the same thread, force interleaving of their execution to ensure the
+    // retry strategy yields the thread in between retries
+    final var barrier = new LinkedTransferQueue<Boolean>();
+    final var future = new CompletableFuture<Void>();
+    final var secondActor = new ControllableActor();
+    schedulerRule.submitActor(test.actor);
+    schedulerRule.submitActor(secondActor);
+
+    // when
+    test.strategy.runWithRetry(
+        () -> {
+          // capture the result before to ensure we're looping
+          final boolean shouldRetry = !future.isDone();
+          barrier.offer(true);
+          return shouldRetry;
+        });
+    // toggle the retry strategy to stop retrying, letting workUntilDone finish
+    secondActor.run(
+        () -> {
+          // wait until the test actor ran at least once, guaranteeing it's currently looping
+          // and retrying
+          barrier.poll();
+          future.complete(null);
+        });
+    // wrap workUntilDone in a timeout condition, as otherwise the test hangs forever there if the
+    // actors are not yielding
+    Awaitility.await("workUntilDone should be finite if each actor yields the thread")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(schedulerRule::workUntilDone);
+
+    // then
+    assertThat(future)
+        .as("future is completed iff second actor can run")
+        .succeedsWithin(Duration.ofSeconds(2));
+  }
 
   private record TestCase<T extends RetryStrategy>(ControllableActor actor, T strategy) {
 
-    // actually used by junit 5, see
+    // used to generate test cases in conjunction with @ValueSource
     // https://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests-argument-conversion-implicit
     @SuppressWarnings("unused")
     static TestCase<?> of(final String type) {

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerExtension.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerExtension.java
@@ -18,14 +18,26 @@ import io.camunda.zeebe.scheduler.TaskScheduler;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.util.Objects;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 public class ControlledActorSchedulerExtension implements BeforeEachCallback, AfterEachCallback {
 
+  private final Consumer<ActorSchedulerBuilder> configurator;
+
   private ActorScheduler actorScheduler;
   private ControlledActorThread controlledActorTaskRunner;
+
+  public ControlledActorSchedulerExtension() {
+    this(builder -> {});
+  }
+
+  public ControlledActorSchedulerExtension(final Consumer<ActorSchedulerBuilder> configurator) {
+    this.configurator = Objects.requireNonNull(configurator, "must specify a configurator");
+  }
 
   @Override
   public void afterEach(final ExtensionContext extensionContext) throws Exception {
@@ -45,6 +57,7 @@ public class ControlledActorSchedulerExtension implements BeforeEachCallback, Af
             .setActorThreadFactory(actorTaskRunnerFactory)
             .setActorTimerQueue(timerQueue);
 
+    configurator.accept(builder);
     actorScheduler = builder.build();
     controlledActorTaskRunner = actorTaskRunnerFactory.controlledThread;
     actorScheduler.start();


### PR DESCRIPTION
## Description

Ensures retry strategies are yielding their thread between retries. Note that this doesn't really apply to the `BackOffRetryStrategy`, as it's already yielding via its usage of timers.

This PR also updates the `RetryStrategyTest` to junit 5, and adds test coverage by applying the existing tests to the other strategies where applicable (previously, only the `RecoverableRetryStrategy` and `AbortableRetryStrategy` were tested there).

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10539 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
