### PR TITLE
fix(engine): fix message transformer of extension elements

### DIFF
--- a/bpmn-model/revapi.json
+++ b/bpmn-model/revapi.json
@@ -64,6 +64,12 @@
           "old": "method void io.camunda.zeebe.model.bpmn.builder.ProcessBuilder::setEventSubProcessCoordinates(io.camunda.zeebe.model.bpmn.instance.bpmndi.BpmnShape)",
           "justification": "change the name to reuse for EventSubProcess and Link Events"
 
+        },
+        {
+          "ignore": true,
+          "code": "java.method.addedToInterface",
+          "new": "method java.util.Optional<T> io.camunda.zeebe.model.bpmn.Query<T extends org.camunda.bpm.model.xml.instance.ModelElementInstance>::findSingleResult()",
+          "justification": "add optional method findSingleResult() for the usage of get single result"
         }
       ]
     }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Query.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Query.java
@@ -17,6 +17,7 @@
 package io.camunda.zeebe.model.bpmn;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.camunda.bpm.model.xml.type.ModelElementType;
@@ -37,4 +38,6 @@ public interface Query<T extends ModelElementInstance> {
   <V extends ModelElementInstance> Query<V> filterByType(Class<V> elementClass);
 
   T singleResult();
+
+  Optional<T> findSingleResult();
 }

--- a/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/QueryImpl.java
+++ b/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/QueryImpl.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.model.bpmn.Query;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.camunda.bpm.model.xml.type.ModelElementType;
@@ -36,6 +37,7 @@ public class QueryImpl<T extends ModelElementInstance> implements Query<T> {
     this.collection = collection;
   }
 
+  @Override
   public Stream<T> stream() {
     return collection.stream();
   }
@@ -72,11 +74,21 @@ public class QueryImpl<T extends ModelElementInstance> implements Query<T> {
 
   @Override
   public T singleResult() {
-    if (collection.size() == 1) {
-      return collection.iterator().next();
+    final Optional<T> optionalSingleResult = findSingleResult();
+    if (optionalSingleResult.isPresent()) {
+      return optionalSingleResult.get();
     } else {
       throw new BpmnModelException(
           "Collection expected to have <1> entry but has <" + collection.size() + ">");
+    }
+  }
+
+  @Override
+  public Optional<T> findSingleResult() {
+    if (collection.size() == 1) {
+      return Optional.of(collection.iterator().next());
+    } else {
+      return Optional.empty();
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/MessageTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/MessageTransformer.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.transformation.Transf
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.Message;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeSubscription;
+import java.util.Optional;
 
 public final class MessageTransformer implements ModelElementTransformer<Message> {
 
@@ -35,12 +36,17 @@ public final class MessageTransformer implements ModelElementTransformer<Message
     final ExtensionElements extensionElements = element.getExtensionElements();
 
     if (extensionElements != null) {
-      final ZeebeSubscription subscription =
-          extensionElements.getElementsQuery().filterByType(ZeebeSubscription.class).singleResult();
-      final Expression correlationKeyExpression =
-          expressionLanguage.parseExpression(subscription.getCorrelationKey());
+      final Optional<ZeebeSubscription> subscription =
+          extensionElements
+              .getElementsQuery()
+              .filterByType(ZeebeSubscription.class)
+              .findSingleResult();
+      if (subscription.isPresent()) {
+        final Expression correlationKeyExpression =
+            expressionLanguage.parseExpression(subscription.get().getCorrelationKey());
 
-      executableElement.setCorrelationKeyExpression(correlationKeyExpression);
+        executableElement.setCorrelationKeyExpression(correlationKeyExpression);
+      }
     }
 
     if (element.getName() != null) {


### PR DESCRIPTION
## Description

Fix message transformer of extension elements for start event.

If a message start event has any extension elements, the error `BpmnModelException: Collection expected to have <1> entry but has <0>` occurs during the deployment.


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10962 
closes #8521 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
