### PR TITLE
Fix boundary event connection in randomized tests

### DIFF
--- a/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BoundaryEventBuilder.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BoundaryEventBuilder.java
@@ -49,7 +49,7 @@ public class BoundaryEventBuilder {
             .boundaryEvent(boundaryEventId, b -> b.error(errorCode));
 
     if (errorEventHasTerminateEndEvent) {
-      return boundaryEventBuilder.endEvent().terminate().moveToNode(flowNodeId);
+      return boundaryEventBuilder.endEvent().terminate().moveToNode(decideNodeToMoveTo());
     } else {
       return boundaryEventBuilder.connectTo(joinGatewayId);
     }
@@ -67,10 +67,16 @@ public class BoundaryEventBuilder {
             .boundaryEvent(boundaryEventId, b -> b.timerWithDurationExpression(boundaryEventId));
 
     if (timerEventHasTerminateEndEvent) {
-      return boundaryEventBuilder.endEvent().terminate().moveToNode(flowNodeId);
+      return boundaryEventBuilder.endEvent().terminate().moveToNode(decideNodeToMoveTo());
     } else {
       return boundaryEventBuilder.connectTo(joinGatewayId);
     }
+  }
+
+  private String decideNodeToMoveTo() {
+    // If a join gateway has been created we have to make sure to move to this gateway, otherwise
+    // we would cause the task to get a second outgoing sequence flow.
+    return joinGatewayCreated ? joinGatewayId : flowNodeId;
   }
 
   public boolean timerEventHasTerminateEndEvent() {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
When a task contains 2 boundary event, of which the 2nd one is a terminate end event we'd move the process builder to the task. If the first boundary created a gateway we should move to the gateway instead.

By adding a small check to decide which node we should move to we can make sure we end up at the correct task to continue processing as expected.


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11072 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
