### PR TITLE
feat: support escalation end events

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
@@ -89,7 +89,7 @@ public final class BpmnEventPublicationBehavior {
   public Either<Failure, CatchEventTuple> findErrorCatchEvent(
       final DirectBuffer errorCode, final BpmnElementContext context) {
     final var flowScopeInstance = elementInstanceState.getInstance(context.getFlowScopeKey());
-    return catchEventAnalyzer.findCatchEvent(errorCode, flowScopeInstance, Optional.empty());
+    return catchEventAnalyzer.findErrorCatchEvent(errorCode, flowScopeInstance, Optional.empty());
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
-import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableIntermediateThrowEvent;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEscalation;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.KeyGenerator;
@@ -113,24 +113,26 @@ public final class BpmnEventPublicationBehavior {
    * event if the given element instance is exists and is accepting events, e.g. isn't terminating,
    * wasn't interrupted, etc.
    *
-   * @param element the instance of the intermediate throw event
-   * @param activated process instance-related data of the element that is executed
+   * @param throwElementId the element id of the escalation throw event
+   * @param escalation the escalation of throw event
+   * @param context process instance-related data of the element that is executed
    * @return returns true if the escalation throw event can be completed, false otherwise
    */
   public boolean throwEscalationEvent(
-      final ExecutableIntermediateThrowEvent element, final BpmnElementContext activated) {
-    final var escalation = element.getEscalation();
+      final DirectBuffer throwElementId,
+      final ExecutableEscalation escalation,
+      final BpmnElementContext context) {
     ensureNotNull("escalation", escalation);
 
     final var escalationCode = escalation.getEscalationCode();
     ensureNotNullOrEmpty("escalationCode", escalationCode);
 
     final var record = new EscalationRecord();
-    record.setThrowElementId(element.getId());
+    record.setThrowElementId(throwElementId);
     record.setEscalationCode(BufferUtil.bufferAsString(escalationCode));
-    record.setProcessInstanceKey(activated.getProcessInstanceKey());
+    record.setProcessInstanceKey(context.getProcessInstanceKey());
 
-    final var escalationCatchEvent = findEscalationCatchEvent(escalationCode, activated);
+    final var escalationCatchEvent = findEscalationCatchEvent(escalationCode, context);
 
     boolean canBeCompleted = true;
     boolean escalated = false;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
@@ -203,7 +203,8 @@ public class IntermediateThrowEventProcessor
 
       final var activated = stateTransitionBehavior.transitionToActivated(activating);
       final boolean canBeCompleted =
-          eventPublicationBehavior.throwEscalationEvent(element, activated);
+          eventPublicationBehavior.throwEscalationEvent(
+              element.getId(), element.getEscalation(), activated);
 
       if (canBeCompleted) {
         stateTransitionBehavior.completeElement(activated);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableEndEvent.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableEndEvent.java
@@ -11,6 +11,7 @@ public class ExecutableEndEvent extends ExecutableFlowNode implements Executable
 
   private JobWorkerProperties jobWorkerProperties;
   private ExecutableError error;
+  private ExecutableEscalation escalation;
 
   private boolean isTerminateEndEvent;
 
@@ -26,6 +27,14 @@ public class ExecutableEndEvent extends ExecutableFlowNode implements Executable
     this.error = error;
   }
 
+  public ExecutableEscalation getEscalation() {
+    return escalation;
+  }
+
+  public void setEscalation(final ExecutableEscalation escalation) {
+    this.escalation = escalation;
+  }
+
   @Override
   public JobWorkerProperties getJobWorkerProperties() {
     return jobWorkerProperties;
@@ -37,11 +46,18 @@ public class ExecutableEndEvent extends ExecutableFlowNode implements Executable
   }
 
   public boolean isNoneEndEvent() {
-    return !isErrorEndEvent() && !isMessageEventEvent() && !isTerminateEndEvent;
+    return !isErrorEndEvent()
+        && !isMessageEventEvent()
+        && !isTerminateEndEvent
+        && !isEscalationEndEvent();
   }
 
   public boolean isErrorEndEvent() {
     return error != null;
+  }
+
+  public boolean isEscalationEndEvent() {
+    return escalation != null;
   }
 
   public boolean isMessageEventEvent() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/EndEventTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/EndEventTransformer.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelE
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
 import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.TerminateEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
@@ -60,6 +61,9 @@ public final class EndEventTransformer implements ModelElementTransformer<EndEve
     } else if (eventDefinition instanceof TerminateEventDefinition) {
       executableElement.setTerminateEndEvent(true);
       executableElement.setEventType(BpmnEventType.TERMINATE);
+    } else if (eventDefinition instanceof EscalationEventDefinition) {
+      transformEscalationEventDefinition(
+          context, executableElement, (EscalationEventDefinition) eventDefinition);
     }
   }
 
@@ -81,5 +85,15 @@ public final class EndEventTransformer implements ModelElementTransformer<EndEve
 
   private boolean hasTaskDefinition(final EndEvent element) {
     return element.getSingleExtensionElement(ZeebeTaskDefinition.class) != null;
+  }
+
+  private void transformEscalationEventDefinition(
+      final TransformContext context,
+      final ExecutableEndEvent executableElement,
+      final EscalationEventDefinition escalationEventDefinition) {
+
+    final var escalation = escalationEventDefinition.getEscalation();
+    final var executableEscalation = context.getEscalation(escalation.getId());
+    executableElement.setEscalation(executableEscalation);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -112,7 +112,7 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
 
     final var errorCode = job.getErrorCodeBuffer();
     final var foundCatchEvent =
-        stateAnalyzer.findCatchEvent(
+        stateAnalyzer.findErrorCatchEvent(
             errorCode, serviceTaskInstance, Optional.of(job.getErrorMessageBuffer()));
     this.foundCatchEvent = foundCatchEvent;
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/analyzers/CatchEventAnalyzer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/analyzers/CatchEventAnalyzer.java
@@ -41,7 +41,7 @@ public final class CatchEventAnalyzer {
     this.elementInstanceState = elementInstanceState;
   }
 
-  public Either<Failure, CatchEventTuple> findCatchEvent(
+  public Either<Failure, CatchEventTuple> findErrorCatchEvent(
       final DirectBuffer errorCode,
       ElementInstance instance,
       final Optional<DirectBuffer> jobErrorMessage) {
@@ -53,7 +53,7 @@ public final class CatchEventAnalyzer {
       final var instanceRecord = instance.getValue();
       final var process = getProcess(instanceRecord.getProcessDefinitionKey());
 
-      final var found = findCatchEventInProcess(errorCode, process, instance);
+      final var found = findErrorCatchEventInProcess(errorCode, process, instance);
       if (found.isRight()) {
         return Either.right(found.get());
       } else {
@@ -85,13 +85,13 @@ public final class CatchEventAnalyzer {
     return Either.left(new Failure(incidentErrorMessage, ErrorType.UNHANDLED_ERROR_EVENT));
   }
 
-  private Either<List<DirectBuffer>, CatchEventTuple> findCatchEventInProcess(
+  private Either<List<DirectBuffer>, CatchEventTuple> findErrorCatchEventInProcess(
       final DirectBuffer errorCode, final ExecutableProcess process, ElementInstance instance) {
 
     final Either<List<DirectBuffer>, CatchEventTuple> availableCatchEvents =
         Either.left(new ArrayList<>());
     while (instance != null && instance.isActive() && !instance.isInterrupted()) {
-      final var found = findCatchEventInScope(errorCode, process, instance);
+      final var found = findErrorCatchEventInScope(errorCode, process, instance);
       if (found.isRight()) {
         return found;
       } else {
@@ -106,7 +106,7 @@ public final class CatchEventAnalyzer {
     return availableCatchEvents;
   }
 
-  private Either<List<DirectBuffer>, CatchEventTuple> findCatchEventInScope(
+  private Either<List<DirectBuffer>, CatchEventTuple> findErrorCatchEventInScope(
       final DirectBuffer errorCode,
       final ExecutableProcess process,
       final ElementInstance instance) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/analyzers/CatchEventAnalyzer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/analyzers/CatchEventAnalyzer.java
@@ -136,10 +136,74 @@ public final class CatchEventAnalyzer {
 
   public Optional<CatchEventTuple> findEscalationCatchEvent(
       final DirectBuffer escalationCode, final ElementInstance instance) {
-    // TODO walk through the scope hierarchy and look for a matching catch event
+    // walk through the scope hierarchy and look for a matching catch event
+    final var instanceRecord = instance.getValue();
+    final var process = getProcess(instanceRecord.getProcessDefinitionKey());
+
+    return findEscalationCatchEventInProcess(escalationCode, process, instance)
+        .or(
+            () -> {
+              // find in parent process instance if exists
+              final ElementInstance parentElementInstance =
+                  elementInstanceState.getInstance(instanceRecord.getParentElementInstanceKey());
+              if (parentElementInstance != null && parentElementInstance.isActive()) {
+                return findEscalationCatchEvent(escalationCode, parentElementInstance);
+              } else {
+                return Optional.empty();
+              }
+            });
+  }
+
+  private Optional<CatchEventTuple> findEscalationCatchEventInProcess(
+      final DirectBuffer escalationCode,
+      final ExecutableProcess process,
+      final ElementInstance instance) {
+    return findEscalationCatchEventInScope(escalationCode, process, instance)
+        .or(
+            () -> {
+              // find in parent scope if exists
+              final ElementInstance parentElementInstance =
+                  elementInstanceState.getInstance(instance.getParentKey());
+              if (parentElementInstance != null
+                  && instance.isActive()
+                  && !instance.isInterrupted()) {
+                return findEscalationCatchEventInProcess(
+                    escalationCode, process, parentElementInstance);
+              } else {
+                return Optional.empty();
+              }
+            });
+  }
+
+  private Optional<CatchEventTuple> findEscalationCatchEventInScope(
+      final DirectBuffer escalationCode,
+      final ExecutableProcess process,
+      final ElementInstance instance) {
+    final var processInstanceRecord = instance.getValue();
+    final var elementId = processInstanceRecord.getElementIdBuffer();
+    final var elementType = processInstanceRecord.getBpmnElementType();
+
+    final var element = process.getElementById(elementId, elementType, ExecutableActivity.class);
+    final Optional<ExecutableCatchEvent> catchEvent =
+        element.getEvents().stream()
+            .filter(ExecutableCatchEvent::isEscalation)
+            .filter(event -> matchesEscalationCode(event, escalationCode))
+            .findFirst();
+
+    if (catchEvent.isPresent()) {
+      catchEventTuple.instance = instance;
+      catchEventTuple.catchEvent = catchEvent.get();
+      return Optional.of(catchEventTuple);
+    }
 
     // no matching catch event found
     return Optional.empty();
+  }
+
+  public boolean matchesEscalationCode(
+      final ExecutableCatchEvent catchEvent, final DirectBuffer escalationCode) {
+    final var eventEscalationCode = catchEvent.getEscalation().getEscalationCode();
+    return eventEscalationCode.capacity() == 0 || eventEscalationCode.equals(escalationCode);
   }
 
   private ExecutableProcess getProcess(final long processDefinitionKey) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/escalation/EscalationCatchEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/escalation/EscalationCatchEventTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.escalation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public final class EscalationCatchEventTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "wf";
+  private static final String THROW_ELEMENT_ID = "throw";
+  private static final String ESCALATION_CODE = "ESCALATION";
+
+  @Parameter(0)
+  public String description;
+
+  @Parameter(1)
+  public BpmnModelInstance process;
+
+  @Parameter(2)
+  public String expectedThrowElementId;
+
+  @Parameter(3)
+  public String expectedCatchElementId;
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Parameters(name = "{0}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {
+        "boundary event on subprocess",
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess(
+                "subprocess",
+                s ->
+                    s.embeddedSubProcess()
+                        .startEvent()
+                        .intermediateThrowEvent(
+                            THROW_ELEMENT_ID, i -> i.escalation(ESCALATION_CODE))
+                        .endEvent())
+            .boundaryEvent("escalation-boundary-event", b -> b.escalation(ESCALATION_CODE))
+            .endEvent()
+            .done(),
+        THROW_ELEMENT_ID,
+        "escalation-boundary-event"
+      },
+      {
+        "boundary event on multi-instance subprocess",
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess(
+                "subprocess",
+                s ->
+                    s.multiInstance(m -> m.zeebeInputCollectionExpression("[1]"))
+                        .embeddedSubProcess()
+                        .startEvent()
+                        .intermediateThrowEvent(
+                            THROW_ELEMENT_ID, i -> i.escalation(ESCALATION_CODE))
+                        .endEvent())
+            .boundaryEvent("escalation-boundary-event", b -> b.escalation(ESCALATION_CODE))
+            .endEvent()
+            .done(),
+        THROW_ELEMENT_ID,
+        "escalation-boundary-event"
+      },
+      {
+        "escalation event subprocess",
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .eventSubProcess(
+                "escalation-event-subprocess",
+                s ->
+                    s.startEvent("escalation-start-event")
+                        .escalation(ESCALATION_CODE)
+                        .interrupting(true)
+                        .endEvent())
+            .startEvent()
+            .intermediateThrowEvent(THROW_ELEMENT_ID, i -> i.escalation(ESCALATION_CODE))
+            .endEvent()
+            .done(),
+        THROW_ELEMENT_ID,
+        "escalation-start-event"
+      },
+      {
+        "favor escalation event subprocess over boundary event on subprocess",
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess(
+                "sub",
+                s ->
+                    s.embeddedSubProcess()
+                        .eventSubProcess(
+                            "escalation-event-subprocess",
+                            e ->
+                                e.startEvent("escalation-start-event")
+                                    .escalation(ESCALATION_CODE)
+                                    .interrupting(true)
+                                    .endEvent())
+                        .startEvent()
+                        .intermediateThrowEvent(
+                            THROW_ELEMENT_ID, i -> i.escalation(ESCALATION_CODE))
+                        .endEvent())
+            .boundaryEvent("escalation", b -> b.escalation(ESCALATION_CODE))
+            .endEvent()
+            .done(),
+        THROW_ELEMENT_ID,
+        "escalation-start-event"
+      },
+    };
+  }
+
+  @Test
+  public void shouldTriggerEvent() {
+    // given
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple(THROW_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(THROW_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(expectedCatchElementId, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(expectedCatchElementId, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    assertIsEscalated(processInstanceKey, expectedCatchElementId, expectedThrowElementId);
+  }
+
+  private void assertIsEscalated(
+      final long processInstanceKey, final String catchElementId, final String throwElementId) {
+    assertThat(
+            RecordingExporter.escalationRecords(EscalationIntent.ESCALATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withCatchElementId(catchElementId)
+                .withThrowElementId(throwElementId)
+                .withEscalationCode(ESCALATION_CODE)
+                .exists())
+        .isTrue();
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/escalation/EscalationEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/escalation/EscalationEventTest.java
@@ -12,12 +12,16 @@ import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.AbstractBoundaryEventBuilder;
+import io.camunda.zeebe.model.bpmn.builder.EventSubProcessBuilder;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.function.Consumer;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,6 +33,8 @@ public class EscalationEventTest {
   private static final String TASK_ELEMENT_ID = "task";
   private static final String PROCESS_ID = "wf";
   private static final String ESCALATION_CODE = "ESCALATION";
+  private static final String THROW_ELEMENT_ID = "throw";
+  private static final String CATCH_ELEMENT_ID = "catch";
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
@@ -100,10 +106,407 @@ public class EscalationEventTest {
     assertIsNotEscalated("end", ESCALATION_CODE);
   }
 
+  @Test
+  public void shouldCatchEscalationOnBoundaryEventWithoutEscalationCode() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess(
+                "subprocess",
+                s ->
+                    s.embeddedSubProcess()
+                        .startEvent()
+                        .intermediateThrowEvent(
+                            THROW_ELEMENT_ID, i -> i.escalation(ESCALATION_CODE)))
+            .boundaryEvent(CATCH_ELEMENT_ID, AbstractBoundaryEventBuilder::escalation)
+            .manualTask(TASK_ELEMENT_ID)
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(
+                BpmnElementType.INTERMEDIATE_THROW_EVENT,
+                ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(
+                BpmnElementType.INTERMEDIATE_THROW_EVENT, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.MANUAL_TASK, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.MANUAL_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    assertIsEscalated(processInstanceKey, CATCH_ELEMENT_ID, THROW_ELEMENT_ID, ESCALATION_CODE);
+  }
+
+  @Test
+  public void shouldCatchEscalationInsideMultiInstanceSubprocess() {
+    // given
+    final Consumer<EventSubProcessBuilder> eventSubprocess =
+        s ->
+            s.startEvent("escalation-start-event")
+                .escalation(ESCALATION_CODE)
+                .interrupting(false)
+                .endEvent();
+
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess(
+                "subprocess",
+                s ->
+                    s.multiInstance(m -> m.zeebeInputCollectionExpression("items"))
+                        .embeddedSubProcess()
+                        .eventSubProcess("escalation-subprocess", eventSubprocess)
+                        .startEvent()
+                        .intermediateThrowEvent(
+                            THROW_ELEMENT_ID, i -> i.escalation(ESCALATION_CODE))
+                        .manualTask(TASK_ELEMENT_ID))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("items", List.of(1, 2))
+            .create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType())
+        .containsSubsequence(
+            BpmnElementType.INTERMEDIATE_THROW_EVENT,
+            BpmnElementType.INTERMEDIATE_THROW_EVENT,
+            BpmnElementType.START_EVENT,
+            BpmnElementType.MANUAL_TASK,
+            BpmnElementType.START_EVENT,
+            BpmnElementType.MANUAL_TASK,
+            BpmnElementType.EVENT_SUB_PROCESS,
+            BpmnElementType.EVENT_SUB_PROCESS,
+            BpmnElementType.SUB_PROCESS,
+            BpmnElementType.SUB_PROCESS,
+            BpmnElementType.MULTI_INSTANCE_BODY,
+            BpmnElementType.PROCESS);
+
+    assertIsEscalated(
+        processInstanceKey, "escalation-start-event", THROW_ELEMENT_ID, ESCALATION_CODE);
+  }
+
+  @Test
+  public void shouldCatchEscalationOutsideMultiInstanceSubprocess() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess(
+                "subprocess",
+                s ->
+                    s.multiInstance(m -> m.zeebeInputCollectionExpression("[1]"))
+                        .embeddedSubProcess()
+                        .startEvent()
+                        .endEvent(THROW_ELEMENT_ID, e -> e.escalation(ESCALATION_CODE)))
+            .boundaryEvent("escalation-boundary-event", b -> b.escalation(ESCALATION_CODE))
+            .manualTask(TASK_ELEMENT_ID)
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.MULTI_INSTANCE_BODY, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.MULTI_INSTANCE_BODY, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.MANUAL_TASK, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.MANUAL_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    assertIsEscalated(
+        processInstanceKey, "escalation-boundary-event", THROW_ELEMENT_ID, ESCALATION_CODE);
+  }
+
+  @Test
+  public void shouldThrowEscalationEventHierarchical() {
+    // given
+    final var processChild =
+        Bpmn.createExecutableProcess("wf-child")
+            .startEvent()
+            .subProcess(
+                "subprocess",
+                s ->
+                    s.embeddedSubProcess()
+                        .startEvent()
+                        .intermediateThrowEvent(
+                            THROW_ELEMENT_ID, b -> b.escalation(ESCALATION_CODE))
+                        .endEvent())
+            .endEvent()
+            .done();
+
+    final var processParent =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .callActivity("call", c -> c.zeebeProcessId("wf-child"))
+            .boundaryEvent(CATCH_ELEMENT_ID, b -> b.escalation(ESCALATION_CODE))
+            .endEvent()
+            .done();
+
+    ENGINE
+        .deployment()
+        .withXmlResource("wf-child.bpmn", processChild)
+        .withXmlResource("wf-parent.bpmn", processParent)
+        .deploy();
+
+    // when
+    final var parentProcessInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(parentProcessInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    final var childProcessInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(parentProcessInstanceKey)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+    assertIsEscalated(childProcessInstanceKey, CATCH_ELEMENT_ID, THROW_ELEMENT_ID, ESCALATION_CODE);
+  }
+
+  @Test
+  public void
+      shouldCatchEscalationOnNonInterruptingBoundaryEventWhenThrowEscalationEventHierarchical() {
+    // given
+    final var processChild =
+        Bpmn.createExecutableProcess("wf-child")
+            .startEvent()
+            .subProcess(
+                "subprocess",
+                s ->
+                    s.embeddedSubProcess()
+                        .startEvent()
+                        .intermediateThrowEvent(
+                            THROW_ELEMENT_ID, b -> b.escalation(ESCALATION_CODE))
+                        .manualTask(TASK_ELEMENT_ID)
+                        .endEvent())
+            .endEvent()
+            .done();
+
+    final var processParent =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .callActivity("call", c -> c.zeebeProcessId("wf-child"))
+            .boundaryEvent(CATCH_ELEMENT_ID, b -> b.escalation(ESCALATION_CODE))
+            .cancelActivity(false)
+            .endEvent()
+            .done();
+
+    ENGINE
+        .deployment()
+        .withXmlResource("wf-child.bpmn", processChild)
+        .withXmlResource("wf-parent.bpmn", processParent)
+        .deploy();
+
+    // when
+    final var parentProcessInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(parentProcessInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    final var childProcessInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(parentProcessInstanceKey)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(childProcessInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType())
+        .containsSubsequence(
+            BpmnElementType.INTERMEDIATE_THROW_EVENT,
+            BpmnElementType.MANUAL_TASK,
+            BpmnElementType.END_EVENT);
+
+    assertIsEscalated(childProcessInstanceKey, CATCH_ELEMENT_ID, THROW_ELEMENT_ID, ESCALATION_CODE);
+  }
+
+  @Test
+  public void shouldCatchEscalationOnEscalationStartEventWhenThrowEscalationEventHierarchical() {
+    // given
+    final var processChild =
+        Bpmn.createExecutableProcess("wf-child")
+            .startEvent()
+            .intermediateThrowEvent(THROW_ELEMENT_ID, b -> b.escalation(ESCALATION_CODE))
+            .endEvent()
+            .done();
+
+    final var processParent =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .eventSubProcess(
+                "escalation-event-subprocess",
+                e ->
+                    e.startEvent(CATCH_ELEMENT_ID)
+                        .interrupting(false)
+                        .escalation(ESCALATION_CODE)
+                        .manualTask(TASK_ELEMENT_ID)
+                        .endEvent())
+            .startEvent()
+            .callActivity("call", c -> c.zeebeProcessId("wf-child"))
+            .endEvent()
+            .done();
+
+    ENGINE
+        .deployment()
+        .withXmlResource("wf-child.bpmn", processChild)
+        .withXmlResource("wf-parent.bpmn", processParent)
+        .deploy();
+
+    // when
+    final var parentProcessInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(parentProcessInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.MANUAL_TASK, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.MANUAL_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    final var childProcessInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(parentProcessInstanceKey)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+
+    assertIsEscalated(childProcessInstanceKey, CATCH_ELEMENT_ID, THROW_ELEMENT_ID, ESCALATION_CODE);
+  }
+
+  @Test
+  public void shouldCatchEscalationEventsByEscalationCode() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess(
+                "subprocess",
+                s ->
+                    s.embeddedSubProcess()
+                        .startEvent()
+                        .parallelGateway("fork")
+                        .intermediateThrowEvent("throw-1", i -> i.escalation("escalation-1"))
+                        .moveToLastGateway()
+                        .intermediateThrowEvent("throw-2", i -> i.escalation("escalation-2")))
+            .boundaryEvent("catch-1", b -> b.escalation("escalation-1"))
+            .cancelActivity(false)
+            .endEvent()
+            .moveToActivity("subprocess")
+            .boundaryEvent("catch-2", b -> b.escalation("escalation-2"))
+            .cancelActivity(false)
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted()
+                .withElementType(BpmnElementType.BOUNDARY_EVENT))
+        .extracting(r -> r.getValue().getElementId())
+        .contains("catch-1", "catch-2");
+
+    assertIsEscalated(processInstanceKey, "catch-1", "throw-1", "escalation-1");
+    assertIsEscalated(processInstanceKey, "catch-2", "throw-2", "escalation-2");
+  }
+
   private void assertIsNotEscalated(final String throwElementId, final String escalationCode) {
     assertThat(
             RecordingExporter.escalationRecords(EscalationIntent.NOT_ESCALATED)
                 .withCatchElementId("")
+                .withThrowElementId(throwElementId)
+                .withEscalationCode(escalationCode)
+                .exists())
+        .isTrue();
+  }
+
+  private void assertIsEscalated(
+      final long processInstanceKey,
+      final String catchElementId,
+      final String throwElementId,
+      final String escalationCode) {
+    assertThat(
+            RecordingExporter.escalationRecords(EscalationIntent.ESCALATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withCatchElementId(catchElementId)
                 .withThrowElementId(throwElementId)
                 .withEscalationCode(escalationCode)
                 .exists())


### PR DESCRIPTION
## Description
I can throw an escalation using an end event.

* Escalations thrown from a called activity or sub process can be handled by catching on a boundary event.
* Throw escalations can be handled by catching on an event subprocess.

## Related issues
closes #10686
closes #10684
closes #10690
closes #10763

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
