### PR TITLE
docs(backup): add open api spec for list backup api

### DIFF
--- a/docs/actuator-api-spec/backup-management-api.yaml
+++ b/docs/actuator-api-spec/backup-management-api.yaml
@@ -1,0 +1,185 @@
+openapi: "3.0.2"
+info:
+  title: Backup Management API
+  version: "1.0"
+  description: Management endpoint to query, take, and delete backups of Zeebe.
+servers:
+  - url: "{schema}://{host}:{port}/actuator/backups"
+    variables:
+      host:
+        default: localhost
+        description: Management server hostname
+      port:
+        default: "9600"
+        description: Management server port
+      schema:
+        default: http
+        description: Management server schema
+paths:
+  /:
+    get:
+      summary: Lists all available backups
+      description: |
+        Returns a list of all available backups with their state and additional info,
+        sorted in descending order of backupId.
+      responses:
+        '200':
+          $ref: '#/components/responses/BackupList'
+        '500':
+          description: Internal Error
+          content:
+            text/plain:
+              schema:
+                type: string
+
+components:
+  responses:
+    BackupList:
+      description: |
+       List of all available backups.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/BackupList'
+
+  schemas:
+    BackupId:
+      title: Backup ID
+      description: |
+        The ID of the backup. The ID of the backup must be a positive numerical value. As backups
+        are logically ordered by their IDs (ascending), each successive backup must use a higher
+        ID than the previous one.
+      type: number
+      example: 1
+      minimum: 0
+
+    PartitionId:
+      title: Partition ID
+      description: |
+        The ID of a partition. This is always a positive number greater than or equal to 1.
+      type: number
+      minimum: 1
+      example: 3
+
+    StateCode:
+      title: Backup State
+      description: The state of the backup.
+      type: string
+      enum:
+        - DOES_NOT_EXIST
+        - IN_PROGRESS
+        - COMPLETED
+        - FAILED
+        - INCOMPLETE
+      example: IN_PROGRESS
+
+    BackupList:
+      title: List of backups
+      description: List of backups with their state and additional info
+      type: array
+      items:
+        $ref: '#/components/schemas/BackupInfo'
+
+    BackupInfo:
+      title: Backup Info
+      description: |
+        Detailed status of a backup. The aggregated state is computed from the backup state of each partition as:
+        - If the backup of all partitions is in state 'COMPLETED', then the overall state is 'COMPLETED'.
+        - If one is 'FAILED', then the overall state is 'FAILED'.
+        - Otherwise, if one is 'DOES_NOT_EXIST', then the overall state is 'INCOMPLETE'.
+        - Otherwise, if one is 'IN_PROGRESS', then the overall state is 'IN_PROGRESS'.
+      type: object
+      properties:
+        backupId:
+          readOnly: true
+          allOf:
+            - $ref: '#/components/schemas/BackupId'
+        state:
+          readOnly: true
+          allOf:
+            - $ref: '#/components/schemas/StateCode'
+        failureReason:
+          description: Reason for failure if the state is 'FAILED'
+          type: string
+          example: ""
+        details:
+          readOnly: true
+          description: |
+            Detailed list of the status of the backup per partition. It should always contain all
+            partitions known to the cluster.
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/PartitionBackupInfo'
+      required:
+        - backupId
+        - state
+        - partitions
+
+    PartitionBackupInfo:
+      title: Partition's Backup Info
+      description: Detailed info of the backup for a given partition.
+      type: object
+      properties:
+        partitionId:
+          readOnly: true
+          allOf:
+            - $ref: '#/components/schemas/PartitionId'
+        state:
+          readOnly: true
+          allOf:
+            - $ref: '#/components/schemas/StateCode'
+        createdAt:
+          description: The timestamp at which the backup was started on this partition.
+          readOnly: true
+          type: string
+          format: date-time
+          example: "2022-09-15T13:10:38.176514094Z"
+        lastUpdatedAt:
+          description: |
+            The timestamp at which the backup was last updated on this partition, e.g. changed
+            state from IN_PROGRESS to COMPLETED.
+          readOnly: true
+          type: string
+          format: date-time
+          example: "2022-09-15T13:10:38.176514094Z"
+        descriptor:
+          readOnly: true
+          allOf:
+            - $ref: '#/components/schemas/BackupDescriptor'
+      required:
+        - id
+        - state
+
+    BackupDescriptor:
+      title: Backup Descriptor
+      description: |
+        Context information about the specific backup and what it contains for a given partition.
+      type: object
+      properties:
+        snapshotId:
+          description: The ID of the snapshot which is included in this backup.
+          type: string
+          readOnly: true
+          example: 238632143-55-690906332-690905294
+        checkpointPosition:
+          description: The position of the checkpoint for this backup.
+          type: number
+          readOnly: true
+          example: 10
+        brokerId:
+          description: The ID of the broker from which the backup was taken for this partition.
+          type: number
+          readOnly: true
+          example: 0
+          minimum: 0
+        brokerVersion:
+          description: The version of the broker from which the backup was taken for this partition.
+          type: string
+          readOnly: true
+          example: 8.1.2
+      required:
+        - snapshotId
+        - checkpointPosition
+        - brokerId
+        - brokerVersion

--- a/docs/actuator-api-spec/backup-management-api.yaml
+++ b/docs/actuator-api-spec/backup-management-api.yaml
@@ -114,7 +114,7 @@ components:
       required:
         - backupId
         - state
-        - partitions
+        - details
 
     PartitionBackupInfo:
       title: Partition's Backup Info
@@ -129,6 +129,10 @@ components:
           readOnly: true
           allOf:
             - $ref: '#/components/schemas/StateCode'
+        failureReason:
+          description: Failure reason if stats is 'FAILED'
+          type: string
+          example: ""
         createdAt:
           description: The timestamp at which the backup was started on this partition.
           readOnly: true
@@ -148,7 +152,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/BackupDescriptor'
       required:
-        - id
+        - partitionId
         - state
 
     BackupDescriptor:


### PR DESCRIPTION
## Description

This PR adds an open api spec for list backup api. List operation is not implemented yet. The goal is to define the spec now, and the implementation would follow this spec.

You can list all backup via `GET  actuator/backups/`. It returns a list of backups with detailed info of each backup. ([Ref](https://docs.google.com/document/d/1pITW-pvUiGuJ8kIeR1vqjnoqmhs0unnNN955jUkhF6w/edit#heading=h.8pku8i8evwlw)) 

The other operations (take, get and delete) will be added later to the same spec.

You can visualize the spec online using https://editor.swagger.io/.

## Related issues

related to #10712 