### PR TITLE
build(.github): fix picking the minor version branch

### DIFF
--- a/.github/workflows/daily-qa.yml
+++ b/.github/workflows/daily-qa.yml
@@ -32,15 +32,15 @@ jobs:
       - uses: actions/checkout@v3
       - run: git fetch --tags
       - run: |
-          latest=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -Vr | head -n1)
-          previous=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | grep -Ev "^${latest%\.[0-9]}.*$" | sort -Vr | head -n1)
+          latest=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sed -E -e 's/\.[0-9]+$//' | sort -Vr | head -n1)
+          previous=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sed -E -e 's/\.[0-9]+$//' | grep -v "${latest}" | sort -Vr | head -n1)
           if [ ! -z $latest ] && [ ! -z $previous ]; then
             echo "Successfully computed latest versions: ${latest} and ${previous}"
           else
             echo "Failed to compute latest versions"
           fi
-          echo "LATEST_VERSION=${latest%\.[0-9]+}" >> $GITHUB_ENV
-          echo "PREVIOUS_LATEST_VERSION=${previous%\.[0-9]+}" >> $GITHUB_ENV
+          echo "LATEST_VERSION=${latest}" >> $GITHUB_ENV
+          echo "PREVIOUS_LATEST_VERSION=${previous}" >> $GITHUB_ENV
   # Runs the qa-testbench workflow against the stable branches. It assumes that branches follow the
   # pattern of `stable/VERSION`, and generations of `Zeebe VERSION`.
   #
@@ -50,6 +50,8 @@ jobs:
     needs:
       - get-versions
     strategy:
+      # do not cancel other jobs if one fails
+      fail-fast: false
       matrix:
         branch:
           - 'main'

--- a/.github/workflows/qa-testbench.yaml
+++ b/.github/workflows/qa-testbench.yaml
@@ -28,7 +28,7 @@ on:
 env:
   BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
   GENERATION_TEMPLATE: ${{ inputs.generation }}
-  BRANCH: ${{ inputs.branch }}
+  BRANCH_NAME: ${{ inputs.branch }}
 
 jobs:
   qa-testbench:


### PR DESCRIPTION
## Description

This PR fixes picking the right minor version branch, and also disables the fail fast behavior of the matrix strategy, allowing specific QA jobs to keep going even if one fails.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
