### PR TITLE
deps(maven): bump protobuf-bom from 3.19.4 to 3.19.6

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -77,7 +77,7 @@
     <version.netty>4.1.74.Final</version.netty>
     <version.objenesis>3.2</version.objenesis>
     <version.prometheus>0.15.0</version.prometheus>
-    <version.protobuf>3.19.4</version.protobuf>
+    <version.protobuf>3.19.6</version.protobuf>
     <version.protobuf-common>2.8.0</version.protobuf-common>
     <version.micrometer>1.8.4</version.micrometer>
     <version.rocksdbjni>6.28.2</version.rocksdbjni>


### PR DESCRIPTION
## Description

Update protobuf-bom to 3.19.6

## Related issues

related to #11013 
