### PR TITLE
Activate element inside given flow scope using ancestor selection

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -184,6 +184,7 @@ public final class ElementActivationBehavior {
     final List<ElementInstance> elementInstancesOfScope =
         findElementInstances(flowScope, flowScopeKey);
 
+    final long activatedInstanceKey;
     if (elementInstancesOfScope.isEmpty()) {
       // there is no active instance of this flow scope
       // - create/activate a new instance and continue with the remaining flow scopes
@@ -191,20 +192,13 @@ public final class ElementActivationBehavior {
           activateFlowScope(
               processInstanceRecord, flowScopeKey, flowScope, createVariablesCallback);
       activatedElementKeys.addFlowScopeKey(elementInstanceKey);
-      return activateFlowScopes(
-          processInstanceRecord,
-          elementInstanceKey,
-          flowScopes,
-          ancestorScopeKey,
-          createVariablesCallback,
-          activatedElementKeys);
+      activatedInstanceKey = elementInstanceKey;
 
     } else if (elementInstancesOfScope.size() == 1) {
       // there is an active instance of this flow scope
 
       final var elementInstance = elementInstancesOfScope.get(0);
 
-      final long activatedInstanceKey;
       if (ancestorScopeKey != NO_ANCESTOR_SCOPE_KEY
           && isAncestorOfElementInstance(ancestorScopeKey, elementInstance)) {
         // the active instance is a descendant of the selected ancestor
@@ -221,13 +215,6 @@ public final class ElementActivationBehavior {
 
       createVariablesCallback.accept(flowScope.getId(), activatedInstanceKey);
       activatedElementKeys.addFlowScopeKey(activatedInstanceKey);
-      return activateFlowScopes(
-          processInstanceRecord,
-          activatedInstanceKey,
-          flowScopes,
-          ancestorScopeKey,
-          createVariablesCallback,
-          activatedElementKeys);
 
     } else {
       // there are multiple active instances of this flow scope
@@ -241,7 +228,6 @@ public final class ElementActivationBehavior {
             flowScopeId, processInstanceRecord.getBpmnProcessId());
       }
 
-      final long activatedInstanceKey;
       if (elementInstancesOfScope.stream()
           .anyMatch(instance -> instance.getKey() == ancestorScopeKey)) {
         // one of the existing element instances of 'flow scope' is the selected ancestor
@@ -281,15 +267,15 @@ public final class ElementActivationBehavior {
 
       createVariablesCallback.accept(flowScope.getId(), activatedInstanceKey);
       activatedElementKeys.addFlowScopeKey(activatedInstanceKey);
-
-      return activateFlowScopes(
-          processInstanceRecord,
-          activatedInstanceKey,
-          flowScopes,
-          ancestorScopeKey,
-          createVariablesCallback,
-          activatedElementKeys);
     }
+
+    return activateFlowScopes(
+        processInstanceRecord,
+        activatedInstanceKey,
+        flowScopes,
+        ancestorScopeKey,
+        createVariablesCallback,
+        activatedElementKeys);
   }
 
   private boolean isAncestorOfElementInstance(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -181,8 +181,9 @@ public final class ElementActivationBehavior {
     }
     final var flowScope = flowScopes.poll();
 
+    final var bpmnProcessId = processInstanceRecord.getBpmnProcessId();
     final Optional<Long> flowScopeInstanceKey =
-        findScopeKey(processInstanceRecord, flowScopeKey, ancestorScopeKey, flowScope);
+        findScopeKey(bpmnProcessId, flowScopeKey, ancestorScopeKey, flowScope);
 
     final long activatedInstanceKey;
     if (flowScopeInstanceKey.isPresent()) {
@@ -213,7 +214,7 @@ public final class ElementActivationBehavior {
    *
    * <p>If a new instance should be created, it simply doesn't find the instance.
    *
-   * @param processInstanceRecord the record of the process instance
+   * @param bpmnProcessId the id of the process
    * @param flowScopeKey the key of the flow scope instance whose children are the only instances
    *     considered
    * @param ancestorScopeKey the key of an ancestor (indirect/direct flow scope) used for ancestor
@@ -222,7 +223,7 @@ public final class ElementActivationBehavior {
    * @return optionally the key of the instance it found, otherwise an empty optional.
    */
   private Optional<Long> findScopeKey(
-      final ProcessInstanceRecord processInstanceRecord,
+      final String bpmnProcessId,
       final long flowScopeKey,
       final long ancestorScopeKey,
       final ExecutableFlowElement flowScope) {
@@ -257,8 +258,7 @@ public final class ElementActivationBehavior {
       // no ancestor selected
       // - reject by throwing an exception
       final var flowScopeId = BufferUtil.bufferAsString(flowScope.getId());
-      throw new MultipleFlowScopeInstancesFoundException(
-          flowScopeId, processInstanceRecord.getBpmnProcessId());
+      throw new MultipleFlowScopeInstancesFoundException(flowScopeId, bpmnProcessId);
     }
 
     if (elementInstancesOfScope.stream()
@@ -291,8 +291,7 @@ public final class ElementActivationBehavior {
     // non-existing element instance. We cannot decide what to do here.
     // - reject by throwing an exception
     final var flowScopeId = BufferUtil.bufferAsString(flowScope.getId());
-    throw new MultipleFlowScopeInstancesFoundException(
-        flowScopeId, processInstanceRecord.getBpmnProcessId());
+    throw new MultipleFlowScopeInstancesFoundException(flowScopeId, bpmnProcessId);
   }
 
   private boolean isAncestorOfElementInstance(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -188,11 +188,9 @@ public final class ElementActivationBehavior {
     if (elementInstancesOfScope.isEmpty()) {
       // there is no active instance of this flow scope
       // - create/activate a new instance and continue with the remaining flow scopes
-      final long elementInstanceKey =
+      activatedInstanceKey =
           activateFlowScope(
               processInstanceRecord, flowScopeKey, flowScope, createVariablesCallback);
-      activatedElementKeys.addFlowScopeKey(elementInstanceKey);
-      activatedInstanceKey = elementInstanceKey;
 
     } else if (elementInstancesOfScope.size() == 1) {
       // there is an active instance of this flow scope
@@ -214,7 +212,6 @@ public final class ElementActivationBehavior {
       }
 
       createVariablesCallback.accept(flowScope.getId(), activatedInstanceKey);
-      activatedElementKeys.addFlowScopeKey(activatedInstanceKey);
 
     } else {
       // there are multiple active instances of this flow scope
@@ -266,8 +263,9 @@ public final class ElementActivationBehavior {
       }
 
       createVariablesCallback.accept(flowScope.getId(), activatedInstanceKey);
-      activatedElementKeys.addFlowScopeKey(activatedInstanceKey);
     }
+
+    activatedElementKeys.addFlowScopeKey(activatedInstanceKey);
 
     return activateFlowScopes(
         processInstanceRecord,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -256,6 +256,23 @@ public final class ElementActivationBehavior {
             activateFlowScope(
                 processInstanceRecord, flowScopeKey, flowScope, createVariablesCallback);
 
+      } else if (elementInstancesOfScope.stream()
+          .anyMatch(
+              instance ->
+                  isAncestorOfElementInstance(
+                      instance.getKey(), elementInstanceState.getInstance(ancestorScopeKey)))) {
+        // we found instances of a flow scope that itself is an ancestor of the ancestor scopeKey.
+        // - no need to create a new instance, because we can use the instance explicitly.
+        activatedInstanceKey =
+            elementInstancesOfScope.stream()
+                .filter(
+                    instance ->
+                        isAncestorOfElementInstance(
+                            instance.getKey(), elementInstanceState.getInstance(ancestorScopeKey)))
+                .findAny()
+                .get()
+                .getKey();
+
       } else {
         // the selected ancestor is not an ancestor of the existing element instances. It's also not
         // one of the existing element instances itself. We cannot decide what to do here.

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -208,8 +208,6 @@ public final class ElementActivationBehavior {
         flowScopeInstanceKey = elementInstance.getKey();
       }
 
-      createVariablesCallback.accept(flowScope.getId(), flowScopeInstanceKey);
-
     } else {
       // there are multiple active instances of this flow scope
       // - try to use ancestor selection
@@ -256,8 +254,6 @@ public final class ElementActivationBehavior {
               flowScopeId, processInstanceRecord.getBpmnProcessId());
         }
       }
-
-      createVariablesCallback.accept(flowScope.getId(), flowScopeInstanceKey);
     }
 
     final long activatedInstanceKey;
@@ -268,6 +264,7 @@ public final class ElementActivationBehavior {
               processInstanceRecord, flowScopeKey, flowScope, createVariablesCallback);
     } else {
       activatedInstanceKey = flowScopeInstanceKey;
+      createVariablesCallback.accept(flowScope.getId(), flowScopeInstanceKey);
     }
 
     activatedElementKeys.addFlowScopeKey(activatedInstanceKey);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -286,10 +286,10 @@ public final class ElementActivationBehavior {
       return Optional.of(activatedInstance.get().getKey());
     }
 
-    // the selected ancestor is not an ancestor of the existing element instances. It's also
-    // not one of the existing element instances itself. We cannot decide what to do here.
+    // the selected ancestor is not one of the existing element instances, nor an ancestor of them,
+    // nor a descendant of them. It might be a completely unrelated element instance, or a
+    // non-existing element instance. We cannot decide what to do here.
     // - reject by throwing an exception
-    // todo: verify whether this situation can occur
     final var flowScopeId = BufferUtil.bufferAsString(flowScope.getId());
     throw new MultipleFlowScopeInstancesFoundException(
         flowScopeId, processInstanceRecord.getBpmnProcessId());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -256,31 +256,27 @@ public final class ElementActivationBehavior {
             activateFlowScope(
                 processInstanceRecord, flowScopeKey, flowScope, createVariablesCallback);
 
-      } else if (elementInstancesOfScope.stream()
-          .anyMatch(
-              instance ->
-                  isAncestorOfElementInstance(
-                      instance.getKey(), elementInstanceState.getInstance(ancestorScopeKey)))) {
-        // we found instances of a flow scope that itself is an ancestor of the ancestor scopeKey.
-        // - no need to create a new instance, because we can use the instance explicitly.
-        activatedInstanceKey =
+      } else {
+        final var selectedAncestor = elementInstanceState.getInstance(ancestorScopeKey);
+        final var activatedInstance =
             elementInstancesOfScope.stream()
                 .filter(
-                    instance ->
-                        isAncestorOfElementInstance(
-                            instance.getKey(), elementInstanceState.getInstance(ancestorScopeKey)))
-                .findAny()
-                .get()
-                .getKey();
+                    instance -> isAncestorOfElementInstance(instance.getKey(), selectedAncestor))
+                .findAny();
+        if (activatedInstance.isPresent()) {
+          // we found instances of a flow scope that itself is an ancestor of the ancestor scopeKey.
+          // - no need to create a new instance, because we can use the instance explicitly.
+          activatedInstanceKey = activatedInstance.get().getKey();
 
-      } else {
-        // the selected ancestor is not an ancestor of the existing element instances. It's also not
-        // one of the existing element instances itself. We cannot decide what to do here.
-        // - reject by throwing an exception
-        // todo: verify whether this situation can occur
-        final var flowScopeId = BufferUtil.bufferAsString(flowScope.getId());
-        throw new MultipleFlowScopeInstancesFoundException(
-            flowScopeId, processInstanceRecord.getBpmnProcessId());
+        } else {
+          // the selected ancestor is not an ancestor of the existing element instances. It's also
+          // not one of the existing element instances itself. We cannot decide what to do here.
+          // - reject by throwing an exception
+          // todo: verify whether this situation can occur
+          final var flowScopeId = BufferUtil.bufferAsString(flowScope.getId());
+          throw new MultipleFlowScopeInstancesFoundException(
+              flowScopeId, processInstanceRecord.getBpmnProcessId());
+        }
       }
 
       createVariablesCallback.accept(flowScope.getId(), activatedInstanceKey);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -238,7 +238,7 @@ public final class ElementActivationBehavior {
       // there is an active instance of this flow scope
       final var elementInstance = elementInstancesOfScope.get(0);
 
-      if (ancestorScopeKey != NO_ANCESTOR_SCOPE_KEY
+      if (isAncestorSelected(ancestorScopeKey)
           && isAncestorOfElementInstance(ancestorScopeKey, elementInstance)) {
         // the active instance is a descendant of the selected ancestor
         // - don't use this instance as the flow scope
@@ -253,7 +253,7 @@ public final class ElementActivationBehavior {
 
     // there are multiple active instances of this flow scope
     // - try to use ancestor selection
-    if (ancestorScopeKey == NO_ANCESTOR_SCOPE_KEY) {
+    if (!isAncestorSelected(ancestorScopeKey)) {
       // no ancestor selected
       // - reject by throwing an exception
       final var flowScopeId = BufferUtil.bufferAsString(flowScope.getId());
@@ -437,6 +437,10 @@ public final class ElementActivationBehavior {
         throw new EventSubscriptionException(message);
       }
     }
+  }
+
+  private static boolean isAncestorSelected(final long ancestorScopeKey) {
+    return ancestorScopeKey != NO_ANCESTOR_SCOPE_KEY;
   }
 
   public static class ActivatedElementKeys {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -230,10 +230,9 @@ public final class ElementActivationBehavior {
         findElementInstances(flowScope, flowScopeKey);
 
     // we need to find the element instance that we want to use as flow scope
-    final long flowScopeInstanceKey;
     if (elementInstancesOfScope.isEmpty()) {
       // there is no active instance of this flow scope
-      flowScopeInstanceKey = -1;
+      return -1;
 
     } else if (elementInstancesOfScope.size() == 1) {
       // there is an active instance of this flow scope
@@ -244,13 +243,13 @@ public final class ElementActivationBehavior {
           && isAncestorOfElementInstance(ancestorScopeKey, elementInstance)) {
         // the active instance is a descendant of the selected ancestor
         // - don't use this instance as the flow scope
-        flowScopeInstanceKey = -1;
+        return -1;
 
       } else {
         // no ancestor selection used, or the active instance isn't a descendant of it.
         // most often this means that the active instance IS the selected ancestor
         // - no need to create a new instance; we can use this one
-        flowScopeInstanceKey = elementInstance.getKey();
+        return elementInstance.getKey();
       }
 
     } else {
@@ -269,13 +268,13 @@ public final class ElementActivationBehavior {
           .anyMatch(instance -> instance.getKey() == ancestorScopeKey)) {
         // one of the existing element instances of 'flow scope' is the selected ancestor
         // - we can use the selected instance
-        flowScopeInstanceKey = ancestorScopeKey;
+        return ancestorScopeKey;
 
       } else if (elementInstancesOfScope.stream()
           .anyMatch(instance -> isAncestorOfElementInstance(ancestorScopeKey, instance))) {
         // the selected ancestor is the (in)direct flow scope one of the element instances
         // - we need to create a new instance of 'flow scope' inside the selected ancestor instance
-        flowScopeInstanceKey = -1;
+        return -1;
 
       } else {
         final var selectedAncestor = elementInstanceState.getInstance(ancestorScopeKey);
@@ -287,7 +286,7 @@ public final class ElementActivationBehavior {
         if (activatedInstance.isPresent()) {
           // we found an instance of a flow scope that is an ancestor of the selected ancestor
           // - we can use that instance directly
-          flowScopeInstanceKey = activatedInstance.get().getKey();
+          return activatedInstance.get().getKey();
 
         } else {
           // the selected ancestor is not an ancestor of the existing element instances. It's also
@@ -300,7 +299,6 @@ public final class ElementActivationBehavior {
         }
       }
     }
-    return flowScopeInstanceKey;
   }
 
   private boolean isAncestorOfElementInstance(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationProcessor.java
@@ -177,11 +177,13 @@ public final class ProcessInstanceModificationProcessor
                 instruction -> {
                   final var elementToActivate =
                       process.getProcess().getElementById(instruction.getElementId());
+                  final var ancestorScopeKey = instruction.getAncestorScopeKey();
 
                   final ActivatedElementKeys activatedElementKeys =
                       elementActivationBehavior.activateElement(
                           processInstanceRecord,
                           elementToActivate,
+                          ancestorScopeKey,
                           (elementId, scopeKey) ->
                               executeVariableInstruction(
                                   BufferUtil.bufferAsString(elementId),

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -876,7 +876,7 @@ public class ModifyProcessInstanceTest {
             .findAny();
     assertThat(activatedTaskB).describedAs("Expect that task B is activated").isPresent();
     assertThat(activatedTaskB.get().getValue())
-        .describedAs("Expect that task B is exists inside of flow scope " + ancestorScopeKey)
+        .describedAs("Expect that task B exists inside of flow scope " + ancestorScopeKey)
         .hasFlowScopeKey(ancestorScopeKey);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -297,8 +297,24 @@ public final class ProcessInstanceClient {
      * @return this ActivationInstruction builder for chaining
      */
     public ActivationInstructionBuilder activateElement(final String elementId) {
+      final var noAncestorScopeKey = -1;
+      return activateElement(elementId, noAncestorScopeKey);
+    }
+
+    /**
+     * Add an activate element instruction with ancestor selection.
+     *
+     * @param elementId the id of the element to activate
+     * @param ancestorScopeKey the key of the ancestor scope that should be used as the (in)direct
+     *     flow scope instance of the element to activate; or -1 to disable ancestor selection
+     * @return this ActivationInstruction builder for chaining
+     */
+    public ActivationInstructionBuilder activateElement(
+        final String elementId, final long ancestorScopeKey) {
       final var activateInstruction =
-          new ProcessInstanceModificationActivateInstruction().setElementId(elementId);
+          new ProcessInstanceModificationActivateInstruction()
+              .setElementId(elementId)
+              .setAncestorScopeKey(ancestorScopeKey);
       activateInstructions.add(activateInstruction);
       return new ActivationInstructionBuilder(
           environmentRule, processInstanceKey, record, activateInstructions, activateInstruction);


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This enables ancestor selection for activate instructions of process instance modification.

When multiple instances of a flow scope of the activate instruction's target element exist, then the engine must somehow choose which of these instances to use as the flow scope of the newly activated element instance. The engine cannot make this choice. It should be up to the user. By providing an ancestor scope key along with the activate instruction, the user can decide this for the engine.

- If the ancestor scope key refers to an element instance that is **the direct flow scope** of the activate instruction's target element, then the engine will create the new element instance directly inside of the selected ancestor.

- If the ancestor scope key refers to an element instance that is **an indirect flow scope** of the activate instruction's target element, then the engine will create a new element instance of each indirect and direct flow scope in between the selected ancestor and the target element.

- If no ancestor scope key is provided, the modification command is rejected like before, with a rejection message clarifying what happened. This does not yet mention the ability to use ancestor selection, as this is meant to be resolved in #11032.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #9646 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
