### PR TITLE
fix(engine): use link events in different flow scopes

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/EmbeddedSubProcessBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/EmbeddedSubProcessBuilder.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.model.bpmn.builder;
 
 import static io.camunda.zeebe.model.bpmn.builder.AbstractBaseElementBuilder.SPACE;
 
+import io.camunda.zeebe.model.bpmn.instance.IntermediateCatchEvent;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
 import io.camunda.zeebe.model.bpmn.instance.SubProcess;
 import io.camunda.zeebe.model.bpmn.instance.bpmndi.BpmnShape;
@@ -90,6 +91,26 @@ public class EmbeddedSubProcessBuilder
     final EventSubProcessBuilder builder = eventSubProcess(id);
     consumer.accept(builder);
     return this;
+  }
+
+  public IntermediateCatchEventBuilder intermediateCatchEvent(
+      final String id, final Consumer<IntermediateCatchEventBuilder> catchEventBuilderConsumer) {
+    final IntermediateCatchEventBuilder catchEventBuilder = intermediateCatchEvent(id);
+
+    catchEventBuilderConsumer.accept(catchEventBuilder);
+
+    return catchEventBuilder;
+  }
+
+  public IntermediateCatchEventBuilder intermediateCatchEvent(final String id) {
+    final IntermediateCatchEvent catchEvent =
+        subProcessBuilder.createChild(IntermediateCatchEvent.class, id);
+    final BpmnShape bpmnShape = subProcessBuilder.createBpmnShape(catchEvent);
+
+    subProcessBuilder.setCoordinates(bpmnShape);
+    subProcessBuilder.resizeBpmnShape(bpmnShape);
+
+    return catchEvent.builder();
   }
 
   protected void setCoordinates(final BpmnShape targetBpmnShape) {

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/ModelUtil.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/util/ModelUtil.java
@@ -88,10 +88,17 @@ public class ModelUtil {
 
   public static List<EventDefinition> getEventDefinitionsForLinkCatchEvents(
       final ModelElementInstance element) {
-    return element.getChildElementsByType(IntermediateCatchEvent.class).stream()
-        .flatMap(i -> i.getEventDefinitions().stream())
-        .filter(e -> e instanceof LinkEventDefinition)
-        .collect(Collectors.toList());
+    final List<EventDefinition> definitions =
+        element.getChildElementsByType(IntermediateCatchEvent.class).stream()
+            .flatMap(i -> i.getEventDefinitions().stream())
+            .filter(e -> e instanceof LinkEventDefinition)
+            .collect(Collectors.toList());
+
+    element.getChildElementsByType(SubProcess.class).stream()
+        .map(ModelUtil::getEventDefinitionsForLinkCatchEvents)
+        .forEach(definitions::addAll);
+
+    return definitions;
   }
 
   public static List<EventDefinition> getEventDefinitionsForLinkThrowEvents(

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SubProcessValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SubProcessValidator.java
@@ -66,6 +66,9 @@ public class SubProcessValidator implements ModelElementValidator<SubProcess> {
 
     ModelUtil.verifyNoDuplicatedEventSubprocesses(
         element, error -> validationResultCollector.addError(0, error));
+
+    ModelUtil.verifyLinkIntermediateEvents(
+        element, error -> validationResultCollector.addError(0, error));
   }
 
   private void validateEmbeddedSubprocess(


### PR DESCRIPTION
## Description

I can use link events in different flow scopes.

## Related issues
closes #10854 

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
