### PR TITLE
fix: exclusive gateway's default flow not allowed to have a condition

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExclusiveGatewayValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExclusiveGatewayValidator.java
@@ -34,9 +34,6 @@ public class ExclusiveGatewayValidator implements ModelElementValidator<Exclusiv
     final SequenceFlow defaultFlow = element.getDefault();
 
     if (defaultFlow != null) {
-      if (defaultFlow.getConditionExpression() != null) {
-        validationResultCollector.addError(0, "Default flow must not have a condition");
-      }
       if (defaultFlow.getSource() != element) {
         validationResultCollector.addError(0, "Default flow must start at gateway");
       }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeGatewayValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeGatewayValidationTest.java
@@ -72,17 +72,6 @@ public class ZeebeGatewayValidationTest extends AbstractZeebeValidationTest {
             expect(
                 "join", "Currently the inclusive gateway can only have one incoming sequence flow"))
       },
-      {
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .exclusiveGateway("gateway")
-            .sequenceFlowId("flow")
-            .condition("name", "foo")
-            .defaultFlow()
-            .endEvent()
-            .done(),
-        singletonList(expect("gateway", "Default flow must not have a condition"))
-      },
       {"default-flow.bpmn", singletonList(expect("gateway", "Default flow must start at gateway"))},
       {
         "default-flow-inclusive-gateway.bpmn",

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
@@ -95,15 +95,18 @@ public final class ExclusiveGatewayProcessor
     }
 
     for (final ExecutableSequenceFlow sequenceFlow : element.getOutgoingWithCondition()) {
-      final Expression condition = sequenceFlow.getCondition();
-      final Either<Failure, Boolean> isFulfilledOrFailure =
-          expressionBehavior.evaluateBooleanExpression(condition, context.getElementInstanceKey());
-      if (isFulfilledOrFailure.isLeft()) {
-        return Either.left(isFulfilledOrFailure.getLeft());
+      if (element.getDefaultFlow() == null || element.getDefaultFlow() != sequenceFlow) {
+        final Expression condition = sequenceFlow.getCondition();
+        final Either<Failure, Boolean> isFulfilledOrFailure =
+            expressionBehavior.evaluateBooleanExpression(
+                condition, context.getElementInstanceKey());
+        if (isFulfilledOrFailure.isLeft()) {
+          return Either.left(isFulfilledOrFailure.getLeft());
 
-      } else if (isFulfilledOrFailure.get()) {
-        // the condition is fulfilled
-        return Either.right(Optional.of(sequenceFlow));
+        } else if (isFulfilledOrFailure.get()) {
+          // the condition is fulfilled
+          return Either.right(Optional.of(sequenceFlow));
+        }
       }
     }
 


### PR DESCRIPTION
## Description

Fix exclusive gateway's default flow not allowed to have a condition.

This PR makes it so that:
- the default flow is allowed to have a condition
- the condition of the default flow is not evaluated

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10966 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
