### PR TITLE
ci(smoke-test): multi-arch container smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,13 +172,17 @@ jobs:
         with:
           name: "unit tests"
   smoke-tests:
-    name: Smoke tests on ${{ matrix.os }}
+    name: Smoke tests ${{ matrix.os }} on ${{ matrix.arch }}
     timeout-minutes: 20
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ macos-latest, windows-latest, ubuntu-latest ]
+        arch: [ amd64 ]
+        include:
+          - os: ubuntu-latest
+            arch: arm64
     env:
       JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64M
     steps:
@@ -189,21 +193,36 @@ jobs:
           # setting up maven often times out on macOS
           maven: ${{ matrix.os != 'macos-latest' }}
       - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
         with:
           go: false
-          maven-extra-args: -am -pl qa/integration-tests -T1C
-      - name: Run smoke test
+          maven-extra-args: -T1C
+      - uses: ./.github/actions/build-docker
+        id: build-docker
+        # Currently only Linux runners support building docker images without further ado
+        if: ${{ runner.os == 'Linux' }}
+        with:
+          version: current-test
+          distball: ${{ steps.build-zeebe.outputs.distball }}
+          platforms: linux/${{ matrix.arch }}
+          push: false
+      - name: Run smoke test on ${{ matrix.arch }}
+        env:
+          DOCKER_DEFAULT_PLATFORM: linux/${{ matrix.arch }}
+          # For non Linux runners there is no container available for testing, see build-docker job
+          EXCLUDED_TEST_GROUPS: ${{ runner.os != 'Linux' && 'container' }}
         run: >
           mvn -B --no-snapshot-updates
           -DskipUTs -DskipChecks -Dsurefire.rerunFailingTestsCount=3
           -pl qa/integration-tests
           -P smoke-test,extract-flaky-tests
+          -D excludedGroups=$EXCLUDED_TEST_GROUPS
           verify
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
         if: always()
         with:
-          name: Smoke Tests ${{ matrix.os }}
+          name: Smoke Tests ${{ matrix.os }} on ${{ matrix.arch }}
   property-tests:
     name: Property Tests
     runs-on: [ self-hosted, linux, "16" ]

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/ContainerClusterSmokeIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/ContainerClusterSmokeIT.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.smoke;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.zeebe.containers.cluster.ZeebeCluster;
+import java.util.concurrent.TimeUnit;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+final class ContainerClusterSmokeIT {
+
+  @Container
+  private final ZeebeCluster cluster =
+      ZeebeCluster.builder()
+          .withBrokersCount(1)
+          .withGatewaysCount(1)
+          .withPartitionsCount(1)
+          .withEmbeddedGateway(false)
+          .withImage(ZeebeTestContainerDefaults.defaultTestImage())
+          .build();
+
+  /** A smoke test which checks that a gateway of a cluster can be accessed. */
+  @ContainerSmokeTest
+  void connectSmokeTest() {
+    // given
+    try (final var client = cluster.newClientBuilder().build()) {
+      // when
+      final var topology = client.newTopologyRequest().send();
+
+      // then
+      final var result = topology.join(5L, TimeUnit.SECONDS);
+      assertThat(result.getBrokers()).as("There is one connected broker").hasSize(1);
+    }
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/ContainerSmokeTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/ContainerSmokeTest.java
@@ -11,6 +11,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
 
 /**
  * {@code @ContainerSmokeTest} is used to signal that the annotated method is a container based
@@ -19,5 +20,6 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
+@Tag("container")
 @SmokeTest
 public @interface ContainerSmokeTest {}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/ContainerSmokeTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/ContainerSmokeTest.java
@@ -8,22 +8,16 @@
 package io.camunda.zeebe.it.smoke;
 
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 
 /**
- * {@code @SmokeTest} is used to signal that the annotated method is smoke test case.
- *
- * <p>A smoke test is simple test case that verifies whether the system starts properly by verifying
- * health indicators and/or by performing simple API interaction.
+ * {@code @ContainerSmokeTest} is used to signal that the annotated method is a container based
+ * smoke test case, a special kind of {@link @SmokeTest} that verifies the system running within
+ * containers.
  */
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-@Tag("smoke-test")
-@Test
-@Inherited
-public @interface SmokeTest {}
+@SmokeTest
+public @interface ContainerSmokeTest {}


### PR DESCRIPTION
## Description

Docker builds and smoke tests are only run on Linux machines as building docker containers on macOS and windows runners introduces complexity to the CI setup that we consider not worth the effort:
- macOS runners require the setup of [colima as a docker runtime](https://github.com/actions/runner-images/issues/6216) which adds another 1.5-2m to the runtime
- on macOS testcontainers failed to detect the docker environment unless [additional environment variables](https://www.testcontainers.org/features/configuration/#customizing-docker-host-detection) have been set 
- some docker related actions are not supported on windows runners like [`docker/build-push-action`](https://github.com/docker/build-push-action/issues/18#issuecomment-629987132)
- the docker setup on Githubs windows runners seems to be bound to the `windows/amd64` platform, see e.g. this [log](https://github.com/camunda/zeebe/actions/runs/3500015748/jobs/5862231609)

Usage of native arm64 runners is listed as a separate sub-task on #10986.


## Related issues

closes #11020

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
