### PR TITLE
feat(exporter/elasticsearch): Add sequence to record template 

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -73,7 +73,7 @@ class ElasticsearchClient implements AutoCloseable {
     client.close();
   }
 
-  public void index(final Record<?> record) {
+  public void index(final Record<?> record, final RecordSequence recordSequence) {
     if (metrics == null) {
       metrics = new ElasticsearchMetrics(record.getPartitionId());
     }
@@ -83,7 +83,7 @@ class ElasticsearchClient implements AutoCloseable {
             indexRouter.indexFor(record),
             indexRouter.idFor(record),
             indexRouter.routingFor(record));
-    bulkIndexRequest.index(action, record);
+    bulkIndexRequest.index(action, record, recordSequence);
   }
 
   /**

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -22,8 +22,6 @@ import org.slf4j.LoggerFactory;
 
 public class ElasticsearchExporter implements Exporter {
 
-  public static final String ZEEBE_RECORD_TEMPLATE_JSON = "/zeebe-record-template.json";
-
   // by default, the bulk request may not be bigger than 100MB
   private static final int RECOMMENDED_MAX_BULK_MEMORY_LIMIT = 100 * 1024 * 1024;
 

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.time.Duration;
+import java.util.EnumMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +27,8 @@ public class ElasticsearchExporter implements Exporter {
   // by default, the bulk request may not be bigger than 100MB
   private static final int RECOMMENDED_MAX_BULK_MEMORY_LIMIT = 100 * 1024 * 1024;
 
+  private static final long INITIAL_RECORD_COUNTER = 0L;
+
   private Logger log = LoggerFactory.getLogger(getClass().getPackageName());
   private Controller controller;
   private ElasticsearchExporterConfiguration configuration;
@@ -33,6 +36,11 @@ public class ElasticsearchExporter implements Exporter {
 
   private long lastPosition = -1;
   private boolean indexTemplatesCreated;
+
+  /**
+   * Stores a counter per value type. The counter is used to create a sequence for a given record.
+   */
+  private final EnumMap<ValueType, Long> recordCountersByValueType = new EnumMap<>(ValueType.class);
 
   @Override
   public void configure(final Context context) {
@@ -79,12 +87,29 @@ public class ElasticsearchExporter implements Exporter {
       createIndexTemplates();
     }
 
-    client.index(record);
+    final var recordSequence = getNextRecordSequence(record);
+    client.index(record, recordSequence);
     lastPosition = record.getPosition();
 
     if (client.shouldFlush()) {
       flush();
     }
+    updateRecordCounters(record, recordSequence);
+  }
+
+  private RecordSequence getNextRecordSequence(final Record<?> record) {
+    final var valueType = record.getValueType();
+    final long recordCounter =
+        recordCountersByValueType.getOrDefault(valueType, INITIAL_RECORD_COUNTER);
+
+    final long nextCounter = recordCounter + 1;
+    return new RecordSequence(record.getPartitionId(), nextCounter);
+  }
+
+  private void updateRecordCounters(final Record<?> record, final RecordSequence recordSequence) {
+    final var valueType = record.getValueType();
+    final var counter = recordSequence.counter();
+    recordCountersByValueType.put(valueType, counter);
   }
 
   private void validate(final ElasticsearchExporterConfiguration configuration) {

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordSequence.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordSequence.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter;
+
+/**
+ * The record sequence is a combination of the partition id and the counter.
+ *
+ * <p>The Elasticsearch exporter puts the sequence together with the record in the index. It can be
+ * used to limit the number of records when reading from the index, for example, by using a range
+ * query.
+ *
+ * @param partitionId the partition id of the record
+ * @param counter the counter based on the record's value type
+ * @see <a href="https://github.com/camunda/zeebe/issues/10568">Related issue</a>
+ */
+public record RecordSequence(int partitionId, long counter) {
+
+  /**
+   * The record sequence is calculated based on the following formula.
+   *
+   * <pre>
+   *   ((long) partitionId << 51) + counter
+   * </pre>
+   *
+   * @return the record sequence
+   */
+  public long sequence() {
+    return ((long) partitionId << 51) + counter;
+  }
+}

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
@@ -41,6 +41,9 @@
         },
         "brokerVersion": {
           "type": "keyword"
+        },
+        "sequence": {
+          "type": "long"
         }
       }
     }

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -49,8 +49,8 @@ final class BulkIndexRequestTest {
             new BulkIndexAction("index2", "id2", "routing2"));
 
     // when
-    request.index(actions.get(0), records.get(0));
-    request.index(actions.get(1), records.get(1));
+    request.index(actions.get(0), records.get(0), recordSequence);
+    request.index(actions.get(1), records.get(1), recordSequence);
 
     // then
     final var expectedMemoryUsage =
@@ -67,8 +67,8 @@ final class BulkIndexRequestTest {
         List.of(
             new BulkIndexAction("index", "id", "routing"),
             new BulkIndexAction("index2", "id2", "routing2"));
-    request.index(actions.get(0), records.get(0));
-    request.index(actions.get(1), records.get(1));
+    request.index(actions.get(0), records.get(0), recordSequence);
+    request.index(actions.get(1), records.get(1), recordSequence);
 
     // when
     request.clear();
@@ -90,8 +90,8 @@ final class BulkIndexRequestTest {
       final var action = new BulkIndexAction("index", "id", "routing");
 
       // when - doesn't matter what the records are, if the metadata is the same we skip it
-      request.index(action, records.get(0));
-      request.index(action, records.get(1));
+      request.index(action, records.get(0), recordSequence);
+      request.index(action, records.get(1), recordSequence);
 
       // then
       assertThat(request.bulkOperations())
@@ -111,8 +111,8 @@ final class BulkIndexRequestTest {
               new BulkIndexAction("index2", "id2", "routing2"));
 
       // when
-      request.index(actions.get(0), records.get(0));
-      request.index(actions.get(1), records.get(1));
+      request.index(actions.get(0), records.get(0), recordSequence);
+      request.index(actions.get(1), records.get(1), recordSequence);
 
       // then
       assertThat(request.bulkOperations())
@@ -132,7 +132,7 @@ final class BulkIndexRequestTest {
       final var action = new BulkIndexAction("index", "id", "routing");
 
       // when
-      request.index(action, record);
+      request.index(action, record, recordSequence);
 
       // then
       final var operations = request.bulkOperations();
@@ -150,8 +150,8 @@ final class BulkIndexRequestTest {
           List.of(
               new BulkIndexAction("index", "id", "routing"),
               new BulkIndexAction("index2", "id2", "routing2"));
-      request.index(actions.get(0), records.get(0));
-      request.index(actions.get(1), records.get(1));
+      request.index(actions.get(0), records.get(0), recordSequence);
+      request.index(actions.get(1), records.get(1), recordSequence);
 
       // when
       final byte[] serializedBuffer;

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
@@ -41,6 +41,8 @@ final class ElasticsearchClientIT {
           .withEnv("xpack.security.authc.anonymous.roles", "superuser")
           .withEnv("xpack.security.authc.anonymous.authz_exception", "true");
 
+  private static final int PARTITION_ID = 1;
+
   private final ProtocolFactory recordFactory = new ProtocolFactory();
   private final ElasticsearchExporterConfiguration config =
       new ElasticsearchExporterConfiguration();
@@ -65,7 +67,7 @@ final class ElasticsearchClientIT {
             RestClientFactory.of(config),
             indexRouter,
             templateReader,
-            new ElasticsearchMetrics(1));
+            new ElasticsearchMetrics(PARTITION_ID));
   }
 
   @AfterEach
@@ -79,7 +81,7 @@ final class ElasticsearchClientIT {
     // date, which must be a positive number of milliseconds since the UNIX epoch
     final var invalidRecord =
         recordFactory.generateRecord(ValueType.VARIABLE, b -> b.withTimestamp(Long.MIN_VALUE));
-    client.index(invalidRecord);
+    client.index(invalidRecord, new RecordSequence(PARTITION_ID, 1));
     client.putComponentTemplate();
     client.putIndexTemplate(ValueType.VARIABLE);
 

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.time.Duration;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -36,6 +38,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 
 final class ElasticsearchExporterTest {
 
@@ -337,6 +340,159 @@ final class ElasticsearchExporterTest {
 
       // when - then
       assertThatCode(() -> exporter.configure(context)).isInstanceOf(ExporterException.class);
+    }
+  }
+
+  @Nested
+  final class RecordSequenceTest {
+
+    private static final int PARTITION_ID = 123;
+
+    @BeforeEach
+    void initExporter() {
+      exporter.configure(context);
+      exporter.open(controller);
+    }
+
+    @Test
+    void shouldIndexRecordWithSequence() {
+      // given
+      final var record = newRecord(PARTITION_ID, ValueType.PROCESS_INSTANCE);
+
+      // when
+      exporter.export(record);
+
+      // then
+      final var recordSequenceCaptor = ArgumentCaptor.forClass(RecordSequence.class);
+      verify(client).index(any(), recordSequenceCaptor.capture());
+
+      final var value = recordSequenceCaptor.getValue();
+
+      assertThat(value)
+          .describedAs("Expect that the record is indexed with a sequence")
+          .isNotNull();
+
+      assertThat(value.partitionId())
+          .describedAs("Expect that the partition id is equal to the record")
+          .isEqualTo(PARTITION_ID);
+
+      assertThat(value.counter()).describedAs("Expect that the counter starts at 1").isEqualTo(1);
+
+      assertThat(value.sequence())
+          .describedAs(
+              "Expect that the sequence is a combination of the partition id and the counter")
+          .isEqualTo(((long) PARTITION_ID << 51) + 1);
+    }
+
+    @Test
+    void shouldEncodePartitionIdInRecordSequence() {
+      // given
+      final int partitionId1 = 1;
+      final int partitionId2 = 2;
+      final int partitionId3 = 3;
+
+      final var records =
+          List.of(
+              newRecord(partitionId1, ValueType.PROCESS_INSTANCE),
+              newRecord(partitionId2, ValueType.PROCESS_INSTANCE),
+              newRecord(partitionId3, ValueType.PROCESS_INSTANCE),
+              newRecord(partitionId1, ValueType.PROCESS_INSTANCE));
+
+      // when
+      records.forEach(exporter::export);
+
+      // then
+      final var recordSequenceCaptor = ArgumentCaptor.forClass(RecordSequence.class);
+      verify(client, times(records.size())).index(any(), recordSequenceCaptor.capture());
+
+      assertThat(recordSequenceCaptor.getAllValues())
+          .extracting(RecordSequence::partitionId)
+          .containsExactly(partitionId1, partitionId2, partitionId3, partitionId1);
+    }
+
+    @Test
+    void shouldIncrementRecordCounterByValueType() {
+      // given
+      final var records =
+          List.of(
+              newRecord(PARTITION_ID, ValueType.PROCESS_INSTANCE),
+              newRecord(PARTITION_ID, ValueType.PROCESS_INSTANCE),
+              newRecord(PARTITION_ID, ValueType.VARIABLE),
+              newRecord(PARTITION_ID, ValueType.JOB),
+              newRecord(PARTITION_ID, ValueType.PROCESS_INSTANCE),
+              newRecord(PARTITION_ID, ValueType.JOB));
+
+      // when
+      records.forEach(exporter::export);
+
+      // then
+      final var recordSequenceCaptor = ArgumentCaptor.forClass(RecordSequence.class);
+      verify(client, times(records.size())).index(any(), recordSequenceCaptor.capture());
+
+      assertThat(recordSequenceCaptor.getAllValues())
+          .extracting(RecordSequence::counter)
+          .containsExactly(1L, 2L, 1L, 1L, 3L, 2L);
+    }
+
+    @Test
+    void shouldNotIncrementCounterOnIndexErrors() {
+      // given
+      final var record = newRecord(PARTITION_ID, ValueType.PROCESS_INSTANCE);
+
+      // when
+      doThrow(new ElasticsearchExporterException("failed to index"))
+          .when(client)
+          .index(any(), any());
+
+      assertThatCode(() -> exporter.export(record))
+          .isInstanceOf(ElasticsearchExporterException.class);
+
+      // retry index successfully
+      doNothing().when(client).index(any(), any());
+      exporter.export(record);
+
+      // then
+      final var recordSequenceCaptor = ArgumentCaptor.forClass(RecordSequence.class);
+      verify(client, times(2)).index(any(), recordSequenceCaptor.capture());
+
+      assertThat(recordSequenceCaptor.getAllValues())
+          .extracting(RecordSequence::counter)
+          .describedAs("Expect that the record counter is the same on retry")
+          .containsExactly(1L, 1L);
+    }
+
+    @Test
+    void shouldNotIncrementCounterOnFlushErrors() {
+      // given
+      when(client.shouldFlush()).thenReturn(true);
+
+      final var record = newRecord(PARTITION_ID, ValueType.PROCESS_INSTANCE);
+
+      // when
+      doThrow(new ElasticsearchExporterException("failed to flush")).when(client).flush();
+
+      assertThatCode(() -> exporter.export(record))
+          .isInstanceOf(ElasticsearchExporterException.class);
+
+      // retry flush successfully
+      doNothing().when(client).flush();
+      exporter.export(record);
+
+      // then
+      final var recordSequenceCaptor = ArgumentCaptor.forClass(RecordSequence.class);
+      verify(client, times(2)).index(any(), recordSequenceCaptor.capture());
+
+      assertThat(recordSequenceCaptor.getAllValues())
+          .extracting(RecordSequence::counter)
+          .describedAs("Expect that the record counter is the same on retry")
+          .containsExactly(1L, 1L);
+    }
+
+    private static Record<?> newRecord(final int partitionId, final ValueType valueType) {
+      return ImmutableRecord.builder()
+          .withPartitionId(partitionId)
+          .withValueType(valueType)
+          .build();
     }
   }
 }

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -160,7 +160,9 @@ final class ElasticsearchExporterTest {
       exporter.open(controller);
 
       // when
-      exporter.export(mock(Record.class));
+      final var recordMock = mock(Record.class);
+      when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+      exporter.export(recordMock);
 
       // then
       verify(client).putComponentTemplate();
@@ -174,7 +176,9 @@ final class ElasticsearchExporterTest {
       exporter.open(controller);
 
       // when
-      exporter.export(mock(Record.class));
+      final var recordMock = mock(Record.class);
+      when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+      exporter.export(recordMock);
 
       // then
       verify(client, never()).putComponentTemplate();
@@ -190,7 +194,9 @@ final class ElasticsearchExporterTest {
       exporter.open(controller);
 
       // when
-      exporter.export(mock(Record.class));
+      final var recordMock = mock(Record.class);
+      when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+      exporter.export(recordMock);
 
       // then
       verify(client, times(1)).putIndexTemplate(valueType);
@@ -206,7 +212,9 @@ final class ElasticsearchExporterTest {
       exporter.open(controller);
 
       // when
-      exporter.export(mock(Record.class));
+      final var recordMock = mock(Record.class);
+      when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+      exporter.export(recordMock);
 
       // then
       verify(client, never()).putIndexTemplate(valueType);
@@ -223,8 +231,11 @@ final class ElasticsearchExporterTest {
       when(client.shouldFlush()).thenReturn(false, true);
 
       // when
-      exporter.export(mock(Record.class));
-      exporter.export(mock(Record.class));
+      final var recordMock = mock(Record.class);
+      when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+
+      exporter.export(recordMock);
+      exporter.export(recordMock);
 
       // then
       verify(client, times(1)).flush();
@@ -260,7 +271,11 @@ final class ElasticsearchExporterTest {
     @Test
     void shouldUpdateLastExportedPositionOnFlush() {
       // given
-      final var record = ImmutableRecord.builder().withPosition(10L).build();
+      final var record =
+          ImmutableRecord.builder()
+              .withPosition(10L)
+              .withValueType(ValueType.PROCESS_INSTANCE)
+              .build();
       exporter.configure(context);
       exporter.open(controller);
       when(client.shouldFlush()).thenReturn(true);
@@ -275,7 +290,11 @@ final class ElasticsearchExporterTest {
     @Test
     void shouldNotUpdatePositionOnFlushErrors() {
       // given
-      final var record = ImmutableRecord.builder().withPosition(10L).build();
+      final var record =
+          ImmutableRecord.builder()
+              .withPosition(10L)
+              .withValueType(ValueType.PROCESS_INSTANCE)
+              .build();
       exporter.configure(context);
       exporter.open(controller);
       when(client.shouldFlush()).thenReturn(true);


### PR DESCRIPTION
## Description

Add a new property `sequence` to the general record template. It contains a number that is increased for each exported record grouped by its value type.

It can be used to limit the number of records when reading from the index. For example, by using a range query like `RangeQuery: last_imported_sequence < sequence <= last_imported_sequence + batch_size`.

## Related issues

part to #10568 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
