### PR TITLE
ci: create benchmarks for PRs labeled with 'benchmark'

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,6 +52,8 @@ jobs:
     name: Build zeebe image
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      image-tag: ${{ steps.image-tag.outputs.image-tag }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -67,6 +69,10 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           maven-cache: 'true'
+      - name: Get image tag
+        id: image-tag
+        run: |
+          echo "image-tag=${{ inputs.name }}-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
@@ -74,7 +80,7 @@ jobs:
       - uses: ./.github/actions/build-docker
         with:
           repository: gcr.io/zeebe-io/zeebe
-          version: ${{ inputs.name }}
+          version: ${{ steps.image-tag.outputs.image-tag }}
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
   deploy-benchmark-cluster:
@@ -111,9 +117,9 @@ jobs:
           ${{ inputs.name }} camunda/camunda-platform
           -f benchmarks/setup/default/zeebe-values.yaml
           --set zeebe.image.repository=gcr.io/zeebe-io/zeebe
-          --set zeebe.image.tag=${{ inputs.name }}
+          --set zeebe.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
           --set zeebe-gateway.image.repository=gcr.io/zeebe-io/zeebe
-          --set zeebe-gateway.image.tag=${{ inputs.name }}
+          --set zeebe-gateway.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
       - name: Deploy and configure additional benchmark components
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -119,8 +119,8 @@ jobs:
         with:
           # language=javascript
           script: |
-            const namespace = context.payload.inputs.name
-            const load = context.payload.inputs.load
+            const namespace = '${{ inputs.name }}'
+            const load = '${{ inputs.load }}'
             const components = load.split(", ")
             for (const component of components) {
               if (component.includes("=")) {

--- a/.github/workflows/medic-benchmarks.yml
+++ b/.github/workflows/medic-benchmarks.yml
@@ -29,8 +29,8 @@ jobs:
         run: |
           kubectl delete ${{ steps.data.normal }}
           kubectl delete ${{ steps.data.mixed }}
-  setup-new-benchmarks:
-    name: Setup new benchmarks
+  benchmark-data:
+    name: Collect benchmark data
     runs-on: ubuntu-latest
     steps:
       - name: Collect benchmark data
@@ -38,21 +38,27 @@ jobs:
         run: |
           echo "ref=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "cw=$(date +%V)" >> $GITHUB_OUTPUT
-      - uses: ./.github/workflows/benchmark.yaml
-        name: Create normal benchmark
-        with:
-          name: medic-cw-${{ steps.data.outputs.cw }}-${{ steps.data.outputs.ref }}-benchmark
-          cluster: zeebe-cluster
-          cluster-region: europe-west1-b
-          ref: ${{ steps.data.outputs.ref }}
-          load: "worker, starter=200"
-        secrets: inherit
-      - uses: ./.github/workflows/benchmark.yaml
-        name: Create mixed benchmark
-        with:
-          name: medic-cw-${{ steps.data.outputs.cw }}-${{ steps.data.outputs.ref }}-benchmark-mixed
-          cluster: zeebe-cluster
-          cluster-region: europe-west1-b
-          ref: ${{ steps.data.outputs.ref }}
-          load: "worker, starter=100, timer=50, publisher=50"
-        secrets: inherit
+  setup-normal-benchmark:
+    name: Setup normal benchmark
+    needs:
+      - benchmark-data
+    uses: ./.github/workflows/benchmark.yaml
+    secrets: inherit
+    with:
+      name: medic-cw-${{ needs.benchmark-data.outputs.cw }}-${{ needs.benchmark-data.outputs.ref }}-benchmark
+      cluster: zeebe-cluster
+      cluster-region: europe-west1-b
+      ref: ${{ steps.data.outputs.ref }}
+      load: "worker, starter=200"
+  setup-mixed-benchmark:
+    name: Setup mixed benchmark
+    uses: ./.github/workflows/benchmark.yaml
+    secrets: inherit
+    needs:
+      - benchmark-data
+    with:
+      name: medic-cw-${{ needs.benchmark-data.outputs.cw }}-${{ needs.benchmark-data.outputs.ref }}-benchmark-mixed
+      cluster: zeebe-cluster
+      cluster-region: europe-west1-b
+      ref: ${{ steps.data.outputs.ref }}
+      load: "worker, starter=100, timer=50, publisher=50"

--- a/.github/workflows/pr-benchmark.yaml
+++ b/.github/workflows/pr-benchmark.yaml
@@ -1,0 +1,51 @@
+name: Pull Request Benchmark
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - closed
+
+jobs:
+  create-benchmark:
+    name: Create PR benchmark
+    if: github.event.action == 'labeled' && github.event.label.name == 'benchmark'
+    uses: ./.github/workflows/benchmark.yml
+    secrets: inherit
+    with:
+      name: pr-${{github.event.pull_request.number}}-benchmark
+      cluster: zeebe-cluster
+      cluster-region: europe-west1-b
+      ref: ${{ github.event.pull_request.head.ref }}
+  update-benchmark:
+    name: Update PR benchmark
+    if: github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark')
+    uses: ./.github/workflows/benchmark.yml
+    secrets: inherit
+    with:
+      name: pr-${{github.event.pull_request.number}}-benchmark
+      cluster: zeebe-cluster
+      cluster-region: europe-west1-b
+      ref: ${{ github.event.pull_request.head.ref }}
+  delete-benchmark:
+    name: Delete PR benchmark
+    if: >
+      (github.event.action == 'unlabeled' && github.event.label.name == 'benchmark')
+      || (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/auth@v1
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
+      - uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: zeebe-io
+          install_components: gke-gcloud-auth-plugin, kubectl
+      - uses: google-github-actions/get-gke-credentials@v1.0.0
+        with:
+          cluster_name: zeebe-cluster
+          location: europe-west1-b
+      - name: Delete benchmarks
+        run: |
+          kubectl delete ns pr-${{github.event.pull_request.number}}-benchmark


### PR DESCRIPTION
This workflow is triggered when adding/removing a 'benchmark' label to pull requests and when updating/closing labeled pull requests.

When adding the label or updating the pull request, a benchmark is created or updated with a name like 'pr-1234-benchmark'. When removing the label or closing the pull request, the underlying kubernetes namespace is deleted.

**Todo**
- [x] Updating a benchmark should actually update the zeebe pods