### PR TITLE
Don't overwrite cache for java-client CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,7 +289,6 @@ jobs:
         with:
           java-version: '8'
           distribution: 'temurin'
-          cache: maven
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
       - name: Maven Test Build


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

The `java-client` job first builds the project using the required jdk and then switches the jdk when testing that the client works on java 8.

This `cache: maven` line would overwrite the cache, incl. all build modules. So the test did not run on the correct code.

By removing the line, we avoid that the modules compiled in the build-zeebe step are not overwritten.

## Related issues

<!-- Which issues are closed by this PR or are related -->

We originally discovered that this happened: https://github.com/camunda/zeebe/pull/10882#issuecomment-1311906694
We verified that it solves the problem: https://github.com/camunda/zeebe/pull/10882#issuecomment-1311929100
But we were unable to merge this with bors from a fork: https://github.com/camunda/zeebe/pull/10882#issuecomment-1315389680

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
