### PR TITLE
feat(backup/s3): support configurable `basePath` for shared buckets

### DIFF
--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
@@ -27,7 +27,8 @@ import org.apache.commons.compress.compressors.CompressorStreamFactory;
  * @param forcePathStyleAccess Forces the AWS SDK to always use paths for accessing the bucket. Off
  *     by default, which allows the AWS SDK to choose virtual-hosted-style bucket access.
  * @param compressionAlgorithm Algorithm to use (if any) for compressing backup contents.
- * @param basePath Prefix to use for all objects in this bucket. Should not start or end with a '/'.
+ * @param basePath Prefix to use for all objects in this bucket. Must be non-empty and not start or
+ *     end with '/'.
  * @see <a
  *     href=https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html#automatically-determine-the-aws-region-from-the-environment>
  *     Automatically determine the Region from the environment</a>
@@ -62,6 +63,17 @@ public record S3BackupConfig(
         throw new IllegalArgumentException(
             "Can't use compression algorithm %s. Only supports %s"
                 .formatted(compressionAlgorithm.get(), supported));
+      }
+    }
+    if (basePath.isPresent()) {
+      final var prefix = basePath.get();
+      if (prefix.isEmpty()) {
+        throw new IllegalArgumentException(
+            "basePath is set but empty. It must be either unset or not empty.");
+      }
+      if (prefix.startsWith("/") || prefix.endsWith("/")) {
+        throw new IllegalArgumentException(
+            "basePath must not start or end with '/' but was: %s".formatted(prefix));
       }
     }
   }

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
@@ -27,6 +27,7 @@ import org.apache.commons.compress.compressors.CompressorStreamFactory;
  * @param forcePathStyleAccess Forces the AWS SDK to always use paths for accessing the bucket. Off
  *     by default, which allows the AWS SDK to choose virtual-hosted-style bucket access.
  * @param compressionAlgorithm Algorithm to use (if any) for compressing backup contents.
+ * @param basePath Prefix to use for all objects in this bucket. Should not start or end with a '/'.
  * @see <a
  *     href=https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html#automatically-determine-the-aws-region-from-the-environment>
  *     Automatically determine the Region from the environment</a>
@@ -42,7 +43,8 @@ public record S3BackupConfig(
     Optional<Credentials> credentials,
     Optional<Duration> apiCallTimeout,
     boolean forcePathStyleAccess,
-    Optional<String> compressionAlgorithm) {
+    Optional<String> compressionAlgorithm,
+    Optional<String> basePath) {
 
   public S3BackupConfig {
     if (bucketName == null || bucketName.isEmpty()) {
@@ -87,6 +89,7 @@ public record S3BackupConfig(
     private boolean forcePathStyleAccess = false;
     private String compressionAlgorithm;
     private Credentials credentials;
+    private String basePath;
 
     public Builder withBucketName(final String bucketName) {
       this.bucketName = bucketName;
@@ -123,6 +126,11 @@ public record S3BackupConfig(
       return this;
     }
 
+    public Builder withBasePath(final String basePath) {
+      this.basePath = basePath;
+      return this;
+    }
+
     public S3BackupConfig build() {
       return new S3BackupConfig(
           bucketName,
@@ -131,7 +139,8 @@ public record S3BackupConfig(
           Optional.ofNullable(credentials),
           Optional.ofNullable(apiCallTimeoutMs),
           forcePathStyleAccess,
-          Optional.ofNullable(compressionAlgorithm));
+          Optional.ofNullable(compressionAlgorithm),
+          Optional.ofNullable(basePath));
     }
   }
 }

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -122,13 +122,13 @@ public final class S3BackupStore implements BackupStore {
    * BackupIdentifierWildcard#matches(BackupIdentifier id)} to ensure that the listed object
    * matches.
    */
-  private static String wildcardPrefix(final BackupIdentifierWildcard wildcard) {
+  private String wildcardPrefix(final BackupIdentifierWildcard wildcard) {
     //noinspection OptionalGetWithoutIsPresent -- checked by takeWhile
     return Stream.of(wildcard.partitionId(), wildcard.checkpointId(), wildcard.nodeId())
         .takeWhile(Optional::isPresent)
         .map(Optional::get)
         .map(Number::toString)
-        .collect(Collectors.joining("/"));
+        .collect(Collectors.joining("/", config.basePath().map(base -> base + "/").orElse(""), ""));
   }
 
   public String objectPrefix(final BackupIdentifier id) {

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -98,7 +98,7 @@ public final class S3BackupStore implements BackupStore {
     backupIdentifierPattern =
         Pattern.compile(
             "^"
-                + basePath.map(base -> base + "/").orElse("")
+                + basePath.map(base -> base + "/").map(Pattern::quote).orElse("")
                 + "(?<partitionId>\\d+)/(?<checkpointId>\\d+)/(?<nodeId>\\d+).*");
   }
 

--- a/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
+++ b/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupStore.java
@@ -60,7 +60,7 @@ import software.amazon.awssdk.services.s3.model.S3Object;
  * {@link BackupStore} for S3. Stores all backups in a given bucket.
  *
  * <p>All created object keys are prefixed by the {@link BackupIdentifier}, with the following
- * scheme: {@code partitionId/checkpointId/nodeId}
+ * scheme: {@code basePath/partitionId/checkpointId/nodeId}.
  *
  * <p>Each backup contains:
  *
@@ -131,7 +131,11 @@ public final class S3BackupStore implements BackupStore {
         .collect(Collectors.joining("/"));
   }
 
-  public static String objectPrefix(final BackupIdentifier id) {
+  public String objectPrefix(final BackupIdentifier id) {
+    final var base = config.basePath();
+    if (base.isPresent()) {
+      return "%s/%s/%s/%s/".formatted(base.get(), id.partitionId(), id.checkpointId(), id.nodeId());
+    }
     return "%s/%s/%s/".formatted(id.partitionId(), id.checkpointId(), id.nodeId());
   }
 

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CustomBasePathTest.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/CustomBasePathTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.backup.s3;
+
+import io.camunda.zeebe.backup.api.Backup;
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
+import io.camunda.zeebe.backup.testkit.support.BackupAssert;
+import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
+import java.nio.file.Path;
+import java.time.Duration;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactory;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+
+@Testcontainers
+final class CustomBasePathTest {
+  private static final String ACCESS_KEY = "letmein";
+  private static final String SECRET_KEY = "letmein1234";
+  private static final int DEFAULT_PORT = 9000;
+
+  @Nested
+  final class NoBasePathConfigured {
+    @SuppressWarnings("resource")
+    @Container
+    private static final GenericContainer<?> S3 =
+        new GenericContainer<>(DockerImageName.parse("minio/minio"))
+            .withCommand("server /data")
+            .withExposedPorts(DEFAULT_PORT)
+            .withEnv("MINIO_ACCESS_KEY", ACCESS_KEY)
+            .withEnv("MINIO_SECRET_KEY", SECRET_KEY)
+            .withEnv("MINIO_DOMAIN", "localhost")
+            .waitingFor(
+                new HttpWaitStrategy()
+                    .forPath("/minio/health/ready")
+                    .forPort(DEFAULT_PORT)
+                    .withStartupTimeout(Duration.ofMinutes(1)));
+
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void canBackupAndRestore(final Backup backup, @TempDir final Path target) {
+      // given
+      final var config =
+          new Builder()
+              .withBucketName(RandomStringUtils.randomAlphabetic(10).toLowerCase())
+              .withEndpoint("http://%s:%d".formatted(S3.getHost(), S3.getMappedPort(DEFAULT_PORT)))
+              .withRegion(Region.US_EAST_1.id())
+              .withCredentials(ACCESS_KEY, SECRET_KEY)
+              .forcePathStyleAccess(true)
+              .withBasePath(RandomStringUtils.randomAlphabetic(10))
+              .build();
+
+      try (final var client = S3BackupStore.buildClient(config)) {
+        client
+            .createBucket(CreateBucketRequest.builder().bucket(config.bucketName()).build())
+            .join();
+      }
+      final var store = new S3BackupStore(config);
+
+      // when
+      Assertions.assertThat(store.save(backup)).succeedsWithin(Duration.ofSeconds(30));
+
+      // then
+      Assertions.assertThat(store.restore(backup.id(), target))
+          .succeedsWithin(Duration.ofSeconds(30))
+          .asInstanceOf(new InstanceOfAssertFactory<>(Backup.class, BackupAssert::assertThatBackup))
+          .hasSameContentsAs(backup);
+    }
+  }
+
+  @Nested
+  final class BasePathConfigured {
+    @SuppressWarnings("resource")
+    @Container
+    private static final GenericContainer<?> S3 =
+        new GenericContainer<>(DockerImageName.parse("minio/minio"))
+            .withCommand("server /data")
+            .withExposedPorts(DEFAULT_PORT)
+            .withEnv("MINIO_ACCESS_KEY", ACCESS_KEY)
+            .withEnv("MINIO_SECRET_KEY", SECRET_KEY)
+            .withEnv("MINIO_DOMAIN", "localhost")
+            .waitingFor(
+                new HttpWaitStrategy()
+                    .forPath("/minio/health/ready")
+                    .forPort(DEFAULT_PORT)
+                    .withStartupTimeout(Duration.ofMinutes(1)));
+
+    @ParameterizedTest
+    @ArgumentsSource(TestBackupProvider.class)
+    void canBackupAndRestore(final Backup backup, @TempDir final Path target) {
+      // given
+      final var config =
+          new Builder()
+              .withBucketName(RandomStringUtils.randomAlphabetic(10).toLowerCase())
+              .withEndpoint("http://%s:%d".formatted(S3.getHost(), S3.getMappedPort(DEFAULT_PORT)))
+              .withRegion(Region.US_EAST_1.id())
+              .withCredentials(ACCESS_KEY, SECRET_KEY)
+              .forcePathStyleAccess(true)
+              .build();
+
+      try (final var client = S3BackupStore.buildClient(config)) {
+        client
+            .createBucket(CreateBucketRequest.builder().bucket(config.bucketName()).build())
+            .join();
+      }
+      final var store = new S3BackupStore(config);
+
+      // when
+      Assertions.assertThat(store.save(backup)).succeedsWithin(Duration.ofSeconds(30));
+
+      // then
+      Assertions.assertThat(store.restore(backup.id(), target))
+          .succeedsWithin(Duration.ofSeconds(30))
+          .asInstanceOf(new InstanceOfAssertFactory<>(Backup.class, BackupAssert::assertThatBackup))
+          .hasSameContentsAs(backup);
+    }
+  }
+}

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/LocalstackBackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/LocalstackBackupStoreIT.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.backup.s3;
 
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer.Service;
@@ -20,21 +21,40 @@ import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 
 @Testcontainers
 final class LocalstackBackupStoreIT implements S3BackupStoreTests {
+  private static final String BUCKET_NAME = RandomStringUtils.randomAlphabetic(10).toLowerCase();
 
   @Container
   private static final LocalStackContainer S3 =
       new LocalStackContainer(DockerImageName.parse("localstack/localstack"))
           .withServices(Service.S3);
 
-  private static S3AsyncClient client;
+  private S3AsyncClient client;
   private S3BackupStore store;
   private S3BackupConfig config;
 
+  @BeforeAll
+  static void setupBucket() {
+    final var config =
+        new Builder()
+            .withBucketName(BUCKET_NAME)
+            .withEndpoint(S3.getEndpointOverride(Service.S3).toString())
+            .withRegion(S3.getRegion())
+            .withCredentials(S3.getAccessKey(), S3.getSecretKey())
+            .withApiCallTimeout(null)
+            .forcePathStyleAccess(false)
+            .withCompressionAlgorithm(null)
+            .build();
+    try (final var client = S3BackupStore.buildClient(config)) {
+      client.createBucket(CreateBucketRequest.builder().bucket(config.bucketName()).build()).join();
+    }
+  }
+
   @BeforeEach
-  void setupBucket() {
+  void setup() {
     config =
         new Builder()
-            .withBucketName(RandomStringUtils.randomAlphabetic(10).toLowerCase())
+            .withBucketName(BUCKET_NAME)
+            .withBasePath(RandomStringUtils.randomAlphabetic(10).toLowerCase())
             .withEndpoint(S3.getEndpointOverride(Service.S3).toString())
             .withRegion(S3.getRegion())
             .withCredentials(S3.getAccessKey(), S3.getSecretKey())
@@ -44,7 +64,6 @@ final class LocalstackBackupStoreIT implements S3BackupStoreTests {
             .build();
     client = S3BackupStore.buildClient(config);
     store = new S3BackupStore(config, client);
-    client.createBucket(CreateBucketRequest.builder().bucket(config.bucketName()).build()).join();
   }
 
   @Override

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/LocalstackBackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/LocalstackBackupStoreIT.java
@@ -40,9 +40,6 @@ final class LocalstackBackupStoreIT implements S3BackupStoreTests {
             .withEndpoint(S3.getEndpointOverride(Service.S3).toString())
             .withRegion(S3.getRegion())
             .withCredentials(S3.getAccessKey(), S3.getSecretKey())
-            .withApiCallTimeout(null)
-            .forcePathStyleAccess(false)
-            .withCompressionAlgorithm(null)
             .build();
     try (final var client = S3BackupStore.buildClient(config)) {
       client.createBucket(CreateBucketRequest.builder().bucket(config.bucketName()).build()).join();

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
@@ -54,8 +54,7 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
             .getObject(
                 GetObjectRequest.builder()
                     .bucket(getConfig().bucketName())
-                    .key(
-                        S3BackupStore.objectPrefix(backup.id()) + S3BackupStore.MANIFEST_OBJECT_KEY)
+                    .key(getStore().objectPrefix(backup.id()) + S3BackupStore.MANIFEST_OBJECT_KEY)
                     .build(),
                 AsyncResponseTransformer.toBytes())
             .join();
@@ -79,7 +78,7 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
   @ArgumentsSource(TestBackupProvider.class)
   default void snapshotFilesExist(final Backup backup) {
     // given
-    final var prefix = S3BackupStore.objectPrefix(backup.id()) + S3BackupStore.SNAPSHOT_PREFIX;
+    final var prefix = getStore().objectPrefix(backup.id()) + S3BackupStore.SNAPSHOT_PREFIX;
 
     final var expectedObjects =
         backup.snapshot().names().stream().map(name -> prefix + name).toList();
@@ -101,7 +100,7 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
   @ArgumentsSource(TestBackupProvider.class)
   default void segmentFilesExist(final Backup backup) {
     // given
-    final var prefix = S3BackupStore.objectPrefix(backup.id()) + S3BackupStore.SEGMENTS_PREFIX;
+    final var prefix = getStore().objectPrefix(backup.id()) + S3BackupStore.SEGMENTS_PREFIX;
 
     final var expectedObjects =
         backup.segments().names().stream().map(name -> prefix + name).toList();
@@ -123,7 +122,7 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
   @ArgumentsSource(TestBackupProvider.class)
   default void bucketContainsExpectedObjectsOnly(final Backup backup) {
     // given
-    final var prefix = S3BackupStore.objectPrefix(backup.id());
+    final var prefix = getStore().objectPrefix(backup.id());
 
     final var manifest = prefix + S3BackupStore.MANIFEST_OBJECT_KEY;
     final var snapshotObjects =
@@ -168,7 +167,7 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
             .listObjectsV2(
                 req ->
                     req.bucket(getConfig().bucketName())
-                        .prefix(S3BackupStore.objectPrefix(backup.id())))
+                        .prefix(getStore().objectPrefix(backup.id())))
             .join();
     Assertions.assertThat(listed.contents()).isEmpty();
   }
@@ -184,9 +183,7 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
         .putObject(
             req ->
                 req.bucket(getConfig().bucketName())
-                    .key(
-                        S3BackupStore.objectPrefix(backup.id())
-                            + S3BackupStore.MANIFEST_OBJECT_KEY),
+                    .key(getStore().objectPrefix(backup.id()) + S3BackupStore.MANIFEST_OBJECT_KEY),
             AsyncRequestBody.fromString("{s"))
         .join();
 
@@ -210,9 +207,7 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
             delete ->
                 delete
                     .bucket(getConfig().bucketName())
-                    .key(
-                        S3BackupStore.objectPrefix(backup.id())
-                            + S3BackupStore.MANIFEST_OBJECT_KEY))
+                    .key(getStore().objectPrefix(backup.id()) + S3BackupStore.MANIFEST_OBJECT_KEY))
         .join();
 
     // then

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
@@ -142,7 +142,10 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
     // then
     final var listedObjects =
         getClient()
-            .listObjectsV2(req -> req.bucket(getConfig().bucketName()))
+            .listObjectsV2(
+                req ->
+                    req.bucket(getConfig().bucketName())
+                        .prefix(getConfig().basePath().map(base -> base + "/").orElse("")))
             .join()
             .contents()
             .stream()

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -192,6 +192,7 @@ public final class SystemContext {
                 .withApiCallTimeout(s3Config.getApiCallTimeout())
                 .forcePathStyleAccess(s3Config.isForcePathStyleAccess())
                 .withCompressionAlgorithm(s3Config.getCompression())
+                .withBasePath(s3Config.getBasePath())
                 .build();
         S3BackupStore.validateConfig(storeConfig);
       } catch (final Exception e) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
@@ -22,6 +22,8 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
   private boolean forcePathStyleAccess = false;
   private String compression;
 
+  private String basePath;
+
   public String getBucketName() {
     return bucketName;
   }
@@ -90,6 +92,14 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
     }
   }
 
+  public void setBasePath(final String basePath) {
+    this.basePath = basePath;
+  }
+
+  public String getBasePath() {
+    return basePath;
+  }
+
   @Override
   public int hashCode() {
     int result = bucketName != null ? bucketName.hashCode() : 0;
@@ -100,6 +110,7 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
     result = 31 * result + (apiCallTimeout != null ? apiCallTimeout.hashCode() : 0);
     result = 31 * result + (forcePathStyleAccess ? 1 : 0);
     result = 31 * result + (compression != null ? compression.hashCode() : 0);
+    result = 31 * result + (basePath != null ? basePath.hashCode() : 0);
     return result;
   }
 
@@ -135,6 +146,9 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
     if (!Objects.equals(secretKey, that.secretKey)) {
       return false;
     }
+    if (!Objects.equals(basePath, that.basePath)) {
+      return false;
+    }
     return Objects.equals(apiCallTimeout, that.apiCallTimeout);
   }
 
@@ -162,6 +176,8 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
         + forcePathStyleAccess
         + ", compression="
         + compression
+        + ", basePath="
+        + basePath
         + '}';
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -91,6 +91,7 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
               .withApiCallTimeout(s3Config.getApiCallTimeout())
               .forcePathStyleAccess(s3Config.isForcePathStyleAccess())
               .withCompressionAlgorithm(s3Config.getCompression())
+              .withBasePath(s3Config.getBasePath())
               .build();
       final S3BackupStore backupStore = new S3BackupStore(storeConfig);
       context.setBackupStore(backupStore);

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -285,8 +285,8 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_COMPRESSION
           # compression: none
 
-          # When set, all objects in the bucket will use this prefix. Must not start or end with '/'.
-          # Useful for using the same bucket for multiple Zeebe clusters.
+          # When set, all objects in the bucket will use this prefix. Must be non-empty and not start or end with '/'.
+          # Useful for using the same bucket for multiple Zeebe clusters. In this case, basePath must be unique.
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_BASEPATH
           # basePath:
 

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -285,6 +285,11 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_COMPRESSION
           # compression: none
 
+          # When set, all objects in the bucket will use this prefix. Must not start or end with '/'.
+          # Useful for using the same bucket for multiple Zeebe clusters.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_BASEPATH
+          # basePath:
+
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
 

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -225,7 +225,7 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_COMPRESSION
           # compression: none
 
-          # When set, all objects in the bucket will use this prefix. Must not start or end with '/'.
+          # When set, all objects in the bucket will use this prefix. Must be non-empty and not start or end with '/'.
           # Useful for using the same bucket for multiple Zeebe clusters.
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_BASEPATH
           # basePath:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -225,6 +225,11 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_COMPRESSION
           # compression: none
 
+          # When set, all objects in the bucket will use this prefix. Must not start or end with '/'.
+          # Useful for using the same bucket for multiple Zeebe clusters.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_BASEPATH
+          # basePath:
+
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
 

--- a/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
@@ -50,6 +50,7 @@ final class BackupStoreComponent {
               .withApiCallTimeout(s3Config.getApiCallTimeout())
               .forcePathStyleAccess(s3Config.isForcePathStyleAccess())
               .withCompressionAlgorithm(s3Config.getCompression())
+              .withBasePath(s3Config.getBasePath())
               .build();
       return new S3BackupStore(storeConfig);
     } else {


### PR DESCRIPTION
This adds a new config, `zeebe.broker.data.backup.s3.basePath` that is used as a prefix when writing or reading objects in S3.
If the config has a value, objects such as `partitionId/checkpointId/nodeId/manifest.json` would now be stored under `basePath/partitionId/checkpointId/nodeId/manifest.json`.

 This allows multiple Zeebe clusters to share one bucket instead of requiring exclusive access to a bucket.

closes #11018 
related to https://github.com/camunda/camunda-platform-docs/issues/1536