### PR TITLE
ci: fix benchmark namespace

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Deploy benchmark installation
         run: >
           helm upgrade --install
-          --namespace ${{ inputs.ref }}
+          --namespace ${{ inputs.name }}
           --create-namespace
           ${{ inputs.name }} camunda/camunda-platform
           -f benchmarks/setup/default/zeebe-values.yaml


### PR DESCRIPTION
Fixes an oversight from https://github.com/camunda/zeebe/pull/11080 that I didn't notice during testing. 
The namespace that we create should be named like the benchmark, not the `ref`.