### PR TITLE
Run spotless before the release version updates are committed

### DIFF
--- a/.ci/scripts/release/maven-release.sh
+++ b/.ci/scripts/release/maven-release.sh
@@ -11,5 +11,6 @@ mvn -s ${MAVEN_SETTINGS_XML} release:prepare release:perform -B \
     -DpushChanges=${PUSH_CHANGES} \
     -DremoteTagging=${PUSH_CHANGES} \
     -DlocalCheckout=${SKIP_DEPLOY} \
+    -DcompletionGoals="spotless:apply" \
     -P!autoFormat \
-    -Darguments='--settings=${MAVEN_SETTINGS_XML} -P-autoFormat -DskipChecks=true -DskipTests=true -Dgpg.passphrase="${GPG_PASS}" -Dskip.central.release=${SKIP_DEPLOY} -Dskip.camunda.release=${SKIP_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR}'
+    -Darguments='--settings=${MAVEN_SETTINGS_XML} -P-autoFormat -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dgpg.passphrase="${GPG_PASS}" -Dskip.central.release=${SKIP_DEPLOY} -Dskip.camunda.release=${SKIP_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR}'


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
The release plugin updates the versions in our pom files. This update will break the formatting that we have configured in spotless. As a result, when we'd like to merge the release branch back to the main branch, we manually need to run spotless:apply in order to restore the formatting.

We can add a completion goal to the release plugin. This parameter will:

["Goals to run on completion of the preparation step, after transformation back to the next development version but before committing. Space delimited."](https://maven.apache.org/maven-release/maven-release-plugin/prepare-mojo.html#completiongoals)

This means it will execute `spotless:apply` once the release plugin has updated the versions to the next development version, but before the commit is made. Making the correct format part of the release commit.

The comments [here](https://github.com/camunda/zeebe/issues/10602#issuecomment-1329376912) mention the deletion of the `-DskipChecks=true`

  
  **Manual test**

Please see the example branch here: https://github.com/camunda/zeebe/commits/10602_maven_release_spotless_example

The [[maven-release-plugin] prepare release 0.0.0](https://github.com/camunda/zeebe/commit/8bec9c74d18daffed811db320067a35e0e8e4314) commit messes up the formatting of the pom file
In the [[maven-release-plugin] prepare for next development iteration](https://github.com/camunda/zeebe/commit/b08124fad3e3e90325a6d1a77829e8a148178b82) this gets restored.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #10602 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
