### PR TITLE
feat(backup/s3): optionally compress backup contents

### DIFF
--- a/backup-stores/s3/pom.xml
+++ b/backup-stores/s3/pom.xml
@@ -31,6 +31,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.luben</groupId>
+      <artifactId>zstd-jni</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
     </dependency>
@@ -154,6 +159,7 @@
         <configuration>
           <ignoredUnusedDeclaredDependencies>
             <dep>com.amazonaws:aws-java-sdk-core</dep>
+            <dep>com.github.luben:zstd-jni</dep>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/backup-stores/s3/pom.xml
+++ b/backup-stores/s3/pom.xml
@@ -26,6 +26,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
     </dependency>

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/FileSetManager.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/FileSetManager.java
@@ -9,11 +9,19 @@ package io.camunda.zeebe.backup.s3;
 
 import io.camunda.zeebe.backup.api.NamedFileSet;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.backup.s3.S3BackupStoreException.BackupCompressionFailed;
 import io.camunda.zeebe.backup.s3.manifest.FileSet;
 import io.camunda.zeebe.backup.s3.util.CompletableFutureUtils;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
+import org.apache.commons.compress.compressors.CompressorException;
+import org.apache.commons.compress.compressors.CompressorStreamFactory;
+import org.apache.commons.compress.utils.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
@@ -23,6 +31,10 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 final class FileSetManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(FileSetManager.class);
+  private static final String COMPRESSION_ALGORITHM = CompressorStreamFactory.getZstandard();
+  private static final int COMPRESSION_SIZE_THRESHOLD = 8 * 1024 * 1024; // 8 MiB
+  private static final String TMP_COMPRESSION_PREFIX = "zb-backup-compress-";
+  private static final String TMP_DECOMPRESSION_PREFIX = "zb-backup-decompress-";
   private final S3AsyncClient client;
   private final S3BackupConfig config;
 
@@ -42,12 +54,67 @@ final class FileSetManager {
 
   private CompletableFuture<FileSet.FileMetadata> saveFile(
       final String prefix, final String fileName, final Path filePath) {
+    if (shouldCompressFile(filePath)) {
+      final var algorithm = COMPRESSION_ALGORITHM;
+      final var compressed = compressFile(filePath, algorithm);
+      LOG.trace("Saving compressed file {}({}) in prefix {}", fileName, compressed, prefix);
+      return client
+          .putObject(
+              put -> put.bucket(config.bucketName()).key(prefix + fileName),
+              AsyncRequestBody.fromFile(compressed))
+          .thenRunAsync(() -> cleanupCompressedFile(compressed))
+          .thenApply(unused -> FileSet.FileMetadata.withCompression(algorithm));
+    }
+
     LOG.trace("Saving file {}({}) in prefix {}", fileName, filePath, prefix);
     return client
         .putObject(
             put -> put.bucket(config.bucketName()).key(prefix + fileName),
             AsyncRequestBody.fromFile(filePath))
         .thenApply(unused -> FileSet.FileMetadata.none());
+  }
+
+  private void cleanupCompressedFile(final Path compressedFile) {
+    try {
+      Files.delete(compressedFile);
+    } catch (final IOException e) {
+      LOG.warn(
+          "Failed to clean up temporary file used for (de-)compression: {}", compressedFile, e);
+    }
+  }
+
+  private boolean shouldCompressFile(final Path filePath) {
+    try {
+      return config.enableCompression() && Files.size(filePath) > COMPRESSION_SIZE_THRESHOLD;
+    } catch (final IOException e) {
+      LOG.warn("Failed to determine if file should be compressed, assuming no: {}", filePath);
+      return false;
+    }
+  }
+
+  private Path compressFile(final Path file, final String algorithm) {
+    try {
+      final var compressedFile = Files.createTempFile(TMP_COMPRESSION_PREFIX, null);
+      LOG.trace("Compressing file {} to {} using {}", file, compressedFile, algorithm);
+      try (final var input = new BufferedInputStream(Files.newInputStream(file));
+          final var output = new BufferedOutputStream(Files.newOutputStream(compressedFile));
+          final var compressedOutput =
+              new CompressorStreamFactory().createCompressorOutputStream(algorithm, output)) {
+        IOUtils.copy(input, compressedOutput);
+        if (LOG.isTraceEnabled()) {
+          LOG.trace(
+              "Compressed file {} to {}. Uncompressed: {} bytes, compressed: {} bytes",
+              file,
+              compressedFile,
+              Files.size(file),
+              Files.size(compressedFile));
+        }
+        return compressedFile;
+      }
+    } catch (final IOException | CompressorException e) {
+      throw new BackupCompressionFailed(
+          "Failed to compress file %s using %s".formatted(file, algorithm), e);
+    }
   }
 
   CompletableFuture<NamedFileSet> restore(

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/FileSetManager.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/FileSetManager.java
@@ -60,7 +60,7 @@ final class FileSetManager {
   private CompletableFuture<FileSet.FileMetadata> saveFile(
       final String prefix, final String fileName, final Path filePath) {
     if (shouldCompressFile(filePath)) {
-      final var algorithm = COMPRESSION_ALGORITHM;
+      final var algorithm = config.compressionAlgorithm().orElseThrow();
       final var compressed = compressFile(filePath, algorithm);
       LOG.trace("Saving compressed file {}({}) in prefix {}", fileName, compressed, prefix);
       return client
@@ -90,7 +90,8 @@ final class FileSetManager {
 
   private boolean shouldCompressFile(final Path filePath) {
     try {
-      return config.enableCompression() && Files.size(filePath) > COMPRESSION_SIZE_THRESHOLD;
+      return config.compressionAlgorithm().isPresent()
+          && Files.size(filePath) > COMPRESSION_SIZE_THRESHOLD;
     } catch (final IOException e) {
       LOG.warn("Failed to determine if file should be compressed, assuming no: {}", filePath);
       return false;

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
@@ -38,17 +38,26 @@ public record S3BackupConfig(
     Optional<String> region,
     Optional<Credentials> credentials,
     Optional<Duration> apiCallTimeout,
-    boolean forcePathStyleAccess) {
+    boolean forcePathStyleAccess,
+    boolean enableCompression) {
 
   /**
    * Creates a config without setting the region and credentials.
    *
    * @param bucketName Name of the backup that will be used for storing backups
    * @see S3BackupConfig#S3BackupConfig(String bucketName, Optional endpoint, Optional region,
-   *     Optional credentials, Optional apiCallTimeout, boolean forcePathStyleAccess)
+   *     Optional credentials, Optional apiCallTimeout, boolean forcePathStyleAccess, boolean
+   *     enableCompression)
    */
   public S3BackupConfig(final String bucketName) {
-    this(bucketName, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), false);
+    this(
+        bucketName,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        false,
+        false);
   }
 
   public static S3BackupConfig from(
@@ -58,7 +67,8 @@ public record S3BackupConfig(
       final String accessKey,
       final String secretKey,
       final Duration apiCallTimeoutMs,
-      final boolean forcePathStyleAccess) {
+      final boolean forcePathStyleAccess,
+      final boolean enableCompression) {
     Credentials credentials = null;
     if (accessKey != null && secretKey != null) {
       credentials = new Credentials(accessKey, secretKey);
@@ -69,7 +79,8 @@ public record S3BackupConfig(
         Optional.ofNullable(region),
         Optional.ofNullable(credentials),
         Optional.ofNullable(apiCallTimeoutMs),
-        forcePathStyleAccess);
+        forcePathStyleAccess,
+        enableCompression);
   }
 
   record Credentials(String accessKey, String secretKey) {

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
@@ -8,7 +8,9 @@
 package io.camunda.zeebe.backup.s3;
 
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.Optional;
+import org.apache.commons.compress.compressors.CompressorStreamFactory;
 
 /**
  * Holds configuration for the {@link S3BackupStore S3 Backup Store}.
@@ -24,6 +26,7 @@ import java.util.Optional;
  *     the timeout may fail and result in failed backups.
  * @param forcePathStyleAccess Forces the AWS SDK to always use paths for accessing the bucket. Off
  *     by default, which allows the AWS SDK to choose virtual-hosted-style bucket access.
+ * @param compressionAlgorithm Algorithm to use (if any) for compressing backup contents.
  * @see <a
  *     href=https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html#automatically-determine-the-aws-region-from-the-environment>
  *     Automatically determine the Region from the environment</a>
@@ -39,48 +42,26 @@ public record S3BackupConfig(
     Optional<Credentials> credentials,
     Optional<Duration> apiCallTimeout,
     boolean forcePathStyleAccess,
-    boolean enableCompression) {
+    Optional<String> compressionAlgorithm) {
 
-  /**
-   * Creates a config without setting the region and credentials.
-   *
-   * @param bucketName Name of the backup that will be used for storing backups
-   * @see S3BackupConfig#S3BackupConfig(String bucketName, Optional endpoint, Optional region,
-   *     Optional credentials, Optional apiCallTimeout, boolean forcePathStyleAccess, boolean
-   *     enableCompression)
-   */
-  public S3BackupConfig(final String bucketName) {
-    this(
-        bucketName,
-        Optional.empty(),
-        Optional.empty(),
-        Optional.empty(),
-        Optional.empty(),
-        false,
-        false);
-  }
-
-  public static S3BackupConfig from(
-      final String bucketName,
-      final String endpoint,
-      final String region,
-      final String accessKey,
-      final String secretKey,
-      final Duration apiCallTimeoutMs,
-      final boolean forcePathStyleAccess,
-      final boolean enableCompression) {
-    Credentials credentials = null;
-    if (accessKey != null && secretKey != null) {
-      credentials = new Credentials(accessKey, secretKey);
+  public S3BackupConfig {
+    if (bucketName == null || bucketName.isEmpty()) {
+      throw new IllegalArgumentException("Bucket name must not be empty.");
     }
-    return new S3BackupConfig(
-        bucketName,
-        Optional.ofNullable(endpoint),
-        Optional.ofNullable(region),
-        Optional.ofNullable(credentials),
-        Optional.ofNullable(apiCallTimeoutMs),
-        forcePathStyleAccess,
-        enableCompression);
+    if (compressionAlgorithm.isPresent()) {
+      final var inputAlgorithms =
+          CompressorStreamFactory.getSingleton().getInputStreamCompressorNames();
+      final var outputAlgorithms =
+          CompressorStreamFactory.getSingleton().getOutputStreamCompressorNames();
+      final var supported = new HashSet<>(inputAlgorithms);
+      supported.retainAll(outputAlgorithms);
+
+      if (!supported.contains(compressionAlgorithm.get())) {
+        throw new IllegalArgumentException(
+            "Can't use compression algorithm %s. Only supports %s"
+                .formatted(compressionAlgorithm.get(), supported));
+      }
+    }
   }
 
   record Credentials(String accessKey, String secretKey) {
@@ -94,6 +75,63 @@ public record S3BackupConfig(
           + "<redacted>"
           + '\''
           + '}';
+    }
+  }
+
+  public static class Builder {
+
+    private String bucketName;
+    private String endpoint;
+    private String region;
+    private Duration apiCallTimeoutMs;
+    private boolean forcePathStyleAccess = false;
+    private String compressionAlgorithm;
+    private Credentials credentials;
+
+    public Builder withBucketName(final String bucketName) {
+      this.bucketName = bucketName;
+      return this;
+    }
+
+    public Builder withEndpoint(final String endpoint) {
+      this.endpoint = endpoint;
+      return this;
+    }
+
+    public Builder withRegion(final String region) {
+      this.region = region;
+      return this;
+    }
+
+    public Builder withCredentials(final String accessKey, final String secretKey) {
+      this.credentials = new Credentials(accessKey, secretKey);
+      return this;
+    }
+
+    public Builder withApiCallTimeout(final Duration apiCallTimeoutMs) {
+      this.apiCallTimeoutMs = apiCallTimeoutMs;
+      return this;
+    }
+
+    public Builder forcePathStyleAccess(final boolean forcePathStyleAccess) {
+      this.forcePathStyleAccess = forcePathStyleAccess;
+      return this;
+    }
+
+    public Builder withCompressionAlgorithm(final String compressionAlgorithm) {
+      this.compressionAlgorithm = compressionAlgorithm;
+      return this;
+    }
+
+    public S3BackupConfig build() {
+      return new S3BackupConfig(
+          bucketName,
+          Optional.ofNullable(endpoint),
+          Optional.ofNullable(region),
+          Optional.ofNullable(credentials),
+          Optional.ofNullable(apiCallTimeoutMs),
+          forcePathStyleAccess,
+          Optional.ofNullable(compressionAlgorithm));
     }
   }
 }

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStoreException.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStoreException.java
@@ -63,4 +63,16 @@ public abstract sealed class S3BackupStoreException extends RuntimeException {
       super(message, null);
     }
   }
+
+  /**
+   * Thrown when compression of backup contents failed. This is expected when there's no space
+   * available to create a temporary file for the compressed contents but may happen in other cases
+   * as well.
+   */
+  public static final class BackupCompressionFailed extends S3BackupStoreException {
+
+    public BackupCompressionFailed(final String message, final Throwable cause) {
+      super(message, cause);
+    }
+  }
 }

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/FileSet.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/manifest/FileSet.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -47,9 +48,13 @@ public record FileSet(Map<String, FileMetadata> files) {
   }
 
   @JsonInclude(Include.NON_EMPTY)
-  public record FileMetadata() {
+  public record FileMetadata(Optional<String> compressionAlgorithm) {
+    public static FileMetadata withCompression(final String algorithm) {
+      return new FileMetadata(Optional.of(algorithm));
+    }
+
     public static FileMetadata none() {
-      return new FileMetadata();
+      return new FileMetadata(Optional.empty());
     }
   }
 

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CompressionTest.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CompressionTest.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.NamedFileSetImpl;
-import io.camunda.zeebe.backup.s3.S3BackupConfig.Credentials;
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.testkit.support.BackupAssert;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -67,14 +67,14 @@ final class CompressionTest {
   @BeforeEach
   void setupBucket() {
     final var config =
-        new S3BackupConfig(
-            RandomStringUtils.randomAlphabetic(10).toLowerCase(),
-            Optional.of("http://%s:%d".formatted(S3.getHost(), S3.getMappedPort(DEFAULT_PORT))),
-            Optional.of(Region.US_EAST_1.id()),
-            Optional.of(new Credentials(ACCESS_KEY, SECRET_KEY)),
-            Optional.empty(),
-            true,
-            true);
+        new Builder()
+            .withBucketName(RandomStringUtils.randomAlphabetic(10).toLowerCase())
+            .withEndpoint("http://%s:%d".formatted(S3.getHost(), S3.getMappedPort(DEFAULT_PORT)))
+            .withRegion(Region.US_EAST_1.id())
+            .withCredentials(ACCESS_KEY, SECRET_KEY)
+            .forcePathStyleAccess(true)
+            .withCompressionAlgorithm("zstd")
+            .build();
     final var client = S3BackupStore.buildClient(config);
     store = new S3BackupStore(config, client);
     client.createBucket(CreateBucketRequest.builder().bucket(config.bucketName()).build()).join();

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CompressionTest.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CompressionTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import io.camunda.zeebe.backup.api.Backup;
+import io.camunda.zeebe.backup.common.BackupDescriptorImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupImpl;
+import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Credentials;
+import io.camunda.zeebe.backup.testkit.support.BackupAssert;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+
+@Testcontainers
+final class CompressionTest {
+  private static final String ACCESS_KEY = "letmein";
+  private static final String SECRET_KEY = "letmein1234";
+  private static final int DEFAULT_PORT = 9000;
+
+  private static final byte[] COMPRESSIBLE_BYTES = compressibleBytes();
+
+  @SuppressWarnings("resource")
+  @Container
+  private static final GenericContainer<?> S3 =
+      new GenericContainer<>(DockerImageName.parse("minio/minio"))
+          .withCommand("server /data")
+          .withExposedPorts(DEFAULT_PORT)
+          .withEnv("MINIO_ACCESS_KEY", ACCESS_KEY)
+          .withEnv("MINIO_SECRET_KEY", SECRET_KEY)
+          .withEnv("MINIO_DOMAIN", "localhost")
+          .waitingFor(
+              new HttpWaitStrategy()
+                  .forPath("/minio/health/ready")
+                  .forPort(DEFAULT_PORT)
+                  .withStartupTimeout(Duration.ofMinutes(1)));
+
+  private S3BackupStore store;
+
+  @BeforeEach
+  void setupBucket() {
+    final var config =
+        new S3BackupConfig(
+            RandomStringUtils.randomAlphabetic(10).toLowerCase(),
+            Optional.of("http://%s:%d".formatted(S3.getHost(), S3.getMappedPort(DEFAULT_PORT))),
+            Optional.of(Region.US_EAST_1.id()),
+            Optional.of(new Credentials(ACCESS_KEY, SECRET_KEY)),
+            Optional.empty(),
+            true,
+            true);
+    final var client = S3BackupStore.buildClient(config);
+    store = new S3BackupStore(config, client);
+    client.createBucket(CreateBucketRequest.builder().bucket(config.bucketName()).build()).join();
+  }
+
+  @Test
+  void canBackupWithCompression() throws IOException {
+    // given
+    final var backup = compressibleBackup();
+
+    // when
+    final var result = store.save(backup);
+
+    // then
+    Assertions.assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+  }
+
+  @Test
+  void canRestoreBackupWithCompression(@TempDir final Path target) throws IOException {
+    // given
+    final var backup = compressibleBackup();
+
+    // when
+    Assertions.assertThat(store.save(backup)).succeedsWithin(Duration.ofSeconds(30));
+
+    // then
+    Assertions.assertThat(store.restore(backup.id(), target))
+        .succeedsWithin(Duration.ofSeconds(30))
+        .asInstanceOf(new InstanceOfAssertFactory<>(Backup.class, BackupAssert::assertThatBackup))
+        .hasSameContentsAs(backup);
+  }
+
+  private Backup compressibleBackup() throws IOException {
+    final var tempDir = Files.createTempDirectory("backup");
+    Files.createDirectory(tempDir.resolve("segments/"));
+    final var seg1 = Files.createFile(tempDir.resolve("segments/segment-file-1"));
+    final var seg2 = Files.createFile(tempDir.resolve("segments/segment-file-2"));
+    Files.write(seg1, COMPRESSIBLE_BYTES);
+    Files.write(seg2, RandomUtils.nextBytes(1024));
+
+    Files.createDirectory(tempDir.resolve("snapshot/"));
+    final var s1 = Files.createFile(tempDir.resolve("snapshot/snapshot-file-1"));
+    final var s2 = Files.createFile(tempDir.resolve("snapshot/snapshot-file-2"));
+    Files.write(s1, COMPRESSIBLE_BYTES);
+    Files.write(s2, COMPRESSIBLE_BYTES);
+
+    return new BackupImpl(
+        new BackupIdentifierImpl(1, 2, 3),
+        new BackupDescriptorImpl(Optional.of("test-snapshot-id"), 4, 5, "test"),
+        new NamedFileSetImpl(Map.of("segment-file-1", seg1, "segment-file-2", seg2)),
+        new NamedFileSetImpl(Map.of("snapshot-file-1", s1, "snapshot-file-2", s2)));
+  }
+
+  /**
+   * Generates a byte array that should be compressible by most compression algorithms. The byte
+   * array consists of 1000 parts, each randomly chosen from 10 templates that contain between 8 and
+   * 64 KiB of random data.
+   */
+  private static byte[] compressibleBytes() {
+    final Supplier<Integer> partSize = () -> RandomUtils.nextInt(8, 65) * 1024; // 8-64 KiB
+    final var totalPartCount = 1000; // Count of parts chosen for the final result
+    final var templateCount = 10; // Number of templates that are generated
+
+    // Generate templates, each containing random data
+    final var templates =
+        IntStream.range(0, templateCount)
+            .mapToObj(i -> ArrayUtils.toObject(RandomUtils.nextBytes(partSize.get())))
+            .toArray(Byte[][]::new);
+
+    // Build the result by randomly picking from the templates
+    return ArrayUtils.toPrimitive(
+        IntStream.range(0, totalPartCount)
+            .mapToObj(i -> templates[(RandomUtils.nextInt(0, templateCount))])
+            .flatMap(Arrays::stream)
+            .toArray(Byte[]::new));
+  }
+}

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/LocalstackBackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/LocalstackBackupStoreIT.java
@@ -7,17 +7,14 @@
  */
 package io.camunda.zeebe.backup.s3;
 
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer.Service;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 
@@ -33,21 +30,19 @@ final class LocalstackBackupStoreIT implements S3BackupStoreTests {
   private S3BackupStore store;
   private S3BackupConfig config;
 
-  @BeforeAll
-  static void setup() {
-    client =
-        S3AsyncClient.builder()
-            .endpointOverride(S3.getEndpointOverride(Service.S3))
-            .region(Region.of(S3.getRegion()))
-            .credentialsProvider(
-                StaticCredentialsProvider.create(
-                    AwsBasicCredentials.create(S3.getAccessKey(), S3.getSecretKey())))
-            .build();
-  }
-
   @BeforeEach
   void setupBucket() {
-    config = new S3BackupConfig(RandomStringUtils.randomAlphabetic(10).toLowerCase());
+    config =
+        new Builder()
+            .withBucketName(RandomStringUtils.randomAlphabetic(10).toLowerCase())
+            .withEndpoint(S3.getEndpointOverride(Service.S3).toString())
+            .withRegion(S3.getRegion())
+            .withCredentials(S3.getAccessKey(), S3.getSecretKey())
+            .withApiCallTimeout(null)
+            .forcePathStyleAccess(false)
+            .withCompressionAlgorithm(null)
+            .build();
+    client = S3BackupStore.buildClient(config);
     store = new S3BackupStore(config, client);
     client.createBucket(CreateBucketRequest.builder().bucket(config.bucketName()).build()).join();
   }

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/MinioBackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/MinioBackupStoreIT.java
@@ -55,7 +55,8 @@ final class MinioBackupStoreIT implements S3BackupStoreTests {
             Optional.of(Region.US_EAST_1.id()),
             Optional.of(new Credentials(ACCESS_KEY, SECRET_KEY)),
             Optional.empty(),
-            true);
+            true,
+            false);
     client = S3BackupStore.buildClient(config);
     store = new S3BackupStore(config, client);
     client.createBucket(CreateBucketRequest.builder().bucket(config.bucketName()).build()).join();

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/MinioBackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/MinioBackupStoreIT.java
@@ -7,9 +7,8 @@
  */
 package io.camunda.zeebe.backup.s3;
 
-import io.camunda.zeebe.backup.s3.S3BackupConfig.Credentials;
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import java.time.Duration;
-import java.util.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.testcontainers.containers.GenericContainer;
@@ -49,14 +48,13 @@ final class MinioBackupStoreIT implements S3BackupStoreTests {
   @BeforeEach
   void setupBucket() {
     config =
-        new S3BackupConfig(
-            RandomStringUtils.randomAlphabetic(10).toLowerCase(),
-            Optional.of("http://%s:%d".formatted(S3.getHost(), S3.getMappedPort(DEFAULT_PORT))),
-            Optional.of(Region.US_EAST_1.id()),
-            Optional.of(new Credentials(ACCESS_KEY, SECRET_KEY)),
-            Optional.empty(),
-            true,
-            false);
+        new Builder()
+            .withBucketName(RandomStringUtils.randomAlphabetic(10).toLowerCase())
+            .withEndpoint("http://%s:%d".formatted(S3.getHost(), S3.getMappedPort(DEFAULT_PORT)))
+            .withRegion(Region.US_EAST_1.id())
+            .withCredentials(ACCESS_KEY, SECRET_KEY)
+            .forcePathStyleAccess(true)
+            .build();
     client = S3BackupStore.buildClient(config);
     store = new S3BackupStore(config, client);
     client.createBucket(CreateBucketRequest.builder().bucket(config.bucketName()).build()).join();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -190,7 +190,8 @@ public final class SystemContext {
               s3Config.getAccessKey(),
               s3Config.getSecretKey(),
               s3Config.getApiCallTimeout(),
-              s3Config.isForcePathStyleAccess());
+              s3Config.isForcePathStyleAccess(),
+              s3Config.isEnableCompression());
       try {
         S3BackupStore.validateConfig(storeConfig);
       } catch (final Exception e) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirect
 
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.zeebe.backup.s3.S3BackupConfig;
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -181,18 +182,17 @@ public final class SystemContext {
 
     if (backup.getStore() == BackupStoreType.S3) {
       final var s3Config = backup.getS3();
-
-      final S3BackupConfig storeConfig =
-          S3BackupConfig.from(
-              s3Config.getBucketName(),
-              s3Config.getEndpoint(),
-              s3Config.getRegion(),
-              s3Config.getAccessKey(),
-              s3Config.getSecretKey(),
-              s3Config.getApiCallTimeout(),
-              s3Config.isForcePathStyleAccess(),
-              s3Config.isEnableCompression());
       try {
+        final S3BackupConfig storeConfig =
+            new Builder()
+                .withBucketName(s3Config.getBucketName())
+                .withEndpoint(s3Config.getEndpoint())
+                .withRegion(s3Config.getRegion())
+                .withCredentials(s3Config.getAccessKey(), s3Config.getSecretKey())
+                .withApiCallTimeout(s3Config.getApiCallTimeout())
+                .forcePathStyleAccess(s3Config.isForcePathStyleAccess())
+                .withCompressionAlgorithm(s3Config.getCompression())
+                .build();
         S3BackupStore.validateConfig(storeConfig);
       } catch (final Exception e) {
         throw new InvalidConfigurationException("Cannot configure S3 backup store.", e);

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
@@ -20,6 +20,7 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
   private String secretKey;
   private Duration apiCallTimeout = Duration.ofSeconds(180);
   private boolean forcePathStyleAccess = false;
+  private boolean enableCompression = false;
 
   public String getBucketName() {
     return bucketName;
@@ -77,6 +78,14 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
     this.forcePathStyleAccess = forcePathStyleAccess;
   }
 
+  public boolean isEnableCompression() {
+    return enableCompression;
+  }
+
+  public void setEnableCompression(final boolean enableCompression) {
+    this.enableCompression = enableCompression;
+  }
+
   @Override
   public int hashCode() {
     int result = bucketName != null ? bucketName.hashCode() : 0;
@@ -86,6 +95,7 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
     result = 31 * result + (secretKey != null ? secretKey.hashCode() : 0);
     result = 31 * result + (apiCallTimeout != null ? apiCallTimeout.hashCode() : 0);
     result = 31 * result + (forcePathStyleAccess ? 1 : 0);
+    result = 31 * result + (enableCompression ? 1 : 0);
     return result;
   }
 
@@ -101,6 +111,9 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
     final S3BackupStoreConfig that = (S3BackupStoreConfig) o;
 
     if (forcePathStyleAccess != that.forcePathStyleAccess) {
+      return false;
+    }
+    if (enableCompression != that.enableCompression) {
       return false;
     }
     if (!Objects.equals(bucketName, that.bucketName)) {
@@ -139,9 +152,12 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
         + ", secretKey='"
         + "<redacted>"
         + '\''
-        + ", apiCallTimeout='"
+        + ", apiCallTimeout="
         + apiCallTimeout
-        + '\''
+        + ", forcePathStyleAccess="
+        + forcePathStyleAccess
+        + ", enableCompression="
+        + enableCompression
         + '}';
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
@@ -20,7 +20,7 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
   private String secretKey;
   private Duration apiCallTimeout = Duration.ofSeconds(180);
   private boolean forcePathStyleAccess = false;
-  private boolean enableCompression = false;
+  private String compression;
 
   public String getBucketName() {
     return bucketName;
@@ -78,12 +78,16 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
     this.forcePathStyleAccess = forcePathStyleAccess;
   }
 
-  public boolean isEnableCompression() {
-    return enableCompression;
+  public String getCompression() {
+    return compression;
   }
 
-  public void setEnableCompression(final boolean enableCompression) {
-    this.enableCompression = enableCompression;
+  public void setCompression(final String algorithm) {
+    if (Objects.equals(algorithm, "none")) {
+      this.compression = null;
+    } else {
+      this.compression = algorithm;
+    }
   }
 
   @Override
@@ -95,7 +99,7 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
     result = 31 * result + (secretKey != null ? secretKey.hashCode() : 0);
     result = 31 * result + (apiCallTimeout != null ? apiCallTimeout.hashCode() : 0);
     result = 31 * result + (forcePathStyleAccess ? 1 : 0);
-    result = 31 * result + (enableCompression ? 1 : 0);
+    result = 31 * result + (compression != null ? compression.hashCode() : 0);
     return result;
   }
 
@@ -113,7 +117,7 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
     if (forcePathStyleAccess != that.forcePathStyleAccess) {
       return false;
     }
-    if (enableCompression != that.enableCompression) {
+    if (!Objects.equals(compression, that.compression)) {
       return false;
     }
     if (!Objects.equals(bucketName, that.bucketName)) {
@@ -156,8 +160,8 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
         + apiCallTimeout
         + ", forcePathStyleAccess="
         + forcePathStyleAccess
-        + ", enableCompression="
-        + enableCompression
+        + ", compression="
+        + compression
         + '}';
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.system.partitions.impl.steps;
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupConfig;
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
@@ -82,15 +83,15 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
     try {
       final var s3Config = backupCfg.getS3();
       final S3BackupConfig storeConfig =
-          S3BackupConfig.from(
-              s3Config.getBucketName(),
-              s3Config.getEndpoint(),
-              s3Config.getRegion(),
-              s3Config.getAccessKey(),
-              s3Config.getSecretKey(),
-              s3Config.getApiCallTimeout(),
-              s3Config.isForcePathStyleAccess(),
-              s3Config.isEnableCompression());
+          new Builder()
+              .withBucketName(s3Config.getBucketName())
+              .withEndpoint(s3Config.getEndpoint())
+              .withRegion(s3Config.getRegion())
+              .withCredentials(s3Config.getAccessKey(), s3Config.getSecretKey())
+              .withApiCallTimeout(s3Config.getApiCallTimeout())
+              .forcePathStyleAccess(s3Config.isForcePathStyleAccess())
+              .withCompressionAlgorithm(s3Config.getCompression())
+              .build();
       final S3BackupStore backupStore = new S3BackupStore(storeConfig);
       context.setBackupStore(backupStore);
       installed.complete(null);

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -89,7 +89,8 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
               s3Config.getAccessKey(),
               s3Config.getSecretKey(),
               s3Config.getApiCallTimeout(),
-              s3Config.isForcePathStyleAccess());
+              s3Config.isForcePathStyleAccess(),
+              s3Config.isEnableCompression());
       final S3BackupStore backupStore = new S3BackupStore(storeConfig);
       context.setBackupStore(backupStore);
       installed.complete(null);

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -409,7 +409,7 @@ final class SystemContextTest {
         .isInstanceOf(InvalidConfigurationException.class)
         .hasCauseInstanceOf(IllegalArgumentException.class)
         .cause()
-        .hasMessageContaining("bucketName must not be empty");
+        .hasMessageContaining("Bucket name must not be empty");
   }
 
   @Test

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -278,6 +278,10 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_FORCEPATHSTYLEACCESS
           # forcePathStyleAccess: false
 
+          # When enabled, parts of the backup may be compressed.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_ENABLECOMPRESSION
+          # enableCompression: false
+
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
 

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -278,9 +278,12 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_FORCEPATHSTYLEACCESS
           # forcePathStyleAccess: false
 
-          # When enabled, parts of the backup may be compressed.
-          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_ENABLECOMPRESSION
-          # enableCompression: false
+          # When set to an algorithm such as 'zstd', enables compression of backup contents.
+          # When not set or set to 'none', backup content is not compressed.
+          # Enabling compression reduces the required storage space for backups in S3 but also
+          # increases the impact on CPU and disk utilization while taking a backup.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_COMPRESSION
+          # compression: none
 
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -218,6 +218,10 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_FORCEPATHSTYLEACCESS
           # forcePathStyleAccess: false
 
+          # When enabled, parts of the backup may be compressed.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_ENABLECOMPRESSION
+          # enableCompression: false
+
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
 

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -218,9 +218,12 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_FORCEPATHSTYLEACCESS
           # forcePathStyleAccess: false
 
-          # When enabled, parts of the backup may be compressed.
-          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_ENABLECOMPRESSION
-          # enableCompression: false
+          # When set to an algorithm such as 'zstd', enables compression of backup contents.
+          # When not set or set to 'none', backup content is not compressed.
+          # Enabling compression reduces the required storage space for backups in S3 but also
+          # increases the impact on CPU and disk utilization while taking a backup.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_COMPRESSION
+          # compression: none
 
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster

--- a/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
@@ -48,7 +48,8 @@ final class BackupStoreComponent {
               s3Config.getAccessKey(),
               s3Config.getSecretKey(),
               s3Config.getApiCallTimeout(),
-              s3Config.isForcePathStyleAccess());
+              s3Config.isForcePathStyleAccess(),
+              s3Config.isEnableCompression());
       return new S3BackupStore(storeConfig);
     } else {
       throw new IllegalArgumentException(

--- a/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.restore;
 
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupConfig;
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg;
@@ -41,15 +42,15 @@ final class BackupStoreComponent {
     if (store == BackupStoreType.S3) {
       final var s3Config = backupCfg.getS3();
       final S3BackupConfig storeConfig =
-          S3BackupConfig.from(
-              s3Config.getBucketName(),
-              s3Config.getEndpoint(),
-              s3Config.getRegion(),
-              s3Config.getAccessKey(),
-              s3Config.getSecretKey(),
-              s3Config.getApiCallTimeout(),
-              s3Config.isForcePathStyleAccess(),
-              s3Config.isEnableCompression());
+          new Builder()
+              .withBucketName(s3Config.getBucketName())
+              .withEndpoint(s3Config.getEndpoint())
+              .withRegion(s3Config.getRegion())
+              .withCredentials(s3Config.getAccessKey(), s3Config.getSecretKey())
+              .withApiCallTimeout(s3Config.getApiCallTimeout())
+              .forcePathStyleAccess(s3Config.isForcePathStyleAccess())
+              .withCompressionAlgorithm(s3Config.getCompression())
+              .build();
       return new S3BackupStore(storeConfig);
     } else {
       throw new IllegalArgumentException(

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,6 +46,7 @@
     <version.commons-math>3.6.1</version.commons-math>
     <version.commons-codec>1.15</version.commons-codec>
     <version.commons-compress>1.22</version.commons-compress>
+    <version.zstd-jni>1.5.2-4</version.zstd-jni>
     <version.commons-text>1.10.0</version.commons-text>
     <version.cron-utils>9.2.0</version.cron-utils>
     <version.docker-java-api>3.2.13</version.docker-java-api>
@@ -1015,6 +1016,12 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
         <version>${version.commons-compress}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.luben</groupId>
+        <artifactId>zstd-jni</artifactId>
+        <version>${version.zstd-jni}</version>
       </dependency>
 
       <!-- both hamcrest-core (deprecated in favor of hamcrest) and hamcrest are required for

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -45,8 +45,8 @@
     <version.commons-logging>1.2</version.commons-logging>
     <version.commons-math>3.6.1</version.commons-math>
     <version.commons-codec>1.15</version.commons-codec>
-    <version.commons-text>1.10.0</version.commons-text>
     <version.commons-compress>1.22</version.commons-compress>
+    <version.commons-text>1.10.0</version.commons-text>
     <version.cron-utils>9.2.0</version.cron-utils>
     <version.docker-java-api>3.2.13</version.docker-java-api>
     <version.elasticsearch>7.17.5</version.elasticsearch>
@@ -1011,7 +1011,6 @@
         <version>${version.commons-codec}</version>
       </dependency>
 
-      <!-- between testcontainers and zeebe-test-container -->
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupAcceptanceIT.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.it.backup;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.backup.s3.S3BackupConfig;
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.gateway.admin.backup.BackupStatus;
 import io.camunda.zeebe.gateway.admin.backup.PartitionBackupStatus;
@@ -94,15 +94,14 @@ final class BackupAcceptanceIT {
   @BeforeEach
   void beforeEach() {
     final var config =
-        S3BackupConfig.from(
-            bucketName,
-            minio.externalEndpoint(),
-            minio.region(),
-            minio.accessKey(),
-            minio.secretKey(),
-            Duration.ofSeconds(25),
-            true,
-            false);
+        new Builder()
+            .withBucketName(bucketName)
+            .withEndpoint(minio.externalEndpoint())
+            .withRegion(minio.region())
+            .withCredentials(minio.accessKey(), minio.secretKey())
+            .withApiCallTimeout(Duration.ofSeconds(25))
+            .forcePathStyleAccess(true)
+            .build();
     store = new S3BackupStore(config);
 
     try (final var client = S3BackupStore.buildClient(config)) {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupAcceptanceIT.java
@@ -101,7 +101,8 @@ final class BackupAcceptanceIT {
             minio.accessKey(),
             minio.secretKey(),
             Duration.ofSeconds(25),
-            true);
+            true,
+            false);
     store = new S3BackupStore(config);
 
     try (final var client = S3BackupStore.buildClient(config)) {

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupMultiPartitionTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupMultiPartitionTest.java
@@ -114,7 +114,8 @@ class BackupMultiPartitionTest {
             S3.accessKey(),
             S3.secretKey(),
             Duration.ofSeconds(15),
-            true);
+            true,
+            false);
     s3BackupStore = new S3BackupStore(s3ClientConfig);
     try (final var s3Client = S3BackupStore.buildClient(s3ClientConfig)) {
       s3Client.createBucket(builder -> builder.bucket(bucketName).build()).join();

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupMultiPartitionTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupMultiPartitionTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.it.backup;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.backup.s3.S3BackupConfig;
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
@@ -107,15 +108,14 @@ class BackupMultiPartitionTest {
   void createBackupStoreForTest() {
     // Create bucket before for storing backups
     s3ClientConfig =
-        S3BackupConfig.from(
-            bucketName,
-            S3.externalEndpoint(),
-            S3.region(),
-            S3.accessKey(),
-            S3.secretKey(),
-            Duration.ofSeconds(15),
-            true,
-            false);
+        new Builder()
+            .withBucketName(bucketName)
+            .withEndpoint(S3.externalEndpoint())
+            .withRegion(S3.region())
+            .withCredentials(S3.accessKey(), S3.secretKey())
+            .withApiCallTimeout(Duration.ofSeconds(15))
+            .forcePathStyleAccess(true)
+            .build();
     s3BackupStore = new S3BackupStore(s3ClientConfig);
     try (final var s3Client = S3BackupStore.buildClient(s3ClientConfig)) {
       s3Client.createBucket(builder -> builder.bucket(bucketName).build()).join();

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupReplicatedPartitionTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupReplicatedPartitionTest.java
@@ -83,7 +83,8 @@ class BackupReplicatedPartitionTest {
             S3.accessKey(),
             S3.secretKey(),
             Duration.ofSeconds(15),
-            true);
+            true,
+            false);
     try (final var s3Client = S3BackupStore.buildClient(s3ClientConfig)) {
       s3Client.createBucket(builder -> builder.bucket(bucketName).build()).join();
     }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupReplicatedPartitionTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupReplicatedPartitionTest.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.it.backup;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.backup.s3.S3BackupConfig;
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
@@ -76,15 +76,14 @@ class BackupReplicatedPartitionTest {
     backupRequestHandler = new BackupRequestHandler(clusteringRule.getGateway().getBrokerClient());
     // Create bucket before for storing backups
     final var s3ClientConfig =
-        S3BackupConfig.from(
-            bucketName,
-            S3.externalEndpoint(),
-            S3.region(),
-            S3.accessKey(),
-            S3.secretKey(),
-            Duration.ofSeconds(15),
-            true,
-            false);
+        new Builder()
+            .withBucketName(bucketName)
+            .withEndpoint(S3.externalEndpoint())
+            .withRegion(S3.region())
+            .withCredentials(S3.accessKey(), S3.secretKey())
+            .withApiCallTimeout(Duration.ofSeconds(15))
+            .forcePathStyleAccess(true)
+            .build();
     try (final var s3Client = S3BackupStore.buildClient(s3ClientConfig)) {
       s3Client.createBucket(builder -> builder.bucket(bucketName).build()).join();
     }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptanceIT.java
@@ -95,7 +95,8 @@ final class RestoreAcceptanceIT {
             MINIO.accessKey(),
             MINIO.secretKey(),
             Duration.ofSeconds(25),
-            true);
+            true,
+            false);
     try (final var client = S3BackupStore.buildClient(config)) {
       client.createBucket(cfg -> cfg.bucket(BUCKET_NAME)).join();
     }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptanceIT.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
-import io.camunda.zeebe.backup.s3.S3BackupConfig;
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.gateway.admin.backup.BackupStatus;
@@ -88,15 +88,14 @@ final class RestoreAcceptanceIT {
   @BeforeAll
   static void setupBucket() {
     final var config =
-        S3BackupConfig.from(
-            BUCKET_NAME,
-            MINIO.externalEndpoint(),
-            MINIO.region(),
-            MINIO.accessKey(),
-            MINIO.secretKey(),
-            Duration.ofSeconds(25),
-            true,
-            false);
+        new Builder()
+            .withBucketName(BUCKET_NAME)
+            .withEndpoint(MINIO.externalEndpoint())
+            .withRegion(MINIO.region())
+            .withCredentials(MINIO.accessKey(), MINIO.secretKey())
+            .withApiCallTimeout(Duration.ofSeconds(25))
+            .forcePathStyleAccess(true)
+            .build();
     try (final var client = S3BackupStore.buildClient(config)) {
       client.createBucket(cfg -> cfg.bucket(BUCKET_NAME)).join();
     }


### PR DESCRIPTION
Introduces a new configuration option for the S3 backup store: `ZEEBE_BROKER_DATA_BACKUP_S3_ENABLECOMPRESSION`. For now, this is disabled by default.

When enabled, files above a hard coded threshold (currently 8 MiB) are compressed with [Zstandard](https://github.com/facebook/zstd). We first compress to a temporary file before uploading. In-memory or streaming compression is impractical. For each file, the used compression algorithm is stored as metadata in the manifest.

On restore, files that have a compression algorithm stored in the metadata are downloaded to a temporary file and then decompressed to the actual target path.

Compression is handled by [commons-compress](https://commons.apache.org/proper/commons-compress/index.html) which provides a consistent interface for many compression algorithms. If we decide to change the default compression algorithm or make it configurable, restoring will use whatever algorithm was used to compress, thus achieving backwards compatibility. 

Currently, the compression algorithm is hard coded as Zstandard. This requires an additional dependency on the native wrapper library which provides the binaries for all supported architectures: https://github.com/luben/zstd-jni#binary-releases

## Alternatives
At first I considered archiving and compressing the entire backup or at least all segment and snapshot files together. However, this could easily exceed the current limitation of 5 GiB per file upload. It's not too bad though, because this way we can actually compress files in parallel and don't increase the peak disk usage by too much.

Another alternative was to implement this independently from the backup store and let the Zeebe broker handle compression. I believe handling it in the store itself makes more sense as some backends may have support for native compression. Additionally, letting the broker handle compression would again increase peak disk usage. Worst case, if backup content is not at all compressible, this could double the required disk size.

## Improvements

We should consider using a dedicated thread pool or another mechanism to control how many files are (de-)compressed in parallel. We don't have any data yet, but it is easy to imagine that doing a lot of compression in parallel could have a considerable impact on CPU usage, disk usage and disk I/O. 
Actually, it might make sense to use such a mechanism more broadly on parallel upload and download of files to also control the impact on network I/O. 

Some parts of the backup might not be very compressible. In particular, parts of the snapshot are already compressed by RocksDB. It might make sense to not even attempt to compress snapshot files.

closes #10846 