### PR TITLE
feat(ci): run e2e test weekly

### DIFF
--- a/.ci/scripts/distribution/e2e-testbench.sh
+++ b/.ci/scripts/distribution/e2e-testbench.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -eux
-
-chmod +x clients/go/cmd/zbctl/dist/zbctl
-
-zbctl="clients/go/cmd/zbctl/dist/zbctl"
-
-"${zbctl}" create instance e2e_testbench_protocol --variables "{\"zeebeImage\":\"$ZEEBE_IMAGE\", \"generationTemplate\":\"$GENERATION_TEMPLATE\", \"channel\":\"Internal Dev\", \"clusterPlan\":\"Production - M\", \"region\":\"new chaos\", \"properties\":[\"allInstancesAreCompleted\"], \"testProcessId\": \"e2e-test\", \"branch\": \"$BRANCH_NAME\", \"build\": \"$BUILD_URL\", \"testParams\": { \"maxTestDuration\": \"$MAX_TEST_DURATION\", \"starter\": [ {\"rate\": 50, \"processId\": \"one-task-one-timer\" } ], \"verifier\" : { \"maxInstanceDuration\" : \"15m\" } } }"

--- a/.ci/scripts/distribution/e2e-testbench.sh
+++ b/.ci/scripts/distribution/e2e-testbench.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eux
+
+chmod +x clients/go/cmd/zbctl/dist/zbctl
+
+zbctl="clients/go/cmd/zbctl/dist/zbctl"
+
+"${zbctl}" create instance e2e_testbench_protocol --variables "{\"zeebeImage\":\"$ZEEBE_IMAGE\", \"generationTemplate\":\"$GENERATION_TEMPLATE\", \"channel\":\"Internal Dev\", \"clusterPlan\":\"Production - M\", \"region\":\"new chaos\", \"properties\":[\"allInstancesAreCompleted\"], \"testProcessId\": \"e2e-test\", \"branch\": \"$BRANCH_NAME\", \"build\": \"$BUILD_URL\", \"testParams\": { \"maxTestDuration\": \"$MAX_TEST_DURATION\", \"starter\": [ {\"rate\": 50, \"processId\": \"one-task-one-timer\" } ], \"verifier\" : { \"maxInstanceDuration\" : \"15m\" } } }"

--- a/.github/actions/build-push-docker-gcr/action.yml
+++ b/.github/actions/build-push-docker-gcr/action.yml
@@ -1,0 +1,85 @@
+name: Build and push images for given branch
+description: Builds the Zeebe Docker image with tag following SemVer and push it gcr.io/
+
+inputs:
+  branch:
+    description: 'Specifies the branch, for which the image should be build'
+    default: 'main'
+    required: false
+  secret_vault_address:
+    description: 'secret vault url'
+    required: true
+  secret_vault_roleId:
+    description: 'secret vault roleId'
+    required: true
+  secret_vault_secretId:
+    description: 'secret valut secret id'
+    required: true
+
+outputs:
+  image:
+    description: "Fully qualified image name"
+    value: ${{ steps.build-docker.outputs.image }}
+
+runs:
+  using: composite
+  steps:
+    # Dynamic environment variables are not supported by GHA
+    # https://brandur.org/fragments/github-actions-env-vars-in-env-vars
+    #
+    # Since we run the workflow either on demand or via schedule we need to assign some defaults
+    # Furthermore we have branches like stable/1.0 where we have to replace certain patterns, in order to use the branch name as docker image tag
+    - id: evaluate-inputs
+      name: Evaluate Inputs
+      shell: bash
+      run: |
+        branch=${BRANCH/\//-}
+        branch=${branch//\./-}
+        branch=${branch:-main}
+        echo "BRANCH_NAME=$branch" >> $GITHUB_ENV
+      env:
+        BRANCH: "${{ inputs.branch }}"
+    # We need to check out the evaluated branch and setup java (incl. maven), so we can retrieve the current project version
+    # The version is necessary, since CC Saas only accepts SemVer for docker image tags (need to start with a version tag)
+    - uses: actions/checkout@v3
+      with:
+        ref: "${{ github.event.inputs.branch }}"
+    - uses: actions/setup-java@v3.6.0
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+    # Set further environment variables, which are needed for the QA Testbench run
+    - id: generate-tag
+      name: Generate image tag
+      shell: bash
+      run: |
+        version=$(mvn help:evaluate -q -DforceStdout -D"expression=project.version")
+        tag="$version-$BRANCH_NAME-${GITHUB_SHA::8}"
+        echo "TAG=$tag" >> $GITHUB_ENV
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v2.4.2
+      with:
+        url: ${{ inputs.secret_vault_address }}
+        method: approle
+        roleId: ${{ inputs.secret_vault_roleId }}
+        secretId: ${{ inputs.secret_vault_secretId }}
+        secrets: |
+          secret/data/products/zeebe/ci/zeebe ZEEBE_GCR_SERVICEACCOUNT_JSON;
+    - name: Login to GCR
+      uses: docker/login-action@v2
+      with:
+        registry: gcr.io
+        username: _json_key
+        password: ${{ steps.secrets.outputs.ZEEBE_GCR_SERVICEACCOUNT_JSON }}
+    - uses: ./.github/actions/setup-zeebe
+    - uses: ./.github/actions/build-zeebe
+      id: build-zeebe
+    - name: build-docker
+      id: build-docker
+      uses: ./.github/actions/build-docker
+      with:
+        repository: "gcr.io/zeebe-io/zeebe"
+        version: ${{ env.TAG }}
+        push: true
+        distball: ${{ steps.build-zeebe.outputs.distball }}

--- a/.github/actions/build-push-docker-gcr/action.yml
+++ b/.github/actions/build-push-docker-gcr/action.yml
@@ -44,10 +44,8 @@ runs:
     - uses: actions/checkout@v3
       with:
         ref: "${{ github.event.inputs.branch }}"
-    - uses: actions/setup-java@v3.6.0
-      with:
-        distribution: 'temurin'
-        java-version: '17'
+    # Also setup java
+    - uses: ./.github/actions/setup-zeebe
     # Set further environment variables, which are needed for the QA Testbench run
     - id: generate-tag
       name: Generate image tag
@@ -72,7 +70,6 @@ runs:
         registry: gcr.io
         username: _json_key
         password: ${{ steps.secrets.outputs.ZEEBE_GCR_SERVICEACCOUNT_JSON }}
-    - uses: ./.github/actions/setup-zeebe
     - uses: ./.github/actions/build-zeebe
       id: build-zeebe
     - name: build-docker

--- a/.github/workflows/e2e-testbench.yaml
+++ b/.github/workflows/e2e-testbench.yaml
@@ -13,10 +13,6 @@ on:
         required: false
         default: 'Zeebe SNAPSHOT'
         type: string
-      branch:
-        description: 'Specifies the branch, for which the E2E tests should be executed'
-        default: 'main'
-        required: false
   schedule:
     # Run at 7:00 on every monday
     - cron:  '0 7 * * 1'
@@ -32,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: "${{ github.event.inputs.branch || 'main' }}"
+          ref: "${{ github.ref_name || 'main' }}"
 
       - name: Build and push docker
         id: build-docker
@@ -64,6 +60,6 @@ jobs:
           GENERATION_TEMPLATE: "${{ github.event.inputs.generation || 'Zeebe SNAPSHOT'}}"
           # Weekly e2e test run for 5 days.
           MAX_TEST_DURATION: "${{ github.event.inputs.maxTestDuration || 'PT5D'}}"
-          BRANCH_NAME: "${{ github.event.inputs.branch }}"
+          BRANCH_NAME: "${{ github.ref_name }}"
           ZEEBE_AUTHORIZATION_SERVER_URL: 'https://login.cloud.ultrawombat.com/oauth/token'
           ZEEBE_CLIENT_ID: 'S7GNoVCE6J-8L~OdFiI59kWM19P.wvKo'

--- a/.github/workflows/e2e-testbench.yaml
+++ b/.github/workflows/e2e-testbench.yaml
@@ -62,7 +62,7 @@ jobs:
           ZEEBE_IMAGE: ${{ steps.build-docker.outputs.image }}
           GENERATION_TEMPLATE: "${{ github.event.inputs.generation || 'Zeebe SNAPSHOT'}}"
           # Weekly e2e test run for 5 days.
-          MAX_TEST_DURATION: "${{ github.event.inputs.maxTestDuration || 'PT5D'}}"
+          MAX_TEST_DURATION: "${{ github.event.inputs.maxTestDuration || 'P5D'}}"
           BRANCH_NAME: "${{ github.ref_name }}"
           ZEEBE_AUTHORIZATION_SERVER_URL: 'https://login.cloud.ultrawombat.com/oauth/token'
           ZEEBE_CLIENT_ID: 'S7GNoVCE6J-8L~OdFiI59kWM19P.wvKo'

--- a/.github/workflows/e2e-testbench.yaml
+++ b/.github/workflows/e2e-testbench.yaml
@@ -1,0 +1,69 @@
+name: Run E2E Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      maxTestDuration:
+        description: 'Test duration (Eg: PT2H, P3D)'
+        required: true
+        default: 'PT1D'
+        type: string
+      generation:
+        description: 'Specifies the generation template which should be used by the testbench run'
+        required: false
+        default: 'Zeebe SNAPSHOT'
+        type: string
+      branch:
+        description: 'Specifies the branch, for which the E2E tests should be executed'
+        default: 'main'
+        required: false
+  schedule:
+    # Run at 7:00 on every monday
+    - cron:  '0 7 * * 1'
+env:
+  BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+jobs:
+  e2e-testbench:
+    name: E2E Testbench run
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: "${{ github.event.inputs.branch || 'main' }}"
+
+      - name: Build and push docker
+        id: build-docker
+        uses: ./.github/actions/build-push-docker-gcr
+        with:
+          branch: ${{ github.event.inputs.branch }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2.4.2
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/zeebe/ci/zeebe TESTBENCH_PROD_CLIENT_SECRET;
+            secret/data/products/zeebe/ci/zeebe TESTBENCH_PROD_CONTACT_POINT;
+        # Start e2e test instance, do not wait for the result
+      - name: Run E2E Tests
+        run: .ci/scripts/distribution/e2e-testbench.sh
+        env:
+          ZEEBE_CLIENT_SECRET: ${{ steps.secrets.outputs.TESTBENCH_PROD_CLIENT_SECRET }}
+          ZEEBE_ADDRESS: ${{ steps.secrets.outputs.TESTBENCH_PROD_CONTACT_POINT }}
+          ZEEBE_IMAGE: ${{ steps.build-docker.outputs.image }}
+          GENERATION_TEMPLATE: "${{ github.event.inputs.generation || 'Zeebe SNAPSHOT'}}"
+          # Weekly e2e test run for 5 days.
+          MAX_TEST_DURATION: "${{ github.event.inputs.maxTestDuration || 'PT5D'}}"
+          BRANCH_NAME: "${{ github.event.inputs.branch }}"
+          ZEEBE_AUTHORIZATION_SERVER_URL: 'https://login.cloud.ultrawombat.com/oauth/token'
+          ZEEBE_CLIENT_ID: 'S7GNoVCE6J-8L~OdFiI59kWM19P.wvKo'

--- a/.github/workflows/e2e-testbench.yaml
+++ b/.github/workflows/e2e-testbench.yaml
@@ -52,7 +52,10 @@ jobs:
             secret/data/products/zeebe/ci/zeebe TESTBENCH_PROD_CONTACT_POINT;
         # Start e2e test instance, do not wait for the result
       - name: Run E2E Tests
-        run: .ci/scripts/distribution/e2e-testbench.sh
+        run: |
+          chmod +x clients/go/cmd/zbctl/dist/zbctl
+          clients/go/cmd/zbctl/dist/zbctl create instance e2e_testbench_protocol --variables "{\"zeebeImage\":\"$ZEEBE_IMAGE\", \"generationTemplate\":\"$GENERATION_TEMPLATE\", \"channel\":\"Internal Dev\", \"clusterPlan\":\"Production - M\", \"region\":\"new chaos\", \"properties\":[\"allInstancesAreCompleted\"], \"testProcessId\": \"e2e-test\", \"branch\": \"$BRANCH_NAME\", \"build\": \"$BUILD_URL\", \"testParams\": { \"maxTestDuration\": \"$MAX_TEST_DURATION\", \"starter\": [ {\"rate\": 50, \"processId\": \"one-task-one-timer\" } ], \"verifier\" : { \"maxInstanceDuration\" : \"15m\" } } }"
+
         env:
           ZEEBE_CLIENT_SECRET: ${{ steps.secrets.outputs.TESTBENCH_PROD_CLIENT_SECRET }}
           ZEEBE_ADDRESS: ${{ steps.secrets.outputs.TESTBENCH_PROD_CONTACT_POINT }}


### PR DESCRIPTION
## Description

- Added an action to build image from a a specific branch and push it to gcr.io/zeebe-io repo. The tag follows SemVer so that it can be used in tests run via testbench. This action is mostly extracted from `qa_testbench` workflow. 
- Added a workflow to run weekly e2e tests. The workflow does not monitor the test results. Testbench notifies via slack channel if the test fails. Any incidents on the test process will be noticed by the medic. 
