### PR TITLE
feat(benchmarks): unpin grafana version

### DIFF
--- a/benchmarks/docs/setup/zeebe-cluster-prometheus-values.yml
+++ b/benchmarks/docs/setup/zeebe-cluster-prometheus-values.yml
@@ -2,8 +2,6 @@ alertmanager:
   enabled: true
 
 grafana:
-  image:
-    tag: 7.4.5
   admin:
     existingSecret: grafana-admin-password
     userKey: admin-user
@@ -80,4 +78,3 @@ prometheus:
           resources:
             requests:
               storage: 150Gi
-

--- a/benchmarks/docs/setup/zeebe-long-running-prometheus-values.yml
+++ b/benchmarks/docs/setup/zeebe-long-running-prometheus-values.yml
@@ -2,8 +2,6 @@ alertmanager:
   enabled: true
 
 grafana:
-  image:
-    tag: 7.4.5
   admin:
     existingSecret: grafana-admin-password
     userKey: admin-user
@@ -80,4 +78,3 @@ prometheus:
           resources:
             requests:
               storage: 150Gi
-


### PR DESCRIPTION
## Description

Version will be selected based on the helm chart version. After updating the chart to 17.x grafana version is now 8.0.5

## Related issues

closes #10133 