### PR TITLE
refactor(elasticsearch-exporter): output raw message on JSON error

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -162,7 +162,8 @@ class ElasticsearchClient implements AutoCloseable {
 
     final BulkIndexResponse response;
     try {
-      response = MAPPER.readValue(httpResponse.getEntity().getContent(), BulkIndexResponse.class);
+      final var responseBody = httpResponse.getEntity().getContent();
+      response = MAPPER.readValue(responseBody.readAllBytes(), BulkIndexResponse.class);
     } catch (final IOException e) {
       throw new ElasticsearchExporterException("Failed to parse response when flushing", e);
     }
@@ -194,8 +195,9 @@ class ElasticsearchClient implements AutoCloseable {
       request.setJsonEntity(MAPPER.writeValueAsString(template));
 
       final var response = client.performRequest(request);
+      final var responseBody = response.getEntity().getContent();
       final var putIndexTemplateResponse =
-          MAPPER.readValue(response.getEntity().getContent(), PutIndexTemplateResponse.class);
+          MAPPER.readValue(responseBody.readAllBytes(), PutIndexTemplateResponse.class);
       return putIndexTemplateResponse.acknowledged();
     } catch (final IOException e) {
       throw new ElasticsearchExporterException("Failed to put index template", e);
@@ -208,8 +210,9 @@ class ElasticsearchClient implements AutoCloseable {
       request.setJsonEntity(MAPPER.writeValueAsString(template));
 
       final var response = client.performRequest(request);
+      final var responseBody = response.getEntity().getContent();
       final var putIndexTemplateResponse =
-          MAPPER.readValue(response.getEntity().getContent(), PutIndexTemplateResponse.class);
+          MAPPER.readValue(responseBody.readAllBytes(), PutIndexTemplateResponse.class);
       return putIndexTemplateResponse.acknowledged();
     } catch (final IOException e) {
       throw new ElasticsearchExporterException("Failed to put component template", e);


### PR DESCRIPTION
## Description

Ensures that the raw message is printed as part of the stacktrace when the server returns a successful, but invalid message, so we can more easily diagnose what is happening.

## Related issues

closes #10970 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
