### PR TITLE
[Backport stable/8.1] fix(benchmark): publish messages with no TTL

### DIFF
--- a/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
+++ b/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.config.AppCfg;
 import io.camunda.zeebe.config.StarterCfg;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
@@ -135,6 +136,7 @@ public class Starter extends App {
                   .messageName(starterCfg.getMsgName())
                   .correlationKey(UUID.randomUUID().toString())
                   .variables(variables)
+                  .timeToLive(Duration.ZERO)
                   .send());
         } else {
           startViaCommand(starterCfg, processId, requestFutures, client, variables);


### PR DESCRIPTION
# Description
Backport of #10935 to `stable/8.1`.

relates to #10552