### PR TITLE
Unflake timer start event test

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerCatchEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerCatchEventTest.java
@@ -204,8 +204,6 @@ public final class TimerCatchEventTest {
             .withProcessInstanceKey(processInstanceKey)
             .getFirst();
 
-    ENGINE.increaseTime(Duration.ofSeconds(1));
-
     // then
     final Record<TimerRecordValue> triggeredEvent =
         RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
@@ -215,7 +213,7 @@ public final class TimerCatchEventTest {
     assertThat(triggeredEvent.getKey()).isEqualTo(createdEvent.getKey());
     assertThat(triggeredEvent.getValue()).isEqualTo(createdEvent.getValue());
     assertThat(Duration.ofMillis(triggeredEvent.getTimestamp() - createdEvent.getTimestamp()))
-        .isGreaterThanOrEqualTo(Duration.ofSeconds(1));
+        .isBetween(Duration.ofMillis(100), Duration.ofMillis(150));
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
@@ -1284,11 +1284,10 @@ public final class TimerStartEventTest {
     final long processDefinitionKey = deployedProcess.getProcessDefinitionKey();
 
     // when
-    engine.stop();
-    final long engineStoppedTime = engine.getClock().getCurrentTimeInMillis();
+    engine.forEachPartition(engine::pauseProcessing);
+    final long enginePausedTime = engine.getClock().getCurrentTimeInMillis();
     engine.increaseTime(Duration.ofMinutes(35));
-    RecordingExporter.reset();
-    engine.start();
+    engine.forEachPartition(engine::resumeProcessing);
 
     // then
     final Record<TimerRecordValue> firstRecord =
@@ -1301,7 +1300,7 @@ public final class TimerStartEventTest {
         .hasTargetElementId("start")
         .hasElementInstanceKey(TimerInstance.NO_ELEMENT_INSTANCE);
 
-    assertThat(firstRecord.getTimestamp()).isGreaterThan(engineStoppedTime);
+    assertThat(firstRecord.getTimestamp()).isGreaterThan(enginePausedTime);
 
     final TimerRecordValue secondTimerRecord =
         RecordingExporter.timerRecords(TimerIntent.CREATED)

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
@@ -30,7 +30,6 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.stream.Collectors;
-import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -1090,45 +1089,28 @@ public final class TimerStartEventTest {
     // when
     engine.increaseTime(Duration.ofSeconds(5));
 
-    // disable because we'll await with Awaitility
-    RecordingExporter.disableAwaitingIncomingRecords();
-
     // then
-    Awaitility.await()
-        .untilAsserted(
-            () -> {
-              // due timers are only checked if the engine is not currently processing #10112
-              // so we may need to move the clock slightly for each check
-              engine.increaseTime(Duration.ofMillis(100));
-              assertThat(RecordingExporter.timerRecords(TimerIntent.TRIGGERED).limit(4))
-                  .extracting(record -> record.getValue().getProcessDefinitionKey())
-                  .containsExactly(
-                      firstDeploymentProcessDefinitionKey,
-                      secondDeploymentProcessDefinitionKey,
-                      firstDeploymentProcessDefinitionKey,
-                      secondDeploymentProcessDefinitionKey);
-            });
+    assertThat(RecordingExporter.timerRecords(TimerIntent.TRIGGERED).limit(4))
+        .extracting(record -> record.getValue().getProcessDefinitionKey())
+        .containsExactly(
+            firstDeploymentProcessDefinitionKey,
+            secondDeploymentProcessDefinitionKey,
+            firstDeploymentProcessDefinitionKey,
+            secondDeploymentProcessDefinitionKey);
 
     // when
     engine.increaseTime(Duration.ofSeconds(10));
 
     // then
-    Awaitility.await()
-        .untilAsserted(
-            () -> {
-              // due timers are only checked if the engine is not currently processing #10112
-              // so we may need to move the clock slightly for each check
-              engine.increaseTime(Duration.ofMillis(100));
-              assertThat(RecordingExporter.timerRecords(TimerIntent.TRIGGERED).limit(5))
-                  .describedAs("Expect that start_1 triggered twice and start_2 triggered thrice")
-                  .extracting(record -> record.getValue().getProcessDefinitionKey())
-                  .containsExactly(
-                      firstDeploymentProcessDefinitionKey,
-                      secondDeploymentProcessDefinitionKey,
-                      firstDeploymentProcessDefinitionKey,
-                      secondDeploymentProcessDefinitionKey,
-                      secondDeploymentProcessDefinitionKey);
-            });
+    assertThat(RecordingExporter.timerRecords(TimerIntent.TRIGGERED).limit(5))
+        .describedAs("Expect that start_1 triggered twice and start_2 triggered thrice")
+        .extracting(record -> record.getValue().getProcessDefinitionKey())
+        .containsExactly(
+            firstDeploymentProcessDefinitionKey,
+            secondDeploymentProcessDefinitionKey,
+            firstDeploymentProcessDefinitionKey,
+            secondDeploymentProcessDefinitionKey,
+            secondDeploymentProcessDefinitionKey);
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -242,7 +242,8 @@ public final class EngineRule extends ExternalResource {
       // the due date checker is scheduled through a post-commit task. When the engine has reached
       // the end of the log, all post-commit tasks have also been applied, because the state machine
       // will have executed them before switching the hasReachEnd flag.
-      Awaitility.await().until(this::hasReachedEnd);
+      Awaitility.await("Expect that engine reaches the end of the log before increasing the time")
+          .until(this::hasReachedEnd);
     }
 
     environmentRule.getClock().addTime(duration);


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Most cases in the timer start event test were suffering from flakiness. This stabilizes these tests again.

The cause of the flakiness was a race condition between time traveling and scheduling an upcoming timer:
 - the time would be increased after the deployment is completed
 - that includes writing all the deployment events (up to and including fully_distributed)
 - it does not await post-commit task execution
 - upcoming timers are scheduled in a post-commit task
 - this post-commit task could be executed after the time traveling
 - in that case the timer does not trigger after the time travel, as it is scheduled in the future

This changes the time travel to guarantee that the post-commit tasks have been executed. It does that by awaiting that the engine reaches the end of the log.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10272 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
