### PR TITLE
Add feel expressions for error events 

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractEndEventBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractEndEventBuilder.java
@@ -33,6 +33,16 @@ public abstract class AbstractEndEventBuilder<B extends AbstractEndEventBuilder<
   }
 
   /**
+   * Sets a dynamic error code for the error that is retrieved from the given expression
+   *
+   * @param errorCodeExpression the expression for the error
+   * @return the builder object
+   */
+  public B errorExpression(final String errorCodeExpression) {
+    return error(asZeebeExpression(errorCodeExpression));
+  }
+
+  /**
    * Sets an error definition for the given error code. If already an error with this code exists it
    * will be used, otherwise a new error is created.
    *

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ErrorEventDefinitionValidator.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ErrorEventDefinitionValidator.java
@@ -15,12 +15,16 @@
  */
 package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
+import io.camunda.zeebe.model.bpmn.instance.CatchEvent;
 import io.camunda.zeebe.model.bpmn.instance.Error;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 
 public class ErrorEventDefinitionValidator implements ModelElementValidator<ErrorEventDefinition> {
+
+  private static final String ZEEBE_EXPRESSION_PREFIX = "=";
 
   @Override
   public Class<ErrorEventDefinition> getElementType() {
@@ -40,6 +44,13 @@ public class ErrorEventDefinitionValidator implements ModelElementValidator<Erro
       final String errorCode = error.getErrorCode();
       if (errorCode == null || errorCode.isEmpty()) {
         validationResultCollector.addError(0, "ErrorCode must be present and not empty");
+        return;
+      }
+
+      final ModelElementInstance parentElement = element.getParentElement();
+      if (errorCode.startsWith(ZEEBE_EXPRESSION_PREFIX) && parentElement instanceof CatchEvent) {
+        validationResultCollector.addError(
+            0, "The errorCode of the error catch event is not allowed to be an expression");
       }
     }
   }

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeErrorEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeErrorEventValidationTest.java
@@ -53,6 +53,18 @@ public class ZeebeErrorEventValidationTest extends AbstractZeebeValidationTest {
         Bpmn.createExecutableProcess("process")
             .startEvent()
             .serviceTask("task", t -> t.zeebeJobType("type"))
+            .boundaryEvent("catch", b -> b.error("= error"))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ErrorEventDefinition.class,
+                "The errorCode of the error catch event is not allowed to be an expression"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
             .boundaryEvent("catch", b -> b.error("ERROR").cancelActivity(false))
             .endEvent()
             .done(),
@@ -116,6 +128,17 @@ public class ZeebeErrorEventValidationTest extends AbstractZeebeValidationTest {
             .done(),
         singletonList(
             expect(SubProcess.class, "Non-Interrupting event of this type is not allowed"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .eventSubProcess("sub", s -> s.startEvent().error("=  error").endEvent())
+            .startEvent()
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ErrorEventDefinition.class,
+                "The errorCode of the error catch event is not allowed to be an expression"))
       },
       {
         Bpmn.createExecutableProcess("process")

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableError.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableError.java
@@ -7,22 +7,41 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
+import io.camunda.zeebe.el.Expression;
+import java.util.Optional;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public class ExecutableError extends AbstractFlowElement {
 
-  private final DirectBuffer errorCode = new UnsafeBuffer();
+  private DirectBuffer errorCode;
+  private Expression errorCodeExpression;
 
   public ExecutableError(final String id) {
     super(id);
   }
 
-  public DirectBuffer getErrorCode() {
-    return errorCode;
+  /**
+   * Returns the error code, if it has been resolved previously (and is independent of the variable
+   * context). If this returns an empty {@code Optional} then the error code must be resolved by
+   * evaluating {@code getErrorCodeExpression()}
+   *
+   * @return the error code, if it has been resolved previously (and is independent of the variable
+   *     context)
+   */
+  public Optional<DirectBuffer> getErrorCode() {
+    return Optional.ofNullable(errorCode);
   }
 
   public void setErrorCode(final DirectBuffer errorCode) {
-    this.errorCode.wrap(errorCode);
+    this.errorCode = new UnsafeBuffer(errorCode);
+  }
+
+  public Expression getErrorCodeExpression() {
+    return errorCodeExpression;
+  }
+
+  public void setErrorCodeExpression(final Expression errorCodeExpression) {
+    this.errorCodeExpression = errorCodeExpression;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/analyzers/CatchEventAnalyzer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/analyzers/CatchEventAnalyzer.java
@@ -121,12 +121,17 @@ public final class CatchEventAnalyzer {
 
     for (final ExecutableCatchEvent catchEvent : element.getEvents()) {
       if (catchEvent.isError()) {
-        availableCatchEvents.getLeft().add(catchEvent.getError().getErrorCode());
-        if (catchEvent.getError().getErrorCode().equals(errorCode)) {
+        final Optional<DirectBuffer> errorCodeOptional = catchEvent.getError().getErrorCode();
+        // Because a catch event can not contain an expression, we ignore it if not set.
+        if (errorCodeOptional.isPresent()) {
+          final var errorCodeBuffer = errorCodeOptional.get();
+          availableCatchEvents.getLeft().add(errorCodeBuffer);
+          if (errorCodeBuffer.equals(errorCode)) {
 
-          catchEventTuple.instance = instance;
-          catchEventTuple.catchEvent = catchEvent;
-          return Either.right(catchEventTuple);
+            catchEventTuple.instance = instance;
+            catchEventTuple.catchEvent = catchEvent;
+            return Either.right(catchEventTuple);
+          }
         }
       }
     }


### PR DESCRIPTION
## Description

This PR adds feel expression support to error end events.

## Related issues

closes #3801

## Definition of Done


Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
