### PR TITLE
Centralize entry serialization

### DIFF
--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogAppendEntrySerializer.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogAppendEntrySerializer.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.logstreams.impl.log;
+
+import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.metadataOffset;
+import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setKey;
+import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setMetadataLength;
+import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setPosition;
+import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setSourceEventPosition;
+import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setTimestamp;
+import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.valueOffset;
+
+import io.camunda.zeebe.logstreams.log.LogAppendEntry;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.Objects;
+import org.agrona.MutableDirectBuffer;
+
+/**
+ * Temporary central point to serialize log entries to the dispatcher.
+ *
+ * <p>TODO: once we get rid of the dispatcher, we need to maintain backwards compatibility by adding
+ * some padded framing around each entry, unfortunately.
+ */
+final class LogAppendEntrySerializer {
+
+  /**
+   * Serializes an entry into the given destination buffer. Returns the length of the serialized
+   * entry, unframed and unaligned.
+   *
+   * @param writeBuffer the buffer to serialize into
+   * @param writeBufferOffset the offset to start serializing at in the {@code writeBuffer}
+   * @param entry the entry to serialize
+   * @param position the position of the entry
+   * @param sourcePosition the source record position of the entry
+   * @param entryTimestamp the timestamp; useful to pass the same for a complete batch, for example
+   * @return the length of the serialized entry, unframed/unaligned
+   * @throws IllegalArgumentException if the entry's value is empty, i.e. has a length of 0
+   */
+  int serialize(
+      final MutableDirectBuffer writeBuffer,
+      final int writeBufferOffset,
+      final LogAppendEntry entry,
+      final long position,
+      final long sourcePosition,
+      final long entryTimestamp) {
+    Objects.requireNonNull(writeBuffer, "must specify a destination buffer");
+    Objects.requireNonNull(entry, "must specify an entry");
+
+    final var key = entry.key();
+    final var metadata = entry.recordMetadata();
+    final var value = entry.recordValue();
+    final var metadataLength = metadata.getLength();
+
+    if (writeBufferOffset < 0) {
+      throw new IllegalArgumentException(
+          "Expected to serialize entry at a positive offset, but the offset given was %d"
+              .formatted(writeBufferOffset));
+    }
+
+    if (value.getLength() == 0) {
+      throw new IllegalArgumentException(
+          "Expected to serialize an entry with a value, but the entry's value reports a length of 0");
+    }
+
+    if (position < 0) {
+      throw new IllegalArgumentException(
+          "Expected to serialize an entry with a positive position, but the position given was %d"
+              .formatted(position));
+    }
+
+    if (entryTimestamp < 0) {
+      throw new IllegalArgumentException(
+          "Expected to serialize an entry with a positive timestamp, but the timestamp given was %d"
+              .formatted(entryTimestamp));
+    }
+
+    setPosition(writeBuffer, writeBufferOffset, position);
+    setSourceEventPosition(writeBuffer, writeBufferOffset, sourcePosition);
+    setKey(writeBuffer, writeBufferOffset, key);
+    setTimestamp(writeBuffer, writeBufferOffset, entryTimestamp);
+    writeMetadata(writeBuffer, writeBufferOffset, metadata, metadataLength);
+    value.write(writeBuffer, valueOffset(writeBufferOffset, metadataLength));
+
+    return LogEntryDescriptor.headerLength(metadataLength) + value.getLength();
+  }
+
+  private void writeMetadata(
+      final MutableDirectBuffer writeBuffer,
+      final int writeBufferOffset,
+      final BufferWriter metadata,
+      final int metadataLength) {
+    setMetadataLength(writeBuffer, writeBufferOffset, (short) metadataLength);
+    if (metadataLength > 0) {
+      metadata.write(writeBuffer, metadataOffset(writeBufferOffset));
+    }
+  }
+}

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogAppendEntrySerializer.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogAppendEntrySerializer.java
@@ -38,7 +38,7 @@ final class LogAppendEntrySerializer {
    * @param position the position of the entry
    * @param sourcePosition the source record position of the entry
    * @param entryTimestamp the timestamp; useful to pass the same for a complete batch, for example
-   * @return the length of the serialized entry, unframed/unaligned
+   * @return the length of the serialized entry, without dispatcher framing/alignment
    * @throws IllegalArgumentException if the entry's value is empty, i.e. has a length of 0
    */
   int serialize(

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogAppendEntrySerializerTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogAppendEntrySerializerTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.logstreams.impl.log;
+
+import static io.camunda.zeebe.dispatcher.impl.log.DataFrameDescriptor.framedLength;
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.zeebe.dispatcher.impl.log.DataFrameDescriptor;
+import io.camunda.zeebe.logstreams.util.MutableLogAppendEntry;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.util.buffer.BufferReader;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.function.Consumer;
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.junit.jupiter.api.Test;
+
+final class LogAppendEntrySerializerTest {
+  private final MutableDirectBuffer writeBuffer = new ExpandableArrayBuffer();
+  private final int writeBufferOffset = DataFrameDescriptor.messageOffset(0);
+
+  @Test
+  void shouldSerializeEntry() {
+    // given
+    final var serializer = new LogAppendEntrySerializer();
+    final var event = new LoggedEventImpl();
+    final var entry =
+        new MutableLogAppendEntry()
+            .key(1)
+            .recordMetadata(wrapString("metadata"))
+            .recordValue(wrapString("value"));
+
+    // when - as we still use the LoggedEvent to "read" things, it expects to find the event at a
+    // specific offset
+    final var bytesWritten = serializer.serialize(writeBuffer, writeBufferOffset, entry, 2, 3, 4);
+    commitWrite(bytesWritten);
+
+    // then
+    event.wrap(writeBuffer, 0);
+    assertThat(event.getKey()).isEqualTo(1);
+    assertThat(event.getPosition()).isEqualTo(2);
+    assertThat(event.getSourceEventPosition()).isEqualTo(3);
+    assertThat(event.getTimestamp()).isEqualTo(4);
+    assertThat(readString(event::readMetadata)).isEqualTo("metadata");
+    assertThat(readString(event::readValue)).isEqualTo("value");
+  }
+
+  @Test
+  void shouldSkipMetadataIfEmpty() {
+    // given
+    final var serializer = new LogAppendEntrySerializer();
+    final var event = new LoggedEventImpl();
+    final var entry = new MutableLogAppendEntry().recordValue(wrapString("value"));
+
+    // when
+    final var bytesWritten = serializer.serialize(writeBuffer, writeBufferOffset, entry, 2, 3, 4);
+    commitWrite(bytesWritten);
+
+    // then
+    event.wrap(writeBuffer, 0);
+    assertThat(event.getMetadataLength()).isEqualTo((short) 0);
+    assertThat(readString(event::readValue)).isEqualTo("value");
+  }
+
+  @Test
+  void shouldFailWithAnEmptyValue() {
+    // given
+    final var serializer = new LogAppendEntrySerializer();
+    final var entry = new MutableLogAppendEntry();
+
+    // when - then
+    assertThatCode(() -> serializer.serialize(writeBuffer, writeBufferOffset, entry, 2, 3, 4))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldFailWithANegativeTimestamp() {
+    // given
+    final var serializer = new LogAppendEntrySerializer();
+    final var entry = new MutableLogAppendEntry().recordValue(wrapString("value"));
+
+    // when - then
+    assertThatCode(() -> serializer.serialize(writeBuffer, writeBufferOffset, entry, 2, 3, -1))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldFailWithANegativePosition() {
+    // given
+    final var serializer = new LogAppendEntrySerializer();
+    final var entry = new MutableLogAppendEntry().recordValue(wrapString("value"));
+
+    // when - then
+    assertThatCode(() -> serializer.serialize(writeBuffer, writeBufferOffset, entry, -1, 3, 4))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  /**
+   * Simulates the dispatcher's commit method - this should also be removed once we are rid of the
+   * dispatcher
+   */
+  private void commitWrite(final int bytesWritten) {
+    writeBuffer.putInt(
+        DataFrameDescriptor.lengthOffset(0), framedLength(bytesWritten), Protocol.ENDIANNESS);
+  }
+
+  private String readString(final Consumer<BufferReader> reader) {
+    final var value = new StringReader();
+    reader.accept(value);
+    return value.value;
+  }
+
+  private static final class StringReader implements BufferReader {
+    private String value;
+
+    @Override
+    public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+      value = BufferUtil.bufferAsString(buffer, offset, length);
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds a new class to handle the `LogAppendEntry` serialization. This class currently expects to work with the dispatcher, but this is mostly visible in tests. It will need a bit of adapting in the future once the dispatcher is removed to make it really agnostic.

## Related issues

closes #10919 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
