### PR TITLE
Prevent NPE when terminating call activity

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -572,7 +572,9 @@ public final class ProcessInstanceModificationProcessor
     } else if (elementType == BpmnElementType.CALL_ACTIVITY) {
       final var calledActivityElementInstance =
           elementInstanceState.getInstance(elementInstance.getCalledChildInstanceKey());
-      terminateElement(calledActivityElementInstance, sideEffects);
+      if (calledActivityElementInstance != null && calledActivityElementInstance.canTerminate()) {
+        terminateElement(calledActivityElementInstance, sideEffects);
+      }
     }
 
     stateWriter.appendFollowUpEvent(


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
If a parent process has an active call activity element instance there is no guarantee that the called activity is still activate. When the called activity is completed it will try to complete the call activity element. At this point we try to apply the output mappings. If something goes wrong here an incident is created. When we try to terminate the call activity at this point the called activity is already completed and no instance of it will be available. For this reason we must verify that this instance is not null before we try to terminate it.


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10606 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
