### PR TITLE
build(docker): update base image to jdk 17.0.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Override this based on the architecture; this is currently pointing to amd64
-ARG BASE_SHA="4da6bae253f3cb77d87a98e78459ab85ab119a53aa2c66914981588a374f0627"
+ARG BASE_SHA="00a5775f5eb7c24a19cb76ded742cbfcc50c61f062105af9730dadde217e4390"
 
 # Building builder image
 FROM ubuntu:focal as builder

--- a/docker/test/docker-labels.golden.json
+++ b/docker/test/docker-labels.golden.json
@@ -5,7 +5,7 @@
   "io.openshift.non-scalable": "false",
   "io.openshift.tags": "bpmn,orchestration,workflow",
   "org.opencontainers.image.authors": "zeebe@camunda.com",
-  "org.opencontainers.image.base.digest": "4da6bae253f3cb77d87a98e78459ab85ab119a53aa2c66914981588a374f0627",
+  "org.opencontainers.image.base.digest": "00a5775f5eb7c24a19cb76ded742cbfcc50c61f062105af9730dadde217e4390",
   "org.opencontainers.image.base.name": "docker.io/library/eclipse-temurin:17-jre-focal",
   "org.opencontainers.image.created": $DATE,
   "org.opencontainers.image.description": "Workflow engine for microservice orchestration",


### PR DESCRIPTION
## Description

Updates the base image to the latest 17.0.5 release.

https://hub.docker.com/layers/library/eclipse-temurin/17.0.5_8-jre-focal/images/sha256-00a5775f5eb7c24a19cb76ded742cbfcc50c61f062105af9730dadde217e4390?context=explore

## Related issues

closes #10372
