### PR TITLE
Migrate the TypedStreamProcessorTest

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineErrorHandlingTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineErrorHandlingTest.java
@@ -39,7 +39,7 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockitoAnnotations;
 
-public final class TypedStreamProcessorTest {
+public final class EngineErrorHandlingTest {
 
   private static final String STREAM_NAME = "foo";
   protected SynchronousLogStream stream;

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineErrorHandlingTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineErrorHandlingTest.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
-import org.mockito.MockitoAnnotations;
 
 public final class EngineErrorHandlingTest {
 
@@ -57,8 +56,6 @@ public final class EngineErrorHandlingTest {
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
-
     streams = new TestStreams(tempFolder, closeables, actorSchedulerRule.get());
     mockCommandResponseWriter = streams.getMockedResponseWriter();
     stream = streams.createLogStream(STREAM_NAME);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedStreamProcessorTest.java
@@ -71,41 +71,6 @@ public final class TypedStreamProcessorTest {
     keyGenerator = () -> key.getAndIncrement();
   }
 
-  @Test
-  public void shouldWriteSourceEventAndProducerOnBatch() {
-    // given
-    streams.startStreamProcessor(
-        STREAM_NAME,
-        DefaultZeebeDbFactory.defaultFactory(),
-        (processingContext) ->
-            TypedRecordProcessors.processors(keyGenerator, processingContext.getWriters())
-                .onCommand(
-                    ValueType.DEPLOYMENT,
-                    DeploymentIntent.CREATE,
-                    new BatchProcessor(processingContext.getWriters())));
-    final long firstEventPosition =
-        streams
-            .newRecord(STREAM_NAME)
-            .event(deployment("foo"))
-            .recordType(RecordType.COMMAND)
-            .intent(DeploymentIntent.CREATE)
-            .write();
-
-    // when
-    final LoggedEvent writtenEvent =
-        TestUtil.doRepeatedly(
-                () ->
-                    streams
-                        .events(STREAM_NAME)
-                        .filter(
-                            e -> Records.isEvent(e, ValueType.DEPLOYMENT, DeploymentIntent.CREATED))
-                        .findFirst())
-            .until(o -> o.isPresent())
-            .get();
-
-    // then
-    assertThat(writtenEvent.getSourceEventPosition()).isEqualTo(firstEventPosition);
-  }
 
   @Test
   public void shouldSkipFailingEvent() {

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.engine.api.RecordProcessorContext;
 import io.camunda.zeebe.engine.api.TypedRecord;
 import io.camunda.zeebe.engine.state.processing.DbKeyGenerator;
 import io.camunda.zeebe.engine.util.Records;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -554,9 +555,7 @@ public final class StreamProcessorTest {
   public void shouldWriteResponseOnFailedEventProcessing() {
     // given
     final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
-    when(defaultMockedRecordProcessor.process(any(), any()))
-        .thenThrow(new RuntimeException())
-        .thenReturn(EmptyProcessingResult.INSTANCE);
+    when(defaultMockedRecordProcessor.process(any(), any())).thenThrow(new RuntimeException());
 
     final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
     resultBuilder.withResponse(
@@ -570,7 +569,33 @@ public final class StreamProcessorTest {
         1,
         12);
     when(defaultMockedRecordProcessor.onProcessingError(any(), any(), any()))
-        .thenReturn(resultBuilder.build())
+        .thenReturn(resultBuilder.build());
+
+    streamPlatform.startStreamProcessor();
+
+    // when
+    streamPlatform.writeBatch(command().processInstance(ACTIVATE_ELEMENT, RECORD));
+
+    // then
+    verify(defaultMockedRecordProcessor, TIMEOUT.times(1)).process(any(), any());
+    verify(defaultMockedRecordProcessor, TIMEOUT.times(1)).onProcessingError(any(), any(), any());
+
+    final var commandResponseWriter = streamPlatform.getMockCommandResponseWriter();
+
+    verify(commandResponseWriter, TIMEOUT.times(1)).key(3);
+    verify(commandResponseWriter, TIMEOUT.times(1))
+        .intent(ProcessInstanceIntent.ELEMENT_ACTIVATING);
+    verify(commandResponseWriter, TIMEOUT.times(1)).recordType(RecordType.EVENT);
+    verify(commandResponseWriter, TIMEOUT.times(1)).valueType(ValueType.PROCESS_INSTANCE);
+    verify(commandResponseWriter, TIMEOUT.times(1)).tryWriteResponse(anyInt(), anyLong());
+  }
+
+  @Test
+  public void shouldContinueProcessingAfterFailedProcessing() {
+    // given
+    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(defaultMockedRecordProcessor.process(any(), any()))
+        .thenThrow(new RuntimeException())
         .thenReturn(EmptyProcessingResult.INSTANCE);
 
     streamPlatform.startStreamProcessor();
@@ -583,15 +608,38 @@ public final class StreamProcessorTest {
     // then
     verify(defaultMockedRecordProcessor, TIMEOUT.times(2)).process(any(), any());
     verify(defaultMockedRecordProcessor, TIMEOUT.times(1)).onProcessingError(any(), any(), any());
+  }
 
-    final var commandResponseWriter = streamPlatform.getMockCommandResponseWriter();
+  @Test
+  public void shouldBeAbleToWriteRejectionOnErrorHandling() {
+    // given
+    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(defaultMockedRecordProcessor.process(any(), any())).thenThrow(new RuntimeException());
 
-    verify(commandResponseWriter, TIMEOUT.times(1)).key(3);
-    verify(commandResponseWriter, TIMEOUT.times(1))
-        .intent(ProcessInstanceIntent.ELEMENT_ACTIVATING);
-    verify(commandResponseWriter, TIMEOUT.times(1)).recordType(RecordType.EVENT);
-    verify(commandResponseWriter, TIMEOUT.times(1)).valueType(ValueType.PROCESS_INSTANCE);
-    verify(commandResponseWriter, TIMEOUT.times(1)).tryWriteResponse(anyInt(), anyLong());
+    final var resultBuilder = new BufferedProcessingResultBuilder((c, s) -> true);
+    resultBuilder.appendRecordReturnEither(
+        1, RecordType.COMMAND_REJECTION, ACTIVATE_ELEMENT, RejectionType.NULL_VAL, "", RECORD);
+    when(defaultMockedRecordProcessor.onProcessingError(any(), any(), any()))
+        .thenReturn(resultBuilder.build());
+
+    streamPlatform.startStreamProcessor();
+
+    // when
+    streamPlatform.writeBatch(command().processInstance(ACTIVATE_ELEMENT, RECORD));
+
+    // then
+    verify(defaultMockedRecordProcessor, TIMEOUT.times(1)).process(any(), any());
+    verify(defaultMockedRecordProcessor, TIMEOUT.times(1)).onProcessingError(any(), any(), any());
+
+    final var logStreamReader = streamPlatform.getLogStream().newLogStreamReader();
+    logStreamReader.seekToFirstEvent();
+    logStreamReader.next(); // command
+    assertThat(logStreamReader.hasNext()).isTrue(); // rejection
+    final var record = logStreamReader.next();
+    final var recordMetadata = new RecordMetadata();
+    record.readMetadata(recordMetadata);
+    assertThat(recordMetadata.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(record.getSourceEventPosition()).isEqualTo(1);
   }
 
   @Test


### PR DESCRIPTION
## Description

* Rewrote [shouldWriteSourceEventAndProducerOnBatch](https://github.com/camunda/zeebe/commit/dbc19f65f69f98332fe3f60257f9120fd6d6cff1) test and move it to StreamProcessorTest
* Extend StreamProcessorTest:
  * Add test for writing rejection on error handling
  * Split a test such that we test separately whether processing can continue and we can write a response on error
* [iterate over TypedStreamProcessorTest](https://github.com/camunda/zeebe/commit/f6aa792d96fc257ebb5934a90e0c048bf7e250cf)
  * The test makes still sense from the engine perspective since we can verify whether commands which fail to process are automatically rejected etc.
  * 
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to #10455 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
