### PR TITLE
Support escalation intermediate throw event

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
@@ -7,11 +7,16 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
+import static io.camunda.zeebe.util.EnsureUtil.ensureNotNull;
+import static io.camunda.zeebe.util.EnsureUtil.ensureNotNullOrEmpty;
+
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableIntermediateThrowEvent;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.analyzers.CatchEventAnalyzer;
@@ -19,7 +24,10 @@ import io.camunda.zeebe.engine.state.analyzers.CatchEventAnalyzer.CatchEventTupl
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.value.escalation.EscalationRecord;
+import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 
@@ -28,6 +36,8 @@ public final class BpmnEventPublicationBehavior {
   private final ElementInstanceState elementInstanceState;
   private final EventHandle eventHandle;
   private final CatchEventAnalyzer catchEventAnalyzer;
+  private final StateWriter stateWriter;
+  private final KeyGenerator keyGenerator;
 
   public BpmnEventPublicationBehavior(
       final ZeebeState zeebeState,
@@ -43,6 +53,8 @@ public final class BpmnEventPublicationBehavior {
             zeebeState.getProcessState(),
             eventTriggerBehavior);
     catchEventAnalyzer = new CatchEventAnalyzer(zeebeState.getProcessState(), elementInstanceState);
+    stateWriter = writers.state();
+    this.keyGenerator = keyGenerator;
   }
 
   /**
@@ -78,5 +90,75 @@ public final class BpmnEventPublicationBehavior {
       final DirectBuffer errorCode, final BpmnElementContext context) {
     final var flowScopeInstance = elementInstanceState.getInstance(context.getFlowScopeKey());
     return catchEventAnalyzer.findCatchEvent(errorCode, flowScopeInstance, Optional.empty());
+  }
+
+  /**
+   * Finds the right catch event for the given escalation. This is done by going up through the
+   * scope hierarchy recursively until a matching catch event is found. Otherwise, it returns {@link
+   * Optional#empty()}.
+   *
+   * @param escalationCode the escalation code of the escalation event
+   * @param context the current element context
+   * @return a valid {@link CatchEventTuple} if a catch event is found, Otherwise, it returns {@link
+   *     Optional#empty()}
+   */
+  public Optional<CatchEventTuple> findEscalationCatchEvent(
+      final DirectBuffer escalationCode, final BpmnElementContext context) {
+    final var flowScopeInstance = elementInstanceState.getInstance(context.getFlowScopeKey());
+    return catchEventAnalyzer.findEscalationCatchEvent(escalationCode, flowScopeInstance);
+  }
+
+  /**
+   * Throws an escalation event to the given element instance/catch event pair. Only throws the
+   * event if the given element instance is exists and is accepting events, e.g. isn't terminating,
+   * wasn't interrupted, etc.
+   *
+   * @param element the instance of the intermediate throw event
+   * @param activated process instance-related data of the element that is executed
+   * @return returns true if the escalation throw event can be completed, false otherwise
+   */
+  public boolean throwEscalationEvent(
+      final ExecutableIntermediateThrowEvent element, final BpmnElementContext activated) {
+    final var escalation = element.getEscalation();
+    ensureNotNull("escalation", escalation);
+
+    final var escalationCode = escalation.getEscalationCode();
+    ensureNotNullOrEmpty("escalationCode", escalationCode);
+
+    final var record = new EscalationRecord();
+    record.setThrowElementId(element.getId());
+    record.setEscalationCode(BufferUtil.bufferAsString(escalationCode));
+    record.setProcessInstanceKey(activated.getProcessInstanceKey());
+
+    final var escalationCatchEvent = findEscalationCatchEvent(escalationCode, activated);
+
+    boolean canBeCompleted = true;
+    boolean escalated = false;
+    final var key = keyGenerator.nextKey();
+
+    if (escalationCatchEvent.isPresent()) {
+      final var catchEventTuple = escalationCatchEvent.get();
+      final var eventScopeInstance = catchEventTuple.getElementInstance();
+      final ExecutableCatchEvent catchEvent = catchEventTuple.getCatchEvent();
+      // update catch element id
+      record.setCatchElementId(catchEvent.getId());
+
+      // if the escalation catch event is interrupt event, then throw event is not allowed to
+      // complete.
+      canBeCompleted = !catchEvent.isInterrupting();
+
+      if (eventHandle.canTriggerElement(eventScopeInstance, catchEvent.getId())) {
+        eventHandle.activateElement(
+            catchEvent, eventScopeInstance.getKey(), eventScopeInstance.getValue());
+        stateWriter.appendFollowUpEvent(key, EscalationIntent.ESCALATED, record);
+        escalated = true;
+      }
+    }
+
+    if (!escalated) {
+      stateWriter.appendFollowUpEvent(key, EscalationIntent.NOT_ESCALATED, record);
+    }
+
+    return canBeCompleted;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEvent.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEvent.java
@@ -21,10 +21,12 @@ public interface ExecutableCatchEvent extends ExecutableFlowElement {
 
   boolean isError();
 
+  boolean isEscalation();
+
   boolean isLink();
 
   default boolean isNone() {
-    return !isTimer() && !isMessage() && !isError() && !isLink();
+    return !isTimer() && !isMessage() && !isError() && !isLink() && !isEscalation();
   }
 
   ExecutableMessage getMessage();
@@ -36,4 +38,6 @@ public interface ExecutableCatchEvent extends ExecutableFlowElement {
   BiFunction<ExpressionProcessor, Long, Either<Failure, Timer>> getTimerFactory();
 
   ExecutableError getError();
+
+  ExecutableEscalation getEscalation();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEventElement.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEventElement.java
@@ -23,6 +23,7 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
 
   private ExecutableMessage message;
   private ExecutableError error;
+  private ExecutableEscalation escalation;
   private boolean interrupting;
   private BiFunction<ExpressionProcessor, Long, Either<Failure, Timer>> timerFactory;
 
@@ -47,6 +48,11 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
   @Override
   public boolean isError() {
     return error != null;
+  }
+
+  @Override
+  public boolean isEscalation() {
+    return escalation != null;
   }
 
   @Override
@@ -80,6 +86,15 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
 
   public void setError(final ExecutableError error) {
     this.error = error;
+  }
+
+  @Override
+  public ExecutableEscalation getEscalation() {
+    return escalation;
+  }
+
+  public void setEscalation(final ExecutableEscalation escalation) {
+    this.escalation = escalation;
   }
 
   public void setLink(final boolean isLink) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableEscalation.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableEscalation.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.element;
+
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public class ExecutableEscalation extends AbstractFlowElement {
+
+  private final DirectBuffer escalationCode = new UnsafeBuffer();
+
+  public ExecutableEscalation(final String id) {
+    super(id);
+  }
+
+  public DirectBuffer getEscalationCode() {
+    return escalationCode;
+  }
+
+  public void setEscalationCode(final DirectBuffer escalationCode) {
+    this.escalationCode.wrap(escalationCode);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableIntermediateThrowEvent.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableIntermediateThrowEvent.java
@@ -14,6 +14,8 @@ public class ExecutableIntermediateThrowEvent extends ExecutableFlowNode
 
   private ExecutableLink link;
 
+  private ExecutableEscalation escalation;
+
   public ExecutableIntermediateThrowEvent(final String id) {
     super(id);
   }
@@ -36,8 +38,16 @@ public class ExecutableIntermediateThrowEvent extends ExecutableFlowNode
     this.link = link;
   }
 
+  public ExecutableEscalation getEscalation() {
+    return escalation;
+  }
+
+  public void setEscalation(final ExecutableEscalation escalation) {
+    this.escalation = escalation;
+  }
+
   public boolean isNoneThrowEvent() {
-    return !isMessageThrowEvent() && !isLinkThrowEvent();
+    return !isMessageThrowEvent() && !isLinkThrowEvent() && !isEscalationThrowEvent();
   }
 
   public boolean isMessageThrowEvent() {
@@ -46,5 +56,9 @@ public class ExecutableIntermediateThrowEvent extends ExecutableFlowNode
 
   public boolean isLinkThrowEvent() {
     return link != null;
+  }
+
+  public boolean isEscalationThrowEvent() {
+    return escalation != null;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableReceiveTask.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableReceiveTask.java
@@ -40,6 +40,11 @@ public class ExecutableReceiveTask extends ExecutableActivity implements Executa
   }
 
   @Override
+  public boolean isEscalation() {
+    return false;
+  }
+
+  @Override
   public boolean isLink() {
     return false;
   }
@@ -56,6 +61,11 @@ public class ExecutableReceiveTask extends ExecutableActivity implements Executa
 
   @Override
   public ExecutableError getError() {
+    return null;
+  }
+
+  @Override
+  public ExecutableEscalation getEscalation() {
     return null;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.transformer.CatchEven
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.ContextProcessTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.EndEventTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.ErrorTransformer;
+import io.camunda.zeebe.engine.processing.deployment.model.transformer.EscalationTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.EventBasedGatewayTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.ExclusiveGatewayTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.FlowElementInstantiationTransformer;
@@ -68,6 +69,7 @@ public final class BpmnTransformer {
 
     step1Visitor = new TransformationVisitor();
     step1Visitor.registerHandler(new ErrorTransformer());
+    step1Visitor.registerHandler(new EscalationTransformer());
     step1Visitor.registerHandler(new FlowElementInstantiationTransformer());
     step1Visitor.registerHandler(new MessageTransformer());
     step1Visitor.registerHandler(new ProcessTransformer());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/TransformContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformation/TransformContext.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableError;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEscalation;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableLink;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMessage;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
@@ -25,6 +26,7 @@ public final class TransformContext {
   private final Map<DirectBuffer, ExecutableProcess> processes = new HashMap<>();
   private final Map<DirectBuffer, ExecutableMessage> messages = new HashMap<>();
   private final Map<DirectBuffer, ExecutableError> errors = new HashMap<>();
+  private final Map<DirectBuffer, ExecutableEscalation> escalations = new HashMap<>();
   private final Map<DirectBuffer, ExecutableLink> links = new HashMap<>();
 
   private ExpressionLanguage expressionLanguage;
@@ -68,6 +70,14 @@ public final class TransformContext {
 
   public ExecutableError getError(final String id) {
     return errors.get(wrapString(id));
+  }
+
+  public void addEscalation(final ExecutableEscalation escalation) {
+    escalations.put(escalation.getId(), escalation);
+  }
+
+  public ExecutableEscalation getEscalation(final String id) {
+    return escalations.get(wrapString(id));
   }
 
   public void addLink(final ExecutableLink link) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/EscalationTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/EscalationTransformer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.transformer;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEscalation;
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
+import io.camunda.zeebe.model.bpmn.instance.Escalation;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Optional;
+
+public class EscalationTransformer implements ModelElementTransformer<Escalation> {
+
+  @Override
+  public Class<Escalation> getType() {
+    return Escalation.class;
+  }
+
+  @Override
+  public void transform(final Escalation element, final TransformContext context) {
+    final var escalation = new ExecutableEscalation(element.getId());
+    Optional.ofNullable(element.getEscalationCode())
+        .map(BufferUtil::wrapString)
+        .ifPresent(escalation::setEscalationCode);
+    context.addEscalation(escalation);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedEventRegistry.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedEventRegistry.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentDistribu
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
+import io.camunda.zeebe.protocol.impl.record.value.escalation.EscalationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -70,6 +71,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.DECISION_EVALUATION, DecisionEvaluationRecord.class);
 
     registry.put(ValueType.CHECKPOINT, CheckpointRecord.class);
+    registry.put(ValueType.ESCALATION, EscalationRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/analyzers/CatchEventAnalyzer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/analyzers/CatchEventAnalyzer.java
@@ -134,6 +134,14 @@ public final class CatchEventAnalyzer {
     return availableCatchEvents;
   }
 
+  public Optional<CatchEventTuple> findEscalationCatchEvent(
+      final DirectBuffer escalationCode, final ElementInstance instance) {
+    // TODO walk through the scope hierarchy and look for a matching catch event
+
+    // no matching catch event found
+    return Optional.empty();
+  }
+
   private ExecutableProcess getProcess(final long processDefinitionKey) {
 
     final var deployedProcess = processState.getProcessByKey(processDefinitionKey);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/escalation/EscalationEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/escalation/EscalationEventTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.escalation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class EscalationEventTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String TASK_ELEMENT_ID = "task";
+  private static final String PROCESS_ID = "wf";
+  private static final String ESCALATION_CODE = "ESCALATION";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldThrowEscalationFromEscalationIntermediateThrowEvent() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .intermediateThrowEvent("throw", b -> b.escalation(ESCALATION_CODE))
+            .manualTask(TASK_ELEMENT_ID)
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(
+                BpmnElementType.INTERMEDIATE_THROW_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(
+                BpmnElementType.INTERMEDIATE_THROW_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.MANUAL_TASK, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.MANUAL_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    assertIsNotEscalated("throw", ESCALATION_CODE);
+  }
+
+  private void assertIsNotEscalated(final String throwElementId, final String escalationCode) {
+    assertThat(
+            RecordingExporter.escalationRecords(EscalationIntent.NOT_ESCALATED)
+                .withCatchElementId("")
+                .withThrowElementId(throwElementId)
+                .withEscalationCode(escalationCode)
+                .exists())
+        .isTrue();
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/EscalationRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/EscalationRecordStream.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.EscalationRecordValue;
+import java.util.stream.Stream;
+
+public final class EscalationRecordStream
+    extends ExporterRecordStream<EscalationRecordValue, EscalationRecordStream> {
+
+  public EscalationRecordStream(final Stream<Record<EscalationRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected EscalationRecordStream supply(
+      final Stream<Record<EscalationRecordValue>> wrappedStream) {
+    return new EscalationRecordStream(wrappedStream);
+  }
+
+  public EscalationRecordStream withCatchElementId(final String catchElementId) {
+    return valueFilter(v -> catchElementId.equals(v.getCatchElementId()));
+  }
+
+  public EscalationRecordStream withThrowElementId(final String throwElementId) {
+    return valueFilter(v -> throwElementId.equals(v.getThrowElementId()));
+  }
+
+  public EscalationRecordStream withEscalationCode(final String escalationCode) {
+    return valueFilter(v -> escalationCode.equals(v.getEscalationCode()));
+  }
+
+  public EscalationRecordStream withProcessInstanceKey(final long processInstanceKey) {
+    return valueFilter(v -> v.getProcessInstanceKey() == processInstanceKey);
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.EscalationRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
@@ -233,6 +235,14 @@ public final class RecordingExporter implements Exporter {
 
   public static TimerRecordStream timerRecords(final TimerIntent intent) {
     return timerRecords().withIntent(intent);
+  }
+
+  public static EscalationRecordStream escalationRecords() {
+    return new EscalationRecordStream(records(ValueType.ESCALATION, EscalationRecordValue.class));
+  }
+
+  public static EscalationRecordStream escalationRecords(final EscalationIntent intent) {
+    return escalationRecords().withIntent(intent);
   }
 
   public static VariableRecordStream variableRecords() {


### PR DESCRIPTION
## Description
I can throw an escalation from an intermediate event.

<img width="494" alt="image" src="https://user-images.githubusercontent.com/24605947/195340739-d4ef13e4-e83a-4b8c-8727-bb280f84f03f.png">

## Related issues

closes #10685 

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
