### PR TITLE
Add actuator endpoint for list backups

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -407,6 +407,7 @@
               <generateModels>true</generateModels>
               <configOptions>
                 <sourceFolder>src/main</sourceFolder>
+                <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)</additionalModelTypeAnnotations>
               </configOptions>
             </configuration>
           </execution>

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
@@ -85,6 +85,9 @@ public interface BackupActuator {
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   BackupInfo status(@Param final long id);
 
+  @RequestLine("GET /")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  List<BackupInfo> list();
   /**
    * Custom error handler, mapping errors with body to custom types for easier
    * verification/handling. This is somewhat verbose, so any suggestions for improvements are


### PR DESCRIPTION
## Description

A list of backups can be queried by `GET actuator/backups/`. This returns a list of BackupInfo.  This doesn't change the existign status request where If a backupId is provided with the request then instead of a list, it returns the BackupInfo of the given backupId.

Example response
```
[
   {
      "backupId" : 1,
      "details" : [
         {
            "brokerVersion" : "8.2.0-SNAPSHOT",
            "createdAt" : "2022-11-30T10:08:19.762067329Z",
            "failureReason" : "",
            "partitionId" : 1,
            "state" : "COMPLETED"
         },
         {
            "brokerVersion" : "8.2.0-SNAPSHOT",
            "createdAt" : "2022-11-30T10:08:19.702766992Z",
            "failureReason" : "",
            "partitionId" : 2,
            "state" : "COMPLETED"
         }
      ],
      "state" : "COMPLETED"
   },
   {
      "backupId" : 2,
      "details" : [
         {
            "brokerVersion" : "8.2.0-SNAPSHOT",
            "createdAt" : "2022-11-30T10:08:19.797814584Z",
            "failureReason" : "",
            "partitionId" : 1,
            "state" : "COMPLETED"
         },
         {
            "brokerVersion" : "8.2.0-SNAPSHOT",
            "createdAt" : "2022-11-30T10:08:19.803038878Z",
            "failureReason" : "",
            "partitionId" : 2,
            "state" : "COMPLETED"
         }
      ],
      "state" : "COMPLETED"
   }
]
```

## Related issues

closes #10849

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
