### PR TITLE
[Backport stable/8.1] test(exporter): don't fail test if `getPhase` future throws

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorPauseTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorPauseTest.java
@@ -101,6 +101,7 @@ public final class ExporterDirectorPauseTest {
     // Needed to prevent flaky test https://github.com/camunda/zeebe/issues/10439
     Awaitility.await()
         .alias("Exporter is closed")
+        .ignoreExceptions() // joining can still throw if actor is closed after `getPhase` is called
         .until(() -> activeExporter.getDirector().getPhase().join() == ExporterPhase.CLOSED);
 
     // then


### PR DESCRIPTION
# Description
Backport of #10999 to `stable/8.1`.

relates to #10439