### PR TITLE
Broker can handle delete backup request

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -86,8 +86,8 @@ public final class BackupApiRequestHandler
       case TAKE_BACKUP -> CompletableActorFuture.completed(
           handleTakeBackupRequest(
               requestStreamId, requestId, requestReader, responseWriter, errorWriter));
-      case QUERY_STATUS -> handleQueryStatusHandler(requestReader, responseWriter, errorWriter);
-      case LIST -> handleListBackupHandler(responseWriter, errorWriter);
+      case QUERY_STATUS -> handleQueryStatusRequest(requestReader, responseWriter, errorWriter);
+      case LIST -> handleListBackupRequest(responseWriter, errorWriter);
       case DELETE -> handleDeleteBackupRequest(requestReader, responseWriter, errorWriter);
       default -> CompletableActorFuture.completed(
           unknownRequest(errorWriter, requestReader.getMessageDecoder().type()));
@@ -126,7 +126,7 @@ public final class BackupApiRequestHandler
   }
 
   private ActorFuture<Either<ErrorResponseWriter, BackupApiResponseWriter>>
-      handleQueryStatusHandler(
+      handleQueryStatusRequest(
           final BackupApiRequestReader requestReader,
           final BackupApiResponseWriter responseWriter,
           final ErrorResponseWriter errorWriter) {
@@ -148,7 +148,7 @@ public final class BackupApiRequestHandler
     return result;
   }
 
-  private ActorFuture<Either<ErrorResponseWriter, BackupApiResponseWriter>> handleListBackupHandler(
+  private ActorFuture<Either<ErrorResponseWriter, BackupApiResponseWriter>> handleListBackupRequest(
       final BackupApiResponseWriter responseWriter, final ErrorResponseWriter errorWriter) {
     final ActorFuture<Either<ErrorResponseWriter, BackupApiResponseWriter>> result =
         new CompletableActorFuture<>();

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestReader.java
@@ -37,7 +37,7 @@ public final class BackupApiRequestReader implements RequestReader<BackupRequest
     return messageDecoder.backupId();
   }
 
-  public long partitionId() {
+  public int partitionId() {
     return messageDecoder.partitionId();
   }
 

--- a/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/protocol/src/main/resources/cluster-management-protocol.xml
@@ -17,6 +17,7 @@
       <validValue name="TAKE_BACKUP">0</validValue>
       <validValue name="QUERY_STATUS">1</validValue>
       <validValue name="LIST">2</validValue>
+      <validValue name="DELETE">3</validValue>
     </enum>
 
     <enum name="BackupStatusCode" encodingType="uint8">


### PR DESCRIPTION
## Description

- Updated protocol to add delete backup command
- BackupApiRequestHandler can handle delete backup request. When successfully deleted, it returns `BackupStatusResponse` with status = DOES_NOT_EXIST. 

## Related issues

closes #9808 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
