### PR TITLE
Backup manager can list available backups

### DIFF
--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
@@ -34,7 +34,7 @@ public interface BackupManager {
   ActorFuture<BackupStatus> getBackupStatus(long checkpointId);
 
   /**
-   * Get all available backups with status is one of {@link BackupStatusCode#COMPLETED}, {@link
+   * Get all available backups where status is one of {@link BackupStatusCode#COMPLETED}, {@link
    * BackupStatusCode#FAILED}, {@link BackupStatusCode#IN_PROGRESS}
    *
    * @return a collection of backup status

--- a/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.api;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.util.Collection;
 
 /** Manages backup of a partition * */
 public interface BackupManager {
@@ -31,6 +32,14 @@ public interface BackupManager {
    * @return backup status
    */
   ActorFuture<BackupStatus> getBackupStatus(long checkpointId);
+
+  /**
+   * Get all available backups with status is one of {@link BackupStatusCode#COMPLETED}, {@link
+   * BackupStatusCode#FAILED}, {@link BackupStatusCode#IN_PROGRESS}
+   *
+   * @return a collection of backup status
+   */
+  ActorFuture<Collection<BackupStatus>> listBackups();
 
   /**
    * Deletes the backup.

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -136,7 +136,10 @@ public final class BackupService extends Actor implements BackupManager {
 
   @Override
   public ActorFuture<Collection<BackupStatus>> listBackups() {
-    return internalBackupManager.listBackups(partitionId, actor);
+    final var operationMetrics = metrics.startListingBackups();
+    final var resultFuture = internalBackupManager.listBackups(partitionId, actor);
+    resultFuture.onComplete(operationMetrics::complete);
+    return resultFuture;
   }
 
   @Override

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -136,8 +136,7 @@ public final class BackupService extends Actor implements BackupManager {
 
   @Override
   public ActorFuture<Collection<BackupStatus>> listBackups() {
-    return CompletableActorFuture.completedExceptionally(
-        new UnsupportedOperationException("Not implemented"));
+    return internalBackupManager.listBackups(partitionId, actor);
   }
 
   @Override

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Predicate;
 import org.slf4j.Logger;
@@ -131,6 +132,12 @@ public final class BackupService extends Actor implements BackupManager {
             });
     future.onComplete(operationMetrics::complete);
     return future;
+  }
+
+  @Override
+  public ActorFuture<Collection<BackupStatus>> listBackups() {
+    return CompletableActorFuture.completedExceptionally(
+        new UnsupportedOperationException("Not implemented"));
   }
 
   @Override

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/BackupServiceImpl.java
@@ -236,7 +236,6 @@ final class BackupServiceImpl {
                 .thenAccept(ignore -> deleteCompleted.complete(null))
                 .exceptionally(
                     error -> {
-                      LOG.warn("Failed to deleted backups with id {}.", checkpointId, error);
                       deleteCompleted.completeExceptionally(error);
                       return null;
                     }));
@@ -267,7 +266,6 @@ final class BackupServiceImpl {
                 .thenAccept(availableBackupsFuture::complete)
                 .exceptionally(
                     error -> {
-                      LOG.warn("Failed to list available backups", error);
                       availableBackupsFuture.completeExceptionally(error);
                       return null;
                     }));

--- a/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupManager.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupManager.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.processing.state.CheckpointState;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Collection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +36,12 @@ public class NoopBackupManager implements BackupManager {
 
   @Override
   public ActorFuture<BackupStatus> getBackupStatus(final long checkpointId) {
+    return CompletableActorFuture.completedExceptionally(
+        new UnsupportedOperationException(errorMessage));
+  }
+
+  @Override
+  public ActorFuture<Collection<BackupStatus>> listBackups() {
     return CompletableActorFuture.completedExceptionally(
         new UnsupportedOperationException(errorMessage));
   }

--- a/backup/src/main/java/io/camunda/zeebe/backup/metrics/BackupManagerMetrics.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/metrics/BackupManagerMetrics.java
@@ -22,6 +22,7 @@ public class BackupManagerMetrics {
   private static final String COMPLETED = "completed";
   private static final String TAKE_OPERATION = "take";
   private static final String STATUS_OPERATION = "status";
+  private static final String LIST_OPERATION = "list";
   private static final String DELETE_OPERATION = "delete";
 
   private static final Counter TOTAL_OPERATIONS =
@@ -62,6 +63,10 @@ public class BackupManagerMetrics {
     return OperationMetrics.start(partitionId, STATUS_OPERATION);
   }
 
+  public OperationMetrics startListingBackups() {
+    return OperationMetrics.start(partitionId, LIST_OPERATION);
+  }
+
   public OperationMetrics startDeleting() {
     return OperationMetrics.start(partitionId, DELETE_OPERATION);
   }
@@ -70,6 +75,7 @@ public class BackupManagerMetrics {
     OPERATIONS_IN_PROGRESS.labels(partitionId, TAKE_OPERATION).set(0);
     OPERATIONS_IN_PROGRESS.labels(partitionId, DELETE_OPERATION).set(0);
     OPERATIONS_IN_PROGRESS.labels(partitionId, STATUS_OPERATION).set(0);
+    OPERATIONS_IN_PROGRESS.labels(partitionId, LIST_OPERATION).set(0);
   }
 
   public static final class OperationMetrics {

--- a/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -370,6 +370,25 @@ class BackupServiceImplTest {
     verify(backupStore).delete(backup.id());
   }
 
+  @Test
+  void shouldListAvailableBackups() {
+    // given
+    final int partitionId = 1;
+    final BackupStatus backup1 = mock(BackupStatus.class);
+    final BackupStatus backup2 = mock(BackupStatus.class);
+
+    when(backupStore.list(
+            new BackupIdentifierWildcardImpl(
+                Optional.empty(), Optional.of(partitionId), Optional.empty())))
+        .thenReturn(CompletableFuture.completedFuture(List.of(backup1, backup2)));
+
+    // when
+    final var backups = backupService.listBackups(partitionId, concurrencyControl).join();
+
+    // then
+    assertThat(backups).containsExactlyInAnyOrder(backup1, backup2);
+  }
+
   private ActorFuture<Void> failedFuture() {
     final ActorFuture<Void> future = concurrencyControl.createFuture();
     future.completeExceptionally(new RuntimeException("Expected"));


### PR DESCRIPTION
## Description

This PR is a building block for #10712 . According to the spec we defined, the list operation returns a list of available backup with their detailed status info. The status info is same as what is returned by getBackupStatus operation. 

## Related issues

closes #10847 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
