### PR TITLE
refactor(engine): extract decision evaluation logic

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -9,9 +9,11 @@ package io.camunda.zeebe.engine.processing;
 
 import static io.camunda.zeebe.protocol.record.intent.DeploymentIntent.CREATE;
 
+import io.camunda.zeebe.dmn.DecisionEngineFactory;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviorsImpl;
+import io.camunda.zeebe.engine.processing.common.DecisionBehavior;
 import io.camunda.zeebe.engine.processing.deployment.DeploymentCreateProcessor;
 import io.camunda.zeebe.engine.processing.deployment.distribute.CompleteDeploymentDistributionProcessor;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributeProcessor;
@@ -69,6 +71,10 @@ public final class EngineProcessors {
     final var processEngineMetrics = new ProcessEngineMetrics(zeebeState.getPartitionId());
     final var sideEffectQueue = new SideEffectQueue();
 
+    final var decisionBehavior = new DecisionBehavior(
+        DecisionEngineFactory.createDecisionEngine(),
+        zeebeState,
+        processEngineMetrics);
     final BpmnBehaviorsImpl bpmnBehaviors =
         createBehaviors(
             zeebeState,
@@ -77,7 +83,7 @@ public final class EngineProcessors {
             partitionsCount,
             timerChecker,
             jobMetrics,
-            processEngineMetrics,
+            decisionBehavior,
             sideEffectQueue);
 
     addDeploymentRelatedProcessorAndServices(
@@ -121,14 +127,14 @@ public final class EngineProcessors {
       final int partitionsCount,
       final DueDateTimerChecker timerChecker,
       final JobMetrics jobMetrics,
-      final ProcessEngineMetrics processEngineMetrics,
+      final DecisionBehavior decisionBehavior,
       final SideEffectQueue sideEffectQueue) {
     return new BpmnBehaviorsImpl(
         sideEffectQueue,
         zeebeState,
         writers,
         jobMetrics,
-        processEngineMetrics,
+        decisionBehavior,
         subscriptionCommandSender,
         partitionsCount,
         timerChecker);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -71,10 +71,9 @@ public final class EngineProcessors {
     final var processEngineMetrics = new ProcessEngineMetrics(zeebeState.getPartitionId());
     final var sideEffectQueue = new SideEffectQueue();
 
-    final var decisionBehavior = new DecisionBehavior(
-        DecisionEngineFactory.createDecisionEngine(),
-        zeebeState,
-        processEngineMetrics);
+    final var decisionBehavior =
+        new DecisionBehavior(
+            DecisionEngineFactory.createDecisionEngine(), zeebeState, processEngineMetrics);
     final BpmnBehaviorsImpl bpmnBehaviors =
         createBehaviors(
             zeebeState,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
@@ -18,7 +18,7 @@ public interface BpmnBehaviors {
 
   ExpressionProcessor expressionBehavior();
 
-  BpmnDecisionBehavior decisionBehavior();
+  BpmnDecisionBehavior bpmnDecisionBehavior();
 
   BpmnVariableMappingBehavior variableMappingBehavior();
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -27,7 +27,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
   private final ExpressionProcessor expressionBehavior;
-  private final BpmnDecisionBehavior decisionBehavior;
+  private final BpmnDecisionBehavior bpmnDecisionBehavior;
   private final BpmnVariableMappingBehavior variableMappingBehavior;
   private final BpmnEventPublicationBehavior eventPublicationBehavior;
   private final BpmnEventSubscriptionBehavior eventSubscriptionBehavior;
@@ -76,7 +76,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
         new EventTriggerBehavior(
             zeebeState.getKeyGenerator(), catchEventBehavior, writers, zeebeState);
 
-    decisionBehavior =
+    bpmnDecisionBehavior =
         new BpmnDecisionBehavior(
             DecisionEngineFactory.createDecisionEngine(),
             zeebeState,
@@ -138,8 +138,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   }
 
   @Override
-  public BpmnDecisionBehavior decisionBehavior() {
-    return decisionBehavior;
+  public BpmnDecisionBehavior bpmnDecisionBehavior() {
+    return bpmnDecisionBehavior;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -7,12 +7,11 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
-import io.camunda.zeebe.dmn.DecisionEngineFactory;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
-import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.ProcessInstanceStateTransitionGuard;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
+import io.camunda.zeebe.engine.processing.common.DecisionBehavior;
 import io.camunda.zeebe.engine.processing.common.ElementActivationBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
@@ -49,7 +48,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final MutableZeebeState zeebeState,
       final Writers writers,
       final JobMetrics jobMetrics,
-      final ProcessEngineMetrics processEngineMetrics,
+      final DecisionBehavior decisionBehavior,
       final SubscriptionCommandSender subscriptionCommandSender,
       final int partitionsCount,
       final DueDateTimerChecker timerChecker) {
@@ -78,13 +77,12 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
     bpmnDecisionBehavior =
         new BpmnDecisionBehavior(
-            DecisionEngineFactory.createDecisionEngine(),
+            decisionBehavior,
             zeebeState,
             eventTriggerBehavior,
             writers.state(),
             zeebeState.getKeyGenerator(),
-            expressionBehavior,
-            processEngineMetrics);
+            expressionBehavior);
 
     stateBehavior = new BpmnStateBehavior(zeebeState, variableBehavior);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -7,56 +7,30 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
-import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
-
 import io.camunda.zeebe.dmn.DecisionEngine;
 import io.camunda.zeebe.dmn.DecisionEvaluationResult;
-import io.camunda.zeebe.dmn.EvaluatedDecision;
-import io.camunda.zeebe.dmn.EvaluatedInput;
-import io.camunda.zeebe.dmn.EvaluatedOutput;
-import io.camunda.zeebe.dmn.MatchedRule;
-import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
-import io.camunda.zeebe.dmn.impl.VariablesContext;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.engine.processing.common.DecisionBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCalledDecision;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
-import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
-import io.camunda.zeebe.engine.state.deployment.PersistedDecisionRequirements;
-import io.camunda.zeebe.engine.state.immutable.DecisionState;
-import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
-import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
-import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
-import io.camunda.zeebe.protocol.impl.record.value.decision.EvaluatedDecisionRecord;
-import io.camunda.zeebe.protocol.impl.record.value.decision.MatchedRuleRecord;
-import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
-import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.io.ByteArrayInputStream;
-import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
 
 /** Provides decision behavior to the BPMN processors */
 public final class BpmnDecisionBehavior {
 
-  private static final DecisionInfo UNKNOWN_DECISION_INFO = new DecisionInfo(-1L, -1);
-
-  private final DecisionEngine decisionEngine;
-  private final DecisionState decisionState;
+  private final DecisionBehavior decisionBehavior;
   private final EventTriggerBehavior eventTriggerBehavior;
-  private final VariableState variableState;
-  private final StateWriter stateWriter;
-  private final KeyGenerator keyGenerator;
   private final ExpressionProcessor expressionBehavior;
-  private final ProcessEngineMetrics metrics;
 
   public BpmnDecisionBehavior(
       final DecisionEngine decisionEngine,
@@ -66,14 +40,10 @@ public final class BpmnDecisionBehavior {
       final KeyGenerator keyGenerator,
       final ExpressionProcessor expressionBehavior,
       final ProcessEngineMetrics metrics) {
-    this.decisionEngine = decisionEngine;
-    decisionState = zeebeState.getDecisionState();
-    variableState = zeebeState.getVariableState();
+    decisionBehavior =
+        new DecisionBehavior(decisionEngine, zeebeState, metrics, stateWriter, keyGenerator);
     this.eventTriggerBehavior = eventTriggerBehavior;
-    this.stateWriter = stateWriter;
-    this.keyGenerator = keyGenerator;
     this.expressionBehavior = expressionBehavior;
-    this.metrics = metrics;
   }
 
   /**
@@ -93,40 +63,7 @@ public final class BpmnDecisionBehavior {
     }
 
     final var decisionId = decisionIdOrFailure.get();
-    // todo(#8571): avoid parsing drg every time
-    final var decisionOrFailure = findDecisionById(decisionId);
-    final var resultOrFailure =
-        decisionOrFailure
-            .flatMap(this::findDrgByDecision)
-            .mapLeft(
-                failure ->
-                    new Failure(
-                        "Expected to evaluate decision '%s', but %s"
-                            .formatted(decisionId, failure.getMessage())))
-            .flatMap(drg -> parseDrg(drg.getResource()))
-            // all the above failures have the same error type and the correct scope
-            .mapLeft(f -> new Failure(f.getMessage(), ErrorType.CALLED_DECISION_ERROR, scopeKey))
-            .flatMap(
-                drg -> {
-                  final var evaluationResult = evaluateDecisionInDrg(drg, decisionId, scopeKey);
-
-                  final var decision = decisionOrFailure.get();
-                  writeDecisionEvaluationEvent(decision, evaluationResult, context);
-
-                  if (evaluationResult.isFailure()) {
-                    metrics.increaseFailedEvaluatedDmnElements(
-                        evaluationResult.getEvaluatedDecisions().size());
-                    return Either.left(
-                        new Failure(
-                            evaluationResult.getFailureMessage(),
-                            ErrorType.DECISION_EVALUATION_ERROR,
-                            scopeKey));
-                  } else {
-                    metrics.increaseSuccessfullyEvaluatedDmnElements(
-                        evaluationResult.getEvaluatedDecisions().size());
-                    return Either.right(evaluationResult);
-                  }
-                });
+    final var resultOrFailure = decisionBehavior.evaluateDecision(decisionId, scopeKey, context);
 
     resultOrFailure.ifRight(
         result -> {
@@ -144,42 +81,6 @@ public final class BpmnDecisionBehavior {
   private Either<Failure, String> evalDecisionIdExpression(
       final ExecutableCalledDecision element, final long scopeKey) {
     return expressionBehavior.evaluateStringExpression(element.getDecisionId(), scopeKey);
-  }
-
-  private Either<Failure, PersistedDecision> findDecisionById(final String decisionId) {
-    return Either.ofOptional(
-            decisionState.findLatestDecisionById(BufferUtil.wrapString(decisionId)))
-        .orElse(new Failure("no decision found for id '%s'".formatted(decisionId)));
-  }
-
-  private Either<Failure, PersistedDecisionRequirements> findDrgByDecision(
-      final PersistedDecision decision) {
-    final var key = decision.getDecisionRequirementsKey();
-    final var id = decision.getDecisionRequirementsId();
-    return Either.ofOptional(decisionState.findDecisionRequirementsByKey(key))
-        .orElse(new Failure("no drg found for id '%s'".formatted(bufferAsString(id))));
-  }
-
-  private Either<Failure, ParsedDecisionRequirementsGraph> parseDrg(final DirectBuffer resource) {
-    return Either.<Failure, DirectBuffer>right(resource)
-        .map(BufferUtil::bufferAsArray)
-        .map(ByteArrayInputStream::new)
-        .map(decisionEngine::parse)
-        .flatMap(
-            parseResult -> {
-              if (parseResult.isValid()) {
-                return Either.right(parseResult);
-              } else {
-                return Either.left(new Failure(parseResult.getFailureMessage()));
-              }
-            });
-  }
-
-  private DecisionEvaluationResult evaluateDecisionInDrg(
-      final ParsedDecisionRequirementsGraph drg, final String decisionId, final long scopeKey) {
-    final var variables = variableState.getVariablesAsDocument(scopeKey);
-    final var evaluationContext = new VariablesContext(MsgPackConverter.convertToMap(variables));
-    return decisionEngine.evaluateDecisionById(drg, decisionId, evaluationContext);
   }
 
   private void triggerProcessEventWithResultVariable(
@@ -207,129 +108,7 @@ public final class BpmnDecisionBehavior {
     return resultBuffer;
   }
 
-  private void writeDecisionEvaluationEvent(
-      final PersistedDecision decision,
-      final DecisionEvaluationResult decisionResult,
-      final BpmnElementContext context) {
-
-    final var decisionEvaluationEvent =
-        new DecisionEvaluationRecord()
-            .setDecisionKey(decision.getDecisionKey())
-            .setDecisionId(decision.getDecisionId())
-            .setDecisionName(decision.getDecisionName())
-            .setDecisionVersion(decision.getVersion())
-            .setDecisionRequirementsKey(decision.getDecisionRequirementsKey())
-            .setDecisionRequirementsId(decision.getDecisionRequirementsId())
-            .setProcessDefinitionKey(context.getProcessDefinitionKey())
-            .setBpmnProcessId(context.getBpmnProcessId())
-            .setProcessInstanceKey(context.getProcessInstanceKey())
-            .setElementInstanceKey(context.getElementInstanceKey())
-            .setElementId(context.getElementId());
-
-    final var decisionKeysByDecisionId =
-        decisionState
-            .findDecisionsByDecisionRequirementsKey(decision.getDecisionRequirementsKey())
-            .stream()
-            .collect(
-                Collectors.toMap(
-                    persistedDecision -> bufferAsString(persistedDecision.getDecisionId()),
-                    DecisionInfo::new));
-
-    decisionResult
-        .getEvaluatedDecisions()
-        .forEach(
-            evaluatedDecision ->
-                addDecisionToEvaluationEvent(
-                    evaluatedDecision,
-                    decisionKeysByDecisionId.getOrDefault(
-                        evaluatedDecision.decisionId(), UNKNOWN_DECISION_INFO),
-                    decisionEvaluationEvent));
-
-    final DecisionEvaluationIntent decisionEvaluationIntent;
-    if (decisionResult.isFailure()) {
-      decisionEvaluationIntent = DecisionEvaluationIntent.FAILED;
-
-      decisionEvaluationEvent
-          .setEvaluationFailureMessage(decisionResult.getFailureMessage())
-          .setFailedDecisionId(decisionResult.getFailedDecisionId());
-    } else {
-      decisionEvaluationIntent = DecisionEvaluationIntent.EVALUATED;
-
-      decisionEvaluationEvent.setDecisionOutput(decisionResult.getOutput());
-    }
-
-    final var newDecisionEvaluationKey = keyGenerator.nextKey();
-    stateWriter.appendFollowUpEvent(
-        newDecisionEvaluationKey, decisionEvaluationIntent, decisionEvaluationEvent);
-  }
-
-  private void addDecisionToEvaluationEvent(
-      final EvaluatedDecision evaluatedDecision,
-      final DecisionInfo decisionInfo,
-      final DecisionEvaluationRecord decisionEvaluationEvent) {
-
-    final var evaluatedDecisionRecord = decisionEvaluationEvent.evaluatedDecisions().add();
-    evaluatedDecisionRecord
-        .setDecisionId(evaluatedDecision.decisionId())
-        .setDecisionName(evaluatedDecision.decisionName())
-        .setDecisionKey(decisionInfo.key())
-        .setDecisionVersion(decisionInfo.version())
-        .setDecisionType(evaluatedDecision.decisionType().name())
-        .setDecisionOutput(evaluatedDecision.decisionOutput());
-
-    evaluatedDecision
-        .evaluatedInputs()
-        .forEach(
-            evaluatedInput -> addInputToEvaluationEvent(evaluatedInput, evaluatedDecisionRecord));
-
-    evaluatedDecision
-        .matchedRules()
-        .forEach(
-            matchedRule -> addMatchedRuleToEvaluationEvent(matchedRule, evaluatedDecisionRecord));
-  }
-
-  private void addInputToEvaluationEvent(
-      final EvaluatedInput evaluatedInput, final EvaluatedDecisionRecord evaluatedDecisionRecord) {
-    final var inputRecord =
-        evaluatedDecisionRecord
-            .evaluatedInputs()
-            .add()
-            .setInputId(evaluatedInput.inputId())
-            .setInputValue(evaluatedInput.inputValue());
-
-    if (evaluatedInput.inputName() != null) {
-      inputRecord.setInputName(evaluatedInput.inputName());
-    }
-  }
-
-  private void addMatchedRuleToEvaluationEvent(
-      final MatchedRule matchedRule, final EvaluatedDecisionRecord evaluatedDecisionRecord) {
-
-    final var matchedRuleRecord = evaluatedDecisionRecord.matchedRules().add();
-    matchedRuleRecord.setRuleId(matchedRule.ruleId()).setRuleIndex(matchedRule.ruleIndex());
-
-    matchedRule
-        .evaluatedOutputs()
-        .forEach(evaluatedOutput -> addOutputToEvaluationEvent(evaluatedOutput, matchedRuleRecord));
-  }
-
-  private void addOutputToEvaluationEvent(
-      final EvaluatedOutput evaluatedOutput, final MatchedRuleRecord matchedRuleRecord) {
-    final var outputRecord =
-        matchedRuleRecord
-            .evaluatedOutputs()
-            .add()
-            .setOutputId(evaluatedOutput.outputId())
-            .setOutputValue(evaluatedOutput.outputValue());
-
-    if (evaluatedOutput.outputName() != null) {
-      outputRecord.setOutputName(evaluatedOutput.outputName());
-    }
-  }
-
-  private record DecisionInfo(long key, int version) {
-    DecisionInfo(final PersistedDecision persistedDecision) {
-      this(persistedDecision.getDecisionKey(), persistedDecision.getVersion());
-    }
+  public DecisionBehavior getDecisionBehavior() {
+    return decisionBehavior;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -74,15 +74,13 @@ public final class BpmnDecisionBehavior {
     final var decisionId = decisionIdOrFailure.get();
     final var decisionOrFailure = decisionBehavior.findDecisionById(decisionId);
     final Either<Failure, ParsedDecisionRequirementsGraph> drgOrFailure =
-        decisionOrFailure.flatMap(decision -> decisionBehavior.findAndParseDrgByDecision(decision));
-    if (drgOrFailure.isLeft()) {
-      // any failures above have the same error type and the correct scope
-      final Failure formattedFailure =
-          decisionBehavior.formatDecisionLookupFailure(drgOrFailure.getLeft(), decisionId);
-      // decisions invoked by business rule tasks have a different error type
-      return Either.left(
-          new Failure(formattedFailure.getMessage(), ErrorType.CALLED_DECISION_ERROR, scopeKey));
-    }
+        decisionOrFailure
+            .flatMap(decision -> decisionBehavior.findAndParseDrgByDecision(decision))
+            // any failures above have the same error type and the correct scope
+            // decisions invoked by business rule tasks have a different error type
+            .mapLeft(
+                failure ->
+                    new Failure(failure.getMessage(), ErrorType.CALLED_DECISION_ERROR, scopeKey));
 
     final var variables = variableState.getVariablesAsDocument(scopeKey);
     final var resultOrFailure =

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/BusinessRuleTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/BusinessRuleTaskProcessor.java
@@ -80,7 +80,7 @@ public final class BusinessRuleTaskProcessor
     public CalledDecisionBehavior(
         final BpmnBehaviors bpmnBehaviors,
         final BpmnStateTransitionBehavior stateTransitionBehavior) {
-      decisionBehavior = bpmnBehaviors.decisionBehavior();
+      decisionBehavior = bpmnBehaviors.bpmnDecisionBehavior();
       eventSubscriptionBehavior = bpmnBehaviors.eventSubscriptionBehavior();
       incidentBehavior = bpmnBehaviors.incidentBehavior();
       this.stateTransitionBehavior = stateTransitionBehavior;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -57,7 +57,8 @@ public class DecisionBehavior {
         .orElse(new Failure("no decision found for id '%s'".formatted(decisionId)));
   }
 
-  public Either<Failure, ParsedDecisionRequirementsGraph> findAndParseDrgByDecision(final PersistedDecision persistedDecision) {
+  public Either<Failure, ParsedDecisionRequirementsGraph> findAndParseDrgByDecision(
+      final PersistedDecision persistedDecision) {
     return Either.<Failure, PersistedDecision>right(persistedDecision)
         .flatMap(this::findDrgByDecision)
         .mapLeft(
@@ -77,8 +78,7 @@ public class DecisionBehavior {
   }
 
   public Tuple<DecisionEvaluationIntent, DecisionEvaluationRecord> createDecisionEvaluationEvent(
-      final PersistedDecision decision,
-      final DecisionEvaluationResult decisionResult) {
+      final PersistedDecision decision, final DecisionEvaluationResult decisionResult) {
 
     final var decisionEvaluationEvent =
         new DecisionEvaluationRecord()
@@ -126,8 +126,7 @@ public class DecisionBehavior {
 
   public void updateDecisionMetrics(final DecisionEvaluationResult evaluationResult) {
     if (evaluationResult.isFailure()) {
-      metrics.increaseFailedEvaluatedDmnElements(
-          evaluationResult.getEvaluatedDecisions().size());
+      metrics.increaseFailedEvaluatedDmnElements(evaluationResult.getEvaluatedDecisions().size());
     } else {
       metrics.increaseSuccessfullyEvaluatedDmnElements(
           evaluationResult.getEvaluatedDecisions().size());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.common;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.camunda.zeebe.dmn.DecisionEngine;
+import io.camunda.zeebe.dmn.DecisionEvaluationResult;
+import io.camunda.zeebe.dmn.EvaluatedDecision;
+import io.camunda.zeebe.dmn.EvaluatedInput;
+import io.camunda.zeebe.dmn.EvaluatedOutput;
+import io.camunda.zeebe.dmn.MatchedRule;
+import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
+import io.camunda.zeebe.dmn.impl.VariablesContext;
+import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
+import io.camunda.zeebe.engine.state.deployment.PersistedDecisionRequirements;
+import io.camunda.zeebe.engine.state.immutable.DecisionState;
+import io.camunda.zeebe.engine.state.immutable.VariableState;
+import io.camunda.zeebe.engine.state.immutable.ZeebeState;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.decision.EvaluatedDecisionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.decision.MatchedRuleRecord;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.io.ByteArrayInputStream;
+import java.util.stream.Collectors;
+import org.agrona.DirectBuffer;
+
+public class DecisionBehavior {
+
+  private static final DecisionInfo UNKNOWN_DECISION_INFO = new DecisionInfo(-1L, -1);
+  private final DecisionEngine decisionEngine;
+  private final DecisionState decisionState;
+  private final VariableState variableState;
+  private final ProcessEngineMetrics metrics;
+  private final StateWriter stateWriter;
+  private final KeyGenerator keyGenerator;
+
+  public DecisionBehavior(
+      final DecisionEngine decisionEngine,
+      final ZeebeState zeebeState,
+      final ProcessEngineMetrics metrics,
+      final StateWriter stateWriter,
+      final KeyGenerator keyGenerator) {
+    this.decisionEngine = decisionEngine;
+    decisionState = zeebeState.getDecisionState();
+    variableState = zeebeState.getVariableState();
+    this.metrics = metrics;
+    this.stateWriter = stateWriter;
+    this.keyGenerator = keyGenerator;
+  }
+
+  public Either<Failure, DecisionEvaluationResult> evaluateDecision(
+      final String decisionId, final long scopeKey, final BpmnElementContext bpmnContext) {
+
+    // todo(#8571): avoid parsing drg every time
+    final var decisionOrFailure = findDecisionById(decisionId);
+    final var resultOrFailure =
+        decisionOrFailure
+            .flatMap(this::findDrgByDecision)
+            .mapLeft(
+                failure ->
+                    new Failure(
+                        "Expected to evaluate decision '%s', but %s"
+                            .formatted(decisionId, failure.getMessage())))
+            .flatMap(drg -> parseDrg(drg.getResource()))
+            // all the above failures have the same error type and the correct scope
+            .mapLeft(f -> new Failure(f.getMessage(), ErrorType.CALLED_DECISION_ERROR, scopeKey))
+            .flatMap(
+                drg -> {
+                  final var evaluationResult = evaluateDecisionInDrg(drg, decisionId, scopeKey);
+
+                  final var decision = decisionOrFailure.get();
+                  writeDecisionEvaluationEvent(decision, evaluationResult, bpmnContext);
+
+                  if (evaluationResult.isFailure()) {
+                    metrics.increaseFailedEvaluatedDmnElements(
+                        evaluationResult.getEvaluatedDecisions().size());
+                    return Either.left(
+                        new Failure(
+                            evaluationResult.getFailureMessage(),
+                            ErrorType.DECISION_EVALUATION_ERROR,
+                            scopeKey));
+                  } else {
+                    metrics.increaseSuccessfullyEvaluatedDmnElements(
+                        evaluationResult.getEvaluatedDecisions().size());
+                    return Either.right(evaluationResult);
+                  }
+                });
+
+    return resultOrFailure;
+  }
+
+  private Either<Failure, PersistedDecision> findDecisionById(final String decisionId) {
+    return Either.ofOptional(
+            decisionState.findLatestDecisionById(BufferUtil.wrapString(decisionId)))
+        .orElse(new Failure("no decision found for id '%s'".formatted(decisionId)));
+  }
+
+  private Either<Failure, PersistedDecisionRequirements> findDrgByDecision(
+      final PersistedDecision decision) {
+    final var key = decision.getDecisionRequirementsKey();
+    final var id = decision.getDecisionRequirementsId();
+    return Either.ofOptional(decisionState.findDecisionRequirementsByKey(key))
+        .orElse(new Failure("no drg found for id '%s'".formatted(bufferAsString(id))));
+  }
+
+  private Either<Failure, ParsedDecisionRequirementsGraph> parseDrg(final DirectBuffer resource) {
+    return Either.<Failure, DirectBuffer>right(resource)
+        .map(BufferUtil::bufferAsArray)
+        .map(ByteArrayInputStream::new)
+        .map(decisionEngine::parse)
+        .flatMap(
+            parseResult -> {
+              if (parseResult.isValid()) {
+                return Either.right(parseResult);
+              } else {
+                return Either.left(new Failure(parseResult.getFailureMessage()));
+              }
+            });
+  }
+
+  private DecisionEvaluationResult evaluateDecisionInDrg(
+      final ParsedDecisionRequirementsGraph drg, final String decisionId, final long scopeKey) {
+    final var variables = variableState.getVariablesAsDocument(scopeKey);
+    final var evaluationContext = new VariablesContext(MsgPackConverter.convertToMap(variables));
+    return decisionEngine.evaluateDecisionById(drg, decisionId, evaluationContext);
+  }
+
+  private void writeDecisionEvaluationEvent(
+      final PersistedDecision decision,
+      final DecisionEvaluationResult decisionResult,
+      final BpmnElementContext bpmnContext) {
+
+    final var decisionEvaluationEvent =
+        new DecisionEvaluationRecord()
+            .setDecisionKey(decision.getDecisionKey())
+            .setDecisionId(decision.getDecisionId())
+            .setDecisionName(decision.getDecisionName())
+            .setDecisionVersion(decision.getVersion())
+            .setDecisionRequirementsKey(decision.getDecisionRequirementsKey())
+            .setDecisionRequirementsId(decision.getDecisionRequirementsId());
+
+    if (bpmnContext != null) {
+      decisionEvaluationEvent
+          .setProcessDefinitionKey(bpmnContext.getProcessDefinitionKey())
+          .setBpmnProcessId(bpmnContext.getBpmnProcessId())
+          .setProcessInstanceKey(bpmnContext.getProcessInstanceKey())
+          .setElementInstanceKey(bpmnContext.getElementInstanceKey())
+          .setElementId(bpmnContext.getElementId());
+    }
+
+    final var decisionKeysByDecisionId =
+        decisionState
+            .findDecisionsByDecisionRequirementsKey(decision.getDecisionRequirementsKey())
+            .stream()
+            .collect(
+                Collectors.toMap(
+                    persistedDecision -> bufferAsString(persistedDecision.getDecisionId()),
+                    DecisionInfo::new));
+
+    decisionResult
+        .getEvaluatedDecisions()
+        .forEach(
+            evaluatedDecision ->
+                addDecisionToEvaluationEvent(
+                    evaluatedDecision,
+                    decisionKeysByDecisionId.getOrDefault(
+                        evaluatedDecision.decisionId(), UNKNOWN_DECISION_INFO),
+                    decisionEvaluationEvent));
+
+    final DecisionEvaluationIntent decisionEvaluationIntent;
+    if (decisionResult.isFailure()) {
+      decisionEvaluationIntent = DecisionEvaluationIntent.FAILED;
+
+      decisionEvaluationEvent
+          .setEvaluationFailureMessage(decisionResult.getFailureMessage())
+          .setFailedDecisionId(decisionResult.getFailedDecisionId());
+    } else {
+      decisionEvaluationIntent = DecisionEvaluationIntent.EVALUATED;
+
+      decisionEvaluationEvent.setDecisionOutput(decisionResult.getOutput());
+    }
+
+    final var newDecisionEvaluationKey = keyGenerator.nextKey();
+    stateWriter.appendFollowUpEvent(
+        newDecisionEvaluationKey, decisionEvaluationIntent, decisionEvaluationEvent);
+  }
+
+  private void addDecisionToEvaluationEvent(
+      final EvaluatedDecision evaluatedDecision,
+      final DecisionInfo decisionInfo,
+      final DecisionEvaluationRecord decisionEvaluationEvent) {
+
+    final var evaluatedDecisionRecord = decisionEvaluationEvent.evaluatedDecisions().add();
+    evaluatedDecisionRecord
+        .setDecisionId(evaluatedDecision.decisionId())
+        .setDecisionName(evaluatedDecision.decisionName())
+        .setDecisionKey(decisionInfo.key())
+        .setDecisionVersion(decisionInfo.version())
+        .setDecisionType(evaluatedDecision.decisionType().name())
+        .setDecisionOutput(evaluatedDecision.decisionOutput());
+
+    evaluatedDecision
+        .evaluatedInputs()
+        .forEach(
+            evaluatedInput -> addInputToEvaluationEvent(evaluatedInput, evaluatedDecisionRecord));
+
+    evaluatedDecision
+        .matchedRules()
+        .forEach(
+            matchedRule -> addMatchedRuleToEvaluationEvent(matchedRule, evaluatedDecisionRecord));
+  }
+
+  private void addMatchedRuleToEvaluationEvent(
+      final MatchedRule matchedRule, final EvaluatedDecisionRecord evaluatedDecisionRecord) {
+
+    final var matchedRuleRecord = evaluatedDecisionRecord.matchedRules().add();
+    matchedRuleRecord.setRuleId(matchedRule.ruleId()).setRuleIndex(matchedRule.ruleIndex());
+
+    matchedRule
+        .evaluatedOutputs()
+        .forEach(evaluatedOutput -> addOutputToEvaluationEvent(evaluatedOutput, matchedRuleRecord));
+  }
+
+  private void addInputToEvaluationEvent(
+      final EvaluatedInput evaluatedInput, final EvaluatedDecisionRecord evaluatedDecisionRecord) {
+    final var inputRecord =
+        evaluatedDecisionRecord
+            .evaluatedInputs()
+            .add()
+            .setInputId(evaluatedInput.inputId())
+            .setInputValue(evaluatedInput.inputValue());
+
+    if (evaluatedInput.inputName() != null) {
+      inputRecord.setInputName(evaluatedInput.inputName());
+    }
+  }
+
+  private void addOutputToEvaluationEvent(
+      final EvaluatedOutput evaluatedOutput, final MatchedRuleRecord matchedRuleRecord) {
+    final var outputRecord =
+        matchedRuleRecord
+            .evaluatedOutputs()
+            .add()
+            .setOutputId(evaluatedOutput.outputId())
+            .setOutputValue(evaluatedOutput.outputValue());
+
+    if (evaluatedOutput.outputName() != null) {
+      outputRecord.setOutputName(evaluatedOutput.outputName());
+    }
+  }
+
+  private record DecisionInfo(long key, int version) {
+    DecisionInfo(final PersistedDecision persistedDecision) {
+      this(persistedDecision.getDecisionKey(), persistedDecision.getVersion());
+    }
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -54,12 +54,18 @@ public class DecisionBehavior {
   public Either<Failure, PersistedDecision> findDecisionById(final String decisionId) {
     return Either.ofOptional(
             decisionState.findLatestDecisionById(BufferUtil.wrapString(decisionId)))
-        .orElse(new Failure("no decision found for id '%s'".formatted(decisionId)));
+        .orElse(new Failure("no decision found for id '%s'".formatted(decisionId)))
+        .mapLeft(failure -> formatDecisionLookupFailure(failure, decisionId));
   }
 
   public Either<Failure, ParsedDecisionRequirementsGraph> findAndParseDrgByDecision(
       final PersistedDecision persistedDecision) {
-    return findDrgByDecision(persistedDecision).flatMap(drg -> parseDrg(drg.getResource()));
+    return findDrgByDecision(persistedDecision)
+        .flatMap(drg -> parseDrg(drg.getResource()))
+        .mapLeft(
+            failure ->
+                formatDecisionLookupFailure(
+                    failure, BufferUtil.bufferAsString(persistedDecision.getDecisionId())));
   }
 
   public Failure formatDecisionLookupFailure(final Failure failure, final String decisionId) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -59,14 +59,12 @@ public class DecisionBehavior {
 
   public Either<Failure, ParsedDecisionRequirementsGraph> findAndParseDrgByDecision(
       final PersistedDecision persistedDecision) {
-    return Either.<Failure, PersistedDecision>right(persistedDecision)
-        .flatMap(this::findDrgByDecision)
-        .mapLeft(
-            failure ->
-                new Failure(
-                    "Expected to evaluate decision '%s', but %s"
-                        .formatted(persistedDecision.getDecisionId(), failure.getMessage())))
-        .flatMap(drg -> parseDrg(drg.getResource()));
+    return findDrgByDecision(persistedDecision).flatMap(drg -> parseDrg(drg.getResource()));
+  }
+
+  public Failure formatDecisionLookupFailure(final Failure failure, final String decisionId) {
+    return new Failure(
+        "Expected to evaluate decision '%s', but %s".formatted(decisionId, failure.getMessage()));
   }
 
   public DecisionEvaluationResult evaluateDecisionInDrg(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -18,22 +18,18 @@ import io.camunda.zeebe.dmn.MatchedRule;
 import io.camunda.zeebe.dmn.ParsedDecisionRequirementsGraph;
 import io.camunda.zeebe.dmn.impl.VariablesContext;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
-import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecisionRequirements;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
-import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.engine.state.immutable.ZeebeState;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.EvaluatedDecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.MatchedRuleRecord;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
-import io.camunda.zeebe.protocol.record.value.ErrorType;
-import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.camunda.zeebe.util.collection.Tuple;
 import java.io.ByteArrayInputStream;
 import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
@@ -43,106 +39,46 @@ public class DecisionBehavior {
   private static final DecisionInfo UNKNOWN_DECISION_INFO = new DecisionInfo(-1L, -1);
   private final DecisionEngine decisionEngine;
   private final DecisionState decisionState;
-  private final VariableState variableState;
   private final ProcessEngineMetrics metrics;
-  private final StateWriter stateWriter;
-  private final KeyGenerator keyGenerator;
 
   public DecisionBehavior(
       final DecisionEngine decisionEngine,
       final ZeebeState zeebeState,
-      final ProcessEngineMetrics metrics,
-      final StateWriter stateWriter,
-      final KeyGenerator keyGenerator) {
-    this.decisionEngine = decisionEngine;
+      final ProcessEngineMetrics metrics) {
+
     decisionState = zeebeState.getDecisionState();
-    variableState = zeebeState.getVariableState();
+    this.decisionEngine = decisionEngine;
     this.metrics = metrics;
-    this.stateWriter = stateWriter;
-    this.keyGenerator = keyGenerator;
   }
 
-  public Either<Failure, DecisionEvaluationResult> evaluateDecision(
-      final String decisionId, final long scopeKey, final BpmnElementContext bpmnContext) {
-
-    // todo(#8571): avoid parsing drg every time
-    final var decisionOrFailure = findDecisionById(decisionId);
-    final var resultOrFailure =
-        decisionOrFailure
-            .flatMap(this::findDrgByDecision)
-            .mapLeft(
-                failure ->
-                    new Failure(
-                        "Expected to evaluate decision '%s', but %s"
-                            .formatted(decisionId, failure.getMessage())))
-            .flatMap(drg -> parseDrg(drg.getResource()))
-            // all the above failures have the same error type and the correct scope
-            .mapLeft(f -> new Failure(f.getMessage(), ErrorType.CALLED_DECISION_ERROR, scopeKey))
-            .flatMap(
-                drg -> {
-                  final var evaluationResult = evaluateDecisionInDrg(drg, decisionId, scopeKey);
-
-                  final var decision = decisionOrFailure.get();
-                  writeDecisionEvaluationEvent(decision, evaluationResult, bpmnContext);
-
-                  if (evaluationResult.isFailure()) {
-                    metrics.increaseFailedEvaluatedDmnElements(
-                        evaluationResult.getEvaluatedDecisions().size());
-                    return Either.left(
-                        new Failure(
-                            evaluationResult.getFailureMessage(),
-                            ErrorType.DECISION_EVALUATION_ERROR,
-                            scopeKey));
-                  } else {
-                    metrics.increaseSuccessfullyEvaluatedDmnElements(
-                        evaluationResult.getEvaluatedDecisions().size());
-                    return Either.right(evaluationResult);
-                  }
-                });
-
-    return resultOrFailure;
-  }
-
-  private Either<Failure, PersistedDecision> findDecisionById(final String decisionId) {
+  public Either<Failure, PersistedDecision> findDecisionById(final String decisionId) {
     return Either.ofOptional(
             decisionState.findLatestDecisionById(BufferUtil.wrapString(decisionId)))
         .orElse(new Failure("no decision found for id '%s'".formatted(decisionId)));
   }
 
-  private Either<Failure, PersistedDecisionRequirements> findDrgByDecision(
-      final PersistedDecision decision) {
-    final var key = decision.getDecisionRequirementsKey();
-    final var id = decision.getDecisionRequirementsId();
-    return Either.ofOptional(decisionState.findDecisionRequirementsByKey(key))
-        .orElse(new Failure("no drg found for id '%s'".formatted(bufferAsString(id))));
+  public Either<Failure, ParsedDecisionRequirementsGraph> findAndParseDrgByDecision(final PersistedDecision persistedDecision) {
+    return Either.<Failure, PersistedDecision>right(persistedDecision)
+        .flatMap(this::findDrgByDecision)
+        .mapLeft(
+            failure ->
+                new Failure(
+                    "Expected to evaluate decision '%s', but %s"
+                        .formatted(persistedDecision.getDecisionId(), failure.getMessage())))
+        .flatMap(drg -> parseDrg(drg.getResource()));
   }
 
-  private Either<Failure, ParsedDecisionRequirementsGraph> parseDrg(final DirectBuffer resource) {
-    return Either.<Failure, DirectBuffer>right(resource)
-        .map(BufferUtil::bufferAsArray)
-        .map(ByteArrayInputStream::new)
-        .map(decisionEngine::parse)
-        .flatMap(
-            parseResult -> {
-              if (parseResult.isValid()) {
-                return Either.right(parseResult);
-              } else {
-                return Either.left(new Failure(parseResult.getFailureMessage()));
-              }
-            });
-  }
-
-  private DecisionEvaluationResult evaluateDecisionInDrg(
-      final ParsedDecisionRequirementsGraph drg, final String decisionId, final long scopeKey) {
-    final var variables = variableState.getVariablesAsDocument(scopeKey);
+  public DecisionEvaluationResult evaluateDecisionInDrg(
+      final ParsedDecisionRequirementsGraph drg,
+      final String decisionId,
+      final DirectBuffer variables) {
     final var evaluationContext = new VariablesContext(MsgPackConverter.convertToMap(variables));
     return decisionEngine.evaluateDecisionById(drg, decisionId, evaluationContext);
   }
 
-  private void writeDecisionEvaluationEvent(
+  public Tuple<DecisionEvaluationIntent, DecisionEvaluationRecord> createDecisionEvaluationEvent(
       final PersistedDecision decision,
-      final DecisionEvaluationResult decisionResult,
-      final BpmnElementContext bpmnContext) {
+      final DecisionEvaluationResult decisionResult) {
 
     final var decisionEvaluationEvent =
         new DecisionEvaluationRecord()
@@ -152,15 +88,6 @@ public class DecisionBehavior {
             .setDecisionVersion(decision.getVersion())
             .setDecisionRequirementsKey(decision.getDecisionRequirementsKey())
             .setDecisionRequirementsId(decision.getDecisionRequirementsId());
-
-    if (bpmnContext != null) {
-      decisionEvaluationEvent
-          .setProcessDefinitionKey(bpmnContext.getProcessDefinitionKey())
-          .setBpmnProcessId(bpmnContext.getBpmnProcessId())
-          .setProcessInstanceKey(bpmnContext.getProcessInstanceKey())
-          .setElementInstanceKey(bpmnContext.getElementInstanceKey())
-          .setElementId(bpmnContext.getElementId());
-    }
 
     final var decisionKeysByDecisionId =
         decisionState
@@ -194,9 +121,40 @@ public class DecisionBehavior {
       decisionEvaluationEvent.setDecisionOutput(decisionResult.getOutput());
     }
 
-    final var newDecisionEvaluationKey = keyGenerator.nextKey();
-    stateWriter.appendFollowUpEvent(
-        newDecisionEvaluationKey, decisionEvaluationIntent, decisionEvaluationEvent);
+    return new Tuple<>(decisionEvaluationIntent, decisionEvaluationEvent);
+  }
+
+  public void updateDecisionMetrics(final DecisionEvaluationResult evaluationResult) {
+    if (evaluationResult.isFailure()) {
+      metrics.increaseFailedEvaluatedDmnElements(
+          evaluationResult.getEvaluatedDecisions().size());
+    } else {
+      metrics.increaseSuccessfullyEvaluatedDmnElements(
+          evaluationResult.getEvaluatedDecisions().size());
+    }
+  }
+
+  private Either<Failure, PersistedDecisionRequirements> findDrgByDecision(
+      final PersistedDecision decision) {
+    final var key = decision.getDecisionRequirementsKey();
+    final var id = decision.getDecisionRequirementsId();
+    return Either.ofOptional(decisionState.findDecisionRequirementsByKey(key))
+        .orElse(new Failure("no drg found for id '%s'".formatted(bufferAsString(id))));
+  }
+
+  private Either<Failure, ParsedDecisionRequirementsGraph> parseDrg(final DirectBuffer resource) {
+    return Either.<Failure, DirectBuffer>right(resource)
+        .map(BufferUtil::bufferAsArray)
+        .map(ByteArrayInputStream::new)
+        .map(decisionEngine::parse)
+        .flatMap(
+            parseResult -> {
+              if (parseResult.isValid()) {
+                return Either.right(parseResult);
+              } else {
+                return Either.left(new Failure(parseResult.getFailureMessage()));
+              }
+            });
   }
 
   private void addDecisionToEvaluationEvent(


### PR DESCRIPTION
## Description

Extract the Decision evaluation logic from the `BpmnDecisionBehavior` class into the `DecisionBehavior` class to make it reusable.

## Related issues

closes #11038 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
