### PR TITLE
[Backport stable/8.0] Bump jackson-bom to 2.13.4.20221013

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -62,7 +62,7 @@
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.13</version.httpclient>
     <version.httpcomponents>4.4.15</version.httpcomponents>
-    <version.jackson>2.13.2.20220324</version.jackson>
+    <version.jackson>2.13.4.20221013</version.jackson>
     <version.java-grpc-prometheus>0.5.0</version.java-grpc-prometheus>
     <version.jna>5.11.0</version.jna>
     <version.junit>5.8.2</version.junit>


### PR DESCRIPTION
# Description
Backport of #10719  to `stable/8.0`.

relates to https://github.com/camunda/team-automation-platform-8/issues/6