### PR TITLE
test(dispatcher): fixes sigsev due to consumer

### DIFF
--- a/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/ActorFrameworkIntegrationTest.java
+++ b/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/ActorFrameworkIntegrationTest.java
@@ -125,7 +125,7 @@ public final class ActorFrameworkIntegrationTest {
     }
 
     void consume() {
-      subscription.poll(this, Integer.MAX_VALUE);
+      actor.run(() -> subscription.poll(this, Integer.MAX_VALUE));
     }
 
     @Override
@@ -175,9 +175,12 @@ public final class ActorFrameworkIntegrationTest {
     }
 
     void consume() {
-      if (subscription.peekBlock(peek, Integer.MAX_VALUE, true) > 0) {
-        actor.submit(processPeek);
-      }
+      actor.run(
+          () -> {
+            if (subscription.peekBlock(peek, Integer.MAX_VALUE, true) > 0) {
+              actor.submit(processPeek);
+            }
+          });
     }
 
     void processPeek() {

--- a/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/ActorFrameworkIntegrationTest.java
+++ b/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/ActorFrameworkIntegrationTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.dispatcher.ClaimedFragment;
 import io.camunda.zeebe.dispatcher.Dispatcher;
 import io.camunda.zeebe.dispatcher.Dispatchers;
 import io.camunda.zeebe.dispatcher.FragmentHandler;
+import io.camunda.zeebe.dispatcher.Loggers;
 import io.camunda.zeebe.dispatcher.Subscription;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -88,6 +89,11 @@ public final class ActorFrameworkIntegrationTest {
       actor.run(this::produce);
     }
 
+    @Override
+    protected void onActorClosed() {
+      Loggers.DISPATCHER_LOGGER.debug("Producer closed!");
+    }
+
     void produce() {
       if (dispatcher.claimSingleFragment(claim, 4534) >= 0) {
         claim.getBuffer().putInt(claim.getOffset(), counter++);
@@ -107,6 +113,7 @@ public final class ActorFrameworkIntegrationTest {
     final Dispatcher dispatcher;
     Subscription subscription;
     int counter = 0;
+    volatile boolean closed;
 
     Consumer(final Dispatcher dispatcher) {
       this.dispatcher = dispatcher;
@@ -124,7 +131,16 @@ public final class ActorFrameworkIntegrationTest {
           });
     }
 
+    @Override
+    protected void onActorClosed() {
+      closed = true;
+      Loggers.DISPATCHER_LOGGER.debug("Consumer is closed!");
+    }
+
     void consume() {
+      if (closed) {
+        Loggers.DISPATCHER_LOGGER.debug("Consuming next fragment...");
+      }
       actor.run(() -> subscription.poll(this, Integer.MAX_VALUE));
     }
 
@@ -149,6 +165,7 @@ public final class ActorFrameworkIntegrationTest {
     final BlockPeek peek = new BlockPeek();
     Subscription subscription;
     int counter = 0;
+    volatile boolean closed = false;
     final Runnable processPeek =
         () -> {
           try {
@@ -174,7 +191,16 @@ public final class ActorFrameworkIntegrationTest {
           });
     }
 
+    @Override
+    protected void onActorClosed() {
+      closed = true;
+      Loggers.DISPATCHER_LOGGER.debug("Consumer is closed!");
+    }
+
     void consume() {
+      if (closed) {
+        Loggers.DISPATCHER_LOGGER.debug("Consuming next fragment...");
+      }
       actor.run(
           () -> {
             if (subscription.peekBlock(peek, Integer.MAX_VALUE, true) > 0) {


### PR DESCRIPTION
## Description

We didn't fully root cause the issue, as from what we gather, the dispatcher should be closed only when all actors are closed, which means the `Consumer#consume` method should never be called after the dispatcher is closed.

It's a bit hard to say that's true with 100% certainty with how complex the scheduling is, and all the possible race conditions, so for now I added a wrapper in the consume method and more logging. If this occurs again, then we have more info.

In the meantime, possibly we replace the dispatcher with something much simpler, so this can then be closed at that time.

## Related issues

related to #10407 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
