### PR TITLE
test(exporter): don't fail test if `getPhase` future throws

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorPauseTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorPauseTest.java
@@ -101,6 +101,7 @@ public final class ExporterDirectorPauseTest {
     // Needed to prevent flaky test https://github.com/camunda/zeebe/issues/10439
     Awaitility.await()
         .alias("Exporter is closed")
+        .ignoreExceptions() // joining can still throw if actor is closed after `getPhase` is called
         .until(() -> activeExporter.getDirector().getPhase().join() == ExporterPhase.CLOSED);
 
     // then


### PR DESCRIPTION
Previously, we added an await on the exporter phase to prevent race conditions in this test that would result in a flaky test.

As it turns out, getting the exporter phase is itself also racy and might return a future that is completed exceptionally because the actor got closed between calling `getPhase` and before executing the actor call.

As a fix, we simply ignore exceptions while waiting for a closed exporter.

closes #10439 
