### PR TITLE
Allow configuring the segment pre-allocation strategy

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -38,6 +38,7 @@ import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.memory.MemorySize;
 import io.atomix.utils.serializer.Namespace;
 import io.atomix.utils.serializer.Namespaces;
+import io.camunda.zeebe.journal.file.SegmentAllocator;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStoreFactory;
 import java.io.File;
 import java.time.Duration;
@@ -517,15 +518,14 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
     }
 
     /**
-     * Sets whether segment files are pre-allocated at creation. If true, segment files are
-     * pre-allocated to the maximum segment size (see {@link #withSegmentSize(long)}) at creation
-     * before any writes happen.
+     * Sets the segment allocation strategy to use. Defaults to {@link SegmentAllocator::fill}. To
+     * disable, set to {@link SegmentAllocator::noop}.
      *
-     * @param preallocateSegmentFiles true to preallocate files, false otherwise
+     * @param segmentAllocator the segment pre-allocation strategy to use
      * @return this builder for chaining
      */
-    public Builder withPreallocateSegmentFiles(final boolean preallocateSegmentFiles) {
-      config.getStorageConfig().setPreallocateSegmentFiles(preallocateSegmentFiles);
+    public Builder withSegmentAllocator(final SegmentAllocator segmentAllocator) {
+      config.getStorageConfig().setSegmentAllocator(segmentAllocator);
       return this;
     }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
@@ -18,7 +18,9 @@ package io.atomix.raft.partition;
 
 import com.esotericsoftware.kryo.serializers.FieldSerializer.Optional;
 import io.atomix.utils.memory.MemorySize;
+import io.camunda.zeebe.journal.file.SegmentAllocator;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStoreFactory;
+import java.util.Objects;
 
 /** Raft storage configuration. */
 public class RaftStorageConfig {
@@ -29,14 +31,14 @@ public class RaftStorageConfig {
   private static final long DEFAULT_FREE_DISK_SPACE = 1024L * 1024 * 1024;
   private static final int DEFAULT_JOURNAL_INDEX_DENSITY = 100;
 
-  private static final boolean DEFAULT_PREALLOCATE_SEGMENT_FILES = true;
+  private static final SegmentAllocator DEFAULT_SEGMENT_ALLOCATOR = SegmentAllocator.fill();
 
   private String directory;
   private long segmentSize = DEFAULT_MAX_SEGMENT_SIZE;
   private boolean flushExplicitly = DEFAULT_FLUSH_EXPLICITLY;
   private long freeDiskSpace = DEFAULT_FREE_DISK_SPACE;
   private int journalIndexDensity = DEFAULT_JOURNAL_INDEX_DENSITY;
-  private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
+  private SegmentAllocator segmentAllocator = DEFAULT_SEGMENT_ALLOCATOR;
 
   @Optional("SnapshotStoreFactory")
   private ReceivableSnapshotStoreFactory persistedSnapshotStoreFactory;
@@ -157,19 +159,20 @@ public class RaftStorageConfig {
   }
 
   /**
-   * @return true to preallocate segment files, false otherwise
+   * @return the segment allocation strategy to use
    */
-  public boolean isPreallocateSegmentFiles() {
-    return preallocateSegmentFiles;
+  public SegmentAllocator getSegmentAllocator() {
+    return segmentAllocator;
   }
 
   /**
-   * Sets whether segment files are pre-allocated at creation. If true, segment files are
-   * pre-allocated to {@link #segmentSize} at creation before any writes happen.
+   * Sets the segment allocation strategy to use. Defaults to {@link SegmentAllocator::fill}. To
+   * disable, set it to {@link SegmentAllocator::noop}.
    *
-   * @param preallocateSegmentFiles true to preallocate files, false otherwise
+   * @param segmentAllocator the segment allocation strategy to use
    */
-  public void setPreallocateSegmentFiles(final boolean preallocateSegmentFiles) {
-    this.preallocateSegmentFiles = preallocateSegmentFiles;
+  public void setSegmentAllocator(final SegmentAllocator segmentAllocator) {
+    this.segmentAllocator =
+        Objects.requireNonNull(segmentAllocator, "must specify a segment allocator");
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -347,7 +347,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer>, Health
         .withFreeDiskSpace(storageConfig.getFreeDiskSpace())
         .withSnapshotStore(persistedSnapshotStore)
         .withJournalIndexDensity(storageConfig.getJournalIndexDensity())
-        .withPreallocateSegmentFiles(storageConfig.isPreallocateSegmentFiles())
+        .withSegmentAllocator(storageConfig.getSegmentAllocator())
         .build();
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
@@ -16,6 +16,7 @@
 package io.atomix.raft.storage.log;
 
 import io.camunda.zeebe.journal.Journal;
+import io.camunda.zeebe.journal.file.SegmentAllocator;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
 import io.camunda.zeebe.journal.file.SegmentedJournalBuilder;
 import java.io.File;
@@ -119,15 +120,14 @@ public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
   }
 
   /**
-   * Sets whether segment files are pre-allocated at creation. If true, segment files are
-   * pre-allocated to the maximum segment size (see {@link #withMaxSegmentSize(int)}}) at creation
-   * before any writes happen.
+   * Sets the segment allocation strategy to use. Defaults to {@link SegmentAllocator::fill}. To
+   * disable, set to {@link SegmentAllocator::noop}.
    *
-   * @param preallocateSegmentFiles true to preallocate files, false otherwise
+   * @param segmentAllocator the segment allocation strategy to use
    * @return this builder for chaining
    */
-  public RaftLogBuilder withPreallocateSegmentFiles(final boolean preallocateSegmentFiles) {
-    journalBuilder.withPreallocateSegmentFiles(preallocateSegmentFiles);
+  public RaftLogBuilder withSegmentAllocator(final SegmentAllocator segmentAllocator) {
+    journalBuilder.withSegmentAllocator(segmentAllocator);
     return this;
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RaftPartitionGroupFactory.java
@@ -78,7 +78,8 @@ public final class RaftPartitionGroupFactory {
             .withMinStepDownFailureCount(experimentalCfg.getRaft().getMinStepDownFailureCount())
             .withPreferSnapshotReplicationThreshold(
                 experimentalCfg.getRaft().getPreferSnapshotReplicationThreshold())
-            .withPreallocateSegmentFiles(experimentalCfg.getRaft().isPreallocateSegmentFiles());
+            .withSegmentAllocator(
+                experimentalCfg.getRaft().getPreAllocateStrategy().segmentAllocator());
 
     final int maxMessageSize = (int) networkCfg.getMaxMessageSizeInBytes();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.configuration;
 
+import io.camunda.zeebe.journal.file.SegmentAllocator;
 import java.time.Duration;
 
 public final class ExperimentalRaftCfg implements ConfigurationEntry {
@@ -16,6 +17,8 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
   private static final int DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT = 3;
   private static final int DEFAULT_PREFER_SNAPSHOT_REPLICATION_THRESHOLD = 100;
   private static final boolean DEFAULT_PREALLOCATE_SEGMENT_FILES = true;
+  private static final PreAllocateStrategy DEFAULT_PREALLOCATE_SEGMENT_STRATEGY =
+      PreAllocateStrategy.FILL;
 
   private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
   private Duration maxQuorumResponseTimeout = DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT;
@@ -23,6 +26,7 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
   private int preferSnapshotReplicationThreshold = DEFAULT_PREFER_SNAPSHOT_REPLICATION_THRESHOLD;
 
   private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
+  private PreAllocateStrategy preAllocateStrategy = DEFAULT_PREALLOCATE_SEGMENT_STRATEGY;
 
   public Duration getRequestTimeout() {
     return requestTimeout;
@@ -62,5 +66,33 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
 
   public void setPreallocateSegmentFiles(final boolean preallocateSegmentFiles) {
     this.preallocateSegmentFiles = preallocateSegmentFiles;
+  }
+
+  public PreAllocateStrategy getPreAllocateStrategy() {
+    if (!preallocateSegmentFiles) {
+      return PreAllocateStrategy.NOOP;
+    }
+
+    return preAllocateStrategy;
+  }
+
+  public void setPreAllocateStrategy(final PreAllocateStrategy preAllocateStrategy) {
+    this.preAllocateStrategy = preAllocateStrategy;
+  }
+
+  public enum PreAllocateStrategy {
+    NOOP(SegmentAllocator.noop()),
+    FILL(SegmentAllocator.fill()),
+    POSIX(SegmentAllocator.posix());
+
+    private final SegmentAllocator segmentAllocator;
+
+    PreAllocateStrategy(final SegmentAllocator segmentAllocator) {
+      this.segmentAllocator = segmentAllocator;
+    }
+
+    public SegmentAllocator segmentAllocator() {
+      return segmentAllocator;
+    }
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
@@ -83,7 +83,8 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
   public enum PreAllocateStrategy {
     NOOP(SegmentAllocator.noop()),
     FILL(SegmentAllocator.fill()),
-    POSIX(SegmentAllocator.posix());
+    POSIX(SegmentAllocator.posix()),
+    LINUX(SegmentAllocator.linux());
 
     private final SegmentAllocator segmentAllocator;
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -277,9 +277,17 @@
           <assembleDirectory>${project.build.directory}/camunda-zeebe</assembleDirectory>
           <configurationDirectory>config</configurationDirectory>
           <copyConfigurationDirectory>true</copyConfigurationDirectory>
+          <!--
+            "XX:+ExitOnOutOfMemoryError" ensures we will not try to recover if we run out of memory,
+            which is quite hard to do
+            "-Dfile.encoding=UTF-8" enforces UTF-8 as the default application wide charset
+            "add-opens=java.base/java.io=ALL-UNNAMED" is required to use native system calls with
+            raw file descriptors
+            -->
           <extraJvmArguments>-Xms128m
             -XX:+ExitOnOutOfMemoryError
-            -Dfile.encoding=UTF-8</extraJvmArguments>
+            -Dfile.encoding=UTF-8
+            --add-opens=java.base/java.io=ALL-UNNAMED</extraJvmArguments>
           <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
           <platforms>
             <platform>windows</platform>

--- a/journal/pom.xml
+++ b/journal/pom.xml
@@ -52,10 +52,27 @@
       <artifactId>zeebe-util</artifactId>
     </dependency>
 
+    <!-- required to use filesystem system calls -->
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-ffi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-constants</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/LibC.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/LibC.java
@@ -29,7 +29,15 @@ import jnr.ffi.types.off_t;
  */
 @SuppressWarnings({"checkstyle:methodname", "unused"})
 public interface LibC {
+  // https://man7.org/linux/man-pages/man3/posix_fallocate.3.html
   int posix_fallocate(final @In int fd, final @In @off_t long offset, final @In @off_t long len);
+
+  // https://man7.org/linux/man-pages/man2/fallocate.2.html
+  int fallocate(
+      final @In int fd,
+      final @In int mode,
+      final @In @off_t long offset,
+      final @In @off_t long len);
 
   /**
    * Returns an instance of LibC bound to the system's C library (e.g. glibc, musl, etc.).
@@ -61,6 +69,11 @@ public interface LibC {
 
     @Override
     public int posix_fallocate(final int fd, final long offset, final long len) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int fallocate(final int fd, final int mode, final long offset, final long len) {
       throw new UnsupportedOperationException();
     }
   }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/LibC.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/LibC.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import io.camunda.zeebe.util.Loggers;
+import java.util.Map;
+import jnr.ffi.LibraryLoader;
+import jnr.ffi.LibraryOption;
+import jnr.ffi.Platform;
+import jnr.ffi.annotations.In;
+import jnr.ffi.types.off_t;
+
+/**
+ * Used to bind certain calls from libc to Java methods via JNA.
+ *
+ * <p>Note that method names do not follow our conventions, but this is necessary here because the
+ * names must match those of the C library.
+ *
+ * <p>See {@link #ofNativeLibrary()} for an example of how to use this.
+ *
+ * <p>NOTE: this interface must be public for JNR-FFI to generate the bindings. However, this can
+ * most likely be replaced in the future once Project Panama is part of the JDK, and, using
+ * jextract, we can get compile time bindings.
+ */
+@SuppressWarnings({"checkstyle:methodname", "unused"})
+public interface LibC {
+  int posix_fallocate(final @In int fd, final @In @off_t long offset, final @In @off_t long len);
+
+  /**
+   * Returns an instance of LibC bound to the system's C library (e.g. glibc, musl, etc.).
+   *
+   * <p>If it fails to bind to the C library, it will return a {@link InvalidLibC} instance which
+   * throws {@link UnsupportedOperationException} on every call.
+   *
+   * @return an instance of this library
+   */
+  static LibC ofNativeLibrary() {
+    try {
+      return LibraryLoader.loadLibrary(
+          LibC.class,
+          Map.of(LibraryOption.LoadNow, true),
+          Platform.getNativePlatform().getStandardCLibraryName());
+    } catch (final UnsatisfiedLinkError e) {
+      Loggers.FILE_LOGGER.warn(
+          "Failed to load C library; any native calls will not be available", e);
+      return new InvalidLibC();
+    }
+  }
+
+  /**
+   * Dummy implementation which throws {@link UnsupportedOperationException} on every call.
+   * Explicitly left non-final so test classes can extend it and overload only these methods they
+   * care about.
+   */
+  class InvalidLibC implements LibC {
+
+    @Override
+    public int posix_fallocate(final int fd, final long offset, final long len) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/LinuxFs.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/LinuxFs.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import io.camunda.zeebe.journal.JournalException.OutOfDiskSpace;
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.IntSupplier;
+import jnr.constants.platform.Errno;
+import jnr.ffi.LastError;
+import jnr.ffi.Platform;
+import jnr.ffi.Runtime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class LinuxFs {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PosixFs.class);
+  private static final VarHandle FILE_DESCRIPTOR_FD_FIELD;
+
+  static {
+    VarHandle fileDescriptorFd;
+    try {
+      fileDescriptorFd =
+          MethodHandles.privateLookupIn(FileDescriptor.class, MethodHandles.lookup())
+              .findVarHandle(FileDescriptor.class, "fd", int.class);
+    } catch (final NoSuchFieldException | IllegalAccessException e) {
+      LOGGER.warn("Cannot look up file descriptor via reflection; NativeFS will be disabled", e);
+      fileDescriptorFd = null;
+    }
+
+    FILE_DESCRIPTOR_FD_FIELD = fileDescriptorFd;
+  }
+
+  // by default, we assume non-Windows platforms support posix_fallocate. some may not, and some
+  // file systems may not, and normally C libraries will emulate the behavior, but some (e.g. musl)
+  // may return EOPNOTSUPP, in which case we want to set this flag to false.
+  //
+  // note that this flag assumes there is only one underlying filesystem for the whole application
+  private volatile boolean supportsFallocate =
+      FILE_DESCRIPTOR_FD_FIELD != null && Platform.getNativePlatform().isUnix();
+
+  private final LibC libC;
+  private final IntSupplier errnoSupplier;
+
+  LinuxFs() {
+    this(LibC.ofNativeLibrary(), () -> LastError.getLastError(Runtime.getSystemRuntime()));
+  }
+
+  LinuxFs(final LibC libC) {
+    this(libC, () -> LastError.getLastError(Runtime.getSystemRuntime()));
+  }
+
+  LinuxFs(final LibC libC, final IntSupplier errnoSupplier) {
+    this.libC = Objects.requireNonNull(libC, "must specify a LibC implementation");
+    this.errnoSupplier =
+        Objects.requireNonNull(errnoSupplier, "must specify an error code supplier");
+  }
+
+  /**
+   * Returns whether calls to {@link #fallocate(FileDescriptor, long, long, FallocateFlags...)} are
+   * supported or not. If this returns false, then a call to {@link #fallocate(FileDescriptor, long,
+   * long, FallocateFlags...)} will throw an {@link UnsupportedOperationException}.
+   *
+   * @return true if supported, false otherwise
+   */
+  boolean isFallocateEnabled() {
+    return supportsFallocate;
+  }
+
+  /**
+   * Disables usage of {@link #fallocate(FileDescriptor, long, long, FallocateFlags...)}. After
+   * calling this, {@link #isFallocateEnabled()} will return false.
+   */
+  void disableFallocate() {
+    LOGGER.debug("Disabling usage of fallocate optimization");
+    supportsFallocate = false;
+  }
+
+  /**
+   * Calls posix_fallocate system call, delegating the allocation of the blocks to the C library.
+   *
+   * <p>For glibc, this means it will delegate the call to the file system. If it supports it (e.g.
+   * ext4), this is much more performant than writing a file, as the blocks are reserved for the
+   * file, but no I/O operations take place (other than updating the file's metadata). Not only
+   * this, but the blocks reserved are in most cases contiguous, making for less disk fragmentation.
+   *
+   * <p>When the file system does not support the call, then the library will emulate it by actually
+   * zero-ing the file. In some cases (e.g. musl), the library will do no emulation, and instead we
+   * will throw an {@link UnsupportedOperationException} and set {@link #isFallocateEnabled()} to
+   * false.
+   *
+   * <p><a href="https://man7.org/linux/man-pages/man3/posix_fallocate.3.html">See the man pages for
+   * posix_fallocate</a>
+   *
+   * @param descriptor the file descriptor of the file we want to grow
+   * @param offset the offset at which we want to start growing the file
+   * @param length the length, in bytes, of the region to grow
+   * @throws IllegalArgumentException if offset or length is negative
+   * @throws InterruptedIOException if an interrupt occurs while it was allocating the file, meaning
+   *     it may not have been fully allocated
+   * @throws UnsupportedOperationException if the underlying file system does not support this or if
+   *     this function is disabled via {@link #disableFallocate()}
+   * @throws OutOfDiskSpace if there is not enough disk space to allocate the file
+   * @throws IOException if the file descriptor is invalid (e.g. not opened for writing, not
+   *     pointing to a regular file, etc.)
+   */
+  void fallocate(
+      final FileDescriptor descriptor,
+      final long offset,
+      final long length,
+      final FallocateFlags... flags)
+      throws IOException {
+    if (offset < 0) {
+      throw new IllegalArgumentException(
+          String.format("Cannot allocate file with a negative offset of [%d]", offset));
+    }
+
+    if (length < 0) {
+      throw new IllegalArgumentException(
+          String.format("Cannot allocate file with a negative length of [%d]", length));
+    }
+
+    if (!isFallocateEnabled()) {
+      throw new UnsupportedOperationException(
+          "Failed to pre-allocate file natively: fallocate is disabled");
+    }
+
+    final int fd = (int) FILE_DESCRIPTOR_FD_FIELD.get(descriptor);
+    final int mode = computeModeFromFlags(flags);
+    final int result = libC.fallocate(fd, mode, offset, length);
+
+    // success
+    if (result == 0) {
+      return;
+    }
+
+    final Errno error = Errno.valueOf(errnoSupplier.getAsInt());
+    throwExceptionFromErrno(offset, length, error);
+  }
+
+  private int computeModeFromFlags(final FallocateFlags... flags) {
+    return Arrays.stream(flags).map(FallocateFlags::mode).reduce((m1, m2) -> m1 & m2).orElse(0);
+  }
+
+  private void throwExceptionFromErrno(final long offset, final long length, final Errno error)
+      throws IOException {
+    switch (error) {
+      case EBADF -> throw new IOException(
+          "Failed to pre-allocate file: it doesn't have a valid file descriptor, or it's not "
+              + "opened for writing");
+      case EFBIG -> throw new IOException(
+          "Failed to pre-allocate file: it's length [%d] would exceed the system's maximum file length"
+              .formatted(offset + length));
+      case EINVAL -> throw new IllegalArgumentException(
+          "Failed to pre-allocate file: it's offset [%d] or length [%d] was less than or equal to 0"
+              .formatted(offset, length));
+      case EINTR -> throw new InterruptedIOException(
+          "Failed to pre-allocate file interrupted during call");
+      case ENODEV, ESPIPE -> throw new IOException(
+          "Failed to pre-allocate file: the descriptor does not point to a regular file");
+      case ENOSPC -> throw new OutOfDiskSpace(
+          "Failed to pre-allocate file: there is not enough space");
+      default -> throw new UnsupportedOperationException(
+          "Failed to pre-allocate file: the underlying filesystem does not support this operation");
+    }
+  }
+
+  enum FallocateFlags {
+    FALLOC_FL_KEEP_SIZE(0x01),
+    FALLOC_FL_PUNCH_HOLE(0x02),
+    FALLOC_FL_NO_HIDE_STALE(0x04),
+    FALLOC_FL_COLLAPSE_RANGE(0x08),
+    FALLOC_FL_ZERO_RANGE(0x10),
+    FALLOC_FL_INSERT_RANGE(0x20),
+    FALLOC_FL_UNSHARE_RANGE(0x40);
+
+    private final int mode;
+
+    FallocateFlags(final int mode) {
+      this.mode = mode;
+    }
+
+    int mode() {
+      return mode;
+    }
+  }
+}

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/LinuxSegmentAllocator.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/LinuxSegmentAllocator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import io.camunda.zeebe.journal.file.LinuxFs.FallocateFlags;
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class LinuxSegmentAllocator implements SegmentAllocator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LinuxSegmentAllocator.class);
+  private final LinuxFs linuxFs;
+  private final SegmentAllocator fallback;
+
+  LinuxSegmentAllocator() {
+    this(new LinuxFs());
+  }
+
+  LinuxSegmentAllocator(final LinuxFs linuxFs) {
+    this(linuxFs, SegmentAllocator.posix());
+  }
+
+  LinuxSegmentAllocator(final LinuxFs linuxFs, final SegmentAllocator fallback) {
+    this.linuxFs = Objects.requireNonNull(linuxFs, "must specify a Linux file system abstraction");
+    this.fallback =
+        Objects.requireNonNull(
+            fallback, "must specify a fallback allocator or SegmentAllocator::noop");
+  }
+
+  @Override
+  public void allocate(
+      final FileDescriptor descriptor, final FileChannel segmentChannel, final long segmentSize)
+      throws IOException {
+    if (!linuxFs.isFallocateEnabled()) {
+      fallback.allocate(descriptor, segmentChannel, segmentSize);
+      return;
+    }
+
+    try {
+      linuxFs.fallocate(descriptor, 0, segmentSize, FallocateFlags.FALLOC_FL_ZERO_RANGE);
+    } catch (final UnsupportedOperationException e) {
+      LOGGER.warn(
+          "Failed to use native system call to pre-allocate file, will use fallback from now on",
+          e);
+      linuxFs.disableFallocate();
+      fallback.allocate(descriptor, segmentChannel, segmentSize);
+    }
+  }
+}

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/PosixFs.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/PosixFs.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import io.camunda.zeebe.journal.JournalException.OutOfDiskSpace;
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Objects;
+import jnr.constants.platform.Errno;
+import jnr.ffi.Platform;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A helper class to deal with native Unix file system calls, e.g. posix_fallocate. As of now its
+ * goal is just to cover Unix platforms (e.g. Linux, macOS). If this diverges, do refactor or split
+ * this class.
+ */
+final class PosixFs {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PosixFs.class);
+  private static final VarHandle FILE_DESCRIPTOR_FD_FIELD;
+
+  static {
+    VarHandle fileDescriptorFd;
+    try {
+      fileDescriptorFd =
+          MethodHandles.privateLookupIn(FileDescriptor.class, MethodHandles.lookup())
+              .findVarHandle(FileDescriptor.class, "fd", int.class);
+    } catch (final NoSuchFieldException | IllegalAccessException e) {
+      LOGGER.warn("Cannot look up file descriptor via reflection; NativeFS will be disabled", e);
+      fileDescriptorFd = null;
+    }
+
+    FILE_DESCRIPTOR_FD_FIELD = fileDescriptorFd;
+  }
+
+  // by default, we assume non-Windows platforms support posix_fallocate. some may not, and some
+  // file systems may not, and normally C libraries will emulate the behavior, but some (e.g. musl)
+  // may return EOPNOTSUPP, in which case we want to set this flag to false.
+  //
+  // note that this flag assumes there is only one underlying filesystem for the whole application
+  private volatile boolean supportsPosixFallocate =
+      FILE_DESCRIPTOR_FD_FIELD != null && Platform.getNativePlatform().isUnix();
+
+  private final LibC libC;
+
+  PosixFs() {
+    this(LibC.ofNativeLibrary());
+  }
+
+  PosixFs(final LibC libC) {
+    this.libC = Objects.requireNonNull(libC, "must specify a LibC implementation");
+  }
+
+  /**
+   * Returns whether calls to {@link #posixFallocate(FileDescriptor, long, long)} are supported or
+   * not. If this returns false, then a call to {@link #posixFallocate(FileDescriptor, long, long)}
+   * will throw an {@link UnsupportedOperationException}.
+   *
+   * @return true if supported, false otherwise
+   */
+  boolean isPosixFallocateEnabled() {
+    return supportsPosixFallocate;
+  }
+
+  /**
+   * Disables usage of {@link #posixFallocate(FileDescriptor, long, long)}. After calling this,
+   * {@link #isPosixFallocateEnabled()} will return false.
+   */
+  void disablePosixFallocate() {
+    LOGGER.debug("Disabling usage of posix_fallocate optimization");
+    supportsPosixFallocate = false;
+  }
+
+  /**
+   * Calls posix_fallocate system call, delegating the allocation of the blocks to the C library.
+   *
+   * <p>For glibc, this means it will delegate the call to the file system. If it supports it (e.g.
+   * ext4), this is much more performant than writing a file, as the blocks are reserved for the
+   * file, but no I/O operations take place (other than updating the file's metadata). Not only
+   * this, but the blocks reserved are in most cases contiguous, making for less disk fragmentation.
+   *
+   * <p>When the file system does not support the call, then the library will emulate it by actually
+   * zero-ing the file. In some cases (e.g. musl), the library will do no emulation, and instead we
+   * will throw an {@link UnsupportedOperationException} and set {@link #isPosixFallocateEnabled()}
+   * to false.
+   *
+   * <p><a href="https://man7.org/linux/man-pages/man3/posix_fallocate.3.html">See the man pages for
+   * posix_fallocate</a>
+   *
+   * @param descriptor the file descriptor of the file we want to grow
+   * @param offset the offset at which we want to start growing the file
+   * @param length the length, in bytes, of the region to grow
+   * @throws IllegalArgumentException if offset or length is negative
+   * @throws InterruptedIOException if an interrupt occurs while it was allocating the file, meaning
+   *     it may not have been fully allocated
+   * @throws UnsupportedOperationException if the underlying file system does not support this or if
+   *     this function is disabled via {@link #disablePosixFallocate()}
+   * @throws OutOfDiskSpace if there is not enough disk space to allocate the file
+   * @throws IOException if the file descriptor is invalid (e.g. not opened for writing, not
+   *     pointing to a regular file, etc.)
+   */
+  void posixFallocate(final FileDescriptor descriptor, final long offset, final long length)
+      throws IOException {
+    if (offset < 0) {
+      throw new IllegalArgumentException(
+          String.format("Cannot allocate file with a negative offset of [%d]", offset));
+    }
+
+    if (length < 0) {
+      throw new IllegalArgumentException(
+          String.format("Cannot allocate file with a negative length of [%d]", length));
+    }
+
+    if (!isPosixFallocateEnabled()) {
+      throw new UnsupportedOperationException(
+          "Failed to pre-allocate file natively: posix_fallocate is disabled");
+    }
+
+    final int fd = (int) FILE_DESCRIPTOR_FD_FIELD.get(descriptor);
+    final int result = libC.posix_fallocate(fd, offset, length);
+    final Errno error = Errno.valueOf(result);
+
+    // success
+    if (result == 0) {
+      return;
+    }
+
+    throwExceptionFromErrno(offset, length, error);
+  }
+
+  private void throwExceptionFromErrno(final long offset, final long length, final Errno error)
+      throws IOException {
+    switch (error) {
+      case EBADF -> throw new IOException(
+          "Failed to pre-allocate file: it doesn't have a valid file descriptor, or it's not "
+              + "opened for writing");
+      case EFBIG -> throw new IOException(
+          String.format(
+              "Failed to pre-allocate file: it's length [%d] would exceed the system's maximum "
+                  + "file length",
+              offset + length));
+      case EINTR -> throw new InterruptedIOException(
+          "Failed to pre-allocate file interrupted during call");
+      case ENODEV, ESPIPE -> throw new IOException(
+          "Failed to pre-allocate file: the descriptor does not point to a regular file");
+      case ENOSPC -> throw new OutOfDiskSpace(
+          "Failed to pre-allocate file: there is not enough space");
+      default -> {
+        throw new UnsupportedOperationException(
+            "Failed to pre-allocate file: the underlying filesystem does not support this operation");
+      }
+    }
+  }
+}

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/PosixSegmentAllocator.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/PosixSegmentAllocator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class PosixSegmentAllocator implements SegmentAllocator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PosixSegmentAllocator.class);
+  private final PosixFs posixFs;
+  private final SegmentAllocator fallback;
+
+  PosixSegmentAllocator() {
+    this(new PosixFs());
+  }
+
+  PosixSegmentAllocator(final PosixFs posixFs) {
+    this(posixFs, SegmentAllocator.fill());
+  }
+
+  PosixSegmentAllocator(final PosixFs posixFs, final SegmentAllocator fallback) {
+    this.posixFs = Objects.requireNonNull(posixFs, "must specify a POSIX file system abstraction");
+    this.fallback =
+        Objects.requireNonNull(
+            fallback, "must specify a fallback allocator or SegmentAllocator::noop");
+  }
+
+  @Override
+  public void allocate(
+      final FileDescriptor descriptor, final FileChannel segmentChannel, final long segmentSize)
+      throws IOException {
+    if (!posixFs.isPosixFallocateEnabled()) {
+      fallback.allocate(descriptor, segmentChannel, segmentSize);
+      return;
+    }
+
+    try {
+      posixFs.posixFallocate(descriptor, 0, segmentSize);
+    } catch (final UnsupportedOperationException e) {
+      LOGGER.warn(
+          "Failed to use native system call to pre-allocate file, will use fallback from now on",
+          e);
+      posixFs.disablePosixFallocate();
+      fallback.allocate(descriptor, segmentChannel, segmentSize);
+    }
+  }
+}

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentAllocator.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentAllocator.java
@@ -41,4 +41,8 @@ public interface SegmentAllocator {
   static SegmentAllocator posix() {
     return new PosixSegmentAllocator();
   }
+
+  static SegmentAllocator linux() {
+    return new LinuxSegmentAllocator();
+  }
 }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentAllocator.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentAllocator.java
@@ -7,32 +7,38 @@
  */
 package io.camunda.zeebe.journal.file;
 
+import java.io.FileDescriptor;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import org.agrona.IoUtil;
 
 /** Defines the strategy when it comes to pre-allocating segment files. */
 @FunctionalInterface
-interface SegmentAllocator {
+public interface SegmentAllocator {
 
   /**
    * Pre-allocates {@code segmentSize} disk space for file corresponding to the given descriptor and
    * channel.
    *
+   * @param fd an open file descriptor to the file that will be pre-allocated
    * @param channel an open channel to the file to pre-allocate
    * @param segmentSize the desired size of the segment on disk, in bytes
    * @throws IOException if any error occur during pre-allocation; if this is thrown, no guarantees
    *     are made about the state of the file on disk, and no resources are closed
    */
-  void allocate(FileChannel channel, final long segmentSize) throws IOException;
+  void allocate(FileDescriptor fd, FileChannel channel, final long segmentSize) throws IOException;
 
   /** Returns an allocator which does nothing, i.e. does not allocate disk space. */
   static SegmentAllocator noop() {
-    return (c, s) -> {};
+    return (f, c, s) -> {};
   }
 
   /** Returns an allocator which fills the file by writing chunks of zeros to disk. */
   static SegmentAllocator fill() {
-    return (channel, size) -> IoUtil.fill(channel, 0, size, (byte) 0);
+    return (f, c, s) -> IoUtil.fill(c, 0, s, (byte) 0);
+  }
+
+  static SegmentAllocator posix() {
+    return new PosixSegmentAllocator();
   }
 }

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/LinuxFsTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/LinuxFsTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.zeebe.journal.JournalException.OutOfDiskSpace;
+import io.camunda.zeebe.journal.file.LibC.InvalidLibC;
+import io.camunda.zeebe.journal.util.PosixPathAssert;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import jnr.constants.platform.Errno;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@EnabledOnOs(value = OS.LINUX, disabledReason = "Tests specific Linux filesystem functions")
+@Execution(ExecutionMode.CONCURRENT)
+final class LinuxFsTest {
+  private @TempDir Path tmpDir;
+
+  // while a fairly simple test, it's important that this does not break
+  @Test
+  void shouldDisablePosixFallocate() {
+    // given
+    final var linuxFs = new LinuxFs();
+    linuxFs.disableFallocate();
+
+    // then
+    assertThat(linuxFs.isFallocateEnabled()).isFalse();
+  }
+
+  @Test
+  void shouldPreallocateFile() throws IOException {
+    // given
+    final var linuxFs = new LinuxFs();
+    final var path = tmpDir.resolve("file");
+    final var length = 1024 * 1024;
+
+    // when
+    try (final RandomAccessFile file = new RandomAccessFile(path.toFile(), "rw")) {
+      linuxFs.fallocate(file.getFD(), 0, length);
+    }
+
+    // then
+    PosixPathAssert.assertThat(path).hasRealSize(length);
+  }
+
+  @Test
+  void shouldFailWithNegativeOffset() throws IOException {
+    // given
+    final var linuxFs = new LinuxFs();
+    final var path = tmpDir.resolve("file");
+
+    // when
+    try (final RandomAccessFile file = new RandomAccessFile(path.toFile(), "rw")) {
+      assertThatCode(() -> linuxFs.fallocate(file.getFD(), -10, 100))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Test
+  void shouldFailWithNegativeLength() throws IOException {
+    // given
+    final var linuxFs = new LinuxFs(LibC.ofNativeLibrary());
+    final var path = tmpDir.resolve("file");
+
+    // when
+    try (final RandomAccessFile file = new RandomAccessFile(path.toFile(), "rw")) {
+      assertThatCode(() -> linuxFs.fallocate(file.getFD(), 0, -100))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @ParameterizedTest(name = "{0} => {1}")
+  @MethodSource("provideErrorPairs")
+  void shouldMapErrNoToException(final Errno errno, final Class<? extends Exception> exception)
+      throws IOException {
+    // given
+    final var linuxFs = new LinuxFs(new FailingLinuxFallocate(), errno::intValue);
+    final var path = tmpDir.resolve("file");
+
+    // when
+    try (final RandomAccessFile file = new RandomAccessFile(path.toFile(), "rw")) {
+      assertThatCode(() -> linuxFs.fallocate(file.getFD(), 0, 1024 * 1024)).isInstanceOf(exception);
+    }
+  }
+
+  private static Stream<Arguments> provideErrorPairs() {
+    return Stream.of(
+        Arguments.of(Errno.EBADF, IOException.class),
+        Arguments.of(Errno.EFBIG, IOException.class),
+        Arguments.of(Errno.EINTR, InterruptedIOException.class),
+        Arguments.of(Errno.EINVAL, IllegalArgumentException.class),
+        Arguments.of(Errno.ENODEV, IOException.class),
+        Arguments.of(Errno.ESPIPE, IOException.class),
+        Arguments.of(Errno.ENOSPC, OutOfDiskSpace.class));
+  }
+
+  private static final class FailingLinuxFallocate extends InvalidLibC {
+
+    @Override
+    public int fallocate(final int fd, final int mode, final long offset, final long len) {
+      return -1;
+    }
+  }
+}

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/LinuxSegmentAllocatorTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/LinuxSegmentAllocatorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import io.camunda.zeebe.journal.util.PosixPathAssert;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Path;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@EnabledOnOs(value = OS.LINUX, disabledReason = "Tests specific Linux filesystem operations")
+@Execution(ExecutionMode.CONCURRENT)
+final class LinuxSegmentAllocatorTest {
+  @Test
+  void shouldUseFallbackWhenFallocateNotSupported(final @TempDir Path tmpDir) throws IOException {
+    // given
+    final var linuxFs = new LinuxFs(new LibC.InvalidLibC());
+    final var fallback = SegmentAllocator.fill();
+    final var allocator = new LinuxSegmentAllocator(linuxFs, fallback);
+    final var segmentFile = tmpDir.resolve("file");
+    final var size = 1024 * 1024;
+
+    // when
+    try (final var file = new RandomAccessFile(segmentFile.toFile(), "rw")) {
+      allocator.allocate(file.getFD(), file.getChannel(), size);
+    }
+
+    // then
+    PosixPathAssert.assertThat(segmentFile).hasRealSize(size);
+    Assertions.assertThat(linuxFs.isFallocateEnabled()).as("has disabled fallocate").isFalse();
+  }
+
+  @Test
+  void shouldPreallocateFile(final @TempDir Path tmpDir) throws IOException {
+    // given
+    final var linuxFs = new LinuxFs();
+    final var allocator = new LinuxSegmentAllocator(linuxFs);
+    final var segmentFile = tmpDir.resolve("file");
+    final var size = 1024 * 1024;
+
+    // when
+    try (final var file = new RandomAccessFile(segmentFile.toFile(), "rw")) {
+      allocator.allocate(file.getFD(), file.getChannel(), size);
+    }
+
+    // then
+    PosixPathAssert.assertThat(segmentFile).hasRealSize(size);
+  }
+}

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/PosixFsTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/PosixFsTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.zeebe.journal.JournalException.OutOfDiskSpace;
+import io.camunda.zeebe.journal.file.LibC.InvalidLibC;
+import io.camunda.zeebe.journal.util.PosixPathAssert;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import jnr.constants.platform.Errno;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Windows does not provide any LibC")
+@Execution(ExecutionMode.CONCURRENT)
+final class PosixFsTest {
+  private @TempDir Path tmpDir;
+
+  // while a fairly simple test, it's important that this does not break
+  @Test
+  void shouldDisablePosixFallocate() {
+    // given
+    final var posixFs = new PosixFs();
+    posixFs.disablePosixFallocate();
+
+    // then
+    assertThat(posixFs.isPosixFallocateEnabled()).isFalse();
+  }
+
+  @Test
+  void shouldPreallocateFile() throws IOException {
+    // given
+    final var posixFs = new PosixFs();
+    final var path = tmpDir.resolve("file");
+    final var length = 1024 * 1024;
+
+    // when
+    try (final RandomAccessFile file = new RandomAccessFile(path.toFile(), "rw")) {
+      posixFs.posixFallocate(file.getFD(), 0, length);
+    }
+
+    // then
+    PosixPathAssert.assertThat(path).hasRealSize(length);
+  }
+
+  @Test
+  void shouldFailWithNegativeOffset() throws IOException {
+    // given
+    final var posixFs = new PosixFs();
+    final var path = tmpDir.resolve("file");
+
+    // when
+    try (final RandomAccessFile file = new RandomAccessFile(path.toFile(), "rw")) {
+      assertThatCode(() -> posixFs.posixFallocate(file.getFD(), -10, 100))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Test
+  void shouldFailWithNegativeLength() throws IOException {
+    // given
+    final var posixFs = new PosixFs(LibC.ofNativeLibrary());
+    final var path = tmpDir.resolve("file");
+
+    // when
+    try (final RandomAccessFile file = new RandomAccessFile(path.toFile(), "rw")) {
+      assertThatCode(() -> posixFs.posixFallocate(file.getFD(), 0, -100))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @ParameterizedTest(name = "{0} => {1}")
+  @MethodSource("provideErrorPairs")
+  void shouldMapErrNoToException(final Errno errno, final Class<? extends Exception> exception)
+      throws IOException {
+    // given
+    final var posixFs = new PosixFs(new FailingPosixFallocate(errno));
+    final var path = tmpDir.resolve("file");
+
+    // when
+    try (final RandomAccessFile file = new RandomAccessFile(path.toFile(), "rw")) {
+      assertThatCode(() -> posixFs.posixFallocate(file.getFD(), 0, 1024 * 1024))
+          .isInstanceOf(exception);
+    }
+  }
+
+  private static Stream<Arguments> provideErrorPairs() {
+    return Stream.of(
+        Arguments.of(Errno.EBADF, IOException.class),
+        Arguments.of(Errno.EFBIG, IOException.class),
+        Arguments.of(Errno.EINTR, InterruptedIOException.class),
+        Arguments.of(Errno.EINVAL, UnsupportedOperationException.class),
+        Arguments.of(Errno.ENODEV, IOException.class),
+        Arguments.of(Errno.ESPIPE, IOException.class),
+        Arguments.of(Errno.ENOSPC, OutOfDiskSpace.class));
+  }
+
+  private static final class FailingPosixFallocate extends InvalidLibC {
+    private final Errno errno;
+
+    private FailingPosixFallocate(final Errno errno) {
+      this.errno = errno;
+    }
+
+    @Override
+    public int posix_fallocate(final int fd, final long offset, final long len) {
+      return errno.intValue();
+    }
+  }
+}

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/PosixSegmentAllocatorTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/PosixSegmentAllocatorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.journal.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.journal.util.PosixPathAssert;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+final class PosixSegmentAllocatorTest {
+  @Test
+  void shouldUseFallbackWhenPosixNotSupported(final @TempDir Path tmpDir) throws IOException {
+    // given
+    final var posixFs = new PosixFs(new LibC.InvalidLibC());
+    final var fallback = SegmentAllocator.fill();
+    final var allocator = new PosixSegmentAllocator(posixFs, fallback);
+    final var segmentFile = tmpDir.resolve("file");
+    final var size = 1024 * 1024;
+
+    // when
+    try (final var file = new RandomAccessFile(segmentFile.toFile(), "rw")) {
+      allocator.allocate(file.getFD(), file.getChannel(), size);
+    }
+
+    // then
+    PosixPathAssert.assertThat(segmentFile).hasRealSize(size);
+    assertThat(posixFs.isPosixFallocateEnabled()).as("has disabled posixFallocate").isFalse();
+  }
+
+  @Test
+  void shouldPreallocateFile(final @TempDir Path tmpDir) throws IOException {
+    // given
+    final var allocator = new PosixSegmentAllocator();
+    final var segmentFile = tmpDir.resolve("file");
+    final var size = 1024 * 1024;
+
+    // when
+    try (final var file = new RandomAccessFile(segmentFile.toFile(), "rw")) {
+      allocator.allocate(file.getFD(), file.getChannel(), size);
+    }
+
+    // then
+    PosixPathAssert.assertThat(segmentFile).hasRealSize(size);
+  }
+}

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -630,7 +630,7 @@ class SegmentedJournalTest {
     final var segmentSize = 4 * 1024 * 1024;
     final var builder =
         SegmentedJournal.builder()
-            .withPreallocateSegmentFiles(true)
+            .withSegmentAllocator(SegmentAllocator.fill())
             .withMaxSegmentSize(segmentSize)
             .withDirectory(tmpDir.toFile());
     final File firstSegment;
@@ -650,7 +650,7 @@ class SegmentedJournalTest {
     final var segmentSize = 4 * 1024 * 1024;
     final var builder =
         SegmentedJournal.builder()
-            .withPreallocateSegmentFiles(false)
+            .withSegmentAllocator(SegmentAllocator.noop())
             .withMaxSegmentSize(segmentSize)
             .withDirectory(tmpDir.toFile());
     final File firstSegment;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -111,6 +111,8 @@
     <version.archunit>1.0.1</version.archunit>
     <version.easy-random>5.0.0</version.easy-random>
     <version.jcip>1.0</version.jcip>
+    <version.jnr-ffi>2.2.13</version.jnr-ffi>
+    <version.jnr-constants>0.10.3</version.jnr-constants>
     <version.jnr-posix>3.1.16</version.jnr-posix>
     <version.zpt>8.1.5</version.zpt>
     <version.feign>12.1</version.feign>
@@ -939,6 +941,22 @@
         <artifactId>bcprov-jdk15on</artifactId>
         <version>${version.bouncycastle}</version>
         <scope>test</scope>
+      </dependency>
+
+      <!--
+        generate bytecode to access native functions instead of writing JNI C code
+        primarily used to interface with LibC on UNIX systems
+        -->
+      <dependency>
+        <groupId>com.github.jnr</groupId>
+        <artifactId>jnr-ffi</artifactId>
+        <version>${version.jnr-ffi}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.jnr</groupId>
+        <artifactId>jnr-constants</artifactId>
+        <version>${version.jnr-constants}</version>
       </dependency>
 
       <dependency>
@@ -1960,6 +1978,36 @@
                 <phase>post-integration-test</phase>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- profile specifically for JDK 11 runs -->
+    <profile>
+      <id>jdk11</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <!-- required to access the raw file descriptor from FileDescriptor -->
+              <argLine>--add-opens=java.base/java.io=ALL-UNNAMED</argLine>
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <!-- required to access the raw file descriptor from FileDescriptor -->
+              <argLine>--add-opens=java.base/java.io=ALL-UNNAMED</argLine>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
## Description

This PR allows configuring the segment pre-allocation strategy directly, by letting users pick one of the following:

- `NOOP`: will do nothing, and is equivalent to disabling the segment pre-allocation.
- `FILL`: zero-es the file upon creation. This is the default strategy, to keep backwards compatibility.
- `POSIX`: will use `posix_fallocate` where available. This allows reserving disk space without actually performing any I/O, which may reduce write I/O contention in some cases. When the system call is not available, it falls back to `FILL`.
- `LINUX`: will use `fallocate` where available, with mode `FALLOC_FL_ZERO_RANGE`. This allows reserving disk space without actually performing any I/O, which may reduce write I/O contention in some cases. As opposed to POSIX (which is more or less `fallocate` with mode `0`), it will zero the blocks on allocation, which hopefully will keep the write speed equivalent to the normal baseline. When the system call is not available, it falls back to `POSIX`.

This can be configured using the following configuration settings:

```yaml
zeebe:
  broker:
    experimental:
      raft:
        # ZEEBE_BROKER_EXPERIMENTAL_RAFT_PREALLOCATESEGMENTFILES
        preAllocateSegmentFiles: true # if false, is equivalent to setting preAllocateStrategy to NOOP
        # ZEEBE_BROKER_EXPERIMENTAL_RAFT_PREALLOCATESTRATEGY
        preAllocateStrategy: FILL # or NOOP, or POSIX, or LINUX
```

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
