### PR TITLE
[Backport stable/8.0] Yield actor thread between retries

### DIFF
--- a/util/pom.xml
+++ b/util/pom.xml
@@ -94,13 +94,13 @@
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <scope>test</scope>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/util/src/main/java/io/camunda/zeebe/util/retry/AbortableRetryStrategy.java
+++ b/util/src/main/java/io/camunda/zeebe/util/retry/AbortableRetryStrategy.java
@@ -45,6 +45,7 @@ public final class AbortableRetryStrategy implements RetryStrategy {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
         actor.run(this::run);
+        actor.yieldThread();
       }
     } catch (final Exception exception) {
       currentFuture.completeExceptionally(exception);

--- a/util/src/main/java/io/camunda/zeebe/util/retry/EndlessRetryStrategy.java
+++ b/util/src/main/java/io/camunda/zeebe/util/retry/EndlessRetryStrategy.java
@@ -51,12 +51,14 @@ public final class EndlessRetryStrategy implements RetryStrategy {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
         actor.run(this::run);
+        actor.yieldThread();
       }
     } catch (final Exception exception) {
       if (terminateCondition.getAsBoolean()) {
         currentFuture.complete(false);
       } else {
         actor.run(this::run);
+        actor.yieldThread();
         LOG.error(
             "Caught exception {} with message {}, will retry...",
             exception.getClass(),

--- a/util/src/main/java/io/camunda/zeebe/util/retry/RecoverableRetryStrategy.java
+++ b/util/src/main/java/io/camunda/zeebe/util/retry/RecoverableRetryStrategy.java
@@ -48,10 +48,12 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
       final var control = retryMechanism.run();
       if (control == Control.RETRY) {
         actor.run(this::run);
+        actor.yieldThread();
       }
     } catch (final RecoverableException ex) {
       if (!terminateCondition.getAsBoolean()) {
         actor.run(this::run);
+        actor.yieldThread();
       }
     } catch (final Exception exception) {
       currentFuture.completeExceptionally(exception);

--- a/util/src/main/java/io/camunda/zeebe/util/sched/testing/ControlledActorSchedulerExtension.java
+++ b/util/src/main/java/io/camunda/zeebe/util/sched/testing/ControlledActorSchedulerExtension.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util.sched.testing;
+
+import io.camunda.zeebe.util.sched.Actor;
+import io.camunda.zeebe.util.sched.ActorScheduler;
+import io.camunda.zeebe.util.sched.ActorScheduler.ActorSchedulerBuilder;
+import io.camunda.zeebe.util.sched.ActorScheduler.ActorThreadFactory;
+import io.camunda.zeebe.util.sched.ActorThread;
+import io.camunda.zeebe.util.sched.ActorThreadGroup;
+import io.camunda.zeebe.util.sched.ActorTimerQueue;
+import io.camunda.zeebe.util.sched.TaskScheduler;
+import io.camunda.zeebe.util.sched.clock.ActorClock;
+import io.camunda.zeebe.util.sched.clock.ControlledActorClock;
+import io.camunda.zeebe.util.sched.future.ActorFuture;
+import java.util.Objects;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class ControlledActorSchedulerExtension implements BeforeEachCallback, AfterEachCallback {
+
+  private final Consumer<ActorSchedulerBuilder> configurator;
+
+  private ActorScheduler actorScheduler;
+  private ControlledActorThread controlledActorTaskRunner;
+
+  public ControlledActorSchedulerExtension() {
+    this(builder -> {});
+  }
+
+  public ControlledActorSchedulerExtension(final Consumer<ActorSchedulerBuilder> configurator) {
+    this.configurator = Objects.requireNonNull(configurator, "must specify a configurator");
+  }
+
+  @Override
+  public void afterEach(final ExtensionContext extensionContext) throws Exception {
+    actorScheduler.stop();
+  }
+
+  @Override
+  public void beforeEach(final ExtensionContext extensionContext) throws Exception {
+    final ControlledActorThreadFactory actorTaskRunnerFactory = new ControlledActorThreadFactory();
+    final ControlledActorClock clock = new ControlledActorClock();
+    final ActorTimerQueue timerQueue = new ActorTimerQueue(clock, 1);
+    final ActorSchedulerBuilder builder =
+        ActorScheduler.newActorScheduler()
+            .setActorClock(clock)
+            .setCpuBoundActorThreadCount(1)
+            .setIoBoundActorThreadCount(0)
+            .setActorThreadFactory(actorTaskRunnerFactory)
+            .setActorTimerQueue(timerQueue);
+
+    configurator.accept(builder);
+    actorScheduler = builder.build();
+    controlledActorTaskRunner = actorTaskRunnerFactory.controlledThread;
+    actorScheduler.start();
+  }
+
+  public ActorFuture<Void> submitActor(final Actor actor) {
+    return actorScheduler.submitActor(actor);
+  }
+
+  public void workUntilDone() {
+    controlledActorTaskRunner.workUntilDone();
+  }
+
+  static final class ControlledActorThreadFactory implements ActorThreadFactory {
+    private ControlledActorThread controlledThread;
+
+    @Override
+    public ActorThread newThread(
+        final String name,
+        final int id,
+        final ActorThreadGroup threadGroup,
+        final TaskScheduler taskScheduler,
+        final ActorClock clock,
+        final ActorTimerQueue timerQueue) {
+      controlledThread =
+          new ControlledActorThread(name, id, threadGroup, taskScheduler, clock, timerQueue);
+      return controlledThread;
+    }
+  }
+}

--- a/util/src/test/java/io/camunda/zeebe/util/retry/RetryStrategyTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/retry/RetryStrategyTest.java
@@ -12,140 +12,129 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.util.sched.Actor;
 import io.camunda.zeebe.util.sched.ActorControl;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
-import io.camunda.zeebe.util.sched.testing.ControlledActorSchedulerRule;
-import java.lang.reflect.Constructor;
+import io.camunda.zeebe.util.sched.testing.ControlledActorSchedulerExtension;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
-public final class RetryStrategyTest {
+final class RetryStrategyTest {
 
-  @Rule
-  public final ControlledActorSchedulerRule schedulerRule = new ControlledActorSchedulerRule();
+  @RegisterExtension
+  private final ControlledActorSchedulerExtension schedulerRule =
+      new ControlledActorSchedulerExtension();
 
-  @Parameter public Class<RetryStrategy> retryStrategyClass;
-  private RetryStrategy retryStrategy;
-  private ActorControl actorControl;
   private ActorFuture<Boolean> resultFuture;
 
-  @Parameters(name = "{index}: {0}")
-  public static Object[][] reprocessingTriggers() {
-    return new Object[][] {
-      new Object[] {RecoverableRetryStrategy.class}, new Object[] {AbortableRetryStrategy.class}
-    };
-  }
-
-  @Before
-  public void setUp() {
-    final ControllableActor actor = new ControllableActor();
-    actorControl = actor.getActor();
-
-    try {
-      final Constructor<RetryStrategy> constructor =
-          retryStrategyClass.getConstructor(ActorControl.class);
-      retryStrategy = constructor.newInstance(actorControl);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
-    }
-
+  @ParameterizedTest(name = "{0}")
+  @MethodSource({
+    "provideEndlessStrategy",
+    "provideRecoverableStrategy",
+    "provideAbortableStrategy",
+    "provideBackOffStrategy"
+  })
+  void shouldRunUntilDone(final RetryStrategy strategy, final ControllableActor actor) {
+    // given
+    final var count = new AtomicInteger(0);
     schedulerRule.submitActor(actor);
-  }
-
-  @Test
-  public void shouldRunUntilDone() throws Exception {
-    // given
-    final AtomicInteger count = new AtomicInteger(0);
 
     // when
-    actorControl.run(
-        () -> {
-          resultFuture = retryStrategy.runWithRetry(() -> count.incrementAndGet() == 10);
-        });
-
+    actor.run(() -> resultFuture = strategy.runWithRetry(() -> count.incrementAndGet() == 10));
     schedulerRule.workUntilDone();
 
     // then
     assertThat(count.get()).isEqualTo(10);
-    assertThat(resultFuture.isDone()).isTrue();
-    assertThat(resultFuture.get()).isTrue();
+    assertThat(resultFuture).succeedsWithin(Duration.ZERO).isEqualTo(true);
   }
 
-  @Test
-  public void shouldStopWhenAbortConditionReturnsTrue() throws Exception {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource({
+    "provideEndlessStrategy",
+    "provideRecoverableStrategy",
+    "provideAbortableStrategy",
+    "provideBackOffStrategy"
+  })
+  void shouldStopWhenAbortConditionReturnsTrue(
+      final RetryStrategy strategy, final ControllableActor actor) {
     // given
     final AtomicInteger count = new AtomicInteger(0);
+    schedulerRule.submitActor(actor);
 
     // when
-    actorControl.run(
-        () -> {
-          resultFuture =
-              retryStrategy.runWithRetry(() -> false, () -> count.incrementAndGet() == 10);
-        });
-
+    actor.run(
+        () ->
+            resultFuture = strategy.runWithRetry(() -> false, () -> count.incrementAndGet() == 10));
     schedulerRule.workUntilDone();
 
     // then
     assertThat(count.get()).isEqualTo(10);
-    assertThat(resultFuture.isDone()).isTrue();
-    assertThat(resultFuture.get()).isFalse();
+    assertThat(resultFuture).succeedsWithin(Duration.ZERO).isEqualTo(false);
   }
 
-  @Test
-  public void shouldAbortOnOtherException() {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource({"provideRecoverableStrategy", "provideAbortableStrategy"})
+  void shouldAbortOnOtherException(final RetryStrategy strategy, final ControllableActor actor) {
     // given
+    final RuntimeException failure = new RuntimeException("expected");
+    schedulerRule.submitActor(actor);
+
     // when
-    actorControl.run(
+    actor.run(
         () ->
             resultFuture =
-                retryStrategy.runWithRetry(
+                strategy.runWithRetry(
                     () -> {
-                      throw new RuntimeException("expected");
+                      throw failure;
                     }));
-
     schedulerRule.workUntilDone();
 
     // then
-    assertThat(resultFuture.isDone()).isTrue();
-    assertThat(resultFuture.isCompletedExceptionally()).isTrue();
-    assertThat(resultFuture.getException()).isExactlyInstanceOf(RuntimeException.class);
+    assertThat(resultFuture)
+        .failsWithin(Duration.ZERO)
+        .withThrowableOfType(ExecutionException.class)
+        .withCause(failure);
   }
 
-  @Test
-  public void shouldNotInterleaveRetry() {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource({
+    "provideEndlessStrategy",
+    "provideRecoverableStrategy",
+    "provideAbortableStrategy"
+  })
+  void shouldNotInterleaveRetry(final RetryStrategy strategy, final ControllableActor actor) {
     // given
     final AtomicReference<ActorFuture<Boolean>> firstFuture = new AtomicReference<>();
     final AtomicReference<ActorFuture<Boolean>> secondFuture = new AtomicReference<>();
-
     final AtomicInteger executionAttempt = new AtomicInteger(0);
     final AtomicInteger firstResult = new AtomicInteger();
     final AtomicInteger secondResult = new AtomicInteger();
+    schedulerRule.submitActor(actor);
 
     // when
     final var retryCounts = 5;
-    actorControl.run(
+    actor.run(
         () ->
             firstFuture.set(
-                retryStrategy.runWithRetry(
+                strategy.runWithRetry(
                     () -> {
                       firstResult.set(executionAttempt.getAndIncrement());
                       return executionAttempt.get() >= retryCounts;
                     })));
-    actorControl.run(
+    actor.run(
         () ->
             secondFuture.set(
-                retryStrategy.runWithRetry(
+                strategy.runWithRetry(
                     () -> {
                       secondResult.set(executionAttempt.getAndIncrement());
                       return true;
                     })));
-
     schedulerRule.workUntilDone();
 
     // then
@@ -155,9 +144,52 @@ public final class RetryStrategyTest {
     assertThat(secondResult).hasValue(retryCounts);
   }
 
+  private static Stream<Arguments> provideRecoverableStrategy() {
+    return Stream.of(TestCase.of(RecoverableRetryStrategy::new));
+  }
+
+  private static Stream<Arguments> provideAbortableStrategy() {
+    return Stream.of(TestCase.of(AbortableRetryStrategy::new));
+  }
+
+  private static Stream<Arguments> provideEndlessStrategy() {
+    return Stream.of(TestCase.of(EndlessRetryStrategy::new));
+  }
+
+  private static Stream<Arguments> provideBackOffStrategy() {
+    return Stream.of(
+        TestCase.of(
+            // it's important to use a zero delay as otherwise workUntilDone will not wait for
+            // all timers to be triggered
+            actor -> new BackOffRetryStrategy(actor, Duration.ZERO)));
+  }
+
+  private record TestCase<T extends RetryStrategy>(ControllableActor actor, T strategy)
+      implements Arguments {
+
+    private static <T extends RetryStrategy> TestCase<T> of(
+        final Function<ActorControl, T> provider) {
+      final var actor = new ControllableActor();
+      final var strategy = provider.apply(actor.getActor());
+      return new TestCase<>(actor, strategy);
+    }
+
+    @Override
+    public Object[] get() {
+      return new Object[] {Named.of(strategy.getClass().getSimpleName(), strategy), actor};
+    }
+  }
+
   private static final class ControllableActor extends Actor {
     public ActorControl getActor() {
       return actor;
+    }
+
+    @Override
+    public void close() {
+      // do not wait for the close, as the scheduler is already closed by the time the
+      // actor is closed
+      closeAsync();
     }
   }
 }


### PR DESCRIPTION
# Description
Backport of #10844 to `stable/8.1`.

relates to #10539

# Conflicts

I had to backport the `ControlledActorSchedulerExtension`, mostly, but I think that'll be useful in the future for backporting other things (maybe). There was nothing special for the actual test/PR itself.