### PR TITLE
[Backport stable/8.0] Increase timeout and add logging

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -98,7 +98,7 @@ import org.junit.runners.model.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class ClusteringRule extends ExternalResource {
+public class ClusteringRule extends ExternalResource {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ClusteringRule.class);
   private static final AtomicLong CLUSTER_COUNT = new AtomicLong(0);
@@ -157,6 +157,21 @@ public final class ClusteringRule extends ExternalResource {
         clusterSize,
         configurator,
         gatewayCfg -> {},
+        ZeebeClientBuilder::usePlaintext);
+  }
+
+  public ClusteringRule(
+      final int partitionCount,
+      final int replicationFactor,
+      final int clusterSize,
+      final Consumer<BrokerCfg> brokerConfigurator,
+      final Consumer<GatewayCfg> gatewayConfigurator) {
+    this(
+        partitionCount,
+        replicationFactor,
+        clusterSize,
+        brokerConfigurator,
+        gatewayConfigurator,
         ZeebeClientBuilder::usePlaintext);
   }
 
@@ -351,7 +366,7 @@ public final class ClusteringRule extends ExternalResource {
     return brokerCfg;
   }
 
-  private File getBrokerBase(final int nodeId) {
+  protected File getBrokerBase(final int nodeId) {
     final var base = new File(temporaryFolder.getRoot(), String.valueOf(nodeId));
     if (!base.exists()) {
       base.mkdir();

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -95,9 +95,12 @@ import org.junit.rules.ExternalResource;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class ClusteringRule extends ExternalResource {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusteringRule.class);
   private static final AtomicLong CLUSTER_COUNT = new AtomicLong(0);
   private static final boolean ENABLE_DEBUG_EXPORTER = false;
   private static final String RAFT_PARTITION_PATH =
@@ -550,6 +553,9 @@ public final class ClusteringRule extends ExternalResource {
   public void disconnect(final Broker broker) {
     final var atomix = broker.getBrokerContext().getAtomixCluster();
 
+    LOGGER.debug(
+        "Disonnecting node {} to cluster",
+        broker.getSystemContext().getBrokerConfiguration().getCluster().getNodeId());
     ((NettyUnicastService) atomix.getUnicastService()).stop().join();
     ((NettyMessagingService) atomix.getMessagingService()).stop().join();
   }
@@ -557,6 +563,9 @@ public final class ClusteringRule extends ExternalResource {
   public void connect(final Broker broker) {
     final var atomix = broker.getBrokerContext().getAtomixCluster();
 
+    LOGGER.debug(
+        "Connecting node {} to cluster",
+        broker.getSystemContext().getBrokerConfiguration().getCluster().getNodeId());
     ((NettyUnicastService) atomix.getUnicastService()).start().join();
     ((NettyMessagingService) atomix.getMessagingService()).start().join();
   }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRuleExtension.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRuleExtension.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.camunda.zeebe.test.util.record.RecordLogger;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.util.FileUtil;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+
+/** This is a wrapper over {@link ClusteringRule}. */
+public class ClusteringRuleExtension extends ClusteringRule
+    implements BeforeEachCallback, AfterEachCallback, TestWatcher {
+
+  private Path tempDir;
+
+  public ClusteringRuleExtension(
+      final int partitionCount,
+      final int replicationFactor,
+      final int clusterSize,
+      final Consumer<BrokerCfg> brokerConfigurator,
+      final Consumer<GatewayCfg> gatewayConfigurator) {
+    super(partitionCount, replicationFactor, clusterSize, brokerConfigurator, gatewayConfigurator);
+  }
+
+  @Override
+  public void afterEach(final ExtensionContext context) throws Exception {
+    super.after();
+    FileUtil.deleteFolderIfExists(tempDir);
+  }
+
+  @Override
+  public void beforeEach(final ExtensionContext context) throws Exception {
+    RecordingExporter.reset();
+    tempDir = Files.createTempDirectory("clustered-tests");
+    super.before();
+  }
+
+  @Override
+  protected File getBrokerBase(final int nodeId) {
+    final Path base;
+    try {
+      base = tempDir.resolve(String.valueOf(nodeId));
+      FileUtil.ensureDirectoryExists(base);
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    return base.toFile();
+  }
+
+  public ClusteringRule getCluster() {
+    return this;
+  }
+
+  @Override
+  public void testFailed(final ExtensionContext context, final Throwable cause) {
+    RecordLogger.logRecords();
+  }
+}


### PR DESCRIPTION
# Description
Backport of #10868 to `stable/8.1`.

relates to #10234

# Conflicts

There was a minor conflict in `ClusteringRule` around the logging added, mostly due to the changes we did when we moved the construction of `AtomixCluster` into the dist module. Nothing major, just add to move a line.

The PR also backports the `ClusteringRuleExtension`, as it will be useful in the future for more backports, I think.