### PR TITLE
Skip docker verify on 8.0 patch releases

### DIFF
--- a/docker/test/verify.sh
+++ b/docker/test/verify.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eu
+# This script can be used to verify certain properties of a docker image.
+# Returns:
+#   0 on success
+#   1 if one of the properties is invalid
+
+set -o pipefail
+
+echo "The docker image properties only need to verified on versions > 8.0"
+echo "Skipping docker image verification"


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The 8.0.8 patch release failed because the Docker image step (the last step in the pipeline) tried to execute a verify.sh script that did not exist in that code base. The script was not supposed to be executed, due to a specific pipeline build param. However, that param has the value as specified on `main` during execution of the pipeline. Even when releasing older versions like patches for 8.0.

This PR adds a (mostly) empty verify.sh script to the `stable/8.0` branch, making sure the release is not failed by it.

Note that the real verify.sh script already exists in `stable/8.1`, so this PR does not require forward porting.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10895

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
