### PR TITLE
feat(engine): set escalation event type

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/BoundaryEventTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/BoundaryEventTransformer.java
@@ -34,6 +34,8 @@ public final class BoundaryEventTransformer implements ModelElementTransformer<B
       element.setEventType(BpmnEventType.TIMER);
     } else if (element.isError()) {
       element.setEventType(BpmnEventType.ERROR);
+    } else if (element.isEscalation()) {
+      element.setEventType(BpmnEventType.ESCALATION);
     }
 
     element.setInterrupting(event.cancelActivity());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/CatchEventTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/CatchEventTransformer.java
@@ -181,5 +181,6 @@ public final class CatchEventTransformer implements ModelElementTransformer<Catc
       executableEscalation = context.getEscalation(escalation.getId());
     }
     executableElement.setEscalation(executableEscalation);
+    executableElement.setEventType(BpmnEventType.ESCALATION);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/EndEventTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/EndEventTransformer.java
@@ -95,5 +95,6 @@ public final class EndEventTransformer implements ModelElementTransformer<EndEve
     final var escalation = escalationEventDefinition.getEscalation();
     final var executableEscalation = context.getEscalation(escalation.getId());
     executableElement.setEscalation(executableEscalation);
+    executableElement.setEventType(BpmnEventType.ESCALATION);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/IntermediateThrowEventTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/IntermediateThrowEventTransformer.java
@@ -91,5 +91,6 @@ public final class IntermediateThrowEventTransformer
     final var escalation = eventDefinition.getEscalation();
     final var executableEscalation = context.getEscalation(escalation.getId());
     executableElement.setEscalation(executableEscalation);
+    executableElement.setEventType(BpmnEventType.ESCALATION);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/StartEventTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/StartEventTransformer.java
@@ -44,6 +44,8 @@ public final class StartEventTransformer implements ModelElementTransformer<Star
       startEvent.setEventType(BpmnEventType.TIMER);
     } else if (startEvent.isError()) {
       startEvent.setEventType(BpmnEventType.ERROR);
+    } else if (startEvent.isEscalation()) {
+      startEvent.setEventType(BpmnEventType.ESCALATION);
     }
 
     if (element.getScope() instanceof FlowNode) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/BpmnEventTypeTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/BpmnEventTypeTest.java
@@ -219,7 +219,7 @@ public class BpmnEventTypeTest {
             }
           },
           new BpmnEventTypeScenario(
-              "Error Catch Event", BpmnElementType.BOUNDARY_EVENT, BpmnEventType.ERROR) {
+              "Error Boundary Event", BpmnElementType.BOUNDARY_EVENT, BpmnEventType.ERROR) {
             @Override
             BpmnModelInstance modelInstance() {
               return Bpmn.createExecutableProcess(processId())
@@ -322,6 +322,64 @@ public class BpmnEventTypeTest {
                   .withCorrelationKey(CORRELATION_KEY)
                   .publish();
             }
+          },
+          new BpmnEventTypeScenario(
+              "Escalation Start Event", BpmnElementType.START_EVENT, BpmnEventType.ESCALATION) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .eventSubProcess(
+                      "subprocess",
+                      sp -> sp.startEvent(elementId()).escalation(escalationCode()).endEvent())
+                  .startEvent()
+                  .intermediateThrowEvent("throw", i -> i.escalation(escalationCode()))
+                  .endEvent()
+                  .done();
+            }
+          },
+          new BpmnEventTypeScenario(
+              "Escalation Throw Event",
+              BpmnElementType.INTERMEDIATE_THROW_EVENT,
+              BpmnEventType.ESCALATION) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .intermediateThrowEvent(elementId(), e -> e.escalation(escalationCode()))
+                  .endEvent()
+                  .done();
+            }
+          },
+          new BpmnEventTypeScenario(
+              "Escalation Boundary Event",
+              BpmnElementType.BOUNDARY_EVENT,
+              BpmnEventType.ESCALATION) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .subProcess(
+                      "subprocess",
+                      sp ->
+                          sp.embeddedSubProcess()
+                              .startEvent()
+                              .intermediateThrowEvent("throw", e -> e.escalation(escalationCode()))
+                              .endEvent())
+                  .boundaryEvent(elementId(), b -> b.escalation(escalationCode()))
+                  .cancelActivity(false)
+                  .endEvent()
+                  .done();
+            }
+          },
+          new BpmnEventTypeScenario(
+              "Escalation End Event", BpmnElementType.END_EVENT, BpmnEventType.ESCALATION) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .endEvent(elementId(), e -> e.escalation(escalationCode()))
+                  .done();
+            }
           });
 
   @Rule
@@ -385,6 +443,7 @@ public class BpmnEventTypeTest {
     private final String messageName = Strings.newRandomValidBpmnId();
     private final String jobType = Strings.newRandomValidBpmnId();
     private final String errorCode = Strings.newRandomValidBpmnId();
+    private final String escalationCode = Strings.newRandomValidBpmnId();
 
     BpmnEventTypeScenario(
         final String name, final BpmnElementType elementType, final BpmnEventType eventType) {
@@ -425,6 +484,10 @@ public class BpmnEventTypeTest {
 
     String errorCode() {
       return errorCode;
+    }
+
+    String escalationCode() {
+      return escalationCode;
     }
 
     @Override


### PR DESCRIPTION
## Description
Add new event type: `escalation`.

## Related issues
closes #10890

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
