### PR TITLE
Gateway can process list backup request

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupApi.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.admin.backup;
 
+import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 public interface BackupApi {
@@ -34,4 +35,9 @@ public interface BackupApi {
    * @return the status of the backup
    */
   CompletionStage<BackupStatus> getStatus(long backupId);
+
+  /**
+   * @return a list of available backups
+   */
+  CompletionStage<List<BackupStatus>> listBackups();
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupListRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupListRequest.java
@@ -83,7 +83,7 @@ public class BackupListRequest extends BrokerRequest<BackupListResponse> {
 
   @Override
   public String getType() {
-    return "backup#list";
+    return "Backup#list";
   }
 
   @Override

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupListRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupListRequest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.admin.backup;
+
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerRequest;
+import io.camunda.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.camunda.zeebe.protocol.impl.encoding.BackupListResponse;
+import io.camunda.zeebe.protocol.impl.encoding.BackupRequest;
+import io.camunda.zeebe.protocol.management.BackupListResponseDecoder;
+import io.camunda.zeebe.protocol.management.BackupRequestType;
+import io.camunda.zeebe.transport.RequestType;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public class BackupListRequest extends BrokerRequest<BackupListResponse> {
+
+  protected final BackupRequest request = new BackupRequest();
+  protected final BackupListResponse response = new BackupListResponse();
+
+  public BackupListRequest() {
+    super(BackupListResponseDecoder.SCHEMA_ID, BackupListResponseDecoder.TEMPLATE_ID);
+    request.setType(BackupRequestType.LIST);
+  }
+
+  public long getBackupId() {
+    return request.getBackupId();
+  }
+
+  public void setBackupId(final long backupId) {
+    request.setBackupId(backupId);
+  }
+
+  @Override
+  public int getPartitionId() {
+    return request.getPartitionId();
+  }
+
+  @Override
+  public void setPartitionId(final int partitionId) {
+    request.setPartitionId(partitionId);
+  }
+
+  @Override
+  public boolean addressesSpecificPartition() {
+    return true;
+  }
+
+  @Override
+  public boolean requiresPartitionId() {
+    return true;
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return null;
+  }
+
+  @Override
+  protected void setSerializedValue(final DirectBuffer buffer) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected void wrapResponse(final DirectBuffer buffer) {
+    response.wrap(buffer, 0, buffer.capacity());
+  }
+
+  @Override
+  protected BrokerResponse<BackupListResponse> readResponse() {
+    return new BrokerResponse<>(response, getPartitionId(), -1);
+  }
+
+  @Override
+  protected BackupListResponse toResponseDto(final DirectBuffer buffer) {
+    return response;
+  }
+
+  @Override
+  public String getType() {
+    return "backup#list";
+  }
+
+  @Override
+  public RequestType getRequestType() {
+    return RequestType.BACKUP;
+  }
+
+  @Override
+  public int getLength() {
+    return request.getLength();
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    request.write(buffer, offset);
+  }
+}

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupStatusRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BackupStatusRequest.java
@@ -83,7 +83,7 @@ public class BackupStatusRequest extends BrokerRequest<BackupStatusResponse> {
 
   @Override
   public String getType() {
-    return "backup#status";
+    return "Backup#status";
   }
 
   @Override

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BrokerBackupRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/BrokerBackupRequest.java
@@ -99,7 +99,7 @@ public final class BrokerBackupRequest extends BrokerRequest<CheckpointRecord> {
 
   @Override
   public String getType() {
-    return "backup#take";
+    return "Backup#take";
   }
 
   @Override

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/PartitionBackupStatus.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/backup/PartitionBackupStatus.java
@@ -29,7 +29,7 @@ public record PartitionBackupStatus(
     final var status = response.getStatus();
     return switch (status) {
       case FAILED -> failedStatus(response);
-      case DOES_NOT_EXIST -> notExistingStatus(response);
+      case DOES_NOT_EXIST -> notExistingStatus(response.getPartitionId());
       case IN_PROGRESS, COMPLETED -> validStatus(response);
       default -> throw new IllegalArgumentException("Unknown backup status %s".formatted(status));
     };
@@ -50,9 +50,9 @@ public record PartitionBackupStatus(
         Optional.ofNullable(response.getBrokerVersion()));
   }
 
-  private static PartitionBackupStatus notExistingStatus(final BackupStatusResponse response) {
+  static PartitionBackupStatus notExistingStatus(final int partitionId) {
     return new PartitionBackupStatus(
-        response.getPartitionId(),
+        partitionId,
         BackupStatusCode.DOES_NOT_EXIST,
         Optional.empty(),
         Optional.empty(),

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupListResponse.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BackupListResponse.java
@@ -34,6 +34,10 @@ public class BackupListResponse implements BufferReader, BufferWriter {
   // Consists of backup statuses with encoded string
   private List<InternalBackupStatus> internalBackups;
 
+  public BackupListResponse() {
+    // Need an empty constructor to be used in the gateway
+  }
+
   public BackupListResponse(final List<BackupStatus> statuses) {
     internalBackups = statuses.stream().map(InternalBackupStatus::new).toList();
   }


### PR DESCRIPTION
## Description

On receiving list backup request, gateway send the request to all partitions and aggregate the responses. Each partition returns a list of backups. An aggregated status of each backup must be calculated from the statuses returned from each partitions. This is handled in `BackupRequestHandler` and it returns a list of backups.

## Related issues

related #10849 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
