### PR TITLE
Asynchronous LogStreamWriter#tryWrite

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -424,7 +424,6 @@
       <option name="DOWHILE_BRACE_FORCE" value="3" />
       <option name="WHILE_BRACE_FORCE" value="3" />
       <option name="FOR_BRACE_FORCE" value="3" />
-      <option name="PARENT_SETTINGS_INSTALLED" value="true" />
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />
         <option name="TAB_SIZE" value="2" />

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -26,6 +27,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import org.agrona.ExpandableArrayBuffer;
@@ -38,6 +40,7 @@ import org.mockito.ArgumentCaptor;
 
 @Execution(ExecutionMode.CONCURRENT)
 final class InterPartitionCommandReceiverTest {
+  private final TestConcurrencyControl executor = new TestConcurrencyControl();
 
   @Test
   void shouldWriteSentCommandToLogStream() {
@@ -55,7 +58,8 @@ final class InterPartitionCommandReceiverTest {
 
     final var logStreamWriter =
         mock(LogStreamRecordWriter.class, withSettings().defaultAnswer(Answers.RETURNS_SELF));
-    final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
+    doReturn(executor.completedFuture(1L)).when(logStreamWriter).tryWrite();
+    final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter, executor);
 
     // when
     receiver.handleMessage(new MemberId("0"), sentMessage);
@@ -80,7 +84,7 @@ final class InterPartitionCommandReceiverTest {
 
     final var logStreamWriter =
         mock(LogStreamRecordWriter.class, withSettings().defaultAnswer(Answers.RETURNS_SELF));
-    final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
+    final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter, executor);
 
     // when
     receiver.setDiskSpaceAvailable(false);
@@ -104,7 +108,8 @@ final class InterPartitionCommandReceiverTest {
 
     final var logStreamWriter =
         mock(LogStreamRecordWriter.class, withSettings().defaultAnswer(Answers.RETURNS_SELF));
-    final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
+    doReturn(executor.completedFuture(1L)).when(logStreamWriter).tryWrite();
+    final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter, executor);
 
     // when
     receiver.handleMessage(new MemberId("0"), sentMessage);
@@ -146,7 +151,8 @@ final class InterPartitionCommandReceiverTest {
 
     final var logStreamWriter =
         mock(LogStreamRecordWriter.class, withSettings().defaultAnswer(Answers.RETURNS_SELF));
-    final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
+    doReturn(executor.completedFuture(1L)).when(logStreamWriter).tryWrite();
+    final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter, executor);
 
     // when
     receiver.handleMessage(new MemberId("0"), sentMessage);
@@ -182,7 +188,8 @@ final class InterPartitionCommandReceiverTest {
 
     final var logStreamWriter =
         mock(LogStreamRecordWriter.class, withSettings().defaultAnswer(Answers.RETURNS_SELF));
-    final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
+    doReturn(executor.completedFuture(1L)).when(logStreamWriter).tryWrite();
+    final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter, executor);
 
     // when
     receiver.handleMessage(new MemberId("0"), sentMessage);
@@ -207,7 +214,8 @@ final class InterPartitionCommandReceiverTest {
 
     final var logStreamWriter =
         mock(LogStreamRecordWriter.class, withSettings().defaultAnswer(Answers.RETURNS_SELF));
-    final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
+    doReturn(executor.completedFuture(1L)).when(logStreamWriter).tryWrite();
+    final var receiver = new InterPartitionCommandReceiverImpl(logStreamWriter, executor);
 
     // when
     receiver.handleMessage(new MemberId("0"), sentMessage);

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -203,7 +203,7 @@ public class StreamProcessingComposite {
   private static final class WriteActor extends Actor {
     public ActorFuture<Long> submit(final LogStreamWriter writer) {
       final ActorFuture<Long> future = actor.createFuture();
-      actor.runOnCompletion(writer.tryWrite(), future);
+      actor.run(() -> actor.runOnCompletion(writer.tryWrite(), future));
       return future;
     }
   }

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/DispatcherClaimException.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/DispatcherClaimException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.logstreams.impl.log;
+
+import io.camunda.zeebe.util.exception.RecoverableException;
+
+public final class DispatcherClaimException extends RecoverableException {
+
+  public DispatcherClaimException(final String message) {
+    super(message);
+  }
+}

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchWriterImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchWriterImpl.java
@@ -213,7 +213,7 @@ final class LogStreamBatchWriterImpl implements LogStreamBatchWriter, LogEntryBu
     long position = claimBatchForEvents();
     if (position < 0) {
       return CompletableActorFuture.completedExceptionally(
-          new IllegalStateException("Failed to claim batch (result: %d)".formatted(position)));
+          new DispatcherClaimException("Failed to claim batch (result: %d)".formatted(position)));
     }
 
     try {

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamWriterImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamWriterImpl.java
@@ -125,7 +125,7 @@ final class LogStreamWriterImpl implements LogStreamRecordWriter {
     final long claimedPosition = claimLogEntry(valueLength, metadataLength);
     if (claimedPosition < 0) {
       return CompletableActorFuture.completedExceptionally(
-          new IllegalStateException(
+          new DispatcherClaimException(
               "Failed to claim batch (result: %d)".formatted(claimedPosition)));
     }
 

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamWriter.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamWriter.java
@@ -7,12 +7,14 @@
  */
 package io.camunda.zeebe.logstreams.log;
 
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+
 public interface LogStreamWriter {
 
   /**
    * Attempts to write the event to the underlying stream.
    *
-   * @return the event position or a negative value if fails to write the event
+   * @return the event position
    */
-  long tryWrite();
+  ActorFuture<Long> tryWrite();
 }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
@@ -100,7 +100,7 @@ final class LogStorageAppenderTest {
     final var latch = new CountDownLatch(1);
 
     // when
-    final var position = writer.event().valueWriter(value).done().tryWrite();
+    final var position = writer.event().valueWriter(value).done().tryWrite().join();
     logStorage.setPositionListener(i -> latch.countDown());
     scheduler.submitActor(appender).join();
 
@@ -126,7 +126,8 @@ final class LogStorageAppenderTest {
             .event()
             .valueWriter(values.get(1))
             .done()
-            .tryWrite();
+            .tryWrite()
+            .join();
     final var lowestPosition = highestPosition - 1;
     logStorage.setPositionListener(i -> latch.countDown());
     scheduler.submitActor(appender).join();
@@ -183,7 +184,7 @@ final class LogStorageAppenderTest {
     scheduler.submitActor(appender).join();
 
     // when
-    writer.event().valueWriter(value).done().event().valueWriter(value).done().tryWrite();
+    writer.event().valueWriter(value).done().event().valueWriter(value).done().tryWrite().join();
 
     // then
     Awaitility.await("until the actor has failed")

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchWriterImplTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchWriterImplTest.java
@@ -57,7 +57,7 @@ final class LogStreamBatchWriterImplTest {
     writer.event().value(value).metadata(metadata).done();
     final boolean canWriteAdditionalEvent =
         writer.canWriteAdditionalEvent(value.capacity() + metadata.capacity());
-    writer.event().value(value).metadata(metadata).done().tryWrite();
+    writer.event().value(value).metadata(metadata).done().tryWrite().join();
 
     // then
     verify(dispatcher, times(1)).canClaimFragmentBatch(expectedFragmentCount, expectedBatchLength);

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamWriterTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamWriterTest.java
@@ -74,7 +74,7 @@ public final class LogStreamWriterTest {
   @Test
   public void shouldReturnPositionOfWrittenEvent() {
     // when
-    final long position = writer.value(EVENT_VALUE).tryWrite();
+    final long position = writer.value(EVENT_VALUE).tryWrite().join();
 
     // then
     assertThat(position).isGreaterThan(0);
@@ -86,7 +86,7 @@ public final class LogStreamWriterTest {
   @Test
   public void shouldWriteEventWithValueBuffer() {
     // when
-    final long position = writer.value(EVENT_VALUE).tryWrite();
+    final long position = writer.value(EVENT_VALUE).tryWrite().join();
 
     // then
     final LoggedEvent event = getWrittenEvent(position);
@@ -100,7 +100,7 @@ public final class LogStreamWriterTest {
   @Test
   public void shouldWriteEventWithValueBufferPartially() {
     // when
-    final long position = writer.value(EVENT_VALUE, 1, 2).tryWrite();
+    final long position = writer.value(EVENT_VALUE, 1, 2).tryWrite().join();
 
     // then
     final LoggedEvent event = getWrittenEvent(position);
@@ -114,7 +114,8 @@ public final class LogStreamWriterTest {
   @Test
   public void shouldWriteEventWithValueWriter() {
     // when
-    final long position = writer.valueWriter(new DirectBufferWriter().wrap(EVENT_VALUE)).tryWrite();
+    final long position =
+        writer.valueWriter(new DirectBufferWriter().wrap(EVENT_VALUE)).tryWrite().join();
 
     // then
     final LoggedEvent event = getWrittenEvent(position);
@@ -128,7 +129,7 @@ public final class LogStreamWriterTest {
   @Test
   public void shouldWriteEventWithMetadataBuffer() {
     // when
-    final long position = writer.value(EVENT_VALUE).metadata(EVENT_METADATA).tryWrite();
+    final long position = writer.value(EVENT_VALUE).metadata(EVENT_METADATA).tryWrite().join();
 
     // then
     final LoggedEvent event = getWrittenEvent(position);
@@ -142,7 +143,8 @@ public final class LogStreamWriterTest {
   @Test
   public void shouldWriteEventWithMetadataBufferPartially() {
     // when
-    final long position = writer.value(EVENT_VALUE).metadata(EVENT_METADATA, 1, 2).tryWrite();
+    final long position =
+        writer.value(EVENT_VALUE).metadata(EVENT_METADATA, 1, 2).tryWrite().join();
 
     // then
     final LoggedEvent event = getWrittenEvent(position);
@@ -160,7 +162,8 @@ public final class LogStreamWriterTest {
         writer
             .value(EVENT_VALUE)
             .metadataWriter(new DirectBufferWriter().wrap(EVENT_METADATA))
-            .tryWrite();
+            .tryWrite()
+            .join();
 
     // then
     final LoggedEvent event = getWrittenEvent(position);
@@ -174,7 +177,7 @@ public final class LogStreamWriterTest {
   @Test
   public void shouldWriteEventWithKey() {
     // when
-    final long position = writer.key(123L).value(EVENT_VALUE).tryWrite();
+    final long position = writer.key(123L).value(EVENT_VALUE).tryWrite().join();
 
     // then
     assertThat(getWrittenEvent(position).getKey()).isEqualTo(123L);
@@ -183,12 +186,12 @@ public final class LogStreamWriterTest {
   @Test
   public void shouldWriteEventsWithDifferentWriters() {
     // given
-    final long firstPosition = writer.key(123L).value(EVENT_VALUE).tryWrite();
+    final long firstPosition = writer.key(123L).value(EVENT_VALUE).tryWrite().join();
 
     // when
     final SynchronousLogStream logStream = logStreamRule.getLogStream();
     writer = logStream.newLogStreamRecordWriter();
-    final long secondPosition = writer.key(124L).value(EVENT_VALUE).tryWrite();
+    final long secondPosition = writer.key(124L).value(EVENT_VALUE).tryWrite().join();
 
     // then
     assertThat(secondPosition).isGreaterThan(firstPosition);
@@ -199,7 +202,7 @@ public final class LogStreamWriterTest {
   @Test
   public void shouldCloseAllWritersAndWriteAgain() {
     // given
-    final long firstPosition = writer.key(123L).value(EVENT_VALUE).tryWrite();
+    final long firstPosition = writer.key(123L).value(EVENT_VALUE).tryWrite().join();
     writerRule.waitForPositionToBeWritten(firstPosition);
 
     // when
@@ -207,7 +210,7 @@ public final class LogStreamWriterTest {
 
     final SynchronousLogStream logStream = logStreamRule.getLogStream();
     writer = logStream.newLogStreamRecordWriter();
-    final long secondPosition = writer.key(124L).value(EVENT_VALUE).tryWrite();
+    final long secondPosition = writer.key(124L).value(EVENT_VALUE).tryWrite().join();
 
     // then
     assertThat(secondPosition).isGreaterThan(firstPosition);
@@ -217,7 +220,7 @@ public final class LogStreamWriterTest {
 
   @Test
   public void shouldWriteEventWithTimestamp() throws InterruptedException, ExecutionException {
-    final Callable<Long> doWrite = () -> writer.keyNull().value(EVENT_VALUE).tryWrite();
+    final Callable<Long> doWrite = () -> writer.keyNull().value(EVENT_VALUE).tryWrite().join();
 
     // given
     final long firstTimestamp = System.currentTimeMillis();
@@ -245,7 +248,7 @@ public final class LogStreamWriterTest {
   @Test
   public void shouldWriteEventWithSourceEvent() {
     // when
-    final long position = writer.value(EVENT_VALUE).sourceRecordPosition(123L).tryWrite();
+    final long position = writer.value(EVENT_VALUE).sourceRecordPosition(123L).tryWrite().join();
 
     // then
     final LoggedEvent event = getWrittenEvent(position);
@@ -255,7 +258,7 @@ public final class LogStreamWriterTest {
   @Test
   public void shouldWriteEventWithoutSourceEvent() {
     // when
-    final long position = writer.value(EVENT_VALUE).tryWrite();
+    final long position = writer.value(EVENT_VALUE).tryWrite().join();
 
     // then
     final LoggedEvent event = getWrittenEvent(position);
@@ -265,7 +268,7 @@ public final class LogStreamWriterTest {
   @Test
   public void shouldWriteEventWithNullKey() {
     // when
-    final long position = writer.keyNull().value(EVENT_VALUE).tryWrite();
+    final long position = writer.keyNull().value(EVENT_VALUE).tryWrite().join();
 
     // then
     assertThat(getWrittenEvent(position).getKey()).isEqualTo(LogEntryDescriptor.KEY_NULL_VALUE);
@@ -274,7 +277,7 @@ public final class LogStreamWriterTest {
   @Test
   public void shouldWriteNullKeyByDefault() {
     // when
-    final long position = writer.value(EVENT_VALUE).tryWrite();
+    final long position = writer.value(EVENT_VALUE).tryWrite().join();
 
     // then
     assertThat(getWrittenEvent(position).getKey()).isEqualTo(LogEntryDescriptor.KEY_NULL_VALUE);
@@ -283,7 +286,7 @@ public final class LogStreamWriterTest {
   @Test
   public void shouldFailToWriteEventWithoutValue() {
     // when
-    final long pos = writer.keyNull().tryWrite();
+    final long pos = writer.keyNull().tryWrite().join();
 
     // then
     assertThat(pos).isEqualTo(0);

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamWriterRule.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamWriterRule.java
@@ -63,7 +63,7 @@ public final class LogStreamWriterRule extends ExternalResource {
               .atMost(Duration.ofSeconds(5))
               .pollDelay(Duration.ofNanos(0))
               .pollInSameThread()
-              .until(logStreamWriter::tryWrite, position -> position >= 0);
+              .until(() -> logStreamWriter.tryWrite().join(), position -> position >= 0);
     }
 
     waitForPositionToBeWritten(lastPosition);
@@ -101,7 +101,7 @@ public final class LogStreamWriterRule extends ExternalResource {
     writer.accept(eventWriter);
     eventWriter.done();
 
-    return logStreamWriter.tryWrite();
+    return logStreamWriter.tryWrite().join();
   }
 
   public void waitForPositionToBeWritten(final long position) {

--- a/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerRule.java
+++ b/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerRule.java
@@ -44,6 +44,7 @@ public final class ControlledActorSchedulerRule extends ExternalResource {
 
   @Override
   protected void before() {
+    clock.reset();
     actorScheduler.start();
   }
 

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
@@ -356,7 +356,7 @@ public final class StreamPlatform {
   private static final class WriteActor extends Actor {
     public ActorFuture<Long> submit(final LogStreamWriter writer) {
       final ActorFuture<Long> future = actor.createFuture();
-      actor.runOnCompletion(writer.tryWrite(), future);
+      actor.run(() -> actor.runOnCompletion(writer.tryWrite(), future));
       return future;
     }
   }


### PR DESCRIPTION
## Description

This PR modifies the `LogStreamWriter` to make it an asynchronous writer, in preparation for asynchronous writes with the dispatcher replacement. To achieve this:

- We had to remove usage of the `RetryStrategy` since they don't work with asynchronous operations. Instead, each caller must implement retry themselves by using `actor.runOnCompletion`, and in the callback, checking if the exception is recoverable, and if so calling `actor.run(myCallback); actor.yieldThread();`
- Introduce a flag in the scheduling service to avoid overlaps between retries (piggybacking off of the stream processor phase logic)
- Introduce actors/concurrency control to the inter partition command sender implementation

## Related issues

closes #10923 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
