### PR TITLE
[Backport stable/8.1] Unflake timer start event test

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerCatchEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerCatchEventTest.java
@@ -204,8 +204,6 @@ public final class TimerCatchEventTest {
             .withProcessInstanceKey(processInstanceKey)
             .getFirst();
 
-    ENGINE.increaseTime(Duration.ofSeconds(1));
-
     // then
     final Record<TimerRecordValue> triggeredEvent =
         RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
@@ -215,7 +213,7 @@ public final class TimerCatchEventTest {
     assertThat(triggeredEvent.getKey()).isEqualTo(createdEvent.getKey());
     assertThat(triggeredEvent.getValue()).isEqualTo(createdEvent.getValue());
     assertThat(Duration.ofMillis(triggeredEvent.getTimestamp() - createdEvent.getTimestamp()))
-        .isGreaterThanOrEqualTo(Duration.ofSeconds(1));
+        .isBetween(Duration.ofMillis(100), Duration.ofMillis(150));
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
@@ -1284,11 +1284,10 @@ public final class TimerStartEventTest {
     final long processDefinitionKey = deployedProcess.getProcessDefinitionKey();
 
     // when
-    engine.stop();
-    final long engineStoppedTime = engine.getClock().getCurrentTimeInMillis();
+    engine.forEachPartition(engine::pauseProcessing);
+    final long enginePausedTime = engine.getClock().getCurrentTimeInMillis();
     engine.increaseTime(Duration.ofMinutes(35));
-    RecordingExporter.reset();
-    engine.start();
+    engine.forEachPartition(engine::resumeProcessing);
 
     // then
     final Record<TimerRecordValue> firstRecord =
@@ -1301,7 +1300,7 @@ public final class TimerStartEventTest {
         .hasTargetElementId("start")
         .hasElementInstanceKey(TimerInstance.NO_ELEMENT_INSTANCE);
 
-    assertThat(firstRecord.getTimestamp()).isGreaterThan(engineStoppedTime);
+    assertThat(firstRecord.getTimestamp()).isGreaterThan(enginePausedTime);
 
     final TimerRecordValue secondTimerRecord =
         RecordingExporter.timerRecords(TimerIntent.CREATED)

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/TimerStartEventTest.java
@@ -30,7 +30,6 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.stream.Collectors;
-import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -1090,45 +1089,28 @@ public final class TimerStartEventTest {
     // when
     engine.increaseTime(Duration.ofSeconds(5));
 
-    // disable because we'll await with Awaitility
-    RecordingExporter.disableAwaitingIncomingRecords();
-
     // then
-    Awaitility.await()
-        .untilAsserted(
-            () -> {
-              // due timers are only checked if the engine is not currently processing #10112
-              // so we may need to move the clock slightly for each check
-              engine.increaseTime(Duration.ofMillis(100));
-              assertThat(RecordingExporter.timerRecords(TimerIntent.TRIGGERED).limit(4))
-                  .extracting(record -> record.getValue().getProcessDefinitionKey())
-                  .containsExactly(
-                      firstDeploymentProcessDefinitionKey,
-                      secondDeploymentProcessDefinitionKey,
-                      firstDeploymentProcessDefinitionKey,
-                      secondDeploymentProcessDefinitionKey);
-            });
+    assertThat(RecordingExporter.timerRecords(TimerIntent.TRIGGERED).limit(4))
+        .extracting(record -> record.getValue().getProcessDefinitionKey())
+        .containsExactly(
+            firstDeploymentProcessDefinitionKey,
+            secondDeploymentProcessDefinitionKey,
+            firstDeploymentProcessDefinitionKey,
+            secondDeploymentProcessDefinitionKey);
 
     // when
     engine.increaseTime(Duration.ofSeconds(10));
 
     // then
-    Awaitility.await()
-        .untilAsserted(
-            () -> {
-              // due timers are only checked if the engine is not currently processing #10112
-              // so we may need to move the clock slightly for each check
-              engine.increaseTime(Duration.ofMillis(100));
-              assertThat(RecordingExporter.timerRecords(TimerIntent.TRIGGERED).limit(5))
-                  .describedAs("Expect that start_1 triggered twice and start_2 triggered thrice")
-                  .extracting(record -> record.getValue().getProcessDefinitionKey())
-                  .containsExactly(
-                      firstDeploymentProcessDefinitionKey,
-                      secondDeploymentProcessDefinitionKey,
-                      firstDeploymentProcessDefinitionKey,
-                      secondDeploymentProcessDefinitionKey,
-                      secondDeploymentProcessDefinitionKey);
-            });
+    assertThat(RecordingExporter.timerRecords(TimerIntent.TRIGGERED).limit(5))
+        .describedAs("Expect that start_1 triggered twice and start_2 triggered thrice")
+        .extracting(record -> record.getValue().getProcessDefinitionKey())
+        .containsExactly(
+            firstDeploymentProcessDefinitionKey,
+            secondDeploymentProcessDefinitionKey,
+            firstDeploymentProcessDefinitionKey,
+            secondDeploymentProcessDefinitionKey,
+            secondDeploymentProcessDefinitionKey);
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -242,7 +242,8 @@ public final class EngineRule extends ExternalResource {
       // the due date checker is scheduled through a post-commit task. When the engine has reached
       // the end of the log, all post-commit tasks have also been applied, because the state machine
       // will have executed them before switching the hasReachEnd flag.
-      Awaitility.await().until(this::hasReachedEnd);
+      Awaitility.await("Expect that engine reaches the end of the log before increasing the time")
+          .until(this::hasReachedEnd);
     }
 
     environmentRule.getClock().addTime(duration);


### PR DESCRIPTION
# Description
Backport of #10867 to `stable/8.1`.

relates to #10272