### PR TITLE
fix(benchmark): enable the message publisher again

### DIFF
--- a/setupKWBenchmark.sh
+++ b/setupKWBenchmark.sh
@@ -64,7 +64,7 @@ sed_inplace "s/rate=100/rate=50/" timer.yaml
 sed_inplace "s/rate=100/rate=50/" publisher.yaml
 sed_inplace "s/rate=200/rate=100/" starter.yaml
 
-make zeebe starter worker timer # publisher should be enabled after fixing https://github.com/camunda/zeebe/issues/10643
+make zeebe starter worker timer publisher
 
 git add .
 git commit -m "test(benchmark): add $benchmark-mixed"


### PR DESCRIPTION
## Description

Previously, the message process was disabled because it led to big message states (#10643). This issue was fixed by setting the message TTL to ZERO (#10935). So, we can enable the message process again.

## Related issues

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
