### PR TITLE
refactor(backup/s3): handle save and restore of `NamedFileSet`s in dedicated class

### DIFF
--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/FileSetManager.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/FileSetManager.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import io.camunda.zeebe.backup.api.NamedFileSet;
+import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.backup.s3.util.CompletableFutureUtils;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+/** Can save and restore {@link NamedFileSet NamedFileSets}. */
+final class FileSetManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FileSetManager.class);
+  private final S3AsyncClient client;
+  private final S3BackupConfig config;
+
+  public FileSetManager(final S3AsyncClient client, final S3BackupConfig config) {
+    this.client = client;
+    this.config = config;
+  }
+
+  CompletableFuture<Void> save(final String prefix, final NamedFileSet files) {
+    LOG.debug("Saving {} files to prefix {}", files.files().size(), prefix);
+    final var futures =
+        files.namedFiles().entrySet().stream()
+            .map(segmentFile -> saveFile(prefix, segmentFile.getKey(), segmentFile.getValue()))
+            .toList();
+
+    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[] {}));
+  }
+
+  private CompletableFuture<PutObjectResponse> saveFile(
+      final String prefix, final String fileName, final Path filePath) {
+    LOG.trace("Saving file {}({}) in prefix {}", fileName, filePath, prefix);
+    return client.putObject(
+        put -> put.bucket(config.bucketName()).key(prefix + fileName),
+        AsyncRequestBody.fromFile(filePath));
+  }
+
+  CompletableFuture<NamedFileSet> restore(
+      final String sourcePrefix, final Set<String> fileNames, final Path targetFolder) {
+    LOG.debug(
+        "Restoring {} files from prefix {} to {}", fileNames.size(), sourcePrefix, targetFolder);
+    return CompletableFutureUtils.mapAsync(
+            fileNames, fileName -> restoreFile(sourcePrefix, targetFolder, fileName))
+        .thenApply(NamedFileSetImpl::new);
+  }
+
+  private CompletableFuture<Path> restoreFile(
+      final String sourcePrefix, final Path targetFolder, final String fileName) {
+    LOG.trace("Restoring file {} from prefix {} to {}", fileName, sourcePrefix, targetFolder);
+    final var path = targetFolder.resolve(fileName);
+    return client
+        .getObject(req -> req.bucket(config.bucketName()).key(sourcePrefix + fileName), path)
+        .thenApply(response -> path);
+  }
+}

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.backup.s3.manifest.InProgressBackupManifest;
 import io.camunda.zeebe.backup.s3.manifest.Manifest;
 import io.camunda.zeebe.backup.s3.manifest.NoBackupManifest;
 import io.camunda.zeebe.backup.s3.manifest.ValidBackupManifest;
+import io.camunda.zeebe.backup.s3.util.AsyncAggregatingSubscriber;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -83,6 +83,7 @@ public final class S3BackupStore implements BackupStore {
   private static final Logger LOG = LoggerFactory.getLogger(S3BackupStore.class);
   private static final Pattern BACKUP_IDENTIFIER_PATTERN =
       Pattern.compile("^(?<partitionId>\\d+)/(?<checkpointId>\\d+)/(?<nodeId>\\d+).*");
+  private static final int SCAN_PARALLELISM = 16;
   private final S3BackupConfig config;
   private final S3AsyncClient client;
   private final FileSetManager fileSetManager;
@@ -303,7 +304,7 @@ public final class S3BackupStore implements BackupStore {
 
   private CompletableFuture<Collection<Manifest>> readManifestObjects(
       final BackupIdentifierWildcard wildcard) {
-    final var aggregator = new AsyncAggregatingSubscriber<Manifest>(16);
+    final var aggregator = new AsyncAggregatingSubscriber<Manifest>(SCAN_PARALLELISM);
     final var publisher = findBackupIds(wildcard).map(this::readManifestObject);
     publisher.subscribe(aggregator);
 

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -402,21 +402,18 @@ public final class S3BackupStore implements BackupStore {
     LOG.debug("Saving snapshot files for {}", backup.id());
     final var prefix = objectPrefix(backup.id()) + SNAPSHOT_PREFIX;
 
-    final var futures =
-        backup.snapshot().namedFiles().entrySet().stream()
-            .map(
-                snapshotFile ->
-                    saveNamedFile(prefix, snapshotFile.getKey(), snapshotFile.getValue()))
-            .toList();
-
-    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[] {}));
+    return saveNamedFileSet(prefix, backup.snapshot());
   }
 
   private CompletableFuture<Void> saveSegmentFiles(final Backup backup) {
     LOG.debug("Saving segment files for {}", backup.id());
     final var prefix = objectPrefix(backup.id()) + SEGMENTS_PREFIX;
+    return saveNamedFileSet(prefix, backup.segments());
+  }
+
+  private CompletableFuture<Void> saveNamedFileSet(final String prefix, final NamedFileSet files) {
     final var futures =
-        backup.segments().namedFiles().entrySet().stream()
+        files.namedFiles().entrySet().stream()
             .map(segmentFile -> saveNamedFile(prefix, segmentFile.getKey(), segmentFile.getValue()))
             .toList();
 

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.backup.s3;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -322,10 +321,9 @@ public final class S3BackupStore implements BackupStore {
               try {
                 return (Manifest)
                     MAPPER.readValue(response.asInputStream(), ValidBackupManifest.class);
-              } catch (final JsonParseException e) {
-                throw new ManifestParseException("Failed to parse manifest object", e);
               } catch (final IOException e) {
-                throw new BackupReadException("Failed to read manifest object", e);
+                throw new ManifestParseException(
+                    "Failed to read manifest object: %s".formatted(response.asUtf8String()), e);
               }
             })
         .exceptionally(

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -18,10 +18,8 @@ import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
-import io.camunda.zeebe.backup.api.NamedFileSet;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupImpl;
-import io.camunda.zeebe.backup.common.NamedFileSetImpl;
 import io.camunda.zeebe.backup.s3.S3BackupStoreException.BackupDeletionIncomplete;
 import io.camunda.zeebe.backup.s3.S3BackupStoreException.BackupInInvalidStateException;
 import io.camunda.zeebe.backup.s3.S3BackupStoreException.BackupReadException;
@@ -38,9 +36,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -59,7 +55,6 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
-import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
 /**
@@ -90,6 +85,7 @@ public final class S3BackupStore implements BackupStore {
       Pattern.compile("^(?<partitionId>\\d+)/(?<checkpointId>\\d+)/(?<nodeId>\\d+).*");
   private final S3BackupConfig config;
   private final S3AsyncClient client;
+  private final FileSetManager fileSetManager;
 
   public S3BackupStore(final S3BackupConfig config) {
     this(config, buildClient(config));
@@ -98,6 +94,7 @@ public final class S3BackupStore implements BackupStore {
   public S3BackupStore(final S3BackupConfig config, final S3AsyncClient client) {
     this.config = config;
     this.client = client;
+    fileSetManager = new FileSetManager(client, config);
   }
 
   private static Optional<BackupIdentifier> tryParseKeyAsId(final String key) {
@@ -229,10 +226,11 @@ public final class S3BackupStore implements BackupStore {
         .thenApply(Manifest::expectCompleted)
         .thenComposeAsync(
             manifest ->
-                downloadNamedFileSet(
+                fileSetManager
+                    .restore(
                         backupPrefix + SEGMENTS_PREFIX, manifest.segmentFileNames(), targetFolder)
                     .thenCombineAsync(
-                        downloadNamedFileSet(
+                        fileSetManager.restore(
                             backupPrefix + SNAPSHOT_PREFIX,
                             manifest.snapshotFileNames(),
                             targetFolder),
@@ -252,27 +250,6 @@ public final class S3BackupStore implements BackupStore {
   public CompletableFuture<Void> closeAsync() {
     client.close();
     return CompletableFuture.completedFuture(null);
-  }
-
-  private CompletableFuture<NamedFileSet> downloadNamedFileSet(
-      final String sourcePrefix, final Set<String> fileNames, final Path targetFolder) {
-    LOG.debug(
-        "Downloading {} files from prefix {} to {}", fileNames.size(), sourcePrefix, targetFolder);
-    final var downloadedFiles = new ConcurrentHashMap<String, Path>();
-    final CompletableFuture<?>[] futures =
-        fileNames.stream()
-            .map(
-                fileName -> {
-                  final var path = targetFolder.resolve(fileName);
-                  return client
-                      .getObject(
-                          req -> req.bucket(config.bucketName()).key(sourcePrefix + fileName), path)
-                      .thenApply(response -> downloadedFiles.put(fileName, path));
-                })
-            .toArray(CompletableFuture[]::new);
-
-    return CompletableFuture.allOf(futures)
-        .thenApply(ignored -> new NamedFileSetImpl(downloadedFiles));
   }
 
   private CompletableFuture<List<ObjectIdentifier>> listBackupObjects(final BackupIdentifier id) {
@@ -401,31 +378,13 @@ public final class S3BackupStore implements BackupStore {
   private CompletableFuture<Void> saveSnapshotFiles(final Backup backup) {
     LOG.debug("Saving snapshot files for {}", backup.id());
     final var prefix = objectPrefix(backup.id()) + SNAPSHOT_PREFIX;
-
-    return saveNamedFileSet(prefix, backup.snapshot());
+    return fileSetManager.save(prefix, backup.snapshot());
   }
 
   private CompletableFuture<Void> saveSegmentFiles(final Backup backup) {
     LOG.debug("Saving segment files for {}", backup.id());
     final var prefix = objectPrefix(backup.id()) + SEGMENTS_PREFIX;
-    return saveNamedFileSet(prefix, backup.segments());
-  }
-
-  private CompletableFuture<Void> saveNamedFileSet(final String prefix, final NamedFileSet files) {
-    final var futures =
-        files.namedFiles().entrySet().stream()
-            .map(segmentFile -> saveNamedFile(prefix, segmentFile.getKey(), segmentFile.getValue()))
-            .toList();
-
-    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[] {}));
-  }
-
-  private CompletableFuture<PutObjectResponse> saveNamedFile(
-      final String prefix, final String fileName, final Path filePath) {
-    LOG.trace("Saving file {}({}) in prefix {}", fileName, filePath, prefix);
-    return client.putObject(
-        put -> put.bucket(config.bucketName()).key(prefix + fileName),
-        AsyncRequestBody.fromFile(filePath));
+    return fileSetManager.save(prefix, backup.segments());
   }
 
   public static S3AsyncClient buildClient(final S3BackupConfig config) {

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/util/AsyncAggregatingSubscriber.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/util/AsyncAggregatingSubscriber.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.backup.s3;
+package io.camunda.zeebe.backup.s3.util;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -83,7 +83,7 @@ public class AsyncAggregatingSubscriber<T> implements Subscriber<CompletableFutu
   /**
    * @return A future that is completed with the results once all of them have been collected.
    */
-  CompletableFuture<Collection<T>> result() {
+  public CompletableFuture<Collection<T>> result() {
     return CompletableFuture.supplyAsync(phaser::arriveAndAwaitAdvance)
         .thenApply(
             ignored -> {

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/util/CompletableFutureUtils.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/util/CompletableFutureUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.s3.util;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public final class CompletableFutureUtils {
+
+  // Hide default constructor
+  private CompletableFutureUtils() {}
+
+  /**
+   * Maps keys to values by applying a mapping function asynchronously.
+   *
+   * @param keys A collection of keys.
+   * @param m A function that returns a {@link CompletableFuture<V>} for every key.
+   * @return A future that completes with a map of keys to the completed result of applying the
+   *     mapping function. If the mapping function completes exceptionally, the resulting future
+   *     will also complete exceptionally. @ param <K> Type of keys
+   * @param <V> Type of value
+   */
+  public static <K, V> CompletableFuture<Map<K, V>> mapAsync(
+      final Collection<K> keys, final Function<K, CompletableFuture<V>> m) {
+    final var inProgress = keys.stream().collect(Collectors.toMap(Function.identity(), m));
+    return CompletableFuture.allOf(inProgress.values().toArray(CompletableFuture[]::new))
+        .thenApply(
+            unused ->
+                inProgress.entrySet().stream()
+                    .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().join())));
+  }
+}

--- a/backup-stores/s3/src/test/resources/log4j2-test.xml
+++ b/backup-stores/s3/src/test/resources/log4j2-test.xml
@@ -16,8 +16,7 @@
   </Appenders>
 
   <Loggers>
-    <Logger name="io.camunda.zeebe" level="debug"/>
-    <Logger name="software.amazon.awssdk" level="debug" />
+    <Logger name="io.camunda.zeebe" level="trace"/>
     <Logger name="software.amazon.awssdk.request" level="debug" />
 
     <Root level="info">


### PR DESCRIPTION
This PR contains smaller fixes and refactorings with the main goal of extracting the methods for saving and restoring `NameFileSet`s to a dedicated class. This helps a little bit in getting `S3BackupStore` smaller.

`FileSetManager` can also be extended later to add optional compression of individual files.

Extracted from #10940 to keep the PRs small.