### PR TITLE
feat(dist): return 404 when backup does not exist

### DIFF
--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -129,6 +129,25 @@ final class BackupEndpointTest {
     }
 
     @Test
+    void shouldReturn404WhenBackupDoesNotExist() {
+      // given
+      final var api = mock(BackupApi.class);
+      final var endpoint = new BackupEndpoint(api);
+      final var backupStatus =
+          new BackupStatus(1, State.DOES_NOT_EXIST, Optional.empty(), List.of());
+      doReturn(CompletableFuture.completedFuture(backupStatus)).when(api).getStatus(anyLong());
+
+      // when
+      final WebEndpointResponse<?> response = endpoint.status(1);
+
+      // then
+      assertThat(response.getStatus()).isEqualTo(404);
+      assertThat(response.getBody())
+          .asInstanceOf(InstanceOfAssertFactories.type(Error.class))
+          .isEqualTo(new Error().message("Backup with id 1 does not exist"));
+    }
+
+    @Test
     void shouldReturnCompletedBackupStatus() throws JsonProcessingException {
       // given
       final var api = mock(BackupApi.class);

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupAcceptanceIT.java
@@ -129,6 +129,7 @@ final class BackupAcceptanceIT {
     assertThat(response).isEqualTo(new TakeBackupResponse(1L));
     Awaitility.await("until a backup exists with the given ID")
         .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions() // 404 NOT_FOUND throws exception
         .untilAsserted(
             () -> {
               final var status = actuator.status(response.id());

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptanceIT.java
@@ -116,6 +116,7 @@ final class RestoreAcceptanceIT {
     assertThat(response).isEqualTo(new TakeBackupResponse(BACKUP_ID));
     Awaitility.await("until a backup exists with the given ID")
         .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions() // 404 NOT_FOUND throws exception
         .untilAsserted(
             () -> {
               final var status = actuator.status(response.id());
@@ -143,6 +144,7 @@ final class RestoreAcceptanceIT {
     assertThat(response).isEqualTo(new TakeBackupResponse(BACKUP_ID));
     Awaitility.await("until a backup exists with the given ID")
         .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions() // 404 NOT_FOUND throws exception
         .untilAsserted(
             () -> {
               final var status = actuator.status(response.id());


### PR DESCRIPTION
## Description

Previously it returned 200 OK and status = DOES_NOT_EXIST. This is fixed and not it returns 404 when backup does not exists. 

## Related issues

related #10967 


