### PR TITLE
test(smoke): client request timeout of 60s for container smoke test

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -77,7 +77,7 @@ public interface ZeebeClientBuilder {
   /** The time-to-live which is used when none is provided for a message. Default is 1 hour. */
   ZeebeClientBuilder defaultMessageTimeToLive(Duration timeToLive);
 
-  /** The request timeout used if not overridden by the command. Default is 20 seconds. */
+  /** The request timeout used if not overridden by the command. Default is 10 seconds. */
   ZeebeClientBuilder defaultRequestTimeout(Duration requestTimeout);
 
   /** Use a plaintext connection between the client and the gateway. */


### PR DESCRIPTION
## Description

On runs like https://github.com/camunda/zeebe/actions/runs/3564518427/jobs/5988572366 we hit the client timing out when deploying a model. As only one smoke test failed because of this timeout while other interactions succeeded in the same run and given the current emulation of ARM64 is generally less performant I would bump the timeout for all requests as a precaution.

Once we use native runners this should become less likely to happen.

Also fixed a doc issue on the client interface as I wondered why it times out with 10s while the docs say default would be 20s. In the [impl it's actually 10s](https://github.com/camunda/zeebe/blob/main/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java#L58).

## Related issues

<!-- Which issues are closed by this PR or are related -->

related #11110 