### PR TITLE
[Backport stable/8.1] Bump protobuf-bom from 3.21.6 to 3.21.9

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -70,7 +70,7 @@
     <version.netty>4.1.82.Final</version.netty>
     <version.objenesis>3.3</version.objenesis>
     <version.prometheus>0.16.0</version.prometheus>
-    <version.protobuf>3.21.6</version.protobuf>
+    <version.protobuf>3.21.9</version.protobuf>
     <version.protobuf-common>2.9.3</version.protobuf-common>
     <version.micrometer>1.9.4</version.micrometer>
     <version.rocksdbjni>7.5.3</version.rocksdbjni>


### PR DESCRIPTION
Backport of https://github.com/camunda/zeebe/pull/10827 to stable/8.1.

relates to #11013 