### PR TITLE
feat(engine): FEEL expressions for escalation events

### DIFF
--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractThrowEventBuilder.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractThrowEventBuilder.java
@@ -124,6 +124,16 @@ public abstract class AbstractThrowEventBuilder<
   }
 
   /**
+   * Sets a dynamic escalation code for the escalation that is retrieved from the given expression
+   *
+   * @param escalationCodeExpression the expression for the escalation
+   * @return the builder object
+   */
+  public B escalationExpression(final String escalationCodeExpression) {
+    return escalation(asZeebeExpression(escalationCodeExpression));
+  }
+
+  /**
    * Sets an escalation definition for the given escalation code. If already an escalation with this
    * code exists it will be used, otherwise a new escalation is created.
    *

--- a/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEscalationValidationTest.java
+++ b/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeEscalationValidationTest.java
@@ -313,4 +313,43 @@ class ZeebeEscalationValidationTest {
     ProcessValidationUtil.assertThatProcessHasViolations(
         process, expect(Escalation.class, "EscalationCode must be present and not empty"));
   }
+
+  @Test
+  @DisplayName("An escalation boundary event can not contain an expression")
+  void verifyEscalationCodeOfEscalationBoundaryEventCanNotContainAnExpression() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity("call", c -> c.zeebeProcessId("child"))
+            .boundaryEvent("catch", b -> b.escalation("= escalation").endEvent())
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            EscalationEventDefinition.class,
+            "The escalationCode of the escalation catch event is not allowed to be an expression"));
+  }
+
+  @Test
+  @DisplayName("An escalation start event can not contain an expression")
+  void verifyEscalationCodeOfEscalationStartEventCanNotContainAnExpression() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .eventSubProcess(
+                "sub", s -> s.startEvent("start").escalation("= escalation").endEvent())
+            .startEvent()
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            EscalationEventDefinition.class,
+            "The escalationCode of the escalation catch event is not allowed to be an expression"));
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
-import static io.camunda.zeebe.util.EnsureUtil.ensureNotNull;
 import static io.camunda.zeebe.util.EnsureUtil.ensureNotNullOrEmpty;
 
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
@@ -15,7 +14,6 @@ import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
-import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEscalation;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.analyzers.CatchEventAnalyzer;
@@ -132,17 +130,15 @@ public final class BpmnEventPublicationBehavior {
    * wasn't interrupted, etc.
    *
    * @param throwElementId the element id of the escalation throw event
-   * @param escalation the escalation of throw event
+   * @param escalationCode the escalation code of escalation
    * @param context process instance-related data of the element that is executed
    * @return returns true if the escalation throw event can be completed, false otherwise
    */
   public boolean throwEscalationEvent(
       final DirectBuffer throwElementId,
-      final ExecutableEscalation escalation,
+      final DirectBuffer escalationCode,
       final BpmnElementContext context) {
-    ensureNotNull("escalation", escalation);
 
-    final var escalationCode = escalation.getEscalationCode();
     ensureNotNullOrEmpty("escalationCode", escalationCode);
 
     final var record = new EscalationRecord();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableEscalation.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableEscalation.java
@@ -7,22 +7,41 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
+import io.camunda.zeebe.el.Expression;
+import java.util.Optional;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public class ExecutableEscalation extends AbstractFlowElement {
 
-  private final DirectBuffer escalationCode = new UnsafeBuffer();
+  private DirectBuffer escalationCode;
+  private Expression escalationCodeExpression;
 
   public ExecutableEscalation(final String id) {
     super(id);
   }
 
-  public DirectBuffer getEscalationCode() {
-    return escalationCode;
+  /**
+   * Returns the escalation code, if it has been resolved previously (and is independent of the
+   * variable context). If this returns an empty {@code Optional} then the escalation code must be
+   * resolved by evaluating {@code getEscalationCodeExpression()}
+   *
+   * @return the escalation code, if it has been resolved previously (and is independent of the
+   *     variable context)
+   */
+  public Optional<DirectBuffer> getEscalationCode() {
+    return Optional.ofNullable(escalationCode);
   }
 
   public void setEscalationCode(final DirectBuffer escalationCode) {
-    this.escalationCode.wrap(escalationCode);
+    this.escalationCode = new UnsafeBuffer(escalationCode);
+  }
+
+  public Expression getEscalationCodeExpression() {
+    return escalationCodeExpression;
+  }
+
+  public void setEscalationCodeExpression(final Expression escalationCodeExpression) {
+    this.escalationCodeExpression = escalationCodeExpression;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/analyzers/CatchEventAnalyzer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/analyzers/CatchEventAnalyzer.java
@@ -207,7 +207,12 @@ public final class CatchEventAnalyzer {
 
   public boolean matchesEscalationCode(
       final ExecutableCatchEvent catchEvent, final DirectBuffer escalationCode) {
-    final var eventEscalationCode = catchEvent.getEscalation().getEscalationCode();
+    final var eventEscalationCodeOptional = catchEvent.getEscalation().getEscalationCode();
+    // Because a catch event can not contain an expression, we ignore it if not set.
+    if (eventEscalationCodeOptional.isEmpty()) {
+      return false;
+    }
+    final var eventEscalationCode = eventEscalationCodeOptional.get();
     return eventEscalationCode.capacity() == 0 || eventEscalationCode.equals(escalationCode);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/EscalationIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/EscalationIncidentTest.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class EscalationIncidentTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "wf";
+  private static final String ESCALATION_CODE = "ESCALATION";
+  private static final String THROW_ELEMENT_ID = "throw";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCreateIncidentIfEscalationCodeExpressionOfEndEventCannotBeEvaluated() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .endEvent(THROW_ELEMENT_ID, i -> i.escalationExpression("escalationCodeLookup"))
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<IncidentRecordValue> incidentEvent =
+        RecordingExporter.incidentRecords()
+            .withIntent(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    final var endEvent =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.END_EVENT)
+            .getFirst();
+
+    Assertions.assertThat(incidentEvent.getValue())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "failed to evaluate expression 'escalationCodeLookup': no variable found for name 'escalationCodeLookup'")
+        .hasBpmnProcessId(endEvent.getValue().getBpmnProcessId())
+        .hasProcessDefinitionKey(endEvent.getValue().getProcessDefinitionKey())
+        .hasProcessInstanceKey(endEvent.getValue().getProcessInstanceKey())
+        .hasElementId(endEvent.getValue().getElementId())
+        .hasElementInstanceKey(endEvent.getKey())
+        .hasJobKey(-1)
+        .hasVariableScopeKey(endEvent.getKey());
+  }
+
+  @Test
+  public void shouldCreateIncidentIfEscalationCodeExpressionOfEndEventEvaluatesToWrongType() {
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .endEvent(THROW_ELEMENT_ID, i -> i.escalationExpression("escalationCodeLookup"))
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("escalationCodeLookup", 25)
+            .create();
+
+    final Record<ProcessInstanceRecordValue> failureEvent =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementId(THROW_ELEMENT_ID)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // then
+    final Record<IncidentRecordValue> incidentRecord =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(incidentRecord.getValue())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "Expected result of the expression 'escalationCodeLookup' to be 'STRING', but was 'NUMBER'.")
+        .hasBpmnProcessId(PROCESS_ID)
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasElementId(THROW_ELEMENT_ID)
+        .hasElementInstanceKey(failureEvent.getKey())
+        .hasJobKey(-1L)
+        .hasVariableScopeKey(failureEvent.getKey());
+  }
+
+  @Test
+  public void
+      shouldCreateIncidentIfEscalationCodeExpressionOfIntermediateEscalationEventCannotBeEvaluated() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .intermediateThrowEvent(
+                THROW_ELEMENT_ID, i -> i.escalationExpression("escalationCodeLookup"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<IncidentRecordValue> incidentEvent =
+        RecordingExporter.incidentRecords()
+            .withIntent(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    final var intermediateThrowEvent =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.INTERMEDIATE_THROW_EVENT)
+            .getFirst();
+
+    Assertions.assertThat(incidentEvent.getValue())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "failed to evaluate expression 'escalationCodeLookup': no variable found for name 'escalationCodeLookup'")
+        .hasBpmnProcessId(intermediateThrowEvent.getValue().getBpmnProcessId())
+        .hasProcessDefinitionKey(intermediateThrowEvent.getValue().getProcessDefinitionKey())
+        .hasProcessInstanceKey(intermediateThrowEvent.getValue().getProcessInstanceKey())
+        .hasElementId(intermediateThrowEvent.getValue().getElementId())
+        .hasElementInstanceKey(intermediateThrowEvent.getKey())
+        .hasJobKey(-1)
+        .hasVariableScopeKey(intermediateThrowEvent.getKey());
+  }
+
+  @Test
+  public void
+      shouldCreateIncidentIfEscalationCodeExpressionOfIntermediateEscalationEventEvaluatesToWrongType() {
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .intermediateThrowEvent(
+                THROW_ELEMENT_ID, i -> i.escalationExpression("escalationCodeLookup"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("escalationCodeLookup", 25)
+            .create();
+
+    final Record<ProcessInstanceRecordValue> failureEvent =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementId(THROW_ELEMENT_ID)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // then
+    final Record<IncidentRecordValue> incidentRecord =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(incidentRecord.getValue())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "Expected result of the expression 'escalationCodeLookup' to be 'STRING', but was 'NUMBER'.")
+        .hasBpmnProcessId(PROCESS_ID)
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasElementId(THROW_ELEMENT_ID)
+        .hasElementInstanceKey(failureEvent.getKey())
+        .hasJobKey(-1L)
+        .hasVariableScopeKey(failureEvent.getKey());
+  }
+
+  @Test
+  public void shouldResolveIncidentIfEscalationCodeOfEndEventCouldNotBeEvaluated() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .endEvent(THROW_ELEMENT_ID, i -> i.escalationExpression("escalationCodeLookup"))
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final Record<IncidentRecordValue> incidentCreatedRecord =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    ENGINE
+        .variables()
+        .ofScope(incidentCreatedRecord.getValue().getElementInstanceKey())
+        .withDocument(Map.of("escalationCodeLookup", ESCALATION_CODE))
+        .update();
+
+    // when
+    final Record<IncidentRecordValue> incidentResolvedEvent =
+        ENGINE
+            .incident()
+            .ofInstance(processInstanceKey)
+            .withKey(incidentCreatedRecord.getKey())
+            .resolve();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted()
+                .onlyEvents())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    assertThat(incidentResolvedEvent.getKey()).isEqualTo(incidentCreatedRecord.getKey());
+  }
+
+  @Test
+  public void
+      shouldResolveIncidentIfEscalationCodeOfIntermediateEscalationEventCouldNotBeEvaluated() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .intermediateThrowEvent(
+                THROW_ELEMENT_ID, i -> i.escalationExpression("escalationCodeLookup"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final Record<IncidentRecordValue> incidentCreatedRecord =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    ENGINE
+        .variables()
+        .ofScope(incidentCreatedRecord.getValue().getElementInstanceKey())
+        .withDocument(Map.of("escalationCodeLookup", ESCALATION_CODE))
+        .update();
+
+    // when
+    final Record<IncidentRecordValue> incidentResolvedEvent =
+        ENGINE
+            .incident()
+            .ofInstance(processInstanceKey)
+            .withKey(incidentCreatedRecord.getKey())
+            .resolve();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted()
+                .onlyEvents())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(
+                BpmnElementType.INTERMEDIATE_THROW_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(
+                BpmnElementType.INTERMEDIATE_THROW_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    assertThat(incidentResolvedEvent.getKey()).isEqualTo(incidentCreatedRecord.getKey());
+  }
+}


### PR DESCRIPTION
## Description

This PR adds FEEL expression support to escalation events.

Supported escalation events:
* end event
* intermediate throw event

## Related issues

closes #10973 

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
