### PR TITLE
Move event appliers

### DIFF
--- a/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -69,7 +69,7 @@ final class CheckpointRecordsProcessorTest {
       final ProcessingScheduleService executor, final ZeebeDb zeebeDb) {
     final var context = zeebeDb.createContext();
     return new RecordProcessorContextImpl(
-        1, executor, zeebeDb, context, null, null, new DbKeyGenerator(1, zeebeDb, context));
+        1, executor, zeebeDb, context, null, new DbKeyGenerator(1, zeebeDb, context));
   }
 
   @AfterEach

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.engine.Engine;
 import io.camunda.zeebe.engine.api.RecordProcessor;
 import io.camunda.zeebe.engine.api.TypedRecord;
-import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.streamprocessor.StreamProcessor;
@@ -144,7 +143,6 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         .actorSchedulingService(context.getActorSchedulingService())
         .zeebeDb(context.getZeebeDb())
         .recordProcessors(recordProcessors)
-        .eventApplierFactory(EventAppliers::new)
         .nodeId(context.getNodeId())
         .commandResponseWriter(context.getCommandResponseWriter())
         .listener(

--- a/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.ZeebeDbState;
+import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.processing.DbBlackListState;
 import io.camunda.zeebe.logstreams.impl.Loggers;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
@@ -72,7 +73,7 @@ public class Engine implements RecordProcessor {
             recordProcessorContext.getZeebeDb(),
             recordProcessorContext.getTransactionContext(),
             recordProcessorContext.getKeyGenerator());
-    eventApplier = recordProcessorContext.getEventApplierFactory().apply(zeebeState);
+    eventApplier = new EventAppliers(zeebeState);
 
     writers = new Writers(resultBuilderMutex, eventApplier);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessorContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/RecordProcessorContext.java
@@ -9,11 +9,8 @@ package io.camunda.zeebe.engine.api;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
-import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.KeyGenerator;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import java.util.List;
-import java.util.function.Function;
 
 public interface RecordProcessorContext {
 
@@ -24,8 +21,6 @@ public interface RecordProcessorContext {
   ZeebeDb getZeebeDb();
 
   TransactionContext getTransactionContext();
-
-  Function<MutableZeebeState, EventApplier> getEventApplierFactory();
 
   List<StreamProcessorLifecycleAware> getLifecycleListeners();
 

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/RecordProcessorContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/RecordProcessorContextImpl.java
@@ -13,13 +13,10 @@ import io.camunda.zeebe.engine.api.InterPartitionCommandSender;
 import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.api.RecordProcessorContext;
 import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
-import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.KeyGenerator;
 import io.camunda.zeebe.engine.state.KeyGeneratorControls;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 
 public final class RecordProcessorContextImpl implements RecordProcessorContext {
 
@@ -27,7 +24,6 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   private final ProcessingScheduleService scheduleService;
   private final ZeebeDb zeebeDb;
   private final TransactionContext transactionContext;
-  private final Function<MutableZeebeState, EventApplier> eventApplierFactory;
   private final List<StreamProcessorLifecycleAware> lifecycleListeners = new ArrayList<>();
   private final InterPartitionCommandSender partitionCommandSender;
   private final KeyGenerator keyGenerator;
@@ -37,14 +33,12 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
       final ProcessingScheduleService scheduleService,
       final ZeebeDb zeebeDb,
       final TransactionContext transactionContext,
-      final Function<MutableZeebeState, EventApplier> eventApplierFactory,
       final InterPartitionCommandSender partitionCommandSender,
       final KeyGeneratorControls keyGeneratorControls) {
     this.partitionId = partitionId;
     this.scheduleService = scheduleService;
     this.zeebeDb = zeebeDb;
     this.transactionContext = transactionContext;
-    this.eventApplierFactory = eventApplierFactory;
     this.partitionCommandSender = partitionCommandSender;
     keyGenerator = keyGeneratorControls;
   }
@@ -67,11 +61,6 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   @Override
   public TransactionContext getTransactionContext() {
     return transactionContext;
-  }
-
-  @Override
-  public Function<MutableZeebeState, EventApplier> getEventApplierFactory() {
-    return eventApplierFactory;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessor.java
@@ -13,8 +13,6 @@ import io.camunda.zeebe.engine.api.RecordProcessor;
 import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.metrics.StreamProcessorMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.RecordValues;
-import io.camunda.zeebe.engine.state.EventApplier;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.engine.state.processing.DbKeyGenerator;
 import io.camunda.zeebe.logstreams.impl.Loggers;
 import io.camunda.zeebe.logstreams.log.LogRecordAwaiter;
@@ -38,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 import org.slf4j.Logger;
 
 /*
@@ -87,7 +84,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private final ActorSchedulingService actorSchedulingService;
   private final AtomicBoolean isOpened = new AtomicBoolean(false);
   private final List<StreamProcessorLifecycleAware> lifecycleAwareListeners;
-  private final Function<MutableZeebeState, EventApplier> eventApplierFactory;
   private final Set<FailureListener> failureListeners = new HashSet<>();
   private final StreamProcessorMetrics metrics;
 
@@ -117,8 +113,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     actorSchedulingService = processorBuilder.getActorSchedulingService();
     lifecycleAwareListeners = processorBuilder.getLifecycleListeners();
     zeebeDb = processorBuilder.getZeebeDb();
-
-    eventApplierFactory = processorBuilder.getEventApplierFactory();
 
     streamProcessorContext =
         processorBuilder
@@ -340,7 +334,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
             streamProcessorContext.getScheduleService(),
             zeebeDb,
             streamProcessorContext.getTransactionContext(),
-            eventApplierFactory,
             streamProcessorContext.getPartitionCommandSender(),
             streamProcessorContext.getKeyGeneratorControls());
 

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/StreamProcessorBuilder.java
@@ -12,14 +12,11 @@ import io.camunda.zeebe.engine.api.CommandResponseWriter;
 import io.camunda.zeebe.engine.api.InterPartitionCommandSender;
 import io.camunda.zeebe.engine.api.RecordProcessor;
 import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
-import io.camunda.zeebe.engine.state.EventApplier;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
 
 public final class StreamProcessorBuilder {
 
@@ -27,7 +24,6 @@ public final class StreamProcessorBuilder {
   private final List<StreamProcessorLifecycleAware> lifecycleListeners = new ArrayList<>();
   private ActorSchedulingService actorSchedulingService;
   private ZeebeDb zeebeDb;
-  private Function<MutableZeebeState, EventApplier> eventApplierFactory;
   private int nodeId;
 
   private List<RecordProcessor> recordProcessors;
@@ -73,12 +69,6 @@ public final class StreamProcessorBuilder {
     return this;
   }
 
-  public StreamProcessorBuilder eventApplierFactory(
-      final Function<MutableZeebeState, EventApplier> eventApplierFactory) {
-    this.eventApplierFactory = eventApplierFactory;
-    return this;
-  }
-
   public StreamProcessorBuilder streamProcessorMode(final StreamProcessorMode streamProcessorMode) {
     streamProcessorContext.processorMode(streamProcessorMode);
     return this;
@@ -114,10 +104,6 @@ public final class StreamProcessorBuilder {
     return recordProcessors;
   }
 
-  public Function<MutableZeebeState, EventApplier> getEventApplierFactory() {
-    return eventApplierFactory;
-  }
-
   public StreamProcessor build() {
     validate();
 
@@ -128,7 +114,6 @@ public final class StreamProcessorBuilder {
     Objects.requireNonNull(actorSchedulingService, "No task scheduler provided.");
     Objects.requireNonNull(streamProcessorContext.getLogStream(), "No log stream provided.");
     Objects.requireNonNull(zeebeDb, "No database provided.");
-    Objects.requireNonNull(eventApplierFactory, "No factory for the event supplier provided.");
     if (streamProcessorContext.getProcessorMode() == StreamProcessorMode.PROCESSING) {
       Objects.requireNonNull(
           streamProcessorContext.getPartitionCommandSender(),

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.engine.api.CommandResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
-import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.engine.util.StreamProcessingComposite.StreamProcessorTestFactory;
 import io.camunda.zeebe.engine.util.TestStreams.FluentLogWriter;
@@ -36,7 +35,6 @@ import io.camunda.zeebe.util.allocation.DirectBufferAllocator;
 import java.io.File;
 import java.io.IOException;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import org.junit.rules.ExternalResource;
@@ -121,12 +119,6 @@ public final class StreamProcessorRule implements TestRule {
   @Override
   public Statement apply(final Statement base, final Description description) {
     return chain.apply(base, description);
-  }
-
-  public StreamProcessorRule withEventApplierFactory(
-      final Function<MutableZeebeState, EventApplier> eventApplierFactory) {
-    streams.withEventApplierFactory(eventApplierFactory);
-    return this;
   }
 
   public StreamProcessorRule withStreamProcessorMode(

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -24,9 +24,6 @@ import io.camunda.zeebe.engine.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedEventRegistry;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
-import io.camunda.zeebe.engine.state.EventApplier;
-import io.camunda.zeebe.engine.state.appliers.EventAppliers;
-import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.logstreams.log.LogStreamBatchWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamRecordWriter;
@@ -62,7 +59,6 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.junit.rules.TemporaryFolder;
@@ -88,7 +84,6 @@ public final class TestStreams {
   private final Map<String, ProcessorContext> streamContextMap = new HashMap<>();
   private boolean snapshotWasTaken = false;
 
-  private Function<MutableZeebeState, EventApplier> eventApplierFactory = EventAppliers::new;
   private StreamProcessorMode streamProcessorMode = StreamProcessorMode.PROCESSING;
 
   public TestStreams(
@@ -111,11 +106,6 @@ public final class TestStreams {
 
     when(mockCommandResponseWriter.tryWriteResponse(anyInt(), anyLong())).thenReturn(true);
     mockStreamProcessorListener = mock(StreamProcessorListener.class);
-  }
-
-  public void withEventApplierFactory(
-      final Function<MutableZeebeState, EventApplier> eventApplierFactory) {
-    this.eventApplierFactory = eventApplierFactory;
   }
 
   public void withStreamProcessorMode(final StreamProcessorMode streamProcessorMode) {
@@ -293,7 +283,6 @@ public final class TestStreams {
             .commandResponseWriter(mockCommandResponseWriter)
             .listener(new StreamProcessorListenerRelay(streamProcessorListeners))
             .recordProcessors(List.of(new Engine(wrappedFactory)))
-            .eventApplierFactory(eventApplierFactory)
             .streamProcessorMode(streamProcessorMode)
             .partitionCommandSender(mock(InterPartitionCommandSender.class));
 

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamPlatform.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamPlatform.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.engine.api.EmptyProcessingResult;
 import io.camunda.zeebe.engine.api.InterPartitionCommandSender;
 import io.camunda.zeebe.engine.api.RecordProcessor;
 import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
-import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.processing.DbKeyGenerator;
 import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl;
@@ -265,7 +264,6 @@ public final class StreamPlatform {
             .actorSchedulingService(actorScheduler)
             .commandResponseWriter(mockCommandResponseWriter)
             .recordProcessors(recordProcessors)
-            .eventApplierFactory(EventAppliers::new) // todo remove this soon
             .streamProcessorMode(processorMode)
             .listener(mockStreamProcessorListener)
             .partitionCommandSender(mock(InterPartitionCommandSender.class));


### PR DESCRIPTION
## Description

Move the event appliers to the engine, there are not necessary for outside. This reduces the dependency from the stream processor. This makes it possible to split both modules. 
<!-- Please explain the changes you made here. -->

## Related issues

Replacement of https://github.com/camunda/zeebe/pull/10902
<!-- Which issues are closed by this PR or are related -->
closes https://github.com/camunda/zeebe/issues/10027

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
