### PR TITLE
feat(backup/s3): add fileset metadata

### DIFF
--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/CompletedBackupManifest.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/CompletedBackupManifest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.s3.manifest;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
@@ -18,8 +19,8 @@ import java.util.Optional;
 public record CompletedBackupManifest(
     BackupIdentifierImpl id,
     BackupDescriptorImpl descriptor,
-    FileSet snapshotFiles,
-    FileSet segmentFiles,
+    @JsonAlias("snapshotFileNames") FileSet snapshotFiles,
+    @JsonAlias("segmentFileNames") FileSet segmentFiles,
     Instant createdAt,
     Instant modifiedAt)
     implements ValidBackupManifest {

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/CompletedBackupManifest.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/CompletedBackupManifest.java
@@ -14,13 +14,12 @@ import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import java.time.Instant;
 import java.util.Optional;
-import java.util.Set;
 
 public record CompletedBackupManifest(
     BackupIdentifierImpl id,
     BackupDescriptorImpl descriptor,
-    Set<String> snapshotFileNames,
-    Set<String> segmentFileNames,
+    FileSet snapshotFiles,
+    FileSet segmentFiles,
     Instant createdAt,
     Instant modifiedAt)
     implements ValidBackupManifest {
@@ -47,8 +46,8 @@ public record CompletedBackupManifest(
         id,
         Optional.of(descriptor),
         failureReason,
-        snapshotFileNames,
-        segmentFileNames,
+        snapshotFiles,
+        segmentFiles,
         createdAt,
         Instant.now());
   }

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/FailedBackupManifest.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/FailedBackupManifest.java
@@ -14,15 +14,14 @@ import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import java.time.Instant;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 
 public record FailedBackupManifest(
     BackupIdentifierImpl id,
     Optional<BackupDescriptorImpl> descriptor,
     String failureReason,
-    Set<String> snapshotFileNames,
-    Set<String> segmentFileNames,
+    FileSet snapshotFiles,
+    FileSet segmentFiles,
     Instant createdAt,
     Instant modifiedAt)
     implements ValidBackupManifest {

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/FailedBackupManifest.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/FailedBackupManifest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.s3.manifest;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
@@ -20,8 +21,8 @@ public record FailedBackupManifest(
     BackupIdentifierImpl id,
     Optional<BackupDescriptorImpl> descriptor,
     String failureReason,
-    FileSet snapshotFiles,
-    FileSet segmentFiles,
+    @JsonAlias("snapshotFileNames") FileSet snapshotFiles,
+    @JsonAlias("segmentFileNames") FileSet segmentFiles,
     Instant createdAt,
     Instant modifiedAt)
     implements ValidBackupManifest {

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/FileSet.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/FileSet.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.s3.manifest;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a {@link io.camunda.zeebe.backup.api.NamedFileSet} with attached metadata. It is
+ * represented as a JSON object. Keys are file names, values are {@link FileMetadata metadata}.
+ */
+public record FileSet(Map<String, FileMetadata> files) {
+
+  /**
+   * Constructs a {@link FileSet} based on a list of files names. Assumes that none of the files
+   * have any metadata attached.
+   */
+  public static FileSet withoutMetadata(final Set<String> fileNames) {
+    final var savedFiles =
+        fileNames.stream()
+            .collect(Collectors.toMap(String.class::cast, ignored -> FileMetadata.none()));
+    return new FileSet(savedFiles);
+  }
+
+  public static FileSet empty() {
+    return new FileSet(Map.of());
+  }
+
+  public Set<String> names() {
+    return files.keySet();
+  }
+
+  @JsonInclude(Include.NON_EMPTY)
+  public record FileMetadata() {
+    public static FileMetadata none() {
+      return new FileMetadata();
+    }
+  }
+}

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/FileSet.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/FileSet.java
@@ -9,6 +9,13 @@ package io.camunda.zeebe.backup.s3.manifest;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -17,6 +24,7 @@ import java.util.stream.Collectors;
  * Represents a {@link io.camunda.zeebe.backup.api.NamedFileSet} with attached metadata. It is
  * represented as a JSON object. Keys are file names, values are {@link FileMetadata metadata}.
  */
+@JsonDeserialize(using = FileSet.Deserializer.class)
 public record FileSet(Map<String, FileMetadata> files) {
 
   /**
@@ -42,6 +50,34 @@ public record FileSet(Map<String, FileMetadata> files) {
   public record FileMetadata() {
     public static FileMetadata none() {
       return new FileMetadata();
+    }
+  }
+
+  /**
+   * Custom deserializer that supports reading {@link FileSet} from the canonical representation as
+   * a map of string to {@link FileMetadata} while also supporting reading from a plain array of
+   * fileNames which was the serialization format in 8.1
+   */
+  static final class Deserializer extends JsonDeserializer<FileSet> {
+    private static final TypeReference<Map<String, FileMetadata>> WITH_METADATA =
+        new TypeReference<>() {};
+    private static final TypeReference<Set<String>> WITHOUT_METADATA = new TypeReference<>() {};
+
+    @Override
+    public FileSet deserialize(final JsonParser p, final DeserializationContext ctxt)
+        throws IOException {
+      final var codec = p.getCodec();
+      if (p.currentToken() == JsonToken.START_ARRAY) {
+        final var content = codec.readValue(p, WITHOUT_METADATA);
+        return FileSet.withoutMetadata(content);
+      } else if (p.currentToken() == JsonToken.START_OBJECT) {
+        try (final var parser = codec.readTree(p).get("files").traverse(codec)) {
+          final Map<String, FileMetadata> content = parser.readValueAs(WITH_METADATA);
+          return new FileSet(content);
+        }
+      }
+      ctxt.handleUnexpectedToken(FileSet.class, p);
+      return null; // we never reach this, `handleUnexpectedToken` will throw for us.
     }
   }
 }

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/InProgressBackupManifest.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/InProgressBackupManifest.java
@@ -14,13 +14,12 @@ import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import java.time.Instant;
 import java.util.Optional;
-import java.util.Set;
 
 public record InProgressBackupManifest(
     BackupIdentifierImpl id,
     BackupDescriptorImpl descriptor,
-    Set<String> snapshotFileNames,
-    Set<String> segmentFileNames,
+    FileSet snapshotFiles,
+    FileSet segmentFiles,
     Instant createdAt,
     Instant modifiedAt)
     implements ValidBackupManifest {
@@ -30,9 +29,9 @@ public record InProgressBackupManifest(
     return BackupStatusCode.IN_PROGRESS;
   }
 
-  public CompletedBackupManifest asCompleted() {
+  public CompletedBackupManifest asCompleted(final FileSet snapshot, final FileSet segments) {
     return new CompletedBackupManifest(
-        id, descriptor, snapshotFileNames, segmentFileNames, createdAt, Instant.now());
+        id, descriptor, snapshot, segments, createdAt, Instant.now());
   }
 
   @Override
@@ -41,8 +40,8 @@ public record InProgressBackupManifest(
         id,
         Optional.of(descriptor),
         failureMessage,
-        snapshotFileNames,
-        segmentFileNames,
+        snapshotFiles,
+        segmentFiles,
         createdAt,
         Instant.now());
   }

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/InProgressBackupManifest.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/InProgressBackupManifest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.s3.manifest;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
@@ -18,8 +19,8 @@ import java.util.Optional;
 public record InProgressBackupManifest(
     BackupIdentifierImpl id,
     BackupDescriptorImpl descriptor,
-    FileSet snapshotFiles,
-    FileSet segmentFiles,
+    @JsonAlias("snapshotFileNames") FileSet snapshotFiles,
+    @JsonAlias("segmentFileNames") FileSet segmentFiles,
     Instant createdAt,
     Instant modifiedAt)
     implements ValidBackupManifest {

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/NoBackupManifest.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/NoBackupManifest.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.Optional;
 
 public record NoBackupManifest(BackupIdentifierImpl id) implements Manifest {
@@ -34,13 +33,7 @@ public record NoBackupManifest(BackupIdentifierImpl id) implements Manifest {
   public FailedBackupManifest asFailed(final String failureReason) {
     final var now = Instant.now();
     return new FailedBackupManifest(
-        id,
-        Optional.empty(),
-        failureReason,
-        Collections.emptySet(),
-        Collections.emptySet(),
-        now,
-        now);
+        id, Optional.empty(), failureReason, FileSet.empty(), FileSet.empty(), now, now);
   }
 
   public InProgressBackupManifest asInProgress(final Backup backup) {
@@ -48,8 +41,8 @@ public record NoBackupManifest(BackupIdentifierImpl id) implements Manifest {
     return new InProgressBackupManifest(
         BackupIdentifierImpl.from(backup.id()),
         BackupDescriptorImpl.from(backup.descriptor()),
-        backup.snapshot().names(),
-        backup.segments().names(),
+        FileSet.withoutMetadata(backup.snapshot().names()),
+        FileSet.withoutMetadata(backup.segments().names()),
         now,
         now);
   }

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/util/CompletableFutureUtils.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/util/CompletableFutureUtils.java
@@ -23,15 +23,33 @@ public final class CompletableFutureUtils {
    * Maps keys to values by applying a mapping function asynchronously.
    *
    * @param keys A collection of keys.
-   * @param m A function that returns a {@link CompletableFuture<V>} for every key.
+   * @param valueMapper A function that returns a {@link CompletableFuture<V>} for every key.
    * @return A future that completes with a map of keys to the completed result of applying the
    *     mapping function. If the mapping function completes exceptionally, the resulting future
    *     will also complete exceptionally. @ param <K> Type of keys
    * @param <V> Type of value
    */
   public static <K, V> CompletableFuture<Map<K, V>> mapAsync(
-      final Collection<K> keys, final Function<K, CompletableFuture<V>> m) {
-    final var inProgress = keys.stream().collect(Collectors.toMap(Function.identity(), m));
+      final Collection<K> keys, final Function<K, CompletableFuture<V>> valueMapper) {
+    return mapAsync(keys, Function.identity(), valueMapper);
+  }
+
+  /**
+   * Maps keys to values by applying a mapping function asynchronously.
+   *
+   * @param coll A collection where elements will be mapped to keys and value by the provided
+   *     functions.
+   * @param valueMapper A function that returns a {@link CompletableFuture<V>} for every key.
+   * @return A future that completes with a map of keys to the completed result of applying the
+   *     mapping function. If the mapping function completes exceptionally, the resulting future
+   *     will also complete exceptionally. @ param <K> Type of keys
+   * @param <V> Type of value
+   */
+  public static <C, K, V> CompletableFuture<Map<K, V>> mapAsync(
+      final Collection<C> coll,
+      final Function<C, K> keyMapper,
+      final Function<C, CompletableFuture<V>> valueMapper) {
+    final var inProgress = coll.stream().collect(Collectors.toMap(keyMapper, valueMapper));
     return CompletableFuture.allOf(inProgress.values().toArray(CompletableFuture[]::new))
         .thenApply(
             unused ->

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ManifestCompatabilityTest.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ManifestCompatabilityTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import io.camunda.zeebe.backup.s3.manifest.CompletedBackupManifest;
+import io.camunda.zeebe.backup.s3.manifest.FailedBackupManifest;
+import io.camunda.zeebe.backup.s3.manifest.InProgressBackupManifest;
+import io.camunda.zeebe.backup.s3.manifest.ValidBackupManifest;
+import java.io.IOException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class ManifestCompatabilityTest {
+  @Test
+  void shouldParseCompletedManifestFromPreviousVersion() throws IOException {
+    // given
+    final var objectReader = S3BackupStore.MAPPER.readerFor(ValidBackupManifest.class);
+
+    // when
+    final var manifest =
+        objectReader.readValue(
+            getClass().getResourceAsStream("/manifests/8.1/completed.json"),
+            CompletedBackupManifest.class);
+
+    // then
+    Assertions.assertThat(manifest.segmentFiles()).isNotNull();
+    Assertions.assertThat(manifest.snapshotFiles()).isNotNull();
+    Assertions.assertThat(manifest.segmentFiles().files()).isNotEmpty();
+    Assertions.assertThat(manifest.snapshotFiles().files()).isNotEmpty();
+  }
+
+  @Test
+  void shouldParseCompletedManifestWithoutFilesFromPreviousVersion() throws IOException {
+    // given
+    final var objectReader = S3BackupStore.MAPPER.readerFor(ValidBackupManifest.class);
+
+    // when
+    final var manifest =
+        objectReader.readValue(
+            getClass().getResourceAsStream("/manifests/8.1/completed-empty.json"),
+            CompletedBackupManifest.class);
+
+    // then
+    Assertions.assertThat(manifest.segmentFiles()).isNotNull();
+    Assertions.assertThat(manifest.snapshotFiles()).isNotNull();
+    Assertions.assertThat(manifest.segmentFiles().files()).isEmpty();
+    Assertions.assertThat(manifest.snapshotFiles().files()).isEmpty();
+  }
+
+  @Test
+  void shouldParseInProgressManifestFromPreviousVersion() throws IOException {
+    // given
+    final var objectReader = S3BackupStore.MAPPER.readerFor(ValidBackupManifest.class);
+
+    // when
+    final var manifest =
+        objectReader.readValue(
+            getClass().getResourceAsStream("/manifests/8.1/in-progress.json"),
+            InProgressBackupManifest.class);
+
+    // then
+    Assertions.assertThat(manifest.segmentFiles()).isNotNull();
+    Assertions.assertThat(manifest.snapshotFiles()).isNotNull();
+    Assertions.assertThat(manifest.segmentFiles().files()).isNotEmpty();
+    Assertions.assertThat(manifest.snapshotFiles().files()).isNotEmpty();
+  }
+
+  @Test
+  void shouldParseFailedManifestFromPreviousVersion() throws IOException {
+    // given
+    final var objectReader = S3BackupStore.MAPPER.readerFor(ValidBackupManifest.class);
+
+    // when
+    final var manifest =
+        objectReader.readValue(
+            getClass().getResourceAsStream("/manifests/8.1/failed.json"),
+            FailedBackupManifest.class);
+
+    // then
+    Assertions.assertThat(manifest.segmentFiles()).isNotNull();
+    Assertions.assertThat(manifest.snapshotFiles()).isNotNull();
+    Assertions.assertThat(manifest.segmentFiles().files()).isNotEmpty();
+    Assertions.assertThat(manifest.snapshotFiles().files()).isNotEmpty();
+  }
+}

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ManifestCompatabilityTest.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/ManifestCompatabilityTest.java
@@ -25,13 +25,15 @@ final class ManifestCompatabilityTest {
     final var manifest =
         objectReader.readValue(
             getClass().getResourceAsStream("/manifests/8.1/completed.json"),
-            CompletedBackupManifest.class);
+            ValidBackupManifest.class);
 
     // then
-    Assertions.assertThat(manifest.segmentFiles()).isNotNull();
-    Assertions.assertThat(manifest.snapshotFiles()).isNotNull();
-    Assertions.assertThat(manifest.segmentFiles().files()).isNotEmpty();
-    Assertions.assertThat(manifest.snapshotFiles().files()).isNotEmpty();
+    Assertions.assertThat(manifest).isInstanceOf(CompletedBackupManifest.class);
+    final var completed = (CompletedBackupManifest) manifest;
+    Assertions.assertThat(completed.segmentFiles()).isNotNull();
+    Assertions.assertThat(completed.snapshotFiles()).isNotNull();
+    Assertions.assertThat(completed.segmentFiles().files()).isNotEmpty();
+    Assertions.assertThat(completed.snapshotFiles().files()).isNotEmpty();
   }
 
   @Test

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
@@ -71,8 +71,8 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
         .isBeforeOrEqualTo(readManifest.modifiedAt());
     assertThat(readManifest.modifiedAt()).isBeforeOrEqualTo(Instant.now());
 
-    assertThat(readManifest.snapshotFileNames()).isEqualTo(backup.snapshot().names());
-    assertThat(readManifest.segmentFileNames()).isEqualTo(backup.segments().names());
+    assertThat(readManifest.snapshotFiles().names()).isEqualTo(backup.snapshot().names());
+    assertThat(readManifest.segmentFiles().names()).isEqualTo(backup.segments().names());
   }
 
   @ParameterizedTest

--- a/backup-stores/s3/src/test/resources/manifests/8.1/completed-empty.json
+++ b/backup-stores/s3/src/test/resources/manifests/8.1/completed-empty.json
@@ -1,0 +1,20 @@
+{
+  "statusCode": "completed",
+  "id": {
+    "nodeId": 0,
+    "partitionId": 1,
+    "checkpointId": 1668519689
+  },
+  "descriptor": {
+    "snapshotId": "1204500-1-2549184-2548356",
+    "checkpointPosition": 2641349,
+    "numberOfPartitions": 3,
+    "brokerVersion": "8.1.0-SNAPSHOT"
+  },
+  "snapshotFileNames": [
+  ],
+  "segmentFileNames": [
+  ],
+  "createdAt": 1668519689.290560717,
+  "modifiedAt": 1668519690.961439595
+}

--- a/backup-stores/s3/src/test/resources/manifests/8.1/completed.json
+++ b/backup-stores/s3/src/test/resources/manifests/8.1/completed.json
@@ -1,0 +1,31 @@
+{
+  "statusCode": "completed",
+  "id": {
+    "nodeId": 0,
+    "partitionId": 1,
+    "checkpointId": 1668519689
+  },
+  "descriptor": {
+    "snapshotId": "1204500-1-2549184-2548356",
+    "checkpointPosition": 2641349,
+    "numberOfPartitions": 3,
+    "brokerVersion": "8.1.0-SNAPSHOT"
+  },
+  "snapshotFileNames": [
+    "000143.log",
+    "OPTIONS-000007",
+    "000144.sst",
+    "MANIFEST-000005",
+    "zeebe.metadata",
+    "000140.sst",
+    "1204500-1-2549184-2548356.checksum",
+    "CURRENT"
+  ],
+  "segmentFileNames": [
+    "raft-partition-partition-1-49.log",
+    "raft-partition-partition-1-47.log",
+    "raft-partition-partition-1-48.log"
+  ],
+  "createdAt": 1668519689.290560717,
+  "modifiedAt": 1668519690.961439595
+}

--- a/backup-stores/s3/src/test/resources/manifests/8.1/failed.json
+++ b/backup-stores/s3/src/test/resources/manifests/8.1/failed.json
@@ -1,0 +1,32 @@
+{
+  "statusCode": "failed",
+  "failureReason": "Some error occurred",
+  "id": {
+    "nodeId": 0,
+    "partitionId": 1,
+    "checkpointId": 1668519689
+  },
+  "descriptor": {
+    "snapshotId": "1204500-1-2549184-2548356",
+    "checkpointPosition": 2641349,
+    "numberOfPartitions": 3,
+    "brokerVersion": "8.1.0-SNAPSHOT"
+  },
+  "snapshotFileNames": [
+    "000143.log",
+    "OPTIONS-000007",
+    "000144.sst",
+    "MANIFEST-000005",
+    "zeebe.metadata",
+    "000140.sst",
+    "1204500-1-2549184-2548356.checksum",
+    "CURRENT"
+  ],
+  "segmentFileNames": [
+    "raft-partition-partition-1-49.log",
+    "raft-partition-partition-1-47.log",
+    "raft-partition-partition-1-48.log"
+  ],
+  "createdAt": 1668519689.290560717,
+  "modifiedAt": 1668519690.961439595
+}

--- a/backup-stores/s3/src/test/resources/manifests/8.1/in-progress.json
+++ b/backup-stores/s3/src/test/resources/manifests/8.1/in-progress.json
@@ -1,0 +1,31 @@
+{
+  "statusCode": "in_progress",
+  "id": {
+    "nodeId": 0,
+    "partitionId": 1,
+    "checkpointId": 1668519689
+  },
+  "descriptor": {
+    "snapshotId": "1204500-1-2549184-2548356",
+    "checkpointPosition": 2641349,
+    "numberOfPartitions": 3,
+    "brokerVersion": "8.1.0-SNAPSHOT"
+  },
+  "snapshotFileNames": [
+    "000143.log",
+    "OPTIONS-000007",
+    "000144.sst",
+    "MANIFEST-000005",
+    "zeebe.metadata",
+    "000140.sst",
+    "1204500-1-2549184-2548356.checksum",
+    "CURRENT"
+  ],
+  "segmentFileNames": [
+    "raft-partition-partition-1-49.log",
+    "raft-partition-partition-1-47.log",
+    "raft-partition-partition-1-48.log"
+  ],
+  "createdAt": 1668519689.290560717,
+  "modifiedAt": 1668519690.961439595
+}


### PR DESCRIPTION
This changes the manifest schema to allow for attaching metadata to segment and journal files.

Previously manifests looked like this:
```json
{ 
 "snapshotFileNames": [
    "000143.log",
    "OPTIONS-000007",
    "000144.sst"
  ]
}
```

Now, with attached metadata, the structure looks like this:
```json
{ 
 "snapshotFiles": {
    "000143.log": {},
    "OPTIONS-000007": {},
    "000144.sst": {}
  }
}
```

To stay backwards compatible with 8.1, I implemented a custom deserializer that supports both schemes and added name aliases. Unfortunately, I couldn't find a more elegant solution than writing a custom deserializer.

Extracted from https://github.com/camunda/zeebe/pull/10940 to keep the PRs small.