### PR TITLE
[Backport stable/8.0] Run spotless before the release version updates are committed

### DIFF
--- a/.ci/scripts/release/maven-release.sh
+++ b/.ci/scripts/release/maven-release.sh
@@ -11,5 +11,6 @@ mvn -s ${MAVEN_SETTINGS_XML} release:prepare release:perform -B \
     -DpushChanges=${PUSH_CHANGES} \
     -DremoteTagging=${PUSH_CHANGES} \
     -DlocalCheckout=${SKIP_DEPLOY} \
+    -DcompletionGoals="spotless:apply" \
     -P!autoFormat \
-    -Darguments='--settings=${MAVEN_SETTINGS_XML} -P-autoFormat -DskipChecks=true -DskipTests=true -Dgpg.passphrase="${GPG_PASS}" -Dskip.central.release=${SKIP_DEPLOY} -Dskip.camunda.release=${SKIP_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR}'
+    -Darguments='--settings=${MAVEN_SETTINGS_XML} -P-autoFormat -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dgpg.passphrase="${GPG_PASS}" -Dskip.central.release=${SKIP_DEPLOY} -Dskip.camunda.release=${SKIP_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR}'


### PR DESCRIPTION
# Description
Backport of #11125 to `stable/8.0`.

relates to #10602