### PR TITLE
Increase timeout and add logging

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -97,9 +97,11 @@ import org.junit.rules.ExternalResource;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ClusteringRule extends ExternalResource {
-
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusteringRule.class);
   private static final AtomicLong CLUSTER_COUNT = new AtomicLong(0);
   private static final boolean ENABLE_DEBUG_EXPORTER = false;
   private static final String RAFT_PARTITION_PATH =
@@ -588,6 +590,10 @@ public class ClusteringRule extends ExternalResource {
 
   public void disconnect(final Broker broker) {
     final var cluster = broker.getSystemContext().getCluster();
+
+    LOGGER.debug(
+        "Disonnecting node {} to cluster",
+        broker.getSystemContext().getBrokerConfiguration().getCluster().getNodeId());
     ((NettyUnicastService) cluster.getUnicastService()).stop().join();
     ((NettyMessagingService) cluster.getMessagingService()).stop().join();
   }
@@ -595,6 +601,9 @@ public class ClusteringRule extends ExternalResource {
   public void connect(final Broker broker) {
     final var cluster = broker.getSystemContext().getCluster();
 
+    LOGGER.debug(
+        "Connecting node {} to cluster",
+        broker.getSystemContext().getBrokerConfiguration().getCluster().getNodeId());
     ((NettyUnicastService) cluster.getUnicastService()).start().join();
     ((NettyMessagingService) cluster.getMessagingService()).start().join();
   }


### PR DESCRIPTION
## Description

Increases the timeout of the assertion from 15 to 30 seconds, and adds more diagnostic logging for easier debugging next time this occurs (if it does :crossed_fingers:).

See [the last comment](https://github.com/camunda/zeebe/issues/10234#issuecomment-1297316970) for more, specifically the last paragraph.

## Related issues

related to #10234 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
