### PR TITLE
Await record writting

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
@@ -286,6 +286,9 @@ public final class StreamProcessorTest {
     final var firstRecord = logStreamReader.next();
     assertThat(firstRecord.getSourceEventPosition()).isEqualTo(-1);
     final var firstRecordPosition = firstRecord.getPosition();
+
+    await("should write follow up events")
+        .untilAsserted(() -> assertThat(logStreamReader.hasNext()).isTrue());
     while (logStreamReader.hasNext()) {
       final var followUpRecord = logStreamReader.next();
       assertThat(followUpRecord.getSourceEventPosition()).isEqualTo(firstRecordPosition);
@@ -634,7 +637,10 @@ public final class StreamProcessorTest {
     final var logStreamReader = streamPlatform.getLogStream().newLogStreamReader();
     logStreamReader.seekToFirstEvent();
     logStreamReader.next(); // command
-    assertThat(logStreamReader.hasNext()).isTrue(); // rejection
+
+    // rejection
+    await("should write rejection to log")
+        .untilAsserted(() -> assertThat(logStreamReader.hasNext()).isTrue());
     final var record = logStreamReader.next();
     final var recordMetadata = new RecordMetadata();
     record.readMetadata(recordMetadata);


### PR DESCRIPTION
## Description

It might happen that the records are not yet written to the 'log' and this would fail the test, we need to await that the reader can see the new records before continuing
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

resolves a flaky test

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
