### PR TITLE
Support throw error with variables

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ThrowErrorCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ThrowErrorCommandStep1.java
@@ -15,6 +15,9 @@
  */
 package io.camunda.zeebe.client.api.command;
 
+import java.io.InputStream;
+import java.util.Map;
+
 public interface ThrowErrorCommandStep1 {
   /**
    * Set the errorCode for the error.
@@ -38,5 +41,41 @@ public interface ThrowErrorCommandStep1 {
      *     it to the broker.
      */
     ThrowErrorCommandStep2 errorMessage(String errorMsg);
+
+    /**
+     * Set the variables of this job.
+     *
+     * @param variables the variables (JSON) as stream
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    ThrowErrorCommandStep2 variables(InputStream variables);
+
+    /**
+     * Set the variables of this job.
+     *
+     * @param variables the variables (JSON) as String
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    ThrowErrorCommandStep2 variables(String variables);
+
+    /**
+     * Set the variables of this job.
+     *
+     * @param variables the variables as map
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    ThrowErrorCommandStep2 variables(Map<String, Object> variables);
+
+    /**
+     * Set the variables of this job.
+     *
+     * @param variables the variables as object
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    ThrowErrorCommandStep2 variables(Object variables);
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobClientImpl.java
@@ -53,7 +53,7 @@ public final class JobClientImpl implements JobClient {
   }
 
   @Override
-  public CompleteJobCommandStep1 newCompleteCommand(ActivatedJob job) {
+  public CompleteJobCommandStep1 newCompleteCommand(final ActivatedJob job) {
     return newCompleteCommand(job.getKey());
   }
 
@@ -64,18 +64,18 @@ public final class JobClientImpl implements JobClient {
   }
 
   @Override
-  public FailJobCommandStep1 newFailCommand(ActivatedJob job) {
+  public FailJobCommandStep1 newFailCommand(final ActivatedJob job) {
     return newFailCommand(job.getKey());
   }
 
   @Override
-  public ThrowErrorCommandStep1 newThrowErrorCommand(long jobKey) {
+  public ThrowErrorCommandStep1 newThrowErrorCommand(final long jobKey) {
     return new ThrowErrorCommandImpl(
-        asyncStub, jobKey, config.getDefaultRequestTimeout(), retryPredicate);
+        asyncStub, jsonMapper, jobKey, config.getDefaultRequestTimeout(), retryPredicate);
   }
 
   @Override
-  public ThrowErrorCommandStep1 newThrowErrorCommand(ActivatedJob job) {
+  public ThrowErrorCommandStep1 newThrowErrorCommand(final ActivatedJob job) {
     return newThrowErrorCommand(job.getKey());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
@@ -75,6 +75,24 @@ public final class BpmnEventPublicationBehavior {
   }
 
   /**
+   * Throws an error event to the given element instance/catch event pair. Only throws the event if
+   * the given element instance is exists and is accepting events, e.g. isn't terminating, wasn't
+   * interrupted, etc.
+   *
+   * @param catchEventTuple a tuple representing a catch event and its current instance
+   */
+  public void throwErrorEvent(
+      final CatchEventAnalyzer.CatchEventTuple catchEventTuple, final DirectBuffer variables) {
+    final ElementInstance eventScopeInstance = catchEventTuple.getElementInstance();
+    final ExecutableCatchEvent catchEvent = catchEventTuple.getCatchEvent();
+
+    if (eventHandle.canTriggerElement(eventScopeInstance, catchEvent.getId())) {
+      eventHandle.activateElement(
+          catchEvent, eventScopeInstance.getKey(), eventScopeInstance.getValue(), variables);
+    }
+  }
+
+  /**
    * Finds the right catch event for the given error. This is done by going up through the scope
    * hierarchy recursively until a matching catch event is found. If none are found, a failure is
    * returned.

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -119,7 +119,8 @@ public final class BpmnVariableMappingBehavior {
       variableBehavior.mergeDocument(
           elementInstanceKey, processDefinitionKey, processInstanceKey, bpmnProcessId, variables);
     } else if (isConnectedToEventBasedGateway(element)
-        || element.getElementType() == BpmnElementType.BOUNDARY_EVENT
+        || (element.getElementType() == BpmnElementType.BOUNDARY_EVENT
+            && !isConnectedToErrorEvent(element))
         || element.getElementType() == BpmnElementType.START_EVENT) {
       // event variables are set local variables instead of temporary variables
       final var localVariables = variablesState.getVariablesLocalAsDocument(elementInstanceKey);
@@ -144,6 +145,15 @@ public final class BpmnVariableMappingBehavior {
     if (element instanceof ExecutableCatchEventElement) {
       final var catchEvent = (ExecutableCatchEventElement) element;
       return catchEvent.isConnectedToEventBasedGateway();
+    } else {
+      return false;
+    }
+  }
+
+  private boolean isConnectedToErrorEvent(final ExecutableFlowNode element) {
+    if (element instanceof ExecutableCatchEventElement) {
+      final var catchEvent = (ExecutableCatchEventElement) element;
+      return catchEvent.isError();
     } else {
       return false;
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -119,8 +119,7 @@ public final class BpmnVariableMappingBehavior {
       variableBehavior.mergeDocument(
           elementInstanceKey, processDefinitionKey, processInstanceKey, bpmnProcessId, variables);
     } else if (isConnectedToEventBasedGateway(element)
-        || (element.getElementType() == BpmnElementType.BOUNDARY_EVENT
-            && !isConnectedToErrorEvent(element))
+        || (element.getElementType() == BpmnElementType.BOUNDARY_EVENT && !isErrorEvent(element))
         || element.getElementType() == BpmnElementType.START_EVENT) {
       // event variables are set local variables instead of temporary variables
       final var localVariables = variablesState.getVariablesLocalAsDocument(elementInstanceKey);
@@ -150,7 +149,7 @@ public final class BpmnVariableMappingBehavior {
     }
   }
 
-  private boolean isConnectedToErrorEvent(final ExecutableFlowNode element) {
+  private boolean isErrorEvent(final ExecutableFlowNode element) {
     if (element instanceof ExecutableCatchEventElement) {
       final var catchEvent = (ExecutableCatchEventElement) element;
       return catchEvent.isError();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -96,7 +96,7 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
       return;
     }
 
-    eventPublicationBehavior.throwErrorEvent(foundCatchEvent.get());
+    eventPublicationBehavior.throwErrorEvent(foundCatchEvent.get(), job.getVariablesBuffer());
   }
 
   private void acceptCommand(
@@ -106,6 +106,7 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
     final JobRecord job = jobState.getJob(jobKey);
     job.setErrorCode(command.getValue().getErrorCodeBuffer());
     job.setErrorMessage(command.getValue().getErrorMessageBuffer());
+    job.setVariables(command.getValue().getVariablesBuffer());
 
     final var serviceTaskInstanceKey = job.getElementInstanceKey();
     final var serviceTaskInstance = elementInstanceState.getInstance(serviceTaskInstanceKey);

--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -291,6 +291,12 @@ message ThrowErrorRequest {
   string errorCode = 2;
   // an optional error message that provides additional context
   string errorMessage = 3;
+  // JSON document that will instantiate the variables at the local scope of the
+  // error catch event that catches the thrown error; it must be a JSON object, as variables will be mapped in a
+  // key-value fashion. e.g. { "a": 1, "b": 2 } will create two variables, named "a" and
+  // "b" respectively, with their associated values. [{ "a": 1, "b": 2 }] would not be a
+  // valid argument, as the root of the JSON document is an array and not an object.
+  string variables = 4;
 }
 
 message ThrowErrorResponse {

--- a/gateway-protocol/src/main/proto/proto.lock
+++ b/gateway-protocol/src/main/proto/proto.lock
@@ -565,6 +565,11 @@
                 "id": 3,
                 "name": "errorMessage",
                 "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "variables",
+                "type": "string"
               }
             ]
           },

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -95,7 +95,8 @@ public final class RequestMapper {
 
   public static BrokerThrowErrorRequest toThrowErrorRequest(final ThrowErrorRequest grpcRequest) {
     return new BrokerThrowErrorRequest(grpcRequest.getJobKey(), grpcRequest.getErrorCode())
-        .setErrorMessage(grpcRequest.getErrorMessage());
+        .setErrorMessage(grpcRequest.getErrorMessage())
+        .setVariables(ensureJsonSet(grpcRequest.getVariables()));
   }
 
   public static BrokerCompleteJobRequest toCompleteJobRequest(

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerThrowErrorRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerThrowErrorRequest.java
@@ -29,6 +29,11 @@ public final class BrokerThrowErrorRequest extends BrokerExecuteCommand<JobRecor
     return this;
   }
 
+  public BrokerThrowErrorRequest setVariables(final DirectBuffer variables) {
+    requestDto.setVariables(variables);
+    return this;
+  }
+
   @Override
   public JobRecord getRequestWriter() {
     return requestDto;

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/ThrowErrorTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/ThrowErrorTest.java
@@ -17,6 +17,9 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorResponse;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.test.util.JsonUtil;
+import io.camunda.zeebe.test.util.MsgPackUtil;
+import java.util.Collections;
 import org.junit.Test;
 
 public final class ThrowErrorTest extends GatewayTest {
@@ -29,11 +32,14 @@ public final class ThrowErrorTest extends GatewayTest {
 
     final String errorCode = "test";
 
+    final String variables = JsonUtil.toJson(Collections.singletonMap("foo", "bar"));
+
     final ThrowErrorRequest request =
         ThrowErrorRequest.newBuilder()
             .setJobKey(stub.getKey())
             .setErrorCode(errorCode)
             .setErrorMessage("failed")
+            .setVariables(variables)
             .build();
 
     // when
@@ -50,5 +56,8 @@ public final class ThrowErrorTest extends GatewayTest {
     final JobRecord brokerRequestValue = brokerRequest.getRequestWriter();
     assertThat(brokerRequestValue.getErrorCode()).isEqualTo(errorCode);
     assertThat(brokerRequestValue.getErrorMessageBuffer()).isEqualTo(wrapString("failed"));
+
+    MsgPackUtil.assertEqualityExcluding(brokerRequestValue.getVariablesBuffer(), variables);
+    assertThat(brokerRequestValue.getVariables().get("foo")).isEqualTo("bar");
   }
 }


### PR DESCRIPTION
## Description

Support throw error with variables.

![image](https://user-images.githubusercontent.com/26370117/199285371-c30696cc-7468-4691-ae28-390408f812cd.png)


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4337
closes #4080 
closes #9473 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
