### PR TITLE
Prevent activation of failed job without retries

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -198,6 +198,7 @@ public final class DbJobState implements JobState, MutableJobState {
       }
     } else {
       updateJob(key, updatedValue, State.FAILED);
+      makeJobNotActivatable(updatedValue.getTypeBuffer());
     }
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsTest.java
@@ -455,6 +455,36 @@ public final class ActivateJobsTest {
         .isEqualTo(Map.of("foo", "x".repeat(variablesSize), "bar", "x".repeat(variablesSize)));
   }
 
+  // regression test for https://github.com/camunda/zeebe/issues/10308
+  @Test
+  public void shouldNotActivateJobWithNoRemainingRetries() {
+    // given
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", task -> task.zeebeJobType(taskType))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(modelInstance).deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final long jobKey =
+        jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("task")
+            .getFirst()
+            .getKey();
+
+    ENGINE.job().withKey(jobKey).withRetries(0).fail();
+
+    // when
+    final var jobs = activateJobs(taskType, 10);
+
+    // then
+    assertThat(jobs).describedAs("Failed job without retries should not be activated").isEmpty();
+  }
+
   private Record<JobRecordValue> completeJob(final long jobKey) {
     return ENGINE.job().withKey(jobKey).complete();
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
@@ -683,6 +683,24 @@ public final class JobStateTest {
     assertThat(writtenRecord.getTypeBuffer()).isEqualTo(BufferUtil.wrapString("foo"));
   }
 
+  @Test
+  public void shouldMakeJobNotActivatableWhenFailedWithoutRetries() {
+    // given
+    final long key = 1L;
+    final JobRecord jobRecord = newJobRecord().setRetries(0);
+
+    // when
+    jobState.create(key, jobRecord);
+    jobState.fail(key, jobRecord);
+
+    // then
+    assertThat(jobState.exists(key)).isTrue();
+    assertJobState(key, State.FAILED);
+    assertJobRecordIsEqualTo(jobState.getJob(key), jobRecord);
+    refuteListedAsActivatable(key, jobRecord.getTypeBuffer());
+    refuteListedAsTimedOut(key, jobRecord.getDeadline() + 1);
+  }
+
   private void createAndActivateJobRecord(final long key, final JobRecord record) {
     jobState.create(key, record);
     jobState.activate(key, record);


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
When a job has failed and has no retries left, it should no longer be possible to activate this job. Activating this job would result in an incident. Since there already is an incident a second one will be created. This will conflict with the consistency checks, where we only allow a single incident for a task.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10308 
closes #10309 (most likely this will be fixed by this PR as well)

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
