### PR TITLE
Opt-in GMP via additional metrics label & disable collecting self-managed metrics

### DIFF
--- a/benchmarks/setup/cloud-default/starter.yaml
+++ b/benchmarks/setup/cloud-default/starter.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: starter
+        metrics: gmp
     spec:
       containers:
         - name: starter

--- a/benchmarks/setup/cloud-default/worker.yaml
+++ b/benchmarks/setup/cloud-default/worker.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: worker
+        metrics: gmp
     spec:
       containers:
         - name: worker

--- a/benchmarks/setup/default/starter.yaml
+++ b/benchmarks/setup/default/starter.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: starter
+        metrics: gmp
     spec:
       containers:
       - name: starter

--- a/benchmarks/setup/default/worker.yaml
+++ b/benchmarks/setup/default/worker.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: worker
+        metrics: gmp
     spec:
       containers:
       - name: worker

--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -60,6 +60,10 @@ zeebe:
     - name: ZEEBE_BROKER_EXPERIMENTAL_CONSISTENCYCHECKS_ENABLEFOREIGNKEYCHECKS
       value: "true"
 
+  # Enable metrics collections
+  podLabels:
+    metrics: gmp
+
   # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limitsS
   resources:
     limits:
@@ -104,6 +108,10 @@ zeebe-gateway:
       value: "true"
     - name: ZEEBE_GATEWAY_THREADS_MANAGEMENTTHREADS
       value: "1"
+
+  # Enable metrics collections
+  podLabels:
+    metrics: gmp
 
   # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
   resources:
@@ -168,7 +176,6 @@ elasticsearch:
       cpu: 3
       memory: 8Gi
 
-# PrometheusServiceMonitor configuration for the prometheus service monitor
+# Disable the service monitor as we use Google Managed Prometheus
 prometheusServiceMonitor:
-  # PrometheusServiceMonitor.enabled if true then a service monitor will be deployed, which allows a installed prometheus controller to scrape metrics from the broker pods
-  enabled: true
+  enabled: false


### PR DESCRIPTION
## Description

Prepare benchmarks to opt-in to collection for GMP via additional label. We need to add the label `metrics: gmp` to all pods/containers which we care about and want to monitor. See zeebe-io/infra#19 for more. Additionally, we disable collecting metrics for our self-managed Prometheus set up.

## Related issues

related to zeebe-io/infra#19

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
