### PR TITLE
[Backport stable/8.0] test(dispatcher): fixes sigsev due to consumer

### DIFF
--- a/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/ActorFrameworkIntegrationTest.java
+++ b/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/ActorFrameworkIntegrationTest.java
@@ -125,7 +125,7 @@ public final class ActorFrameworkIntegrationTest {
     }
 
     void consume() {
-      subscription.poll(this, Integer.MAX_VALUE);
+      actor.run(() -> subscription.poll(this, Integer.MAX_VALUE));
     }
 
     @Override
@@ -175,9 +175,12 @@ public final class ActorFrameworkIntegrationTest {
     }
 
     void consume() {
-      if (subscription.peekBlock(peek, Integer.MAX_VALUE, true) > 0) {
-        actor.submit(processPeek);
-      }
+      actor.run(
+          () -> {
+            if (subscription.peekBlock(peek, Integer.MAX_VALUE, true) > 0) {
+              actor.submit(processPeek);
+            }
+          });
     }
 
     void processPeek() {

--- a/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/ActorFrameworkIntegrationTest.java
+++ b/dispatcher/src/test/java/io/camunda/zeebe/dispatcher/integration/ActorFrameworkIntegrationTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.dispatcher.ClaimedFragment;
 import io.camunda.zeebe.dispatcher.Dispatcher;
 import io.camunda.zeebe.dispatcher.Dispatchers;
 import io.camunda.zeebe.dispatcher.FragmentHandler;
+import io.camunda.zeebe.dispatcher.Loggers;
 import io.camunda.zeebe.dispatcher.Subscription;
 import io.camunda.zeebe.util.ByteValue;
 import io.camunda.zeebe.util.sched.Actor;
@@ -88,6 +89,11 @@ public final class ActorFrameworkIntegrationTest {
       actor.run(this::produce);
     }
 
+    @Override
+    protected void onActorClosed() {
+      Loggers.DISPATCHER_LOGGER.debug("Producer closed!");
+    }
+
     void produce() {
       if (dispatcher.claimSingleFragment(claim, 4534) >= 0) {
         claim.getBuffer().putInt(claim.getOffset(), counter++);
@@ -107,6 +113,7 @@ public final class ActorFrameworkIntegrationTest {
     final Dispatcher dispatcher;
     Subscription subscription;
     int counter = 0;
+    volatile boolean closed;
 
     Consumer(final Dispatcher dispatcher) {
       this.dispatcher = dispatcher;
@@ -124,7 +131,16 @@ public final class ActorFrameworkIntegrationTest {
           });
     }
 
+    @Override
+    protected void onActorClosed() {
+      closed = true;
+      Loggers.DISPATCHER_LOGGER.debug("Consumer is closed!");
+    }
+
     void consume() {
+      if (closed) {
+        Loggers.DISPATCHER_LOGGER.debug("Consuming next fragment...");
+      }
       actor.run(() -> subscription.poll(this, Integer.MAX_VALUE));
     }
 
@@ -149,6 +165,7 @@ public final class ActorFrameworkIntegrationTest {
     final BlockPeek peek = new BlockPeek();
     Subscription subscription;
     int counter = 0;
+    volatile boolean closed = false;
     final Runnable processPeek =
         () -> {
           try {
@@ -174,7 +191,16 @@ public final class ActorFrameworkIntegrationTest {
           });
     }
 
+    @Override
+    protected void onActorClosed() {
+      closed = true;
+      Loggers.DISPATCHER_LOGGER.debug("Consumer is closed!");
+    }
+
     void consume() {
+      if (closed) {
+        Loggers.DISPATCHER_LOGGER.debug("Consuming next fragment...");
+      }
       actor.run(
           () -> {
             if (subscription.peekBlock(peek, Integer.MAX_VALUE, true) > 0) {


### PR DESCRIPTION
# Description
Backport of #10853 to `stable/8.0`.

relates to #10407