### PR TITLE
[Backport stable/8.0] Prevent activation of failed job without retries

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -198,6 +198,7 @@ public final class DbJobState implements JobState, MutableJobState {
       }
     } else {
       updateJob(key, updatedValue, State.FAILED);
+      makeJobNotActivatable(updatedValue.getTypeBuffer());
     }
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
@@ -683,6 +683,24 @@ public final class JobStateTest {
     assertThat(writtenRecord.getTypeBuffer()).isEqualTo(BufferUtil.wrapString("foo"));
   }
 
+  @Test
+  public void shouldMakeJobNotActivatableWhenFailedWithoutRetries() {
+    // given
+    final long key = 1L;
+    final JobRecord jobRecord = newJobRecord().setRetries(0);
+
+    // when
+    jobState.create(key, jobRecord);
+    jobState.fail(key, jobRecord);
+
+    // then
+    assertThat(jobState.exists(key)).isTrue();
+    assertJobState(key, State.FAILED);
+    assertJobRecordIsEqualTo(jobState.getJob(key), jobRecord);
+    refuteListedAsActivatable(key, jobRecord.getTypeBuffer());
+    refuteListedAsTimedOut(key, jobRecord.getDeadline() + 1);
+  }
+
   private void createAndActivateJobRecord(final long key, final JobRecord record) {
     jobState.create(key, record);
     jobState.activate(key, record);


### PR DESCRIPTION
# Description
Backport of #11109 to `stable/8.0`.

relates to #10308 #10309