### PR TITLE
`LogStream` writers  don't modify written records

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -27,22 +27,24 @@ import io.camunda.zeebe.protocol.record.MessageHeaderDecoder;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.agrona.DirectBuffer;
 
 public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequestDecoder> {
-  static final Map<ValueType, UnifiedRecordValue> RECORDS_BY_TYPE = new EnumMap<>(ValueType.class);
+  static final Map<ValueType, Supplier<UnifiedRecordValue>> RECORDS_BY_TYPE =
+      new EnumMap<>(ValueType.class);
 
   static {
-    RECORDS_BY_TYPE.put(ValueType.DEPLOYMENT, new DeploymentRecord());
-    RECORDS_BY_TYPE.put(ValueType.JOB, new JobRecord());
-    RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE, new ProcessInstanceRecord());
-    RECORDS_BY_TYPE.put(ValueType.MESSAGE, new MessageRecord());
-    RECORDS_BY_TYPE.put(ValueType.JOB_BATCH, new JobBatchRecord());
-    RECORDS_BY_TYPE.put(ValueType.INCIDENT, new IncidentRecord());
-    RECORDS_BY_TYPE.put(ValueType.VARIABLE_DOCUMENT, new VariableDocumentRecord());
-    RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE_CREATION, new ProcessInstanceCreationRecord());
+    RECORDS_BY_TYPE.put(ValueType.DEPLOYMENT, DeploymentRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.JOB, JobRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE, ProcessInstanceRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.MESSAGE, MessageRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.JOB_BATCH, JobBatchRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.INCIDENT, IncidentRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.VARIABLE_DOCUMENT, VariableDocumentRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationRecord::new);
     RECORDS_BY_TYPE.put(
-        ValueType.PROCESS_INSTANCE_MODIFICATION, new ProcessInstanceModificationRecord());
+        ValueType.PROCESS_INSTANCE_MODIFICATION, ProcessInstanceModificationRecord::new);
   }
 
   private UnifiedRecordValue event;
@@ -80,13 +82,14 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
         messageHeaderDecoder.blockLength(),
         messageHeaderDecoder.version());
 
-    final int eventOffset =
-        commandRequestDecoder.limit() + ExecuteCommandRequestDecoder.valueHeaderLength();
-    final int eventLength = commandRequestDecoder.valueLength();
     eventMetadata.protocolVersion(messageHeaderDecoder.version());
-    event = RECORDS_BY_TYPE.get(commandRequestDecoder.valueType());
-    if (event != null) {
-      event.wrap(buffer, eventOffset, eventLength);
+    final var recordSupplier = RECORDS_BY_TYPE.get(commandRequestDecoder.valueType());
+    if (recordSupplier != null) {
+      final int valueOffset =
+          commandRequestDecoder.limit() + ExecuteCommandRequestDecoder.valueHeaderLength();
+      final int valueLength = commandRequestDecoder.valueLength();
+      event = recordSupplier.get();
+      event.wrap(buffer, valueOffset, valueLength);
     }
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -47,18 +47,18 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
         ValueType.PROCESS_INSTANCE_MODIFICATION, ProcessInstanceModificationRecord::new);
   }
 
-  private UnifiedRecordValue event;
-  private final RecordMetadata eventMetadata = new RecordMetadata();
+  private UnifiedRecordValue value;
+  private final RecordMetadata metadata = new RecordMetadata();
   private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
   private final ExecuteCommandRequestDecoder commandRequestDecoder =
       new ExecuteCommandRequestDecoder();
 
   @Override
   public void reset() {
-    if (event != null) {
-      event.reset();
+    if (value != null) {
+      value.reset();
     }
-    eventMetadata.reset();
+    metadata.reset();
   }
 
   @Override
@@ -82,22 +82,22 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
         messageHeaderDecoder.blockLength(),
         messageHeaderDecoder.version());
 
-    eventMetadata.protocolVersion(messageHeaderDecoder.version());
+    metadata.protocolVersion(messageHeaderDecoder.version());
     final var recordSupplier = RECORDS_BY_TYPE.get(commandRequestDecoder.valueType());
     if (recordSupplier != null) {
       final int valueOffset =
           commandRequestDecoder.limit() + ExecuteCommandRequestDecoder.valueHeaderLength();
       final int valueLength = commandRequestDecoder.valueLength();
-      event = recordSupplier.get();
-      event.wrap(buffer, valueOffset, valueLength);
+      value = recordSupplier.get();
+      value.wrap(buffer, valueOffset, valueLength);
     }
   }
 
-  public UnifiedRecordValue event() {
-    return event;
+  public UnifiedRecordValue value() {
+    return value;
   }
 
   public RecordMetadata metadata() {
-    return eventMetadata;
+    return metadata;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandResponseWriterImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandResponseWriterImpl.java
@@ -142,13 +142,13 @@ public final class CommandResponseWriterImpl implements CommandResponseWriter, B
 
     offset = responseEncoder.limit();
 
-    final int eventLength = valueWriter.getLength();
-    buffer.putInt(offset, eventLength, Protocol.ENDIANNESS);
+    final int valueLength = valueWriter.getLength();
+    buffer.putInt(offset, valueLength, Protocol.ENDIANNESS);
 
     offset += valueHeaderLength();
     valueWriter.write(buffer, offset);
 
-    offset += eventLength;
+    offset += valueLength;
 
     responseEncoder.limit(offset);
     responseEncoder.putRejectionReason(rejectionReason, 0, rejectionReason.capacity());

--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
@@ -113,13 +113,14 @@ final class InterPartitionCommandReceiverImpl {
       long checkpointId, Optional<Long> recordKey, RecordMetadata metadata, BufferWriter command) {}
 
   private static final class Decoder {
-    private final UnsafeBuffer messageBuffer = new UnsafeBuffer();
-    private final RecordMetadata recordMetadata = new RecordMetadata();
     private final InterPartitionMessageDecoder messageDecoder = new InterPartitionMessageDecoder();
     private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
-    private final DirectBufferWriter commandBuffer = new DirectBufferWriter();
 
     DecodedMessage decodeMessage(final byte[] message) {
+      final var messageBuffer = new UnsafeBuffer();
+      final var recordMetadata = new RecordMetadata();
+      final var commandBuffer = new DirectBufferWriter();
+
       messageBuffer.wrap(message);
       messageDecoder.wrapAndApplyHeader(messageBuffer, 0, headerDecoder);
 


### PR DESCRIPTION
Updates logstream writers to always hand out immutable records. Currently, this is not required as the logstream writer implementation immediately serializes (and thus copies) the records.
This is an implementation detail that we want to change for #10906 so we need to update the command API and inter-partition command receiver to not reuse records and buffers across requests.

closes #10918 