### PR TITLE
Allow unsupported BPMN elements in non executable pools

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/traversal/ModelWalker.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/traversal/ModelWalker.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.impl.BpmnModelInstanceImpl;
 import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
 import io.camunda.zeebe.model.bpmn.instance.Definitions;
+import io.camunda.zeebe.model.bpmn.instance.Process;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.LinkedList;
@@ -63,6 +64,12 @@ public class ModelWalker {
 
     BpmnModelElementInstance currentElement;
     while ((currentElement = elementsToVisit.poll()) != null) {
+
+      // add a new check here for ignore non-executable processes
+      if (isNonExecutableProcess(currentElement)) {
+        return;
+      }
+
       visitor.visit(currentElement);
       final Collection<ModelElementInstance> children = getChildElements(currentElement);
       children.forEach(
@@ -84,5 +91,14 @@ public class ModelWalker {
       final BpmnModelElementInstance element) {
     return ModelUtil.getModelElementCollection(
         element.getDomElement().getChildElements(), modelInstance);
+  }
+
+  private boolean isNonExecutableProcess(final BpmnModelElementInstance element) {
+    if (element instanceof Process) {
+      final Process process = (Process) element;
+      return !process.isExecutable();
+    } else {
+      return false;
+    }
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -236,4 +236,24 @@ public class DeploymentRejectionTest {
         .contains("stroke")
         .contains("bpmndi:BPMNPlane");
   }
+
+  // https://github.com/camunda/zeebe/issues/9542
+  @Test
+  public void shouldRejectDeploymentIfNoExecutableProcess() {
+    // given
+    final String resource = "/processes/non-executable-process-single.bpmn";
+
+    // when
+    final Record<DeploymentRecordValue> deploymentRejection =
+        ENGINE.deployment().withXmlClasspathResource(resource).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(deploymentRejection)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(deploymentRejection.getRejectionReason())
+        .contains("Must contain at least one executable process");
+  }
 }

--- a/engine/src/test/resources/processes/non-executable-process-pools.bpmn
+++ b/engine/src/test/resources/processes/non-executable-process-pools.bpmn
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1kgp0v2" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+  <bpmn:collaboration id="Collaboration_15knhs4">
+    <bpmn:participant id="Participant_0j12xdt" name="NoneExecutable" processRef="Process_NonExecutable" />
+    <bpmn:participant id="Participant_0wtt8eq" name="Executable" processRef="Process_Executable" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_NonExecutable" isExecutable="false">
+    <bpmn:sequenceFlow id="Flow_1v3y6nm" sourceRef="StartEvent_1" targetRef="Activity_0479jw8" />
+    <bpmn:sequenceFlow id="Flow_1hfdetm" sourceRef="Activity_0479jw8" targetRef="Event_0mc4l18" />
+    <bpmn:userTask id="Activity_0479jw8">
+      <bpmn:incoming>Flow_1v3y6nm</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hfdetm</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1v3y6nm</bpmn:outgoing>
+      <bpmn:conditionalEventDefinition id="conditionalEventDefinition_c2aa9e37-1df8-4541-9745-540b35bb7187">
+        <bpmn:condition id="condition_de3e1102-0824-425c-8391-f6670b912dcc">true</bpmn:condition>
+      </bpmn:conditionalEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_0mc4l18">
+      <bpmn:incoming>Flow_1hfdetm</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:process id="Process_Executable" isExecutable="true">
+    <bpmn:userTask id="Activity_0e1nlla">
+      <bpmn:incoming>Flow_0ehgnzz</bpmn:incoming>
+      <bpmn:outgoing>Flow_18ndycz</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0ehgnzz" sourceRef="Event_1f6tis7" targetRef="Activity_0e1nlla" />
+    <bpmn:sequenceFlow id="Flow_18ndycz" sourceRef="Activity_0e1nlla" targetRef="Event_1gk7uow" />
+    <bpmn:startEvent id="Event_1f6tis7">
+      <bpmn:outgoing>Flow_0ehgnzz</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_1gk7uow">
+      <bpmn:incoming>Flow_18ndycz</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_15knhs4">
+      <bpmndi:BPMNShape id="Participant_0j12xdt_di" bpmnElement="Participant_0j12xdt" isHorizontal="true">
+        <dc:Bounds x="129" y="57" width="600" height="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0vdv85s_di" bpmnElement="Activity_0479jw8">
+        <dc:Bounds x="370" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="192" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0mc4l18_di" bpmnElement="Event_0mc4l18">
+        <dc:Bounds x="622" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1v3y6nm_di" bpmnElement="Flow_1v3y6nm">
+        <di:waypoint x="228" y="170" />
+        <di:waypoint x="370" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hfdetm_di" bpmnElement="Flow_1hfdetm">
+        <di:waypoint x="470" y="170" />
+        <di:waypoint x="622" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_0wtt8eq_di" bpmnElement="Participant_0wtt8eq" isHorizontal="true">
+        <dc:Bounds x="129" y="340" width="600" height="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_066yjtd" bpmnElement="Activity_0e1nlla">
+        <dc:Bounds x="380" y="410" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0vopqjx_di" bpmnElement="Event_1f6tis7">
+        <dc:Bounds x="202" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_10wu371" bpmnElement="Event_1gk7uow">
+        <dc:Bounds x="622" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_0nncof1" bpmnElement="Flow_0ehgnzz">
+        <di:waypoint x="238" y="450" />
+        <di:waypoint x="380" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0dxgrvx" bpmnElement="Flow_18ndycz">
+        <di:waypoint x="480" y="450" />
+        <di:waypoint x="622" y="450" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/engine/src/test/resources/processes/non-executable-process-single.bpmn
+++ b/engine/src/test/resources/processes/non-executable-process-single.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1kgp0v2" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+  <bpmn:process id="Process_1w20sbn" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1v3y6nm</bpmn:outgoing>
+      <bpmn:conditionalEventDefinition id="conditionalEventDefinition_c2aa9e37-1df8-4541-9745-540b35bb7187">
+        <bpmn:condition id="condition_de3e1102-0824-425c-8391-f6670b912dcc">true</bpmn:condition>
+      </bpmn:conditionalEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1v3y6nm" sourceRef="StartEvent_1" targetRef="Activity_0479jw8" />
+    <bpmn:endEvent id="Event_0mc4l18">
+      <bpmn:incoming>Flow_1hfdetm</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1hfdetm" sourceRef="Activity_0479jw8" targetRef="Event_0mc4l18" />
+    <bpmn:userTask id="Activity_0479jw8">
+      <bpmn:incoming>Flow_1v3y6nm</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hfdetm</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1w20sby">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0mc4l18_di" bpmnElement="Event_0mc4l18">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0vdv85s_di" bpmnElement="Activity_0479jw8">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1v3y6nm_di" bpmnElement="Flow_1v3y6nm">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hfdetm_di" bpmnElement="Flow_1hfdetm">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -62,6 +62,11 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
                     .contains(r.getIntent()));
   }
 
+  public ProcessRecordStream processRecords() {
+    return new ProcessRecordStream(
+        filter(r -> r.getValueType() == ValueType.PROCESS).map(Record.class::cast));
+  }
+
   public ProcessInstanceRecordStream processInstanceRecords() {
     return new ProcessInstanceRecordStream(
         filter(r -> r.getValueType() == ValueType.PROCESS_INSTANCE).map(Record.class::cast));


### PR DESCRIPTION
## Description

Zeebe does not need to check elements in non-executable pools.

If there is only one non-executable process in a bpmn definition, it will be blocked by ["Must contain at least one executable process"](https://github.com/camunda/zeebe/blob/main/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/DefinitionsValidator.java#L37)

If there are more the one process in a bpmn definition, only the executable pools will be deployed.

e.g. a definition with one non-executable pool and one executable pool, only the executeable process is deployed.
![2022-11-16_163408](https://user-images.githubusercontent.com/26370117/202132457-ac87483c-a72b-4d6f-af3e-8de360f59724.png)
![2022-11-16_163444](https://user-images.githubusercontent.com/26370117/202132490-3686eb0b-8c60-4bf1-b83e-7dcbb1bf9d41.png)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9542 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
