### PR TITLE
Prevent NPE when activating element inside flow scope that's being terminated

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceModifiedEventApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceModifiedEventApplier.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.Collections;
+import java.util.Objects;
 
 final class ProcessInstanceModifiedEventApplier
     implements TypedEventApplier<
@@ -42,6 +43,9 @@ final class ProcessInstanceModifiedEventApplier
   private void clearInterruptedState(final ProcessInstanceModificationRecord value) {
     value.getAncestorScopeKeys().stream()
         .map(elementInstanceState::getInstance)
+        // These instances can be null when an element in a flow scope gets activated, but the flow
+        // scope gets terminated in this same command
+        .filter(Objects::nonNull)
         .filter(ElementInstance::isInterrupted)
         .forEach(
             instance ->


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
When a modify command contains an activate instruction for an element inside of a subprocess, and also a terminate instruction for the subprocess itself, Zeebe would run into a NullPointer.

This is caused by the fact that we keep track of the ancestor keys of an element that's getting activated. We need these to make sure we can clear the interrupted state from any of these ancestors. This is to ensure we support activating elements in an interrupted flow scope.

Since we first perform the activate instructions and after this the terminate instructions, we have already terminated the parent of the element that's being activated. We can not get the element instance and potentially remove the interrupted state. A null check needs to be added here.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10878

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
