### PR TITLE
Schedule daily QA workflows across all supported versions

### DIFF
--- a/.github/workflows/daily-qa.yml
+++ b/.github/workflows/daily-qa.yml
@@ -42,8 +42,8 @@ jobs:
           else
             echo "Failed to compute latest versions"
           fi
-          echo "LATEST_VERSION=${latest}" >> $GITHUB_ENV
-          echo "PREVIOUS_LATEST_VERSION=${previous}" >> $GITHUB_ENV
+          echo "LATEST_VERSION=${latest%\.[0-9]}" >> $GITHUB_ENV
+          echo "PREVIOUS_LATEST_VERSION=${previous%\.[0-9]}" >> $GITHUB_ENV
   # Runs the qa-testbench workflow against the stable branches. It assumes that branches follow the
   # pattern of `stable/VERSION`, and generations of `Zeebe VERSION`.
   #

--- a/.github/workflows/daily-qa.yml
+++ b/.github/workflows/daily-qa.yml
@@ -14,40 +14,12 @@ on:
 env:
   # This URL is used as the business key for the various QA workflows
   BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  LATEST_STABLE_VERSION: 8.1.3
+  PREVIOUS_LATEST_VERSION: 8.0.8
 
 jobs:
-  # This job will figure out the last supported versions based on the latest tags.
-  #
-  # Versions around found by sorting the tags, removing any that doesn't match semantic version,
-  # and ignoring those with suffixes, and sort in natural order reversed. To get the second-highest
-  # minor branch, we do the same, but we also filter out any versions which match the minor version
-  # of the latest stable version.
-  get-versions:
-    name: Compute branch matrix
-    runs-on: ubuntu-latest
-    outputs:
-      latest-version: ${{ env.LATEST_VERSION }}
-      previous-latest-version: ${{ env.PREVIOUS_LATEST_VERSION }}
-    steps:
-      - uses: actions/checkout@v3
-      - run: git fetch --tags
-      - run: |
-          latest=$(git tag | grep '^[0-9]\.[0-9]\.[0-9]$' | sort -Vr | head -n1)
-          echo "Latest supported version: ${latest}"
-          previous=$(git tag | grep '^[0-9]\.[0-9]\.[0-9]$' | grep -v "^${latest%\.[0-9]}.*$" | sort -Vr | head -n1)
-          echo "Oldest supported version: ${latest}"
-          if [ ! -z $latest ] && [ ! -z $previous ]; then
-            echo "Successfully computed latest versions: ${latest} and ${previous}"
-          else
-            echo "Failed to compute latest versions"
-          fi
-          echo "LATEST_VERSION=${latest}" >> $GITHUB_ENV
-          echo "PREVIOUS_LATEST_VERSION=${previous}" >> $GITHUB_ENV
   # Runs the qa-testbench workflow against the stable branches. It assumes that branches follow the
   # pattern of `stable/VERSION`, and generations of `Zeebe VERSION`.
-  #
-  # NOTE: it's not possible to use the env context in a matrix, which is why we use job outputs
-  # here.
   qa:
     needs:
       - get-versions
@@ -56,10 +28,10 @@ jobs:
         include:
           - branch: 'main'
             generation: 'Zeebe SNAPSHOT'
-          - branch: ${{ format('stable/{0}', needs.get-versions.outputs.latest-version) }}
-            generation: ${{ format('Zeebe {0}', needs.get-versions.outputs.latest-version) }}
-          - branch: ${{ format('stable/{0}', needs.get-versions.outputs.previous-latest-version) }}
-            generation: ${{ format('Zeebe {0}', needs.get-versions.outputs.previous-latest-version) }}
+          - branch: 'stable/8.0'
+            generation: 'Zeebe 8.0.8'
+          - branch: 'stable/8.1'
+            generation: 'Zeebe 8.1.3'
     name: Daily QA
     uses: ./.github/workflows/qa-testbench.yaml
     with:

--- a/.github/workflows/daily-qa.yml
+++ b/.github/workflows/daily-qa.yml
@@ -7,6 +7,7 @@ name: Daily tests
 
 on:
   workflow_dispatch: { }
+  push: { }
   schedule:
     # Runs at 01:00 every day; see this link for more: https://crontab.guru/#0_1_*_*_*
     - cron: '0 1 * * *'
@@ -14,27 +15,52 @@ on:
 env:
   # This URL is used as the business key for the various QA workflows
   BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  LATEST_STABLE_VERSION: 8.1.3
-  PREVIOUS_LATEST_VERSION: 8.0.8
 
 jobs:
+  # This job will figure out the last supported versions based on the latest tags.
+  #
+  # Versions around found by sorting the tags, removing any that doesn't match semantic version,
+  # and ignoring those with suffixes, and sort in natural order reversed. To get the second-highest
+  # minor branch, we do the same, but we also filter out any versions which match the minor version
+  # of the latest stable version.
+  get-versions:
+    name: Compute branch matrix
+    runs-on: ubuntu-latest
+    outputs:
+      latest-version: ${{ env.LATEST_VERSION }}
+      previous-latest-version: ${{ env.PREVIOUS_LATEST_VERSION }}
+    steps:
+      - uses: actions/checkout@v3
+      - run: git fetch --tags
+      - run: |
+          latest=$(git tag | grep '^[0-9]\.[0-9]\.[0-9]$' | sort -Vr | head -n1)
+          echo "Latest supported version: ${latest}"
+          previous=$(git tag | grep '^[0-9]\.[0-9]\.[0-9]$' | grep -v "^${latest%\.[0-9]}.*$" | sort -Vr | head -n1)
+          echo "Oldest supported version: ${latest}"
+          if [ ! -z $latest ] && [ ! -z $previous ]; then
+            echo "Successfully computed latest versions: ${latest} and ${previous}"
+          else
+            echo "Failed to compute latest versions"
+          fi
+          echo "LATEST_VERSION=${latest}" >> $GITHUB_ENV
+          echo "PREVIOUS_LATEST_VERSION=${previous}" >> $GITHUB_ENV
   # Runs the qa-testbench workflow against the stable branches. It assumes that branches follow the
   # pattern of `stable/VERSION`, and generations of `Zeebe VERSION`.
+  #
+  # NOTE: it's not possible to use the env context in a matrix, which is why we use job outputs
+  # here.
   qa:
     needs:
       - get-versions
     strategy:
       matrix:
-        include:
-          - branch: 'main'
-            generation: 'Zeebe SNAPSHOT'
-          - branch: 'stable/8.0'
-            generation: 'Zeebe 8.0.8'
-          - branch: 'stable/8.1'
-            generation: 'Zeebe 8.1.3'
+        branch:
+          - 'main'
+          - ${{ format('stable/{0}', needs.get-versions.outputs.latest-version) }}
+          - ${{ format('stable/{0}', needs.get-versions.outputs.previous-latest-version) }}
     name: Daily QA
     uses: ./.github/workflows/qa-testbench.yaml
     with:
       branch: ${{ matrix.branch }}
-      generation: ${{ matrix.generation }}
+      generation: Zeebe SNAPSHOT
     secrets: inherit

--- a/.github/workflows/daily-qa.yml
+++ b/.github/workflows/daily-qa.yml
@@ -1,0 +1,68 @@
+# This workflow runs our daily scheduled acceptance tests. It runs each test suite against the
+# development head (e.g. main) and all officially supported branches.
+#
+# As this is meant to be run via scheduling, the workflow itself only runs on the default branch
+# (e.g. main), so any changes you make will affect any other branches we test via this workflow.
+name: Daily tests
+
+on:
+  workflow_dispatch: { }
+  schedule:
+    # Runs at 01:00 every day; see this link for more: https://crontab.guru/#0_1_*_*_*
+    - cron: '0 1 * * *'
+
+env:
+  # This URL is used as the business key for the various QA workflows
+  BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+jobs:
+  # This job will figure out the last supported versions based on the latest tags.
+  #
+  # Versions around found by sorting the tags, removing any that doesn't match semantic version,
+  # and ignoring those with suffixes, and sort in natural order reversed. To get the second-highest
+  # minor branch, we do the same, but we also filter out any versions which match the minor version
+  # of the latest stable version.
+  get-versions:
+    name: Compute branch matrix
+    runs-on: ubuntu-latest
+    outputs:
+      latest-version: ${{ env.LATEST_VERSION }}
+      previous-latest-version: ${{ env.PREVIOUS_LATEST_VERSION }}
+    steps:
+      - uses: actions/checkout@v3
+      - run: git fetch --tags
+      - run: |
+          latest=$(git tag | grep '^[0-9]\.[0-9]\.[0-9]$' | sort -Vr | head -n1)
+          echo "Latest supported version: ${latest}"
+          previous=$(git tag | grep '^[0-9]\.[0-9]\.[0-9]$' | grep -v "^${latest%\.[0-9]}.*$" | sort -Vr | head -n1)
+          echo "Oldest supported version: ${latest}"
+          if [ ! -z $latest ] && [ ! -z $previous ]; then
+            echo "Successfully computed latest versions: ${latest} and ${previous}"
+          else
+            echo "Failed to compute latest versions"
+          fi
+          echo "LATEST_VERSION=${latest}" >> $GITHUB_ENV
+          echo "PREVIOUS_LATEST_VERSION=${previous}" >> $GITHUB_ENV
+  # Runs the qa-testbench workflow against the stable branches. It assumes that branches follow the
+  # pattern of `stable/VERSION`, and generations of `Zeebe VERSION`.
+  #
+  # NOTE: it's not possible to use the env context in a matrix, which is why we use job outputs
+  # here.
+  qa:
+    needs:
+      - get-versions
+    strategy:
+      matrix:
+        include:
+          - branch: 'main'
+            generation: 'Zeebe SNAPSHOT'
+          - branch: ${{ format('stable/{0}', needs.get-versions.outputs.latest-version) }}
+            generation: ${{ format('Zeebe {0}', needs.get-versions.outputs.latest-version) }}
+          - branch: ${{ format('stable/{0}', needs.get-versions.outputs.previous-latest-version) }}
+            generation: ${{ format('Zeebe {0}', needs.get-versions.outputs.previous-latest-version) }}
+    name: Daily QA
+    uses: ./.github/workflows/qa-testbench.yaml
+    with:
+      branch: ${{ matrix.branch }}
+      generation: ${{ matrix.generation }}
+    secrets: inherit

--- a/.github/workflows/daily-qa.yml
+++ b/.github/workflows/daily-qa.yml
@@ -32,17 +32,15 @@ jobs:
       - uses: actions/checkout@v3
       - run: git fetch --tags
       - run: |
-          latest=$(git tag | grep '^[0-9]\.[0-9]\.[0-9]$' | sort -Vr | head -n1)
-          echo "Latest supported version: ${latest}"
-          previous=$(git tag | grep '^[0-9]\.[0-9]\.[0-9]$' | grep -v "^${latest%\.[0-9]}.*$" | sort -Vr | head -n1)
-          echo "Oldest supported version: ${latest}"
+          latest=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -Vr | head -n1)
+          previous=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | grep -Ev "^${latest%\.[0-9]}.*$" | sort -Vr | head -n1)
           if [ ! -z $latest ] && [ ! -z $previous ]; then
             echo "Successfully computed latest versions: ${latest} and ${previous}"
           else
             echo "Failed to compute latest versions"
           fi
-          echo "LATEST_VERSION=${latest%\.[0-9]}" >> $GITHUB_ENV
-          echo "PREVIOUS_LATEST_VERSION=${previous%\.[0-9]}" >> $GITHUB_ENV
+          echo "LATEST_VERSION=${latest%\.[0-9]+}" >> $GITHUB_ENV
+          echo "PREVIOUS_LATEST_VERSION=${previous%\.[0-9]+}" >> $GITHUB_ENV
   # Runs the qa-testbench workflow against the stable branches. It assumes that branches follow the
   # pattern of `stable/VERSION`, and generations of `Zeebe VERSION`.
   #

--- a/.github/workflows/daily-qa.yml
+++ b/.github/workflows/daily-qa.yml
@@ -7,7 +7,6 @@ name: Daily tests
 
 on:
   workflow_dispatch: { }
-  push: { }
   schedule:
     # Runs at 01:00 every day; see this link for more: https://crontab.guru/#0_1_*_*_*
     - cron: '0 1 * * *'

--- a/.github/workflows/qa-testbench.yaml
+++ b/.github/workflows/qa-testbench.yaml
@@ -27,6 +27,8 @@ on:
         type: string
 env:
   BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  GENERATION_TEMPLATE: ${{ inputs.generation }}
+  BRANCH: ${{ inputs.branch }}
 
 jobs:
   qa-testbench:
@@ -35,30 +37,25 @@ jobs:
     timeout-minutes: 45
     env:
       IMAGE: "gcr.io/zeebe-io/zeebe"
-      GENERATION_TEMPLATE: "${{ inputs.generation || 'Zeebe Snapshot' }}"
-      BRANCH_NAME: "${{ inputs.branch || github.ref_name || 'main' }}"
+      GENERATION_TEMPLATE: "${{ inputs.generation }}"
+      BRANCH_NAME: "${{ inputs.branch }}"
       ZEEBE_AUTHORIZATION_SERVER_URL: 'https://login.cloud.ultrawombat.com/oauth/token'
       ZEEBE_CLIENT_ID: 'S7GNoVCE6J-8L~OdFiI59kWM19P.wvKo'
 
     steps:
+      # Since we have branches like stable/1.0 where we have to replace certain patterns, in order to use the branch name as docker image tag
+      - id: set-branch-name
+        name: Sanitize branch name
+        run: |
+          branch=${BRANCH_NAME/\//-}
+          branch=${branch//\./-}
+          branch=${branch:-main}
+          echo "BRANCH=$branch" >> $GITHUB_ENV
       # We need to check out the evaluated branch and setup java (incl. maven), so we can retrieve the current project version
       # The version is necessary, since CC Saas only accepts SemVer for docker image tags (need to start with a version tag)
       - uses: actions/checkout@v3
         with:
           ref: "${{ env.BRANCH_NAME }}"
-      # Dynamic environment variables are not supported by GHA
-      # https://brandur.org/fragments/github-actions-env-vars-in-env-vars
-      #
-      # Since we run the workflow either on demand or via schedule we need to assign some defaults
-      # Furthermore we have branches like stable/1.0 where we have to replace certain patterns, in order to use the branch name as docker image tag
-      - id: evaluate-inputs
-        name: Evaluate Inputs
-        run: |
-          branch=${BRANCH_NAME/\//-}
-          branch=${branch//\./-}
-          branch=${branch:-main}
-          echo "BRANCH_NAME=$branch" >> $GITHUB_ENV
-          echo "GENERATION_TEMPLATE=${GENERATION_TEMPLATE:-Zeebe SNAPSHOT}" >> $GITHUB_ENV
       - uses: actions/setup-java@v3.6.0
         with:
           distribution: 'temurin'
@@ -68,11 +65,10 @@ jobs:
         name: Set environment variables
         run: |
           version=$(mvn help:evaluate -q -DforceStdout -D"expression=project.version")
-          tag="$version-$BRANCH_NAME-${GITHUB_SHA::8}"
+          tag="$version-$BRANCH-${GITHUB_SHA::8}"
           echo "TAG=$tag" >> $GITHUB_ENV
           echo "QA_RUN_VARIABLES={\"zeebeImage\": \"$IMAGE:$tag\", \"generationTemplate\": \"$GENERATION_TEMPLATE\", \"channel\": \"Internal Dev\", \"branch\": \"$BRANCH_NAME\", \"build\": \"$BUILD_URL\", \"businessKey\": \"$BUILD_URL\", \"processId\": \"qa-protocol\"}" >> $GITHUB_ENV
           echo "BUSINESS_KEY=$BUILD_URL" >> $GITHUB_ENV
-
       - name: Import Secrets
         id: secrets
         uses: hashicorp/vault-action@v2.4.3
@@ -112,18 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [qa-testbench]
     if: ${{ always() }}
-    env:
-      GENERATION_TEMPLATE: "${{ inputs.generation || 'Zeebe Snapshot' }}"
-      BRANCH_NAME: "${{ inputs.branch || github.ref_name || 'main' }}"
     steps:
-      # Sharing environment variables are not supported, so we have to do it here again
-      - id: evaluate-inputs
-        name: Evaluate Inputs
-        run: |
-          branch=${BRANCH_NAME:-main}
-          echo "BRANCH_NAME=$branch" >> $GITHUB_ENV
-          echo "GENERATION_TEMPLATE=${GENERATION_TEMPLATE:-Zeebe SNAPSHOT}" >> $GITHUB_ENV
-
       - id: slack-failure-notify
         name: Send failure slack notification
         uses: slackapi/slack-github-action@v1.23.0

--- a/.github/workflows/qa-testbench.yaml
+++ b/.github/workflows/qa-testbench.yaml
@@ -7,13 +7,24 @@ on:
         description: 'Specifies the generation template which should be used by the testbench run'
         required: false
         default: 'Zeebe SNAPSHOT'
+        type: string
       branch:
         description: 'Specifies the branch, for which the QA Testbench run should be executed'
         default: 'main'
         required: false
-  schedule:
-  # * is a special character in YAML so you have to quote this string
-    - cron:  '0 23 * * *'
+        type: string
+  workflow_call:
+    inputs:
+      generation:
+        description: 'Specifies the generation template which should be used by the testbench run'
+        required: false
+        default: 'Zeebe SNAPSHOT'
+        type: string
+      branch:
+        description: 'Specifies the branch, for which the QA Testbench run should be executed'
+        default: 'main'
+        required: false
+        type: string
 env:
   BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -24,12 +35,17 @@ jobs:
     timeout-minutes: 45
     env:
       IMAGE: "gcr.io/zeebe-io/zeebe"
-      GENERATION_TEMPLATE: "${{ github.event.inputs.generation }}"
-      BRANCH_NAME: "${{ github.event.inputs.branch }}"
+      GENERATION_TEMPLATE: "${{ inputs.generation || 'Zeebe Snapshot' }}"
+      BRANCH_NAME: "${{ inputs.branch || github.ref_name || 'main' }}"
       ZEEBE_AUTHORIZATION_SERVER_URL: 'https://login.cloud.ultrawombat.com/oauth/token'
       ZEEBE_CLIENT_ID: 'S7GNoVCE6J-8L~OdFiI59kWM19P.wvKo'
 
     steps:
+      # We need to check out the evaluated branch and setup java (incl. maven), so we can retrieve the current project version
+      # The version is necessary, since CC Saas only accepts SemVer for docker image tags (need to start with a version tag)
+      - uses: actions/checkout@v3
+        with:
+          ref: "${{ env.BRANCH_NAME }}"
       # Dynamic environment variables are not supported by GHA
       # https://brandur.org/fragments/github-actions-env-vars-in-env-vars
       #
@@ -43,11 +59,6 @@ jobs:
           branch=${branch:-main}
           echo "BRANCH_NAME=$branch" >> $GITHUB_ENV
           echo "GENERATION_TEMPLATE=${GENERATION_TEMPLATE:-Zeebe SNAPSHOT}" >> $GITHUB_ENV
-      # We need to check out the evaluated branch and setup java (incl. maven), so we can retrieve the current project version
-      # The version is necessary, since CC Saas only accepts SemVer for docker image tags (need to start with a version tag)
-      - uses: actions/checkout@v3
-        with:
-          ref: "${{ github.event.inputs.branch }}"
       - uses: actions/setup-java@v3.6.0
         with:
           distribution: 'temurin'
@@ -102,8 +113,8 @@ jobs:
     needs: [qa-testbench]
     if: ${{ always() }}
     env:
-      GENERATION_TEMPLATE: "${{ github.event.inputs.generation }}"
-      BRANCH_NAME: "${{ github.event.inputs.branch }}"
+      GENERATION_TEMPLATE: "${{ inputs.generation || 'Zeebe Snapshot' }}"
+      BRANCH_NAME: "${{ inputs.branch || github.ref_name || 'main' }}"
     steps:
       # Sharing environment variables are not supported, so we have to do it here again
       - id: evaluate-inputs


### PR DESCRIPTION
## Description

Schedules the `qa-testbench` workflow on a daily basis, across all supported branches. Branches/generations are hardcoded at the moment because of how our release process works. We cannot simply pick up the latest minor releases based on tags, since the template generation may not exist.

While I'd still like to investigate a way to do this (maybe by fetching the available generations first), we can for now still merge this to get immediate value of running our daily QA on the stable branches.

## Related issues

closes #10915 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
