### PR TITLE
feat: log details of cancelled transitions

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
@@ -109,6 +109,9 @@ public final class PartitionTransitionImpl implements PartitionTransition {
       ongoingTransitionFuture = currentTransitionFuture;
 
       final var ongoingTransition = currentTransition;
+
+      LOG.info(
+          "Cancel transition {} in favor of next transition {}", ongoingTransition, nextTransition);
       ongoingTransition.cancel();
     }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
@@ -109,9 +109,12 @@ public final class PartitionTransitionImpl implements PartitionTransition {
       ongoingTransitionFuture = currentTransitionFuture;
 
       final var ongoingTransition = currentTransition;
-
-      LOG.info(
-          "Cancel transition {} in favor of next transition {}", ongoingTransition, nextTransition);
+      if (!ongoingTransition.isCompleted()) {
+        LOG.info(
+            "Cancelling transition {} in favor of next transition {}",
+            ongoingTransition,
+            nextTransition);
+      }
       ongoingTransition.cancel();
     }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -167,6 +167,10 @@ final class PartitionTransitionProcess {
     cancelRequested = true;
   }
 
+  boolean isCompleted() {
+    return completed;
+  }
+
   @Override
   public String toString() {
     return "PartitionTransitionProcess{"

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -19,6 +19,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
 final class PartitionTransitionProcess {
@@ -164,5 +165,27 @@ final class PartitionTransitionProcess {
       LOG.info("Received cancel signal for transition to {} on term {}", role, term);
     }
     cancelRequested = true;
+  }
+
+  @Override
+  public String toString() {
+    return "PartitionTransitionProcess{"
+        + "term="
+        + term
+        + ", role="
+        + role
+        + ", cancelRequested="
+        + cancelRequested
+        + ", completed="
+        + completed
+        + ", stepsToPrepare=["
+        + stepsToPrepare.stream()
+            .map(PartitionTransitionStep::getName)
+            .collect(Collectors.joining(", "))
+        + "], pendingSteps=["
+        + pendingSteps.stream()
+            .map(PartitionTransitionStep::getName)
+            .collect(Collectors.joining(", "))
+        + "]}";
   }
 }


### PR DESCRIPTION
When one transition cancels another, we were only logging a generic "cancel" message. This was lacking context, specifically which transition causes a cancellation.

Here we add a `toString` implementation for `PartitionTransitionProcess` that shows term, role, status and the remaining steps. This is used in a new log statement that should provide us with the necessary context.